### PR TITLE
fix: Disconnect wrong peer when process getheaders message

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -329,7 +329,7 @@ impl<CS: ChainStore> CKBProtocolHandler for Relayer<CS> {
             }
         };
 
-        debug!(target: "relay", "msg {:?}", msg.payload_type());
+        debug!(target: "relay", "received msg {:?} from {}", msg.payload_type(), peer_index);
         self.process(nc.as_ref(), peer_index, msg);
     }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -504,7 +504,7 @@ impl<CS: ChainStore> CKBProtocolHandler for Synchronizer<CS> {
             }
         };
 
-        debug!(target: "sync", "msg {:?}", msg.payload_type());
+        debug!(target: "sync", "received msg {:?} from {}", msg.payload_type(), peer_index);
         self.process(nc.as_ref(), peer_index, msg);
     }
 


### PR DESCRIPTION
Should only disconnect outbound not protected peer and the message length is less `MAX_HEADERS_LEN`