### PR TITLE
feat: add merkle-tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,8 @@ dependencies = [
  "ckb-util 0.4.0-pre",
  "flatbuffers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash 0.4.0-pre",
+ "merkle-root 0.3.0-pre",
+ "merkle-tree 0.1.0",
  "numext-fixed-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1875,7 +1877,15 @@ name = "merkle-root"
 version = "0.4.0-pre"
 dependencies = [
  "hash 0.4.0-pre",
+ "merkle-tree 0.1.0",
  "numext-fixed-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "merkle-tree"
+version = "0.1.0"
+dependencies = [
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
 name = "merkle-tree"
 version = "0.1.0"
 dependencies = [
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
  "ckb-util 0.4.0-pre",
  "flatbuffers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash 0.4.0-pre",
- "merkle-root 0.3.0-pre",
+ "merkle-root 0.4.0-pre",
  "merkle-tree 0.1.0",
  "numext-fixed-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "util/avl",
     "util/logger",
     "util/hash",
+    "util/merkle-tree",
     "util/merkle-root",
     "util/crypto",
     "util/dir",

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -14,3 +14,5 @@ hash = { path = "../util/hash"}
 siphasher = "0.2.2"
 rand = "0.6"
 ckb-util = { path = "../util" }
+merkle-tree = { path = "../util/merkle-tree"}
+merkle-root = { path = "../util/merkle-root"}

--- a/util/merkle-root/Cargo.toml
+++ b/util/merkle-root/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 hash = {path = "../hash"}
+merkle-tree = {path = "../merkle-tree"}

--- a/util/merkle-root/src/lib.rs
+++ b/util/merkle-root/src/lib.rs
@@ -1,10 +1,10 @@
 use hash::Sha3;
-use merkle_tree::{HashKernels, Tree};
+use merkle_tree::{Merge, Tree};
 use numext_fixed_hash::H256;
 
 pub struct H256Sha3;
 
-impl HashKernels for H256Sha3 {
+impl Merge for H256Sha3 {
     type Item = H256;
 
     fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {

--- a/util/merkle-root/src/lib.rs
+++ b/util/merkle-root/src/lib.rs
@@ -1,85 +1,22 @@
 use hash::Sha3;
+use merkle_tree::{HashKernels, Tree};
 use numext_fixed_hash::H256;
 
-fn lowest_children_len(amount: usize) -> usize {
-    let mut n: usize = 1;
-    let mut r: usize = 0;
+pub struct H256Sha3;
 
-    while n <= amount {
-        r = amount - n;
-        n <<= 1;
+impl HashKernels for H256Sha3 {
+    type Item = H256;
+
+    fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {
+        let mut hash = [0u8; 32];
+        let mut sha3 = Sha3::new_sha3_256();
+        sha3.update(left.as_bytes());
+        sha3.update(right.as_bytes());
+        sha3.finalize(&mut hash);
+        hash.into()
     }
-
-    r << 1
 }
 
 pub fn merkle_root(input: &[H256]) -> H256 {
-    let inlen = input.len();
-    // in case of empty slice, just return zero
-    if inlen == 0 {
-        return H256::zero();
-    }
-
-    let lwlen = lowest_children_len(inlen);
-    let mut i: usize = 0;
-    let mut nodes = Vec::with_capacity(inlen);
-
-    while i < lwlen {
-        nodes.push(merge(&input[i], &input[i + 1]));
-        i += 2;
-    }
-
-    for h in input.iter().skip(i) {
-        nodes.push(h.clone());
-    }
-
-    let nlen = nodes.len();
-    let mut d = 1;
-    while d < nlen {
-        let mut j = 0;
-        while j < nlen {
-            nodes[j] = merge(&nodes[j], &nodes[j + d]);
-            j += d + d;
-        }
-        d <<= 1;
-    }
-
-    nodes[0].clone()
-}
-
-fn merge(left: &H256, right: &H256) -> H256 {
-    let mut hash = [0u8; 32];
-    let mut sha3 = Sha3::new_sha3_256();
-    sha3.update(left.as_bytes());
-    sha3.update(right.as_bytes());
-    sha3.finalize(&mut hash);
-    hash.into()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::merkle_root;
-    use numext_fixed_hash::H256;
-    use std::str::FromStr;
-
-    #[test]
-    fn merkle_root_test() {
-        assert_eq!(
-            merkle_root(&[
-                H256::from_str("8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a")
-                    .unwrap(),
-                H256::from_str("768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1")
-                    .unwrap(),
-                H256::from_str("e68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1")
-                    .unwrap(),
-                H256::from_str("f68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1")
-                    .unwrap(),
-                H256::from_str("968dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1")
-                    .unwrap(),
-            ]),
-            H256::from_str("34c5d6f2ec196e6836549e49b0ed73a1b19524acc6f1d0e5c951cfd9652da93c")
-                .unwrap()
-        );
-    }
-
+    Tree::<H256Sha3>::build_root(input).unwrap_or_else(H256::zero)
 }

--- a/util/merkle-tree/Cargo.toml
+++ b/util/merkle-tree/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dev-dependencies]
-rand = "0.6"
+proptest = "0.8"

--- a/util/merkle-tree/Cargo.toml
+++ b/util/merkle-tree/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "merkle-tree"
+version = "0.1.0"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dev-dependencies]
+rand = "0.6"

--- a/util/merkle-tree/src/hash.rs
+++ b/util/merkle-tree/src/hash.rs
@@ -1,5 +1,5 @@
 /// A trait for creating parent node.
-pub trait HashKernels {
+pub trait Merge {
     type Item;
     /// Returns parent node of two nodes
     fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item;

--- a/util/merkle-tree/src/hash.rs
+++ b/util/merkle-tree/src/hash.rs
@@ -1,0 +1,6 @@
+/// A trait for creating parent node.
+pub trait HashKernels {
+    type Item;
+    /// Returns parent node of two nodes
+    fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item;
+}

--- a/util/merkle-tree/src/lib.rs
+++ b/util/merkle-tree/src/lib.rs
@@ -2,6 +2,6 @@ mod hash;
 mod proof;
 mod tree;
 
-pub use crate::hash::HashKernels;
+pub use crate::hash::Merge;
 pub use crate::proof::Proof;
 pub use crate::tree::Tree;

--- a/util/merkle-tree/src/lib.rs
+++ b/util/merkle-tree/src/lib.rs
@@ -1,0 +1,7 @@
+mod hash;
+mod proof;
+mod tree;
+
+pub use crate::hash::HashKernels;
+pub use crate::proof::Proof;
+pub use crate::tree::Tree;

--- a/util/merkle-tree/src/proof.rs
+++ b/util/merkle-tree/src/proof.rs
@@ -1,0 +1,252 @@
+use crate::hash::HashKernels;
+use crate::tree::Tree;
+use std::collections::VecDeque;
+
+/// Merkle Proof can provide a proof for existence of one or more items.
+/// Only sibling of the nodes along the path that form leaves to root,
+/// excluding the nodes already in the path, should be included in the proof.
+/// For example, if we want to show that [T0, T5] is in the list of 6 items,
+/// only nodes [T4, T1, B3] should be included in the proof.
+///
+/// `tree nodes`: [B0, B1, B2, B3, B4, T0, T1, T2, T3, T4, T5]
+/// `leaves`: [(0, T0), (5, T5)]
+/// `lemmas`: [T4, T1, B3]
+/// `leaves_count`: 6
+pub struct Proof<H>
+where
+    H: HashKernels,
+{
+    /// a partial leaves collection keeps the items sorted based on index
+    pub leaves: Vec<(usize, H::Item)>,
+    /// non-calculable nodes, stored in descending order
+    pub lemmas: Vec<H::Item>,
+    /// total leaves count
+    pub leaves_count: usize,
+}
+
+impl<H> Proof<H>
+where
+    H: HashKernels,
+    <H as HashKernels>::Item: Clone + Default,
+{
+    /// Returns the root of the proof, or None if it is empty or lemmas are invalid
+    pub fn root(&self) -> Option<H::Item> {
+        if self.leaves_count == 0 {
+            return None;
+        }
+
+        let mut queue = self
+            .leaves
+            .iter()
+            .rev()
+            .map(|(index, leaf)| (self.leaves_count + index - 1, leaf.clone()))
+            .collect::<VecDeque<_>>();
+
+        let mut lemmas_iter = self.lemmas.iter();
+
+        while let Some((index, node)) = queue.pop_front() {
+            if index == 0 {
+                // ensure that all lemmas and leaves are consumed
+                if lemmas_iter.next().is_none() && queue.is_empty() {
+                    return Some(node);
+                } else {
+                    return None;
+                }
+            }
+
+            if let Some(sibling) = match queue.front() {
+                Some((front, _)) if *front == index.sibling() => {
+                    queue.pop_front().map(|i| i.1.clone())
+                }
+                _ => lemmas_iter.next().cloned(),
+            } {
+                let parent_node = if index.is_left() {
+                    H::merge(&node, &sibling)
+                } else {
+                    H::merge(&sibling, &node)
+                };
+                queue.push_back((index.parent(), parent_node));
+            }
+        }
+
+        None
+    }
+}
+
+impl<H> Tree<H>
+where
+    H: HashKernels,
+    <H as HashKernels>::Item: Clone + Default,
+{
+    /// Returns the proof of the tree, or None if it is empty.
+    /// Assumes that the `leaf_indexes` is sorted.
+    pub fn get_proof(&self, leaf_indexes: &[usize]) -> Option<Proof<H>> {
+        let leaves_count = (self.nodes.len() >> 1) + 1;
+
+        if self.nodes.is_empty()
+            || leaf_indexes.is_empty()
+            || *leaf_indexes.last().unwrap() >= leaves_count
+        {
+            return None;
+        }
+
+        let leaves = leaf_indexes
+            .iter()
+            .map(|&index| (index, self.nodes[leaves_count + index - 1].clone()))
+            .collect::<Vec<_>>();
+
+        let mut lemmas = Vec::new();
+        let mut queue = leaf_indexes
+            .iter()
+            .rev()
+            .map(|index| leaves_count + index - 1)
+            .collect::<VecDeque<_>>();
+        while let Some(index) = queue.pop_front() {
+            if index == 0 {
+                break;
+            }
+            if Some(&index.sibling()) == queue.front() {
+                queue.pop_front();
+            } else {
+                lemmas.push(self.nodes[index.sibling()].clone());
+            }
+
+            queue.push_back(index.parent());
+        }
+
+        Some(Proof {
+            leaves,
+            lemmas,
+            leaves_count,
+        })
+    }
+}
+
+/// A helper trait for node index
+trait NodeIndex {
+    fn sibling(&self) -> usize;
+    fn parent(&self) -> usize;
+    fn is_left(&self) -> bool;
+}
+
+impl NodeIndex for usize {
+    #[inline]
+    fn sibling(&self) -> usize {
+        debug_assert!(*self > 0);
+        ((self + 1) ^ 1) - 1
+    }
+
+    #[inline]
+    fn parent(&self) -> usize {
+        debug_assert!(*self > 0);
+        (self - 1) >> 1
+    }
+
+    #[inline]
+    fn is_left(&self) -> bool {
+        self & 1 == 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::Tree;
+    use rand::distributions::Standard;
+    use rand::{thread_rng, Rng};
+    struct DummyHash;
+
+    impl HashKernels for DummyHash {
+        type Item = i32;
+
+        fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {
+            right.wrapping_sub(*left)
+        }
+    }
+
+    #[test]
+    fn empty() {
+        let proof: Proof<DummyHash> = Proof {
+            leaves: vec![],
+            lemmas: vec![],
+            leaves_count: 0,
+        };
+
+        assert_eq!(None, proof.root());
+    }
+
+    #[test]
+    fn one() {
+        let proof: Proof<DummyHash> = Proof {
+            leaves: vec![(0, 1)],
+            lemmas: vec![],
+            leaves_count: 1,
+        };
+
+        assert_eq!(Some(1), proof.root());
+    }
+
+    #[test]
+    fn extra_lemma() {
+        let proof: Proof<DummyHash> = Proof {
+            leaves: vec![(0, 1)],
+            lemmas: vec![1],
+            leaves_count: 1,
+        };
+
+        assert_eq!(None, proof.root());
+    }
+
+    #[test]
+    fn missing_leaves() {
+        let proof: Proof<DummyHash> = Proof {
+            leaves: vec![(1, 1)],
+            lemmas: vec![],
+            leaves_count: 2,
+        };
+
+        assert_eq!(None, proof.root());
+    }
+
+    #[test]
+    // [ 1,  0,  1,  2,  2,  2,  3,  5,  7, 11, 13]
+    // [B0, B1, B2, B3, B4, T0, T1, T2, T3, T4, T5]
+    // [(0, 2), (5, 13)]
+    // [    T0,      T5]
+    // [11,  3,  2]
+    // [T4, T1, B3]
+    fn two_of_six() {
+        let proof: Proof<DummyHash> = Proof {
+            leaves: vec![(0, 2), (5, 13)],
+            lemmas: vec![11, 3, 2],
+            leaves_count: 6,
+        };
+
+        assert_eq!(Some(1), proof.root());
+    }
+
+    #[test]
+    fn build_proof() {
+        let leaves = vec![2, 3, 5, 7, 11, 13];
+        let tree = Tree::<DummyHash>::new(&leaves);
+        let proof = tree.get_proof(&[0, 5]).unwrap();
+        assert_eq!(vec![(0, 2), (5, 13)], proof.leaves);
+        assert_eq!(vec![11, 3, 2], proof.lemmas);
+        assert_eq!(Some(1), proof.root());
+    }
+
+    #[test]
+    fn random() {
+        let total: usize = thread_rng().gen_range(500, 1000);
+        let leaves: Vec<i32> = thread_rng().sample_iter(&Standard).take(total).collect();
+        let tree = Tree::<DummyHash>::new(&leaves);
+        let mut partial = (0..thread_rng().gen_range(50, total))
+            .map(|_| thread_rng().gen_range(0, total))
+            .collect::<Vec<_>>();
+        partial.sort_unstable();
+        partial.dedup();
+
+        let proof = tree.get_proof(&partial).unwrap();
+        assert_eq!(Tree::<DummyHash>::build_root(&leaves), proof.root());
+    }
+}

--- a/util/merkle-tree/src/proof.rs
+++ b/util/merkle-tree/src/proof.rs
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(Some(1), proof.root());
     }
 
-    fn _tree_root_same_as_proof_root(leaves: &[i32], indexes: &[usize]) {
+    fn _tree_root_is_same_as_proof_root(leaves: &[i32], indexes: &[usize]) {
         let tree = Tree::<DummyHash>::new(leaves);
         let proof = tree.get_proof(indexes).unwrap();
         assert_eq!(Tree::<DummyHash>::build_root(leaves), proof.root());
@@ -246,10 +246,10 @@ mod tests {
 
     proptest! {
         #[test]
-        fn tree_root_same_as_proof_root(input in vec(i32::ANY,  1..1000)
+        fn tree_root_is_same_as_proof_root(input in vec(i32::ANY,  2..1000)
             .prop_flat_map(|leaves| (Just(leaves.clone()), subsequence((0..leaves.len()).collect::<Vec<usize>>(), 1..leaves.len())))
         ) {
-            _tree_root_same_as_proof_root(&input.0, &input.1);
+            _tree_root_is_same_as_proof_root(&input.0, &input.1);
         }
     }
 }

--- a/util/merkle-tree/src/tree.rs
+++ b/util/merkle-tree/src/tree.rs
@@ -114,8 +114,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::distributions::Standard;
-    use rand::{thread_rng, Rng};
+    use proptest::collection::vec;
+    use proptest::num::i32;
+    use proptest::{proptest, proptest_helper};
 
     struct DummyHash;
 
@@ -162,11 +163,15 @@ mod tests {
         assert_eq!(Some(4), Tree::<DummyHash>::build_root(&leaves));
     }
 
-    #[test]
-    fn random() {
-        let total: usize = thread_rng().gen_range(500, 1000);
-        let leaves: Vec<i32> = thread_rng().sample_iter(&Standard).take(total).collect();
-        let tree = Tree::<DummyHash>::new(&leaves);
-        assert_eq!(Tree::<DummyHash>::build_root(&leaves), tree.root());
+    fn _build_root_is_same_as_tree_root(leaves: &[i32]) {
+        let tree = Tree::<DummyHash>::new(leaves);
+        assert_eq!(Tree::<DummyHash>::build_root(leaves), tree.root());
+    }
+
+    proptest! {
+        #[test]
+        fn build_root_is_same_as_tree_root(ref leaves in vec(i32::ANY,  0..1000)) {
+            _build_root_is_same_as_tree_root(leaves);
+        }
     }
 }

--- a/util/merkle-tree/src/tree.rs
+++ b/util/merkle-tree/src/tree.rs
@@ -1,0 +1,172 @@
+use crate::hash::HashKernels;
+use std::collections::VecDeque;
+
+/// Merkle tree is a tree in which every leaf node is labelled with the hash of a data block and
+/// every non-leaf node is labelled with the cryptographic hash of the labels of its child nodes.
+///
+/// [Article on Wikipedia](https://en.wikipedia.org/wiki/Merkle_tree)
+///
+/// This implementation use `Full and Complete Binary Tree` to store the data.
+///
+/// ```text
+///         with 6 leaves                       with 7 leaves
+///
+///               B0                                 B0
+///              /  \                               /  \
+///            /      \                           /      \
+///          /          \                       /          \
+///        /              \                   /              \
+///       B1              B2                 B1              B2
+///      /  \            /  \               /  \            /  \
+///     /    \          /    \             /    \          /    \
+///    /      \        /      \           /      \        /      \
+///   B3      B4      TO      T1         B3      B4      B5      T0
+///  /  \    /  \                       /  \    /  \    /  \
+/// T2  T3  T4  T5                     T1  T2  T3  T4  T5  T6
+/// ```
+///
+/// the two trees above can be represented as:
+/// [B0, B1, B2, B3, B4, T0, T1, T2, T3, T4, T5]
+/// [B0, B1, B2, B3, B4, B5, T0, T1, T2, T3, T4, T5, T6]
+pub struct Tree<H>
+where
+    H: HashKernels,
+{
+    pub(crate) nodes: Vec<H::Item>,
+}
+
+impl<H> Tree<H>
+where
+    H: HashKernels,
+    <H as HashKernels>::Item: Clone + Default,
+{
+    /// Create a merkle tree with leaves
+    /// # Examples
+    /// ```
+    /// use merkle_tree::{HashKernels, Tree};
+    /// struct DummyHash;
+    ///
+    /// impl HashKernels for DummyHash {
+    ///     type Item = i32;
+    ///
+    ///     fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {
+    ///         right.wrapping_sub(*left)
+    ///     }
+    /// }
+    ///
+    /// let leaves = vec![2, 3, 5, 7, 11, 13];
+    /// let tree = Tree::<DummyHash>::new(&leaves);
+    /// assert_eq!(vec![1, 0, 1, 2, 2, 2, 3, 5, 7, 11, 13], tree.nodes());
+    /// assert_eq!(Some(1), tree.root());
+    /// ```
+    pub fn new(leaves: &[H::Item]) -> Self {
+        let len = leaves.len();
+        if len > 0 {
+            let mut vec = vec![H::Item::default(); len - 1];
+            vec.extend(leaves.to_vec());
+
+            (0..len - 1)
+                .rev()
+                .for_each(|i| vec[i] = H::merge(&vec[(i << 1) + 1], &vec[(i << 1) + 2]));
+
+            Self { nodes: vec }
+        } else {
+            Self { nodes: vec![] }
+        }
+    }
+
+    /// Returns all nodes of the tree
+    pub fn nodes(&self) -> &[H::Item] {
+        &self.nodes
+    }
+
+    /// Returns the root of the tree, or None if it is empty.
+    pub fn root(&self) -> Option<H::Item> {
+        self.nodes.first().cloned()
+    }
+
+    /// Build merkle root directly without tree initialization
+    pub fn build_root(leaves: &[H::Item]) -> Option<H::Item> {
+        if leaves.is_empty() {
+            return None;
+        }
+
+        let mut queue = VecDeque::with_capacity((leaves.len() + 1) >> 1);
+
+        let mut iter = leaves.rchunks_exact(2);
+        while let Some([leaf1, leaf2]) = iter.next() {
+            queue.push_back(H::merge(leaf1, leaf2))
+        }
+        if let [leaf] = iter.remainder() {
+            queue.push_front(leaf.clone())
+        }
+
+        while queue.len() > 1 {
+            let right = queue.pop_front().unwrap();
+            let left = queue.pop_front().unwrap();
+            queue.push_back(H::merge(&left, &right));
+        }
+
+        queue.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::distributions::Standard;
+    use rand::{thread_rng, Rng};
+
+    struct DummyHash;
+
+    impl HashKernels for DummyHash {
+        type Item = i32;
+
+        fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {
+            right.wrapping_sub(*left)
+        }
+    }
+
+    #[test]
+    fn build_empty() {
+        let leaves = vec![];
+        let tree = Tree::<DummyHash>::new(&leaves);
+        assert!(tree.nodes().is_empty());
+        assert!(tree.root().is_none());
+    }
+
+    #[test]
+    fn build_one() {
+        let leaves = vec![1];
+        let tree = Tree::<DummyHash>::new(&leaves);
+        assert_eq!(vec![1], tree.nodes());
+    }
+
+    #[test]
+    fn build_two() {
+        let leaves = vec![1, 2];
+        let tree = Tree::<DummyHash>::new(&leaves);
+        assert_eq!(vec![1, 1, 2], tree.nodes());
+    }
+
+    #[test]
+    fn build_five() {
+        let leaves = vec![2, 3, 5, 7, 11];
+        let tree = Tree::<DummyHash>::new(&leaves);
+        assert_eq!(vec![4, -2, 2, 4, 2, 3, 5, 7, 11], tree.nodes());
+    }
+
+    #[test]
+    fn build_root_directly() {
+        let leaves = vec![2, 3, 5, 7, 11];
+        assert_eq!(Some(4), Tree::<DummyHash>::build_root(&leaves));
+    }
+
+    #[test]
+    fn random() {
+        let total: usize = thread_rng().gen_range(500, 1000);
+        let leaves: Vec<i32> = thread_rng().sample_iter(&Standard).take(total).collect();
+        let tree = Tree::<DummyHash>::new(&leaves);
+        assert_eq!(Tree::<DummyHash>::build_root(&leaves), tree.root());
+    }
+}


### PR DESCRIPTION
This PR implements a Merkle Tree, replaced old `merkle_root` with this new struct and added proof generation function to `FilteredBlock`.

We changed the Merkle Tree internal nodes storage layout. It is a BREAKING change, need to delete old chain data and restart from genesis block.

Closes #131 
Closes #145 