### PR TITLE
feat: capacity uses unit shannon which is 10e-8 CKBytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,6 @@ dependencies = [
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "occupied-capacity 0.11.0-pre",
- "occupied-capacity-derive 0.11.0-pre",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,6 @@ dependencies = [
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "occupied-capacity 0.11.0-pre",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "stop-handler 0.11.0-pre",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,14 +1950,26 @@ dependencies = [
 name = "occupied-capacity"
 version = "0.11.0-pre"
 dependencies = [
- "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "occupied-capacity-derive 0.11.0-pre",
+ "occupied-capacity-core 0.11.0-pre",
+ "occupied-capacity-macros 0.11.0-pre",
+ "proc-macro-hack 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "occupied-capacity-derive"
+name = "occupied-capacity-core"
 version = "0.11.0-pre"
 dependencies = [
+ "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "occupied-capacity-macros"
+version = "0.11.0-pre"
+dependencies = [
+ "occupied-capacity-core 0.11.0-pre",
+ "proc-macro-hack 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -6,6 +6,7 @@ use ckb_core::script::Script;
 use ckb_core::transaction::{
     CellInput, CellOutput, OutPoint, ProposalShortId, Transaction, TransactionBuilder,
 };
+use ckb_core::{capacity_bytes, Capacity};
 use ckb_db::{CacheDB, DBConfig, RocksDB};
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
@@ -135,7 +136,12 @@ fn new_chain() -> (
 ) {
     let cellbase = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(0))
-        .output(CellOutput::new(0, vec![], Script::default(), None))
+        .output(CellOutput::new(
+            Capacity::zero(),
+            vec![],
+            Script::default(),
+            None,
+        ))
         .build();
 
     // create genesis block with 100 tx
@@ -144,7 +150,7 @@ fn new_chain() -> (
             TransactionBuilder::default()
                 .input(CellInput::new(OutPoint::null(), 0, vec![]))
                 .output(CellOutput::new(
-                    50000,
+                    capacity_bytes!(50_000),
                     vec![i],
                     Script::always_success(),
                     None,
@@ -184,7 +190,12 @@ fn gen_block(blocks: &mut Vec<Block>, parent_index: usize) {
 
     let cellbase = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
-        .output(CellOutput::new(0, vec![], Script::default(), None))
+        .output(CellOutput::new(
+            Capacity::zero(),
+            vec![],
+            Script::default(),
+            None,
+        ))
         .build();
 
     // spent n-2 block's tx and proposal n-1 block's tx
@@ -226,7 +237,7 @@ fn gen_block(blocks: &mut Vec<Block>, parent_index: usize) {
 fn create_transaction(hash: H256) -> Transaction {
     TransactionBuilder::default()
         .output(CellOutput::new(
-            50000,
+            capacity_bytes!(50_000),
             vec![],
             Script::always_success(),
             None,

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -28,3 +28,4 @@ hash = {path = "../util/hash"}
 [dev-dependencies]
 env_logger = "0.6"
 tempfile = "3.0"
+regex = "1"

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -243,14 +243,17 @@ fn test_transaction_conflict_in_same_block() {
             .process_block(Arc::new(block.clone()))
             .expect("process block ok");
     }
-    assert_eq!(
-        SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
-        chain_controller
-            .process_block(Arc::new(chain[3].clone()))
-            .unwrap_err()
-            .downcast()
-            .unwrap()
-    );
+    let error = chain_controller
+        .process_block(Arc::new(chain[3].clone()))
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    if let SharedError::InvalidTransaction(errmsg) = error {
+        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
+        assert!(re.is_match(&errmsg));
+    } else {
+        panic!("should be the Conflict Transactions error");
+    }
 }
 
 #[test]
@@ -331,14 +334,17 @@ fn test_transaction_conflict_in_different_blocks() {
             .process_block(Arc::new(block.clone()))
             .expect("process block ok");
     }
-    assert_eq!(
-        SharedError::InvalidTransaction("Transactions((0, Conflict))".to_string()),
-        chain_controller
-            .process_block(Arc::new(chain[4].clone()))
-            .unwrap_err()
-            .downcast()
-            .unwrap()
-    );
+    let error = chain_controller
+        .process_block(Arc::new(chain[4].clone()))
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    if let SharedError::InvalidTransaction(errmsg) = error {
+        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
+        assert!(re.is_match(&errmsg));
+    } else {
+        panic!("should be the Conflict Transactions error");
+    }
 }
 
 #[test]

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -6,6 +6,7 @@ use ckb_core::cell::{CellProvider, CellStatus};
 use ckb_core::header::HeaderBuilder;
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
+use ckb_core::{capacity_bytes, Capacity};
 use ckb_shared::error::SharedError;
 use ckb_traits::ChainProvider;
 use numext_fixed_uint::U256;
@@ -17,7 +18,7 @@ fn test_genesis_transaction_spend() {
         .input(CellInput::new(OutPoint::null(), 0, Default::default()))
         .outputs(vec![
             CellOutput::new(
-                100_000_000,
+                capacity_bytes!(100_000_000),
                 vec![],
                 Script::default(),
                 None
@@ -353,7 +354,7 @@ fn test_genesis_transaction_fetch() {
         .input(CellInput::new(OutPoint::null(), 0, Default::default()))
         .outputs(vec![
             CellOutput::new(
-                100_000_000,
+                capacity_bytes!(100_000_000),
                 vec![],
                 Script::default(),
                 None

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -90,14 +90,17 @@ fn test_dead_cell_in_same_block() {
             .expect("process block ok");
     }
 
-    assert_eq!(
-        SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
-        chain_controller
-            .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
-            .unwrap_err()
-            .downcast()
-            .unwrap()
-    );
+    let error = chain_controller
+        .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    if let SharedError::InvalidTransaction(errmsg) = error {
+        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
+        assert!(re.is_match(&errmsg));
+    } else {
+        panic!("should be the Conflict Transactions error");
+    }
 }
 
 #[test]
@@ -192,12 +195,15 @@ fn test_dead_cell_in_different_block() {
             .expect("process block ok");
     }
 
-    assert_eq!(
-        SharedError::InvalidTransaction("Transactions((0, Conflict))".to_string()),
-        chain_controller
-            .process_block(Arc::new(chain2[switch_fork_number + 2].clone()))
-            .unwrap_err()
-            .downcast()
-            .unwrap()
-    );
+    let error = chain_controller
+        .process_block(Arc::new(chain2[switch_fork_number + 2].clone()))
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    if let SharedError::InvalidTransaction(errmsg) = error {
+        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
+        assert!(re.is_match(&errmsg));
+    } else {
+        panic!("should be the Conflict Transactions error");
+    }
 }

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -6,7 +6,7 @@ use ckb_core::header::{Header, HeaderBuilder};
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
 use ckb_core::uncle::UncleBlock;
-use ckb_core::BlockNumber;
+use ckb_core::{capacity_bytes, BlockNumber, Capacity};
 use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::Shared;
@@ -37,7 +37,7 @@ fn create_cellbase(number: BlockNumber) -> Transaction {
     TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
         .output(CellOutput::new(
-            5000,
+            capacity_bytes!(5000),
             vec![],
             Script::always_success(),
             None,
@@ -76,7 +76,7 @@ pub(crate) fn gen_block(
 pub(crate) fn create_transaction(parent: H256, unique_data: u8) -> Transaction {
     TransactionBuilder::default()
         .output(CellOutput::new(
-            5000,
+            capacity_bytes!(5000),
             vec![unique_data],
             Script::always_success(),
             None,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heap
 hash = {path = "../util/hash"}
 crypto = {path = "../util/crypto"}
 occupied-capacity = {path = "../util/occupied-capacity"}
-occupied-capacity-derive = {path = "../util/occupied-capacity-derive"}
 bit-vec = "0.5.1"
 crossbeam-channel = "0.3"
 ckb-util = { path = "../util" }

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -295,6 +295,7 @@ impl ResolvedTransaction {
 mod tests {
     use super::super::script::Script;
     use super::*;
+    use crate::{capacity_bytes, Capacity};
     use numext_fixed_hash::H256;
     use std::collections::HashMap;
 
@@ -332,7 +333,7 @@ mod tests {
         let o = CellMeta {
             block_number: Some(1),
             cell_output: CellOutput {
-                capacity: 2,
+                capacity: capacity_bytes!(2),
                 data: vec![],
                 lock: Script::default(),
                 type_: None,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,8 +16,8 @@ pub mod uncle;
 
 pub use crate::error::Error;
 
+pub use occupied_capacity::{capacity_bytes, Capacity};
 pub type PublicKey = numext_fixed_hash::H512;
 pub type BlockNumber = u64;
-pub type Capacity = u64;
 pub type Cycle = u64;
 pub type Version = u32;

--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -83,9 +83,16 @@ mod tests {
         let expect = h256!("0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21");
         assert_eq!(script.hash(), expect);
 
-        let expect_occupied_capacity =
-            script.args.occupied_capacity() + script.binary_hash.occupied_capacity();
-        assert_eq!(script.occupied_capacity(), expect_occupied_capacity);
+        let expect_occupied_capacity = script
+            .args
+            .occupied_capacity()
+            .unwrap()
+            .safe_add(script.binary_hash.occupied_capacity().unwrap())
+            .unwrap();
+        assert_eq!(
+            script.occupied_capacity().unwrap(),
+            expect_occupied_capacity
+        );
     }
 
     #[test]
@@ -97,19 +104,33 @@ mod tests {
         let expect = h256!("0x9a9a6bdbc38d4905eace1822f85237e3a1e238bb3f277aa7b7c8903441123510");
         assert_eq!(script.hash(), expect);
 
-        let expect_occupied_capacity =
-            script.args.occupied_capacity() + script.binary_hash.occupied_capacity();
-        assert_eq!(script.occupied_capacity(), expect_occupied_capacity);
+        let expect_occupied_capacity = script
+            .args
+            .occupied_capacity()
+            .unwrap()
+            .safe_add(script.binary_hash.occupied_capacity().unwrap())
+            .unwrap();
+        assert_eq!(
+            script.occupied_capacity().unwrap(),
+            expect_occupied_capacity
+        );
     }
 
     #[test]
     fn one_script_hash() {
-        let one = Script::new(vec![vec![1]], H256::zero());
+        let script = Script::new(vec![vec![1]], H256::zero());
         let expect = h256!("0xdade0e507e27e2a5995cf39c8cf454b6e70fa80d03c1187db7a4cb2c9eab79da");
-        assert_eq!(one.hash(), expect);
+        assert_eq!(script.hash(), expect);
 
-        let expect_occupied_capacity =
-            one.args.occupied_capacity() + one.binary_hash.occupied_capacity();
-        assert_eq!(one.occupied_capacity(), expect_occupied_capacity);
+        let expect_occupied_capacity = script
+            .args
+            .occupied_capacity()
+            .unwrap()
+            .safe_add(script.binary_hash.occupied_capacity().unwrap())
+            .unwrap();
+        assert_eq!(
+            script.occupied_capacity().unwrap(),
+            expect_occupied_capacity
+        );
     }
 }

--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -1,7 +1,7 @@
 use faster_hex::hex_encode;
 use hash::blake2b_256;
 use numext_fixed_hash::{h256, H256};
-use occupied_capacity_derive::OccupiedCapacity;
+use occupied_capacity::HasOccupiedCapacity;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::io::Write;
@@ -10,7 +10,7 @@ pub const ALWAYS_SUCCESS_HASH: H256 = h256!("0x1");
 
 // TODO: when flatbuffer work is done, remove Serialize/Deserialize here and
 // implement proper From trait
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, OccupiedCapacity)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, HasOccupiedCapacity)]
 pub struct Script {
     pub args: Vec<Vec<u8>>,
     // Binary hash here can be used to refer to binary in one of the dep

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -440,11 +440,11 @@ mod test {
 
         assert_eq!(
             format!("{:x}", tx.hash()),
-            "a896bfe8c8439305f099e1f07b47844ba0a5a27ec1e26ec25b236fa7e4831115"
+            "a2cfcbc6b5f4d153ea90b6e203b14f7ab1ead6eab61450f88203e414a7e68c2c"
         );
         assert_eq!(
             format!("{:x}", tx.witness_hash()),
-            "3f08580e373cad9a828173efe614ce3a8310957351c77f2859a18fc49d4cd227"
+            "4bb6ed9e544f5609749cfaa91f315adc7facecbe18b0d507330ed070fb2a4247"
         );
     }
 }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -257,8 +257,11 @@ impl Transaction {
         self.outputs.get(i).cloned()
     }
 
-    pub fn outputs_capacity(&self) -> Capacity {
-        self.outputs.iter().map(|output| output.capacity).sum()
+    pub fn outputs_capacity(&self) -> ::occupied_capacity::Result<Capacity> {
+        self.outputs
+            .iter()
+            .map(|output| output.capacity)
+            .try_fold(Capacity::zero(), Capacity::safe_add)
     }
 }
 

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -423,12 +423,13 @@ impl ProposalShortId {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{capacity_bytes, Capacity};
 
     #[test]
     fn test_tx_hash() {
         let tx = TransactionBuilder::default()
             .output(CellOutput::new(
-                5000,
+                capacity_bytes!(5000),
                 vec![1, 2, 3],
                 Script::default(),
                 None,

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -7,7 +7,7 @@ use bincode::{deserialize, serialize};
 use faster_hex::hex_string;
 use hash::blake2b_256;
 use numext_fixed_hash::H256;
-use occupied_capacity::OccupiedCapacity;
+use occupied_capacity::HasOccupiedCapacity;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -15,7 +15,7 @@ use std::ops::{Deref, DerefMut};
 
 pub const TX_VERSION: Version = 0;
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, OccupiedCapacity)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, HasOccupiedCapacity)]
 pub struct OutPoint {
     // Hash of Transaction
     pub hash: H256,
@@ -60,7 +60,9 @@ impl OutPoint {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, OccupiedCapacity)]
+#[derive(
+    Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, HasOccupiedCapacity,
+)]
 pub struct CellInput {
     pub previous_output: OutPoint,
     pub valid_since: u64,
@@ -96,7 +98,7 @@ impl CellInput {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, OccupiedCapacity)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, HasOccupiedCapacity)]
 pub struct CellOutput {
     pub capacity: Capacity,
     #[serde(with = "serde_bytes")]
@@ -147,7 +149,7 @@ impl CellOutput {
 
 pub type Witness = Vec<Vec<u8>>;
 
-#[derive(Clone, Serialize, Deserialize, Eq, Debug, Default, OccupiedCapacity)]
+#[derive(Clone, Serialize, Deserialize, Eq, Debug, Default, HasOccupiedCapacity)]
 pub struct Transaction {
     version: Version,
     deps: Vec<OutPoint>,

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -491,7 +491,7 @@ mod tests {
     use ckb_core::transaction::{
         CellInput, CellOutput, ProposalShortId, Transaction, TransactionBuilder,
     };
-    use ckb_core::BlockNumber;
+    use ckb_core::{BlockNumber, Capacity};
     use ckb_db::memorydb::MemoryKeyValueDB;
     use ckb_notify::{NotifyController, NotifyService};
     use ckb_pow::Pow;
@@ -635,7 +635,12 @@ mod tests {
     fn create_cellbase(number: BlockNumber) -> Transaction {
         TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))
-            .output(CellOutput::new(0, vec![], Script::default(), None))
+            .output(CellOutput::new(
+                Capacity::zero(),
+                vec![],
+                Script::default(),
+                None,
+            ))
             .build()
     }
 

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -206,7 +206,7 @@ impl<'a> FbsCellOutput<'a> {
         let lock = FbsScript::build(fbb, &cell_output.lock);
         let type_ = cell_output.type_.as_ref().map(|s| FbsScript::build(fbb, s));
         let mut builder = CellOutputBuilder::new(fbb);
-        builder.add_capacity(cell_output.capacity);
+        builder.add_capacity(cell_output.capacity.as_u64());
         builder.add_data(data);
         builder.add_lock(lock);
         if let Some(s) = type_ {

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -297,7 +297,7 @@ impl<'a> TryFrom<ckb_protocol::CellOutput<'a>> for ckb_core::transaction::CellOu
         };
 
         Ok(ckb_core::transaction::CellOutput {
-            capacity: cell_output.capacity(),
+            capacity: ckb_core::Capacity::shannons(cell_output.capacity()),
             data: cast!(cell_output.data().and_then(|s| s.seq()))?.to_vec(),
             lock: TryInto::try_into(lock)?,
             type_,

--- a/script/src/syscalls/builder.rs
+++ b/script/src/syscalls/builder.rs
@@ -43,7 +43,7 @@ fn build_output<'b>(
     output: &CellOutput,
 ) -> WIPOffset<FbsCellOutput<'b>> {
     let mut builder = CellOutputBuilder::new(fbb);
-    builder.add_capacity(output.capacity);
+    builder.add_capacity(output.capacity.as_u64());
     builder.finish()
 }
 

--- a/script/src/syscalls/load_cell_by_field.rs
+++ b/script/src/syscalls/load_cell_by_field.rs
@@ -65,7 +65,7 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for LoadCellByField<'a> {
         let (return_code, data_length) = match field {
             CellField::Capacity => {
                 let mut buffer = vec![];
-                buffer.write_u64::<LittleEndian>(cell.capacity)?;
+                buffer.write_u64::<LittleEndian>(cell.capacity.as_u64())?;
                 store_data(machine, &buffer)?;
                 (SUCCESS, buffer.len())
             }

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -92,6 +92,7 @@ mod tests {
     use byteorder::{LittleEndian, WriteBytesExt};
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, OutPoint};
+    use ckb_core::{capacity_bytes, Capacity};
     use ckb_protocol::{
         Bytes as FbsBytes, CellInputBuilder, CellOutput as FbsCellOutput, OutPoint as FbsOutPoint,
     };
@@ -231,9 +232,9 @@ mod tests {
             .store64(&size_addr, &(data.len() as u64))
             .is_ok());
 
-        let output = CellOutput::new(100, data.to_vec(), Script::default(), None);
+        let output = CellOutput::new(capacity_bytes!(100), data.to_vec(), Script::default(), None);
         let input_cell = CellOutput::new(
-            100,
+            capacity_bytes!(100),
             data.iter().rev().cloned().collect(),
             Script::default(),
             None,
@@ -267,9 +268,9 @@ mod tests {
         machine.set_register(A4, Source::Input as u64); //source: 1 input
         machine.set_register(A7, LOAD_CELL_SYSCALL_NUMBER); // syscall number
 
-        let output = CellOutput::new(100, data.to_vec(), Script::default(), None);
+        let output = CellOutput::new(capacity_bytes!(100), data.to_vec(), Script::default(), None);
         let input_cell = CellOutput::new(
-            100,
+            capacity_bytes!(100),
             data.iter().rev().cloned().collect(),
             Script::default(),
             None,
@@ -358,9 +359,9 @@ mod tests {
         machine.set_register(A4, Source::Input as u64); //source: 1 input
         machine.set_register(A7, LOAD_CELL_SYSCALL_NUMBER); // syscall number
 
-        let output = CellOutput::new(100, data.to_vec(), Script::default(), None);
+        let output = CellOutput::new(capacity_bytes!(100), data.to_vec(), Script::default(), None);
         let input_cell = CellOutput::new(
-            100,
+            capacity_bytes!(100),
             data.iter().rev().cloned().collect(),
             Script::default(),
             None,
@@ -407,9 +408,9 @@ mod tests {
         machine.set_register(A4, Source::Input as u64); // source: 1 input
         machine.set_register(A7, LOAD_CELL_SYSCALL_NUMBER); // syscall number
 
-        let output = CellOutput::new(100, data.to_vec(), Script::default(), None);
+        let output = CellOutput::new(capacity_bytes!(100), data.to_vec(), Script::default(), None);
         let input_cell = CellOutput::new(
-            100,
+            capacity_bytes!(100),
             data.iter().rev().cloned().collect(),
             Script::default(),
             None,
@@ -461,7 +462,7 @@ mod tests {
         machine.set_register(A7, LOAD_CELL_SYSCALL_NUMBER); // syscall number
 
         let input_cell = CellOutput::new(
-            100,
+            capacity_bytes!(100),
             data.iter().rev().cloned().collect(),
             Script::default(),
             None,
@@ -506,7 +507,7 @@ mod tests {
         }
     }
 
-    fn _test_load_cell_capacity(capacity: u64) -> Result<(), TestCaseError> {
+    fn _test_load_cell_capacity(capacity: Capacity) -> Result<(), TestCaseError> {
         let mut machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::default();
         let size_addr: u64 = 0;
         let addr: u64 = 100;
@@ -533,7 +534,7 @@ mod tests {
         prop_assert_eq!(machine.memory_mut().load64(&size_addr), Ok(8));
 
         let mut buffer = vec![];
-        buffer.write_u64::<LittleEndian>(capacity).unwrap();
+        buffer.write_u64::<LittleEndian>(capacity.as_u64()).unwrap();
 
         for (i, addr) in (addr..addr + buffer.len() as u64).enumerate() {
             prop_assert_eq!(machine.memory_mut().load8(&addr), Ok(u64::from(buffer[i])));
@@ -544,7 +545,7 @@ mod tests {
     proptest! {
         #[test]
         fn test_load_cell_capacity(capacity in any::<u64>()) {
-            _test_load_cell_capacity(capacity)?;
+            _test_load_cell_capacity(Capacity::shannons(capacity))?;
         }
     }
 
@@ -564,7 +565,7 @@ mod tests {
         let script = Script::new(vec![data.to_vec()], H256::zero());
         let h = script.hash();
         let hash = h.as_bytes();
-        let input_cell = CellOutput::new(100, vec![], script, None);
+        let input_cell = CellOutput::new(capacity_bytes!(100), vec![], script, None);
         let outputs = vec![];
         let input_cells = vec![];
         let dep_cells = vec![];
@@ -618,7 +619,7 @@ mod tests {
         machine.set_register(A5, CellField::Type as u64); //field: 4 type
         machine.set_register(A7, LOAD_CELL_BY_FIELD_SYSCALL_NUMBER); // syscall number
 
-        let output_cell = CellOutput::new(100, vec![], Script::default(), None);
+        let output_cell = CellOutput::new(capacity_bytes!(100), vec![], Script::default(), None);
         let outputs = vec![&output_cell];
         let input_cells = vec![];
         let dep_cells = vec![];
@@ -848,8 +849,13 @@ mod tests {
         machine.set_register(A5, CellField::Data as u64); //field: 1 data
         machine.set_register(A7, LOAD_CELL_BY_FIELD_SYSCALL_NUMBER); // syscall number
 
-        let input_cell = CellOutput::new(1000, vec![], Script::default(), None);
-        let dep_cell = CellOutput::new(1000, data.to_vec(), Script::default(), None);
+        let input_cell = CellOutput::new(capacity_bytes!(1000), vec![], Script::default(), None);
+        let dep_cell = CellOutput::new(
+            capacity_bytes!(1000),
+            data.to_vec(),
+            Script::default(),
+            None,
+        );
         let outputs = vec![];
         let input_cells = vec![&input_cell];
         let dep_cells = vec![&dep_cell];
@@ -894,8 +900,13 @@ mod tests {
         machine.set_register(A5, CellField::DataHash as u64); //field: 2 data hash
         machine.set_register(A7, LOAD_CELL_BY_FIELD_SYSCALL_NUMBER); // syscall number
 
-        let input_cell = CellOutput::new(1000, vec![], Script::default(), None);
-        let dep_cell = CellOutput::new(1000, data.to_vec(), Script::default(), None);
+        let input_cell = CellOutput::new(capacity_bytes!(1000), vec![], Script::default(), None);
+        let dep_cell = CellOutput::new(
+            capacity_bytes!(1000),
+            data.to_vec(),
+            Script::default(),
+            None,
+        );
         let outputs = vec![];
         let input_cells = vec![&input_cell];
         let dep_cells = vec![&dep_cell];

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -204,7 +204,7 @@ mod tests {
     use ckb_core::cell::{CellMeta, CellStatus, LiveCell};
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
-    use ckb_core::Capacity;
+    use ckb_core::{capacity_bytes, Capacity};
     use crypto::secp::Generator;
     use faster_hex::hex_encode;
     use hash::{blake2b_256, sha3_256};
@@ -220,7 +220,12 @@ mod tests {
     #[test]
     fn check_always_success_hash() {
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
+            cell_output: CellOutput::new(
+                capacity_bytes!(100),
+                vec![],
+                Script::always_success(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
@@ -271,7 +276,12 @@ mod tests {
         let binary_hash: H256 = (&blake2b_256(&buffer)).into();
         let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellMeta {
-            cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
+            cell_output: CellOutput::new(
+                Capacity::bytes(buffer.len()).unwrap(),
+                buffer,
+                Script::default(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
@@ -286,7 +296,7 @@ mod tests {
             .build();
 
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], script, None),
+            cell_output: CellOutput::new(capacity_bytes!(100), vec![], script, None),
             block_number: Some(1),
             cellbase: false,
         };
@@ -334,7 +344,12 @@ mod tests {
         let binary_hash: H256 = (&blake2b_256(&buffer)).into();
         let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellMeta {
-            cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
+            cell_output: CellOutput::new(
+                Capacity::bytes(buffer.len()).unwrap(),
+                buffer,
+                Script::default(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
@@ -349,7 +364,7 @@ mod tests {
             .build();
 
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], script, None),
+            cell_output: CellOutput::new(capacity_bytes!(100), vec![], script, None),
             block_number: Some(1),
             cellbase: false,
         };
@@ -399,7 +414,12 @@ mod tests {
         let binary_hash: H256 = (&blake2b_256(&buffer)).into();
         let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellMeta {
-            cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
+            cell_output: CellOutput::new(
+                Capacity::bytes(buffer.len()).unwrap(),
+                buffer,
+                Script::default(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
@@ -414,7 +434,7 @@ mod tests {
             .build();
 
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], script, None),
+            cell_output: CellOutput::new(capacity_bytes!(100), vec![], script, None),
             block_number: Some(1),
             cellbase: false,
         };
@@ -471,7 +491,7 @@ mod tests {
             .build();
 
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], script, None),
+            cell_output: CellOutput::new(capacity_bytes!(100), vec![], script, None),
             block_number: Some(1),
             cellbase: false,
         };
@@ -517,14 +537,19 @@ mod tests {
 
         let input = CellInput::new(OutPoint::null(), 0, vec![]);
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
+            cell_output: CellOutput::new(
+                capacity_bytes!(100),
+                vec![],
+                Script::always_success(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
 
         let script = Script::new(args, (&blake2b_256(&buffer)).into());
         let output = CellOutput::new(
-            0,
+            Capacity::zero(),
             Vec::new(),
             Script::new(vec![], H256::zero()),
             Some(script),
@@ -532,7 +557,12 @@ mod tests {
 
         let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellMeta {
-            cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
+            cell_output: CellOutput::new(
+                Capacity::bytes(buffer.len()).unwrap(),
+                buffer,
+                Script::default(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
@@ -586,17 +616,32 @@ mod tests {
 
         let input = CellInput::new(OutPoint::null(), 0, vec![]);
         let dummy_cell = CellMeta {
-            cell_output: CellOutput::new(100, vec![], Script::always_success(), None),
+            cell_output: CellOutput::new(
+                capacity_bytes!(100),
+                vec![],
+                Script::always_success(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };
 
         let script = Script::new(args, (&blake2b_256(&buffer)).into());
-        let output = CellOutput::new(0, Vec::new(), Script::default(), Some(script));
+        let output = CellOutput::new(
+            Capacity::zero(),
+            Vec::new(),
+            Script::default(),
+            Some(script),
+        );
 
         let dep_out_point = OutPoint::new(H256::from_trimmed_hex_str("123").unwrap(), 8);
         let dep_cell = CellMeta {
-            cell_output: CellOutput::new(buffer.len() as Capacity, buffer, Script::default(), None),
+            cell_output: CellOutput::new(
+                Capacity::bytes(buffer.len()).unwrap(),
+                buffer,
+                Script::default(),
+                None,
+            ),
             block_number: Some(1),
             cellbase: false,
         };

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -22,7 +22,6 @@ log = "0.4"
 ckb-traits = { path = "../traits" }
 failure = "0.1.5"
 ckb-verification = { path = "../verification" }
-occupied-capacity = { path = "../util/occupied-capacity" }
 linked-hash-map = { git = "https://github.com/nervosnetwork/linked-hash-map", rev = "df27f21" }
 
 [dev-dependencies]

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -624,6 +624,7 @@ mod tests {
     use super::*;
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, Transaction, TransactionBuilder};
+    use ckb_core::Capacity;
     use numext_fixed_hash::H256;
 
     fn build_tx(inputs: Vec<(H256, u32)>, outputs_len: usize) -> PoolEntry {
@@ -638,7 +639,14 @@ mod tests {
             )
             .outputs(
                 (0..outputs_len)
-                    .map(|i| CellOutput::new((i + 1) as u64, Vec::new(), Script::default(), None))
+                    .map(|i| {
+                        CellOutput::new(
+                            Capacity::bytes(i + 1).unwrap(),
+                            Vec::new(),
+                            Script::default(),
+                            None,
+                        )
+                    })
                     .collect(),
             )
             .build();

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -8,7 +8,6 @@ use ckb_verification::TransactionError;
 use failure::Fail;
 use fnv::{FnvHashMap, FnvHashSet};
 use linked_hash_map::LinkedHashMap;
-use occupied_capacity::OccupiedCapacity;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::fmt;
@@ -95,8 +94,6 @@ pub struct PoolEntry {
     pub transaction: Transaction,
     /// refs count
     pub refs_count: usize,
-    /// Bytes size
-    pub bytes_size: usize,
     /// Cycles
     pub cycles: Option<Cycle>,
 }
@@ -105,7 +102,6 @@ impl PoolEntry {
     /// Create new transaction pool entry
     pub fn new(tx: Transaction, count: usize, cycles: Option<Cycle>) -> PoolEntry {
         PoolEntry {
-            bytes_size: tx.occupied_capacity(),
             transaction: tx,
             refs_count: count,
             cycles,

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -1,12 +1,11 @@
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::HeaderBuilder;
-use ckb_core::transaction::Capacity;
-use ckb_core::{BlockNumber, Cycle, Version};
+use ckb_core::{capacity_bytes, BlockNumber, Capacity, Cycle, Version};
 use ckb_pow::{Pow, PowEngine};
 use numext_fixed_uint::U256;
 use std::sync::Arc;
 
-pub(crate) const DEFAULT_BLOCK_REWARD: Capacity = 5_000;
+pub(crate) const DEFAULT_BLOCK_REWARD: Capacity = capacity_bytes!(5_000);
 pub(crate) const MAX_UNCLE_NUM: usize = 2;
 pub(crate) const MAX_UNCLE_AGE: usize = 6;
 pub(crate) const TX_PROPOSAL_WINDOW: ProposalWindow = ProposalWindow(2, 10);

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -202,7 +202,7 @@ pub mod test {
         // Tx and Output hash will be used in some test cases directly, assert here for convenience
         assert_eq!(
             format!("{:x}", tx.hash()),
-            "913a98b7a6521b879e60a02a2c38ea14355f3e98beb60215e67e2512b6e0a235"
+            "48168c5b2460bfa698f60e67f08df5298b1d43b2da7939a219ffd863e1380d11"
         );
 
         let reference = tx.outputs()[0].data_hash();

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -768,6 +768,7 @@ mod tests {
     use ckb_core::header::{Header, HeaderBuilder};
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, Transaction, TransactionBuilder};
+    use ckb_core::Capacity;
     use ckb_db::memorydb::MemoryKeyValueDB;
     use ckb_network::{
         errors::Error as NetworkError, multiaddr::ToMultiaddr, CKBProtocolContext, Peer, PeerIndex,
@@ -827,7 +828,12 @@ mod tests {
     fn create_cellbase(number: BlockNumber) -> Transaction {
         TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))
-            .output(CellOutput::new(0, vec![], Script::default(), None))
+            .output(CellOutput::new(
+                Capacity::zero(),
+                vec![],
+                Script::default(),
+                None,
+            ))
             .build()
     }
 

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -7,6 +7,7 @@ use ckb_core::block::BlockBuilder;
 use ckb_core::header::HeaderBuilder;
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
+use ckb_core::{capacity_bytes, Capacity};
 use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_network::ProtocolId;
 use ckb_notify::NotifyService;
@@ -55,7 +56,12 @@ fn relay_compact_block_with_one_tx() {
                     0,
                     vec![],
                 ))
-                .output(CellOutput::new(50, Vec::new(), Script::default(), None))
+                .output(CellOutput::new(
+                    capacity_bytes!(50),
+                    Vec::new(),
+                    Script::default(),
+                    None,
+                ))
                 .build();
 
             {
@@ -208,7 +214,12 @@ fn relay_compact_block_with_missing_indexs() {
                             0,
                             vec![],
                         ))
-                        .output(CellOutput::new(50, vec![i], Script::default(), None))
+                        .output(CellOutput::new(
+                            capacity_bytes!(50),
+                            vec![i],
+                            Script::default(),
+                            None,
+                        ))
                         .build()
                 })
                 .collect::<Vec<_>>();
@@ -359,7 +370,14 @@ fn setup_node(
         let timestamp = block.header().timestamp() + 1;
         let difficulty = shared.calculate_difficulty(&block.header()).unwrap();
         let outputs = (0..20)
-            .map(|_| CellOutput::new(50, Vec::new(), Script::always_success(), None))
+            .map(|_| {
+                CellOutput::new(
+                    capacity_bytes!(50),
+                    Vec::new(),
+                    Script::always_success(),
+                    None,
+                )
+            })
             .collect::<Vec<_>>();
         let cellbase = TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -4,7 +4,7 @@ use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::{HeaderBuilder, Seal};
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
-use ckb_core::BlockNumber;
+use ckb_core::{capacity_bytes, BlockNumber, Capacity};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
 use jsonrpc_types::{BlockTemplate, CellbaseTemplate};
 use log::info;
@@ -218,7 +218,12 @@ impl Node {
         let script = Script::always_success();
 
         TransactionBuilder::default()
-            .output(CellOutput::new(50000, vec![], script.clone(), None))
+            .output(CellOutput::new(
+                capacity_bytes!(50_000),
+                vec![],
+                script.clone(),
+                None,
+            ))
             .input(CellInput::new(OutPoint::new(hash, 0), 0, vec![]))
             .build()
     }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -429,6 +429,7 @@ impl TryFrom<Block> for CoreBlock {
 mod tests {
     use super::*;
     use ckb_core::transaction::ProposalShortId as CoreProposalShortId;
+    use ckb_core::Capacity;
     use proptest::{collection::size_range, prelude::*};
 
     fn mock_script(arg: Vec<u8>) -> CoreScript {
@@ -436,7 +437,12 @@ mod tests {
     }
 
     fn mock_cell_output(data: Vec<u8>, arg: Vec<u8>) -> CoreCellOutput {
-        CoreCellOutput::new(0, data, CoreScript::default(), Some(mock_script(arg)))
+        CoreCellOutput::new(
+            Capacity::zero(),
+            data,
+            CoreScript::default(),
+            Some(mock_script(arg)),
+        )
     }
 
     fn mock_cell_input(arg: Vec<u8>) -> CoreCellInput {

--- a/util/occupied-capacity-derive/src/lib.rs
+++ b/util/occupied-capacity-derive/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{
     parse_macro_input, parse_quote, Data, DeriveInput, Fields, GenericParam, Generics, Index,
 };
 
-#[proc_macro_derive(OccupiedCapacity)]
+#[proc_macro_derive(HasOccupiedCapacity)]
 pub fn derive_occupied_capacity(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Parse the input tokens into a syntax tree.
     let input = parse_macro_input!(input as DeriveInput);

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dependencies]
-numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
-occupied-capacity-derive = { path = "../occupied-capacity-derive" }
+occupied-capacity-macros = { path = "macros" }
+occupied-capacity-core = { path = "core" }
+proc-macro-hack = "0.5"

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "occupied-capacity-core"
+version = "0.11.0-pre"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
+serde = "1.0"
+serde_derive = "1.0"

--- a/util/occupied-capacity/core/src/lib.rs
+++ b/util/occupied-capacity/core/src/lib.rs
@@ -1,0 +1,7 @@
+//! Data structure measurement.
+
+mod traits;
+mod units;
+
+pub use traits::OccupiedCapacity;
+pub use units::{Capacity, Error, Result};

--- a/util/occupied-capacity/core/src/traits.rs
+++ b/util/occupied-capacity/core/src/traits.rs
@@ -1,0 +1,73 @@
+use numext_fixed_hash::H256;
+use std::mem;
+
+use crate::{Capacity, Result};
+
+pub trait OccupiedCapacity {
+    /// Measure the occupied capacity of structures
+    fn occupied_capacity(&self) -> Result<Capacity>;
+}
+
+impl<T: OccupiedCapacity> OccupiedCapacity for [T] {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        self.iter()
+            .map(OccupiedCapacity::occupied_capacity)
+            .try_fold(Capacity::zero(), |acc, rhs| {
+                rhs.and_then(|x| acc.safe_add(x))
+            })
+    }
+}
+
+impl<T: OccupiedCapacity> OccupiedCapacity for Option<T> {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        self.as_ref()
+            .map_or(Ok(Capacity::zero()), OccupiedCapacity::occupied_capacity)
+    }
+}
+
+impl<T: OccupiedCapacity> OccupiedCapacity for Vec<T> {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        self.iter()
+            .map(OccupiedCapacity::occupied_capacity)
+            .try_fold(Capacity::zero(), |acc, rhs| {
+                rhs.and_then(|x| acc.safe_add(x))
+            })
+    }
+}
+
+impl OccupiedCapacity for H256 {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        Capacity::bytes(H256::size_of())
+    }
+}
+
+macro_rules! impl_mem_size_of {
+    ($type:ty) => {
+        impl OccupiedCapacity for $type {
+            fn occupied_capacity(&self) -> Result<Capacity> {
+                Capacity::bytes(mem::size_of::<$type>())
+            }
+        }
+    };
+}
+
+// https://github.com/rust-lang/rust/issues/31844#
+// Currently, specialization haven't implemented
+impl OccupiedCapacity for Vec<u8> {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        Capacity::bytes(self.len())
+    }
+}
+
+impl OccupiedCapacity for [u8] {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        Capacity::bytes(self.len())
+    }
+}
+
+// conflicting implementation for `std::vec::Vec<u8>`
+// impl_mem_size_of!(u8);
+impl_mem_size_of!(u32);
+impl_mem_size_of!(u64);
+impl_mem_size_of!(bool);
+impl_mem_size_of!(());

--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -1,12 +1,94 @@
-use serde_derive::{Deserialize, Serialize};
+use serde;
 
 use crate::OccupiedCapacity;
 
 // The inner is the amount of `Shannons`.
-#[derive(
-    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Capacity(u64);
+
+impl serde::Serialize for Capacity {
+    fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("Capacity", &(self.0 / 100_000_000))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Capacity {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_u64(CapacityVisitor)
+    }
+}
+
+struct CapacityVisitor;
+
+impl<'de> serde::de::Visitor<'de> for CapacityVisitor {
+    type Value = Capacity;
+
+    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("an integer between 0 and 2^64")
+    }
+
+    fn visit_u8<E>(self, value: u8) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity(u64::from(value) * 100_000_000))
+    }
+
+    fn visit_u16<E>(self, value: u16) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity(u64::from(value) * 100_000_000))
+    }
+
+    fn visit_u32<E>(self, value: u32) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity(u64::from(value) * 100_000_000))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity(value * 100_000_000))
+    }
+
+    fn visit_i8<E>(self, value: i8) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity((value as u64) * 100_000_000))
+    }
+
+    fn visit_i16<E>(self, value: i16) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity((value as u64) * 100_000_000))
+    }
+
+    fn visit_i32<E>(self, value: i32) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity((value as u64) * 100_000_000))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Capacity((value as u64) * 100_000_000))
+    }
+}
 
 // Be careful: if the inner type of `Capacity` was changed, update this!
 impl OccupiedCapacity for Capacity {

--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -1,0 +1,87 @@
+use serde_derive::{Deserialize, Serialize};
+
+use crate::OccupiedCapacity;
+
+// The inner is the amount of `Shannons`.
+#[derive(
+    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct Capacity(u64);
+
+// Be careful: if the inner type of `Capacity` was changed, update this!
+impl OccupiedCapacity for Capacity {
+    fn occupied_capacity(&self) -> Result<Capacity> {
+        self.0.occupied_capacity()
+    }
+}
+
+// A `Byte` contains how many `Shannons`.
+const BYTE_SHANNONS: u64 = 100_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    Overflow,
+}
+
+impl ::std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "OccupiedCapacity: overflow")
+    }
+}
+
+impl ::std::error::Error for Error {}
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+impl Capacity {
+    pub const fn zero() -> Self {
+        Capacity(0)
+    }
+
+    pub const fn one() -> Self {
+        Capacity(1)
+    }
+
+    pub const fn shannons(val: u64) -> Self {
+        Capacity(val)
+    }
+
+    pub fn bytes(val: usize) -> Result<Self> {
+        (val as u64)
+            .checked_mul(BYTE_SHANNONS)
+            .map(Capacity::shannons)
+            .ok_or(Error::Overflow)
+    }
+
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn safe_add(self, rhs: Self) -> Result<Self> {
+        self.0
+            .checked_add(rhs.0)
+            .map(Capacity::shannons)
+            .ok_or(Error::Overflow)
+    }
+
+    pub fn safe_sub(self, rhs: Self) -> Result<Self> {
+        self.0
+            .checked_sub(rhs.0)
+            .map(Capacity::shannons)
+            .ok_or(Error::Overflow)
+    }
+}
+
+impl ::std::string::ToString for Capacity {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl ::std::str::FromStr for Capacity {
+    type Err = ::std::num::ParseIntError;
+
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+        Ok(Capacity(s.parse::<u64>()?))
+    }
+}

--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -1,94 +1,12 @@
-use serde;
+use serde_derive::{Deserialize, Serialize};
 
 use crate::OccupiedCapacity;
 
 // The inner is the amount of `Shannons`.
-#[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct Capacity(u64);
-
-impl serde::Serialize for Capacity {
-    fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_newtype_struct("Capacity", &(self.0 / 100_000_000))
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Capacity {
-    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_u64(CapacityVisitor)
-    }
-}
-
-struct CapacityVisitor;
-
-impl<'de> serde::de::Visitor<'de> for CapacityVisitor {
-    type Value = Capacity;
-
-    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("an integer between 0 and 2^64")
-    }
-
-    fn visit_u8<E>(self, value: u8) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity(u64::from(value) * 100_000_000))
-    }
-
-    fn visit_u16<E>(self, value: u16) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity(u64::from(value) * 100_000_000))
-    }
-
-    fn visit_u32<E>(self, value: u32) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity(u64::from(value) * 100_000_000))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity(value * 100_000_000))
-    }
-
-    fn visit_i8<E>(self, value: i8) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity((value as u64) * 100_000_000))
-    }
-
-    fn visit_i16<E>(self, value: i16) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity((value as u64) * 100_000_000))
-    }
-
-    fn visit_i32<E>(self, value: i32) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity((value as u64) * 100_000_000))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(Capacity((value as u64) * 100_000_000))
-    }
-}
 
 // Be careful: if the inner type of `Capacity` was changed, update this!
 impl OccupiedCapacity for Capacity {

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "occupied-capacity-derive"
+name = "occupied-capacity-macros"
 version = "0.11.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,3 +11,5 @@ proc-macro = true
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.15"
+proc-macro-hack = "0.5"
+occupied-capacity-core = { path = "../core" }

--- a/util/occupied-capacity/src/lib.rs
+++ b/util/occupied-capacity/src/lib.rs
@@ -1,7 +1,7 @@
 //! Data structure measurement.
 
 use numext_fixed_hash::H256;
-pub use occupied_capacity_derive::*;
+pub use occupied_capacity_derive::HasOccupiedCapacity;
 use std::mem;
 
 pub trait OccupiedCapacity {

--- a/util/occupied-capacity/src/lib.rs
+++ b/util/occupied-capacity/src/lib.rs
@@ -1,65 +1,9 @@
 //! Data structure measurement.
 
-use numext_fixed_hash::H256;
-pub use occupied_capacity_derive::HasOccupiedCapacity;
-use std::mem;
+use proc_macro_hack::proc_macro_hack;
 
-pub trait OccupiedCapacity {
-    /// Measure the occupied capacity of structures
-    fn occupied_capacity(&self) -> usize;
-}
+pub use occupied_capacity_core::{Capacity, Error, OccupiedCapacity, Result};
+pub use occupied_capacity_macros::HasOccupiedCapacity;
 
-impl<T: OccupiedCapacity> OccupiedCapacity for [T] {
-    fn occupied_capacity(&self) -> usize {
-        self.iter().map(OccupiedCapacity::occupied_capacity).sum()
-    }
-}
-
-impl<T: OccupiedCapacity> OccupiedCapacity for Option<T> {
-    fn occupied_capacity(&self) -> usize {
-        self.as_ref().map_or(0, OccupiedCapacity::occupied_capacity)
-    }
-}
-
-impl<T: OccupiedCapacity> OccupiedCapacity for Vec<T> {
-    fn occupied_capacity(&self) -> usize {
-        self.iter().map(OccupiedCapacity::occupied_capacity).sum()
-    }
-}
-
-impl OccupiedCapacity for H256 {
-    fn occupied_capacity(&self) -> usize {
-        H256::size_of()
-    }
-}
-
-macro_rules! impl_mem_size_of {
-    ($type:ty) => {
-        impl OccupiedCapacity for $type {
-            fn occupied_capacity(&self) -> usize {
-                mem::size_of::<$type>()
-            }
-        }
-    };
-}
-
-// https://github.com/rust-lang/rust/issues/31844#
-// Currently, specialization haven't implemented
-impl OccupiedCapacity for Vec<u8> {
-    fn occupied_capacity(&self) -> usize {
-        self.len()
-    }
-}
-
-impl OccupiedCapacity for [u8] {
-    fn occupied_capacity(&self) -> usize {
-        self.len()
-    }
-}
-
-// conflicting implementation for `std::vec::Vec<u8>`
-// impl_mem_size_of!(u8);
-impl_mem_size_of!(u32);
-impl_mem_size_of!(u64);
-impl_mem_size_of!(bool);
-impl_mem_size_of!(());
+#[proc_macro_hack]
+pub use occupied_capacity_macros::capacity_bytes;

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     ExceededMaximumCycles,
     /// The field version in block header is not allowed.
     Version,
+    /// Overflow when do computation for capacity.
+    CapacityOverflow,
 }
 
 impl fmt::Display for Error {
@@ -150,4 +152,20 @@ pub enum TransactionError {
     /// Invalid ValidSince flags
     InvalidValidSince,
     CellbaseImmaturity,
+}
+
+impl From<occupied_capacity::Error> for TransactionError {
+    fn from(error: occupied_capacity::Error) -> Self {
+        match error {
+            occupied_capacity::Error::Overflow => TransactionError::CapacityOverflow,
+        }
+    }
+}
+
+impl From<occupied_capacity::Error> for Error {
+    fn from(error: occupied_capacity::Error) -> Self {
+        match error {
+            occupied_capacity::Error::Overflow => Error::CapacityOverflow,
+        }
+    }
 }

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -5,7 +5,7 @@ use crate::Verifier;
 use ckb_core::block::BlockBuilder;
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
-use ckb_core::Capacity;
+use ckb_core::{capacity_bytes, Capacity};
 use numext_fixed_hash::H256;
 
 fn create_cellbase_transaction_with_capacity(capacity: Capacity) -> Transaction {
@@ -21,7 +21,7 @@ fn create_cellbase_transaction_with_capacity(capacity: Capacity) -> Transaction 
 }
 
 fn create_cellbase_transaction() -> Transaction {
-    create_cellbase_transaction_with_capacity(100)
+    create_cellbase_transaction_with_capacity(capacity_bytes!(100))
 }
 
 fn create_normal_transaction() -> Transaction {
@@ -31,7 +31,12 @@ fn create_normal_transaction() -> Transaction {
             0,
             Default::default(),
         ))
-        .output(CellOutput::new(100, Vec::new(), Script::default(), None))
+        .output(CellOutput::new(
+            capacity_bytes!(100),
+            Vec::new(),
+            Script::default(),
+            None,
+        ))
         .build()
 }
 
@@ -56,7 +61,9 @@ pub fn test_block_with_one_cellbase_at_first() {
         .commit_transaction(transaction)
         .build();
 
-    let provider = DummyChainProvider { block_reward: 100 };
+    let provider = DummyChainProvider {
+        block_reward: capacity_bytes!(100),
+    };
 
     let verifier = CellbaseVerifier::new(provider);
     assert!(verifier.verify(&block).is_ok());
@@ -95,11 +102,15 @@ pub fn test_cellbase_with_less_reward() {
     let transaction = create_normal_transaction();
 
     let block = BlockBuilder::default()
-        .commit_transaction(create_cellbase_transaction_with_capacity(50))
+        .commit_transaction(create_cellbase_transaction_with_capacity(capacity_bytes!(
+            50
+        )))
         .commit_transaction(transaction)
         .build();
 
-    let provider = DummyChainProvider { block_reward: 100 };
+    let provider = DummyChainProvider {
+        block_reward: capacity_bytes!(100),
+    };
 
     let verifier = CellbaseVerifier::new(provider);
     assert!(verifier.verify(&block).is_ok());
@@ -110,11 +121,15 @@ pub fn test_cellbase_with_fee() {
     let transaction = create_normal_transaction();
 
     let block = BlockBuilder::default()
-        .commit_transaction(create_cellbase_transaction_with_capacity(110))
+        .commit_transaction(create_cellbase_transaction_with_capacity(capacity_bytes!(
+            110
+        )))
         .commit_transaction(transaction)
         .build();
 
-    let provider = DummyChainProvider { block_reward: 100 };
+    let provider = DummyChainProvider {
+        block_reward: capacity_bytes!(100),
+    };
 
     let verifier = CellbaseVerifier::new(provider);
     assert!(verifier.verify(&block).is_ok());
@@ -124,7 +139,9 @@ pub fn test_cellbase_with_fee() {
 pub fn test_empty_transactions() {
     let block = BlockBuilder::default().build();
 
-    let provider = DummyChainProvider { block_reward: 150 };
+    let provider = DummyChainProvider {
+        block_reward: capacity_bytes!(150),
+    };
 
     let full_verifier = BlockVerifier::new(provider);
     // short-circuit, Empty check first

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -9,7 +9,7 @@ use ckb_core::transaction::{
     CellInput, CellOutput, OutPoint, ProposalShortId, Transaction, TransactionBuilder,
 };
 use ckb_core::uncle::UncleBlock;
-use ckb_core::BlockNumber;
+use ckb_core::{capacity_bytes, BlockNumber, Capacity};
 use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
@@ -46,9 +46,9 @@ fn gen_block(
 }
 
 fn create_transaction(parent: &H256) -> Transaction {
-    let capacity = 100_000_000 / 100 as u64;
+    let capacity = 100_000_000 / 100 as usize;
     let output = CellOutput::new(
-        capacity,
+        Capacity::bytes(capacity).unwrap(),
         Vec::new(),
         Script::always_success(),
         Some(Script::always_success()),
@@ -83,7 +83,12 @@ fn start_chain(
 fn create_cellbase(number: BlockNumber) -> Transaction {
     TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
-        .outputs(vec![CellOutput::new(0, vec![], Script::default(), None)])
+        .outputs(vec![CellOutput::new(
+            Capacity::zero(),
+            vec![],
+            Script::default(),
+            None,
+        )])
         .build()
 }
 
@@ -96,7 +101,7 @@ fn setup_env() -> (
         .input(CellInput::new(OutPoint::null(), 0, Default::default()))
         .outputs(vec![
             CellOutput::new(
-                1_000_000,
+                capacity_bytes!(1_000_000),
                 Vec::new(),
                 Script::always_success(),
                 Some(Script::always_success()),

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -7,6 +7,7 @@ use ckb_core::cell::CellStatus;
 use ckb_core::cell::ResolvedTransaction;
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
+use ckb_core::{capacity_bytes, Capacity};
 use ckb_traits::BlockMedianTimeContext;
 use numext_fixed_hash::H256;
 
@@ -34,14 +35,19 @@ pub fn test_empty() {
 #[test]
 pub fn test_capacity_outofbound() {
     let transaction = TransactionBuilder::default()
-        .output(CellOutput::new(50, vec![1; 51], Script::default(), None))
+        .output(CellOutput::new(
+            capacity_bytes!(50),
+            vec![1; 51],
+            Script::default(),
+            None,
+        ))
         .build();
 
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             None,
             false,
         )],
@@ -57,14 +63,19 @@ pub fn test_capacity_outofbound() {
 #[test]
 pub fn test_cellbase_maturity() {
     let transaction = TransactionBuilder::default()
-        .output(CellOutput::new(50, vec![1; 51], Script::default(), None))
+        .output(CellOutput::new(
+            capacity_bytes!(50),
+            vec![1; 51],
+            Script::default(),
+            None,
+        ))
         .build();
 
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(30),
             true,
         )],
@@ -89,8 +100,8 @@ pub fn test_cellbase_maturity() {
 pub fn test_capacity_invalid() {
     let transaction = TransactionBuilder::default()
         .outputs(vec![
-            CellOutput::new(50, Vec::new(), Script::default(), None),
-            CellOutput::new(100, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(100), Vec::new(), Script::default(), None),
         ])
         .build();
 
@@ -99,12 +110,12 @@ pub fn test_capacity_invalid() {
         dep_cells: Vec::new(),
         input_cells: vec![
             CellStatus::live_output(
-                CellOutput::new(49, Vec::new(), Script::default(), None),
+                CellOutput::new(capacity_bytes!(49), Vec::new(), Script::default(), None),
                 None,
                 false,
             ),
             CellStatus::live_output(
-                CellOutput::new(100, Vec::new(), Script::default(), None),
+                CellOutput::new(capacity_bytes!(100), Vec::new(), Script::default(), None),
                 None,
                 false,
             ),
@@ -174,7 +185,7 @@ pub fn test_valid_since() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
         )],
@@ -202,7 +213,7 @@ pub fn test_valid_since() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
         )],
@@ -230,7 +241,7 @@ pub fn test_valid_since() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
         )],
@@ -266,7 +277,7 @@ pub fn test_valid_since() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
-            CellOutput::new(50, Vec::new(), Script::default(), None),
+            CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
         )],

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -8,7 +8,7 @@ use ckb_core::script::Script;
 use ckb_core::transaction::{
     CellInput, CellOutput, ProposalShortId, Transaction, TransactionBuilder,
 };
-use ckb_core::BlockNumber;
+use ckb_core::{BlockNumber, Capacity};
 use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
@@ -57,7 +57,12 @@ fn start_chain(
 fn create_cellbase(number: BlockNumber) -> Transaction {
     TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
-        .output(CellOutput::new(0, vec![], Script::default(), None))
+        .output(CellOutput::new(
+            Capacity::zero(),
+            vec![],
+            Script::default(),
+            None,
+        ))
         .build()
 }
 


### PR DESCRIPTION
### Commits

- fix: some tests about transactions are not deterministic
- refactor: refactor the `Capacity`
  - refactor: rename the occupied capacity derive to fix naming conflict
  - refactor: use the last 8 digits of capacity as the fractional part
    **BREAKING CHANGE**:
    The value of capacity is `10^8` times of the old value, since the last 8 digits of capacity are used as the fractional part.
  - refactor: apply the new capacity to all crates
  - ci: apply the new capacity to all tests
  - ci: test if only `Capacity` was changed
  - ci: remove test code and update some hardcode hash in tests

### Summary

- I split this PR into several commits, since review these commits one by one is more easy than review them all at once.
- The first part has only one commit(432256bea073a1c01c4a146bd3e23a10c6e99171) which fixed a bug (#527). I had to fix it before I push other commits.
- In the second part:
  - The second commit(3bb7109d940de4afbe8a6c6bbafce20ddb6f6a8e) and the third commit(85f485426e3a30781ee6417acf355c78c891019d) is the core commits of the refactor.
  - The fifth commit(deee2c2266d2d62916643deb7f1856f4a0e26ad5) proves the changes about hardcode hashes in the last commit is right.