### PR TITLE
chore: make bump.sh compatible for Linux

### DIFF
--- a/devtools/release/bump.sh
+++ b/devtools/release/bump.sh
@@ -10,7 +10,7 @@ main() {
     exit 1
   fi
   local v="$1"
-  find . -name 'Cargo.toml' -print0 | xargs -0 sed -i .bak 's/^version = .*/version = "'"$v"'"/'
+  find . -name 'Cargo.toml' -print0 | xargs -0 sed -i.bak 's/^version = .*/version = "'"$v"'"/'
   find . -name 'Cargo.toml.bak' -exec rm -f {} \;
   cargo check
 }


### PR DESCRIPTION
Change `-i .bak` to `-i.bak`, which works for both BSD and Linux.