### PR TITLE
chore: add a make task `security-audit` to audit Cargo.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ stats:
 	@cargo count --version || cargo +nightly install --git https://github.com/kbknapp/cargo-count
 	@cargo count --separator , --unsafe-statistics
 
+# Use cargo-audit to audit Cargo.lock for crates with security vulnerabilities
+# expecting to see "Success No vulnerable packages found"
+security-audit:
+	@cargo audit --version || cargo install cargo-audit
+	@cargo audit
+
 .PHONY: build build-integration-test
 .PHONY: fmt test clippy proto doc doc-deps check stats
-.PHONY: ci ci-quick info
+.PHONY: ci ci-quick info security-audit


### PR DESCRIPTION
```
↪  make security-audit                                                                                                                                Wed Nov 28 19:21:09 CST 2018
cargo-audit 0.5.2
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 14 security advisories (from /Users/rain/.cargo/advisory-db)
    Scanning Cargo.lock for vulnerabilities (353 crate dependencies)
error: Vulnerable crates found!

ID:	 RUSTSEC-2018-0003
Crate:	 smallvec
Version: 0.2.1
Date:	 2018-07-19
URL:	 https://github.com/servo/rust-smallvec/issues/96
Title:	 Possible double free during unwinding in SmallVec::insert_many
Solution: upgrade to: >= 0.6.3 OR ^0.3.4 OR ^0.4.5 OR ^0.5.1

ID:	 RUSTSEC-2018-0001
Crate:	 untrusted
Version: 0.5.1
Date:	 2018-06-21
URL:	 https://github.com/briansmith/untrusted/pull/20
Title:	 An integer underflow could lead to panic
Solution: upgrade to: >= 0.6.2

ID:	 RUSTSEC-2018-0006
Crate:	 yaml-rust
Version: 0.3.5
Date:	 2018-09-17
URL:	 https://github.com/chyh1990/yaml-rust/pull/109
Title:	 Uncontrolled recursion leads to abort in deserialization
Solution: upgrade to: >= 0.4.1

error: 3 vulnerabilities found!
make: *** [security-audit] Error 1

```

We can use this task in CI job , it will exit with status 1 if there is any vulnerable crate found.
