### PR TITLE
[ᚬtestnet] fix: Remove feeler in peer registry when dial error

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -404,6 +404,9 @@ impl ServiceHandle for EventHandler {
                         .insert(addr, std::u8::MAX);
                 }
                 if let Some(peer_id) = extract_peer_id(address) {
+                    self.network_state.with_peer_registry_mut(|reg| {
+                        reg.remove_feeler(&peer_id);
+                    });
                     self.network_state
                         .failed_dials
                         .write()


### PR DESCRIPTION
When feeler added to peer registry in outbound peer service, the feeler will removed when peer disconnect. But if dial error, the feeler PeerId will remain in memory cause memory leak.