### PR TITLE
feature: cellbase maturity verify

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -468,6 +468,8 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                         .map(|x| resolve_transaction(x, &mut seen_inputs, &cell_provider))
                         .collect();
 
+                    let cellbase_maturity = { self.shared.consensus().cellbase_maturity() };
+
                     match txs_verifier.verify(
                         chain_state.mut_txs_verify_cache(),
                         &resolved,
@@ -478,6 +480,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                             consensus: self.shared.consensus(),
                         },
                         b.header().number(),
+                        cellbase_maturity,
                     ) {
                         Ok(_) => {
                             cell_set_diff.push_new(b);

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -175,7 +175,8 @@ fn test_transaction_spend_in_same_block() {
             .cell(&OutPoint::new(tx2_hash, 0)),
         CellStatus::Live(CellMeta {
             cell_output: tx2_output,
-            block_number: Some(4)
+            block_number: Some(4),
+            cellbase: false,
         })
     );
 }

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -22,7 +22,7 @@ pub(crate) fn start_chain(
 ) -> (ChainController, Shared<ChainKVStore<MemoryKeyValueDB>>) {
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
     let shared = builder
-        .consensus(consensus.unwrap_or_else(Default::default))
+        .consensus(consensus.unwrap_or_else(|| Consensus::default().set_cellbase_maturity(0)))
         .build();
 
     let notify = NotifyService::default().start::<&str>(None);

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -10,6 +10,13 @@ use std::slice;
 pub struct CellMeta {
     pub cell_output: CellOutput,
     pub block_number: Option<u64>,
+    pub cellbase: bool,
+}
+
+impl CellMeta {
+    pub fn is_cellbase(&self) -> bool {
+        self.cellbase
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -123,6 +130,7 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
                 Some(x) => CellStatus::Live(CellMeta {
                     cell_output: x.clone(),
                     block_number: Some(self.block.header().number()),
+                    cellbase: *i == 0,
                 }),
                 None => CellStatus::Unknown,
             }
@@ -256,6 +264,7 @@ mod tests {
                 lock: Script::default(),
                 type_: None,
             },
+            cellbase: false,
         };
 
         db.cells.insert(p1.clone(), Some(o.clone()));

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -222,6 +222,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
             block_number: Some(1),
+            cellbase: false,
         };
         let input = CellInput::new(OutPoint::null(), 0, vec![]);
 
@@ -272,6 +273,7 @@ mod tests {
         let dep_cell = CellMeta {
             cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let script = Script::new(args, binary_hash);
@@ -286,6 +288,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], script, None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let rtx = ResolvedTransaction {
@@ -333,6 +336,7 @@ mod tests {
         let dep_cell = CellMeta {
             cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let script = Script::new(args, binary_hash);
@@ -347,6 +351,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], script, None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let rtx = ResolvedTransaction {
@@ -396,6 +401,7 @@ mod tests {
         let dep_cell = CellMeta {
             cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let script = Script::new(args, binary_hash);
@@ -410,6 +416,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], script, None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let rtx = ResolvedTransaction {
@@ -466,6 +473,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], script, None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let rtx = ResolvedTransaction {
@@ -511,6 +519,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let script = Script::new(args, (&blake2b_256(&buffer)).into());
@@ -525,6 +534,7 @@ mod tests {
         let dep_cell = CellMeta {
             cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let transaction = TransactionBuilder::default()
@@ -578,6 +588,7 @@ mod tests {
         let dummy_cell = CellMeta {
             cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let script = Script::new(args, (&blake2b_256(&buffer)).into());
@@ -587,6 +598,7 @@ mod tests {
         let dep_cell = CellMeta {
             cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
             block_number: Some(1),
+            cellbase: false,
         };
 
         let transaction = TransactionBuilder::default()

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -223,8 +223,13 @@ impl<CS: ChainStore> ChainState<CS> {
         match ret {
             Some(cycles) => Ok(cycles),
             None => {
-                let cycles =
-                    TransactionVerifier::new(&rtx, &self, self.tip_number()).verify(max_cycles)?;
+                let cycles = TransactionVerifier::new(
+                    &rtx,
+                    &self,
+                    self.tip_number(),
+                    self.consensus().cellbase_maturity,
+                )
+                .verify(max_cycles)?;
                 // write cache
                 self.txs_verify_cache.borrow_mut().insert(tx_hash, cycles);
                 Ok(cycles)
@@ -429,6 +434,7 @@ impl<CS: ChainStore> CellProvider for ChainState<CS> {
                     CellStatus::Live(CellMeta {
                         cell_output: tx.outputs()[out_point.index as usize].clone(),
                         block_number: Some(tx_meta.block_number()),
+                        cellbase: tx_meta.is_cellbase(),
                     })
                 }
             }

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -225,6 +225,7 @@ impl CellProvider for StagingPool {
                 CellStatus::Live(CellMeta {
                     cell_output: self.get_output(o).expect("output"),
                     block_number: None,
+                    cellbase: false,
                 })
             }
         } else if self.edges.get_outer(o).is_some() {

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -114,6 +114,11 @@ impl Consensus {
         self
     }
 
+    pub fn set_cellbase_maturity(mut self, cellbase_maturity: usize) -> Self {
+        self.cellbase_maturity = cellbase_maturity;
+        self
+    }
+
     pub fn genesis_block(&self) -> &Block {
         &self.genesis_block
     }

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -81,7 +81,8 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
             Err(PoolError::InvalidTx(TransactionError::UnknownInput))
             | Err(PoolError::InvalidTx(TransactionError::Conflict))
             | Err(PoolError::Duplicate)
-            | Err(PoolError::InvalidTx(TransactionError::Immature)) => {
+            | Err(PoolError::InvalidTx(TransactionError::Immature))
+            | Err(PoolError::InvalidTx(TransactionError::CellbaseImmaturity)) => {
                 // this error may occured when peer's tip is different with us,
                 // we can't proof peer is bad so just ignore this
                 debug!(target: "relay", "peer {} relay a conflict or missing input tx: {:?}", self.peer, tx);

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -339,7 +339,9 @@ fn setup_node(
             .timestamp(unix_time_as_millis())
             .difficulty(U256::from(1000u64)),
     );
-    let consensus = Consensus::default().set_genesis_block(block.clone());
+    let consensus = Consensus::default()
+        .set_genesis_block(block.clone())
+        .set_cellbase_maturity(0);
 
     let shared = SharedBuilder::<MemoryKeyValueDB>::new()
         .consensus(consensus)

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -353,6 +353,7 @@ impl TransactionsVerifier {
         block_reward: Capacity,
         block_median_time_context: M,
         tip_number: BlockNumber,
+        cellbase_maturity: usize,
     ) -> Result<(), Error>
     where
         M: BlockMedianTimeContext + Sync,
@@ -377,10 +378,15 @@ impl TransactionsVerifier {
                         .map_err(|e| Error::Transactions((index, e)))
                         .map(|_| (None, *cycles))
                 } else {
-                    TransactionVerifier::new(&tx, &block_median_time_context, tip_number)
-                        .verify(self.max_cycles)
-                        .map_err(|e| Error::Transactions((index, e)))
-                        .map(|cycles| (Some(tx.transaction.hash()), cycles))
+                    TransactionVerifier::new(
+                        &tx,
+                        &block_median_time_context,
+                        tip_number,
+                        cellbase_maturity,
+                    )
+                    .verify(self.max_cycles)
+                    .map_err(|e| Error::Transactions((index, e)))
+                    .map(|cycles| (Some(tx.transaction.hash()), cycles))
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -148,4 +148,5 @@ pub enum TransactionError {
     Immature,
     /// Invalid ValidSince flags
     InvalidValidSince,
+    CellbaseImmaturity,
 }


### PR DESCRIPTION
#367 

> Updated,
> https://github.com/nervosnetwork/ckb/pull/367/files#diff-b2197becbc6452c42618e284e3dbf52eR226
> But I am not sure whether the cellbase_maturity and cell_set are correct, because the `max_cycles` coming from the function params, and the `cellbase_maturity` coming from the `self.consensus`.

> 
> @jjyr is going to take a look at this PR.@quake Do you prefer to merge it after your store refactoring, or it doesn't matter.

> Please rebase this PR to latest develop and ensure:
> 
> Make this a configurable option in chain spec.
> Only enable it in testnet chain spec. Disable it in dev and integration.