### PR TITLE
perf: use 3 commands to remove about 70 useless `clone()`

### DIFF
--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -261,7 +261,7 @@ fn gen_block(
         .proposals(proposals)
         .with_header_builder(
             HeaderBuilder::default()
-                .parent_hash(p_block.header().hash().clone())
+                .parent_hash(p_block.header().hash())
                 .number(number)
                 .timestamp(timestamp)
                 .difficulty(difficulty)

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -352,7 +352,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                     .shared
                     .block(&index.hash)
                     .expect("block data stored before alignment_fork");
-                index.forward(new_block.header().parent_hash().clone());
+                index.forward(new_block.header().parent_hash().to_owned());
                 fork.attached_blocks.push(new_block);
             }
         }
@@ -392,7 +392,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                 .shared
                 .block(&index.hash)
                 .expect("attached block stored before find_fork_until_latest_common");
-            index.forward(attached_block.header().parent_hash().clone());
+            index.forward(attached_block.header().parent_hash().to_owned());
             fork.attached_blocks.push(attached_block);
         }
     }
@@ -413,7 +413,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
 
         let mut index = GlobalIndex::new(
             new_tip_number - 1,
-            new_tip_block.header().parent_hash().clone(),
+            new_tip_block.header().parent_hash().to_owned(),
             true,
         );
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -222,7 +222,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
             .expect("parent already store");
 
         let cannon_total_difficulty = parent_ext.total_difficulty + block.header().difficulty();
-        let current_total_difficulty = chain_state.total_difficulty().clone();
+        let current_total_difficulty = chain_state.total_difficulty().to_owned();
 
         debug!(
             target: "chain",
@@ -270,7 +270,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
         batch.commit()?;
 
         if new_best_block {
-            let tip_header = block.header().clone();
+            let tip_header = block.header().to_owned();
             // finalize proposal_id table change
             // then, update tx_pool
             let detached_proposal_id = chain_state.proposal_ids_finalize(tip_header.number());

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -27,7 +27,7 @@ fn test_genesis_transaction_spend() {
         ])
         .build();
 
-    let mut root_hash = tx.hash().clone();
+    let mut root_hash = tx.hash();
 
     let genesis_tx_hash = root_hash.clone();
 
@@ -45,7 +45,7 @@ fn test_genesis_transaction_spend() {
     for i in 1..end {
         let difficulty = parent.difficulty().clone();
         let tx = create_transaction(root_hash, i as u8);
-        root_hash = tx.hash().clone();
+        root_hash = tx.hash();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(1u64),
@@ -91,11 +91,11 @@ fn test_transaction_spend_in_same_block() {
     }
 
     let last_cell_base = &chain.last().unwrap().transactions()[0];
-    let last_cell_base_hash = last_cell_base.hash().clone();
+    let last_cell_base_hash = last_cell_base.hash();
     let tx1 = create_transaction(last_cell_base_hash.clone(), 1);
-    let tx1_hash = tx1.hash().clone();
+    let tx1_hash = tx1.hash();
     let tx2 = create_transaction(tx1_hash.clone(), 2);
-    let tx2_hash = tx2.hash().clone();
+    let tx2_hash = tx2.hash();
     let tx2_output = tx2.outputs()[0].clone();
 
     let txs = vec![tx1, tx2];
@@ -373,7 +373,7 @@ fn test_genesis_transaction_fetch() {
         ])
         .build();
 
-    let root_hash = tx.hash().clone();
+    let root_hash = tx.hash();
 
     let genesis_block = BlockBuilder::default()
         .transaction(tx)

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -43,7 +43,7 @@ fn test_genesis_transaction_spend() {
     let mut blocks1: Vec<Block> = vec![];
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for i in 1..end {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let tx = create_transaction(root_hash, i as u8);
         root_hash = tx.hash();
         let new_block = gen_block(
@@ -54,7 +54,7 @@ fn test_genesis_transaction_spend() {
             vec![],
         );
         blocks1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &blocks1[0..10] {
@@ -78,7 +78,7 @@ fn test_transaction_spend_in_same_block() {
     let mut chain: Vec<Block> = Vec::new();
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -86,7 +86,7 @@ fn test_transaction_spend_in_same_block() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
 
@@ -117,7 +117,7 @@ fn test_transaction_spend_in_same_block() {
     }
     // proposal txs
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -125,12 +125,12 @@ fn test_transaction_spend_in_same_block() {
             txs.clone(),
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // empty N+1 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -138,12 +138,12 @@ fn test_transaction_spend_in_same_block() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // commit txs in N+2 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -194,7 +194,7 @@ fn test_transaction_conflict_in_same_block() {
     let mut chain: Vec<Block> = Vec::new();
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -202,7 +202,7 @@ fn test_transaction_conflict_in_same_block() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
 
@@ -213,7 +213,7 @@ fn test_transaction_conflict_in_same_block() {
     let txs = vec![tx1, tx2, tx3];
     // proposal txs
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -221,12 +221,12 @@ fn test_transaction_conflict_in_same_block() {
             txs.clone(),
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // empty N+1 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -234,12 +234,12 @@ fn test_transaction_conflict_in_same_block() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // commit txs in N+2 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -273,7 +273,7 @@ fn test_transaction_conflict_in_different_blocks() {
     let mut chain: Vec<Block> = Vec::new();
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -281,7 +281,7 @@ fn test_transaction_conflict_in_different_blocks() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
 
@@ -291,7 +291,7 @@ fn test_transaction_conflict_in_different_blocks() {
     let tx3 = create_transaction(tx1.hash(), 3);
     // proposal txs
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -299,12 +299,12 @@ fn test_transaction_conflict_in_different_blocks() {
             vec![tx1.clone(), tx2.clone(), tx3.clone()],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // empty N+1 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -312,12 +312,12 @@ fn test_transaction_conflict_in_different_blocks() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // commit tx1 and tx2 in N+2 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -325,12 +325,12 @@ fn test_transaction_conflict_in_different_blocks() {
             vec![],
             vec![],
         );
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
         chain.push(new_block);
     }
     // commit tx3 in N+3 block
     {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -397,7 +397,7 @@ fn test_chain_fork_by_total_difficulty() {
 
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -406,12 +406,12 @@ fn test_chain_fork_by_total_difficulty() {
             vec![],
         );
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for i in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let j = if i > 10 { 110 } else { 99 };
         let new_block = gen_block(
             &parent,
@@ -421,7 +421,7 @@ fn test_chain_fork_by_total_difficulty() {
             vec![],
         );
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &chain1 {
@@ -451,7 +451,7 @@ fn test_chain_fork_by_hash() {
 
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -460,12 +460,12 @@ fn test_chain_fork_by_hash() {
             vec![],
         );
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -474,7 +474,7 @@ fn test_chain_fork_by_hash() {
             vec![],
         );
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &chain1 {
@@ -519,7 +519,7 @@ fn test_chain_get_ancestor() {
 
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -528,12 +528,12 @@ fn test_chain_get_ancestor() {
             vec![],
         );
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -542,7 +542,7 @@ fn test_chain_get_ancestor() {
             vec![],
         );
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &chain1 {
@@ -594,7 +594,7 @@ fn test_calculate_difficulty() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
@@ -609,9 +609,9 @@ fn test_calculate_difficulty() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
-    let tip = shared.chain_state().lock().tip_header().clone();
+    let tip = shared.chain_state().lock().tip_header().to_owned();
     let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
     assert_eq!(total_uncles_count, 25);
     let difficulty = shared.calculate_difficulty(&tip).unwrap();
@@ -639,9 +639,9 @@ fn test_calculate_difficulty() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
-    let tip = shared.chain_state().lock().tip_header().clone();
+    let tip = shared.chain_state().lock().tip_header().to_owned();
     let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
     assert_eq!(total_uncles_count, 10);
     let difficulty = shared.calculate_difficulty(&tip).unwrap();
@@ -669,9 +669,9 @@ fn test_calculate_difficulty() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
-    let tip = shared.chain_state().lock().tip_header().clone();
+    let tip = shared.chain_state().lock().tip_header().to_owned();
     let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
     assert_eq!(total_uncles_count, 150);
     let difficulty = shared.calculate_difficulty(&tip).unwrap();

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -16,7 +16,7 @@ fn test_dead_cell_in_same_block() {
 
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -25,12 +25,12 @@ fn test_dead_cell_in_same_block() {
             vec![],
         );
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..switch_fork_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(99u64),
@@ -39,7 +39,7 @@ fn test_dead_cell_in_same_block() {
             vec![],
         );
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
@@ -48,7 +48,7 @@ fn test_dead_cell_in_same_block() {
     let tx3 = create_transaction(tx1.hash(), 3);
     let txs = vec![tx1, tx2, tx3];
     for i in switch_fork_number..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = if i == switch_fork_number {
             gen_block(
                 &parent,
@@ -75,7 +75,7 @@ fn test_dead_cell_in_same_block() {
             )
         };
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &chain1 {
@@ -114,7 +114,7 @@ fn test_dead_cell_in_different_block() {
 
     let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(100u64),
@@ -123,12 +123,12 @@ fn test_dead_cell_in_different_block() {
             vec![],
         );
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
     for _ in 1..switch_fork_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
             &parent,
             difficulty + U256::from(99u64),
@@ -137,7 +137,7 @@ fn test_dead_cell_in_different_block() {
             vec![],
         );
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
@@ -145,7 +145,7 @@ fn test_dead_cell_in_different_block() {
     let tx2 = create_transaction(tx1.hash(), 2);
     let tx3 = create_transaction(tx1.hash(), 3);
     for i in switch_fork_number..final_number {
-        let difficulty = parent.difficulty().clone();
+        let difficulty = parent.difficulty().to_owned();
         let new_block = if i == switch_fork_number {
             gen_block(
                 &parent,
@@ -180,7 +180,7 @@ fn test_dead_cell_in_different_block() {
             )
         };
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     for block in &chain1 {

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -35,14 +35,14 @@ fn test_find_fork_case1() {
     for _ in 0..4 {
         let new_block = gen_block(&parent, U256::from(100u64), vec![], vec![], vec![]);
         fork1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let mut parent = genesis.clone();
     for _ in 0..3 {
         let new_block = gen_block(&parent, U256::from(90u64), vec![], vec![], vec![]);
         fork2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     // fork1 total_difficulty 400
@@ -107,14 +107,14 @@ fn test_find_fork_case2() {
     for _ in 0..4 {
         let new_block = gen_block(&parent, U256::from(100u64), vec![], vec![], vec![]);
         fork1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
-    let mut parent = fork1[0].header().clone();
+    let mut parent = fork1[0].header().to_owned();
     for _ in 0..2 {
         let new_block = gen_block(&parent, U256::from(90u64), vec![], vec![], vec![]);
         fork2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     // fork2 total_difficulty 400
@@ -129,7 +129,7 @@ fn test_find_fork_case2() {
 
     let tip_number = { shared.chain_state().lock().tip_number() };
 
-    let difficulty = parent.difficulty().clone();
+    let difficulty = parent.difficulty().to_owned();
     let new_block = gen_block(
         &parent,
         difficulty + U256::from(200u64),
@@ -185,14 +185,14 @@ fn test_find_fork_case3() {
     for _ in 0..3 {
         let new_block = gen_block(&parent, U256::from(80u64), vec![], vec![], vec![]);
         fork1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let mut parent = genesis.clone();
     for _ in 0..5 {
         let new_block = gen_block(&parent, U256::from(40u64), vec![], vec![], vec![]);
         fork2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     // fork2 total_difficulty 240
@@ -257,14 +257,14 @@ fn test_find_fork_case4() {
     for _ in 0..5 {
         let new_block = gen_block(&parent, U256::from(40u64), vec![], vec![], vec![]);
         fork1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let mut parent = genesis.clone();
     for _ in 0..2 {
         let new_block = gen_block(&parent, U256::from(80u64), vec![], vec![], vec![]);
         fork2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     // fork2 total_difficulty 200

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -56,7 +56,7 @@ pub(crate) fn gen_block(
     let number = parent_header.number() + 1;
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash().clone())
+        .parent_hash(parent_header.hash())
         .timestamp(unix_time_as_millis())
         .number(number)
         .difficulty(difficulty);

--- a/core/src/uncle.rs
+++ b/core/src/uncle.rs
@@ -17,7 +17,7 @@ pub struct UncleBlock {
 impl From<Block> for UncleBlock {
     fn from(block: Block) -> Self {
         UncleBlock {
-            header: block.header().clone(),
+            header: block.header().to_owned(),
             proposals: block.proposals().to_vec(),
         }
     }

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -431,12 +431,12 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         excluded.insert(block_hash.clone());
         for _depth in 0..max_uncles_age {
             if let Some(block) = self.shared.block(&block_hash) {
-                excluded.insert(block.header().parent_hash().clone());
+                excluded.insert(block.header().parent_hash().to_owned());
                 for uncle in block.uncles() {
                     excluded.insert(uncle.header.hash());
                 }
 
-                block_hash = block.header().parent_hash().clone();
+                block_hash = block.header().parent_hash().to_owned();
             } else {
                 break;
             }

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -302,7 +302,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         let chain_state = self.shared.chain_state().lock();
         let last_txs_updated_at = chain_state.get_last_txs_updated_at();
 
-        let header = chain_state.tip_header().clone();
+        let header = chain_state.tip_header().to_owned();
         let number = chain_state.tip_number() + 1;
         let current_time = cmp::max(unix_time_as_millis(), header.timestamp() + 1);
 
@@ -476,7 +476,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
                 bad_uncles.push(hash.clone());
             } else {
                 let uncle = UncleBlock {
-                    header: block.header().clone(),
+                    header: block.header().to_owned(),
                     proposals: block.proposals().to_vec(),
                 };
                 uncles.push(uncle);
@@ -669,12 +669,12 @@ mod tests {
         let block_assembler_controller = block_assembler.start(Some("test"), &notify.clone());
 
         let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
-        let block0_0 = gen_block(&genesis, 10, genesis.difficulty().clone());
-        let block0_1 = gen_block(&genesis, 11, genesis.difficulty().clone());
+        let block0_0 = gen_block(&genesis, 10, genesis.difficulty().to_owned());
+        let block0_1 = gen_block(&genesis, 11, genesis.difficulty().to_owned());
         let block1_1 = gen_block(
             block0_1.header(),
             10,
-            block0_1.header().difficulty().clone(),
+            block0_1.header().difficulty().to_owned(),
         );
 
         chain_controller
@@ -697,7 +697,7 @@ mod tests {
         let block2_1 = gen_block(
             block1_1.header(),
             10,
-            block1_1.header().difficulty().clone(),
+            block1_1.header().difficulty().to_owned(),
         );
         chain_controller
             .process_block(Arc::new(block2_1.clone()))

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -206,7 +206,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
                     }
                     recv(new_uncle_receiver) -> msg => match msg {
                         Ok(uncle_block) => {
-                            let hash = uncle_block.header().hash().clone();
+                            let hash = uncle_block.header().hash();
                             self.candidate_uncles.insert(hash, uncle_block);
                             self.last_uncles_updated_at
                                 .store(unix_time_as_millis(), Ordering::SeqCst);
@@ -427,13 +427,13 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         // tip.p^4  -----------/  6
         // tip.p^5  -------------/
         // tip.p^6
-        let mut block_hash = tip.hash().clone();
+        let mut block_hash = tip.hash();
         excluded.insert(block_hash.clone());
         for _depth in 0..max_uncles_age {
             if let Some(block) = self.shared.block(&block_hash) {
                 excluded.insert(block.header().parent_hash().clone());
                 for uncle in block.uncles() {
-                    excluded.insert(uncle.header.hash().clone());
+                    excluded.insert(uncle.header.hash());
                 }
 
                 block_hash = block.header().parent_hash().clone();
@@ -627,7 +627,7 @@ mod tests {
         let number = parent_header.number() + 1;
         let cellbase = create_cellbase(number);
         let header = HeaderBuilder::default()
-            .parent_hash(parent_header.hash().clone())
+            .parent_hash(parent_header.hash())
             .timestamp(parent_header.timestamp() + 10)
             .number(number)
             .difficulty(difficulty)

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -48,7 +48,7 @@ impl Miner {
     }
 
     fn mine(&self) -> Result<Option<(String, Block)>, Error> {
-        let current_work = { self.current_work.lock().clone() };
+        let current_work = { self.current_work.lock().to_owned() };
         if let Some(template) = current_work {
             let BlockTemplate {
                 version,
@@ -101,7 +101,7 @@ impl Miner {
                 )
                 .with_header_builder(header_builder);
 
-            let raw_header = block.header().raw().clone();
+            let raw_header = block.header().raw().to_owned();
 
             Ok(self
                 .mine_loop(&raw_header)

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -701,12 +701,12 @@ impl NetworkService {
         let disc_service = DiscoveryService::new(Arc::clone(&network_state), disc_receiver);
         let ping_service = PingService::new(
             Arc::clone(&network_state),
-            p2p_service.control().clone(),
+            p2p_service.control().to_owned(),
             ping_receiver,
         );
         let outbound_peer_service = OutboundPeerService::new(
             Arc::clone(&network_state),
-            p2p_service.control().clone(),
+            p2p_service.control().to_owned(),
             Duration::from_secs(config.connect_outbound_interval_secs),
         );
         let bg_services = vec![
@@ -769,7 +769,7 @@ impl NetworkService {
             self.network_state
                 .dial_all(self.p2p_service.control(), &peer_id, addr);
         }
-        let p2p_control = self.p2p_service.control().clone();
+        let p2p_control = self.p2p_service.control().to_owned();
         let network_state = Arc::clone(&self.network_state);
 
         // Mainly for test: give a empty thread_name
@@ -780,7 +780,7 @@ impl NetworkService {
         let (sender, receiver) = crossbeam_channel::bounded(1);
         let thread = thread_builder
             .spawn(move || {
-                let inner_p2p_control = self.p2p_service.control().clone();
+                let inner_p2p_control = self.p2p_service.control().to_owned();
                 let mut runtime = Runtime::new().expect("Network tokio runtime init failed");
                 runtime.spawn(self.p2p_service.for_each(|_| Ok(())));
 

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -148,7 +148,7 @@ impl ServiceProtocol for CKBHandler {
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
-            p2p_control: context.control().clone(),
+            p2p_control: context.control().to_owned(),
         };
         nc.set_notify(Duration::from_secs(6), std::u64::MAX);
         self.handler.init(Box::new(nc));
@@ -158,7 +158,7 @@ impl ServiceProtocol for CKBHandler {
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
-            p2p_control: context.control().clone(),
+            p2p_control: context.control().to_owned(),
         };
         let peer_index = context.session.id;
         self.handler.connected(Box::new(nc), peer_index, version);
@@ -168,7 +168,7 @@ impl ServiceProtocol for CKBHandler {
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
-            p2p_control: context.control().clone(),
+            p2p_control: context.control().to_owned(),
         };
         let peer_index = context.session.id;
         self.handler.disconnected(Box::new(nc), peer_index);
@@ -179,7 +179,7 @@ impl ServiceProtocol for CKBHandler {
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
-            p2p_control: context.control().clone(),
+            p2p_control: context.control().to_owned(),
         };
         let peer_index = context.session.id;
         self.handler.received(Box::new(nc), peer_index, data);
@@ -192,7 +192,7 @@ impl ServiceProtocol for CKBHandler {
             let nc = DefaultCKBProtocolContext {
                 proto_id: self.proto_id,
                 network_state: Arc::clone(&self.network_state),
-                p2p_control: context.control().clone(),
+                p2p_control: context.control().to_owned(),
             };
             self.handler.notify(Box::new(nc), token);
         }
@@ -202,7 +202,7 @@ impl ServiceProtocol for CKBHandler {
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
-            p2p_control: context.control().clone(),
+            p2p_control: context.control().to_owned(),
         };
         self.handler.poll(Box::new(nc));
     }

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -281,8 +281,7 @@ impl<'a> FbsUncleBlock<'a> {
         fbb: &mut FlatBufferBuilder<'b>,
         uncle_block: &UncleBlock,
     ) -> WIPOffset<FbsUncleBlock<'b>> {
-        // TODO how to avoid clone here?
-        let header = FbsHeader::build(fbb, &uncle_block.header().clone());
+        let header = FbsHeader::build(fbb, &uncle_block.header());
         let vec = uncle_block
             .proposals
             .iter()

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -131,7 +131,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
                     if output.lock.hash() == lock_hash && (!transaction_meta.is_dead(i)) {
                         result.push(CellOutputWithOutPoint {
                             out_point: OutPoint {
-                                tx_hash: transaction.hash().clone(),
+                                tx_hash: transaction.hash(),
                                 index: i as u32,
                             },
                             capacity: output.capacity.to_string(),

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -87,7 +87,7 @@ impl<CS: ChainStore + 'static> MinerRpc for MinerRpcImpl<CS> {
                 let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
-                Ok(Some(block.header().hash().clone()))
+                Ok(Some(block.header().hash()))
             } else {
                 let chain_state = self.shared.chain_state().lock();
                 error!(target: "rpc", "submit_block process_block {:?}", ret);

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -68,7 +68,7 @@ impl<CS: ChainStore> ChainState<CS> {
                     .map_err(|_| {
                         SharedError::InvalidData("failed to init genesis block".to_owned())
                     })
-                    .map(|_| genesis.header().clone()),
+                    .map(|_| genesis.header().to_owned()),
             }
         }?;
 

--- a/shared/src/tx_pool/orphan.rs
+++ b/shared/src/tx_pool/orphan.rs
@@ -152,13 +152,13 @@ mod tests {
         let mut pool = OrphanPool::new();
 
         let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
-        let tx1_hash = tx1.hash().clone();
+        let tx1_hash = tx1.hash();
 
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);
-        let tx2_hash = tx2.hash().clone();
+        let tx2_hash = tx2.hash();
 
         let tx3 = build_tx(vec![(tx2_hash, 0)], 1);
-        let tx3_hash = tx3.hash().clone();
+        let tx3_hash = tx3.hash();
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 
@@ -184,13 +184,13 @@ mod tests {
         let mut pool = OrphanPool::new();
 
         let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
-        let tx1_hash = tx1.hash().clone();
+        let tx1_hash = tx1.hash();
 
         let tx2 = build_tx(vec![(H256::zero(), 1)], 1);
-        let tx2_hash = tx2.hash().clone();
+        let tx2_hash = tx2.hash();
 
         let tx3 = build_tx(vec![(tx1_hash, 0), (tx2_hash, 1)], 1);
-        let tx3_hash = tx3.hash().clone();
+        let tx3_hash = tx3.hash();
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 
@@ -219,13 +219,13 @@ mod tests {
         let mut pool = OrphanPool::new();
 
         let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
-        let tx1_hash = tx1.hash().clone();
+        let tx1_hash = tx1.hash();
 
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);
-        let tx2_hash = tx2.hash().clone();
+        let tx2_hash = tx2.hash();
 
         let tx3 = build_tx(vec![(tx2_hash, 0)], 1);
-        let tx3_hash = tx3.hash().clone();
+        let tx3_hash = tx3.hash();
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 

--- a/shared/src/tx_pool/staging.rs
+++ b/shared/src/tx_pool/staging.rs
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_add_entry() {
         let tx1 = build_tx(vec![(H256::zero(), 1), (H256::zero(), 2)], 1);
-        let tx1_hash = tx1.hash().clone();
+        let tx1_hash = tx1.hash();
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);
 
         let mut pool = StagingPool::new();
@@ -416,13 +416,13 @@ mod tests {
     fn test_add_no_roots() {
         let tx1 = build_tx(vec![(H256::zero(), 1)], 3);
         let tx2 = build_tx(vec![], 4);
-        let tx1_hash = tx1.hash().clone();
-        let tx2_hash = tx2.hash().clone();
+        let tx1_hash = tx1.hash();
+        let tx2_hash = tx2.hash();
 
         let tx3 = build_tx(vec![(tx1_hash.clone(), 0), (H256::zero(), 2)], 2);
         let tx4 = build_tx(vec![(tx1_hash.clone(), 1), (tx2_hash.clone(), 0)], 2);
 
-        let tx3_hash = tx3.hash().clone();
+        let tx3_hash = tx3.hash();
         let tx5 = build_tx(vec![(tx1_hash.clone(), 2), (tx3_hash.clone(), 0)], 2);
 
         let id1 = tx1.proposal_short_id();

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -171,7 +171,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
         let genesis_hash = genesis.header().hash();
         let ext = BlockExt {
             received_at: genesis.header().timestamp(),
-            total_difficulty: genesis.header().difficulty().clone(),
+            total_difficulty: genesis.header().difficulty().to_owned(),
             total_uncles_count: 0,
             txs_verified: Some(true),
         };
@@ -410,7 +410,7 @@ mod tests {
 
         let ext = BlockExt {
             received_at: block.header().timestamp(),
-            total_difficulty: block.header().difficulty().clone(),
+            total_difficulty: block.header().difficulty().to_owned(),
             total_uncles_count: block.uncles().len() as u64,
             txs_verified: Some(true),
         };

--- a/sync/src/net_time_checker.rs
+++ b/sync/src/net_time_checker.rs
@@ -79,7 +79,7 @@ pub struct NetTimeProtocol {
 impl Clone for NetTimeProtocol {
     fn clone(&self) -> Self {
         NetTimeProtocol {
-            checker: RwLock::new(self.checker.read().clone()),
+            checker: RwLock::new(self.checker.read().to_owned()),
         }
     }
 }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -80,7 +80,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
             {
                 let resolver = HeaderResolverWrapper::new(
                     &compact_block.header,
-                    self.relayer.shared.shared().clone(),
+                    self.relayer.shared.shared().to_owned(),
                 );
                 let header_verifier = HeaderVerifier::new(
                     CompactBlockMedianTimeView {

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -29,8 +29,8 @@ where
         let (tip_header, total_difficulty) = {
             let chain_state = synchronizer.shared.chain_state().lock();
             (
-                chain_state.tip_header().clone(),
-                chain_state.total_difficulty().clone(),
+                chain_state.tip_header().to_owned(),
+                chain_state.total_difficulty().to_owned(),
             )
         };
         BlockFetcher {
@@ -110,7 +110,7 @@ where
             .shared
             .get_ancestor(&global_best_known_header.hash(), header.number())
         {
-            if ancestor != header.inner().clone() {
+            if &ancestor != header.inner() {
                 debug!(
                     target: "sync",
                     "[block downloader] peer best_known_header is not ancestor of global_best_known_header"
@@ -158,7 +158,7 @@ where
         // of its current best_known_header. Go back enough to fix that.
         let fixed_last_common_header = try_option!(self.last_common_header(&best_known_header));
 
-        if fixed_last_common_header == best_known_header.inner().clone() {
+        if &fixed_last_common_header == best_known_header.inner() {
             debug!(target: "sync", "[block downloader] fixed_last_common_header == best_known_header");
             return None;
         }
@@ -191,15 +191,14 @@ where
                 let to_fetch_hash = to_fetch.hash();
 
                 let block_status = self.synchronizer.get_block_status(&to_fetch_hash);
-                if block_status == BlockStatus::VALID_MASK
-                    && inflight.insert(to_fetch_hash.clone().clone())
+                if block_status == BlockStatus::VALID_MASK && inflight.insert(to_fetch_hash.clone())
                 {
                     trace!(
                         target: "sync", "[Synchronizer] inflight insert {:?}------------{:x}",
                         to_fetch.number(),
                         to_fetch_hash
                     );
-                    v_fetch.push(to_fetch_hash.clone());
+                    v_fetch.push(to_fetch_hash);
                 }
             }
         }

--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -26,7 +26,7 @@ impl OrphanBlockPool {
     pub fn insert(&self, block: Block) {
         self.blocks
             .write()
-            .entry(block.header().parent_hash().clone())
+            .entry(block.header().parent_hash().to_owned())
             .or_insert_with(FnvHashSet::default)
             .insert(block);
     }

--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -88,13 +88,13 @@ mod tests {
         let consensus = Consensus::default();
         let block_number = 200;
         let mut blocks: Vec<Block> = Vec::new();
-        let mut parent = consensus.genesis_block().header().clone();
+        let mut parent = consensus.genesis_block().header().to_owned();
         let pool = OrphanBlockPool::with_capacity(200);
         for _ in 1..block_number {
             let new_block = gen_block(&parent);
             blocks.push(new_block.clone());
             pool.insert(new_block.clone());
-            parent = new_block.header().clone();
+            parent = new_block.header().to_owned();
         }
 
         let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().header().hash());

--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -40,7 +40,7 @@ impl OrphanBlockPool {
         while let Some(parent_hash) = queue.pop_front() {
             if let Entry::Occupied(entry) = guard.entry(parent_hash) {
                 let (_, orphaned) = entry.remove_entry();
-                queue.extend(orphaned.iter().map(|b| b.header().hash().clone()));
+                queue.extend(orphaned.iter().map(|b| b.header().hash()));
                 removed.extend(orphaned.into_iter());
             }
         }
@@ -74,7 +74,7 @@ mod tests {
 
     fn gen_block(parent_header: &Header) -> Block {
         let header = HeaderBuilder::default()
-            .parent_hash(parent_header.hash().clone())
+            .parent_hash(parent_header.hash())
             .timestamp(unix_time_as_millis())
             .number(parent_header.number() + 1)
             .nonce(parent_header.nonce() + 1)

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -415,28 +415,28 @@ where
         if self.prev_block_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} prev_block", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash().clone(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
             return result;
         }
 
         if self.non_contextual_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} non_contextual", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash().clone(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
             return result;
         }
 
         if self.version_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} version", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash().clone(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
             return result;
         }
 
         self.synchronizer
             .insert_header_view(&self.header, self.peer);
         self.synchronizer
-            .insert_block_status(self.header.hash().clone(), BlockStatus::VALID_MASK);
+            .insert_block_status(self.header.hash(), BlockStatus::VALID_MASK);
         result
     }
 }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -205,8 +205,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
             };
 
             self.peers.new_header_received(peer, &header_view);
-            self.shared
-                .insert_header_view(header.hash().clone(), header_view);
+            self.shared.insert_header_view(header.hash(), header_view);
         }
     }
 
@@ -230,7 +229,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
     fn accept_block(&self, peer: PeerIndex, block: &Arc<Block>) -> Result<(), FailureError> {
         self.chain.process_block(Arc::clone(&block))?;
         self.shared.remove_header_view(&block.header().hash());
-        self.mark_block_stored(block.header().hash().clone());
+        self.mark_block_stored(block.header().hash());
         self.peers.set_last_common_header(peer, &block.header());
         Ok(())
     }
@@ -638,7 +637,7 @@ mod tests {
         let number = parent_header.number() + 1;
         let cellbase = create_cellbase(number);
         let header_builder = HeaderBuilder::default()
-            .parent_hash(parent_header.hash().clone())
+            .parent_hash(parent_header.hash())
             .timestamp(now)
             .number(number)
             .difficulty(difficulty)

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -345,8 +345,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
                     let (tip_header, local_total_difficulty) = {
                         let chain_state = self.shared.chain_state().lock();
                         (
-                            chain_state.tip_header().clone(),
-                            chain_state.total_difficulty().clone(),
+                            chain_state.tip_header().to_owned(),
+                            chain_state.total_difficulty().to_owned(),
                         )
                     };
                     if best_known_header.map(HeaderView::total_difficulty)
@@ -416,8 +416,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
             let (header, total_difficulty) = {
                 let chain_state = self.shared.chain_state().lock();
                 (
-                    chain_state.tip_header().clone(),
-                    chain_state.total_difficulty().clone(),
+                    chain_state.tip_header().to_owned(),
+                    chain_state.total_difficulty().to_owned(),
                 )
             };
             let best_known = self.shared.best_known_header();
@@ -747,7 +747,7 @@ mod tests {
         let block_number = 200;
 
         let mut blocks: Vec<Block> = Vec::new();
-        let mut parent = consensus.genesis_block().header().clone();
+        let mut parent = consensus.genesis_block().header().to_owned();
         for i in 1..block_number {
             let difficulty = shared1.calculate_difficulty(&parent).unwrap();
             let new_block = gen_block(&parent, difficulty, i);
@@ -759,10 +759,10 @@ mod tests {
             chain_controller2
                 .process_block(Arc::new(new_block.clone()))
                 .expect("process block ok");
-            parent = new_block.header().clone();
+            parent = new_block.header().to_owned();
         }
 
-        parent = blocks[150].header().clone();
+        parent = blocks[150].header().to_owned();
         let fork = parent.number();
         for i in 1..=block_number {
             let difficulty = shared2.calculate_difficulty(&parent).unwrap();
@@ -771,7 +771,7 @@ mod tests {
             chain_controller2
                 .process_block(Arc::new(new_block.clone()))
                 .expect("process block ok");
-            parent = new_block.header().clone();
+            parent = new_block.header().to_owned();
         }
 
         let synchronizer1 = gen_synchronizer(chain_controller1.clone(), shared1.clone());
@@ -822,7 +822,7 @@ mod tests {
         assert!(noop.is_none());
         assert_eq!(
             tip.unwrap(),
-            shared.chain_state().lock().tip_header().clone()
+            shared.chain_state().lock().tip_header().to_owned()
         );
         assert_eq!(
             header.unwrap(),
@@ -851,7 +851,7 @@ mod tests {
             chain_controller1
                 .process_block(Arc::new(new_block.clone()))
                 .expect("process block ok");
-            parent = new_block.header().clone();
+            parent = new_block.header().to_owned();
             blocks.push(new_block);
         }
         let synchronizer = gen_synchronizer(chain_controller2.clone(), shared2.clone());
@@ -881,7 +881,7 @@ mod tests {
             chain_controller
                 .process_block(Arc::new(new_block.clone()))
                 .expect("process block ok");
-            parent = new_block.header().clone();
+            parent = new_block.header().to_owned();
         }
 
         let synchronizer = gen_synchronizer(chain_controller.clone(), shared.clone());
@@ -1160,8 +1160,8 @@ mod tests {
             // Either way, set a new timeout based on current tip.
             let (tip, total_difficulty) = {
                 let chain_state = shared.chain_state().lock();
-                let header = chain_state.tip_header().clone();
-                let total_difficulty = chain_state.total_difficulty().clone();
+                let header = chain_state.tip_header().to_owned();
+                let total_difficulty = chain_state.total_difficulty().to_owned();
                 (header, total_difficulty)
             };
             assert_eq!(

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -690,7 +690,7 @@ mod tests {
             expect.push(shared.block_hash(*i).unwrap());
         }
         //genesis_hash must be the last one
-        expect.push(shared.genesis_hash().clone());
+        expect.push(shared.genesis_hash().to_owned());
 
         assert_eq!(expect, locator);
     }

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -52,7 +52,7 @@ fn relay_compact_block_with_one_tx() {
             // building tx and broadcast it
             let tx = TransactionBuilder::default()
                 .input(CellInput::new(
-                    OutPoint::new(last_cellbase.hash().clone(), 0),
+                    OutPoint::new(last_cellbase.hash(), 0),
                     0,
                     vec![],
                 ))
@@ -86,7 +86,7 @@ fn relay_compact_block_with_one_tx() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash().clone())
+                    .parent_hash(last_block.header().hash())
                     .number(number)
                     .timestamp(timestamp)
                     .difficulty(difficulty);
@@ -121,7 +121,7 @@ fn relay_compact_block_with_one_tx() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash().clone())
+                    .parent_hash(last_block.header().hash())
                     .number(number)
                     .timestamp(timestamp)
                     .difficulty(difficulty);
@@ -199,7 +199,7 @@ fn relay_compact_block_with_missing_indexs() {
                 .map(|i| {
                     TransactionBuilder::default()
                         .input(CellInput::new(
-                            OutPoint::new(last_cellbase.hash().clone(), u32::from(i)),
+                            OutPoint::new(last_cellbase.hash(), u32::from(i)),
                             0,
                             vec![],
                         ))
@@ -238,7 +238,7 @@ fn relay_compact_block_with_missing_indexs() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash().clone())
+                    .parent_hash(last_block.header().hash())
                     .number(number)
                     .timestamp(timestamp)
                     .difficulty(difficulty);
@@ -273,7 +273,7 @@ fn relay_compact_block_with_missing_indexs() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash().clone())
+                    .parent_hash(last_block.header().hash())
                     .number(number)
                     .timestamp(timestamp)
                     .difficulty(difficulty);
@@ -365,7 +365,7 @@ fn setup_node(
             .build();
 
         let header_builder = HeaderBuilder::default()
-            .parent_hash(block.header().hash().clone())
+            .parent_hash(block.header().hash())
             .number(number)
             .timestamp(timestamp)
             .difficulty(difficulty);

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -95,7 +95,7 @@ fn setup_node(
             .build();
 
         let header_builder = HeaderBuilder::default()
-            .parent_hash(block.header().hash().clone())
+            .parent_hash(block.header().hash())
             .number(number)
             .timestamp(timestamp)
             .difficulty(difficulty);

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -348,8 +348,8 @@ impl<CS: ChainStore> SyncSharedState<CS> {
                 .block_ext(&chain_state.tip_hash())
                 .expect("tip block_ext must exist");
             (
-                chain_state.total_difficulty().clone(),
-                chain_state.tip_header().clone(),
+                chain_state.total_difficulty().to_owned(),
+                chain_state.tip_header().to_owned(),
                 block_ext.total_uncles_count,
             )
         };
@@ -385,7 +385,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         self.shared.block(hash)
     }
     pub fn tip_header(&self) -> Header {
-        self.shared.chain_state().lock().tip_header().clone()
+        self.shared.chain_state().lock().tip_header().to_owned()
     }
     pub fn consensus(&self) -> &Consensus {
         self.shared.consensus()
@@ -397,7 +397,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     }
 
     pub fn best_known_header(&self) -> HeaderView {
-        self.best_known_header.read().clone()
+        self.best_known_header.read().to_owned()
     }
     pub fn set_best_known_header(&self, header: HeaderView) {
         *self.best_known_header.write() = header;

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -461,7 +461,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
             let header = self
                 .get_ancestor(&base, index)
                 .expect("index calculated in get_locator");
-            locator.push(header.hash().clone());
+            locator.push(header.hash());
 
             if locator.len() >= 10 {
                 step <<= 1;

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -470,7 +470,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
             if index < step {
                 // always include genesis hash
                 if index != 0 {
-                    locator.push(self.shared.genesis_hash().clone());
+                    locator.push(self.shared.genesis_hash().to_owned());
                 }
                 break;
             }
@@ -534,7 +534,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
             .get(index - 1)
             .and_then(|hash| self.shared.block_header(hash))
         {
-            let mut block_hash = header.parent_hash().clone();
+            let mut block_hash = header.parent_hash().to_owned();
             loop {
                 let block_header = match self.shared.block_header(&block_hash) {
                     None => break latest_common,
@@ -545,7 +545,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
                     return Some(block_number);
                 }
 
-                block_hash = block_header.parent_hash().clone();
+                block_hash = block_header.parent_hash().to_owned();
             }
         } else {
             latest_common

--- a/test/src/specs/tx_pool/cellbase_immature_tx.rs
+++ b/test/src/specs/tx_pool/cellbase_immature_tx.rs
@@ -15,7 +15,7 @@ impl Spec for CellbaseImmatureTx {
 
         info!("Use generated block's cellbase as tx input");
         let tip_block = node.get_tip_block();
-        let tx = node.new_transaction(tip_block.transactions()[0].hash().clone());
+        let tx = node.new_transaction(tip_block.transactions()[0].hash());
         let transaction_hash = tx.hash();
         node.rpc_client()
             .enqueue_test_transaction((&tx).into())

--- a/test/src/specs/tx_pool/depend_tx_in_same_block.rs
+++ b/test/src/specs/tx_pool/depend_tx_in_same_block.rs
@@ -1,4 +1,5 @@
 use crate::{sleep, Net, Spec};
+use ckb_core::transaction::Transaction;
 use log::info;
 
 pub struct DepentTxInSameBlock;
@@ -12,7 +13,7 @@ impl Spec for DepentTxInSameBlock {
         node0.generate_block();
         let tx_hash_0 = node0.generate_transaction();
         let tx = node0.new_transaction(tx_hash_0.clone());
-        let tx_hash_1 = tx.hash().clone();
+        let tx_hash_1 = tx.hash();
         node0.rpc_client().send_transaction((&tx).into());
 
         // mine 2 txs
@@ -30,7 +31,7 @@ impl Spec for DepentTxInSameBlock {
         let commit_txs_hash: Vec<_> = tip_block
             .transactions()
             .iter()
-            .map(|tx| tx.hash().clone())
+            .map(Transaction::hash)
             .collect();
 
         info!("2 txs should included in commit_transactions");

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -61,7 +61,7 @@ impl Setup {
         // Initialization of logger must do before sentry, since `logger::init()` and
         // `sentry_config::init()` both registers custom panic hooks, but `logger::init()`
         // replaces all hooks previously registered.
-        let logger_guard = logger::init(self.config.logger().clone())?;
+        let logger_guard = logger::init(self.config.logger().to_owned())?;
 
         let sentry_guard = if self.is_sentry_enabled {
             let sentry_config = self.config.sentry();

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -353,14 +353,14 @@ impl<'a> From<&'a CoreHeader> for Header {
     fn from(core: &CoreHeader) -> Header {
         Header {
             version: core.version(),
-            parent_hash: core.parent_hash().clone(),
+            parent_hash: core.parent_hash().to_owned(),
             timestamp: core.timestamp().to_string(),
             number: core.number().to_string(),
             transactions_root: core.transactions_root().clone(),
             proposals_root: core.proposals_root().clone(),
             witnesses_root: core.witnesses_root().clone(),
             difficulty: core.difficulty().clone(),
-            uncles_hash: core.uncles_hash().clone(),
+            uncles_hash: core.uncles_hash().to_owned(),
             uncles_count: core.uncles_count(),
             seal: core.seal().clone().into(),
             hash: core.hash(),

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -363,7 +363,7 @@ impl<'a> From<&'a CoreHeader> for Header {
             uncles_hash: core.uncles_hash().clone(),
             uncles_count: core.uncles_count(),
             seal: core.seal().clone().into(),
-            hash: core.hash().clone(),
+            hash: core.hash(),
         }
     }
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -356,13 +356,13 @@ impl<'a> From<&'a CoreHeader> for Header {
             parent_hash: core.parent_hash().to_owned(),
             timestamp: core.timestamp().to_string(),
             number: core.number().to_string(),
-            transactions_root: core.transactions_root().clone(),
-            proposals_root: core.proposals_root().clone(),
-            witnesses_root: core.witnesses_root().clone(),
-            difficulty: core.difficulty().clone(),
+            transactions_root: core.transactions_root().to_owned(),
+            proposals_root: core.proposals_root().to_owned(),
+            witnesses_root: core.witnesses_root().to_owned(),
+            difficulty: core.difficulty().to_owned(),
             uncles_hash: core.uncles_hash().to_owned(),
             uncles_count: core.uncles_count(),
-            seal: core.seal().clone().into(),
+            seal: core.seal().to_owned().into(),
             hash: core.hash(),
         }
     }

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -307,7 +307,7 @@ impl<CP: ChainProvider + Clone> UnclesVerifier<CP> {
 
             let uncle_header = uncle.header.clone();
 
-            let uncle_hash = uncle_header.hash().clone();
+            let uncle_hash = uncle_header.hash();
             if included.contains(&uncle_hash) {
                 return Err(Error::Uncles(UnclesError::Duplicate(uncle_hash)));
             }

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -218,7 +218,7 @@ impl<CP: ChainProvider + Clone> UnclesVerifier<CP> {
         let actual_uncles_hash = block.cal_uncles_hash();
         if &actual_uncles_hash != block.header().uncles_hash() {
             return Err(Error::Uncles(UnclesError::InvalidHash {
-                expected: block.header().uncles_hash().clone(),
+                expected: block.header().uncles_hash().to_owned(),
                 actual: actual_uncles_hash,
             }));
         }
@@ -273,11 +273,11 @@ impl<CP: ChainProvider + Clone> UnclesVerifier<CP> {
         let mut excluded = FnvHashSet::default();
         let mut included = FnvHashSet::default();
         excluded.insert(block.header().hash());
-        let mut block_hash = block.header().parent_hash().clone();
+        let mut block_hash = block.header().parent_hash().to_owned();
         excluded.insert(block_hash.clone());
         for _ in 0..max_uncles_age {
             if let Some(header) = self.provider.block_header(&block_hash) {
-                let parent_hash = header.parent_hash().clone();
+                let parent_hash = header.parent_hash().to_owned();
                 excluded.insert(parent_hash.clone());
                 if let Some(uncles) = self.provider.uncles(&block_hash) {
                     uncles.iter().for_each(|uncle| {
@@ -450,7 +450,7 @@ impl<CP: ChainProvider + Clone> CommitVerifier<CP> {
                     .for_each(|uncle| proposal_txs_ids.extend(uncle.proposals()));
             }
 
-            block_hash = header.parent_hash().clone();
+            block_hash = header.parent_hash().to_owned();
             proposal_end -= 1;
         }
 

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -42,7 +42,7 @@ impl<T: HeaderResolver, M: BlockMedianTimeContext> Verifier for HeaderVerifier<T
         PowVerifier::new(header, &self.pow).verify()?;
         let parent = target
             .parent()
-            .ok_or_else(|| Error::UnknownParent(header.parent_hash().clone()))?;
+            .ok_or_else(|| Error::UnknownParent(header.parent_hash().to_owned()))?;
         NumberVerifier::new(parent, header).verify()?;
         TimestampVerifier::new(&self.block_median_time_context, header).verify()?;
         DifficultyVerifier::verify(target)?;
@@ -94,7 +94,7 @@ impl<'a, M: BlockMedianTimeContext> TimestampVerifier<'a, M> {
             .and_then(|n| self.block_median_time_context.block_median_time(n))
         {
             Some(time) => time,
-            None => return Err(Error::UnknownParent(self.header.parent_hash().clone())),
+            None => return Err(Error::UnknownParent(self.header.parent_hash().to_owned())),
         };
         if self.header.timestamp() <= min {
             return Err(Error::Timestamp(TimestampError::BlockTimeTooOld {

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -138,7 +138,7 @@ fn test_proposal() {
     chain_controller
         .process_block(Arc::new(block.clone()))
         .unwrap();
-    parent = block.header().clone();
+    parent = block.header().to_owned();
 
     //commit in proposal gap is invalid
     for _ in (proposed + 1)..(proposed + proposal_window.end()) {
@@ -154,7 +154,7 @@ fn test_proposal() {
         chain_controller
             .process_block(Arc::new(new_block.clone()))
             .unwrap();
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     //commit in proposal window
@@ -168,7 +168,7 @@ fn test_proposal() {
         chain_controller
             .process_block(Arc::new(new_block.clone()))
             .unwrap();
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     //proposal expired
@@ -200,7 +200,7 @@ fn test_uncle_proposal() {
     chain_controller
         .process_block(Arc::new(block.clone()))
         .unwrap();
-    parent = block.header().clone();
+    parent = block.header().to_owned();
 
     //commit in proposal gap is invalid
     for _ in (proposed + 1)..(proposed + proposal_window.end()) {
@@ -216,7 +216,7 @@ fn test_uncle_proposal() {
         chain_controller
             .process_block(Arc::new(new_block.clone()))
             .unwrap();
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     //commit in proposal window
@@ -230,7 +230,7 @@ fn test_uncle_proposal() {
         chain_controller
             .process_block(Arc::new(new_block.clone()))
             .unwrap();
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     //proposal expired

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -31,7 +31,7 @@ fn gen_block(
     let difficulty = parent_header.difficulty() + U256::from(1u64);
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash().clone())
+        .parent_hash(parent_header.hash())
         .timestamp(now)
         .number(number)
         .difficulty(difficulty)
@@ -124,7 +124,7 @@ fn test_proposal() {
     for _ in 0..20 {
         let tx = create_transaction(&prev_tx_hash);
         txs20.push(tx.clone());
-        prev_tx_hash = tx.hash().clone();
+        prev_tx_hash = tx.hash();
     }
 
     let proposal_window = shared.consensus().tx_proposal_window();
@@ -185,7 +185,7 @@ fn test_uncle_proposal() {
     for _ in 0..20 {
         let tx = create_transaction(&prev_tx_hash);
         txs20.push(tx.clone());
-        prev_tx_hash = tx.hash().clone();
+        prev_tx_hash = tx.hash();
     }
 
     let proposal_window = shared.consensus().tx_proposal_window();

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -94,7 +94,7 @@ fn test_uncle_verifier() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain1.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
@@ -107,7 +107,7 @@ fn test_uncle_verifier() {
             .process_block(Arc::new(new_block.clone()))
             .expect("process block ok");
         chain2.push(new_block.clone());
-        parent = new_block.header().clone();
+        parent = new_block.header().to_owned();
     }
 
     let verifier = UnclesVerifier::new(shared.clone());
@@ -150,7 +150,7 @@ fn test_uncle_verifier() {
             .block(chain1.last().cloned().unwrap())
             .header(
                 HeaderBuilder::default()
-                    .header(chain1.last().cloned().unwrap().header().clone())
+                    .header(chain1.last().cloned().unwrap().header().to_owned())
                     .uncles_count(0)
                     .uncles_hash(uncles_hash.clone())
                     .build(),
@@ -172,7 +172,7 @@ fn test_uncle_verifier() {
             .block(chain2.last().cloned().unwrap())
             .uncle(chain1.last().cloned().unwrap().into())
             .with_header_builder(
-                HeaderBuilder::default().header(chain2.last().unwrap().header().clone()),
+                HeaderBuilder::default().header(chain2.last().unwrap().header().to_owned()),
             );
         assert_eq!(
             verifier.verify(&block),
@@ -189,13 +189,13 @@ fn test_uncle_verifier() {
         let uncle = BlockBuilder::default()
             .block(chain1.get(uncle_number - 1).cloned().unwrap())
             .with_header_builder(
-                HeaderBuilder::default().header(chain1[uncle_number - 1].header().clone()),
+                HeaderBuilder::default().header(chain1[uncle_number - 1].header().to_owned()),
             );
         let block = BlockBuilder::default()
             .block(chain2.get(block_number - 1).cloned().unwrap())
             .uncle(uncle.into())
             .with_header_builder(
-                HeaderBuilder::default().header(chain2[block_number - 1].header().clone()),
+                HeaderBuilder::default().header(chain2[block_number - 1].header().to_owned()),
             );
         assert_eq!(
             verifier.verify(&block),
@@ -214,7 +214,7 @@ fn test_uncle_verifier() {
             .uncle(chain2[6].clone().into())
             .with_header_builder(
                 HeaderBuilder::default()
-                    .header(chain1[8].header().clone())
+                    .header(chain1[8].header().to_owned())
                     .difficulty(U256::from(2u64)),
             );
         assert_eq!(
@@ -231,7 +231,7 @@ fn test_uncle_verifier() {
             .block(chain1.get(block_number).cloned().unwrap())          // block.number 10 epoch 1
             .uncle(chain1.get(uncle_number).cloned().unwrap().into())   // block.number 7 epoch 0
             .with_header_builder(HeaderBuilder::default().header(
-                chain1[7].header().clone()
+                chain1[7].header().to_owned()
             ));
         assert_eq!(
             verifier.verify(&block),
@@ -249,7 +249,7 @@ fn test_uncle_verifier() {
             .block(chain1.get(block_number).cloned().unwrap())          // epoch 1
             .uncle(chain2.get(uncle_number).cloned().unwrap().into())   // epoch 0
             .with_header_builder(HeaderBuilder::default().header(
-                chain1[block_number].header().clone()
+                chain1[block_number].header().to_owned()
             ));
         assert_eq!(
             verifier.verify(&block),
@@ -266,7 +266,7 @@ fn test_uncle_verifier() {
         let block = BlockBuilder::default()
             .block(chain1.get(8).cloned().unwrap())
             .uncle(uncle.into())
-            .with_header_builder(HeaderBuilder::default().header(chain1[8].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain1[8].header().to_owned()));
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::ProposalTransactionsRoot))
@@ -278,11 +278,11 @@ fn test_uncle_verifier() {
         let uncle = BlockBuilder::default()
             .block(chain2.get(6).cloned().unwrap())
             .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-            .with_header_builder(HeaderBuilder::default().header(chain2[6].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain2[6].header().to_owned()));
         let block = BlockBuilder::default()
             .block(chain1.get(8).cloned().unwrap())
             .uncle(uncle.into())
-            .with_header_builder(HeaderBuilder::default().header(chain1[8].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain1[8].header().to_owned()));
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::ProposalTransactionDuplicate))
@@ -293,15 +293,15 @@ fn test_uncle_verifier() {
     {
         let uncle1 = BlockBuilder::default()
             .block(chain1.get(10).cloned().unwrap())
-            .with_header_builder(HeaderBuilder::default().header(chain1[10].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain1[10].header().to_owned()));
         let uncle2 = BlockBuilder::default()
             .block(chain1.get(10).cloned().unwrap())
-            .with_header_builder(HeaderBuilder::default().header(chain1[10].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain1[10].header().to_owned()));
         let block = BlockBuilder::default()
             .block(chain2.get(12).cloned().unwrap())
             .uncle(uncle1.into())
             .uncle(uncle2.into())
-            .with_header_builder(HeaderBuilder::default().header(chain2[12].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain2[12].header().to_owned()));
         // uncle duplicate
         assert_eq!(
             verifier.verify(&block),
@@ -318,13 +318,15 @@ fn test_uncle_verifier() {
         for _ in 0..=max_uncles_num {
             let uncle = BlockBuilder::default()
                 .block(chain1.get(10).cloned().unwrap())
-                .with_header_builder(HeaderBuilder::default().header(chain1[10].header().clone()));
+                .with_header_builder(
+                    HeaderBuilder::default().header(chain1[10].header().to_owned()),
+                );
             uncles.push(uncle.into());
         }
         let block = BlockBuilder::default()
             .block(chain2.get(12).cloned().unwrap())
             .uncles(uncles)
-            .with_header_builder(HeaderBuilder::default().header(chain2[12].header().clone()));
+            .with_header_builder(HeaderBuilder::default().header(chain2[12].header().to_owned()));
         // uncle overcount
         assert_eq!(
             verifier.verify(&block),
@@ -337,19 +339,19 @@ fn test_uncle_verifier() {
 
     let uncle = BlockBuilder::default()
         .block(chain2.get(6).cloned().unwrap())
-        .with_header_builder(HeaderBuilder::default().header(chain2[6].header().clone()));
+        .with_header_builder(HeaderBuilder::default().header(chain2[6].header().to_owned()));
     let block = BlockBuilder::default()
         .block(chain1.get(8).cloned().unwrap())
         .uncle(uncle.into())
-        .with_header_builder(HeaderBuilder::default().header(chain1[8].header().clone()));
+        .with_header_builder(HeaderBuilder::default().header(chain1[8].header().to_owned()));
     assert_eq!(verifier.verify(&block), Ok(()));
 
     let uncle = BlockBuilder::default()
         .block(chain1[10].clone())
-        .with_header_builder(HeaderBuilder::default().header(chain1[10].header().clone()));
+        .with_header_builder(HeaderBuilder::default().header(chain1[10].header().to_owned()));
     let block = BlockBuilder::default()
         .block(chain2.get(12).cloned().unwrap())
         .uncle(uncle.into())
-        .with_header_builder(HeaderBuilder::default().header(chain2[12].header().clone()));
+        .with_header_builder(HeaderBuilder::default().header(chain2[12].header().to_owned()));
     assert_eq!(verifier.verify(&block), Ok(()));
 }

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -26,7 +26,7 @@ fn gen_block(parent_header: &Header, nonce: u64, difficulty: U256) -> Block {
     let number = parent_header.number() + 1;
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash().clone())
+        .parent_hash(parent_header.hash())
         .timestamp(now)
         .number(number)
         .difficulty(difficulty)
@@ -306,7 +306,7 @@ fn test_uncle_verifier() {
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::Duplicate(
-                block.uncles()[1].header().hash().clone()
+                block.uncles()[1].header().hash()
             )))
         );
     }


### PR DESCRIPTION
When I read the code, I find a lot of useless `clone()`, so I did this PR.

- perf: remove lots of useless clone

  Just run `sed -i "s/[.]hash().clone()/.hash()/g" $(grep -rl "[.]hash().clone()")`

- style: use `to_owned()` to instead of `clone()`

  Just run `sed -i "s/hash().clone()/hash().to_owned()/g" $(grep -rl 'hash().clone()' [a-zA-Z]*)`.

  **Structs with ownership can not call `to_owned()`, so I can classify useful `clone()` and useless `clone()` clearly.**

- perf: find useless `clone()` via replace them to `to_owned()`

  Just run `sed -i "s/().clone()/().to_owned()/g" $(grep -rl "()[.]clone()")`. Then I compile the project, the compiler throw 6 errors, so I remove 6 useless `clone()`.

- I didn't check the remain `clone()` because I didn't find other general rules.

  _(I am not stupid ~~)_

### Suggest

If a variable is able to `to_owned()`, use `to_owned()` instead of `clone()`.
So we can find useless `clone()` more easily.

For example (double `clone()`):

https://github.com/nervosnetwork/ckb/blob/63aebb20616fb4c241ee06c5a523ad96d4e5d29b/sync/src/synchronizer/block_fetcher.rs#L194-L196