### PR TITLE
fix: RPC `local_node_info` returns duplicated addr

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -221,6 +221,7 @@ impl NetworkState {
         let original_listened_addresses = self.original_listened_addresses.read();
         self.listened_addresses(max_urls.saturating_sub(original_listened_addresses.len()))
             .into_iter()
+            .filter(|(addr, _)| !original_listened_addresses.contains(addr))
             .chain(
                 original_listened_addresses
                     .iter()


### PR DESCRIPTION
fix https://github.com/nervosnetwork/ckb/issues/436