### PR TITLE
refactor: CellProvider

### DIFF
--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -244,7 +244,7 @@ fn test_transaction_conflict_in_same_block() {
             .expect("process block ok");
     }
     assert_eq!(
-        SharedError::InvalidTransaction("Transactions((2, Conflict))".to_string()),
+        SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
         chain_controller
             .process_block(Arc::new(chain[3].clone()))
             .unwrap_err()

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -91,7 +91,7 @@ fn test_dead_cell_in_same_block() {
     }
 
     assert_eq!(
-        SharedError::InvalidTransaction("Transactions((2, Conflict))".to_string()),
+        SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
         chain_controller
             .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
             .unwrap_err()

--- a/shared/src/tests/cell_set.rs
+++ b/shared/src/tests/cell_set.rs
@@ -3,10 +3,9 @@ use crate::{
     shared::{Shared, SharedBuilder},
     store::ChainKVStore,
 };
-use ckb_core::cell::{resolve_transaction, CellStatus, LiveCell};
+use ckb_core::cell::{CellProvider, CellStatus, LiveCell};
 use ckb_core::transaction::Transaction;
 use ckb_db::memorydb::MemoryKeyValueDB;
-use fnv::FnvHashSet;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -51,12 +50,9 @@ fn case_no1() {
     let cell_set_overlay = chain_state.new_cell_set_overlay(&cell_set_diff);
 
     let transcations = transcations();
-    // let cell_provider = OverlayCellProvider::new(&overlay, &cell_set);
-
-    let mut seen_inputs = FnvHashSet::default();
 
     //Outpoint::null should be live
-    let rtx0 = resolve_transaction(&transcations[0], &mut seen_inputs, &cell_set_overlay);
+    let rtx0 = cell_set_overlay.resolve_transaction(&transcations[0]);
     assert_eq!(rtx0.input_cells[0], CellStatus::Live(LiveCell::Null));
 
     let out_point = transcations[1].inputs()[0].previous_output.clone();


### PR DESCRIPTION
This refactor PR removes `OutPoint` clone which was required by `seen_inputs` HashMap, and also fixed the bug which has been resolved in testnet by https://github.com/nervosnetwork/ckb/pull/516