### PR TITLE
chore: run security-audit in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clippy:
 	cd test && cargo clippy ${VERBOSE} --all --all-targets --all-features -- -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from
 
 
-ci: fmt clippy test
+ci: fmt clippy security-audit test
 	git diff --exit-code Cargo.lock
 
 info:

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -9,4 +9,5 @@ fi
 
 if [ "$CHECK" = true ]; then
   cargo clippy --version || rustup component add clippy
+  cargo audit --version || cargo install cargo-audit
 fi

--- a/devtools/ci/script.sh
+++ b/devtools/ci/script.sh
@@ -23,6 +23,7 @@ if [ "$RUN_TEST" = true ]; then
   if [ "$CHECK" = true ]; then
     make check
     make clippy
+    make security-audit
   fi
   if [ "$TEST" = true ]; then
     make test


### PR DESCRIPTION
Since #96 is closed, we are able to run security-audit in CI now.