### PR TITLE
feat: add parameters to control the block generation rate in dummy mode

### DIFF
--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -604,7 +604,8 @@ mod tests {
         let resolver = HeaderResolverWrapper::new(block.header(), shared.clone());
         let header_verify_result = {
             let chain_state = shared.chain_state().lock();
-            let header_verifier = HeaderVerifier::new(&*chain_state, Pow::Dummy.engine());
+            let header_verifier =
+                HeaderVerifier::new(&*chain_state, Pow::Dummy(Default::default()).engine());
             header_verifier.verify(&resolver)
         };
         assert!(header_verify_result.is_ok());

--- a/pow/src/dummy.rs
+++ b/pow/src/dummy.rs
@@ -1,19 +1,96 @@
 use super::PowEngine;
 use ckb_core::header::{BlockNumber, Header, RawHeader, Seal};
-use rand::{thread_rng, Rng};
-use std::{thread, time};
+use rand::{
+    distributions::{self as dist, Distribution as _},
+    thread_rng,
+};
+use serde_derive::Deserialize;
+use std::{fmt, thread, time};
 
-#[derive(Copy, Clone)]
-pub struct DummyPowEngine {}
+#[derive(Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+pub struct DummyPowParams {
+    // Delay offset (in milliseconds)
+    #[serde(default)]
+    delay: Distribution,
+}
 
-impl DummyPowEngine {
-    pub fn new() -> Self {
-        DummyPowEngine {}
+impl fmt::Display for DummyPowParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(delay: {:?})", self.delay)
     }
 }
+
+impl DummyPowParams {
+    fn gen_delay(&self) -> DummyPowDelay {
+        match self.delay {
+            Distribution::Constant { value } => DummyPowDelay::Constant(value),
+            Distribution::Uniform { low, high } => {
+                DummyPowDelay::Uniform(dist::Uniform::new(low, high))
+            }
+            Distribution::Normal { mean, std_dev } => {
+                DummyPowDelay::Normal(dist::Normal::new(mean as f64, std_dev as f64))
+            }
+            Distribution::Poisson { lambda } => {
+                DummyPowDelay::Poisson(dist::Poisson::new(lambda as f64))
+            }
+        }
+    }
+}
+
+// TODO Enhance: we can add more distributions to mock POW
+// Ref: https://docs.rs/rand/latest/rand/distributions/index.html
+#[derive(Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Distribution {
+    Constant { value: u64 },
+    Uniform { low: u64, high: u64 },
+    Normal { mean: u64, std_dev: u64 },
+    Poisson { lambda: u64 },
+}
+
+impl Default for Distribution {
+    fn default() -> Self {
+        Distribution::Constant { value: 5000 }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum DummyPowDelay {
+    Constant(u64),
+    Uniform(dist::Uniform<u64>),
+    Normal(dist::Normal),
+    Poisson(dist::Poisson),
+}
+
+impl DummyPowDelay {
+    fn duration(&self) -> time::Duration {
+        let mut rng = thread_rng();
+        let millis = match self {
+            DummyPowDelay::Constant(v) => *v,
+            DummyPowDelay::Uniform(ref d) => d.sample(&mut rng),
+            DummyPowDelay::Normal(ref d) => d.sample(&mut rng) as u64,
+            DummyPowDelay::Poisson(ref d) => d.sample(&mut rng),
+        };
+        time::Duration::from_millis(millis)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyPowEngine {
+    delay: DummyPowDelay,
+}
+
+impl DummyPowEngine {
+    pub fn new(params: DummyPowParams) -> Self {
+        let delay = params.gen_delay();
+        DummyPowEngine { delay }
+    }
+}
+
 impl Default for DummyPowEngine {
     fn default() -> Self {
-        Self::new()
+        let params = DummyPowParams::default();
+        Self::new(params)
     }
 }
 
@@ -26,9 +103,7 @@ impl PowEngine for DummyPowEngine {
 
     fn solve_header(&self, _header: &RawHeader, nonce: u64) -> Option<Seal> {
         // Sleep for some time before returning result to miner
-        let seconds = thread_rng().gen_range(5, 20);
-        let duration = time::Duration::from_secs(seconds);
-        thread::sleep(duration);
+        thread::sleep(self.delay.duration());
         Some(Seal::new(nonce, vec![]))
     }
 

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -11,19 +11,19 @@ mod cuckoo;
 mod dummy;
 
 pub use crate::cuckoo::{Cuckoo, CuckooEngine, CuckooParams};
-pub use crate::dummy::DummyPowEngine;
+pub use crate::dummy::{DummyPowEngine, DummyPowParams};
 
 #[derive(Clone, Deserialize, Eq, PartialEq, Hash, Debug)]
 #[serde(tag = "func", content = "params")]
 pub enum Pow {
-    Dummy,
+    Dummy(DummyPowParams),
     Cuckoo(CuckooParams),
 }
 
 impl fmt::Display for Pow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Pow::Dummy => write!(f, "Dummy"),
+            Pow::Dummy(params) => write!(f, "Dummy{}", params),
             Pow::Cuckoo(params) => write!(f, "Cuckoo{}", params),
         }
     }
@@ -32,7 +32,7 @@ impl fmt::Display for Pow {
 impl Pow {
     pub fn engine(&self) -> Arc<dyn PowEngine> {
         match *self {
-            Pow::Dummy => Arc::new(DummyPowEngine::new()),
+            Pow::Dummy(params) => Arc::new(DummyPowEngine::new(params)),
             Pow::Cuckoo(params) => Arc::new(CuckooEngine::new(params)),
         }
     }

--- a/resource/specs/integration.toml
+++ b/resource/specs/integration.toml
@@ -21,6 +21,11 @@ cellbase_maturity = 0
 [pow]
 func = "Dummy"
 
+# Delay offset (in milliseconds)
+[pow.params.delay]
+type = "constant"
+value = 5000
+
 # An array list paths to system cell files, which is absolute or relative to
 # the directory containing this config file.
 [[system_cells]]

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -78,7 +78,7 @@ impl Default for Consensus {
             pow_time_span: POW_TIME_SPAN,
             pow_spacing: POW_SPACING,
             tx_proposal_window: TX_PROPOSAL_WINDOW,
-            pow: Pow::Dummy,
+            pow: Pow::Dummy(Default::default()),
             cellbase_maturity: CELLBASE_MATURITY,
             median_time_block_count: MEDIAN_TIME_BLOCK_COUNT,
             max_block_cycles: MAX_BLOCK_CYCLES,


### PR DESCRIPTION
When I do tests in my laptop, the speed of product block is too slow.

Ref: #389