### PR TITLE
fix: Initial block download message storm

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -59,6 +59,10 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                 return Ok(());
             }
         } else {
+            // If self is in the IBD state, do nothing
+            if self.relayer.shared.is_initial_block_download() {
+                return Ok(());
+            }
             debug!(target: "relay", "UnknownParent: {}, send_getheaders_to_peer({})", block_hash, self.peer);
             self.relayer.shared.send_getheaders_to_peer(
                 self.nc,

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -477,7 +477,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
         let message = SyncMessage::build_get_blocks(fbb, v_fetch);
         fbb.finish(message, None);
         nc.send_message_to(peer, fbb.finished_data().into());
-        trace!(target: "sync", "send_getblocks len={:?} to peer={}", v_fetch.len() , peer);
+        debug!(target: "sync", "send_getblocks len={:?} to peer={}", v_fetch.len() , peer);
     }
 }
 


### PR DESCRIPTION
When IBD, received compact block message, can't find it's parent, do nothing