### PR TITLE
[HOLD] refactor: CellProvider and TransactionVerifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,6 @@ dependencies = [
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -30,4 +30,3 @@ serde_derive = "1.0"
 [dev-dependencies]
 env_logger = "0.6"
 tempfile = "3.0"
-regex = "1"

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -12,7 +12,7 @@ use ckb_shared::error::SharedError;
 use ckb_shared::shared::Shared;
 use ckb_shared::store::{ChainStore, StoreBatch};
 use ckb_traits::{BlockMedianTimeContext, ChainProvider};
-use ckb_verification::{BlockVerifier, TransactionsVerifier, Verifier};
+use ckb_verification::{BlockVerifier, Error as VerificationError, TransactionsVerifier, Verifier};
 use crossbeam_channel::{self, select, Receiver, Sender};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
@@ -466,37 +466,42 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                     let block_cp = BlockCellProvider::new(b);
                     let cell_provider = OverlayCellProvider::new(&block_cp, &cell_set_overlay);
 
-                    let resolved: Vec<ResolvedTransaction> = b
+                    let resolved: Result<Vec<ResolvedTransaction>, _> = b
                         .transactions()
                         .iter()
                         .map(|x| cell_provider.resolve_transaction(x))
                         .collect();
 
-                    let cellbase_maturity = { self.shared.consensus().cellbase_maturity() };
+                    if resolved.is_err() {
+                        found_error = Some(VerificationError::Unresolvable(resolved.unwrap_err()));
+                        ext.txs_verified = Some(false);
+                    } else {
+                        let cellbase_maturity = { self.shared.consensus().cellbase_maturity() };
 
-                    match txs_verifier.verify(
-                        &resolved,
-                        self.shared.block_reward(b.header().number()),
-                        ForkContext {
-                            fork_blocks: &fork.attached_blocks,
-                            store: Arc::clone(self.shared.store()),
-                            consensus: self.shared.consensus(),
-                        },
-                        b.header().number(),
-                        cellbase_maturity,
-                    ) {
-                        Ok(_) => {
-                            cell_set_diff.push_new(b);
-                            outputs.extend(
-                                b.transactions().iter().map(|tx| (tx.hash(), tx.outputs())),
-                            );
-                            ext.txs_verified = Some(true);
-                        }
-                        Err(err) => {
-                            error!(target: "chain", "cell_set_diff {}", serde_json::to_string(&cell_set_diff).unwrap());
-                            error!(target: "chain", "block {}", serde_json::to_string(b).unwrap());
-                            found_error = Some(err);
-                            ext.txs_verified = Some(false);
+                        match txs_verifier.verify(
+                            &resolved.unwrap(),
+                            self.shared.block_reward(b.header().number()),
+                            ForkContext {
+                                fork_blocks: &fork.attached_blocks,
+                                store: Arc::clone(self.shared.store()),
+                                consensus: self.shared.consensus(),
+                            },
+                            b.header().number(),
+                            cellbase_maturity,
+                        ) {
+                            Ok(_) => {
+                                cell_set_diff.push_new(b);
+                                outputs.extend(
+                                    b.transactions().iter().map(|tx| (tx.hash(), tx.outputs())),
+                                );
+                                ext.txs_verified = Some(true);
+                            }
+                            Err(err) => {
+                                error!(target: "chain", "cell_set_diff {}", serde_json::to_string(&cell_set_diff).unwrap());
+                                error!(target: "chain", "block {}", serde_json::to_string(b).unwrap());
+                                found_error = Some(err);
+                                ext.txs_verified = Some(false);
+                            }
                         }
                     }
                 } else {

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -67,7 +67,7 @@ fn test_genesis_transaction_spend() {
         shared
             .chain_state()
             .lock()
-            .get_cell_status(&OutPoint::new(genesis_tx_hash, 0)),
+            .cell(&OutPoint::new(genesis_tx_hash, 0)),
         CellStatus::Dead
     );
 }
@@ -93,7 +93,7 @@ fn test_transaction_spend_in_same_block() {
     let last_cell_base = &chain.last().unwrap().transactions()[0];
     let last_cell_base_hash = last_cell_base.hash().clone();
     let tx1 = create_transaction(last_cell_base_hash.clone(), 1);
-    let tx1_hash = tx1.hash().clone();
+    let tx1_hash = tx1.hash();
     let tx2 = create_transaction(tx1_hash.clone(), 2);
     let tx2_hash = tx2.hash().clone();
     let tx2_output = tx2.outputs()[0].clone();
@@ -111,7 +111,7 @@ fn test_transaction_spend_in_same_block() {
             shared
                 .chain_state()
                 .lock()
-                .get_cell_status(&OutPoint::new(hash.clone(), 0)),
+                .cell(&OutPoint::new(hash.clone(), 0)),
             CellStatus::Unknown
         );
     }
@@ -164,7 +164,7 @@ fn test_transaction_spend_in_same_block() {
             shared
                 .chain_state()
                 .lock()
-                .get_cell_status(&OutPoint::new(hash.clone(), 0)),
+                .cell(&OutPoint::new(hash.clone(), 0)),
             CellStatus::Dead
         );
     }
@@ -173,7 +173,7 @@ fn test_transaction_spend_in_same_block() {
         shared
             .chain_state()
             .lock()
-            .get_cell_status(&OutPoint::new(tx2_hash, 0)),
+            .cell(&OutPoint::new(tx2_hash, 0)),
         CellStatus::live_output(tx2_output, Some(4), false)
     );
 }
@@ -198,8 +198,9 @@ fn test_transaction_conflict_in_same_block() {
 
     let last_cell_base = &chain.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
-    let tx2 = create_transaction(tx1.hash(), 2);
-    let tx3 = create_transaction(tx1.hash(), 3);
+    let tx1_hash = tx1.hash();
+    let tx2 = create_transaction(tx1_hash.clone(), 2);
+    let tx3 = create_transaction(tx1_hash.clone(), 3);
     let txs = vec![tx1, tx2, tx3];
     // proposal txs
     {
@@ -245,9 +246,10 @@ fn test_transaction_conflict_in_same_block() {
             .expect("process block ok");
     }
     assert_eq!(
-        // TODO Q
-        // SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
-        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        SharedError::InvalidTransaction(format!(
+            "Unresolvable(Dead(OutPoint {{ tx_hash: 0x{:x}, index: 0 }}))",
+            tx1_hash
+        )),
         chain_controller
             .process_block(Arc::new(chain[3].clone()))
             .unwrap_err()
@@ -276,8 +278,9 @@ fn test_transaction_conflict_in_different_blocks() {
 
     let last_cell_base = &chain.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
-    let tx2 = create_transaction(tx1.hash(), 2);
-    let tx3 = create_transaction(tx1.hash(), 3);
+    let tx1_hash = tx1.hash();
+    let tx2 = create_transaction(tx1_hash.clone(), 2);
+    let tx3 = create_transaction(tx1_hash.clone(), 3);
     // proposal txs
     {
         let difficulty = parent.difficulty().clone();
@@ -336,9 +339,10 @@ fn test_transaction_conflict_in_different_blocks() {
     }
 
     assert_eq!(
-        // TODO Q
-        // SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
-        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        SharedError::InvalidTransaction(format!(
+            "Unresolvable(Dead(OutPoint {{ tx_hash: 0x{:x}, index: 0 }}))",
+            tx1_hash
+        )),
         chain_controller
             .process_block(Arc::new(chain[4].clone()))
             .unwrap_err()
@@ -372,7 +376,7 @@ fn test_genesis_transaction_fetch() {
     let (_chain_controller, shared) = start_chain(Some(consensus), false);
 
     let out_point = OutPoint::new(root_hash, 0);
-    let state = shared.chain_state().lock().get_cell_status(&out_point);
+    let state = shared.chain_state().lock().cell(&out_point);
     assert!(state.is_live());
 }
 

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -244,17 +244,16 @@ fn test_transaction_conflict_in_same_block() {
             .process_block(Arc::new(block.clone()))
             .expect("process block ok");
     }
-    let error = chain_controller
-        .process_block(Arc::new(chain[3].clone()))
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    if let SharedError::InvalidTransaction(errmsg) = error {
-        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
-        assert!(re.is_match(&errmsg));
-    } else {
-        panic!("should be the Conflict Transactions error");
-    }
+    assert_eq!(
+        // TODO Q
+        // SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
+        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        chain_controller
+            .process_block(Arc::new(chain[3].clone()))
+            .unwrap_err()
+            .downcast()
+            .unwrap()
+    );
 }
 
 #[test]
@@ -335,17 +334,17 @@ fn test_transaction_conflict_in_different_blocks() {
             .process_block(Arc::new(block.clone()))
             .expect("process block ok");
     }
-    let error = chain_controller
-        .process_block(Arc::new(chain[4].clone()))
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    if let SharedError::InvalidTransaction(errmsg) = error {
-        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
-        assert!(re.is_match(&errmsg));
-    } else {
-        panic!("should be the Conflict Transactions error");
-    }
+
+    assert_eq!(
+        // TODO Q
+        // SharedError::InvalidTransaction("Transactions((1, Conflict))".to_string()),
+        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        chain_controller
+            .process_block(Arc::new(chain[4].clone()))
+            .unwrap_err()
+            .downcast()
+            .unwrap()
+    );
 }
 
 #[test]

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -89,18 +89,14 @@ fn test_dead_cell_in_same_block() {
             .process_block(Arc::new(block.clone()))
             .expect("process block ok");
     }
-
-    let error = chain_controller
-        .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    if let SharedError::InvalidTransaction(errmsg) = error {
-        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
-        assert!(re.is_match(&errmsg));
-    } else {
-        panic!("should be the Conflict Transactions error");
-    }
+    assert_eq!(
+        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        chain_controller
+            .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
+            .unwrap_err()
+            .downcast()
+            .unwrap()
+    )
 }
 
 #[test]
@@ -195,15 +191,12 @@ fn test_dead_cell_in_different_block() {
             .expect("process block ok");
     }
 
-    let error = chain_controller
-        .process_block(Arc::new(chain2[switch_fork_number + 2].clone()))
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    if let SharedError::InvalidTransaction(errmsg) = error {
-        let re = regex::Regex::new(r#"Transactions\(\([0-9], Conflict\)\)"#).unwrap();
-        assert!(re.is_match(&errmsg));
-    } else {
-        panic!("should be the Conflict Transactions error");
-    }
+    assert_eq!(
+        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        chain_controller
+            .process_block(Arc::new(chain2[switch_fork_number + 2].clone()))
+            .unwrap_err()
+            .downcast()
+            .unwrap()
+    )
 }

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -44,8 +44,9 @@ fn test_dead_cell_in_same_block() {
 
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
-    let tx2 = create_transaction(tx1.hash(), 2);
-    let tx3 = create_transaction(tx1.hash(), 3);
+    let tx1_hash = tx1.hash();
+    let tx2 = create_transaction(tx1_hash.clone(), 2);
+    let tx3 = create_transaction(tx1_hash.clone(), 3);
     let txs = vec![tx1, tx2, tx3];
     for i in switch_fork_number..final_number {
         let difficulty = parent.difficulty().clone();
@@ -90,7 +91,10 @@ fn test_dead_cell_in_same_block() {
             .expect("process block ok");
     }
     assert_eq!(
-        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        SharedError::InvalidTransaction(format!(
+            "Unresolvable(Dead(OutPoint {{ tx_hash: 0x{:x}, index: 0 }}))",
+            tx1_hash
+        )),
         chain_controller
             .process_block(Arc::new(chain2[switch_fork_number + 1].clone()))
             .unwrap_err()
@@ -138,8 +142,9 @@ fn test_dead_cell_in_different_block() {
 
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
-    let tx2 = create_transaction(tx1.hash(), 2);
-    let tx3 = create_transaction(tx1.hash(), 3);
+    let tx1_hash = tx1.hash();
+    let tx2 = create_transaction(tx1_hash.clone(), 2);
+    let tx3 = create_transaction(tx1_hash.clone(), 3);
     for i in switch_fork_number..final_number {
         let difficulty = parent.difficulty().clone();
         let new_block = if i == switch_fork_number {
@@ -192,7 +197,10 @@ fn test_dead_cell_in_different_block() {
     }
 
     assert_eq!(
-        SharedError::InvalidTransaction("Unresolvable(Dead)".to_string()),
+        SharedError::InvalidTransaction(format!(
+            "Unresolvable(Dead(OutPoint {{ tx_hash: 0x{:x}, index: 0 }}))",
+            tx1_hash
+        )),
         chain_controller
             .process_block(Arc::new(chain2[switch_fork_number + 2].clone()))
             .unwrap_err()

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -1,7 +1,7 @@
 use crate::block::Block;
 use crate::transaction::{CellOutput, OutPoint, Transaction};
 use crate::Capacity;
-use fnv::{FnvHashMap, FnvHashSet};
+use fnv::FnvHashMap;
 use numext_fixed_hash::H256;
 use std::iter::Chain;
 use std::slice;
@@ -104,6 +104,26 @@ pub trait CellProvider {
             self.cell(out_point)
         }
     }
+
+    fn resolve_transaction(&self, transaction: &Transaction) -> ResolvedTransaction {
+        let input_cells = transaction
+            .input_pts()
+            .iter()
+            .map(|input| self.get_cell_status(input))
+            .collect();
+
+        let dep_cells = transaction
+            .dep_pts()
+            .iter()
+            .map(|dep| self.get_cell_status(dep))
+            .collect();
+
+        ResolvedTransaction {
+            transaction: transaction.clone(),
+            input_cells,
+            dep_cells,
+        }
+    }
 }
 
 pub struct OverlayCellProvider<'a> {
@@ -132,19 +152,31 @@ impl<'a> CellProvider for OverlayCellProvider<'a> {
 
 pub struct BlockCellProvider<'a> {
     output_indices: FnvHashMap<H256, usize>,
+    duplicate_inputs_counter: FnvHashMap<&'a OutPoint, usize>,
     block: &'a Block,
 }
 
 impl<'a> BlockCellProvider<'a> {
     pub fn new(block: &'a Block) -> Self {
+        let mut duplicate_inputs_counter = FnvHashMap::default();
+
         let output_indices = block
             .transactions()
             .iter()
             .enumerate()
-            .map(|(idx, tx)| (tx.hash(), idx))
+            .map(|(idx, tx)| {
+                tx.inputs().iter().for_each(|input| {
+                    duplicate_inputs_counter
+                        .entry(&input.previous_output)
+                        .and_modify(|c| *c += 1)
+                        .or_default();
+                });
+                (tx.hash(), idx)
+            })
             .collect();
         Self {
             output_indices,
+            duplicate_inputs_counter,
             block,
         }
     }
@@ -152,7 +184,13 @@ impl<'a> BlockCellProvider<'a> {
 
 impl<'a> CellProvider for BlockCellProvider<'a> {
     fn cell(&self, out_point: &OutPoint) -> CellStatus {
-        if let Some(i) = self.output_indices.get(&out_point.tx_hash) {
+        if let Some(true) = self
+            .duplicate_inputs_counter
+            .get(out_point)
+            .map(|counter| *counter > 0)
+        {
+            CellStatus::Dead
+        } else if let Some(i) = self.output_indices.get(&out_point.tx_hash) {
             match self.block.transactions()[*i]
                 .outputs()
                 .get(out_point.index as usize)
@@ -168,39 +206,38 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
     }
 }
 
-pub fn resolve_transaction<CP: CellProvider>(
-    transaction: &Transaction,
-    seen_inputs: &mut FnvHashSet<OutPoint>,
-    cell_provider: &CP,
-) -> ResolvedTransaction {
-    let input_cells = transaction
-        .input_pts()
-        .iter()
-        .map(|input| {
-            if seen_inputs.insert(input.clone()) {
-                cell_provider.get_cell_status(input)
-            } else {
-                CellStatus::Dead
-            }
-        })
-        .collect();
+pub struct TransactionCellProvider<'a> {
+    duplicate_inputs_counter: FnvHashMap<&'a OutPoint, usize>,
+}
 
-    let dep_cells = transaction
-        .dep_pts()
-        .iter()
-        .map(|dep| {
-            if seen_inputs.contains(dep) {
-                CellStatus::Dead
-            } else {
-                cell_provider.get_cell_status(dep)
-            }
-        })
-        .collect();
+impl<'a> TransactionCellProvider<'a> {
+    pub fn new(transaction: &'a Transaction) -> Self {
+        let mut duplicate_inputs_counter = FnvHashMap::default();
 
-    ResolvedTransaction {
-        transaction: transaction.clone(),
-        input_cells,
-        dep_cells,
+        transaction.inputs().iter().for_each(|input| {
+            duplicate_inputs_counter
+                .entry(&input.previous_output)
+                .and_modify(|c| *c += 1)
+                .or_default();
+        });
+
+        Self {
+            duplicate_inputs_counter,
+        }
+    }
+}
+
+impl<'a> CellProvider for TransactionCellProvider<'a> {
+    fn cell(&self, out_point: &OutPoint) -> CellStatus {
+        if let Some(true) = self
+            .duplicate_inputs_counter
+            .get(out_point)
+            .map(|counter| *counter > 0)
+        {
+            CellStatus::Dead
+        } else {
+            CellStatus::Unknown
+        }
     }
 }
 

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -74,8 +74,8 @@ impl CellStatus {
 
 /// Transaction with resolved input cells.
 #[derive(Debug)]
-pub struct ResolvedTransaction {
-    pub transaction: Transaction,
+pub struct ResolvedTransaction<'a> {
+    pub transaction: &'a Transaction,
     pub dep_cells: Vec<CellMeta>,
     pub input_cells: Vec<CellMeta>,
 }
@@ -89,10 +89,10 @@ pub enum UnresolvableError {
 pub trait CellProvider {
     fn cell(&self, out_point: &OutPoint) -> CellStatus;
 
-    fn resolve_transaction(
+    fn resolve_transaction<'a>(
         &self,
-        transaction: &Transaction,
-    ) -> Result<ResolvedTransaction, UnresolvableError> {
+        transaction: &'a Transaction,
+    ) -> Result<ResolvedTransaction<'a>, UnresolvableError> {
         // setup empty input cells for cellbase
         let input_cells = if transaction.is_cellbase() {
             Ok(Vec::new())
@@ -127,7 +127,7 @@ pub trait CellProvider {
         }
 
         Ok(ResolvedTransaction {
-            transaction: transaction.clone(),
+            transaction,
             input_cells: input_cells.unwrap(),
             dep_cells: dep_cells.unwrap(),
         })
@@ -249,7 +249,7 @@ impl<'a> CellProvider for TransactionCellProvider<'a> {
     }
 }
 
-impl ResolvedTransaction {
+impl<'a> ResolvedTransaction<'a> {
     pub fn is_cellbase(&self) -> bool {
         self.input_cells.is_empty()
     }

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -129,7 +129,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
             .shared
             .chain_state()
             .lock()
-            .get_cell_status(&(out_point.try_into().map_err(|_| Error::parse_error())?))
+            .cell(&(out_point.try_into().map_err(|_| Error::parse_error())?))
             .into())
     }
 

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -3,7 +3,7 @@ use crate::{
     syscalls::{build_tx, Debugger, LoadCell, LoadCellByField, LoadInputByField, LoadTx},
     ScriptError,
 };
-use ckb_core::cell::{LiveCell, ResolvedTransaction};
+use ckb_core::cell::{CellMeta, ResolvedTransaction};
 use ckb_core::script::{Script, ALWAYS_SUCCESS_HASH};
 use ckb_core::transaction::{CellInput, CellOutput};
 use ckb_core::Cycle;
@@ -29,16 +29,9 @@ pub struct TransactionScriptsVerifier<'a> {
 
 impl<'a> TransactionScriptsVerifier<'a> {
     pub fn new(rtx: &'a ResolvedTransaction) -> TransactionScriptsVerifier<'a> {
-        let dep_cells: Vec<&'a CellOutput> = rtx
-            .dep_cells
-            .iter()
-            .filter_map(LiveCell::get_live_output)
-            .collect();
-        let input_cells = rtx
-            .input_cells
-            .iter()
-            .filter_map(LiveCell::get_live_output)
-            .collect();
+        let dep_cells: Vec<&'a CellOutput> =
+            rtx.dep_cells.iter().map(CellMeta::cell_output).collect();
+        let input_cells = rtx.input_cells.iter().map(CellMeta::cell_output).collect();
         let inputs = rtx.transaction.inputs().iter().collect();
         let outputs = rtx.transaction.outputs().iter().collect();
         let witnesses: FnvHashMap<u32, &'a [Vec<u8>]> = rtx
@@ -191,7 +184,7 @@ impl<'a> TransactionScriptsVerifier<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ckb_core::cell::{CellMeta, LiveCell};
+    use ckb_core::cell::CellMeta;
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
     use ckb_core::{capacity_bytes, Capacity};
@@ -226,7 +219,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -293,8 +286,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![LiveCell::Output(dep_cell)],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            dep_cells: vec![dep_cell],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -361,8 +354,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![LiveCell::Output(dep_cell)],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            dep_cells: vec![dep_cell],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -431,8 +424,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![LiveCell::Output(dep_cell)],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            dep_cells: vec![dep_cell],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -489,7 +482,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -565,8 +558,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![LiveCell::Output(dep_cell)],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            dep_cells: vec![dep_cell],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -644,8 +637,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![LiveCell::Output(dep_cell)],
-            input_cells: vec![LiveCell::Output(dummy_cell)],
+            dep_cells: vec![dep_cell],
+            input_cells: vec![dummy_cell],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -3,7 +3,7 @@ use crate::{
     syscalls::{build_tx, Debugger, LoadCell, LoadCellByField, LoadInputByField, LoadTx},
     ScriptError,
 };
-use ckb_core::cell::ResolvedTransaction;
+use ckb_core::cell::{LiveCell, ResolvedTransaction};
 use ckb_core::script::{Script, ALWAYS_SUCCESS_HASH};
 use ckb_core::transaction::{CellInput, CellOutput};
 use ckb_core::Cycle;
@@ -32,22 +32,12 @@ impl<'a> TransactionScriptsVerifier<'a> {
         let dep_cells: Vec<&'a CellOutput> = rtx
             .dep_cells
             .iter()
-            .map(|cell| {
-                &cell
-                    .get_live_output()
-                    .expect("already verifies that all dep cells are valid")
-                    .cell_output
-            })
+            .filter_map(LiveCell::get_live_output)
             .collect();
         let input_cells = rtx
             .input_cells
             .iter()
-            .map(|cell| {
-                &cell
-                    .get_live_output()
-                    .expect("already verifies that all input cells are valid")
-                    .cell_output
-            })
+            .filter_map(LiveCell::get_live_output)
             .collect();
         let inputs = rtx.transaction.inputs().iter().collect();
         let outputs = rtx.transaction.outputs().iter().collect();
@@ -201,7 +191,7 @@ impl<'a> TransactionScriptsVerifier<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ckb_core::cell::{CellMeta, CellStatus, LiveCell};
+    use ckb_core::cell::{CellMeta, LiveCell};
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
     use ckb_core::{capacity_bytes, Capacity};
@@ -236,7 +226,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -303,8 +293,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![LiveCell::Output(dep_cell)],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -371,8 +361,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![LiveCell::Output(dep_cell)],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -441,8 +431,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![LiveCell::Output(dep_cell)],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -499,7 +489,7 @@ mod tests {
         let rtx = ResolvedTransaction {
             transaction,
             dep_cells: vec![],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -575,8 +565,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![LiveCell::Output(dep_cell)],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);
@@ -654,8 +644,8 @@ mod tests {
 
         let rtx = ResolvedTransaction {
             transaction,
-            dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
-            input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
+            dep_cells: vec![LiveCell::Output(dep_cell)],
+            input_cells: vec![LiveCell::Output(dummy_cell)],
         };
 
         let verifier = TransactionScriptsVerifier::new(&rtx);

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -217,7 +217,7 @@ mod tests {
         let transaction = TransactionBuilder::default().input(input.clone()).build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![],
             input_cells: vec![dummy_cell],
         };
@@ -285,7 +285,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![dep_cell],
             input_cells: vec![dummy_cell],
         };
@@ -353,7 +353,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![dep_cell],
             input_cells: vec![dummy_cell],
         };
@@ -423,7 +423,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![dep_cell],
             input_cells: vec![dummy_cell],
         };
@@ -480,7 +480,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![],
             input_cells: vec![dummy_cell],
         };
@@ -557,7 +557,7 @@ mod tests {
             .build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![dep_cell],
             input_cells: vec![dummy_cell],
         };
@@ -636,7 +636,7 @@ mod tests {
             .build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![dep_cell],
             input_cells: vec![dummy_cell],
         };

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -190,11 +190,11 @@ impl<CS: ChainStore> ChainState<CS> {
         })
     }
 
-    fn resolve_tx_from_pending_and_staging(
+    fn resolve_tx_from_pending_and_staging<'a>(
         &self,
-        tx: &Transaction,
+        tx: &'a Transaction,
         tx_pool: &TxPool,
-    ) -> Result<ResolvedTransaction, PoolError> {
+    ) -> Result<ResolvedTransaction<'a>, PoolError> {
         let transaction_provider = TransactionCellProvider::new(tx);
         let staging_provider = OverlayCellProvider::new(&tx_pool.staging, self);
         let pending_and_staging_provider =
@@ -206,11 +206,11 @@ impl<CS: ChainStore> ChainState<CS> {
             .map_err(|_| PoolError::Conflict)
     }
 
-    fn resolve_tx_from_staging(
+    fn resolve_tx_from_staging<'a>(
         &self,
-        tx: &Transaction,
+        tx: &'a Transaction,
         tx_pool: &TxPool,
-    ) -> Result<ResolvedTransaction, PoolError> {
+    ) -> Result<ResolvedTransaction<'a>, PoolError> {
         let transaction_provider = TransactionCellProvider::new(tx);
         let staging_provider = OverlayCellProvider::new(&tx_pool.staging, self);
         let cell_provider = OverlayCellProvider::new(&transaction_provider, &staging_provider);

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -399,14 +399,12 @@ impl<CS: ChainStore> ChainState<CS> {
     }
 }
 
-#[allow(dead_code)] // incorrect lint
 pub struct ChainCellSetOverlay<'a, CS> {
     pub(crate) overlay: CellSetOverlay<'a>,
     pub(crate) store: Arc<CS>,
     pub(crate) outputs: &'a FnvHashMap<H256, &'a [CellOutput]>,
 }
 
-#[cfg(not(test))]
 impl<CS: ChainStore> CellProvider for ChainState<CS> {
     fn cell(&self, out_point: &OutPoint) -> CellStatus {
         match self.cell_set().get(&out_point.tx_hash) {
@@ -430,7 +428,6 @@ impl<CS: ChainStore> CellProvider for ChainState<CS> {
     }
 }
 
-#[cfg(not(test))]
 impl<'a, CS: ChainStore> CellProvider for ChainCellSetOverlay<'a, CS> {
     fn cell(&self, out_point: &OutPoint) -> CellStatus {
         match self.overlay.get(&out_point.tx_hash) {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -16,8 +16,11 @@ pub mod store;
 pub mod tx_pool;
 mod tx_proposal_table;
 
-#[cfg(test)]
-mod tests;
+// These tests are from testnet data dump, they are hard to maintenance.
+// Although they pass curruent unit tests, we still comment out here,
+// Keep the code for future unit test refactoring reference.
+// #[cfg(test)]
+// mod tests;
 
 use ckb_db::Col;
 

--- a/shared/src/tests/data/no1/txs.json
+++ b/shared/src/tests/data/no1/txs.json
@@ -39,12 +39,7 @@
     },
     {
         "version": 0,
-        "deps": [
-            {
-                "tx_hash": "0x206925a8e9636a5546d554f1eb9d26c98bb2d99d4afb40cb761701bae102b96e",
-                "index": 0
-            }
-        ],
+        "deps": [],
         "inputs": [
             {
                 "previous_output": {

--- a/shared/src/tests/no1.rs
+++ b/shared/src/tests/no1.rs
@@ -3,10 +3,10 @@ use crate::{
     shared::{Shared, SharedBuilder},
     store::ChainKVStore,
 };
-use ckb_core::cell::{resolve_transaction, CellStatus, LiveCell};
+use ckb_core::cell::{CellProvider, CellStatus, LiveCell};
 use ckb_core::transaction::Transaction;
 use ckb_db::memorydb::MemoryKeyValueDB;
-use fnv::{FnvHashMap, FnvHashSet};
+use fnv::FnvHashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -52,25 +52,19 @@ fn case_no1() {
 
     let cell_set_overlay = chain_state.new_cell_set_overlay(&cell_set_diff, &outputs);
     let transcations = transcations();
-    // let cell_provider = OverlayCellProvider::new(&overlay, &cell_set);
 
-    let mut seen = FnvHashSet::default();
     //Outpoint::null should be live
-    let rtx0 = resolve_transaction(&transcations[0], &mut seen, &cell_set_overlay);
+    let rtx0 = cell_set_overlay.resolve_transaction(&transcations[0]);
     assert_eq!(rtx0.input_cells[0], CellStatus::Live(LiveCell::Null));
-
-    // let out_point = transcations[1].inputs()[0].previous_output.clone();
 
     // cell A (0x8aa8799cd6ad56dd6929fd6ac05f5cab6a5339562297abb619839ab2da519f35, 0)
     // A is dead in old fork
-    let mut seen_inputs = seen.clone();
-    let rtx1 = resolve_transaction(&transcations[1], &mut seen_inputs, &*chain_state);
+    let rtx1 = chain_state.resolve_transaction(&transcations[1]);
     assert_eq!(rtx1.input_cells[0], CellStatus::Dead);
 
     // A include in cell_set_diff old_inputs
     // A is live in cell_set_overlay
-    let mut seen_inputs = seen.clone();
-    let rtx1_overlay = resolve_transaction(&transcations[1], &mut seen_inputs, &cell_set_overlay);
+    let rtx1_overlay = cell_set_overlay.resolve_transaction(&transcations[1]);
     assert_eq!(
         rtx1_overlay.input_cells[0],
         CellStatus::Live(LiveCell::Null)

--- a/shared/src/tests/no1.rs
+++ b/shared/src/tests/no1.rs
@@ -57,7 +57,7 @@ fn case_no1() {
     let rtx0 = cell_set_overlay
         .resolve_transaction(&transcations[0])
         .unwrap();
-    assert_eq!(rtx0.input_cells[0], CellStatus::Live(LiveCell::Null));
+    assert_eq!(rtx0.input_cells[0], LiveCell::Null);
 
     // cell A (0x8aa8799cd6ad56dd6929fd6ac05f5cab6a5339562297abb619839ab2da519f35, 0)
     // A is dead in old fork
@@ -70,10 +70,7 @@ fn case_no1() {
     let rtx1_overlay = cell_set_overlay
         .resolve_transaction(&transcations[1])
         .unwrap();
-    assert_eq!(
-        rtx1_overlay.input_cells[0],
-        CellStatus::Live(LiveCell::Null)
-    );
+    assert_eq!(rtx1_overlay.input_cells[0], LiveCell::Null);
 
     // assert_eq!(
     //     rtx1_overlay.input_cells[0],

--- a/shared/src/tests/no1.rs
+++ b/shared/src/tests/no1.rs
@@ -3,7 +3,7 @@ use crate::{
     shared::{Shared, SharedBuilder},
     store::ChainKVStore,
 };
-use ckb_core::cell::{CellProvider, CellStatus, LiveCell, UnresolvableError};
+use ckb_core::cell::{CellProvider, CellStatus, UnresolvableError};
 use ckb_core::transaction::Transaction;
 use ckb_db::memorydb::MemoryKeyValueDB;
 use fnv::FnvHashMap;

--- a/shared/src/tests/no2.rs
+++ b/shared/src/tests/no2.rs
@@ -41,10 +41,7 @@ fn case_no2() {
     assert!(block
         .transactions()
         .iter()
-        .map(|tx| chain_state
-            .resolve_transaction(tx)
-            .expect("resolve should be ok")
-            .dep_cells)
-        .flatten()
-        .all(|status| status.is_live()));
+        .map(|tx| chain_state.resolve_transaction(tx))
+        .collect::<Result<Vec<_>, _>>()
+        .is_ok());
 }

--- a/shared/src/tests/no2.rs
+++ b/shared/src/tests/no2.rs
@@ -4,9 +4,8 @@ use crate::{
     store::ChainKVStore,
 };
 use ckb_core::block::Block;
-use ckb_core::cell::resolve_transaction;
+use ckb_core::cell::CellProvider;
 use ckb_db::memorydb::MemoryKeyValueDB;
-use fnv::FnvHashSet;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -37,13 +36,12 @@ fn case_no2() {
     let shared = new_shared();
     let mut chain_state = shared.chain_state().lock();
     chain_state.cell_set = cell_set();
-    let mut seen_inputs = FnvHashSet::default();
 
     // dep status
     assert!(block
         .transactions()
         .iter()
-        .map(|tx| resolve_transaction(tx, &mut seen_inputs, &*chain_state).dep_cells)
+        .map(|tx| chain_state.resolve_transaction(tx).dep_cells)
         .flatten()
         .all(|status| status.is_live()));
 }

--- a/shared/src/tests/no2.rs
+++ b/shared/src/tests/no2.rs
@@ -41,7 +41,10 @@ fn case_no2() {
     assert!(block
         .transactions()
         .iter()
-        .map(|tx| chain_state.resolve_transaction(tx).dep_cells)
+        .map(|tx| chain_state
+            .resolve_transaction(tx)
+            .expect("resolve should be ok")
+            .dep_cells)
         .flatten()
         .all(|status| status.is_live()));
 }

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -290,9 +290,9 @@ pub mod test {
             "55a809b92c5c404989bfe523639a741f4368ecaa3d4c42d1eb8854445b1b798b"
         );
 
-        assert!(
-            chain_spec.to_consensus().is_ok(),
-            format!("{:?}", chain_spec.to_consensus())
-        );
+        // assert!(
+        //     chain_spec.to_consensus().is_ok(),
+        //     format!("{:?}", chain_spec.to_consensus())
+        // );
     }
 }

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -290,9 +290,9 @@ pub mod test {
             "55a809b92c5c404989bfe523639a741f4368ecaa3d4c42d1eb8854445b1b798b"
         );
 
-        // assert!(
-        //     chain_spec.to_consensus().is_ok(),
-        //     format!("{:?}", chain_spec.to_consensus())
-        // );
+        assert!(
+            chain_spec.to_consensus().is_ok(),
+            format!("{:?}", chain_spec.to_consensus())
+        );
     }
 }

--- a/util/jsonrpc-types/src/cell.rs
+++ b/util/jsonrpc-types/src/cell.rs
@@ -1,5 +1,5 @@
 use crate::{Capacity, CellOutput, OutPoint, Script};
-use ckb_core::cell::{CellStatus, LiveCell};
+use ckb_core::cell::CellStatus;
 use serde_derive::{Deserialize, Serialize};
 
 // This is used as return value of get_cells_by_type_hash RPC:
@@ -21,15 +21,12 @@ pub struct CellWithStatus {
 impl From<CellStatus> for CellWithStatus {
     fn from(status: CellStatus) -> Self {
         let (cell, status) = match status {
-            CellStatus::Live(cell) => match cell {
-                LiveCell::Null => (None, "live"),
-                LiveCell::Output(o) => (Some(o), "live"),
-            },
+            CellStatus::Live(cell_meta) => (Some(cell_meta.cell_output), "live"),
             CellStatus::Dead => (None, "dead"),
             CellStatus::Unknown => (None, "unknown"),
         };
         Self {
-            cell: cell.map(|cell| cell.cell_output.into()),
+            cell: cell.map(Into::into),
             status: status.to_string(),
         }
     }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -1,3 +1,4 @@
+use ckb_core::cell::UnresolvableError;
 use ckb_core::BlockNumber;
 use ckb_script::ScriptError;
 use numext_fixed_hash::H256;
@@ -13,6 +14,7 @@ use std::fmt;
 /// If the Rust community has better patterns in the future, then look back here
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    Unresolvable(UnresolvableError),
     /// PoW proof is corrupt or does not meet the difficulty target.
     Pow(PowError),
     /// The field timestamp in block header is invalid.

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -148,8 +148,6 @@ pub enum TransactionError {
     InvalidScript,
     ScriptFailure(ScriptError),
     InvalidSignature,
-    Conflict,
-    Unknown,
     Version,
     /// Tx not satisfied since condition
     Immature,

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -12,9 +12,7 @@ pub use crate::block_verifier::{
 };
 pub use crate::error::{Error, TransactionError};
 pub use crate::header_verifier::{HeaderResolver, HeaderVerifier};
-pub use crate::transaction_verifier::{
-    InputVerifier, PoolTransactionVerifier, TransactionVerifier,
-};
+pub use crate::transaction_verifier::{PoolTransactionVerifier, TransactionVerifier};
 
 pub trait Verifier {
     type Target;

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -1,10 +1,8 @@
 use super::super::transaction_verifier::{
-    CapacityVerifier, DuplicateInputsVerifier, EmptyVerifier, MaturityVerifier, NullVerifier,
-    ValidSinceVerifier,
+    CapacityVerifier, EmptyVerifier, MaturityVerifier, NullVerifier, ValidSinceVerifier,
 };
 use crate::error::TransactionError;
-use ckb_core::cell::CellStatus;
-use ckb_core::cell::ResolvedTransaction;
+use ckb_core::cell::{LiveCell, ResolvedTransaction};
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
 use ckb_core::{capacity_bytes, Capacity};
@@ -46,7 +44,7 @@ pub fn test_capacity_outofbound() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             None,
             false,
@@ -74,7 +72,7 @@ pub fn test_cellbase_maturity() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(30),
             true,
@@ -109,12 +107,12 @@ pub fn test_capacity_invalid() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![
-            CellStatus::live_output(
+            LiveCell::live_output(
                 CellOutput::new(capacity_bytes!(49), Vec::new(), Script::default(), None),
                 None,
                 false,
             ),
-            CellStatus::live_output(
+            LiveCell::live_output(
                 CellOutput::new(capacity_bytes!(100), Vec::new(), Script::default(), None),
                 None,
                 false,
@@ -126,31 +124,6 @@ pub fn test_capacity_invalid() {
     assert_eq!(
         verifier.verify().err(),
         Some(TransactionError::OutputsSumOverflow)
-    );
-}
-
-#[test]
-pub fn test_duplicate_inputs() {
-    let transaction = TransactionBuilder::default()
-        .inputs(vec![
-            CellInput::new(
-                OutPoint::new(H256::from_trimmed_hex_str("1").unwrap(), 0),
-                0,
-                Default::default(),
-            ),
-            CellInput::new(
-                OutPoint::new(H256::from_trimmed_hex_str("1").unwrap(), 0),
-                0,
-                Default::default(),
-            ),
-        ])
-        .build();
-
-    let verifier = DuplicateInputsVerifier::new(&transaction);
-
-    assert_eq!(
-        verifier.verify().err(),
-        Some(TransactionError::DuplicateInputs)
     );
 }
 
@@ -184,7 +157,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -212,7 +185,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -240,7 +213,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -276,7 +249,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_output(
+        input_cells: vec![LiveCell::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -308,7 +281,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![CellStatus::live_null()],
+        input_cells: vec![LiveCell::Null],
     };
 
     let median_time_context = FakeMedianTime {

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -42,7 +42,7 @@ pub fn test_capacity_outofbound() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -70,7 +70,7 @@ pub fn test_cellbase_maturity() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -104,7 +104,7 @@ pub fn test_capacity_invalid() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![
             CellMeta::new(
@@ -155,7 +155,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -183,7 +183,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -211,7 +211,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -247,7 +247,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -2,7 +2,7 @@ use super::super::transaction_verifier::{
     CapacityVerifier, EmptyVerifier, MaturityVerifier, NullVerifier, ValidSinceVerifier,
 };
 use crate::error::TransactionError;
-use ckb_core::cell::{LiveCell, ResolvedTransaction};
+use ckb_core::cell::{CellMeta, ResolvedTransaction};
 use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
 use ckb_core::{capacity_bytes, Capacity};
@@ -44,7 +44,7 @@ pub fn test_capacity_outofbound() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             None,
             false,
@@ -72,7 +72,7 @@ pub fn test_cellbase_maturity() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(30),
             true,
@@ -107,12 +107,12 @@ pub fn test_capacity_invalid() {
         transaction,
         dep_cells: Vec::new(),
         input_cells: vec![
-            LiveCell::live_output(
+            CellMeta::new(
                 CellOutput::new(capacity_bytes!(49), Vec::new(), Script::default(), None),
                 None,
                 false,
             ),
-            LiveCell::live_output(
+            CellMeta::new(
                 CellOutput::new(capacity_bytes!(100), Vec::new(), Script::default(), None),
                 None,
                 false,
@@ -157,7 +157,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -185,7 +185,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -213,7 +213,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -249,7 +249,7 @@ pub fn test_since() {
     let rtx = ResolvedTransaction {
         transaction,
         dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::live_output(
+        input_cells: vec![CellMeta::new(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
             Some(1),
             false,
@@ -265,27 +265,6 @@ pub fn test_since() {
             0, 1, 2, 3, 4, 100_000, 1_124_000, 2_000_000, 3_000_000, 4_000_000, 5_000_000,
             6_000_000,
         ],
-    };
-    let verifier = ValidSinceVerifier::new(&rtx, &median_time_context, 10);
-    assert!(verifier.verify().is_ok());
-
-    // null should be ok
-    let transaction = TransactionBuilder::default()
-        .inputs(vec![CellInput::new(
-            OutPoint::null(),
-            0x0000_0000_0000_000a,
-            Default::default(),
-        )])
-        .build();
-
-    let rtx = ResolvedTransaction {
-        transaction,
-        dep_cells: Vec::new(),
-        input_cells: vec![LiveCell::Null],
-    };
-
-    let median_time_context = FakeMedianTime {
-        timestamps: vec![0; 11],
     };
     let verifier = ValidSinceVerifier::new(&rtx, &median_time_context, 10);
     assert!(verifier.verify().is_ok());

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -98,7 +98,7 @@ impl<'a> VersionVerifier<'a> {
 }
 
 pub struct ScriptVerifier<'a> {
-    resolved_transaction: &'a ResolvedTransaction,
+    resolved_transaction: &'a ResolvedTransaction<'a>,
 }
 
 impl<'a> ScriptVerifier<'a> {
@@ -134,14 +134,14 @@ impl<'a> EmptyVerifier<'a> {
 }
 
 pub struct MaturityVerifier<'a> {
-    transaction: &'a ResolvedTransaction,
+    transaction: &'a ResolvedTransaction<'a>,
     tip_number: BlockNumber,
     cellbase_maturity: BlockNumber,
 }
 
 impl<'a> MaturityVerifier<'a> {
     pub fn new(
-        transaction: &'a ResolvedTransaction,
+        transaction: &'a ResolvedTransaction<'a>,
         tip_number: BlockNumber,
         cellbase_maturity: BlockNumber,
     ) -> Self {
@@ -200,7 +200,7 @@ impl<'a> NullVerifier<'a> {
 }
 
 pub struct CapacityVerifier<'a> {
-    resolved_transaction: &'a ResolvedTransaction,
+    resolved_transaction: &'a ResolvedTransaction<'a>,
 }
 
 impl<'a> CapacityVerifier<'a> {
@@ -301,7 +301,7 @@ impl ValidSince {
 
 /// https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/0017-tx-valid-since.md#detailed-specification
 pub struct ValidSinceVerifier<'a, M> {
-    rtx: &'a ResolvedTransaction,
+    rtx: &'a ResolvedTransaction<'a>,
     block_median_time_context: &'a M,
     tip_number: BlockNumber,
     median_timestamps_cache: RefCell<LruCache<BlockNumber, Option<u64>>>,


### PR DESCRIPTION
I split this PR to 5 small commits, make sure they pass the unit test individuallly, and it's easier to review one by one than whole change log.

1. Move resolve_transaction fn to CellProvider and avoid some clone

2. Return short circuit `UnresolvableError` in resolve_transaction fn

3. ResolvedTransaction contains live cell only, simplify code and remove some unnecessary verifiers

4. ResolvedTransaction contains `CellMeta` only

5. Add lifetime to ResolvedTransaction, avoiding transaction clone

After this PR is merged, I will rebase https://github.com/nervosnetwork/ckb/pull/552, it's just 2 or 3 lines to enable cellbase script type verification.