### PR TITLE
refactor: rename outpoint to out_point as its type is OutPoint

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -533,8 +533,8 @@ pub mod test {
             .set_verification(false);
         let (_chain_controller, shared) = start_chain(Some(consensus));
 
-        let outpoint = OutPoint::new(root_hash, 0);
-        let state = shared.cell(&outpoint);
+        let out_point = OutPoint::new(root_hash, 0);
+        let state = shared.cell(&out_point);
         assert!(state.is_current());
     }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -92,7 +92,7 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
                     for (i, output) in transaction.outputs().iter().enumerate() {
                         if output.lock == type_hash && (!transaction_meta.is_spent(i)) {
                             result.push(CellOutputWithOutPoint {
-                                outpoint: OutPoint::new(transaction.hash().clone(), i as u32),
+                                out_point: OutPoint::new(transaction.hash().clone(), i as u32),
                                 capacity: output.capacity,
                                 lock: output.lock.clone(),
                             });

--- a/rpc/src/types.rs
+++ b/rpc/src/types.rs
@@ -45,7 +45,7 @@ impl From<Block> for BlockWithHash {
 // cell's own data such as lock and capacity
 #[derive(Serialize)]
 pub struct CellOutputWithOutPoint {
-    pub outpoint: OutPoint,
+    pub out_point: OutPoint,
     pub capacity: Capacity,
     pub lock: H256,
 }

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -740,7 +740,8 @@ mod tests {
             Ok(out_point_data.len() as u64)
         );
 
-        for (i, addr) in (addr as usize..addr as usize + out_point_data.len() as usize).enumerate() {
+        for (i, addr) in (addr as usize..addr as usize + out_point_data.len() as usize).enumerate()
+        {
             assert_eq!(machine.memory_mut().load8(addr), Ok(out_point_data[i]));
         }
     }

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -702,7 +702,7 @@ mod tests {
         }
     }
 
-    fn _test_load_self_input_outpoint(data: Vec<u8>) {
+    fn _test_load_self_input_out_point(data: Vec<u8>) {
         let mut machine = DefaultCoreMachine::<u64, SparseMemory>::default();
         let size_addr = 0;
         let addr = 100;
@@ -712,24 +712,24 @@ mod tests {
         machine.registers_mut()[A2] = 0; // offset
         machine.registers_mut()[A3] = 0; //index
         machine.registers_mut()[A4] = 2; //source: 2 self
-        machine.registers_mut()[A5] = 1; //field: 1 outpoint
+        machine.registers_mut()[A5] = 1; //field: 1 out_point
         machine.registers_mut()[A7] = LOAD_INPUT_BY_FIELD_SYSCALL_NUMBER; // syscall number
 
         let unlock = Script::new(0, vec![], None, Some(vec![]), vec![]);
         let sha3_data = sha3_256(data);
-        let outpoint = OutPoint::new(H256::from_slice(&sha3_data).unwrap(), 3);
+        let out_point = OutPoint::new(H256::from_slice(&sha3_data).unwrap(), 3);
         let mut builder = FlatBufferBuilder::new();
-        let fbs_offset = FbsOutPoint::build(&mut builder, &outpoint);
+        let fbs_offset = FbsOutPoint::build(&mut builder, &out_point);
         builder.finish(fbs_offset, None);
-        let outpoint_data = builder.finished_data();
+        let out_point_data = builder.finished_data();
 
-        let input = CellInput::new(outpoint, unlock);
+        let input = CellInput::new(out_point, unlock);
         let inputs = vec![];
         let mut load_input = LoadInputByField::new(&inputs, Some(&input));
 
         assert!(machine
             .memory_mut()
-            .store64(size_addr as usize, outpoint_data.len() as u64 + 5)
+            .store64(size_addr as usize, out_point_data.len() as u64 + 5)
             .is_ok());
 
         assert!(load_input.ecall(&mut machine).is_ok());
@@ -737,23 +737,23 @@ mod tests {
 
         assert_eq!(
             machine.memory_mut().load64(size_addr as usize),
-            Ok(outpoint_data.len() as u64)
+            Ok(out_point_data.len() as u64)
         );
 
-        for (i, addr) in (addr as usize..addr as usize + outpoint_data.len() as usize).enumerate() {
-            assert_eq!(machine.memory_mut().load8(addr), Ok(outpoint_data[i]));
+        for (i, addr) in (addr as usize..addr as usize + out_point_data.len() as usize).enumerate() {
+            assert_eq!(machine.memory_mut().load8(addr), Ok(out_point_data[i]));
         }
     }
 
     proptest! {
         #[test]
-        fn test_load_self_input_outpoint(data in any_with::<Vec<u8>>(size_range(1000).lift())) {
-            _test_load_self_input_outpoint(data);
+        fn test_load_self_input_out_point(data in any_with::<Vec<u8>>(size_range(1000).lift())) {
+            _test_load_self_input_out_point(data);
         }
     }
 
     #[test]
-    fn test_load_missing_self_output_outpoint() {
+    fn test_load_missing_self_output_out_point() {
         let mut machine = DefaultCoreMachine::<u64, SparseMemory>::default();
         let size_addr = 0;
         let addr = 100;
@@ -763,7 +763,7 @@ mod tests {
         machine.registers_mut()[A2] = 0; // offset
         machine.registers_mut()[A3] = 0; //index
         machine.registers_mut()[A4] = 2; //source: 2 self
-        machine.registers_mut()[A5] = 1; //field: 1 outpoint
+        machine.registers_mut()[A5] = 1; //field: 1 out_point
         machine.registers_mut()[A7] = LOAD_INPUT_BY_FIELD_SYSCALL_NUMBER; // syscall number
 
         let inputs = vec![];

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -288,10 +288,10 @@ mod tests {
         hex_to(&signature_der, &mut hex_signature).expect("hex privkey");
         args.insert(0, hex_signature);
 
-        let dep_outpoint = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellOutput::new(buffer.len() as Capacity, buffer, H256::zero(), None);
         let mut dep_cells = FnvHashMap::default();
-        dep_cells.insert(&dep_outpoint, &dep_cell);
+        dep_cells.insert(&dep_out_point, &dep_cell);
 
         let privkey = privkey.pubkey().unwrap().serialize();
         let mut hex_privkey = vec![0; privkey.len() * 2];
@@ -302,7 +302,7 @@ mod tests {
 
         let transaction = TransactionBuilder::default()
             .input(input.clone())
-            .dep(dep_outpoint.clone())
+            .dep(dep_out_point.clone())
             .build();
 
         let dummy_cell = CellOutput::new(100, vec![], H256::default(), None);
@@ -340,7 +340,7 @@ mod tests {
         hex_to(&signature_der, &mut hex_signature).expect("hex privkey");
         args.insert(0, hex_signature);
 
-        let dep_outpoint = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
 
         let privkey = privkey.pubkey().unwrap().serialize();
         let mut hex_privkey = vec![0; privkey.len() * 2];
@@ -357,7 +357,7 @@ mod tests {
 
         let transaction = TransactionBuilder::default()
             .input(input.clone())
-            .dep(dep_outpoint)
+            .dep(dep_out_point)
             .build();
 
         let dummy_cell = CellOutput::new(100, vec![], H256::default(), None);

--- a/src/cli/run_impl.rs
+++ b/src/cli/run_impl.rs
@@ -157,7 +157,7 @@ pub fn sign(setup: &Setup, matches: &ArgMatches) {
     let system_cell_tx = &consensus.genesis_block().commit_transactions()[0];
     let system_cell_data_hash = system_cell_tx.outputs()[0].data_hash();
     let system_cell_tx_hash = system_cell_tx.hash();
-    let system_cell_outpoint = OutPoint::new(system_cell_tx_hash.clone(), 0);
+    let system_cell_out_point = OutPoint::new(system_cell_tx_hash.clone(), 0);
 
     let privkey: Privkey = value_t!(matches.value_of("private-key"), H256)
         .unwrap_or_else(|e| e.exit())
@@ -199,7 +199,7 @@ pub fn sign(setup: &Setup, matches: &ArgMatches) {
     // Then, sign each input
     let result = TransactionBuilder::default()
         .transaction(transaction)
-        .dep(system_cell_outpoint)
+        .dep(system_cell_out_point)
         .inputs_clear()
         .inputs(inputs)
         .build();


### PR DESCRIPTION
Although `outpoint` is well recgonized (especially in Bitcoin world) we have the type as `OutPoint` so it makes sense to follow the variable naming convention. 

See #91.