### PR TITLE
fix: apply the new capacity to all configuration files

### DIFF
--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -14,7 +14,7 @@ nonce = 0
 proof = [0]
 
 [params]
-initial_block_reward = 50000
+initial_block_reward = 5_000_000_000_000
 max_block_cycles = 100000000
 cellbase_maturity = 0
 

--- a/resource/specs/integration.toml
+++ b/resource/specs/integration.toml
@@ -14,7 +14,7 @@ nonce = 0
 proof = [0]
 
 [params]
-initial_block_reward = 50000
+initial_block_reward = 5_000_000_000_000
 max_block_cycles = 100000000
 cellbase_maturity = 0
 

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -15,7 +15,7 @@ nonce = 0
 proof = [0]
 
 [params]
-initial_block_reward = 50000
+initial_block_reward = 5_000_000_000_000
 max_block_cycles = 100000000
 cellbase_maturity = 10
 


### PR DESCRIPTION
Fix the [integration tests](https://travis-ci.com/nervosnetwork/ckb/jobs/194822193).

BREAKING CHANGE:
- `initial_block_reward` in configuration files have to be updated.
  The unit of it is changed from "CK Byte" to "CK Shannon".