### PR TITLE
chore: fix version of ckb-app-config, bump to v0.11.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ name = "ckb"
 version = "0.11.0-pre"
 dependencies = [
  "build-info 0.11.0-pre",
- "ckb-app-config 0.9.0-pre",
+ "ckb-app-config 0.11.0-pre",
  "ckb-chain 0.11.0-pre",
  "ckb-chain-spec 0.11.0-pre",
  "ckb-core 0.11.0-pre",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-app-config"
-version = "0.9.0-pre"
+version = "0.11.0-pre"
 dependencies = [
  "build-info 0.11.0-pre",
  "ckb-chain-spec 0.11.0-pre",

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-app-config"
-version = "0.9.0-pre"
+version = "0.11.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
All crates are v0.11.0-pre, only ckb-app-config is v0.9.0-pre.

I'm not sure if it's a typo or not.