### PR TITLE
[HOLD] feat: verify cellbase output type

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -275,7 +275,6 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                 fork.detached_blocks().iter(),
                 fork.attached_blocks().iter(),
                 fork.detached_proposal_id().iter(),
-                self.shared.consensus().max_block_cycles(),
             );
             if log_enabled!(target: "chain", log::Level::Debug) {
                 self.print_chain(&chain_state, 10);

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -67,7 +67,7 @@ fn test_genesis_transaction_spend() {
         shared
             .chain_state()
             .lock()
-            .get_cell_status(&OutPoint::new(genesis_tx_hash, 0)),
+            .cell(&OutPoint::new(genesis_tx_hash, 0)),
         CellStatus::Dead
     );
 }
@@ -111,7 +111,7 @@ fn test_transaction_spend_in_same_block() {
             shared
                 .chain_state()
                 .lock()
-                .get_cell_status(&OutPoint::new(hash.clone(), 0)),
+                .cell(&OutPoint::new(hash.clone(), 0)),
             CellStatus::Unknown
         );
     }
@@ -164,7 +164,7 @@ fn test_transaction_spend_in_same_block() {
             shared
                 .chain_state()
                 .lock()
-                .get_cell_status(&OutPoint::new(hash.clone(), 0)),
+                .cell(&OutPoint::new(hash.clone(), 0)),
             CellStatus::Dead
         );
     }
@@ -173,7 +173,7 @@ fn test_transaction_spend_in_same_block() {
         shared
             .chain_state()
             .lock()
-            .get_cell_status(&OutPoint::new(tx2_hash, 0)),
+            .cell(&OutPoint::new(tx2_hash, 0)),
         CellStatus::live_output(tx2_output, Some(4), false)
     );
 }
@@ -373,7 +373,7 @@ fn test_genesis_transaction_fetch() {
     let (_chain_controller, shared) = start_chain(Some(consensus), false);
 
     let out_point = OutPoint::new(root_hash, 0);
-    let state = shared.chain_state().lock().get_cell_status(&out_point);
+    let state = shared.chain_state().lock().cell(&out_point);
     assert!(state.is_live());
 }
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -111,7 +111,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
             .shared
             .chain_state()
             .lock()
-            .get_cell_status(&(out_point.try_into().map_err(|_| Error::parse_error())?))
+            .cell(&(out_point.try_into().map_err(|_| Error::parse_error())?))
             .into())
     }
 

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -6,7 +6,6 @@ use ckb_shared::shared::Shared;
 use ckb_shared::store::ChainStore;
 use ckb_shared::tx_pool::types::PoolEntry;
 use ckb_sync::NetworkProtocol;
-use ckb_traits::chain_provider::ChainProvider;
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
@@ -36,8 +35,7 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
 
         let mut chain_state = self.shared.chain_state().lock();
-        let rtx = chain_state.rpc_resolve_tx_from_pool(&tx, &chain_state.tx_pool());
-        let tx_result = chain_state.verify_rtx(&rtx, self.shared.consensus().max_block_cycles());
+        let tx_result = chain_state.verify_transaction_with_pending(&tx);
         debug!(target: "rpc", "send_transaction add to pool result: {:?}", tx_result);
         match tx_result {
             Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),

--- a/rpc/src/module/trace.rs
+++ b/rpc/src/module/trace.rs
@@ -6,7 +6,6 @@ use ckb_shared::shared::Shared;
 use ckb_shared::store::ChainStore;
 use ckb_shared::tx_pool::types::PoolEntry;
 use ckb_sync::NetworkProtocol;
-use ckb_traits::chain_provider::ChainProvider;
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
@@ -33,8 +32,7 @@ impl<CS: ChainStore + 'static> TraceRpc for TraceRpcImpl<CS> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
 
         let mut chain_state = self.shared.chain_state().lock();
-        let rtx = chain_state.rpc_resolve_tx_from_pool(&tx, &chain_state.tx_pool());
-        let tx_result = chain_state.verify_rtx(&rtx, self.shared.consensus().max_block_cycles());
+        let tx_result = chain_state.verify_transaction_with_pending(&tx);
         match tx_result {
             Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
             Ok(cycles) => {

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -3,7 +3,7 @@ use crate::{
     syscalls::{build_tx, Debugger, LoadCell, LoadCellByField, LoadInputByField, LoadTx},
     ScriptError,
 };
-use ckb_core::cell::ResolvedTransaction;
+use ckb_core::cell::{CellStatus, ResolvedTransaction};
 use ckb_core::script::{Script, ALWAYS_SUCCESS_HASH};
 use ckb_core::transaction::{CellInput, CellOutput};
 use ckb_core::Cycle;
@@ -32,15 +32,12 @@ impl<'a> TransactionScriptsVerifier<'a> {
         let dep_cells: Vec<&'a CellOutput> = rtx
             .dep_cells
             .iter()
-            .filter_map(|cell_status|
-                cell_status
-                    .get_live_output()
-            )
+            .filter_map(CellStatus::get_live_output)
             .collect();
         let input_cells = rtx
             .input_cells
             .iter()
-            .filter_map(|cell_status| cell_status.get_live_output())
+            .filter_map(CellStatus::get_live_output)
             .collect();
         let inputs = rtx.transaction.inputs().iter().collect();
         let outputs = rtx.transaction.outputs().iter().collect();

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -32,22 +32,15 @@ impl<'a> TransactionScriptsVerifier<'a> {
         let dep_cells: Vec<&'a CellOutput> = rtx
             .dep_cells
             .iter()
-            .map(|cell| {
-                &cell
+            .filter_map(|cell_status|
+                cell_status
                     .get_live_output()
-                    .expect("already verifies that all dep cells are valid")
-                    .cell_output
-            })
+            )
             .collect();
         let input_cells = rtx
             .input_cells
             .iter()
-            .map(|cell| {
-                &cell
-                    .get_live_output()
-                    .expect("already verifies that all input cells are valid")
-                    .cell_output
-            })
+            .filter_map(|cell_status| cell_status.get_live_output())
             .collect();
         let inputs = rtx.transaction.inputs().iter().collect();
         let outputs = rtx.transaction.outputs().iter().collect();
@@ -201,7 +194,7 @@ impl<'a> TransactionScriptsVerifier<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ckb_core::cell::{CellMeta, CellStatus, LiveCell};
+    use ckb_core::cell::{CellMeta, CellStatus};
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
     use ckb_core::{capacity_bytes, Capacity};
@@ -236,7 +229,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -303,8 +296,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![CellStatus::Live(dep_cell)],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -371,8 +364,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![CellStatus::Live(dep_cell)],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -441,8 +434,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![CellStatus::Live(dep_cell)],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -499,7 +492,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -575,8 +568,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![CellStatus::Live(dep_cell)],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -654,8 +647,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![CellStatus::Live(dep_cell)],
+            input_cells: vec![CellStatus::Live(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -372,6 +372,9 @@ impl<CS: ChainStore> ChainState<CS> {
             self.tx_pool.committed(tx);
         }
 
+        // TODO Q
+        // Cannot mutating one field while iterating over another immutable field, use `cloned` as a temp soluction here.
+        // We can remove this clone after refactoring `staging_tx` and `update_orphan_from_tx` to an inner struct field method later.
         let ids: Vec<_> = self.proposal_ids.get_ids_iter().cloned().collect();
         for id in ids.iter() {
             if let Some(entry) = self.tx_pool.remove_pending_from_proposal(id) {

--- a/shared/src/tests/cell_set.rs
+++ b/shared/src/tests/cell_set.rs
@@ -3,7 +3,11 @@ use crate::{
     shared::{Shared, SharedBuilder},
     store::ChainKVStore,
 };
+<<<<<<< HEAD
 use ckb_core::cell::{CellProvider, CellStatus, LiveCell};
+=======
+use ckb_core::cell::resolve_transaction;
+>>>>>>> refactor: revert CellStatus
 use ckb_core::transaction::Transaction;
 use ckb_db::memorydb::MemoryKeyValueDB;
 use std::fs::File;

--- a/shared/src/tests/cell_set.rs
+++ b/shared/src/tests/cell_set.rs
@@ -3,11 +3,6 @@ use crate::{
     shared::{Shared, SharedBuilder},
     store::ChainKVStore,
 };
-<<<<<<< HEAD
-use ckb_core::cell::{CellProvider, CellStatus, LiveCell};
-=======
-use ckb_core::cell::resolve_transaction;
->>>>>>> refactor: revert CellStatus
 use ckb_core::transaction::Transaction;
 use ckb_db::memorydb::MemoryKeyValueDB;
 use std::fs::File;
@@ -54,10 +49,6 @@ fn case_no1() {
     let cell_set_overlay = chain_state.new_cell_set_overlay(&cell_set_diff);
 
     let transcations = transcations();
-
-    //Outpoint::null should be live
-    let rtx0 = cell_set_overlay.resolve_transaction(&transcations[0]);
-    assert_eq!(rtx0.input_cells[0], CellStatus::Live(LiveCell::Null));
 
     let out_point = transcations[1].inputs()[0].previous_output.clone();
 

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -1,7 +1,6 @@
 use crate::relayer::Relayer;
 use ckb_protocol::{cast, BlockProposal, FlatbuffersVectorIterator};
 use ckb_shared::store::ChainStore;
-use ckb_traits::chain_provider::ChainProvider;
 use failure::Error as FailureError;
 use log::warn;
 use std::convert::TryInto;
@@ -17,13 +16,10 @@ impl<'a, CS: ChainStore> BlockProposalProcess<'a, CS> {
     }
 
     pub fn execute(self) -> Result<(), FailureError> {
-        let chain_state = self.relayer.shared.chain_state().lock();
+        let mut chain_state = self.relayer.shared.chain_state().lock();
         let txs = FlatbuffersVectorIterator::new(cast!(self.message.transactions())?);
         for tx in txs {
-            let ret = chain_state.add_tx_to_pool(
-                TryInto::try_into(tx)?,
-                self.relayer.shared.consensus().max_block_cycles(),
-            );
+            let ret = chain_state.add_tx_to_pool(TryInto::try_into(tx)?);
             if ret.is_err() {
                 warn!(target: "relay", "BlockProposal add_tx_to_pool error {:?}", ret)
             }

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -5,7 +5,6 @@ use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{RelayMessage, RelayTransaction as FbsRelayTransaction};
 use ckb_shared::store::ChainStore;
 use ckb_shared::tx_pool::types::PoolError;
-use ckb_traits::chain_provider::ChainProvider;
 use ckb_verification::TransactionError;
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
@@ -48,9 +47,8 @@ impl<'a, CS: ChainStore> TransactionProcess<'a, CS> {
         }
 
         let tx_result = {
-            let chain_state = self.relayer.shared.chain_state().lock();
-            let max_block_cycles = self.relayer.shared.consensus().max_block_cycles();
-            chain_state.add_tx_to_pool(tx.clone(), max_block_cycles)
+            let mut chain_state = self.relayer.shared.chain_state().lock();
+            chain_state.add_tx_to_pool(tx.clone())
         };
         // disconnect peer if cycles mismatch
         match tx_result {

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -66,10 +66,8 @@ fn relay_compact_block_with_one_tx() {
 
             {
                 let chain_state = shared1.chain_state().lock();
-                let rtx = chain_state.resolve_tx_from_pool(&tx, &chain_state.tx_pool());
-                println!("rtx {:?}", rtx);
                 let cycles = chain_state
-                    .verify_rtx(&rtx, shared1.consensus().max_block_cycles())
+                    .verify_transaction(&tx)
                     .expect("verify relay tx");
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = RelayMessage::build_transaction(fbb, &tx, cycles);
@@ -219,10 +217,7 @@ fn relay_compact_block_with_missing_indexs() {
                 let tx = &txs[*i];
                 let cycles = {
                     let chain_state = shared1.chain_state().lock();
-                    let rtx = chain_state.resolve_tx_from_pool(tx, &chain_state.tx_pool());
-                    chain_state
-                        .verify_rtx(&rtx, shared1.consensus().max_block_cycles())
-                        .expect("verify relay tx")
+                    chain_state.verify_transaction(tx).expect("verify relay tx")
                 };
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = RelayMessage::build_transaction(fbb, tx, cycles);

--- a/util/jsonrpc-types/src/cell.rs
+++ b/util/jsonrpc-types/src/cell.rs
@@ -1,5 +1,5 @@
 use crate::{Capacity, CellOutput, OutPoint, Script};
-use ckb_core::cell::{CellStatus, LiveCell};
+use ckb_core::cell::CellStatus;
 use serde_derive::{Deserialize, Serialize};
 
 // This is used as return value of get_cells_by_type_hash RPC:
@@ -21,15 +21,12 @@ pub struct CellWithStatus {
 impl From<CellStatus> for CellWithStatus {
     fn from(status: CellStatus) -> Self {
         let (cell, status) = match status {
-            CellStatus::Live(cell) => match cell {
-                LiveCell::Null => (None, "live"),
-                LiveCell::Output(o) => (Some(o), "live"),
-            },
+            CellStatus::Live(meta) => (Some(meta.cell_output), "live"),
             CellStatus::Dead => (None, "dead"),
             CellStatus::Unknown => (None, "unknown"),
         };
         Self {
-            cell: cell.map(|cell| cell.cell_output.into()),
+            cell: cell.map(Into::into),
             status: status.to_string(),
         }
     }

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -360,12 +360,10 @@ impl TransactionsVerifier {
         if cellbase.transaction.outputs_capacity()? > block_reward.safe_add(fee)? {
             return Err(Error::Cellbase(CellbaseError::InvalidReward));
         }
-        // TODO use TransactionScriptsVerifier to verify cellbase script
 
         // make verifiers orthogonal
         let cycles_set = resolved
-            .par_iter()
-            .skip(1)
+            .iter()
             .enumerate()
             .map(|(index, tx)| {
                 if let Some(cycles) = txs_verify_cache.get(&tx.transaction.hash()) {

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -90,15 +90,6 @@ impl<CP: ChainProvider + Clone> CellbaseVerifier<CP> {
             return Err(Error::Cellbase(CellbaseError::InvalidInput));
         }
 
-        // currently, we enforce`type` field of a cellbase output cell must be absent
-        if cellbase_transaction
-            .outputs()
-            .iter()
-            .any(|op| op.type_.is_some())
-        {
-            return Err(Error::Cellbase(CellbaseError::InvalidOutput));
-        }
-
         Ok(())
     }
 }

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -363,7 +363,7 @@ impl TransactionsVerifier {
 
         // make verifiers orthogonal
         let cycles_set = resolved
-            .iter()
+            .par_iter()
             .enumerate()
             .map(|(index, tx)| {
                 if let Some(cycles) = txs_verify_cache.get(&tx.transaction.hash()) {

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -150,3 +150,29 @@ pub fn test_empty_transactions() {
         Err(VerifyError::Cellbase(CellbaseError::InvalidQuantity))
     );
 }
+
+#[test]
+pub fn test_cellbase_with_type() {
+    let transaction = create_normal_transaction();
+    let cellbase = TransactionBuilder::default()
+        .input(CellInput::new_cellbase_input(0))
+        .output(CellOutput::new(
+            capacity_bytes!(110),
+            Vec::new(),
+            Script::default(),
+            Some(Script::default()),
+        ))
+        .build();
+
+    let block = BlockBuilder::default()
+        .transaction(cellbase)
+        .transaction(transaction)
+        .build();
+
+    let provider = DummyChainProvider {
+        block_reward: capacity_bytes!(100),
+    };
+
+    let verifier = CellbaseVerifier::new(provider);
+    assert!(verifier.verify(&block).is_ok());
+}

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -1,6 +1,5 @@
 use super::super::transaction_verifier::{
-    CapacityVerifier, DuplicateInputsVerifier, EmptyVerifier, MaturityVerifier, NullVerifier,
-    ValidSinceVerifier,
+    CapacityVerifier, EmptyVerifier, MaturityVerifier, ValidSinceVerifier,
 };
 use crate::error::TransactionError;
 use ckb_core::cell::CellStatus;
@@ -10,19 +9,6 @@ use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder}
 use ckb_core::{capacity_bytes, Capacity};
 use ckb_traits::BlockMedianTimeContext;
 use numext_fixed_hash::H256;
-
-#[test]
-pub fn test_null() {
-    let transaction = TransactionBuilder::default()
-        .input(CellInput::new(
-            OutPoint::new(H256::zero(), u32::max_value()),
-            0,
-            Default::default(),
-        ))
-        .build();
-    let verifier = NullVerifier::new(&transaction);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::NullInput));
-}
 
 #[test]
 pub fn test_empty() {
@@ -126,31 +112,6 @@ pub fn test_capacity_invalid() {
     assert_eq!(
         verifier.verify().err(),
         Some(TransactionError::OutputsSumOverflow)
-    );
-}
-
-#[test]
-pub fn test_duplicate_inputs() {
-    let transaction = TransactionBuilder::default()
-        .inputs(vec![
-            CellInput::new(
-                OutPoint::new(H256::from_trimmed_hex_str("1").unwrap(), 0),
-                0,
-                Default::default(),
-            ),
-            CellInput::new(
-                OutPoint::new(H256::from_trimmed_hex_str("1").unwrap(), 0),
-                0,
-                Default::default(),
-            ),
-        ])
-        .build();
-
-    let verifier = DuplicateInputsVerifier::new(&transaction);
-
-    assert_eq!(
-        verifier.verify().err(),
-        Some(TransactionError::DuplicateInputs)
     );
 }
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -165,8 +165,8 @@ impl<'a> MaturityVerifier<'a> {
 
     pub fn verify(&self) -> Result<(), TransactionError> {
         let cellbase_immature = |cell_status: &CellStatus| -> bool {
-            match cell_status.get_live_output() {
-                Some(ref meta)
+            match cell_status {
+                CellStatus::Live(meta)
                     if meta.is_cellbase()
                         && self.tip_number
                             < meta.block_number.expect(

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -203,7 +203,9 @@ impl<'a> CapacityVerifier<'a> {
             .input_cells
             .iter()
             .filter_map(CellStatus::get_live_output)
-            .try_fold(Capacity::zero(), |acc, output| acc.safe_add(output.capacity))?;
+            .try_fold(Capacity::zero(), |acc, output| {
+                acc.safe_add(output.capacity)
+            })?;
 
         let outputs_total = self
             .resolved_transaction
@@ -398,7 +400,7 @@ where
             if let CellStatus::Live(meta) = cell_status {
                 self.verify_relative_lock(since, meta)?;
             } else {
-                return Err(TransactionError::Conflict)
+                return Err(TransactionError::Conflict);
             }
         }
         Ok(())


### PR DESCRIPTION
This PR allows the miner to set cellbase's output type, and some refactoring:

1.  Remove unused `NullVerifier` and  `DuplicateInputsVerifier `
2. Revert changes of `get_cell_status` and `LiveCell`
3. Refactoring `ChainState`