### PR TITLE
refactor: unify h256 and ProposalShortId serialization

### DIFF
--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -168,26 +168,13 @@ impl<'a> FbsCellOutput<'a> {
         fbb: &mut FlatBufferBuilder<'b>,
         cell_output: &CellOutput,
     ) -> WIPOffset<FbsCellOutput<'b>> {
-<<<<<<< HEAD
-<<<<<<< HEAD
         let data = FbsBytes::build(fbb, &cell_output.data);
-        let lock = FbsBytes::build(fbb, &cell_output.lock.as_bytes());
-        let type_ = cell_output.type_.as_ref().map(|s| FbsScript::build(fbb, s));
-=======
-        let data = fbb.create_vector_direct(&cell_output.data);
-=======
-        let data = FbsBytes::build(fbb, &cell_output.data);
->>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
         let lock = (&cell_output.lock).into();
-        let contract = cell_output
-            .contract
-            .as_ref()
-            .map(|s| FbsScript::build(fbb, s));
->>>>>>> refactor: replace flatten Bytes with [ubyte]
+        let type_ = cell_output.type_.as_ref().map(|s| FbsScript::build(fbb, s));
         let mut builder = CellOutputBuilder::new(fbb);
         builder.add_capacity(cell_output.capacity);
         builder.add_data(data);
-        builder.add_lock(lock);
+        builder.add_lock(&lock);
         if let Some(s) = type_ {
             builder.add_type_(s);
         }

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -43,8 +43,8 @@ impl<'a> FbsHeader<'a> {
         let parent_hash = header.parent_hash().into();
         let txs_commit = header.txs_commit().into();
         let txs_proposal = header.txs_proposal().into();
-        let difficulty = FbsBytes::build(fbb, &uint_to_bytes(header.difficulty()));
-        let proof = FbsBytes::build(fbb, &header.proof());
+        let difficulty = fbb.create_vector_direct(&uint_to_bytes(header.difficulty()));
+        let proof = fbb.create_vector_direct(&header.proof());
         let cellbase_id = header.cellbase_id().into();
         let uncles_hash = header.uncles_hash().into();
         let mut builder = HeaderBuilder::new(fbb);
@@ -137,7 +137,7 @@ impl<'a> FbsScript<'a> {
             .collect::<Vec<_>>();
         let args = fbb.create_vector(&vec);
 
-        let binary = script.binary.as_ref().map(|s| FbsBytes::build(fbb, s));
+        let binary = script.binary.as_ref().map(|s| fbb.create_vector_direct(s));
 
         let reference = script.reference.as_ref().map(Into::into);
 
@@ -167,9 +167,18 @@ impl<'a> FbsCellOutput<'a> {
         fbb: &mut FlatBufferBuilder<'b>,
         cell_output: &CellOutput,
     ) -> WIPOffset<FbsCellOutput<'b>> {
+<<<<<<< HEAD
         let data = FbsBytes::build(fbb, &cell_output.data);
         let lock = FbsBytes::build(fbb, &cell_output.lock.as_bytes());
         let type_ = cell_output.type_.as_ref().map(|s| FbsScript::build(fbb, s));
+=======
+        let data = fbb.create_vector_direct(&cell_output.data);
+        let lock = (&cell_output.lock).into();
+        let contract = cell_output
+            .contract
+            .as_ref()
+            .map(|s| FbsScript::build(fbb, s));
+>>>>>>> refactor: replace flatten Bytes with [ubyte]
         let mut builder = CellOutputBuilder::new(fbb);
         builder.add_capacity(cell_output.capacity);
         builder.add_data(data);

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -43,8 +43,8 @@ impl<'a> FbsHeader<'a> {
         let parent_hash = header.parent_hash().into();
         let txs_commit = header.txs_commit().into();
         let txs_proposal = header.txs_proposal().into();
-        let difficulty = fbb.create_vector_direct(&uint_to_bytes(header.difficulty()));
-        let proof = fbb.create_vector_direct(&header.proof());
+        let difficulty = FbsBytes::build(fbb, &uint_to_bytes(header.difficulty()));
+        let proof = FbsBytes::build(fbb, &header.proof());
         let cellbase_id = header.cellbase_id().into();
         let uncles_hash = header.uncles_hash().into();
         let mut builder = HeaderBuilder::new(fbb);
@@ -137,7 +137,7 @@ impl<'a> FbsScript<'a> {
             .collect::<Vec<_>>();
         let args = fbb.create_vector(&vec);
 
-        let binary = script.binary.as_ref().map(|s| fbb.create_vector_direct(s));
+        let binary = script.binary.as_ref().map(|s| FbsBytes::build(fbb, s));
 
         let reference = script.reference.as_ref().map(Into::into);
 
@@ -168,11 +168,15 @@ impl<'a> FbsCellOutput<'a> {
         cell_output: &CellOutput,
     ) -> WIPOffset<FbsCellOutput<'b>> {
 <<<<<<< HEAD
+<<<<<<< HEAD
         let data = FbsBytes::build(fbb, &cell_output.data);
         let lock = FbsBytes::build(fbb, &cell_output.lock.as_bytes());
         let type_ = cell_output.type_.as_ref().map(|s| FbsScript::build(fbb, s));
 =======
         let data = fbb.create_vector_direct(&cell_output.data);
+=======
+        let data = FbsBytes::build(fbb, &cell_output.data);
+>>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
         let lock = (&cell_output.lock).into();
         let contract = cell_output
             .contract

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -5,10 +5,11 @@ use crate::protocol_generated::ckb::protocol::{
     FilteredBlock, FilteredBlockBuilder, GetBlockProposalBuilder, GetBlockTransactionsBuilder,
     GetBlocks as FbsGetBlocks, GetBlocksBuilder, GetHeaders as FbsGetHeaders, GetHeadersBuilder,
     Header as FbsHeader, HeaderBuilder, Headers as FbsHeaders, HeadersBuilder,
-    IndexTransactionBuilder, OutPoint as FbsOutPoint, OutPointBuilder, RelayMessage,
-    RelayMessageBuilder, RelayPayload, Script as FbsScript, ScriptBuilder, SyncMessage,
-    SyncMessageBuilder, SyncPayload, Transaction as FbsTransaction, TransactionBuilder,
-    UncleBlock as FbsUncleBlock, UncleBlockBuilder, H256 as FbsH256,
+    IndexTransactionBuilder, OutPoint as FbsOutPoint, OutPointBuilder,
+    ProposalShortId as FbsProposalShortId, RelayMessage, RelayMessageBuilder, RelayPayload,
+    Script as FbsScript, ScriptBuilder, SyncMessage, SyncMessageBuilder, SyncPayload,
+    Transaction as FbsTransaction, TransactionBuilder, UncleBlock as FbsUncleBlock,
+    UncleBlockBuilder, H256 as FbsH256,
 };
 use crate::{short_transaction_id, short_transaction_id_keys};
 use ckb_core::block::Block;
@@ -215,8 +216,8 @@ impl<'a> FbsBlock<'a> {
         let vec = block
             .proposal_transactions()
             .iter()
-            .map(|id| FbsBytes::build(fbb, &id[..]))
-            .collect::<Vec<_>>();
+            .map(Into::into)
+            .collect::<Vec<FbsProposalShortId>>();
         let proposal_transactions = fbb.create_vector(&vec);
 
         let mut builder = BlockBuilder::new(fbb);
@@ -239,8 +240,8 @@ impl<'a> FbsUncleBlock<'a> {
         let vec = uncle_block
             .proposal_transactions
             .iter()
-            .map(|id| FbsBytes::build(fbb, &id[..]))
-            .collect::<Vec<_>>();
+            .map(Into::into)
+            .collect::<Vec<FbsProposalShortId>>();
         let proposal_transactions = fbb.create_vector(&vec);
 
         let mut builder = UncleBlockBuilder::new(fbb);
@@ -437,8 +438,8 @@ impl<'a> CompactBlock<'a> {
         let vec = block
             .proposal_transactions()
             .iter()
-            .map(|id| FbsBytes::build(fbb, &id[..]))
-            .collect::<Vec<_>>();
+            .map(Into::into)
+            .collect::<Vec<FbsProposalShortId>>();
         let proposal_transactions = fbb.create_vector(&vec);
 
         let mut builder = CompactBlockBuilder::new(fbb);
@@ -529,8 +530,8 @@ impl<'a> RelayMessage<'a> {
         let get_block_proposal = {
             let vec = proposal_transactions
                 .iter()
-                .map(|id| FbsBytes::build(fbb, &id[..]))
-                .collect::<Vec<_>>();
+                .map(Into::into)
+                .collect::<Vec<FbsProposalShortId>>();
             let proposal_transactions = fbb.create_vector(&vec);
             let mut builder = GetBlockProposalBuilder::new(fbb);
             builder.add_block_number(block_number);

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -110,14 +110,11 @@ impl<'a> From<ckb_protocol::Header<'a>> for ckb_core::header::Header {
             .number(header.number())
             .txs_commit(header.txs_commit().unwrap().into())
             .txs_proposal(header.txs_proposal().unwrap().into())
-            .difficulty(
-                U256::from_little_endian(header.difficulty().and_then(|b| b.seq()).unwrap())
-                    .unwrap(),
-            )
+            .difficulty(U256::from_little_endian(header.difficulty().unwrap()).unwrap())
             .cellbase_id(header.cellbase_id().unwrap().into())
             .uncles_hash(header.uncles_hash().unwrap().into())
             .nonce(header.nonce())
-            .proof(header.proof().and_then(|b| b.seq()).unwrap().to_vec())
+            .proof(header.proof().unwrap().to_vec())
             .uncles_count(header.uncles_count())
             .build()
     }
@@ -168,7 +165,7 @@ impl<'a> From<ckb_protocol::Script<'a>> for ckb_core::script::Script {
         ckb_core::script::Script {
             version: script.version(),
             args,
-            binary: script.binary().and_then(|s| s.seq()).map(|s| s.to_vec()),
+            binary: script.binary().map(Into::into),
             signed_args,
             reference: script.reference().map(Into::into),
         }
@@ -191,6 +188,7 @@ impl<'a> From<ckb_protocol::CellOutput<'a>> for ckb_core::transaction::CellOutpu
     fn from(cell_output: ckb_protocol::CellOutput<'a>) -> Self {
         ckb_core::transaction::CellOutput {
             capacity: cell_output.capacity(),
+<<<<<<< HEAD
             data: cell_output.data().and_then(|b| b.seq()).unwrap().to_vec(),
             lock: H256::from_slice(cell_output.lock().and_then(|b| b.seq()).unwrap()).unwrap(),
             type_: cell_output.type_().map(Into::into),
@@ -203,6 +201,11 @@ impl<'a> From<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::Ind
         ckb_core::transaction::IndexTransaction {
             index: it.index() as usize,
             transaction: it.transaction().unwrap().into(),
+=======
+            data: cell_output.data().unwrap().into(),
+            lock: cell_output.lock().unwrap().into(),
+            contract: cell_output.contract().map(Into::into),
+>>>>>>> refactor: replace flatten Bytes with [ubyte]
         }
     }
 }

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -4,6 +4,58 @@ use ckb_core;
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
 
+impl From<&H256> for ckb_protocol::H256 {
+    fn from(h256: &H256) -> Self {
+        let bytes = h256.as_fixed_bytes();
+        Self::new(
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+            bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23],
+            bytes[24], bytes[25], bytes[26], bytes[27], bytes[28], bytes[29], bytes[30], bytes[31],
+        )
+    }
+}
+
+impl From<&ckb_protocol::H256> for H256 {
+    fn from(h256: &ckb_protocol::H256) -> Self {
+        H256::from_slice(&[
+            h256.u0(),
+            h256.u1(),
+            h256.u2(),
+            h256.u3(),
+            h256.u4(),
+            h256.u5(),
+            h256.u6(),
+            h256.u7(),
+            h256.u8_(),
+            h256.u9(),
+            h256.u10(),
+            h256.u11(),
+            h256.u12(),
+            h256.u13(),
+            h256.u14(),
+            h256.u15(),
+            h256.u16_(),
+            h256.u17(),
+            h256.u18(),
+            h256.u19(),
+            h256.u20(),
+            h256.u21(),
+            h256.u22(),
+            h256.u23(),
+            h256.u24(),
+            h256.u25(),
+            h256.u26(),
+            h256.u27(),
+            h256.u28(),
+            h256.u29(),
+            h256.u30(),
+            h256.u31(),
+        ])
+        .unwrap()
+    }
+}
+
 impl<'a> From<ckb_protocol::Block<'a>> for ckb_core::block::Block {
     fn from(block: ckb_protocol::Block<'a>) -> Self {
         let commit_transactions =
@@ -53,27 +105,17 @@ impl<'a> From<ckb_protocol::Header<'a>> for ckb_core::header::Header {
     fn from(header: ckb_protocol::Header<'a>) -> Self {
         ckb_core::header::HeaderBuilder::default()
             .version(header.version())
-            .parent_hash(
-                H256::from_slice(header.parent_hash().and_then(|b| b.seq()).unwrap()).unwrap(),
-            )
+            .parent_hash(header.parent_hash().unwrap().into())
             .timestamp(header.timestamp())
             .number(header.number())
-            .txs_commit(
-                H256::from_slice(header.txs_commit().and_then(|b| b.seq()).unwrap()).unwrap(),
-            )
-            .txs_proposal(
-                H256::from_slice(header.txs_proposal().and_then(|b| b.seq()).unwrap()).unwrap(),
-            )
+            .txs_commit(header.txs_commit().unwrap().into())
+            .txs_proposal(header.txs_proposal().unwrap().into())
             .difficulty(
                 U256::from_little_endian(header.difficulty().and_then(|b| b.seq()).unwrap())
                     .unwrap(),
             )
-            .cellbase_id(
-                H256::from_slice(header.cellbase_id().and_then(|b| b.seq()).unwrap()).unwrap(),
-            )
-            .uncles_hash(
-                H256::from_slice(header.uncles_hash().and_then(|b| b.seq()).unwrap()).unwrap(),
-            )
+            .cellbase_id(header.cellbase_id().unwrap().into())
+            .uncles_hash(header.uncles_hash().unwrap().into())
             .nonce(header.nonce())
             .proof(header.proof().and_then(|b| b.seq()).unwrap().to_vec())
             .uncles_count(header.uncles_count())
@@ -107,7 +149,7 @@ impl<'a> From<ckb_protocol::Transaction<'a>> for ckb_core::transaction::Transact
 impl<'a> From<ckb_protocol::OutPoint<'a>> for ckb_core::transaction::OutPoint {
     fn from(out_point: ckb_protocol::OutPoint<'a>) -> Self {
         ckb_core::transaction::OutPoint {
-            hash: H256::from_slice(out_point.hash().and_then(|b| b.seq()).unwrap()).unwrap(),
+            hash: out_point.hash().unwrap().into(),
             index: out_point.index(),
         }
     }
@@ -128,10 +170,7 @@ impl<'a> From<ckb_protocol::Script<'a>> for ckb_core::script::Script {
             args,
             binary: script.binary().and_then(|s| s.seq()).map(|s| s.to_vec()),
             signed_args,
-            reference: script
-                .reference()
-                .and_then(|s| s.seq())
-                .map(|s| H256::from_slice(s).unwrap()),
+            reference: script.reference().map(Into::into),
         }
     }
 }
@@ -140,7 +179,7 @@ impl<'a> From<ckb_protocol::CellInput<'a>> for ckb_core::transaction::CellInput 
     fn from(cell_input: ckb_protocol::CellInput<'a>) -> Self {
         ckb_core::transaction::CellInput {
             previous_output: ckb_core::transaction::OutPoint {
-                hash: H256::from_slice(cell_input.hash().and_then(|b| b.seq()).unwrap()).unwrap(),
+                hash: cell_input.hash().unwrap().into(),
                 index: cell_input.index(),
             },
             unlock: cell_input.unlock().unwrap().into(),

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -167,3 +167,12 @@ impl<'a> From<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::Ind
         }
     }
 }
+
+impl<'a> From<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::IndexTransaction {
+    fn from(it: ckb_protocol::IndexTransaction<'a>) -> Self {
+        ckb_core::transaction::IndexTransaction {
+            index: it.index() as usize,
+            transaction: it.transaction().unwrap().into(),
+        }
+    }
+}

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -110,11 +110,14 @@ impl<'a> From<ckb_protocol::Header<'a>> for ckb_core::header::Header {
             .number(header.number())
             .txs_commit(header.txs_commit().unwrap().into())
             .txs_proposal(header.txs_proposal().unwrap().into())
-            .difficulty(U256::from_little_endian(header.difficulty().unwrap()).unwrap())
+            .difficulty(
+                U256::from_little_endian(header.difficulty().and_then(|b| b.seq()).unwrap())
+                    .unwrap(),
+            )
             .cellbase_id(header.cellbase_id().unwrap().into())
             .uncles_hash(header.uncles_hash().unwrap().into())
             .nonce(header.nonce())
-            .proof(header.proof().unwrap().to_vec())
+            .proof(header.proof().and_then(|b| b.seq()).unwrap().to_vec())
             .uncles_count(header.uncles_count())
             .build()
     }
@@ -165,7 +168,7 @@ impl<'a> From<ckb_protocol::Script<'a>> for ckb_core::script::Script {
         ckb_core::script::Script {
             version: script.version(),
             args,
-            binary: script.binary().map(Into::into),
+            binary: script.binary().and_then(|s| s.seq()).map(|s| s.to_vec()),
             signed_args,
             reference: script.reference().map(Into::into),
         }
@@ -189,6 +192,7 @@ impl<'a> From<ckb_protocol::CellOutput<'a>> for ckb_core::transaction::CellOutpu
         ckb_core::transaction::CellOutput {
             capacity: cell_output.capacity(),
 <<<<<<< HEAD
+<<<<<<< HEAD
             data: cell_output.data().and_then(|b| b.seq()).unwrap().to_vec(),
             lock: H256::from_slice(cell_output.lock().and_then(|b| b.seq()).unwrap()).unwrap(),
             type_: cell_output.type_().map(Into::into),
@@ -203,6 +207,9 @@ impl<'a> From<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::Ind
             transaction: it.transaction().unwrap().into(),
 =======
             data: cell_output.data().unwrap().into(),
+=======
+            data: cell_output.data().and_then(|b| b.seq()).unwrap().to_vec(),
+>>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
             lock: cell_output.lock().unwrap().into(),
             contract: cell_output.contract().map(Into::into),
 >>>>>>> refactor: replace flatten Bytes with [ubyte]

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -216,28 +216,9 @@ impl<'a> From<ckb_protocol::CellOutput<'a>> for ckb_core::transaction::CellOutpu
     fn from(cell_output: ckb_protocol::CellOutput<'a>) -> Self {
         ckb_core::transaction::CellOutput {
             capacity: cell_output.capacity(),
-<<<<<<< HEAD
-<<<<<<< HEAD
             data: cell_output.data().and_then(|b| b.seq()).unwrap().to_vec(),
-            lock: H256::from_slice(cell_output.lock().and_then(|b| b.seq()).unwrap()).unwrap(),
-            type_: cell_output.type_().map(Into::into),
-        }
-    }
-}
-
-impl<'a> From<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::IndexTransaction {
-    fn from(it: ckb_protocol::IndexTransaction<'a>) -> Self {
-        ckb_core::transaction::IndexTransaction {
-            index: it.index() as usize,
-            transaction: it.transaction().unwrap().into(),
-=======
-            data: cell_output.data().unwrap().into(),
-=======
-            data: cell_output.data().and_then(|b| b.seq()).unwrap().to_vec(),
->>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
             lock: cell_output.lock().unwrap().into(),
-            contract: cell_output.contract().map(Into::into),
->>>>>>> refactor: replace flatten Bytes with [ubyte]
+            type_: cell_output.type_().map(Into::into),
         }
     }
 }

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -81,19 +81,9 @@ table CellInput {
 
 table CellOutput {
     capacity:       uint64;
-<<<<<<< HEAD
-<<<<<<< HEAD
     data:           Bytes;
-    lock:           Bytes;
-    type:           Script;
-=======
-    data:           [ubyte];
-=======
-    data:           Bytes;
->>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
     lock:           H256;
-    contract:       Script;
->>>>>>> refactor: replace flatten Bytes with [ubyte]
+    type:           Script;
 }
 
 table Script {

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -52,13 +52,13 @@ table Block {
     header:                 Header;
     uncles:                 [UncleBlock];
     commit_transactions:    [Transaction];
-    proposal_transactions:  [Bytes];
+    proposal_transactions:  [ProposalShortId];
 }
 
 table UncleBlock {
     header:                 Header;
     cellbase:               Transaction;
-    proposal_transactions:  [Bytes];
+    proposal_transactions:  [ProposalShortId];
 }
 
 table Transaction {
@@ -125,7 +125,7 @@ table CompactBlock {
     short_ids:                  [Bytes];
     prefilled_transactions:     [IndexTransaction];
     uncles:                     [UncleBlock];
-    proposal_transactions:      [Bytes];
+    proposal_transactions:      [ProposalShortId];
 }
 
 table IndexTransaction {
@@ -145,11 +145,24 @@ table BlockTransactions {
 
 table GetBlockProposal {
     block_number:              uint64;
-    proposal_transactions:     [Bytes];
+    proposal_transactions:     [ProposalShortId];
 }
 
 table BlockProposal {
     transactions:              [Transaction];
+}
+
+struct ProposalShortId {
+    u0: uint8;
+    u1: uint8;
+    u2: uint8;
+    u3: uint8;
+    u4: uint8;
+    u5: uint8;
+    u6: uint8;
+    u7: uint8;
+    u8: uint8;
+    u9: uint8;
 }
 
 struct H256 {

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -40,9 +40,9 @@ table Header {
     number:         uint64;
     txs_commit:     H256;
     txs_proposal:   H256;
-    difficulty:     [ubyte];
+    difficulty:     Bytes;
     nonce:          uint64;
-    proof:          [ubyte];
+    proof:          Bytes;
     cellbase_id:    H256;
     uncles_hash:    H256;
     uncles_count:   uint32;
@@ -82,11 +82,15 @@ table CellInput {
 table CellOutput {
     capacity:       uint64;
 <<<<<<< HEAD
+<<<<<<< HEAD
     data:           Bytes;
     lock:           Bytes;
     type:           Script;
 =======
     data:           [ubyte];
+=======
+    data:           Bytes;
+>>>>>>> Revert "refactor: replace flatten Bytes with [ubyte]"
     lock:           H256;
     contract:       Script;
 >>>>>>> refactor: replace flatten Bytes with [ubyte]
@@ -95,7 +99,7 @@ table CellOutput {
 table Script {
     version:        uint8;
     args:           [Bytes];
-    binary:         [ubyte];
+    binary:         Bytes;
     reference:      H256;
     signed_args:    [Bytes];
 }

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -21,12 +21,12 @@ table Bytes {
 
 table GetHeaders {
     version:                uint32;
-    block_locator_hashes:   [Bytes];
-    hash_stop:              Bytes;
+    block_locator_hashes:   [H256];
+    hash_stop:              H256;
 }
 
 table GetBlocks {
-    block_hashes:           [Bytes];
+    block_hashes:           [H256];
 }
 
 table Headers {
@@ -35,16 +35,16 @@ table Headers {
 
 table Header {
     version:        uint32;
-    parent_hash:    Bytes;
+    parent_hash:    H256;
     timestamp:      uint64;
     number:         uint64;
-    txs_commit:     Bytes;
-    txs_proposal:   Bytes;
+    txs_commit:     H256;
+    txs_proposal:   H256;
     difficulty:     Bytes;
     nonce:          uint64;
     proof:          Bytes;
-    cellbase_id:    Bytes;
-    uncles_hash:    Bytes;
+    cellbase_id:    H256;
+    uncles_hash:    H256;
     uncles_count:   uint32;
 }
 
@@ -69,12 +69,12 @@ table Transaction {
 }
 
 table OutPoint {
-    hash:           Bytes;
+    hash:           H256;
     index:          uint32;
 }
 
 table CellInput {
-    hash:           Bytes;
+    hash:           H256;
     index:          uint32;
     unlock:         Script;
 }
@@ -90,7 +90,7 @@ table Script {
     version:        uint8;
     args:           [Bytes];
     binary:         Bytes;
-    reference:      Bytes;
+    reference:      H256;
     signed_args:    [Bytes];
 }
 
@@ -124,12 +124,12 @@ table IndexTransaction {
 }
 
 table GetBlockTransactions {
-    hash:                      Bytes;
+    hash:                      H256;
     indexes:                   [uint32];
 }
 
 table BlockTransactions {
-    hash:                      Bytes;
+    hash:                      H256;
     transactions:              [Transaction];
 }
 

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -40,9 +40,9 @@ table Header {
     number:         uint64;
     txs_commit:     H256;
     txs_proposal:   H256;
-    difficulty:     Bytes;
+    difficulty:     [ubyte];
     nonce:          uint64;
-    proof:          Bytes;
+    proof:          [ubyte];
     cellbase_id:    H256;
     uncles_hash:    H256;
     uncles_count:   uint32;
@@ -81,15 +81,21 @@ table CellInput {
 
 table CellOutput {
     capacity:       uint64;
+<<<<<<< HEAD
     data:           Bytes;
     lock:           Bytes;
     type:           Script;
+=======
+    data:           [ubyte];
+    lock:           H256;
+    contract:       Script;
+>>>>>>> refactor: replace flatten Bytes with [ubyte]
 }
 
 table Script {
     version:        uint8;
     args:           [Bytes];
-    binary:         Bytes;
+    binary:         [ubyte];
     reference:      H256;
     signed_args:    [Bytes];
 }

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -971,16 +971,16 @@ impl<'a> Header<'a> {
     self._tab.get::<H256>(Header::VT_TXS_PROPOSAL, None)
   }
   #[inline]
-  pub fn difficulty(&self) -> Option<&'a [u8]> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Header::VT_DIFFICULTY, None).map(|v| v.safe_slice())
+  pub fn difficulty(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_DIFFICULTY, None)
   }
   #[inline]
   pub fn nonce(&self) -> u64 {
     self._tab.get::<u64>(Header::VT_NONCE, Some(0)).unwrap()
   }
   #[inline]
-  pub fn proof(&self) -> Option<&'a [u8]> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Header::VT_PROOF, None).map(|v| v.safe_slice())
+  pub fn proof(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_PROOF, None)
   }
   #[inline]
   pub fn cellbase_id(&self) -> Option<&'a H256> {
@@ -1003,9 +1003,9 @@ pub struct HeaderArgs<'a> {
     pub number: u64,
     pub txs_commit: Option<&'a  H256>,
     pub txs_proposal: Option<&'a  H256>,
-    pub difficulty: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
+    pub difficulty: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
     pub nonce: u64,
-    pub proof: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
+    pub proof: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
     pub cellbase_id: Option<&'a  H256>,
     pub uncles_hash: Option<&'a  H256>,
     pub uncles_count: u32,
@@ -1059,16 +1059,16 @@ impl<'a: 'b, 'b> HeaderBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<&H256>(Header::VT_TXS_PROPOSAL, txs_proposal);
   }
   #[inline]
-  pub fn add_difficulty(&mut self, difficulty: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Header::VT_DIFFICULTY, difficulty);
+  pub fn add_difficulty(&mut self, difficulty: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_DIFFICULTY, difficulty);
   }
   #[inline]
   pub fn add_nonce(&mut self, nonce: u64) {
     self.fbb_.push_slot::<u64>(Header::VT_NONCE, nonce, 0);
   }
   #[inline]
-  pub fn add_proof(&mut self, proof: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Header::VT_PROOF, proof);
+  pub fn add_proof(&mut self, proof: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_PROOF, proof);
   }
   #[inline]
   pub fn add_cellbase_id(&mut self, cellbase_id: &'b  H256) {
@@ -1655,8 +1655,8 @@ impl<'a> CellOutput<'a> {
     self._tab.get::<u64>(CellOutput::VT_CAPACITY, Some(0)).unwrap()
   }
   #[inline]
-  pub fn data(&self) -> Option<&'a [u8]> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(CellOutput::VT_DATA, None).map(|v| v.safe_slice())
+  pub fn data(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(CellOutput::VT_DATA, None)
   }
   #[inline]
   pub fn lock(&self) -> Option<&'a H256> {
@@ -1695,8 +1695,8 @@ impl<'a: 'b, 'b> CellOutputBuilder<'a, 'b> {
     self.fbb_.push_slot::<u64>(CellOutput::VT_CAPACITY, capacity, 0);
   }
   #[inline]
-  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CellOutput::VT_DATA, data);
+  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(CellOutput::VT_DATA, data);
   }
   #[inline]
   pub fn add_lock(&mut self, lock: &'b  H256) {
@@ -1773,8 +1773,8 @@ impl<'a> Script<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(Script::VT_ARGS, None)
   }
   #[inline]
-  pub fn binary(&self) -> Option<&'a [u8]> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Script::VT_BINARY, None).map(|v| v.safe_slice())
+  pub fn binary(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Script::VT_BINARY, None)
   }
   #[inline]
   pub fn reference(&self) -> Option<&'a H256> {
@@ -1789,7 +1789,7 @@ impl<'a> Script<'a> {
 pub struct ScriptArgs<'a> {
     pub version: u8,
     pub args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
-    pub binary: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
+    pub binary: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
     pub reference: Option<&'a  H256>,
     pub signed_args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
 }
@@ -1819,8 +1819,8 @@ impl<'a: 'b, 'b> ScriptBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Script::VT_ARGS, args);
   }
   #[inline]
-  pub fn add_binary(&mut self, binary: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Script::VT_BINARY, binary);
+  pub fn add_binary(&mut self, binary: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Script::VT_BINARY, binary);
   }
   #[inline]
   pub fn add_reference(&mut self, reference: &'b  H256) {

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -1772,7 +1772,7 @@ impl<'a> CellOutput<'a> {
 pub struct CellOutputArgs<'a> {
     pub capacity: u64,
     pub data: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
-    pub lock: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub lock: Option<&'a  H256>,
     pub type_: Option<flatbuffers::WIPOffset<Script<'a >>>,
 }
 impl<'a> Default for CellOutputArgs<'a> {

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -182,6 +182,107 @@ pub fn enum_name_relay_payload(e: RelayPayload) -> &'static str {
 }
 
 pub struct RelayPayloadUnionTableOffset {}
+// struct ProposalShortId, aligned to 1
+#[repr(C, align(1))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ProposalShortId {
+  u0_: u8,
+  u1_: u8,
+  u2_: u8,
+  u3_: u8,
+  u4_: u8,
+  u5_: u8,
+  u6_: u8,
+  u7_: u8,
+  u8__: u8,
+  u9_: u8,
+} // pub struct ProposalShortId
+impl flatbuffers::SafeSliceAccess for ProposalShortId {}
+impl<'a> flatbuffers::Follow<'a> for ProposalShortId {
+  type Inner = &'a ProposalShortId;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    <&'a ProposalShortId>::follow(buf, loc)
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for &'a ProposalShortId {
+  type Inner = &'a ProposalShortId;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::follow_cast_ref::<ProposalShortId>(buf, loc)
+  }
+}
+impl<'b> flatbuffers::Push for ProposalShortId {
+    type Output = ProposalShortId;
+    #[inline]
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::std::slice::from_raw_parts(self as *const ProposalShortId as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
+    }
+}
+impl<'b> flatbuffers::Push for &'b ProposalShortId {
+    type Output = ProposalShortId;
+
+    #[inline]
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::std::slice::from_raw_parts(*self as *const ProposalShortId as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
+    }
+}
+
+
+impl ProposalShortId {
+  pub fn new<'a>(_u0: u8, _u1: u8, _u2: u8, _u3: u8, _u4: u8, _u5: u8, _u6: u8, _u7: u8, _u8_: u8, _u9: u8) -> Self {
+    ProposalShortId {
+      u0_: _u0.to_little_endian(),
+      u1_: _u1.to_little_endian(),
+      u2_: _u2.to_little_endian(),
+      u3_: _u3.to_little_endian(),
+      u4_: _u4.to_little_endian(),
+      u5_: _u5.to_little_endian(),
+      u6_: _u6.to_little_endian(),
+      u7_: _u7.to_little_endian(),
+      u8__: _u8_.to_little_endian(),
+      u9_: _u9.to_little_endian(),
+
+    }
+  }
+  pub fn u0<'a>(&'a self) -> u8 {
+    self.u0_.from_little_endian()
+  }
+  pub fn u1<'a>(&'a self) -> u8 {
+    self.u1_.from_little_endian()
+  }
+  pub fn u2<'a>(&'a self) -> u8 {
+    self.u2_.from_little_endian()
+  }
+  pub fn u3<'a>(&'a self) -> u8 {
+    self.u3_.from_little_endian()
+  }
+  pub fn u4<'a>(&'a self) -> u8 {
+    self.u4_.from_little_endian()
+  }
+  pub fn u5<'a>(&'a self) -> u8 {
+    self.u5_.from_little_endian()
+  }
+  pub fn u6<'a>(&'a self) -> u8 {
+    self.u6_.from_little_endian()
+  }
+  pub fn u7<'a>(&'a self) -> u8 {
+    self.u7_.from_little_endian()
+  }
+  pub fn u8_<'a>(&'a self) -> u8 {
+    self.u8__.from_little_endian()
+  }
+  pub fn u9<'a>(&'a self) -> u8 {
+    self.u9_.from_little_endian()
+  }
+}
+
 // struct H256, aligned to 1
 #[repr(C, align(1))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1151,8 +1252,8 @@ impl<'a> Block<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Transaction<'a>>>>>(Block::VT_COMMIT_TRANSACTIONS, None)
   }
   #[inline]
-  pub fn proposal_transactions(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(Block::VT_PROPOSAL_TRANSACTIONS, None)
+  pub fn proposal_transactions(&self) -> Option<&'a [ProposalShortId]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<ProposalShortId>>>(Block::VT_PROPOSAL_TRANSACTIONS, None).map(|v| v.safe_slice() )
   }
 }
 
@@ -1160,7 +1261,7 @@ pub struct BlockArgs<'a> {
     pub header: Option<flatbuffers::WIPOffset<Header<'a >>>,
     pub uncles: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<UncleBlock<'a >>>>>,
     pub commit_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Transaction<'a >>>>>,
-    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
 }
 impl<'a> Default for BlockArgs<'a> {
     #[inline]
@@ -1191,7 +1292,7 @@ impl<'a: 'b, 'b> BlockBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Block::VT_COMMIT_TRANSACTIONS, commit_transactions);
   }
   #[inline]
-  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , ProposalShortId>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Block::VT_PROPOSAL_TRANSACTIONS, proposal_transactions);
   }
   #[inline]
@@ -1257,15 +1358,15 @@ impl<'a> UncleBlock<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<Transaction<'a>>>(UncleBlock::VT_CELLBASE, None)
   }
   #[inline]
-  pub fn proposal_transactions(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(UncleBlock::VT_PROPOSAL_TRANSACTIONS, None)
+  pub fn proposal_transactions(&self) -> Option<&'a [ProposalShortId]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<ProposalShortId>>>(UncleBlock::VT_PROPOSAL_TRANSACTIONS, None).map(|v| v.safe_slice() )
   }
 }
 
 pub struct UncleBlockArgs<'a> {
     pub header: Option<flatbuffers::WIPOffset<Header<'a >>>,
     pub cellbase: Option<flatbuffers::WIPOffset<Transaction<'a >>>,
-    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
 }
 impl<'a> Default for UncleBlockArgs<'a> {
     #[inline]
@@ -1291,7 +1392,7 @@ impl<'a: 'b, 'b> UncleBlockBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Transaction>>(UncleBlock::VT_CELLBASE, cellbase);
   }
   #[inline]
-  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , ProposalShortId>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(UncleBlock::VT_PROPOSAL_TRANSACTIONS, proposal_transactions);
   }
   #[inline]
@@ -2059,8 +2160,8 @@ impl<'a> CompactBlock<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<UncleBlock<'a>>>>>(CompactBlock::VT_UNCLES, None)
   }
   #[inline]
-  pub fn proposal_transactions(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(CompactBlock::VT_PROPOSAL_TRANSACTIONS, None)
+  pub fn proposal_transactions(&self) -> Option<&'a [ProposalShortId]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<ProposalShortId>>>(CompactBlock::VT_PROPOSAL_TRANSACTIONS, None).map(|v| v.safe_slice() )
   }
 }
 
@@ -2070,7 +2171,7 @@ pub struct CompactBlockArgs<'a> {
     pub short_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
     pub prefilled_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<IndexTransaction<'a >>>>>,
     pub uncles: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<UncleBlock<'a >>>>>,
-    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
 }
 impl<'a> Default for CompactBlockArgs<'a> {
     #[inline]
@@ -2111,7 +2212,7 @@ impl<'a: 'b, 'b> CompactBlockBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CompactBlock::VT_UNCLES, uncles);
   }
   #[inline]
-  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , ProposalShortId>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CompactBlock::VT_PROPOSAL_TRANSACTIONS, proposal_transactions);
   }
   #[inline]
@@ -2435,14 +2536,14 @@ impl<'a> GetBlockProposal<'a> {
     self._tab.get::<u64>(GetBlockProposal::VT_BLOCK_NUMBER, Some(0)).unwrap()
   }
   #[inline]
-  pub fn proposal_transactions(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(GetBlockProposal::VT_PROPOSAL_TRANSACTIONS, None)
+  pub fn proposal_transactions(&self) -> Option<&'a [ProposalShortId]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<ProposalShortId>>>(GetBlockProposal::VT_PROPOSAL_TRANSACTIONS, None).map(|v| v.safe_slice() )
   }
 }
 
 pub struct GetBlockProposalArgs<'a> {
     pub block_number: u64,
-    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub proposal_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
 }
 impl<'a> Default for GetBlockProposalArgs<'a> {
     #[inline]
@@ -2463,7 +2564,7 @@ impl<'a: 'b, 'b> GetBlockProposalBuilder<'a, 'b> {
     self.fbb_.push_slot::<u64>(GetBlockProposal::VT_BLOCK_NUMBER, block_number, 0);
   }
   #[inline]
-  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_proposal_transactions(&mut self, proposal_transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , ProposalShortId>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetBlockProposal::VT_PROPOSAL_TRANSACTIONS, proposal_transactions);
   }
   #[inline]

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -681,19 +681,19 @@ impl<'a> GetHeaders<'a> {
     self._tab.get::<u32>(GetHeaders::VT_VERSION, Some(0)).unwrap()
   }
   #[inline]
-  pub fn block_locator_hashes(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(GetHeaders::VT_BLOCK_LOCATOR_HASHES, None)
+  pub fn block_locator_hashes(&self) -> Option<&'a [H256]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<H256>>>(GetHeaders::VT_BLOCK_LOCATOR_HASHES, None).map(|v| v.safe_slice() )
   }
   #[inline]
-  pub fn hash_stop(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(GetHeaders::VT_HASH_STOP, None)
+  pub fn hash_stop(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(GetHeaders::VT_HASH_STOP, None)
   }
 }
 
 pub struct GetHeadersArgs<'a> {
     pub version: u32,
-    pub block_locator_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
-    pub hash_stop: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub block_locator_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , H256>>>,
+    pub hash_stop: Option<&'a  H256>,
 }
 impl<'a> Default for GetHeadersArgs<'a> {
     #[inline]
@@ -715,12 +715,12 @@ impl<'a: 'b, 'b> GetHeadersBuilder<'a, 'b> {
     self.fbb_.push_slot::<u32>(GetHeaders::VT_VERSION, version, 0);
   }
   #[inline]
-  pub fn add_block_locator_hashes(&mut self, block_locator_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_block_locator_hashes(&mut self, block_locator_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , H256>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetHeaders::VT_BLOCK_LOCATOR_HASHES, block_locator_hashes);
   }
   #[inline]
-  pub fn add_hash_stop(&mut self, hash_stop: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(GetHeaders::VT_HASH_STOP, hash_stop);
+  pub fn add_hash_stop(&mut self, hash_stop: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(GetHeaders::VT_HASH_STOP, hash_stop);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GetHeadersBuilder<'a, 'b> {
@@ -773,13 +773,13 @@ impl<'a> GetBlocks<'a> {
     pub const VT_BLOCK_HASHES: flatbuffers::VOffsetT = 4;
 
   #[inline]
-  pub fn block_hashes(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(GetBlocks::VT_BLOCK_HASHES, None)
+  pub fn block_hashes(&self) -> Option<&'a [H256]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<H256>>>(GetBlocks::VT_BLOCK_HASHES, None).map(|v| v.safe_slice() )
   }
 }
 
 pub struct GetBlocksArgs<'a> {
-    pub block_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub block_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , H256>>>,
 }
 impl<'a> Default for GetBlocksArgs<'a> {
     #[inline]
@@ -795,7 +795,7 @@ pub struct GetBlocksBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> GetBlocksBuilder<'a, 'b> {
   #[inline]
-  pub fn add_block_hashes(&mut self, block_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_block_hashes(&mut self, block_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , H256>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetBlocks::VT_BLOCK_HASHES, block_hashes);
   }
   #[inline]
@@ -951,8 +951,8 @@ impl<'a> Header<'a> {
     self._tab.get::<u32>(Header::VT_VERSION, Some(0)).unwrap()
   }
   #[inline]
-  pub fn parent_hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_PARENT_HASH, None)
+  pub fn parent_hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Header::VT_PARENT_HASH, None)
   }
   #[inline]
   pub fn timestamp(&self) -> u64 {
@@ -963,12 +963,12 @@ impl<'a> Header<'a> {
     self._tab.get::<u64>(Header::VT_NUMBER, Some(0)).unwrap()
   }
   #[inline]
-  pub fn txs_commit(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_TXS_COMMIT, None)
+  pub fn txs_commit(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Header::VT_TXS_COMMIT, None)
   }
   #[inline]
-  pub fn txs_proposal(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_TXS_PROPOSAL, None)
+  pub fn txs_proposal(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Header::VT_TXS_PROPOSAL, None)
   }
   #[inline]
   pub fn difficulty(&self) -> Option<Bytes<'a>> {
@@ -983,12 +983,12 @@ impl<'a> Header<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_PROOF, None)
   }
   #[inline]
-  pub fn cellbase_id(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_CELLBASE_ID, None)
+  pub fn cellbase_id(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Header::VT_CELLBASE_ID, None)
   }
   #[inline]
-  pub fn uncles_hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_UNCLES_HASH, None)
+  pub fn uncles_hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Header::VT_UNCLES_HASH, None)
   }
   #[inline]
   pub fn uncles_count(&self) -> u32 {
@@ -998,16 +998,16 @@ impl<'a> Header<'a> {
 
 pub struct HeaderArgs<'a> {
     pub version: u32,
-    pub parent_hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub parent_hash: Option<&'a  H256>,
     pub timestamp: u64,
     pub number: u64,
-    pub txs_commit: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
-    pub txs_proposal: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub txs_commit: Option<&'a  H256>,
+    pub txs_proposal: Option<&'a  H256>,
     pub difficulty: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
     pub nonce: u64,
     pub proof: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
-    pub cellbase_id: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
-    pub uncles_hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub cellbase_id: Option<&'a  H256>,
+    pub uncles_hash: Option<&'a  H256>,
     pub uncles_count: u32,
 }
 impl<'a> Default for HeaderArgs<'a> {
@@ -1039,8 +1039,8 @@ impl<'a: 'b, 'b> HeaderBuilder<'a, 'b> {
     self.fbb_.push_slot::<u32>(Header::VT_VERSION, version, 0);
   }
   #[inline]
-  pub fn add_parent_hash(&mut self, parent_hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_PARENT_HASH, parent_hash);
+  pub fn add_parent_hash(&mut self, parent_hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Header::VT_PARENT_HASH, parent_hash);
   }
   #[inline]
   pub fn add_timestamp(&mut self, timestamp: u64) {
@@ -1051,12 +1051,12 @@ impl<'a: 'b, 'b> HeaderBuilder<'a, 'b> {
     self.fbb_.push_slot::<u64>(Header::VT_NUMBER, number, 0);
   }
   #[inline]
-  pub fn add_txs_commit(&mut self, txs_commit: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_TXS_COMMIT, txs_commit);
+  pub fn add_txs_commit(&mut self, txs_commit: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Header::VT_TXS_COMMIT, txs_commit);
   }
   #[inline]
-  pub fn add_txs_proposal(&mut self, txs_proposal: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_TXS_PROPOSAL, txs_proposal);
+  pub fn add_txs_proposal(&mut self, txs_proposal: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Header::VT_TXS_PROPOSAL, txs_proposal);
   }
   #[inline]
   pub fn add_difficulty(&mut self, difficulty: flatbuffers::WIPOffset<Bytes<'b >>) {
@@ -1071,12 +1071,12 @@ impl<'a: 'b, 'b> HeaderBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_PROOF, proof);
   }
   #[inline]
-  pub fn add_cellbase_id(&mut self, cellbase_id: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_CELLBASE_ID, cellbase_id);
+  pub fn add_cellbase_id(&mut self, cellbase_id: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Header::VT_CELLBASE_ID, cellbase_id);
   }
   #[inline]
-  pub fn add_uncles_hash(&mut self, uncles_hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_UNCLES_HASH, uncles_hash);
+  pub fn add_uncles_hash(&mut self, uncles_hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Header::VT_UNCLES_HASH, uncles_hash);
   }
   #[inline]
   pub fn add_uncles_count(&mut self, uncles_count: u32) {
@@ -1459,8 +1459,8 @@ impl<'a> OutPoint<'a> {
     pub const VT_INDEX: flatbuffers::VOffsetT = 6;
 
   #[inline]
-  pub fn hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(OutPoint::VT_HASH, None)
+  pub fn hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(OutPoint::VT_HASH, None)
   }
   #[inline]
   pub fn index(&self) -> u32 {
@@ -1469,7 +1469,7 @@ impl<'a> OutPoint<'a> {
 }
 
 pub struct OutPointArgs<'a> {
-    pub hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub hash: Option<&'a  H256>,
     pub index: u32,
 }
 impl<'a> Default for OutPointArgs<'a> {
@@ -1487,8 +1487,8 @@ pub struct OutPointBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> OutPointBuilder<'a, 'b> {
   #[inline]
-  pub fn add_hash(&mut self, hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(OutPoint::VT_HASH, hash);
+  pub fn add_hash(&mut self, hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(OutPoint::VT_HASH, hash);
   }
   #[inline]
   pub fn add_index(&mut self, index: u32) {
@@ -1549,8 +1549,8 @@ impl<'a> CellInput<'a> {
     pub const VT_UNLOCK: flatbuffers::VOffsetT = 8;
 
   #[inline]
-  pub fn hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(CellInput::VT_HASH, None)
+  pub fn hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(CellInput::VT_HASH, None)
   }
   #[inline]
   pub fn index(&self) -> u32 {
@@ -1563,7 +1563,7 @@ impl<'a> CellInput<'a> {
 }
 
 pub struct CellInputArgs<'a> {
-    pub hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub hash: Option<&'a  H256>,
     pub index: u32,
     pub unlock: Option<flatbuffers::WIPOffset<Script<'a >>>,
 }
@@ -1583,8 +1583,8 @@ pub struct CellInputBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> CellInputBuilder<'a, 'b> {
   #[inline]
-  pub fn add_hash(&mut self, hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(CellInput::VT_HASH, hash);
+  pub fn add_hash(&mut self, hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(CellInput::VT_HASH, hash);
   }
   #[inline]
   pub fn add_index(&mut self, index: u32) {
@@ -1659,8 +1659,8 @@ impl<'a> CellOutput<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(CellOutput::VT_DATA, None)
   }
   #[inline]
-  pub fn lock(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(CellOutput::VT_LOCK, None)
+  pub fn lock(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(CellOutput::VT_LOCK, None)
   }
   #[inline]
   pub fn type_(&self) -> Option<Script<'a>> {
@@ -1699,8 +1699,8 @@ impl<'a: 'b, 'b> CellOutputBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(CellOutput::VT_DATA, data);
   }
   #[inline]
-  pub fn add_lock(&mut self, lock: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(CellOutput::VT_LOCK, lock);
+  pub fn add_lock(&mut self, lock: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(CellOutput::VT_LOCK, lock);
   }
   #[inline]
   pub fn add_type_(&mut self, type_: flatbuffers::WIPOffset<Script<'b >>) {
@@ -1777,8 +1777,8 @@ impl<'a> Script<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Script::VT_BINARY, None)
   }
   #[inline]
-  pub fn reference(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Script::VT_REFERENCE, None)
+  pub fn reference(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(Script::VT_REFERENCE, None)
   }
   #[inline]
   pub fn signed_args(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
@@ -1790,7 +1790,7 @@ pub struct ScriptArgs<'a> {
     pub version: u8,
     pub args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
     pub binary: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
-    pub reference: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub reference: Option<&'a  H256>,
     pub signed_args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
 }
 impl<'a> Default for ScriptArgs<'a> {
@@ -1823,8 +1823,8 @@ impl<'a: 'b, 'b> ScriptBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Script::VT_BINARY, binary);
   }
   #[inline]
-  pub fn add_reference(&mut self, reference: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Script::VT_REFERENCE, reference);
+  pub fn add_reference(&mut self, reference: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(Script::VT_REFERENCE, reference);
   }
   #[inline]
   pub fn add_signed_args(&mut self, signed_args: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
@@ -2255,8 +2255,8 @@ impl<'a> GetBlockTransactions<'a> {
     pub const VT_INDEXES: flatbuffers::VOffsetT = 6;
 
   #[inline]
-  pub fn hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(GetBlockTransactions::VT_HASH, None)
+  pub fn hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(GetBlockTransactions::VT_HASH, None)
   }
   #[inline]
   pub fn indexes(&self) -> Option<flatbuffers::Vector<'a, u32>> {
@@ -2265,7 +2265,7 @@ impl<'a> GetBlockTransactions<'a> {
 }
 
 pub struct GetBlockTransactionsArgs<'a> {
-    pub hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub hash: Option<&'a  H256>,
     pub indexes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u32>>>,
 }
 impl<'a> Default for GetBlockTransactionsArgs<'a> {
@@ -2283,8 +2283,8 @@ pub struct GetBlockTransactionsBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> GetBlockTransactionsBuilder<'a, 'b> {
   #[inline]
-  pub fn add_hash(&mut self, hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(GetBlockTransactions::VT_HASH, hash);
+  pub fn add_hash(&mut self, hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(GetBlockTransactions::VT_HASH, hash);
   }
   #[inline]
   pub fn add_indexes(&mut self, indexes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
@@ -2343,8 +2343,8 @@ impl<'a> BlockTransactions<'a> {
     pub const VT_TRANSACTIONS: flatbuffers::VOffsetT = 6;
 
   #[inline]
-  pub fn hash(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(BlockTransactions::VT_HASH, None)
+  pub fn hash(&self) -> Option<&'a H256> {
+    self._tab.get::<H256>(BlockTransactions::VT_HASH, None)
   }
   #[inline]
   pub fn transactions(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Transaction<'a>>>> {
@@ -2353,7 +2353,7 @@ impl<'a> BlockTransactions<'a> {
 }
 
 pub struct BlockTransactionsArgs<'a> {
-    pub hash: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub hash: Option<&'a  H256>,
     pub transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Transaction<'a >>>>>,
 }
 impl<'a> Default for BlockTransactionsArgs<'a> {
@@ -2371,8 +2371,8 @@ pub struct BlockTransactionsBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> BlockTransactionsBuilder<'a, 'b> {
   #[inline]
-  pub fn add_hash(&mut self, hash: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(BlockTransactions::VT_HASH, hash);
+  pub fn add_hash(&mut self, hash: &'b  H256) {
+    self.fbb_.push_slot_always::<&H256>(BlockTransactions::VT_HASH, hash);
   }
   #[inline]
   pub fn add_transactions(&mut self, transactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Transaction<'b >>>>) {

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -971,16 +971,16 @@ impl<'a> Header<'a> {
     self._tab.get::<H256>(Header::VT_TXS_PROPOSAL, None)
   }
   #[inline]
-  pub fn difficulty(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_DIFFICULTY, None)
+  pub fn difficulty(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Header::VT_DIFFICULTY, None).map(|v| v.safe_slice())
   }
   #[inline]
   pub fn nonce(&self) -> u64 {
     self._tab.get::<u64>(Header::VT_NONCE, Some(0)).unwrap()
   }
   #[inline]
-  pub fn proof(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Header::VT_PROOF, None)
+  pub fn proof(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Header::VT_PROOF, None).map(|v| v.safe_slice())
   }
   #[inline]
   pub fn cellbase_id(&self) -> Option<&'a H256> {
@@ -1003,9 +1003,9 @@ pub struct HeaderArgs<'a> {
     pub number: u64,
     pub txs_commit: Option<&'a  H256>,
     pub txs_proposal: Option<&'a  H256>,
-    pub difficulty: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub difficulty: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
     pub nonce: u64,
-    pub proof: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub proof: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
     pub cellbase_id: Option<&'a  H256>,
     pub uncles_hash: Option<&'a  H256>,
     pub uncles_count: u32,
@@ -1059,16 +1059,16 @@ impl<'a: 'b, 'b> HeaderBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<&H256>(Header::VT_TXS_PROPOSAL, txs_proposal);
   }
   #[inline]
-  pub fn add_difficulty(&mut self, difficulty: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_DIFFICULTY, difficulty);
+  pub fn add_difficulty(&mut self, difficulty: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Header::VT_DIFFICULTY, difficulty);
   }
   #[inline]
   pub fn add_nonce(&mut self, nonce: u64) {
     self.fbb_.push_slot::<u64>(Header::VT_NONCE, nonce, 0);
   }
   #[inline]
-  pub fn add_proof(&mut self, proof: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Header::VT_PROOF, proof);
+  pub fn add_proof(&mut self, proof: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Header::VT_PROOF, proof);
   }
   #[inline]
   pub fn add_cellbase_id(&mut self, cellbase_id: &'b  H256) {
@@ -1655,8 +1655,8 @@ impl<'a> CellOutput<'a> {
     self._tab.get::<u64>(CellOutput::VT_CAPACITY, Some(0)).unwrap()
   }
   #[inline]
-  pub fn data(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(CellOutput::VT_DATA, None)
+  pub fn data(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(CellOutput::VT_DATA, None).map(|v| v.safe_slice())
   }
   #[inline]
   pub fn lock(&self) -> Option<&'a H256> {
@@ -1695,8 +1695,8 @@ impl<'a: 'b, 'b> CellOutputBuilder<'a, 'b> {
     self.fbb_.push_slot::<u64>(CellOutput::VT_CAPACITY, capacity, 0);
   }
   #[inline]
-  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(CellOutput::VT_DATA, data);
+  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CellOutput::VT_DATA, data);
   }
   #[inline]
   pub fn add_lock(&mut self, lock: &'b  H256) {
@@ -1773,8 +1773,8 @@ impl<'a> Script<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(Script::VT_ARGS, None)
   }
   #[inline]
-  pub fn binary(&self) -> Option<Bytes<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Script::VT_BINARY, None)
+  pub fn binary(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Script::VT_BINARY, None).map(|v| v.safe_slice())
   }
   #[inline]
   pub fn reference(&self) -> Option<&'a H256> {
@@ -1789,7 +1789,7 @@ impl<'a> Script<'a> {
 pub struct ScriptArgs<'a> {
     pub version: u8,
     pub args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
-    pub binary: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub binary: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
     pub reference: Option<&'a  H256>,
     pub signed_args: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
 }
@@ -1819,8 +1819,8 @@ impl<'a: 'b, 'b> ScriptBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Script::VT_ARGS, args);
   }
   #[inline]
-  pub fn add_binary(&mut self, binary: flatbuffers::WIPOffset<Bytes<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Script::VT_BINARY, binary);
+  pub fn add_binary(&mut self, binary: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Script::VT_BINARY, binary);
   }
   #[inline]
   pub fn add_reference(&mut self, reference: &'b  H256) {

--- a/script/src/syscalls/builder.rs
+++ b/script/src/syscalls/builder.rs
@@ -1,7 +1,7 @@
 use ckb_core::transaction::{CellInput, CellOutput, Transaction};
 use ckb_protocol::{
-    Bytes as FbsBytes, CellInput as FbsCellInput, CellInputBuilder, CellOutput as FbsCellOutput,
-    CellOutputBuilder, OutPoint as FbsOutPoint, Transaction as FbsTransaction, TransactionBuilder,
+    CellInput as FbsCellInput, CellInputBuilder, CellOutput as FbsCellOutput, CellOutputBuilder,
+    OutPoint as FbsOutPoint, Transaction as FbsTransaction, TransactionBuilder,
 };
 use flatbuffers::{FlatBufferBuilder, WIPOffset};
 
@@ -42,10 +42,10 @@ fn build_output<'b>(
     fbb: &mut FlatBufferBuilder<'b>,
     output: &CellOutput,
 ) -> WIPOffset<FbsCellOutput<'b>> {
-    let lock = FbsBytes::build(fbb, output.lock.as_bytes());
+    let lock = (&output.lock).into();
     let mut builder = CellOutputBuilder::new(fbb);
     builder.add_capacity(output.capacity);
-    builder.add_lock(lock);
+    builder.add_lock(&lock);
     builder.finish()
 }
 
@@ -53,9 +53,9 @@ fn build_input<'b>(
     fbb: &mut FlatBufferBuilder<'b>,
     input: &CellInput,
 ) -> WIPOffset<FbsCellInput<'b>> {
-    let hash = FbsBytes::build(fbb, input.previous_output.hash.as_bytes());
+    let hash = (&input.previous_output.hash).into();
     let mut builder = CellInputBuilder::new(fbb);
-    builder.add_hash(hash);
+    builder.add_hash(&hash);
     builder.add_index(input.previous_output.index);
     builder.finish()
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -112,7 +112,10 @@ impl<'a> TransactionScriptsVerifier<'a> {
                     let fbs_script = get_root::<FbsScript>(&cell_output.data);
                     // This way we can avoid copying the actual script binary one more
                     // time, which could be a lot of data.
-                    let binary = fbs_script.binary().ok_or(ScriptError::NoScript)?;
+                    let binary = fbs_script
+                        .binary()
+                        .and_then(|s| s.seq())
+                        .ok_or(ScriptError::NoScript)?;
                     // When the reference script has signed arguments, we will concat
                     // signed arguments from the reference script with the signed
                     // arguments from the main script together.

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -112,10 +112,7 @@ impl<'a> TransactionScriptsVerifier<'a> {
                     let fbs_script = get_root::<FbsScript>(&cell_output.data);
                     // This way we can avoid copying the actual script binary one more
                     // time, which could be a lot of data.
-                    let binary = fbs_script
-                        .binary()
-                        .and_then(|s| s.seq())
-                        .ok_or(ScriptError::NoScript)?;
+                    let binary = fbs_script.binary().ok_or(ScriptError::NoScript)?;
                     // When the reference script has signed arguments, we will concat
                     // signed arguments from the reference script with the signed
                     // arguments from the main script together.

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -4,7 +4,6 @@ use ckb_network::CKBProtocolContext;
 use ckb_network::PeerIndex;
 use ckb_protocol::{BlockTransactions, FlatbuffersVectorIterator};
 use ckb_shared::index::ChainIndex;
-use numext_fixed_hash::H256;
 use std::sync::Arc;
 
 pub struct BlockTransactionsProcess<'a, CI: ChainIndex + 'a> {
@@ -33,7 +32,7 @@ where
     }
 
     pub fn execute(self) {
-        let hash = H256::from_slice(self.message.hash().and_then(|b| b.seq()).unwrap()).unwrap();
+        let hash = self.message.hash().unwrap().into();
         if let Some(compact_block) = self
             .relayer
             .state

--- a/sync/src/relayer/compact_block.rs
+++ b/sync/src/relayer/compact_block.rs
@@ -37,11 +37,12 @@ impl<'a> From<ckb_protocol::CompactBlock<'a>> for CompactBlock {
                 .map(Into::into)
                 .collect(),
 
-            proposal_transactions: FlatbuffersVectorIterator::new(
-                b.proposal_transactions().unwrap(),
-            )
-            .filter_map(|bytes| ProposalShortId::from_slice(bytes.seq().unwrap()))
-            .collect(),
+            proposal_transactions: b
+                .proposal_transactions()
+                .unwrap()
+                .iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -1,7 +1,6 @@
 use crate::relayer::Relayer;
-use ckb_core::transaction::ProposalShortId;
 use ckb_network::{CKBProtocolContext, PeerIndex};
-use ckb_protocol::{FlatbuffersVectorIterator, GetBlockProposal, RelayMessage};
+use ckb_protocol::{GetBlockProposal, RelayMessage};
 use ckb_shared::index::ChainIndex;
 use flatbuffers::FlatBufferBuilder;
 
@@ -34,8 +33,11 @@ where
         let mut pending_proposals_request = self.relayer.state.pending_proposals_request.lock();
 
         let transactions = {
-            FlatbuffersVectorIterator::new(self.message.proposal_transactions().unwrap())
-                .filter_map(|bytes| ProposalShortId::from_slice(bytes.seq().unwrap()))
+            self.message
+                .proposal_transactions()
+                .unwrap()
+                .iter()
+                .map(Into::into)
                 .filter_map(|short_id| {
                     self.relayer.tx_pool.get_transaction(short_id).or({
                         pending_proposals_request

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -4,7 +4,6 @@ use ckb_protocol::{GetBlockTransactions, RelayMessage};
 use ckb_shared::index::ChainIndex;
 use flatbuffers::FlatBufferBuilder;
 use log::debug;
-use numext_fixed_hash::H256;
 
 pub struct GetBlockTransactionsProcess<'a, CI: ChainIndex + 'a> {
     message: &'a GetBlockTransactions<'a>,
@@ -32,8 +31,7 @@ where
     }
 
     pub fn execute(self) {
-        let hash =
-            H256::from_slice(self.message.hash().and_then(|bytes| bytes.seq()).unwrap()).unwrap();
+        let hash = self.message.hash().unwrap().into();
         debug!(target: "relay", "get_block_transactions {:?}", hash);
 
         if let Some(block) = self.relayer.get_block(&hash) {

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -1,10 +1,9 @@
 use crate::synchronizer::Synchronizer;
 use ckb_network::{CKBProtocolContext, PeerIndex};
-use ckb_protocol::{FlatbuffersVectorIterator, GetBlocks, SyncMessage};
+use ckb_protocol::{GetBlocks, SyncMessage};
 use ckb_shared::index::ChainIndex;
 use flatbuffers::FlatBufferBuilder;
 use log::debug;
-use numext_fixed_hash::H256;
 
 pub struct GetBlocksProcess<'a, CI: ChainIndex + 'a> {
     message: &'a GetBlocks<'a>,
@@ -32,8 +31,8 @@ where
     }
 
     pub fn execute(self) {
-        FlatbuffersVectorIterator::new(self.message.block_hashes().unwrap()).for_each(|bytes| {
-            let block_hash = H256::from_slice(bytes.seq().unwrap()).unwrap();
+        self.message.block_hashes().unwrap().iter().for_each(|fbs_h256| {
+            let block_hash = fbs_h256.into();
             debug!(target: "sync", "get_blocks {:?}", block_hash);
             if let Some(block) = self.synchronizer.get_block(&block_hash) {
                 debug!(target: "sync", "respond_block {} {:?}", block.header().number(), block.header().hash());

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -2,7 +2,7 @@ use crate::synchronizer::Synchronizer;
 use crate::MAX_LOCATOR_SIZE;
 use ckb_core::header::Header;
 use ckb_network::{CKBProtocolContext, PeerIndex, Severity};
-use ckb_protocol::{FlatbuffersVectorIterator, GetHeaders, SyncMessage};
+use ckb_protocol::{GetHeaders, SyncMessage};
 use ckb_shared::index::ChainIndex;
 use flatbuffers::FlatBufferBuilder;
 use log::{debug, info, warn};
@@ -48,9 +48,7 @@ where
             }
 
             let hash_stop = H256::zero(); // TODO PENDING self.message.hash_stop().unwrap().into();
-            let block_locator_hashes = FlatbuffersVectorIterator::new(locator)
-                .map(|bytes| H256::from_slice(bytes.seq().unwrap()).unwrap())
-                .collect::<Vec<_>>();
+            let block_locator_hashes = locator.iter().map(Into::into).collect::<Vec<_>>();
 
             if let Some(block_number) = self
                 .synchronizer


### PR DESCRIPTION
This PR did code refactoring for H256 serialization. Needs rebase after https://github.com/nervosnetwork/ckb/pull/119 

TODO:
- [x] 1. Should we unify these `Bytes` field also?
*NO* `difficulty` / U256 
*YES*`proposal_transactions` and `short_ids` / [u8; 10]

- [x] 2. Client SDK change
