### PR TITLE
feat: support ckb prof command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ build-info = { path = "util/build-info" }
 ckb-traits = { path = "traits" }
 sentry = "^0.15.2"
 ckb-verification = { path = "verification" }
+tempfile = "3.0"
 
 [dev-dependencies]
-tempfile = "3.0"
 
 [workspace]
 members = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn run_app() -> Result<(), ExitCode> {
     match app_matches.subcommand() {
         (cli::CMD_RUN, _) => subcommand::run(setup.run()?),
         (cli::CMD_MINER, _) => subcommand::miner(setup.miner()?),
+        (cli::CMD_PROF, Some(matches)) => subcommand::profile(setup.prof(&matches)?),
         (cli::CMD_EXPORT, Some(matches)) => subcommand::export(setup.export(&matches)?),
         (cli::CMD_IMPORT, Some(matches)) => subcommand::import(setup.import(&matches)?),
         _ => unreachable!(),

--- a/src/subcommand/mod.rs
+++ b/src/subcommand/mod.rs
@@ -3,10 +3,12 @@ mod export;
 mod import;
 mod init;
 mod miner;
+mod prof;
 mod run;
 
 pub use self::export::export;
 pub use self::import::import;
 pub use self::init::init;
 pub use self::miner::miner;
+pub use self::prof::profile;
 pub use self::run::run;

--- a/src/subcommand/prof.rs
+++ b/src/subcommand/prof.rs
@@ -1,0 +1,48 @@
+use ckb_app_config::{ExitCode, ProfArgs};
+use ckb_chain::chain::ChainBuilder;
+use ckb_db::{CacheDB, DBConfig, RocksDB};
+use ckb_notify::NotifyService;
+use ckb_shared::shared::{Shared, SharedBuilder};
+use ckb_shared::store::ChainStore;
+use std::sync::Arc;
+
+pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
+    let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+        .consensus(args.consensus.clone())
+        .db(&args.config.db)
+        .tx_pool_config(args.config.tx_pool.clone())
+        .build();
+
+    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let tmp_shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+        .consensus(args.consensus)
+        .db(&DBConfig {
+            path: tmp_dir.as_ref().to_path_buf(),
+            options: None,
+        })
+        .tx_pool_config(args.config.tx_pool)
+        .build();
+
+    let from = std::cmp::max(1, args.from);
+    let to = std::cmp::min(shared.chain_state().lock().tip_number(), args.to);
+    profile_block_process(shared, tmp_shared, from, to);
+    Ok(())
+}
+
+fn profile_block_process<CS: ChainStore + 'static>(
+    shared: Shared<CS>,
+    tmp_shared: Shared<CS>,
+    from: u64,
+    to: u64,
+) {
+    let notify = NotifyService::default().start::<&str>(Some("notify"));
+    let chain = ChainBuilder::new(tmp_shared, notify).build();
+    let chain_controller = chain.start(Some("chain"));
+    for index in from..=to {
+        let block = {
+            let block_hash = shared.store().get_block_hash(index).unwrap();
+            shared.store().get_block(&block_hash).unwrap()
+        };
+        chain_controller.process_block(Arc::new(block)).unwrap();
+    }
+}

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -84,7 +84,6 @@ pub fn run(args: RunArgs) -> Result<(), ExitCode> {
 
     rpc_server.close();
     info!(target: "main", "Jsonrpc shutdown");
-
     Ok(())
 }
 

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -26,6 +26,13 @@ pub struct RunArgs {
     pub consensus: Consensus,
 }
 
+pub struct ProfArgs {
+    pub config: Box<CKBAppConfig>,
+    pub consensus: Consensus,
+    pub from: u64,
+    pub to: u64,
+}
+
 pub struct MinerArgs {
     pub config: MinerConfig,
     pub pow_engine: Arc<dyn PowEngine>,

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -9,6 +9,7 @@ pub const CMD_IMPORT: &str = "import";
 pub const CMD_INIT: &str = "init";
 pub const CMD_CLI: &str = "cli";
 pub const CMD_KEYGEN: &str = "keygen";
+pub const CMD_PROF: &str = "prof";
 
 pub const ARG_CONFIG_DIR: &str = "config-dir";
 pub const ARG_FORMAT: &str = "format";
@@ -47,6 +48,7 @@ pub fn get_matches() -> ArgMatches<'static> {
         .subcommand(import())
         .subcommand(cli())
         .subcommand(init())
+        .subcommand(prof())
         .get_matches()
 }
 
@@ -56,6 +58,27 @@ fn run() -> App<'static, 'static> {
 
 fn miner() -> App<'static, 'static> {
     SubCommand::with_name(CMD_MINER).about("Running ckb miner")
+}
+
+fn prof() -> App<'static, 'static> {
+    SubCommand::with_name(CMD_PROF)
+        .about(
+            "Profling ckb node\n\
+             Example: Process 1..500 blocks then output flagme graph\n\
+             cargo flamegraph --bin ckb -- -C <dir> prof 1 500",
+        )
+        .arg(
+            Arg::with_name("from")
+                .required(true)
+                .index(1)
+                .help("from block number."),
+        )
+        .arg(
+            Arg::with_name("to")
+                .required(true)
+                .index(2)
+                .help("to block number."),
+        )
 }
 
 fn arg_format() -> Arg<'static, 'static> {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -5,7 +5,7 @@ mod exit_code;
 mod sentry_config;
 
 pub use app_config::{AppConfig, CKBAppConfig, MinerAppConfig};
-pub use args::{ExportArgs, ImportArgs, InitArgs, MinerArgs, RunArgs};
+pub use args::{ExportArgs, ImportArgs, InitArgs, MinerArgs, ProfArgs, RunArgs};
 pub use exit_code::ExitCode;
 
 use ckb_chain_spec::{consensus::Consensus, ChainSpec};
@@ -103,6 +103,20 @@ impl Setup {
         Ok(MinerArgs {
             pow_engine,
             config: config.miner,
+        })
+    }
+
+    pub fn prof<'m>(self, matches: &ArgMatches<'m>) -> Result<ProfArgs, ExitCode> {
+        let consensus = self.consensus()?;
+        let config = self.config.into_ckb()?;
+        let from = value_t!(matches.value_of("from"), u64)?;
+        let to = value_t!(matches.value_of("to"), u64)?;
+
+        Ok(ProfArgs {
+            config,
+            consensus,
+            from,
+            to,
         })
     }
 


### PR DESCRIPTION
Support `ckb prof` command

1. `cargo install flamegraph`
2. `sudo cargo flamegraph --bin ckb -- -C <node_dir> prof 1 500`

`prof` will re-process block `1..500`, then output the flame graph.