### PR TITLE
[HOLD] fix: channels select loop

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -105,7 +105,8 @@ impl<CI: ChainIndex + 'static> ChainService<CI> {
                             error!(target: "chain", "process_block_receiver closed");
                             break;
                         },
-                    }
+                    },
+                    recv(crossbeam_channel::never::<()>()) -> _ => {},
                 }
             })
             .expect("Start ChainService failed");

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -153,7 +153,8 @@ impl<CI: ChainIndex + 'static> BlockAssembler<CI> {
                             error!(target: "miner", "get_block_template_receiver closed");
                             break;
                         },
-                    }
+                    },
+                    recv(crossbeam_channel::never::<()>()) -> _ => {},
                 }
             }).expect("Start MinerAgent failed");
         let stop = StopHandler::new(SignalSender::Crossbeam(signal_sender), thread);

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -103,7 +103,6 @@ impl NotifyService {
                     recv(signal_receiver) -> _ => {
                         break;
                     }
-
                     recv(new_transaction_register_receiver) -> msg => Self::handle_register_new_transaction(
                         &mut new_transaction_subscribers, msg
                     ),
@@ -128,7 +127,8 @@ impl NotifyService {
                     ),
                     recv(switch_fork_receiver) -> msg => Self::handle_notify_switch_fork(
                         &switch_fork_subscribers, msg
-                    )
+                    ),
+                    recv(crossbeam_channel::never::<()>()) -> _ => {},
                 }
             }).expect("Start notify service failed");
 

--- a/pool/src/txs_pool/pool.rs
+++ b/pool/src/txs_pool/pool.rs
@@ -274,7 +274,8 @@ where
                         _ => {
                             error!(target: "txs_pool", "channel get_trace_receiver closed");
                         }
-                    }
+                    },
+                    recv(crossbeam_channel::never::<()>()) -> _ => {},
                 }
             }).expect("Start TransactionPoolService failed!");
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -68,13 +68,13 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
         to: BlockNumber,
     ) -> Result<Vec<CellOutputWithOutPoint>> {
         let mut result = Vec::new();
+        let chain_state = self.shared.chain_state().read();
         for block_number in from..=to {
             if let Some(block_hash) = self.shared.block_hash(block_number) {
                 let block = self
                     .shared
                     .block(&block_hash)
                     .ok_or_else(Error::internal_error)?;
-                let chain_state = self.shared.chain_state().read();
                 for transaction in block.commit_transactions() {
                     let transaction_meta = chain_state
                         .txo_set()


### PR DESCRIPTION
Select will choose an operation that doesn't need to block, not an operation that will return immediately, using a `never` channel to initial ready