### PR TITLE
chore: revert 91b8e06f3409875ff63e69ca7e6cc749a10e3d00

### DIFF
--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -250,6 +250,12 @@ pub mod test {
         let chain_spec = dev.unwrap();
         let tx = chain_spec.build_system_cell_transaction().unwrap();
 
+        // Tx and Output hash will be used in some test cases directly, assert here for convenience
+        assert_eq!(
+            format!("{:x}", tx.hash()),
+            "013d8bd8c65e22655cc907c146c8ca8eaa2cfef46bf5b5f08dc145d72bf65a60"
+        );
+
         let reference = tx.outputs()[0].data_hash();
         assert_eq!(
             format!("{:x}", reference),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -257,13 +257,23 @@ impl Node {
 
     pub fn new_transaction(&self, hash: H256) -> Transaction {
         // OutPoint and Script reference hash values are from spec#always_success_type_hash test
-        let script = Script::always_success();
+        let out_point = OutPoint::new(
+            H256::from_hex_str("013d8bd8c65e22655cc907c146c8ca8eaa2cfef46bf5b5f08dc145d72bf65a60")
+                .unwrap(),
+            0,
+        );
+        let script = Script::new(
+            vec![],
+            H256::from_hex_str("28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5")
+                .unwrap(),
+        );
 
         TransactionBuilder::default()
+            .dep(out_point)
             .output(CellOutput::new(
                 capacity_bytes!(50_000),
                 Bytes::new(),
-                script.clone(),
+                script,
                 None,
             ))
             .input(CellInput::new(OutPoint::new(hash, 0), 0, vec![]))


### PR DESCRIPTION
Revert https://github.com/nervosnetwork/ckb/commit/91b8e06f3409875ff63e69ca7e6cc749a10e3d00 , we should use script reference hash in the integeration test, which will cover all VM related code.