### PR TITLE
feat: check if genesis hash in config file was same as 0th block hash in db

### DIFF
--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -198,7 +198,8 @@ fn new_chain(
             options: None,
         })
         .consensus(consensus)
-        .build();
+        .build()
+        .unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let chain_service = ChainBuilder::new(shared.clone(), notify).build();
     (

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[test]
 fn test_find_fork_case1() {
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
-    let shared = builder.consensus(Consensus::default()).build();
+    let shared = builder.consensus(Consensus::default()).build().unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainBuilder::new(shared.clone(), notify)
         .verification(false)
@@ -92,7 +92,7 @@ fn test_find_fork_case1() {
 #[test]
 fn test_find_fork_case2() {
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
-    let shared = builder.consensus(Consensus::default()).build();
+    let shared = builder.consensus(Consensus::default()).build().unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainBuilder::new(shared.clone(), notify)
         .verification(false)
@@ -170,7 +170,7 @@ fn test_find_fork_case2() {
 #[test]
 fn test_find_fork_case3() {
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
-    let shared = builder.consensus(Consensus::default()).build();
+    let shared = builder.consensus(Consensus::default()).build().unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainBuilder::new(shared.clone(), notify)
         .verification(false)
@@ -242,7 +242,7 @@ fn test_find_fork_case3() {
 #[test]
 fn test_find_fork_case4() {
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
-    let shared = builder.consensus(Consensus::default()).build();
+    let shared = builder.consensus(Consensus::default()).build().unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainBuilder::new(shared.clone(), notify)
         .verification(false)

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -23,7 +23,8 @@ pub(crate) fn start_chain(
     let builder = SharedBuilder::<MemoryKeyValueDB>::new();
     let shared = builder
         .consensus(consensus.unwrap_or_else(|| Consensus::default().set_cellbase_maturity(0)))
-        .build();
+        .build()
+        .unwrap();
 
     let notify = NotifyService::default().start::<&str>(None);
     let chain_service = ChainBuilder::new(shared.clone(), notify)

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -509,7 +509,7 @@ mod tests {
         if let Some(consensus) = consensus {
             builder = builder.consensus(consensus);
         }
-        let shared = builder.build();
+        let shared = builder.build().unwrap();
 
         let notify = notify.unwrap_or_else(|| NotifyService::default().start::<&str>(None));
         let chain_service = ChainBuilder::new(shared.clone(), notify.clone())

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -7,6 +7,8 @@ pub enum SharedError {
     InvalidTransaction(String),
     #[fail(display = "InvalidParentBlock")]
     InvalidParentBlock,
+    #[fail(display = "InvalidData error: {}", _0)]
+    InvalidData(String),
     #[fail(display = "DB error: {}", _0)]
     DB(DBError),
 }

--- a/shared/src/tests/no1.rs
+++ b/shared/src/tests/no1.rs
@@ -38,7 +38,7 @@ fn transcations() -> Vec<Transaction> {
 }
 
 fn new_shared() -> Shared<ChainKVStore<MemoryKeyValueDB>> {
-    SharedBuilder::<MemoryKeyValueDB>::new().build()
+    SharedBuilder::<MemoryKeyValueDB>::new().build().unwrap()
 }
 
 #[test]

--- a/shared/src/tests/no2.rs
+++ b/shared/src/tests/no2.rs
@@ -28,7 +28,7 @@ fn cell_set() -> CellSet {
     serde_json::from_reader(reader).unwrap()
 }
 fn new_shared() -> Shared<ChainKVStore<MemoryKeyValueDB>> {
-    SharedBuilder::<MemoryKeyValueDB>::new().build()
+    SharedBuilder::<MemoryKeyValueDB>::new().build().unwrap()
 }
 
 #[test]

--- a/shared/src/tests/shared.rs
+++ b/shared/src/tests/shared.rs
@@ -44,7 +44,7 @@ impl<'a, CS: ChainStore> CellProvider for ChainCellSetOverlay<'a, CS> {
 }
 
 fn new_shared() -> Shared<ChainKVStore<MemoryKeyValueDB>> {
-    SharedBuilder::<MemoryKeyValueDB>::new().build()
+    SharedBuilder::<MemoryKeyValueDB>::new().build().unwrap()
 }
 
 fn insert_block_timestamps<T>(store: &ChainKVStore<T>, timestamps: &[u64])

--- a/src/subcommand/export.rs
+++ b/src/subcommand/export.rs
@@ -7,7 +7,11 @@ pub fn export(args: ExportArgs) -> Result<(), ExitCode> {
     let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
         .consensus(args.consensus)
         .db(&args.config.db)
-        .build();
+        .build()
+        .map_err(|err| {
+            eprintln!("Export error: {:?}", err);
+            ExitCode::Failure
+        })?;
     Export::new(shared, args.format, args.target)
         .execute()
         .map_err(|err| {

--- a/src/subcommand/import.rs
+++ b/src/subcommand/import.rs
@@ -9,7 +9,11 @@ pub fn import(args: ImportArgs) -> Result<(), ExitCode> {
     let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
         .consensus(args.consensus)
         .db(&args.config.db)
-        .build();
+        .build()
+        .map_err(|err| {
+            eprintln!("Import error: {:?}", err);
+            ExitCode::Failure
+        })?;
 
     let notify = NotifyService::default().start::<&str>(None);
     let chain_service = ChainBuilder::new(shared.clone(), notify).build();

--- a/src/subcommand/prof.rs
+++ b/src/subcommand/prof.rs
@@ -12,7 +12,11 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
         .consensus(args.consensus.clone())
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool.clone())
-        .build();
+        .build()
+        .map_err(|err| {
+            eprintln!("Prof error: {:?}", err);
+            ExitCode::Failure
+        })?;
 
     let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
     let tmp_shared = SharedBuilder::<CacheDB<RocksDB>>::default()
@@ -22,7 +26,11 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
             options: None,
         })
         .tx_pool_config(args.config.tx_pool)
-        .build();
+        .build()
+        .map_err(|err| {
+            eprintln!("Prof error: {:?}", err);
+            ExitCode::Failure
+        })?;
 
     let from = std::cmp::max(1, args.from);
     let to = std::cmp::min(shared.chain_state().lock().tip_number(), args.to);

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -20,7 +20,11 @@ pub fn run(args: RunArgs) -> Result<(), ExitCode> {
         .consensus(args.consensus)
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool)
-        .build();
+        .build()
+        .map_err(|err| {
+            eprintln!("Run error: {:?}", err);
+            ExitCode::Failure
+        })?;
 
     let notify = NotifyService::default().start(Some("notify"));
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -803,7 +803,7 @@ mod tests {
         if let Some(consensus) = consensus {
             builder = builder.consensus(consensus);
         }
-        let shared = builder.build();
+        let shared = builder.build().unwrap();
 
         let notify = notify.unwrap_or_else(|| NotifyService::default().start::<&str>(None));
         let chain_service = ChainBuilder::new(shared.clone(), notify.clone())

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -335,7 +335,8 @@ fn setup_node(
 
     let shared = SharedBuilder::<MemoryKeyValueDB>::new()
         .consensus(consensus)
-        .build();
+        .build()
+        .unwrap();
 
     let notify = NotifyService::default().start(Some(thread_name));
 

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -76,7 +76,8 @@ fn setup_node(
     let consensus = Consensus::default().set_genesis_block(block.clone());
     let shared = SharedBuilder::<MemoryKeyValueDB>::new()
         .consensus(consensus)
-        .build();
+        .build()
+        .unwrap();
     let notify = NotifyService::default().start(Some(thread_name));
 
     let chain_service = ChainBuilder::new(shared.clone(), notify)

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -70,7 +70,7 @@ fn start_chain(
     if let Some(consensus) = consensus {
         builder = builder.consensus(consensus);
     }
-    let shared = builder.build();
+    let shared = builder.build().unwrap();
 
     let notify = NotifyService::default().start::<&str>(None);
     let chain_service = ChainBuilder::new(shared.clone(), notify)

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -44,7 +44,7 @@ fn start_chain(
     if let Some(consensus) = consensus {
         builder = builder.consensus(consensus);
     }
-    let shared = builder.build();
+    let shared = builder.build().unwrap();
 
     let notify = NotifyService::default().start::<&str>(None);
     let chain_service = ChainBuilder::new(shared.clone(), notify)


### PR DESCRIPTION
At startup:
- Read genesis hash from configuration files.
- Try to fetch tip header from database.
- (new) If tip header is existed, then fetch the 0th block hash from database.
- (new) Check if the 0th block hash was same as the genesis hash.

Replace several `expect(..)` by `Result`.
Add a lot of `unwrap()` in tests.