### PR TITLE
fix: testnet relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -63,6 +63,18 @@ pub enum PoolError {
     UnknownInputs(Vec<OutPoint>),
 }
 
+impl PoolError {
+    /// Transaction error may be caused by different tip between peers if this method return false,
+    /// Otherwise we consider the Bad Tx is constructed intendedly.
+    pub fn is_bad_tx(&self) -> bool {
+        match self {
+            PoolError::InvalidTx(err) => err.is_bad_tx(),
+            PoolError::NullInput => true,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for PoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self, f)

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -29,6 +29,7 @@ failure = "0.1.5"
 bytes = "0.4.12"
 hash = {path = "../util/hash"}
 lru-cache = { git = "https://github.com/nervosnetwork/lru-cache" }
+sentry = "^0.15.2"
 
 [dev-dependencies]
 ckb-notify = { path = "../notify" }

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -4,7 +4,6 @@ use ckb_core::{transaction::Transaction, Cycle};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{RelayMessage, RelayTransaction as FbsRelayTransaction};
 use ckb_shared::store::ChainStore;
-use ckb_traits::chain_provider::ChainProvider;
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
 use log::debug;
@@ -84,7 +83,7 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
             }
             Err(err) => {
                 if err.is_bad_tx() {
-                    debug!(target: "relay", "peer {} relay a invalid tx: {:?}, error: {:?}", self.peer, tx, err);
+                    debug!(target: "relay", "peer {} relay a invalid tx: {:?}, error: {:?}", self.peer, tx_hash, err);
                     sentry::capture_message(
                         &format!(
                             "ban peer {} {:?}, reason: relay invalid tx: {:?}, error: {:?}",
@@ -94,7 +93,7 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
                     );
                     self.nc.ban_peer(self.peer, DEFAULT_BAN_TIME);
                 } else {
-                    debug!(target: "relay", "peer {} relay a conflict or missing input tx: {:?}, error: {:?}", self.peer, tx, err);
+                    debug!(target: "relay", "peer {} relay a conflict or missing input tx: {:?}, error: {:?}", self.peer, tx_hash, err);
                 }
             }
         }

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -86,7 +86,6 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
             | Err(PoolError::InvalidTx(TransactionError::InvalidSignature))
             | Err(PoolError::InvalidTx(TransactionError::InvalidValidSince)) => {
                 debug!(target: "relay", "peer {} relay a invalid tx: {:?}", self.peer, tx);
-                // TODO use report score interface
                 self.nc.ban_peer(self.peer, DEFAULT_BAN_TIME);
             }
             Ok(cycles) => {
@@ -95,13 +94,12 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
                     "peer {} relay wrong cycles tx: {:?} real cycles {} wrong cycles {}",
                     self.peer, tx, cycles, relay_cycles,
                 );
-                // TODO use report score interface
                 self.nc.ban_peer(self.peer, DEFAULT_BAN_TIME);
             }
             Err(err) => {
                 // this error may occured when peer's tip is different with us,
                 // we can't proof peer is bad so just ignore this
-                debug!(target: "relay", "peer {} relay tx verify err: {:?}, error: {:?}", self.peer, tx, err);
+                debug!(target: "relay", "peer {} relay a conflict or missing input tx: {:?}, error: {:?}", self.peer, tx, err);
             }
         }
 

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -156,6 +156,20 @@ pub enum TransactionError {
     CellbaseImmaturity,
 }
 
+impl TransactionError {
+    /// Transaction error may be caused by different tip between peers if this method return false,
+    /// Otherwise we consider the Bad Tx is constructed intendedly.
+    pub fn is_bad_tx(self) -> bool {
+        use TransactionError::*;
+        match self {
+            NullInput | NullDep | CapacityOverflow | DuplicateInputs | Empty
+            | OutputsSumOverflow | InvalidScript | ScriptFailure(_) | InvalidSignature
+            | InvalidValidSince => true,
+            _ => false,
+        }
+    }
+}
+
 impl From<occupied_capacity::Error> for TransactionError {
     fn from(error: occupied_capacity::Error) -> Self {
         match error {


### PR DESCRIPTION
Refactoring ugly code,
Add `is_bad_tx` function on `PoolError` and `TransactionError`, use this method to detect a tx is intended bad tx or just caused by the different tip.