### PR TITLE
[ᚬmaster] sync: improve the performance of get_locator

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -245,7 +245,7 @@ impl<CI: ChainIndex> Synchronizer<CI> {
         let mut step = 1;
         let mut locator = Vec::with_capacity(32);
         let mut index = start.number();
-        let base = start.hash();
+        let mut base = start.hash();
         loop {
             let header = self
                 .get_ancestor(&base, index)
@@ -264,6 +264,7 @@ impl<CI: ChainIndex> Synchronizer<CI> {
                 break;
             }
             index -= step;
+            base = header.hash();
         }
         locator
     }


### PR DESCRIPTION
Use the last header as the `base` to avoid scan from tip.