### PR TITLE
fix: fix IBD sync process

### DIFF
--- a/sync/src/synchronizer/peers.rs
+++ b/sync/src/synchronizer/peers.rs
@@ -134,7 +134,7 @@ impl Peers {
                 chain_sync.protect = protect;
                 PeerState {
                     negotiate: Negotiate::default(),
-                    sync_started: true,
+                    sync_started: false,
                     last_block_announcement: None,
                     headers_sync_timeout: Some(headers_sync_timeout),
                     disconnect: false,
@@ -163,17 +163,6 @@ impl Peers {
 
     pub fn getheaders_received(&self, _peer: PeerIndex) {
         // TODO:
-    }
-
-    pub fn connected(&self, peer: PeerIndex) {
-        self.state.write().entry(peer).or_insert_with(|| PeerState {
-            negotiate: Negotiate::default(),
-            sync_started: true,
-            last_block_announcement: None,
-            headers_sync_timeout: None,
-            disconnect: false,
-            chain_sync: ChainSyncState::default(),
-        });
     }
 
     pub fn disconnected(&self, peer: PeerIndex) {

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -73,6 +73,17 @@ impl TestNode {
                 local_index,
             )
         }
+
+        if let Some(handler) = remote.protocols.get(&protocol) {
+            handler.connected(
+                Box::new(TestNetworkContext {
+                    protocol,
+                    msg_senders: remote.msg_senders.clone(),
+                    timer_senders: remote.timer_senders.clone(),
+                }),
+                local_index,
+            )
+        }
     }
 
     pub fn start<F: Fn(&[u8]) -> bool>(&self, signal: Sender<()>, pred: F) {

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -14,7 +14,7 @@ use flatbuffers::get_root;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
-use synchronizer::BLOCK_FETCH_TOKEN;
+use synchronizer::{BLOCK_FETCH_TOKEN, SEND_GET_HEADERS_TOKEN, TIMEOUT_EVICTION_TOKEN};
 use tests::TestNode;
 use {Config, Synchronizer, SYNC_PROTOCOL_ID};
 
@@ -100,7 +100,11 @@ fn setup_node(height: u64) -> (TestNode, Shared<ChainKVStore<MemoryKeyValueDB>>)
     node.add_protocol(
         SYNC_PROTOCOL_ID,
         Arc::new(synchronizer),
-        vec![BLOCK_FETCH_TOKEN],
+        vec![
+            SEND_GET_HEADERS_TOKEN,
+            BLOCK_FETCH_TOKEN,
+            TIMEOUT_EVICTION_TOKEN,
+        ],
     );
     (node, shared)
 }


### PR DESCRIPTION
Fix duplicated Headers messages between peers.

Fix the logic by correct the IBD and `sync` flag to their original intention.