### PR TITLE
refactor: use derive clone and some tiny improvements

### DIFF
--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -68,6 +68,7 @@ pub struct Shared<CI> {
     consensus: Consensus,
 }
 
+// https://github.com/rust-lang/rust/issues/40754
 impl<CI: ChainIndex> ::std::clone::Clone for Shared<CI> {
     fn clone(&self) -> Self {
         Shared {

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -34,22 +34,12 @@ use std::time::Duration;
 
 pub const TX_PROPOSAL_TOKEN: TimerToken = 0;
 
+#[derive(Clone)]
 pub struct Relayer<CI: ChainIndex> {
     chain: ChainController,
     shared: Shared<CI>,
     tx_pool: TransactionPoolController,
     state: Arc<RelayState>,
-}
-
-impl<CI: ChainIndex> ::std::clone::Clone for Relayer<CI> {
-    fn clone(&self) -> Self {
-        Relayer {
-            chain: self.chain.clone(),
-            shared: self.shared.clone(),
-            tx_pool: self.tx_pool.clone(),
-            state: Arc::clone(&self.state),
-        }
-    }
 }
 
 impl<CI> Relayer<CI>

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -24,12 +24,12 @@ impl<CI> BlockFetcher<CI>
 where
     CI: ChainIndex,
 {
-    pub fn new(synchronizer: &Synchronizer<CI>, peer: PeerIndex) -> Self {
+    pub fn new(synchronizer: Synchronizer<CI>, peer: PeerIndex) -> Self {
         let tip_header = synchronizer.shared.tip_header().read().clone();
         BlockFetcher {
             tip_header,
             peer,
-            synchronizer: synchronizer.clone(),
+            synchronizer,
         }
     }
     pub fn initial_and_check_inflight(&self) -> bool {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -83,6 +83,7 @@ pub struct Synchronizer<CI: ChainIndex> {
     pub outbound_peers_with_protect: Arc<AtomicUsize>,
 }
 
+// https://github.com/rust-lang/rust/issues/40754
 impl<CI: ChainIndex> ::std::clone::Clone for Synchronizer<CI> {
     fn clone(&self) -> Self {
         Synchronizer {
@@ -477,7 +478,7 @@ impl<CI: ChainIndex> Synchronizer<CI> {
     }
 
     pub fn get_blocks_to_fetch(&self, peer: PeerIndex) -> Option<Vec<H256>> {
-        BlockFetcher::new(&self, peer).fetch()
+        BlockFetcher::new(self.clone(), peer).fetch()
     }
 
     fn on_connected(&self, nc: &CKBProtocolContext, peer: PeerIndex) {


### PR DESCRIPTION
I searched through the `fn clone`, and found the other three places. Fixed one, but the other two could not simply derive Clone, it occurred some strange compile error. I reckon the problem is https://github.com/rust-lang/rust/issues/26925.