### PR TITLE
chore: travis cache tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,15 @@ matrix:
   include:
     - rust: 1.31.1
       os: osx
-      env: FMT=true CHECK=true TEST=true
+      env: FMT=true CHECK=true TEST=true CACHE_NAME=osx-rust-1.31.1-pr
       if: type = pull_request
     - rust: 1.31.1
       os: osx
-      env: FMT=true CHECK=true TEST=true
+      env: FMT=true CHECK=true TEST=true CACHE_NAME=osx-rust-1.31.1-not-pr
       if: type != pull_request
     - rust: 1.31.1
       os: linux
-      env: TEST=true
+      env: TEST=true CACHE_NAME=osx-linux-1.31.1-not-pr
       if: type != pull_request
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,5 @@ script:
 - git diff --exit-code Cargo.lock
 
 before_cache:
+- rm -rf ./target/debug/incremental/
 - cargo sweep -f

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ addons:
 install:
 - if [ "$FMT" = true ]; then cargo fmt --version || rustup component add rustfmt; fi
 - if [ "$CHECK" = true ]; then cargo clippy --version || rustup component add clippy; fi
-- cargo sweep --version || cargo install cargo-sweep
+- cargo sweep --version || cargo install --git https://github.com/holmgr/cargo-sweep --rev 4770deda37a2203c783e301b8c0c895964e8971e
 
 script:
-- cargo sweep -s ./target
+- cargo sweep -s
 - if [ "$FMT" = true ]; then make fmt; fi
 - if [ "$CHECK" = true ]; then make check; fi
 - if [ "$CHECK" = true ]; then make clippy; fi
@@ -53,4 +53,4 @@ script:
 - git diff --exit-code Cargo.lock
 
 before_cache:
-- cargo sweep -f ./target
+- cargo sweep -f

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: rust
 sudo: true
 cache:
+  cargo: true
   timeout: 1024
-  directories:
-    - $HOME/.cargo
-    - $HOME/.rustup
+
 git:
   depth: 2
   submodules: false
@@ -19,15 +18,15 @@ matrix:
   include:
     - rust: 1.31.1
       os: osx
-      env: FMT=true CHECK=true TEST=true CACHE_NAME=osx-rust-1.31.1-pr
+      env: FMT=true CHECK=true TEST=true
       if: type = pull_request
     - rust: 1.31.1
       os: osx
-      env: FMT=true CHECK=true TEST=true CACHE_NAME=osx-rust-1.31.1-not-pr
+      env: FMT=true CHECK=true TEST=true
       if: type != pull_request
     - rust: 1.31.1
       os: linux
-      env: TEST=true CACHE_NAME=osx-linux-1.31.1-not-pr
+      env: TEST=true
       if: type != pull_request
 
 addons:
@@ -43,8 +42,10 @@ addons:
 install:
 - if [ "$FMT" = true ]; then cargo fmt --version || rustup component add rustfmt; fi
 - if [ "$CHECK" = true ]; then cargo clippy --version || rustup component add clippy; fi
+- cargo sweep --version || cargo install cargo-sweep
 
 script:
+- cargo sweep -s
 - if [ "$FMT" = true ]; then make fmt; fi
 - if [ "$CHECK" = true ]; then make check; fi
 - if [ "$CHECK" = true ]; then make clippy; fi
@@ -52,4 +53,4 @@ script:
 - git diff --exit-code Cargo.lock
 
 before_cache:
-- rm -rf $HOME/.cargo/registry
+- cargo sweep -f

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   timeout: 1024
   directories:
     - $HOME/.cargo
+    - $HOME/.rustup
 git:
   depth: 2
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 - cargo sweep --version || cargo install cargo-sweep
 
 script:
-- cargo sweep -s
+- cargo sweep -s ./target
 - if [ "$FMT" = true ]; then make fmt; fi
 - if [ "$CHECK" = true ]; then make check; fi
 - if [ "$CHECK" = true ]; then make clippy; fi
@@ -53,4 +53,4 @@ script:
 - git diff --exit-code Cargo.lock
 
 before_cache:
-- cargo sweep -f
+- cargo sweep -f ./target

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,5 +21,3 @@ pub type PublicKey = numext_fixed_hash::H512;
 pub type BlockNumber = u64;
 pub type Capacity = u64;
 pub type Cycle = u64;
-
-pub type TriggerForCi = u64;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,3 +21,5 @@ pub type PublicKey = numext_fixed_hash::H512;
 pub type BlockNumber = u64;
 pub type Capacity = u64;
 pub type Cycle = u64;
+
+pub type TriggerForCi = u64;


### PR DESCRIPTION
try to improve travis build time via `cargo sweep`

Ran for 15 min 23 sec without 3rd lib rebuilding:
https://travis-ci.com/nervosnetwork/ckb/builds/97910636

========outdated below========
~~reduce `rustup` installation time from 3xs to 0.7s~~

before: 33.68s
```
curl -sSf https://build.travis-ci.com/files/rustup-init.sh | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION -y
info: downloading installer
info: syncing channel updates for '1.32.0-x86_64-apple-darwin'
```

after: 0.70s 
```
$ curl -sSf https://build.travis-ci.com/files/rustup-init.sh | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION -y
info: downloading installer
info: updating existing rustup installation
Rust is installed now. Great!
```

