### PR TITLE
feat: Add tx_pool_info RPC

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -484,6 +484,32 @@ echo '{
 }
 ```
 
+### tx_pool_info
+
+Return the transaction pool information
+
+#### Examples
+
+``` bash
+curl -H 'content-type:application/json' \
+    -d '{"params": [], "method": "tx_pool_info", "jsonrpc": "2.0", "id": 2}' \
+    http://localhost:8114
+```
+
+``` json
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {
+        "pending": 34,
+        "staging": 22,
+        "orphan": 33,
+        "last_txs_updated_at": "1555507787683"
+    }
+}
+```
+
+
 ## Trace
 
 ### trace_transaction

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -8,7 +8,7 @@ use ckb_sync::NetworkProtocol;
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
-use jsonrpc_types::Transaction;
+use jsonrpc_types::{Transaction, TxPoolInfo};
 use numext_fixed_hash::H256;
 use std::convert::TryInto;
 
@@ -17,6 +17,10 @@ pub trait PoolRpc {
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"send_transaction","params": [{"version":2, "deps":[], "inputs":[], "outputs":[]}]}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "send_transaction")]
     fn send_transaction(&self, _tx: Transaction) -> Result<H256>;
+
+    // curl -d '{"params": [], "method": "tx_pool_info", "jsonrpc": "2.0", "id": 2}' -H 'content-type:application/json' http://localhost:8114
+    #[rpc(name = "tx_pool_info")]
+    fn tx_pool_info(&self) -> Result<TxPoolInfo>;
 }
 
 pub(crate) struct PoolRpcImpl<CS> {
@@ -46,5 +50,16 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
         }
+    }
+
+    fn tx_pool_info(&self) -> Result<TxPoolInfo> {
+        let chain_state = self.shared.chain_state().lock();
+        let tx_pool = chain_state.tx_pool();
+        Ok(TxPoolInfo {
+            pending: tx_pool.pending_size(),
+            staging: tx_pool.staging_size(),
+            orphan: tx_pool.orphan_size(),
+            last_txs_updated_at: chain_state.get_last_txs_updated_at().to_string(),
+        })
     }
 }

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -46,6 +46,16 @@ impl TxPool {
         }
     }
 
+    pub fn pending_size(&self) -> u32 {
+        self.pending.size() as u32
+    }
+    pub fn staging_size(&self) -> u32 {
+        self.staging.vertices.len() as u32
+    }
+    pub fn orphan_size(&self) -> u32 {
+        self.orphan.vertices.len() as u32
+    }
+
     // enqueue_tx inserts a new transaction into the non-verifiable transaction queue.
     pub fn enqueue_tx(&mut self, cycles: Option<Cycle>, tx: Transaction) -> bool {
         self.pending.add_tx(cycles, tx).is_none()

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -75,6 +75,7 @@ impl Node {
             if let Ok(result) = client.local_node_info().call() {
                 info!("RPC service ready, {:?}", result);
                 self.node_id = Some(result.node_id);
+                assert!(client.tx_pool_info().call().is_ok());
                 break;
             } else if let Some(ref mut child) = self.guard {
                 match child.0.try_wait() {
@@ -100,6 +101,7 @@ impl Node {
             .local_node_info()
             .call()
             .expect("rpc call local_node_info failed");
+
         let node_id = node_info.node_id;
         self.rpc_client()
             .add_node(

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,6 +1,6 @@
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_types::{
-    Block, BlockTemplate, Header, Node, Transaction, TransactionWithStatus, TxTrace,
+    Block, BlockTemplate, Header, Node, Transaction, TransactionWithStatus, TxPoolInfo, TxTrace,
 };
 use numext_fixed_hash::H256;
 
@@ -14,6 +14,7 @@ jsonrpc_client!(pub struct RpcClient {
     pub fn submit_block(&mut self, work_id: String, data: Block) -> RpcRequest<Option<H256>>;
 
     pub fn send_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
+    pub fn tx_pool_info(&mut self) -> RpcRequest<TxPoolInfo>;
     pub fn trace_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
     pub fn get_transaction_trace(&mut self, hash: H256) -> RpcRequest<Option<Vec<TxTrace>>>;
 

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -3,6 +3,7 @@ mod blockchain;
 mod bytes;
 mod cell;
 mod net;
+mod pool;
 mod proposal_short_id;
 mod trace;
 
@@ -20,6 +21,7 @@ pub use self::blockchain::{
 pub use self::bytes::Bytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};
 pub use self::net::{Node, NodeAddress};
+pub use self::pool::TxPoolInfo;
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::trace::{Action, TxTrace};
 pub use ckb_core::Version;

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -1,0 +1,10 @@
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct TxPoolInfo {
+    pub pending: u32,
+    pub staging: u32,
+    pub orphan: u32,
+    // timestamp(u64)
+    pub last_txs_updated_at: String,
+}


### PR DESCRIPTION
Add a new RPC interface `tx_pool_info` to get transaction pool information.