### PR TITLE
feature: index whether a tx is a cellbase in the chain

### DIFF
--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -140,7 +140,7 @@ impl<CI: ChainIndex> Shared<CI> {
                     cell_set.mark_dead(&o);
                 }
 
-                cell_set.insert(tx.hash(), output_len);
+                cell_set.insert(tx.hash(), n, tx.is_cellbase(), output_len);
             }
         }
 


### PR DESCRIPTION
Index whether a tx is a cellbase in the chain, prepare for the cellbase outputs maturity checking.

Now saving the cellbase index and block number in the `TransactionMeta`, there is another implementation which creates a `HashMap<tx_hash, number>`. The second one may be a little memory saving, but this one is more simple. I think both are ok.

https://github.com/nervosnetwork/ckb/issues/54