### PR TITLE
perf: Improve relay tx performance

### DIFF
--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -38,15 +38,14 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
         };
 
         match result {
-            Ok(_) => {
-                let tx_hash = tx.hash();
+            Ok(cycles) => {
                 let fbb = &mut FlatBufferBuilder::new();
-                let message = RelayMessage::build_transaction_hash(fbb, &tx_hash);
+                let message = RelayMessage::build_transaction(fbb, &tx, cycles);
                 fbb.finish(message, None);
                 let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
-                Ok(tx_hash)
+                Ok(tx.hash())
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
         }

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -31,6 +31,11 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
     }
 
     pub fn execute(self) -> Result<(), FailureError> {
+        if self.relayer.shared.is_initial_block_download() {
+            debug!(target: "relay", "Do not ask for transaction when initial block download");
+            return Ok(());
+        }
+
         let tx_hash: H256 = (*self.message).try_into()?;
         let short_id = ProposalShortId::from_tx_hash(&tx_hash);
         if self.relayer.state.already_known(&tx_hash) {


### PR DESCRIPTION
### Improvements
- Relay transaction body when send transaction from RPC
- Insert into known list when tx in pool
- Do not handle relay tx hash when initial block download