### PR TITLE
chore: make block hash always exist

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -218,9 +218,26 @@ curl -H 'content-type:application/json' \
 #### `tx_status` Possible Values
 
 ```
-tx_status: { status: "pending" }
-tx_status: { status: "proposed" }
-tx_status: { status: "committed", block_hash = "0xef285e5da29247ce39385cbd8dc36535f7ea1b5b0379db26e9d459a8b47d0d71" }
+{
+    "tx_status": {
+        "status": "pending",
+        "block_hash": null
+    }
+}
+
+{
+    "tx_status": {
+        "status": "proposed",
+        "block_hash": null
+    }
+}
+
+{
+    "tx_status": {
+        "status": "committed",
+        "block_hash": "0xef285e5da29247ce39385cbd8dc36535f7ea1b5b0379db26e9d459a8b47d0d71"
+    }
+}
 ```
 
 ### get_cells_by_lock_hash

--- a/test/src/specs/pool.rs
+++ b/test/src/specs/pool.rs
@@ -28,7 +28,9 @@ impl Spec for PoolReconcile {
             .call()
             .unwrap()
             .unwrap()
-            .is_committed());
+            .tx_status
+            .block_hash
+            .is_some());
 
         info!("Generate 5 blocks on node1");
         (0..5).for_each(|_| {
@@ -42,13 +44,15 @@ impl Spec for PoolReconcile {
         sleep(10);
 
         info!("Tx should be re-added to node0's pool");
-        assert!(!node0
+        assert!(node0
             .rpc_client()
             .get_transaction(hash.clone())
             .call()
             .unwrap()
             .unwrap()
-            .is_committed());
+            .tx_status
+            .block_hash
+            .is_none());
     }
 
     fn num_nodes(&self) -> usize {

--- a/test/src/specs/transaction_relay.rs
+++ b/test/src/specs/transaction_relay.rs
@@ -18,20 +18,24 @@ impl Spec for TransactionRelayBasic {
         sleep(3);
 
         info!("Transaction should be relayed to node0 and node2");
-        assert!(!node0
+        assert!(node0
             .rpc_client()
             .get_transaction(hash.clone())
             .call()
             .unwrap()
             .unwrap()
-            .is_committed());
+            .tx_status
+            .block_hash
+            .is_none());
 
-        assert!(!node2
+        assert!(node2
             .rpc_client()
             .get_transaction(hash.clone())
             .call()
             .unwrap()
             .unwrap()
-            .is_committed());
+            .tx_status
+            .block_hash
+            .is_none());
     }
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -243,7 +243,7 @@ impl TransactionWithStatus {
     /// Build with pending status
     pub fn with_pending(tx: CoreTransaction) -> Self {
         Self {
-            tx_status: TxStatus::Pending,
+            tx_status: TxStatus::pending(),
             transaction: (&tx).into(),
         }
     }
@@ -251,7 +251,7 @@ impl TransactionWithStatus {
     /// Build with proposed status
     pub fn with_proposed(tx: CoreTransaction) -> Self {
         Self {
-            tx_status: TxStatus::Proposed,
+            tx_status: TxStatus::proposed(),
             transaction: (&tx).into(),
         }
     }
@@ -259,47 +259,51 @@ impl TransactionWithStatus {
     /// Build with committed status
     pub fn with_committed(tx: CoreTransaction, hash: H256) -> Self {
         Self {
-            tx_status: TxStatus::Committed(hash),
+            tx_status: TxStatus::committed(hash),
             transaction: (&tx).into(),
-        }
-    }
-
-    /// status is pending ?
-    pub fn is_pending(&self) -> bool {
-        match self.tx_status {
-            TxStatus::Pending => true,
-            _ => false,
-        }
-    }
-
-    /// status is proposed ?
-    pub fn is_proposed(&self) -> bool {
-        match self.tx_status {
-            TxStatus::Proposed => true,
-            _ => false,
-        }
-    }
-
-    /// status is committed ?
-    pub fn is_committed(&self) -> bool {
-        match self.tx_status {
-            TxStatus::Committed(_) => true,
-            _ => false,
         }
     }
 }
 
-/// Can see the serialization results on the links: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=c48782574d5ebe42dd24cd3650313cca
+/// Status for transaction
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-#[serde(tag = "status", content = "block_hash")]
 #[serde(rename_all = "lowercase")]
-pub enum TxStatus {
+pub enum Status {
     /// Transaction on pool, not proposed
     Pending,
     /// Transaction on pool, proposed
     Proposed,
     /// Transaction commit on block
-    Committed(H256),
+    Committed,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct TxStatus {
+    pub status: Status,
+    pub block_hash: Option<H256>,
+}
+
+impl TxStatus {
+    pub fn pending() -> Self {
+        Self {
+            status: Status::Pending,
+            block_hash: None,
+        }
+    }
+
+    pub fn proposed() -> Self {
+        Self {
+            status: Status::Proposed,
+            block_hash: None,
+        }
+    }
+
+    pub fn committed(hash: H256) -> Self {
+        Self {
+            status: Status::Committed,
+            block_hash: Some(hash),
+        }
+    }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
Make `block_hash` always exist

Although I think the meaning of the block hash exist is not particularly large, but for the sake of unification...

This modification may present potential risks, and if someone does not build the state according to the standard, unexpected results may occur.