### PR TITLE
fix: Testnet hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,10 +543,10 @@ dependencies = [
  "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stop-handler 0.11.0-pre",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-discovery 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-identify 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-ping 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-discovery 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-identify 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-ping 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tentacle-secio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.2 (git+https://github.com/paritytech/unsigned-varint)",
@@ -1056,26 +1056,6 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "data-encoding-macro"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding-macro-internal 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "debugid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,11 +1096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
@@ -1831,11 +1806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "nix"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,14 +2134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-hack-impl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro-hack"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2179,11 +2141,6 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "proc-macro-hack-impl"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -2219,24 +2176,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2739,17 +2682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,30 +2726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2846,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2858,12 +2772,12 @@ dependencies = [
  "tentacle-secio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-yamux 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-yamux 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-discovery"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2874,29 +2788,26 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-identify"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers-verifier 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-ping"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2905,7 +2816,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3191,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3208,49 +3119,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "trust-dns"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3321,11 +3189,6 @@ dependencies = [
 [[package]]
 name = "unicode-width"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3570,15 +3433,12 @@ dependencies = [
 "checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 "checksum ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5531b7f0698d9220b4729f8811931dbe0e91a05be2f7b3245fdc50dd856bae26"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
-"checksum data-encoding-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b87bf377fc964606c3679c1de6822a9a9d8b69aae2651ca4af28cb2d1550b37"
-"checksum data-encoding-macro-internal 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22b318a8d6d56c45df45c61fcc7d2dbf98ea014d4987e7c74ef1f86c9b87e503"
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
-"checksum endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -3654,7 +3514,6 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
@@ -3688,15 +3547,11 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-"checksum proc-macro-hack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c725b36c99df7af7bf9324e9c999b9e37d92c8f8caf106d82e1d7953218d2d8"
 "checksum proc-macro-hack 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6a9bed9ebc40cf53e3a76d7486c54d05002eae6485b2711ab9104476fb2eb8bc"
-"checksum proc-macro-hack-impl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b753ad9ed99dd8efeaa7d2fb8453c8f6bc3e54b97966d35f1bc77ca6865254a"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24f5844db2f839e97e3021980975f6ebf8691d9b9b2ca67ed3feb38dc3edb52c"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcf72e767017c1aa4b63d4dd0b0b836a243b648fd81d41c6bf6e850ef7a95c7"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -3750,22 +3605,19 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
-"checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
-"checksum tentacle 0.2.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dae87203f8a19fcdbc5cabf08fa9c1a337ff015a14221919754c5191a3773e1"
-"checksum tentacle-discovery 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a377a602798077a0b1414490fea3df8239625782d9b8bffcaeb94ca2b0d59e"
-"checksum tentacle-identify 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "232645ea902f99ca0314c8a95ec779a11a65d3458fea3b2d52975f5b388fc9c1"
-"checksum tentacle-ping 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "788731325d7179435a8c9711619b1eee8ad2cbd716d29584cffdb2040799796f"
+"checksum tentacle 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62c19e861dc1716394dbe8191982b34114b4d660331e2f6759e7b16d3c19ffa7"
+"checksum tentacle-discovery 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83d83e7f002deb77c447b94d3719b9570106824990608ac8be2eaa4f170d1a8f"
+"checksum tentacle-identify 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717833b734c373c73a676c3fcce39a4e8c23b2324051c6d230169145f9ed8690"
+"checksum tentacle-ping 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "42804d1cfc00d89b3ed9a4be3d62ea12a20f53292b890baa4781dc66e37705f2"
 "checksum tentacle-secio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f13591b37fad9bfdc167a646eb7cdd97faac3d606bac3be04107d9f2a816fcc"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
@@ -3790,10 +3642,8 @@ dependencies = [
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
-"checksum tokio-yamux 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "50e8f25455f7b9e9202b5cf713170bd94e01886d44905dce2db8060e738c44e1"
+"checksum tokio-yamux 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "60b801178878cf335e616aba372fcb42a0800e2e1c9aae39bf1ed9eefbd84c6b"
 "checksum toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87c5890a989fa47ecdc7bcb4c63a77a82c18f306714104b1decfd722db17b39e"
-"checksum trust-dns 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "65096825b064877da37eeeb9a83390bd23433eabfc503a6476dc5b1949034aa7"
-"checksum trust-dns-proto 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09144f0992b0870fa8d2972cc069cbf1e3c0fda64d1f3d45c4d68d0e0b52ad4e"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
@@ -3804,7 +3654,6 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unsigned-varint 0.2.2 (git+https://github.com/paritytech/unsigned-varint)" = "<none>"
 "checksum unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c64cdf40b4a9645534a943668681bcb219faf51874d4b65d2e0abda1b10a2ab"

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -289,7 +289,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         let chain_state = self.shared.chain_state().lock();
         let last_txs_updated_at = chain_state.get_last_txs_updated_at();
 
-        let header = chain_state.tip_header();
+        let header = chain_state.tip_header().clone();
         let number = chain_state.tip_number() + 1;
         let current_time = cmp::max(unix_time_as_millis(), header.timestamp() + 1);
 
@@ -308,10 +308,12 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
 
         let difficulty = self
             .shared
-            .calculate_difficulty(header)
+            .calculate_difficulty(&header)
             .expect("get difficulty");
 
         let (proposals, transactions) = chain_state.get_proposal_and_staging_txs(10000, 10000);
+        // Release the lock as soon as possible, let other services do their work
+        drop(chain_state);
 
         let (uncles, bad_uncles) = self.prepare_uncles(&header, &difficulty);
         if !bad_uncles.is_empty() {
@@ -330,8 +332,10 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
 
         // dummy cellbase
         let cellbase_lock = Script::new(args, self.config.code_hash.clone());
-        let cellbase = self.create_cellbase_transaction(header, &transactions, cellbase_lock)?;
+        let cellbase = self.create_cellbase_transaction(&header, &transactions, cellbase_lock)?;
 
+        // Should recalculate current time after create cellbase (create cellbase may spend a lot of time)
+        let current_time = cmp::max(unix_time_as_millis(), header.timestamp() + 1);
         let template = BlockTemplate {
             version,
             difficulty,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -23,11 +23,11 @@ tokio = "0.1.18"
 futures = "0.1"
 snap = "0.2"
 crossbeam-channel = "0.3"
-p2p = { version="0.2.0-alpha.5", package="tentacle" }
+p2p = { version="0.2.0-alpha.6", package="tentacle" }
 secio = { version="0.1.1", package="tentacle-secio" }
-p2p-ping = { version="0.3.0", package="tentacle-ping" }
-p2p-discovery = { version="0.2.0", package="tentacle-discovery" }
-p2p-identify = { version="0.2.0", package="tentacle-identify" }
+p2p-ping = { version="0.3.1", package="tentacle-ping" }
+p2p-discovery = { version="0.2.1", package="tentacle-discovery" }
+p2p-identify = { version="0.2.1", package="tentacle-identify" }
 faketime = "0.2.0"
 rusqlite = {version = "0.16.0", features = ["bundled"]}
 lazy_static = "1.3.0"

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -22,6 +22,7 @@ use log::{debug, error, info, trace, warn};
 use lru_cache::LruCache;
 use p2p::{
     builder::{MetaBuilder, ServiceBuilder},
+    bytes::Bytes,
     context::{ServiceContext, SessionContext},
     error::Error as P2pError,
     multiaddr::{self, multihash::Multihash, Multiaddr},
@@ -874,7 +875,7 @@ impl NetworkController {
         })
     }
 
-    pub fn broadcast(&self, proto_id: ProtocolId, data: Vec<u8>) {
+    pub fn broadcast(&self, proto_id: ProtocolId, data: Bytes) {
         let session_ids = self.network_state.peer_registry.read().connected_peers();
         if let Err(err) =
             self.p2p_control
@@ -884,7 +885,7 @@ impl NetworkController {
         }
     }
 
-    pub fn send_message_to(&self, session_id: SessionId, proto_id: ProtocolId, data: Vec<u8>) {
+    pub fn send_message_to(&self, session_id: SessionId, proto_id: ProtocolId, data: Bytes) {
         if let Err(err) = self.p2p_control.send_message_to(session_id, proto_id, data) {
             warn!(target: "network", "send message to {} {} failed: {:?}", session_id, proto_id, err);
         }

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod ping;
 use log::{error, trace};
 use p2p::{
     builder::MetaBuilder,
+    bytes::Bytes,
     context::{ProtocolContext, ProtocolContextMutRef},
     service::{ProtocolHandle, ProtocolMeta, ServiceControl, TargetSession},
     traits::ServiceProtocol,
@@ -23,10 +24,10 @@ use crate::{Behaviour, NetworkState, Peer, PeerRegistry, ProtocolVersion, MAX_FR
 pub trait CKBProtocolContext: Send {
     // Interact with underlying p2p service
     fn set_notify(&self, interval: Duration, token: u64);
-    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Vec<u8>);
-    fn send_message_to(&self, peer_index: PeerIndex, data: Vec<u8>);
+    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Bytes);
+    fn send_message_to(&self, peer_index: PeerIndex, data: Bytes);
     // TODO allow broadcast to target ProtocolId
-    fn filter_broadcast(&self, target: TargetSession, data: Vec<u8>);
+    fn filter_broadcast(&self, target: TargetSession, data: Bytes);
     fn disconnect(&self, peer_index: PeerIndex);
     // Interact with NetworkState
     fn get_peer(&self, peer_index: PeerIndex) -> Option<Peer>;
@@ -222,7 +223,7 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             error!(target: "network", "send message to p2p service error: {:?}", err);
         }
     }
-    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Vec<u8>) {
+    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Bytes) {
         trace!(target: "network", "[send message]: {}, to={}, length={}", proto_id, peer_index, data.len());
         if let Err(err) = self
             .p2p_control
@@ -231,7 +232,7 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             error!(target: "network", "send message to p2p service error: {:?}", err);
         }
     }
-    fn send_message_to(&self, peer_index: PeerIndex, data: Vec<u8>) {
+    fn send_message_to(&self, peer_index: PeerIndex, data: Bytes) {
         trace!(target: "network", "[send message to]: {}, to={}, length={}", self.proto_id, peer_index, data.len());
         if let Err(err) = self
             .p2p_control
@@ -240,7 +241,7 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             error!(target: "network", "send message to p2p service error: {:?}", err);
         }
     }
-    fn filter_broadcast(&self, target: TargetSession, data: Vec<u8>) {
+    fn filter_broadcast(&self, target: TargetSession, data: Bytes) {
         if let Err(err) = self
             .p2p_control
             .filter_broadcast(target, self.proto_id, data)

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -83,7 +83,7 @@ impl<CS: ChainStore + 'static> MinerRpc for MinerRpcImpl<CS> {
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = RelayMessage::build_compact_block(fbb, &block, &HashSet::new());
                 fbb.finish(message, None);
-                let data = fbb.finished_data().to_vec();
+                let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
                 Ok(Some(block.header().hash().clone()))

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -42,7 +42,7 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = RelayMessage::build_transaction(fbb, &tx, cycles);
                 fbb.finish(message, None);
-                let data = fbb.finished_data().to_vec();
+                let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
                 Ok(tx.hash())

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::config::Config;
 pub use crate::net_time_checker::NetTimeProtocol;
 pub use crate::relayer::Relayer;
 pub use crate::synchronizer::Synchronizer;
+pub use crate::types::SyncSharedState;
 use std::time::Duration;
 
 pub const MAX_HEADERS_LEN: usize = 2_000;

--- a/sync/src/net_time_checker.rs
+++ b/sync/src/net_time_checker.rs
@@ -117,7 +117,7 @@ impl CKBProtocolHandler for NetTimeProtocol {
             let fbb = &mut FlatBufferBuilder::new();
             let message = TimeMessage::build_time(fbb, now);
             fbb.finish(message, None);
-            nc.send_message_to(peer_index, fbb.finished_data().to_vec());
+            nc.send_message_to(peer_index, fbb.finished_data().into());
         }
     }
 

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -125,7 +125,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
             );
             fbb.finish(message, None);
             self.nc
-                .send_message_to(self.peer, fbb.finished_data().to_vec());
+                .send_message_to(self.peer, fbb.finished_data().into());
         }
         Ok(())
     }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -6,7 +6,7 @@ use ckb_protocol::{CompactBlock as FbsCompactBlock, RelayMessage};
 use ckb_shared::shared::Shared;
 use ckb_shared::store::ChainStore;
 use ckb_traits::{BlockMedianTimeContext, ChainProvider};
-use ckb_verification::{HeaderResolverWrapper, HeaderVerifier, Verifier, Error as VerifyError};
+use ckb_verification::{Error as VerifyError, HeaderResolverWrapper, HeaderVerifier, Verifier};
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
 use fnv::FnvHashMap;

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -40,19 +40,35 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
     pub fn execute(self) -> Result<(), FailureError> {
         let compact_block: CompactBlock = (*self.message).try_into()?;
         let block_hash = compact_block.header.hash();
+        if let Some(header_view) = self.relayer.shared.get_header_view(&block_hash) {
+            let best_known_header = self.relayer.shared.best_known_header();
+            if header_view.total_difficulty() <= best_known_header.total_difficulty() {
+                debug!(
+                    target: "relay",
+                    "Received a compact block({}), total difficulty {} <= {}",
+                    block_hash,
+                    header_view.total_difficulty(),
+                    best_known_header.total_difficulty(),
+                );
+                return Ok(());
+            }
+        }
+
         let mut missing_indexes: Vec<usize> = Vec::new();
         {
             let mut pending_compact_blocks = self.relayer.state.pending_compact_blocks.lock();
             if pending_compact_blocks.get(&block_hash).is_none()
-                && self.relayer.get_block(&block_hash).is_none()
+                && self.relayer.shared.get_block(&block_hash).is_none()
             {
-                let resolver =
-                    HeaderResolverWrapper::new(&compact_block.header, self.relayer.shared.clone());
+                let resolver = HeaderResolverWrapper::new(
+                    &compact_block.header,
+                    self.relayer.shared.shared().clone(),
+                );
                 let header_verifier = HeaderVerifier::new(
                     CompactBlockMedianTimeView {
                         header: &compact_block.header,
                         pending_compact_blocks: &pending_compact_blocks,
-                        shared: &self.relayer.shared,
+                        shared: self.relayer.shared.shared(),
                     },
                     Arc::clone(&self.relayer.shared.consensus().pow_engine()),
                 );
@@ -83,7 +99,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                     }
                     Err(VerifyError::UnknownParent(hash)) => {
                         debug!(target: "relay", "UnknownParent: {}, send_getheaders_to_peer({})", hash, self.peer);
-                        self.relayer.send_getheaders_to_peer(
+                        self.relayer.shared.send_getheaders_to_peer(
                             self.nc,
                             self.peer,
                             self.relayer.shared.chain_state().lock().tip_header(),

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -60,7 +60,7 @@ impl<'a, CS: ChainStore> GetBlockProposalProcess<'a, CS> {
         fbb.finish(message, None);
 
         self.nc
-            .send_message_to(self.peer, fbb.finished_data().to_vec());
+            .send_message_to(self.peer, fbb.finished_data().into());
         Ok(())
     }
 }

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -35,7 +35,7 @@ impl<'a, CS: ChainStore> GetBlockTransactionsProcess<'a, CS> {
 
         let indexes = cast!(self.message.indexes())?;
 
-        if let Some(block) = self.relayer.get_block(&block_hash) {
+        if let Some(block) = self.relayer.shared.get_block(&block_hash) {
             let transactions = indexes
                 .safe_slice()
                 .iter()

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -47,7 +47,7 @@ impl<'a, CS: ChainStore> GetBlockTransactionsProcess<'a, CS> {
             fbb.finish(message, None);
 
             self.nc
-                .send_message_to(self.peer, fbb.finished_data().to_vec());
+                .send_message_to(self.peer, fbb.finished_data().into());
         }
 
         Ok(())

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 
 pub const TX_PROPOSAL_TOKEN: u64 = 0;
 pub const MAX_RELAY_PEERS: usize = 128;
-pub const TX_FILTER_SIZE: usize = 1000;
+pub const TX_FILTER_SIZE: usize = 50000;
 
 pub struct Relayer<CS> {
     chain: ChainController,

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -176,6 +176,7 @@ impl<CS: ChainStore> Relayer<CS> {
         if ret.is_ok() {
             debug!(target: "relay", "[block_relay] relayer accept_block {} {}", block.header().hash(), unix_time_as_millis());
             let block_hash = block.header().hash();
+            self.shared.remove_header_view(&block_hash);
             let fbb = &mut FlatBufferBuilder::new();
             let message = RelayMessage::build_compact_block(fbb, block, &HashSet::new());
             fbb.finish(message, None);

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -166,7 +166,7 @@ impl<CS: ChainStore> Relayer<CS> {
                 RelayMessage::build_get_block_proposal(fbb, block.header.number(), &unknown_ids);
             fbb.finish(message, None);
 
-            nc.send_message_to(peer, fbb.finished_data().to_vec());
+            nc.send_message_to(peer, fbb.finished_data().into());
         }
     }
 
@@ -192,7 +192,7 @@ impl<CS: ChainStore> Relayer<CS> {
 
             // TODO: use filter broadcast
             for target_peer in selected_peers {
-                nc.send_message_to(target_peer, fbb.finished_data().to_vec());
+                nc.send_message_to(target_peer, fbb.finished_data().into());
             }
         } else {
             debug!(target: "relay", "accept_block verify error {:?}", ret);
@@ -294,13 +294,12 @@ impl<CS: ChainStore> Relayer<CS> {
             pending_proposals_request.remove(&id);
         }
 
-        // TODO: use filter_broadcast
         for (peer_index, txs) in peer_txs {
             let fbb = &mut FlatBufferBuilder::new();
             let message =
                 RelayMessage::build_block_proposal(fbb, &txs.into_iter().collect::<Vec<_>>());
             fbb.finish(message, None);
-            nc.send_message_to(peer_index, fbb.finished_data().to_vec());
+            nc.send_message_to(peer_index, fbb.finished_data().into());
         }
     }
 

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -44,7 +44,7 @@ where
                 let message = SyncMessage::build_block(fbb, &block);
                 fbb.finish(message, None);
                 self.nc
-                    .send_message_to(self.peer, fbb.finished_data().to_vec());
+                    .send_message_to(self.peer, fbb.finished_data().into());
             } else {
                 // TODO response not found
                 // TODO add timeout check in synchronizer

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -38,7 +38,7 @@ where
         for fbs_h256 in block_hashes {
             let block_hash = fbs_h256.try_into()?;
             debug!(target: "sync", "get_blocks {:x}", block_hash);
-            if let Some(block) = self.synchronizer.get_block(&block_hash) {
+            if let Some(block) = self.synchronizer.shared.get_block(&block_hash) {
                 debug!(target: "sync", "respond_block {} {:x}", block.header().number(), block.header().hash());
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = SyncMessage::build_block(fbb, &block);

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -79,7 +79,7 @@ where
             let message = SyncMessage::build_headers(fbb, &headers);
             fbb.finish(message, None);
             self.nc
-                .send_message_to(self.peer, fbb.finished_data().to_vec());
+                .send_message_to(self.peer, fbb.finished_data().into());
         } else {
             warn!(target: "sync", "\n\nunknown block headers from peer {} {:#?}\n\n", self.peer, block_locator_hashes);
             // Got 'headers' message without known blocks

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -36,7 +36,7 @@ where
     }
 
     pub fn execute(self) -> Result<(), FailureError> {
-        if self.synchronizer.is_initial_block_download() {
+        if self.synchronizer.shared.is_initial_block_download() {
             info!(target: "sync", "Ignoring getheaders from peer={} because node is in initial block download", self.peer);
             return Ok(());
         }
@@ -56,13 +56,20 @@ where
 
         if let Some(block_number) = self
             .synchronizer
+            .shared
             .locate_latest_common_block(&hash_stop, &block_locator_hashes[..])
         {
-            debug!(target: "sync", "\n\nheaders latest_common={} tip={} begin\n\n", block_number, {self.synchronizer.tip_header().number()});
+            debug!(
+                target: "sync",
+                "\n\nheaders latest_common={} tip={} begin\n\n",
+                block_number,
+                self.synchronizer.shared.tip_header().number(),
+            );
 
             self.synchronizer.peers.getheaders_received(self.peer);
             let headers: Vec<Header> = self
                 .synchronizer
+                .shared
                 .get_locator_response(block_number, &hash_stop);
             // response headers
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -290,6 +290,7 @@ where
         // chain. Disconnect peers that are on chains with insufficient work.
         if self.synchronizer.shared.is_initial_block_download() && headers.len() != MAX_HEADERS_LEN
         {
+            self.nc.disconnect(self.peer);
         }
 
         // TODO: optimize: if last is an ancestor of BestKnownHeader, continue from there instead.

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -5,7 +5,7 @@ use ckb_core::{header::Header, BlockNumber};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, FlatbuffersVectorIterator, Headers};
 use ckb_shared::store::ChainStore;
-use ckb_traits::{BlockMedianTimeContext, ChainProvider};
+use ckb_traits::BlockMedianTimeContext;
 use ckb_verification::{Error as VerifyError, HeaderResolver, HeaderVerifier, Verifier};
 use failure::Error as FailureError;
 use log::{self, debug, log_enabled, warn};
@@ -71,7 +71,7 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
         let mut block_hash = parent.hash().to_owned();
         let mut timestamps: Vec<u64> = Vec::with_capacity(count as usize);
         for _ in 0..count {
-            let header = match self.synchronizer.get_header(&block_hash) {
+            let header = match self.synchronizer.shared.get_header(&block_hash) {
                 Some(h) => h,
                 None => break,
             };
@@ -99,6 +99,7 @@ impl<'a, CS: ChainStore> HeaderResolver for VerifierResolver<'a, CS> {
 
             let interval = self
                 .synchronizer
+                .shared
                 .consensus()
                 .difficulty_adjustment_interval();
 
@@ -108,25 +109,29 @@ impl<'a, CS: ChainStore> HeaderResolver for VerifierResolver<'a, CS> {
 
             let start = parent_number.saturating_sub(interval);
 
-            if let Some(start_header) = self.synchronizer.get_ancestor(&parent_hash, start) {
+            if let Some(start_header) = self.synchronizer.shared.get_ancestor(&parent_hash, start) {
                 let start_total_uncles_count = self
                     .synchronizer
+                    .shared
                     .get_header_view(&start_header.hash())
                     .expect("start header_view exist")
                     .total_uncles_count();
 
                 let last_total_uncles_count = self
                     .synchronizer
+                    .shared
                     .get_header_view(&parent_hash)
                     .expect("last header_view exist")
                     .total_uncles_count();
 
                 let difficulty = last_difficulty
                     * U256::from(last_total_uncles_count - start_total_uncles_count)
-                    * U256::from((1.0 / self.synchronizer.consensus().orphan_rate_target()) as u64)
+                    * U256::from(
+                        (1.0 / self.synchronizer.shared.consensus().orphan_rate_target()) as u64,
+                    )
                     / U256::from(interval);
 
-                let min_difficulty = self.synchronizer.consensus().min_difficulty();
+                let min_difficulty = self.synchronizer.shared.consensus().min_difficulty();
                 let max_difficulty = last_difficulty * 2u32;
                 if difficulty > max_difficulty {
                     return Some(max_difficulty);
@@ -183,7 +188,7 @@ where
     }
 
     pub fn accept_first(&self, first: &Header) -> ValidationResult {
-        let parent = self.synchronizer.get_header(&first.parent_hash());
+        let parent = self.synchronizer.shared.get_header(&first.parent_hash());
         let resolver = VerifierResolver::new(parent.as_ref(), &first, &self.synchronizer);
         let verifier = HeaderVerifier::new(
             resolver.clone(),
@@ -255,7 +260,7 @@ where
         }
 
         if log_enabled!(target: "sync", log::Level::Debug) {
-            let own = { self.synchronizer.best_known_header.read().clone() };
+            let own = self.synchronizer.shared.best_known_header();
             let chain_state = self.synchronizer.shared.chain_state().lock();
             let peer_state = self.synchronizer.peers.best_known_header(self.peer);
             debug!(
@@ -283,12 +288,15 @@ where
 
         // If we're in IBD, we want outbound peers that will serve us a useful
         // chain. Disconnect peers that are on chains with insufficient work.
-        if self.synchronizer.is_initial_block_download() && headers.len() != MAX_HEADERS_LEN {}
+        if self.synchronizer.shared.is_initial_block_download() && headers.len() != MAX_HEADERS_LEN
+        {
+        }
 
         // TODO: optimize: if last is an ancestor of BestKnownHeader, continue from there instead.
         if headers.len() == MAX_HEADERS_LEN {
             let start = headers.last().expect("empty checked");
             self.synchronizer
+                .shared
                 .send_getheaders_to_peer(self.nc, self.peer, start);
         }
         Ok(())

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -475,7 +475,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
         let fbb = &mut FlatBufferBuilder::new();
         let message = SyncMessage::build_get_blocks(fbb, v_fetch);
         fbb.finish(message, None);
-        nc.send_message_to(peer, fbb.finished_data().to_vec());
+        nc.send_message_to(peer, fbb.finished_data().into());
         trace!(target: "sync", "send_getblocks len={:?} to peer={}", v_fetch.len() , peer);
     }
 }
@@ -927,9 +927,10 @@ mod tests {
         fn set_notify(&self, _interval: Duration, _token: u64) {
             unimplemented!();
         }
-        fn send_message(&self, _proto_id: ProtocolId, _peer_index: PeerIndex, _data: Vec<u8>) {}
-        fn send_message_to(&self, _peer_index: PeerIndex, _data: Vec<u8>) {}
-        fn filter_broadcast(&self, _target: TargetSession, _data: Vec<u8>) {
+        fn send_message(&self, _proto_id: ProtocolId, _peer_index: PeerIndex, _data: bytes::Bytes) {
+        }
+        fn send_message_to(&self, _peer_index: PeerIndex, _data: bytes::Bytes) {}
+        fn filter_broadcast(&self, _target: TargetSession, _data: bytes::Bytes) {
             unimplemented!();
         }
         fn disconnect(&self, peer_index: PeerIndex) {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -206,7 +206,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
             self.peers.new_header_received(peer, &header_view);
             self.shared
-                .insert_header(header.hash().clone(), header_view);
+                .insert_header_view(header.hash().clone(), header_view);
         }
     }
 
@@ -229,6 +229,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
     fn accept_block(&self, peer: PeerIndex, block: &Arc<Block>) -> Result<(), FailureError> {
         self.chain.process_block(Arc::clone(&block))?;
+        self.shared.remove_header_view(&block.header().hash());
         self.mark_block_stored(block.header().hash().clone());
         self.peers.set_last_common_header(peer, &block.header());
         Ok(())

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -158,6 +158,11 @@ impl CKBProtocolContext for TestNetworkContext {
             });
         }
     }
+    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Vec<u8>) {
+        if let Some(sender) = self.msg_senders.get(&(proto_id, peer_index)) {
+            let _ = sender.send(data);
+        }
+    }
     fn send_message_to(&self, peer_index: PeerIndex, data: Vec<u8>) {
         if let Some(sender) = self.msg_senders.get(&(self.protocol, peer_index)) {
             let _ = sender.send(data);

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -18,8 +18,8 @@ mod synchronizer;
 struct TestNode {
     pub peers: Vec<PeerIndex>,
     pub protocols: HashMap<ProtocolId, Arc<RwLock<CKBProtocolHandler + Send + Sync>>>,
-    pub msg_senders: HashMap<(ProtocolId, PeerIndex), Sender<Vec<u8>>>,
-    pub msg_receivers: HashMap<(ProtocolId, PeerIndex), Receiver<Vec<u8>>>,
+    pub msg_senders: HashMap<(ProtocolId, PeerIndex), Sender<Bytes>>,
+    pub msg_receivers: HashMap<(ProtocolId, PeerIndex), Receiver<Bytes>>,
     pub timer_senders: HashMap<(ProtocolId, u64), Sender<()>>,
     pub timer_receivers: HashMap<(ProtocolId, u64), Receiver<()>>,
 }
@@ -103,7 +103,7 @@ impl TestNode {
                                 timer_senders: self.timer_senders.clone(),
                             }),
                             *peer,
-                            Bytes::from(payload.clone()),
+                            payload.clone(),
                         )
                     };
 
@@ -135,7 +135,7 @@ impl TestNode {
             .iter()
             .for_each(|((protocol_id, _), sender)| {
                 if *protocol_id == protocol {
-                    let _ = sender.send(msg.to_vec());
+                    let _ = sender.send(msg.into());
                 }
             })
     }
@@ -143,7 +143,7 @@ impl TestNode {
 
 struct TestNetworkContext {
     protocol: ProtocolId,
-    msg_senders: HashMap<(ProtocolId, PeerIndex), Sender<Vec<u8>>>,
+    msg_senders: HashMap<(ProtocolId, PeerIndex), Sender<bytes::Bytes>>,
     timer_senders: HashMap<(ProtocolId, u64), Sender<()>>,
 }
 
@@ -158,18 +158,30 @@ impl CKBProtocolContext for TestNetworkContext {
             });
         }
     }
-    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Vec<u8>) {
+    fn send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: bytes::Bytes) {
         if let Some(sender) = self.msg_senders.get(&(proto_id, peer_index)) {
             let _ = sender.send(data);
         }
     }
-    fn send_message_to(&self, peer_index: PeerIndex, data: Vec<u8>) {
+    fn send_message_to(&self, peer_index: PeerIndex, data: bytes::Bytes) {
         if let Some(sender) = self.msg_senders.get(&(self.protocol, peer_index)) {
             let _ = sender.send(data);
         }
     }
-    fn filter_broadcast(&self, _target: TargetSession, _data: Vec<u8>) {
-        unimplemented!();
+    fn filter_broadcast(&self, target: TargetSession, data: bytes::Bytes) {
+        match target {
+            TargetSession::Single(peer) => {
+                self.send_message_to(peer, data);
+            }
+            TargetSession::Multi(peers) => {
+                for peer in peers {
+                    self.send_message_to(peer, data.clone());
+                }
+            }
+            TargetSession::All => {
+                unimplemented!();
+            }
+        }
     }
     fn disconnect(&self, _peer_index: PeerIndex) {}
     // Interact with NetworkState

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -1,6 +1,6 @@
 use crate::relayer::TX_PROPOSAL_TOKEN;
 use crate::tests::TestNode;
-use crate::{NetworkProtocol, Relayer};
+use crate::{NetworkProtocol, Relayer, SyncSharedState};
 use ckb_chain::chain::{ChainBuilder, ChainController};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::block::BlockBuilder;
@@ -378,9 +378,10 @@ fn setup_node(
             .expect("process block should be OK");
     }
 
+    let sync_shared_state = Arc::new(SyncSharedState::new(shared.clone()));
     let relayer = Relayer::new(
         chain_controller.clone(),
-        shared.clone(),
+        sync_shared_state,
         Arc::new(Default::default()),
     );
 

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -1,6 +1,6 @@
 use crate::synchronizer::{BLOCK_FETCH_TOKEN, SEND_GET_HEADERS_TOKEN, TIMEOUT_EVICTION_TOKEN};
 use crate::tests::TestNode;
-use crate::{Config, NetworkProtocol, Synchronizer};
+use crate::{Config, NetworkProtocol, SyncSharedState, Synchronizer};
 use ckb_chain::chain::ChainBuilder;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::block::BlockBuilder;
@@ -108,7 +108,8 @@ fn setup_node(
             .expect("process block should be OK");
     }
 
-    let synchronizer = Synchronizer::new(chain_controller, shared.clone(), Config::default());
+    let sync_shared_state = Arc::new(SyncSharedState::new(shared.clone()));
+    let synchronizer = Synchronizer::new(chain_controller, sync_shared_state, Config::default());
     let mut node = TestNode::default();
     let protocol = Arc::new(RwLock::new(synchronizer)) as Arc<_>;
     node.add_protocol(

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -507,7 +507,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         nc.send_message(
             NetworkProtocol::SYNC.into(),
             peer,
-            fbb.finished_data().to_vec(),
+            fbb.finished_data().into(),
         );
     }
 }

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -333,18 +333,12 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         *self.best_known_header.write() = header;
     }
 
-    pub fn insert_header(&self, hash: H256, header: HeaderView) {
+    pub fn insert_header_view(&self, hash: H256, header: HeaderView) {
         self.header_map.write().insert(hash, header);
     }
-    pub fn get_header(&self, hash: &H256) -> Option<Header> {
-        self.header_map
-            .read()
-            .get(hash)
-            .map(HeaderView::inner)
-            .cloned()
-            .or_else(|| self.shared.block_header(hash))
+    pub fn remove_header_view(&self, hash: &H256) {
+        self.header_map.write().remove(hash);
     }
-
     pub fn get_header_view(&self, hash: &H256) -> Option<HeaderView> {
         self.header_map.read().get(hash).cloned().or_else(|| {
             self.shared.block_header(hash).and_then(|header| {
@@ -357,6 +351,14 @@ impl<CS: ChainStore> SyncSharedState<CS> {
                 })
             })
         })
+    }
+    pub fn get_header(&self, hash: &H256) -> Option<Header> {
+        self.header_map
+            .read()
+            .get(hash)
+            .map(HeaderView::inner)
+            .cloned()
+            .or_else(|| self.shared.block_header(hash))
     }
 
     pub fn get_ancestor(&self, base: &H256, number: BlockNumber) -> Option<Header> {

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -11,7 +11,7 @@ use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
 use std::collections::hash_map::Entry;
 
-const FILTER_SIZE: usize = 500;
+const FILTER_SIZE: usize = 20000;
 
 // State used to enforce CHAIN_SYNC_TIMEOUT
 // Only in effect for outbound, non-manual connections, with

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -105,7 +105,7 @@ impl Net {
         );
     }
 
-    pub fn send(&self, protocol_id: ProtocolId, peer: PeerIndex, data: Vec<u8>) {
+    pub fn send(&self, protocol_id: ProtocolId, peer: PeerIndex, data: Bytes) {
         self.controller
             .as_ref()
             .unwrap()

--- a/test/src/specs/protocols.rs
+++ b/test/src/specs/protocols.rs
@@ -19,9 +19,17 @@ impl Spec for MalformedMessage {
         assert_eq!(SyncPayload::GetHeaders, msg.payload_type());
 
         info!("Send malformed message to node0 twice");
-        net.send(NetworkProtocol::SYNC.into(), peer_id, vec![0, 0, 0, 0]);
+        net.send(
+            NetworkProtocol::SYNC.into(),
+            peer_id,
+            vec![0, 0, 0, 0].into(),
+        );
         sleep(3);
-        net.send(NetworkProtocol::SYNC.into(), peer_id, vec![0, 1, 2, 3]);
+        net.send(
+            NetworkProtocol::SYNC.into(),
+            peer_id,
+            vec![0, 1, 2, 3].into(),
+        );
         sleep(3);
 
         info!("Node0 should disconnect test node");


### PR DESCRIPTION
**Main changes**:
1. Adjust relay filter size to avoid message flood
2. Send `getheaders` message when get UnknownParent Error
3. Fix send message to wrong protocol cause peer banned
4. Update `p2p` dependency
5. Fix BlockAssembler hold chain state lock most of the time when cellbase is large