### PR TITLE
feat: enforce `type` field of a cellbase output cell must be absent

### DIFF
--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -27,8 +27,6 @@ pub enum Error {
     Transactions((usize, TransactionError)),
     /// This is a wrapper of error encountered when invoking chain API.
     Chain(String),
-    /// The committed transactions list is empty.
-    CommitTransactionsEmpty,
     /// There are duplicate proposed transactions.
     ProposalTransactionDuplicate,
     /// There are duplicate committed transactions.
@@ -71,6 +69,7 @@ pub enum CellbaseError {
     InvalidReward,
     InvalidQuantity,
     InvalidPosition,
+    InvalidOutput,
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -1,4 +1,4 @@
-use super::super::block_verifier::{BlockVerifier, CellbaseVerifier, EmptyVerifier};
+use super::super::block_verifier::{BlockVerifier, CellbaseVerifier};
 use super::super::error::{CellbaseError, Error as VerifyError};
 use super::dummy::DummyChainProvider;
 use crate::Verifier;
@@ -244,15 +244,10 @@ pub fn test_empty_transactions() {
         transaction_fees,
     };
 
-    let verifier = EmptyVerifier::new();
     let full_verifier = BlockVerifier::new(provider);
-    assert_eq!(
-        verifier.verify(&block),
-        Err(VerifyError::CommitTransactionsEmpty)
-    );
     // short-circuit, Empty check first
     assert_eq!(
         full_verifier.verify(&block),
-        Err(VerifyError::CommitTransactionsEmpty)
+        Err(VerifyError::Cellbase(CellbaseError::InvalidQuantity))
     );
 }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -50,13 +50,14 @@ impl<'a> InputVerifier<'a> {
     }
 
     pub fn verify(&self) -> Result<(), TransactionError> {
-        let mut inputs = self.resolved_transaction.transaction.inputs().iter();
-        for cs in &self.resolved_transaction.input_cells {
+        let inputs = self.resolved_transaction.transaction.inputs().iter();
+        let input_cells = self.resolved_transaction.input_cells.iter();
+        for (input, cs) in inputs.zip(input_cells) {
             if cs.is_live() {
-                if let Some(ref input) = cs.get_live() {
+                if let Some(ref input_cell) = cs.get_live() {
                     // TODO: remove this once VM mmap is in place so we can
                     // do P2SH within the VM.
-                    if input.lock != inputs.next().unwrap().unlock.type_hash() {
+                    if input_cell.lock != input.unlock.type_hash() {
                         return Err(TransactionError::InvalidScript);
                     }
                 }


### PR DESCRIPTION
* remove redundant EmptyVerifier
* enforce `type` field of a cellbase output cell must be absent