### PR TITLE
fix: try to repair a corrupted rocksdb automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "ckb-util 0.9.0-pre",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 failure = "0.1.5"
+log = "0.4"
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
I have test this patch with a corrupted database (from @TheWaWaR).

But I can not reproduce the bug by myself, so I did not write any test case.

The database works, but the data is still corrupted (**because `header` add new fields?**):

```
2019-04-09 07:39:24.154 +00:00 main WARN ckb_db::diskdb  Try repairing the rocksdb since Corruption: SST file is ahead of WALs ...
2019-04-09 07:39:24.384 +00:00 main WARN ckb_db::diskdb  Try opening the repaired rocksdb ...
thread 'main' panicked at 'header deserializing should be ok: Custom("invalid length 3, expected a 0x-prefixed hex string with 64 digits")', src/libcore/result.rs:997:5
stack backtrace:
```

Ref:
- [RocksDB: Repairer](https://github.com/facebook/rocksdb/wiki/RocksDB-Repairer)
- [RocksDB: WAL Recovery Modes](https://github.com/facebook/rocksdb/wiki/WAL-Recovery-Modes)
- [`pub fn set_wal_recovery_mode(&mut self, mode: DBRecoveryMode)`](https://github.com/rust-rocksdb/rust-rocksdb/blob/267d92cbf9fdcbce9052ef06d7cb90b3111c6c54/src/db_options.rs#L1042-L1046)