### PR TITLE
docs: add how to contribute title to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The wiki also lists some [known issues](https://github.com/nervosnetwork/ckb/wik
 
 The `master` branch is regularly built and tested, however, it is not guaranteed to be completely stable; The `develop` branch is the work branch to merge new features, and it's not stable. The CHANGELOG is available in [Releases](https://github.com/nervosnetwork/ckb/releases) and [CHANGELOG.md](https://github.com/nervosnetwork/ckb/blob/master/CHANGELOG.md) in the `master` branch.
 
+## How to Contribute
+
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md), and security policy is described in [SECURITY.md](SECURITY.md). To propose new protocol or standard for Nervos, see [Nervos RFC](https://github.com/nervosnetwork/rfcs).
 
 ---


### PR DESCRIPTION
In the original version of readme, the content of how to make contribution is mixed with the development flow.

IMO by adding a title to this part of content can make it more easier for contributors to find this information and thus helps to attract contributors.

This little change could make community developers feel like they are more than welcomed to this project. This project is not just for a certain group of developers at Cryptape. It's also for the community members who wants to make this world a better place.

So pls kindly consider this pr, thx.

