### PR TITLE
refactor: add lifetime to ResolvedTransaction

### DIFF
--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -88,8 +88,8 @@ impl CellStatus {
 
 /// Transaction with resolved input cells.
 #[derive(Debug)]
-pub struct ResolvedTransaction {
-    pub transaction: Transaction,
+pub struct ResolvedTransaction<'a> {
+    pub transaction: &'a Transaction,
     pub dep_cells: Vec<CellStatus>,
     pub input_cells: Vec<CellStatus>,
 }
@@ -168,11 +168,11 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
     }
 }
 
-pub fn resolve_transaction<CP: CellProvider>(
-    transaction: &Transaction,
+pub fn resolve_transaction<'a, CP: CellProvider>(
+    transaction: &'a Transaction,
     seen_inputs: &mut FnvHashSet<OutPoint>,
     cell_provider: &CP,
-) -> ResolvedTransaction {
+) -> ResolvedTransaction<'a> {
     let input_cells = transaction
         .input_pts()
         .iter()
@@ -198,13 +198,13 @@ pub fn resolve_transaction<CP: CellProvider>(
         .collect();
 
     ResolvedTransaction {
-        transaction: transaction.clone(),
+        transaction,
         input_cells,
         dep_cells,
     }
 }
 
-impl ResolvedTransaction {
+impl<'a> ResolvedTransaction<'a> {
     pub fn cells_iter(&self) -> Chain<slice::Iter<CellStatus>, slice::Iter<CellStatus>> {
         self.dep_cells.iter().chain(&self.input_cells)
     }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -234,7 +234,7 @@ mod tests {
         let transaction = TransactionBuilder::default().input(input.clone()).build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -302,7 +302,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -370,7 +370,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -440,7 +440,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -497,7 +497,7 @@ mod tests {
         };
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -574,7 +574,7 @@ mod tests {
             .build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };
@@ -653,7 +653,7 @@ mod tests {
             .build();
 
         let rtx = ResolvedTransaction {
-            transaction,
+            transaction: &transaction,
             dep_cells: vec![CellStatus::Live(LiveCell::Output(dep_cell))],
             input_cells: vec![CellStatus::Live(LiveCell::Output(dummy_cell))],
         };

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -213,11 +213,11 @@ impl<CS: ChainStore> ChainState<CS> {
         })
     }
 
-    pub fn resolve_tx_from_pending_and_staging(
+    pub fn resolve_tx_from_pending_and_staging<'a>(
         &self,
-        tx: &Transaction,
+        tx: &'a Transaction,
         tx_pool: &TxPool,
-    ) -> ResolvedTransaction {
+    ) -> ResolvedTransaction<'a> {
         let staging_provider = OverlayCellProvider::new(&tx_pool.staging, self);
         let pending_and_staging_provider =
             OverlayCellProvider::new(&tx_pool.pending, &staging_provider);
@@ -225,11 +225,11 @@ impl<CS: ChainStore> ChainState<CS> {
         resolve_transaction(tx, &mut seen_inputs, &pending_and_staging_provider)
     }
 
-    pub fn resolve_tx_from_staging(
+    pub fn resolve_tx_from_staging<'a>(
         &self,
-        tx: &Transaction,
+        tx: &'a Transaction,
         tx_pool: &TxPool,
-    ) -> ResolvedTransaction {
+    ) -> ResolvedTransaction<'a> {
         let cell_provider = OverlayCellProvider::new(&tx_pool.staging, self);
         let mut seen_inputs = FnvHashSet::default();
         resolve_transaction(tx, &mut seen_inputs, &cell_provider)

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -44,7 +44,7 @@ pub fn test_capacity_outofbound() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -72,7 +72,7 @@ pub fn test_cellbase_maturity() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -106,7 +106,7 @@ pub fn test_capacity_invalid() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![
             CellStatus::live_output(
@@ -182,7 +182,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -210,7 +210,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -238,7 +238,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -274,7 +274,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_output(
             CellOutput::new(capacity_bytes!(50), Vec::new(), Script::default(), None),
@@ -306,7 +306,7 @@ pub fn test_since() {
         .build();
 
     let rtx = ResolvedTransaction {
-        transaction,
+        transaction: &transaction,
         dep_cells: Vec::new(),
         input_cells: vec![CellStatus::live_null()],
     };

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -105,7 +105,7 @@ impl<'a> VersionVerifier<'a> {
 }
 
 pub struct InputVerifier<'a> {
-    resolved_transaction: &'a ResolvedTransaction,
+    resolved_transaction: &'a ResolvedTransaction<'a>,
 }
 
 impl<'a> InputVerifier<'a> {
@@ -136,7 +136,7 @@ impl<'a> InputVerifier<'a> {
 }
 
 pub struct ScriptVerifier<'a> {
-    resolved_transaction: &'a ResolvedTransaction,
+    resolved_transaction: &'a ResolvedTransaction<'a>,
 }
 
 impl<'a> ScriptVerifier<'a> {
@@ -172,7 +172,7 @@ impl<'a> EmptyVerifier<'a> {
 }
 
 pub struct MaturityVerifier<'a> {
-    transaction: &'a ResolvedTransaction,
+    transaction: &'a ResolvedTransaction<'a>,
     tip_number: BlockNumber,
     cellbase_maturity: BlockNumber,
 }
@@ -265,7 +265,7 @@ impl<'a> NullVerifier<'a> {
 }
 
 pub struct CapacityVerifier<'a> {
-    resolved_transaction: &'a ResolvedTransaction,
+    resolved_transaction: &'a ResolvedTransaction<'a>,
 }
 
 impl<'a> CapacityVerifier<'a> {
@@ -365,7 +365,7 @@ impl ValidSince {
 
 /// https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/0017-tx-valid-since.md#detailed-specification
 pub struct ValidSinceVerifier<'a, M> {
-    rtx: &'a ResolvedTransaction,
+    rtx: &'a ResolvedTransaction<'a>,
     block_median_time_context: &'a M,
     tip_number: BlockNumber,
     median_timestamps_cache: RefCell<LruCache<BlockNumber, Option<u64>>>,


### PR DESCRIPTION
Add lifetime to ResolvedTransaction, avoiding transaction clone