### PR TITLE
chore: use new constructors to make fixed structs more readable

### DIFF
--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -1,15 +1,13 @@
 use faster_hex::hex_encode;
 use hash::blake2b_256;
-use numext_fixed_hash::H256;
+use numext_fixed_hash::{h256, H256};
 use occupied_capacity::OccupiedCapacity;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::io::Write;
 use std::mem;
 
-pub const ALWAYS_SUCCESS_HASH: [u8; 32] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-];
+pub const ALWAYS_SUCCESS_HASH: H256 = h256!("0x1");
 
 // TODO: when flatbuffer work is done, remove Serialize/Deserialize here and
 // implement proper From trait
@@ -59,7 +57,7 @@ impl Script {
     }
 
     pub fn always_success() -> Self {
-        Self::new(0, vec![], H256(ALWAYS_SUCCESS_HASH))
+        Self::new(0, vec![], ALWAYS_SUCCESS_HASH)
     }
 
     pub fn destruct(self) -> ScriptTuple {

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -119,7 +119,7 @@ impl<'a> TransactionScriptsVerifier<'a> {
         current_input: Option<&'a CellInput>,
         max_cycles: Cycle,
     ) -> Result<Cycle, ScriptError> {
-        if script.binary_hash.as_fixed_bytes() == &ALWAYS_SUCCESS_HASH {
+        if script.binary_hash == ALWAYS_SUCCESS_HASH {
             return Ok(0);
         }
         let mut args = vec![b"verify".to_vec()];

--- a/util/crypto/src/secp/signature.rs
+++ b/util/crypto/src/secp/signature.rs
@@ -3,7 +3,7 @@ use super::pubkey::Pubkey;
 use super::Message;
 use super::SECP256K1;
 use faster_hex::hex_string;
-use numext_fixed_hash::{H256, H520};
+use numext_fixed_hash::{h256, H256, H520};
 use secp256k1::Message as SecpMessage;
 use secp256k1::{RecoverableSignature, RecoveryId};
 use std::fmt;
@@ -13,18 +13,10 @@ use std::str::FromStr;
 #[derive(Clone)]
 pub struct Signature([u8; 65]);
 
-const HALF_N: H256 = H256([
-    127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 93, 87, 110,
-    115, 87, 164, 80, 29, 223, 233, 47, 70, 104, 27, 32, 160,
-]);
-const N: H256 = H256([
-    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 186, 174, 220,
-    230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65,
-]);
-
-const ONE: H256 = H256([
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-]);
+const HALF_N: H256 =
+    h256!("0x7fffffff_ffffffff_ffffffff_ffffffff_5d576e73_57a4501d_dfe92f46_681b20a0");
+const N: H256 = h256!("0xffffffff_ffffffff_ffffffff_fffffffe_baaedce6_af48a03b_bfd25e8c_d0364141");
+const ONE: H256 = h256!("0x1");
 
 impl Signature {
     /// Get a slice into the 'r' portion of the data.


### PR DESCRIPTION
Should I delete this unit test?

https://github.com/nervosnetwork/ckb/blob/32be9aa704fce9c269b93b247b64e5a87dece575/util/crypto/src/secp/signature.rs#L159-L173