### PR TITLE
chore: add an integration test for RBF (Replace-By-Fees)

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
             "malformed_message" => Box::new(MalformedMessage),
             "depent_tx_in_same_block" => Box::new(DepentTxInSameBlock),
             "cellbase_immature_tx" => Box::new(CellbaseImmatureTx),
+            "different_txs_with_same_input" => Box::new(DifferentTxsWithSameInput),
             _ => panic!("invalid spec"),
         };
         let net = spec.setup_net(&binary, start_port);
@@ -47,6 +48,7 @@ fn main() {
             Box::new(MalformedMessage),
             Box::new(DepentTxInSameBlock),
             Box::new(CellbaseImmatureTx),
+            Box::new(DifferentTxsWithSameInput),
         ];
 
         specs.iter().for_each(|spec| {

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -14,7 +14,7 @@ pub use p2p::{Disconnect, Discovery};
 pub use pool::{PoolReconcile, PoolTrace};
 pub use protocols::MalformedMessage;
 pub use transaction_relay::TransactionRelayBasic;
-pub use tx_pool::{CellbaseImmatureTx, DepentTxInSameBlock};
+pub use tx_pool::{CellbaseImmatureTx, DepentTxInSameBlock, DifferentTxsWithSameInput};
 
 use crate::Net;
 use ckb_core::BlockNumber;

--- a/test/src/specs/transaction.rs
+++ b/test/src/specs/transaction.rs
@@ -1,3 +1,0 @@
-mod depend_tx_in_same_block;
-
-pub use depend_tx_in_same_block::DepentTxInSameBlock;

--- a/test/src/specs/tx_pool/depend_tx_in_same_block.rs
+++ b/test/src/specs/tx_pool/depend_tx_in_same_block.rs
@@ -1,5 +1,5 @@
-use crate::{sleep, Net, Spec};
-use ckb_core::transaction::Transaction;
+use crate::{Net, Spec};
+use ckb_core::transaction::{ProposalShortId, Transaction};
 use log::info;
 
 pub struct DepentTxInSameBlock;
@@ -14,19 +14,27 @@ impl Spec for DepentTxInSameBlock {
         let tx_hash_0 = node0.generate_transaction();
         let tx = node0.new_transaction(tx_hash_0.clone());
         let tx_hash_1 = tx.hash();
-        node0.rpc_client().send_transaction((&tx).into());
+        node0
+            .rpc_client()
+            .send_transaction((&tx).into())
+            .call()
+            .unwrap();
 
-        // mine 2 txs
-        info!("Mine 2 tx");
+        info!("Generated 2 tx should be included in the next block's proposals");
         node0.generate_block();
-        sleep(1);
-        node0.generate_block();
-        sleep(1);
-        // mine one block, 2 txs should be commit
-        info!("Waiting for mine");
-        node0.generate_block();
-        sleep(1);
+        let proposal_block = node0.get_tip_block();
+        let proposals_hash: Vec<_> = proposal_block
+            .proposals()
+            .iter()
+            .map(Clone::clone)
+            .collect();
+        assert!(proposals_hash.contains(&ProposalShortId::from_tx_hash(&tx_hash_0)));
+        assert!(proposals_hash.contains(&ProposalShortId::from_tx_hash(&tx_hash_1)));
 
+        node0.generate_block();
+
+        info!("Generated 2 tx should be included in the next + 2 block");
+        node0.generate_block();
         let tip_block = node0.get_tip_block();
         let commit_txs_hash: Vec<_> = tip_block
             .transactions()
@@ -34,7 +42,6 @@ impl Spec for DepentTxInSameBlock {
             .map(Transaction::hash)
             .collect();
 
-        info!("2 txs should included in commit_transactions");
         assert!(commit_txs_hash.contains(&tx_hash_0));
         assert!(commit_txs_hash.contains(&tx_hash_1));
     }

--- a/test/src/specs/tx_pool/different_txs_with_same_input.rs
+++ b/test/src/specs/tx_pool/different_txs_with_same_input.rs
@@ -1,0 +1,57 @@
+use crate::{Net, Spec};
+use ckb_core::transaction::{Transaction, TransactionBuilder};
+use ckb_core::{capacity_bytes, Capacity};
+use log::info;
+
+pub struct DifferentTxsWithSameInput;
+
+impl Spec for DifferentTxsWithSameInput {
+    fn run(&self, net: Net) {
+        info!("Running DifferentTxsWithSameInput");
+        let node0 = &net.nodes[0];
+
+        node0.generate_block();
+        let tx_hash_0 = node0.generate_transaction();
+        info!("Generate 2 txs with same input");
+        let tx1 = node0.new_transaction(tx_hash_0.clone());
+        let tx2_temp = node0.new_transaction(tx_hash_0.clone());
+        // Set tx2 fee to a higher value
+        let mut output = tx2_temp.outputs()[0].clone();
+        output.capacity = capacity_bytes!(40_000);
+        let tx2 = TransactionBuilder::default()
+            .transaction(tx2_temp)
+            .outputs_clear()
+            .output(output)
+            .build();
+        node0
+            .rpc_client()
+            .send_transaction((&tx1).into())
+            .call()
+            .unwrap();
+        node0
+            .rpc_client()
+            .send_transaction((&tx1).into())
+            .call()
+            .unwrap();
+
+        node0.generate_block();
+        node0.generate_block();
+
+        info!("RBF (Replace-By-Fees) is not implemented");
+        info!("Tx1 should be included in the next + 2 block");
+        node0.generate_block();
+        let tip_block = node0.get_tip_block();
+        let commit_txs_hash: Vec<_> = tip_block
+            .transactions()
+            .iter()
+            .map(Transaction::hash)
+            .collect();
+
+        assert!(commit_txs_hash.contains(&tx1.hash()));
+        assert!(!commit_txs_hash.contains(&tx2.hash()));
+    }
+
+    fn num_nodes(&self) -> usize {
+        1
+    }
+}

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -1,5 +1,7 @@
 mod cellbase_immature_tx;
 mod depend_tx_in_same_block;
+mod different_txs_with_same_input;
 
 pub use cellbase_immature_tx::CellbaseImmatureTx;
 pub use depend_tx_in_same_block::DepentTxInSameBlock;
+pub use different_txs_with_same_input::DifferentTxsWithSameInput;


### PR DESCRIPTION
This integration test is needed to check `BlockTemplate` generation, although RBF was not implemented yet.