### PR TITLE
chore: include dir test in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ doc-deps:
 
 check:
 	cargo check ${VERBOSE} --all
+	cd test && cargo check ${VERBOSE} --all
 
 build:
 	cargo build ${VERBOSE} --release
@@ -25,9 +26,11 @@ prod-test:
 
 fmt:
 	cargo fmt ${VERBOSE} --all -- --check
+	cd test && cargo fmt ${VERBOSE} --all -- --check
 
 clippy:
 	cargo clippy ${VERBOSE} --all --all-targets --all-features -- -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from
+	cd test && cargo clippy ${VERBOSE} --all --all-targets --all-features -- -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from
 
 
 ci: fmt clippy test


### PR DESCRIPTION
Dir test is excluded from the workspace in c0992b15894a301ec040cb442745ace39db4ae1a .

This commit will check fmt and clippy in the test directory so we can discover
errors earlier.