### PR TITLE
feat: Change all u64 fields in RPC to String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "ckb-shared 0.9.0-pre",
  "ckb-sync 0.9.0-pre",
  "ckb-traits 0.9.0-pre",
+ "ckb-util 0.9.0-pre",
  "ckb-verification 0.9.0-pre",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1538,6 +1539,8 @@ name = "jsonrpc-types"
 version = "0.9.0-pre"
 dependencies = [
  "ckb-core 0.9.0-pre",
+ "ckb-util 0.9.0-pre",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -428,6 +428,7 @@ mod tests {
     use ckb_shared::shared::SharedBuilder;
     use ckb_shared::store::ChainKVStore;
     use ckb_traits::ChainProvider;
+    use ckb_util::TryInto;
     use ckb_verification::{BlockVerifier, HeaderResolverWrapper, HeaderVerifier, Verifier};
     use jsonrpc_types::{BlockTemplate, CellbaseTemplate};
     use numext_fixed_hash::H256;
@@ -505,10 +506,28 @@ mod tests {
             .parent_hash(parent_hash);
 
         let block = BlockBuilder::default()
-            .uncles(uncles.into_iter().map(Into::into).collect())
-            .commit_transaction(cellbase.into())
-            .commit_transactions(commit_transactions.into_iter().map(Into::into).collect())
-            .proposal_transactions(proposal_transactions.into_iter().map(Into::into).collect())
+            .uncles(
+                uncles
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()
+                    .unwrap(),
+            )
+            .commit_transaction(cellbase.try_into().unwrap())
+            .commit_transactions(
+                commit_transactions
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()
+                    .unwrap(),
+            )
+            .proposal_transactions(
+                proposal_transactions
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()
+                    .unwrap(),
+            )
             .with_header_builder(header_builder);
 
         let resolver = HeaderResolverWrapper::new(block.header(), shared.clone());

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -5,7 +5,6 @@ use ckb_core::script::Script;
 use ckb_core::service::{Request, DEFAULT_CHANNEL_SIZE, SIGNAL_CHANNEL_SIZE};
 use ckb_core::transaction::{CellInput, CellOutput, Transaction, TransactionBuilder};
 use ckb_core::uncle::UncleBlock;
-use ckb_core::BlockNumber;
 use ckb_core::{Cycle, Version};
 use ckb_notify::NotifyController;
 use ckb_shared::{index::ChainIndex, shared::Shared, tx_pool::PoolEntry};
@@ -45,7 +44,7 @@ impl TemplateCache {
         last_uncles_updated_at: u64,
         last_txs_updated_at: u64,
         current_time: u64,
-        number: BlockNumber,
+        number: String,
     ) -> bool {
         last_uncles_updated_at != self.uncles_updated_at
             || last_txs_updated_at != self.txs_updated_at
@@ -245,7 +244,7 @@ impl<CI: ChainIndex + 'static> BlockAssembler<CI> {
                 last_uncles_updated_at,
                 last_txs_updated_at,
                 current_time,
-                number,
+                number.to_string(),
             ) {
                 return Ok(template_cache.template.clone());
             }
@@ -274,11 +273,11 @@ impl<CI: ChainIndex + 'static> BlockAssembler<CI> {
         let template = BlockTemplate {
             version,
             difficulty,
-            current_time,
-            number,
+            current_time: current_time.to_string(),
+            number: number.to_string(),
             parent_hash: header.hash(),
-            cycles_limit,
-            bytes_limit,
+            cycles_limit: cycles_limit.to_string(),
+            bytes_limit: bytes_limit.to_string(),
             uncles_count_limit,
             uncles: uncles.into_iter().map(Self::transform_uncle).collect(),
             commit_transactions: commit_transactions
@@ -500,9 +499,9 @@ mod tests {
 
         let header_builder = HeaderBuilder::default()
             .version(version)
-            .number(number)
+            .number(number.parse::<BlockNumber>().unwrap())
             .difficulty(difficulty)
-            .timestamp(current_time)
+            .timestamp(current_time.parse::<u64>().unwrap())
             .parent_hash(parent_hash);
 
         let block = BlockBuilder::default()

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -2,6 +2,7 @@ use crate::client::Client;
 use crate::Work;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::{HeaderBuilder, RawHeader, Seal};
+use ckb_core::BlockNumber;
 use ckb_pow::PowEngine;
 use ckb_util::TryInto;
 use crossbeam_channel::Receiver;
@@ -72,9 +73,9 @@ impl Miner {
 
             let header_builder = HeaderBuilder::default()
                 .version(version)
-                .number(number)
+                .number(number.parse::<BlockNumber>()?)
                 .difficulty(difficulty)
-                .timestamp(current_time)
+                .timestamp(current_time.parse::<u64>()?)
                 .parent_hash(parent_hash);
 
             let block = BlockBuilder::default()

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -74,10 +74,12 @@ impl Miner {
             let uncles = uncles.into_iter().map(TryInto::try_into).collect();
             if let Err(ref e) = uncles {
                 error!(target: "miner", "error parsing uncles: {:?}", e);
+                return None;
             }
             let cellbase = cellbase.try_into();
             if let Err(ref e) = cellbase {
                 error!(target: "miner", "error parsing cellbase: {:?}", e);
+                return None;
             }
             let commit_transactions = commit_transactions
                 .into_iter()
@@ -85,6 +87,7 @@ impl Miner {
                 .collect();
             if let Err(ref e) = commit_transactions {
                 error!(target: "miner", "error parsing commit transactions: {:?}", e);
+                return None;
             }
             let proposal_transactions = proposal_transactions
                 .into_iter()
@@ -92,6 +95,7 @@ impl Miner {
                 .collect();
             if let Err(ref e) = proposal_transactions {
                 error!(target: "miner", "error parsing proposal transactions: {:?}", e);
+                return None;
             }
 
             let block = BlockBuilder::default()

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -33,7 +33,7 @@ build-info = { path = "../util/build-info" }
 futures = "0.1"
 ckb-verification = { path = "../verification" }
 ckb-traits = { path = "../traits" }
-
+ckb-util = { path = "../util" }
 
 [dev-dependencies]
 ckb-db = { path = "../db" }

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -17,7 +17,7 @@ pub trait ChainRpc {
     fn get_transaction(&self, _hash: H256) -> Result<Option<Transaction>>;
 
     #[rpc(name = "get_block_hash")]
-    fn get_block_hash(&self, _number: u64) -> Result<Option<H256>>;
+    fn get_block_hash(&self, _number: String) -> Result<Option<H256>>;
 
     #[rpc(name = "get_tip_header")]
     fn get_tip_header(&self) -> Result<Header>;
@@ -26,15 +26,15 @@ pub trait ChainRpc {
     fn get_cells_by_lock_hash(
         &self,
         _lock_hash: H256,
-        _from: BlockNumber,
-        _to: BlockNumber,
+        _from: String,
+        _to: String,
     ) -> Result<Vec<CellOutputWithOutPoint>>;
 
     #[rpc(name = "get_live_cell")]
     fn get_live_cell(&self, _out_point: OutPoint) -> Result<CellWithStatus>;
 
     #[rpc(name = "get_tip_block_number")]
-    fn get_tip_block_number(&self) -> Result<BlockNumber>;
+    fn get_tip_block_number(&self) -> Result<String>;
 }
 
 pub(crate) struct ChainRpcImpl<CI> {
@@ -50,8 +50,12 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
         Ok(self.shared.get_transaction(&hash).as_ref().map(Into::into))
     }
 
-    fn get_block_hash(&self, number: BlockNumber) -> Result<Option<H256>> {
-        Ok(self.shared.block_hash(number))
+    fn get_block_hash(&self, number: String) -> Result<Option<H256>> {
+        Ok(self.shared.block_hash(
+            number
+                .parse::<BlockNumber>()
+                .map_err(|_| Error::parse_error())?,
+        ))
     }
 
     fn get_tip_header(&self) -> Result<Header> {
@@ -62,11 +66,17 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
     fn get_cells_by_lock_hash(
         &self,
         lock_hash: H256,
-        from: BlockNumber,
-        to: BlockNumber,
+        from: String,
+        to: String,
     ) -> Result<Vec<CellOutputWithOutPoint>> {
         let mut result = Vec::new();
         let chain_state = self.shared.chain_state().lock();
+        let from = from
+            .parse::<BlockNumber>()
+            .map_err(|_| Error::parse_error())?;
+        let to = to
+            .parse::<BlockNumber>()
+            .map_err(|_| Error::parse_error())?;
         for block_number in from..=to {
             if let Some(block_hash) = self.shared.block_hash(block_number) {
                 let block = self
@@ -105,7 +115,7 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
             .into())
     }
 
-    fn get_tip_block_number(&self) -> Result<BlockNumber> {
-        Ok(self.shared.chain_state().lock().tip_number())
+    fn get_tip_block_number(&self) -> Result<String> {
+        Ok(self.shared.chain_state().lock().tip_number().to_string())
     }
 }

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -2,6 +2,7 @@ use ckb_core::cell::CellProvider;
 use ckb_core::BlockNumber;
 use ckb_shared::{index::ChainIndex, shared::Shared};
 use ckb_traits::ChainProvider;
+use ckb_util::TryInto;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_types::{Block, CellOutputWithOutPoint, CellWithStatus, Header, OutPoint, Transaction};
@@ -100,7 +101,7 @@ impl<CI: ChainIndex + 'static> ChainRpc for ChainRpcImpl<CI> {
             .shared
             .chain_state()
             .lock()
-            .cell(&(out_point.into()))
+            .cell(&(out_point.try_into().map_err(|_| Error::parse_error())?))
             .into())
     }
 

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -6,6 +6,7 @@ use ckb_protocol::RelayMessage;
 use ckb_shared::{index::ChainIndex, shared::Shared};
 use ckb_sync::NetworkProtocol;
 use ckb_traits::ChainProvider;
+use ckb_util::TryInto;
 use ckb_verification::{HeaderResolverWrapper, HeaderVerifier, Verifier};
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_core::{Error, Result};
@@ -52,7 +53,7 @@ impl<CI: ChainIndex + 'static> MinerRpc for MinerRpcImpl<CI> {
     }
 
     fn submit_block(&self, _work_id: String, data: Block) -> Result<Option<H256>> {
-        let block: Arc<CoreBlock> = Arc::new(data.into());
+        let block: Arc<CoreBlock> = Arc::new(data.try_into().map_err(|_| Error::parse_error())?);
         let resolver = HeaderResolverWrapper::new(block.header(), self.shared.clone());
         let header_verifier = HeaderVerifier::new(
             self.shared.clone(),

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -7,9 +7,10 @@ use ckb_shared::shared::Shared;
 use ckb_shared::tx_pool::types::PoolEntry;
 use ckb_sync::NetworkProtocol;
 use ckb_traits::chain_provider::ChainProvider;
+use ckb_util::TryInto;
 use ckb_verification::TransactionError;
 use flatbuffers::FlatBufferBuilder;
-use jsonrpc_core::Result;
+use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_types::Transaction;
 use log::debug;
@@ -33,7 +34,7 @@ pub(crate) struct PoolRpcImpl<CI> {
 
 impl<CI: ChainIndex + 'static> PoolRpc for PoolRpcImpl<CI> {
     fn send_transaction(&self, tx: Transaction) -> Result<H256> {
-        let tx: CoreTransaction = tx.into();
+        let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
         let tx_hash = tx.hash().clone();
         let cycles = {
             let mut chain_state = self.shared.chain_state().lock();

--- a/rpc/src/module/trace.rs
+++ b/rpc/src/module/trace.rs
@@ -8,9 +8,10 @@ use ckb_shared::tx_pool::types::PoolEntry;
 use ckb_shared::tx_pool::TxTrace;
 use ckb_sync::NetworkProtocol;
 use ckb_traits::chain_provider::ChainProvider;
+use ckb_util::TryInto;
 use ckb_verification::TransactionError;
 use flatbuffers::FlatBufferBuilder;
-use jsonrpc_core::Result;
+use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_types::Transaction;
 use log::debug;
@@ -32,7 +33,7 @@ pub(crate) struct TraceRpcImpl<CI> {
 
 impl<CI: ChainIndex + 'static> TraceRpc for TraceRpcImpl<CI> {
     fn trace_transaction(&self, tx: Transaction) -> Result<H256> {
-        let tx: CoreTransaction = tx.into();
+        let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
         let tx_hash = tx.hash().clone();
         let cycles = {
             let mut chain_state = self.shared.chain_state().lock();

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -13,6 +13,7 @@ ckb-network = { path = "../network" }
 ckb-shared = { path = "../shared" }
 ckb-sync = { path = "../sync" }
 ckb-protocol = { path = "../protocol"}
+ckb-util = { path = "../util" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 fs_extra = "1.1"
 tempfile = "3.0"

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -4,6 +4,7 @@ use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::{HeaderBuilder, Seal};
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
+use ckb_core::BlockNumber;
 use ckb_util::TryInto;
 use fs_extra::dir::{copy, CopyOptions};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
@@ -188,9 +189,17 @@ impl Node {
 
         let header_builder = HeaderBuilder::default()
             .version(version)
-            .number(number)
+            .number(
+                number
+                    .parse::<BlockNumber>()
+                    .expect("parse block number failed"),
+            )
             .difficulty(difficulty)
-            .timestamp(current_time)
+            .timestamp(
+                current_time
+                    .parse::<u64>()
+                    .expect("parse current time failed"),
+            )
             .parent_hash(parent_hash)
             .seal(Seal::new(rand::random(), Vec::new()));
 

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,4 +1,3 @@
-use ckb_core::BlockNumber;
 use ckb_shared::tx_pool::TxTrace;
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_types::{Block, BlockTemplate, Header, Node, Transaction};
@@ -10,7 +9,7 @@ jsonrpc_client!(pub struct RpcClient {
 
     pub fn add_node(&mut self, peer_id: String, address: String) -> RpcRequest<()>;
 
-    pub fn get_block_template(&mut self, cycles_limit: Option<u64>, bytes_limit: Option<u64>, max_version: Option<u32>) -> RpcRequest<BlockTemplate>;
+    pub fn get_block_template(&mut self, cycles_limit: Option<String>, bytes_limit: Option<String>, max_version: Option<u32>) -> RpcRequest<BlockTemplate>;
     pub fn submit_block(&mut self, work_id: String, data: Block) -> RpcRequest<Option<H256>>;
 
     pub fn send_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
@@ -20,7 +19,7 @@ jsonrpc_client!(pub struct RpcClient {
 
     pub fn get_block(&mut self, hash: H256) -> RpcRequest<Option<Block>>;
     pub fn get_transaction(&mut self, hash: H256) -> RpcRequest<Option<Transaction>>;
-    pub fn get_block_hash(&mut self, number: u64) -> RpcRequest<Option<H256>>;
+    pub fn get_block_hash(&mut self, number: String) -> RpcRequest<Option<H256>>;
     pub fn get_tip_header(&mut self) -> RpcRequest<Header>;
-    pub fn get_tip_block_number(&mut self) -> RpcRequest<BlockNumber>;
+    pub fn get_tip_block_number(&mut self) -> RpcRequest<String>;
 });

--- a/test/src/specs/mining.rs
+++ b/test/src/specs/mining.rs
@@ -1,6 +1,7 @@
 use crate::{Net, Spec};
 use ckb_core::block::Block;
 use ckb_core::transaction::ProposalShortId;
+use ckb_util::TryInto;
 use log::info;
 
 pub struct MiningBasic;
@@ -25,14 +26,16 @@ impl Spec for MiningBasic {
             .call()
             .unwrap()
             .unwrap()
-            .into();
+            .try_into()
+            .unwrap();
         let block3: Block = node
             .rpc_client()
             .get_block(block3_hash)
             .call()
             .unwrap()
             .unwrap()
-            .into();
+            .try_into()
+            .unwrap();
 
         info!("Generated tx should be included in next block's proposal txs");
         assert!(block1

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -14,6 +14,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 faster-hex = "0.3"
 jsonrpc-core = "10.1"
+failure = "0.1.5"
+ckb-util = { path = ".." }
 
 [dev-dependencies]
 proptest = "0.9"

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,6 +1,6 @@
 use crate::proposal_short_id::ProposalShortId;
 use crate::{Header, Transaction};
-use ckb_core::{BlockNumber, Cycle, Version};
+use ckb_core::{Cycle, Version};
 use ckb_util::{TryFrom, TryInto};
 use failure::Error as FailureError;
 use numext_fixed_hash::H256;
@@ -14,11 +14,11 @@ use ckb_core::uncle::UncleBlock as CoreUncleBlock;
 pub struct BlockTemplate {
     pub version: Version,
     pub difficulty: U256,
-    pub current_time: u64,
-    pub number: BlockNumber,
+    pub current_time: String,
+    pub number: String,
     pub parent_hash: H256,
-    pub cycles_limit: Cycle,
-    pub bytes_limit: u64,
+    pub cycles_limit: String,
+    pub bytes_limit: String,
     pub uncles_count_limit: u32,
     pub uncles: Vec<UncleTemplate>,
     pub commit_transactions: Vec<TransactionTemplate>,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -45,7 +45,7 @@ impl From<CoreScript> for Script {
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct CellOutput {
-    pub capacity: Capacity,
+    pub capacity: String,
     pub data: Bytes,
     pub lock: Script,
     #[serde(rename = "type")]
@@ -56,7 +56,7 @@ impl From<CoreCellOutput> for CellOutput {
     fn from(core: CoreCellOutput) -> CellOutput {
         let (capacity, data, lock, type_) = core.destruct();
         CellOutput {
-            capacity,
+            capacity: capacity.to_string(),
             data: Bytes::new(data),
             lock: lock.into(),
             type_: type_.map(Into::into),
@@ -81,7 +81,7 @@ impl TryFrom<CellOutput> for CoreCellOutput {
         };
 
         Ok(CoreCellOutput::new(
-            capacity,
+            capacity.parse::<Capacity>()?,
             data.into_vec(),
             lock.try_into()?,
             type_,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -233,7 +233,7 @@ impl TryFrom<Transaction> for CoreTransaction {
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct Seal {
-    pub nonce: u64,
+    pub nonce: String,
     pub proof: Bytes,
 }
 
@@ -241,7 +241,7 @@ impl From<CoreSeal> for Seal {
     fn from(core: CoreSeal) -> Seal {
         let (nonce, proof) = core.destruct();
         Seal {
-            nonce,
+            nonce: nonce.to_string(),
             proof: Bytes::new(proof),
         }
     }
@@ -252,7 +252,7 @@ impl TryFrom<Seal> for CoreSeal {
 
     fn try_from(json: Seal) -> Result<Self, Self::Error> {
         let Seal { nonce, proof } = json;
-        Ok(CoreSeal::new(nonce, proof.into_vec()))
+        Ok(CoreSeal::new(nonce.parse::<u64>()?, proof.into_vec()))
     }
 }
 
@@ -260,8 +260,8 @@ impl TryFrom<Seal> for CoreSeal {
 pub struct Header {
     pub version: u32,
     pub parent_hash: H256,
-    pub timestamp: u64,
-    pub number: BlockNumber,
+    pub timestamp: String,
+    pub number: String,
     pub txs_commit: H256,
     pub txs_proposal: H256,
     pub witnesses_root: H256,
@@ -278,8 +278,8 @@ impl<'a> From<&'a CoreHeader> for Header {
         Header {
             version: core.version(),
             parent_hash: core.parent_hash().clone(),
-            timestamp: core.timestamp(),
-            number: core.number(),
+            timestamp: core.timestamp().to_string(),
+            number: core.number().to_string(),
             txs_commit: core.txs_commit().clone(),
             txs_proposal: core.txs_proposal().clone(),
             witnesses_root: core.witnesses_root().clone(),
@@ -314,8 +314,8 @@ impl TryFrom<Header> for CoreHeader {
         Ok(HeaderBuilder::default()
             .version(version)
             .parent_hash(parent_hash)
-            .timestamp(timestamp)
-            .number(number)
+            .timestamp(timestamp.parse::<u64>()?)
+            .number(number.parse::<BlockNumber>()?)
             .txs_commit(txs_commit)
             .txs_proposal(txs_proposal)
             .witnesses_root(witnesses_root)

--- a/util/jsonrpc-types/src/proposal_short_id.rs
+++ b/util/jsonrpc-types/src/proposal_short_id.rs
@@ -1,4 +1,6 @@
 use ckb_core::transaction::ProposalShortId as CoreProposalShortId;
+use ckb_util::TryFrom;
+use failure::Error as FailureError;
 use faster_hex::{hex_decode, hex_encode};
 use std::fmt;
 
@@ -21,9 +23,11 @@ impl From<CoreProposalShortId> for ProposalShortId {
     }
 }
 
-impl From<ProposalShortId> for CoreProposalShortId {
-    fn from(json: ProposalShortId) -> CoreProposalShortId {
-        CoreProposalShortId::new(json.into_inner())
+impl TryFrom<ProposalShortId> for CoreProposalShortId {
+    type Error = FailureError;
+
+    fn try_from(json: ProposalShortId) -> Result<Self, Self::Error> {
+        Ok(CoreProposalShortId::new(json.into_inner()))
     }
 }
 


### PR DESCRIPTION
This PR actually contains 2 parts:

* refactor: Use TryFrom when parsing RPC request data
* feat: Change capacity field to String type in RPC