### PR TITLE
refactor: merge two transaction rpc interface

### DIFF
--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -77,7 +77,7 @@ impl<'a> FeeCalculator<'a> {
         self.txs_map
             .get(tx_hash)
             .map(|index| self.txs[*index].transaction.clone())
-            .or_else(|| self.provider.get_transaction(tx_hash))
+            .or_else(|| self.provider.get_transaction(tx_hash).map(|info| info.0))
     }
 
     fn calculate_transaction_fee(

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -177,33 +177,39 @@ curl -H 'content-type:application/json' \
 {
     "jsonrpc": "2.0",
     "result": {
-        "deps": [],
-        "hash": "0xa093b2e820f3f2202a6802314ece2eee3f863b177b3abe11bf16b1588152d31b",
-        "inputs": [
-            {
-                "args": [],
-                "previous_output": {
-                    "tx_hash": "0xeea31bfdcc4ac3bcb0204c450f08fb46c3840042b0a4e657edff3180cbb01c47",
-                    "index": 2996
-                },
-                "since": "0"
-            }
-        ],
-        "outputs": [
-            {
-                "capacity": "1000",
-                "data": "0x",
-                "lock": {
-                    "args": [
-                        "0x79616e676279"
-                    ],
-                    "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000001"
-                },
-                "type": null
-            }
-        ],
-        "version": 0,
-        "witnesses": []
+        "transaction" : {
+            "deps": [],
+            "hash": "0xa093b2e820f3f2202a6802314ece2eee3f863b177b3abe11bf16b1588152d31b",
+            "inputs": [
+                {
+                    "args": [],
+                    "previous_output": {
+                        "tx_hash": "0xeea31bfdcc4ac3bcb0204c450f08fb46c3840042b0a4e657edff3180cbb01c47",
+                        "index": 2996
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "1000",
+                    "data": "0x",
+                    "lock": {
+                        "args": [
+                            "0x79616e676279"
+                        ],
+                        "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    },
+                    "type": null
+                }
+            ],
+            "version": 0,
+            "witnesses": []
+        },
+        "tx_status": {
+            "status": "committed",
+            "block_hash": "0xef285e5da29247ce39385cbd8dc36535f7ea1b5b0379db26e9d459a8b47d0d71"
+        }
     },
     "id": 2
 }
@@ -449,59 +455,6 @@ echo '{
 {
     "jsonrpc": "2.0",
     "result": "0xee577cd94b1f2f1667316ff3cb44810902fd35cf901db28cde955b82eea56725",
-    "id": 2
-}
-```
-
-### get_pool_transaction
-
-Returns the information about a transaction in the transaction pool requested by transaction hash.
-
-#### Parameters
-
-    hash - Hash of a transaction.
-
-#### Example
-
-```bash
-curl -H 'content-type:application/json' \
-    -d '{"id": 2, "jsonrpc": "2.0", "method": "get_pool_transaction", "params": ["0xced4b0ccaf0e09d5d38ab717fc60f96a6097182f4c1ae2522d0689618306a229"]}' \
-    http://localhost:8114'
-```
-
-
-```json
-{
-    "jsonrpc": "2.0",
-    "result": {
-        "deps": [],
-        "hash": "0xced4b0ccaf0e09d5d38ab717fc60f96a6097182f4c1ae2522d0689618306a229",
-        "inputs": [
-            {
-                "args": [],
-                "previous_output": {
-                    "tx_hash": "0xeea31bfdcc4ac3bcb0204c450f08fb46c3840042b0a4e657edff3180cbb01c47",
-                    "index": 2994
-                },
-                "since": "0"
-            }
-        ],
-        "outputs": [
-            {
-                "capacity": "1000",
-                "data": "0x",
-                "lock": {
-                    "args": [
-                        "0x79616e676279"
-                    ],
-                    "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000001"
-                },
-                "type": null
-            }
-        ],
-        "version": 0,
-        "witnesses": []
-    },
     "id": 2
 }
 ```

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -1,5 +1,5 @@
 use crate::error::RPCError;
-use ckb_core::transaction::{ProposalShortId, Transaction as CoreTransaction};
+use ckb_core::transaction::Transaction as CoreTransaction;
 use ckb_network::NetworkController;
 use ckb_protocol::RelayMessage;
 use ckb_shared::shared::Shared;
@@ -17,10 +17,6 @@ pub trait PoolRpc {
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"send_transaction","params": [{"version":2, "deps":[], "inputs":[], "outputs":[]}]}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "send_transaction")]
     fn send_transaction(&self, _tx: Transaction) -> Result<H256>;
-
-    // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"get_pool_transaction","params": [""]}' -H 'content-type:application/json' 'http://localhost:8114'
-    #[rpc(name = "get_pool_transaction")]
-    fn get_pool_transaction(&self, _hash: H256) -> Result<Option<Transaction>>;
 }
 
 pub(crate) struct PoolRpcImpl<CS> {
@@ -49,16 +45,5 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
         }
-    }
-
-    fn get_pool_transaction(&self, hash: H256) -> Result<Option<Transaction>> {
-        let id = ProposalShortId::from_tx_hash(&hash);
-        Ok(self
-            .shared
-            .chain_state()
-            .lock()
-            .tx_pool()
-            .get_tx(&id)
-            .map(|tx| (&tx).into()))
     }
 }

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -452,7 +452,7 @@ impl<CS: ChainStore> CellProvider for ChainState<CS> {
                 if tx_meta.is_dead(out_point.index as usize) {
                     CellStatus::Dead
                 } else {
-                    let tx = self
+                    let (tx, _) = self
                         .store
                         .get_transaction(&out_point.tx_hash)
                         .expect("store should be consistent with cell_set");
@@ -483,7 +483,7 @@ impl<'a, CS: ChainStore> CellProvider for ChainCellSetOverlay<'a, CS> {
                         .or_else(|| {
                             self.store
                                 .get_transaction(&out_point.tx_hash)
-                                .map(|tx| tx.outputs()[out_point.index as usize].clone())
+                                .map(|(tx, _)| tx.outputs()[out_point.index as usize].clone())
                         })
                         .expect("store should be consistent with cell_set");
 

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -97,7 +97,7 @@ impl<CS: ChainStore> ChainProvider for Shared<CS> {
         self.consensus.genesis_hash()
     }
 
-    fn get_transaction(&self, hash: &H256) -> Option<Transaction> {
+    fn get_transaction(&self, hash: &H256) -> Option<(Transaction, H256)> {
         self.store.get_transaction(hash)
     }
 

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -133,6 +133,10 @@ impl TxPool {
             .cloned()
     }
 
+    pub fn get_tx_from_staging(&self, id: &ProposalShortId) -> Option<Transaction> {
+        self.staging.get_tx(id).cloned()
+    }
+
     //FIXME: use memsize
     pub fn is_full(&self) -> bool {
         self.capacity() > self.config.max_pool_size

--- a/traits/src/chain_provider.rs
+++ b/traits/src/chain_provider.rs
@@ -26,7 +26,7 @@ pub trait ChainProvider: Sync + Send {
 
     fn genesis_hash(&self) -> &H256;
 
-    fn get_transaction(&self, hash: &H256) -> Option<Transaction>;
+    fn get_transaction(&self, hash: &H256) -> Option<(Transaction, H256)>;
 
     fn contain_transaction(&self, hash: &H256) -> bool;
 

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -265,18 +265,16 @@ impl TransactionWithStatus {
     }
 }
 
-/// Can see the serialization results on the links: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=475702fa87bc741e5d482fca52ba139f
+/// Can see the serialization results on the links: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=c48782574d5ebe42dd24cd3650313cca
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 #[serde(tag = "status", content = "block_hash")]
+#[serde(rename_all = "lowercase")]
 pub enum TxStatus {
     /// Transaction on pool, not proposed
-    #[serde(rename = "pending")]
     Pending,
     /// Transaction on pool, proposed
-    #[serde(rename = "proposed")]
     Proposed,
     /// Transaction commit on block
-    #[serde(rename = "committed")]
     Committed(H256),
 }
 

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -232,6 +232,54 @@ impl TryFrom<Transaction> for CoreTransaction {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct TransactionWithStatus {
+    pub transaction: Transaction,
+    /// Indicate the Transaction status
+    pub tx_status: TxStatus,
+}
+
+impl TransactionWithStatus {
+    /// Build with pending status
+    pub fn with_pending(tx: CoreTransaction) -> Self {
+        Self {
+            tx_status: TxStatus::Pending,
+            transaction: (&tx).into(),
+        }
+    }
+
+    /// Build with proposed status
+    pub fn with_proposed(tx: CoreTransaction) -> Self {
+        Self {
+            tx_status: TxStatus::Proposed,
+            transaction: (&tx).into(),
+        }
+    }
+
+    /// Build with committed status
+    pub fn with_committed(tx: CoreTransaction, hash: H256) -> Self {
+        Self {
+            tx_status: TxStatus::Committed(hash),
+            transaction: (&tx).into(),
+        }
+    }
+}
+
+/// Can see the serialization results on the links: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=475702fa87bc741e5d482fca52ba139f
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+#[serde(tag = "status", content = "block_hash")]
+pub enum TxStatus {
+    /// Transaction on pool, not proposed
+    #[serde(rename = "pending")]
+    Pending,
+    /// Transaction on pool, proposed
+    #[serde(rename = "proposed")]
+    Proposed,
+    /// Transaction commit on block
+    #[serde(rename = "committed")]
+    Committed(H256),
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct Seal {
     pub nonce: String,

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -14,7 +14,8 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, CellInput, CellOutput, Header, OutPoint, Script, Seal, Transaction, UncleBlock, Witness,
+    Block, CellInput, CellOutput, Header, OutPoint, Script, Seal, Transaction,
+    TransactionWithStatus, TxStatus, UncleBlock, Witness,
 };
 pub use self::bytes::Bytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};

--- a/verification/src/tests/dummy.rs
+++ b/verification/src/tests/dummy.rs
@@ -59,7 +59,7 @@ impl ChainProvider for DummyChainProvider {
         panic!("Not implemented!");
     }
 
-    fn get_transaction(&self, _hash: &H256) -> Option<Transaction> {
+    fn get_transaction(&self, _hash: &H256) -> Option<(Transaction, H256)> {
         panic!("Not implemented!");
     }
 


### PR DESCRIPTION
1. Modify the return value of the `get_transaction` interface
2. Modify the return type of the `get_transaction`