### PR TITLE
hotfix: fix VM hang bug for certain invalid programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-core 0.9.0-pre",
  "ckb-protocol 0.9.0-pre",
- "ckb-vm 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=d4638be)",
+ "ckb-vm 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=9a74ffe)",
  "crypto 0.9.0-pre",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "ckb-vm"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/ckb-vm?rev=d4638be#d4638be0a211d9213756cd8e359db4f67bddf12d"
+source = "git+https://github.com/nervosnetwork/ckb-vm?rev=9a74ffe#9a74ffe912ca3b05147858d06b17c13868cfec38"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3529,7 +3529,7 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum ckb-vm 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=d4638be)" = "<none>"
+"checksum ckb-vm 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=9a74ffe)" = "<none>"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -11,7 +11,7 @@ byteorder = "1.3.1"
 crypto = {path = "../util/crypto"}
 ckb-core = { path = "../core" }
 hash = {path = "../util/hash"}
-ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "d4638be" }
+ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "9a74ffe" }
 faster-hex = "0.3"
 fnv = "1.0.3"
 flatbuffers = "0.5.0"


### PR DESCRIPTION
This is a hotfix for VM bug fixed at here: https://github.com/nervosnetwork/ckb-vm/pull/47

Since it would result in CKB hanging there forever, it's better we handle this earlier as a hotfix than next VM upgrade.