### PR TITLE
feat: verify compact block

### DIFF
--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -38,15 +38,15 @@ impl<'a, CS: ChainStore> BlockTransactionsProcess<'a, CS> {
             .lock()
             .remove(&block_hash)
         {
-            let transactions: Result<Vec<Transaction>, FailureError> =
+            let transactions: Vec<Transaction> =
                 FlatbuffersVectorIterator::new(cast!(self.message.transactions())?)
                     .map(TryInto::try_into)
-                    .collect();
+                    .collect::<Result<_, FailureError>>()?;
 
             let ret = {
                 let chain_state = self.relayer.shared.chain_state().lock();
                 self.relayer
-                    .reconstruct_block(&chain_state, &compact_block, transactions?)
+                    .reconstruct_block(&chain_state, &compact_block, transactions)
             };
 
             if let Ok(block) = ret {

--- a/sync/src/relayer/compact_block.rs
+++ b/sync/src/relayer/compact_block.rs
@@ -7,7 +7,7 @@ use std::convert::{TryFrom, TryInto};
 
 pub type ShortTransactionID = [u8; 6];
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct CompactBlock {
     pub header: Header,
     pub uncles: Vec<UncleBlock>,

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -95,7 +95,10 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                     Arc::clone(&self.relayer.shared.consensus().pow_engine()),
                 );
                 let compact_block_verifier = CompactBlockVerifier::new();
-                header_verifier.verify(&resolver)?;
+                if let Err(err) = header_verifier.verify(&resolver) {
+                    debug!(target: "relay", "unexpected header verify failed: {}", err);
+                    return Ok(());
+                }
                 compact_block_verifier.verify(&compact_block)?;
             }
 

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -1,4 +1,5 @@
-use super::compact_block::CompactBlock;
+use crate::relayer::compact_block::CompactBlock;
+use crate::relayer::compact_block_verifier::CompactBlockVerifier;
 use crate::relayer::Relayer;
 use ckb_core::{header::Header, BlockNumber};
 use ckb_network::{CKBProtocolContext, PeerIndex};
@@ -58,11 +59,10 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                 );
                 return Ok(());
             }
-        } else {
+        } else if self.relayer.shared.is_initial_block_download() {
             // If self is in the IBD state, do nothing
-            if self.relayer.shared.is_initial_block_download() {
-                return Ok(());
-            }
+            return Ok(());
+        } else {
             debug!(target: "relay", "UnknownParent: {}, send_getheaders_to_peer({})", block_hash, self.peer);
             self.relayer.shared.send_getheaders_to_peer(
                 self.nc,
@@ -72,12 +72,16 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
             return Ok(());
         }
 
+        // The new arrived has greater difficulty than local best known chain
         let mut missing_indexes: Vec<usize> = Vec::new();
         {
+            // Verify compact block
             let mut pending_compact_blocks = self.relayer.state.pending_compact_blocks.lock();
-            if pending_compact_blocks.get(&block_hash).is_none()
-                && self.relayer.shared.get_block(&block_hash).is_none()
+            if pending_compact_blocks.get(&block_hash).is_some()
+                || self.relayer.shared.get_block(&block_hash).is_some()
             {
+                debug!(target: "relay", "already processed compact block {}", block_hash);
+            } else {
                 let resolver = HeaderResolverWrapper::new(
                     &compact_block.header,
                     self.relayer.shared.shared().to_owned(),
@@ -90,37 +94,31 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                     },
                     Arc::clone(&self.relayer.shared.consensus().pow_engine()),
                 );
-                match header_verifier.verify(&resolver) {
-                    Ok(_) => {
-                        let ret = {
-                            let chain_state = self.relayer.shared.chain_state().lock();
-                            self.relayer.request_proposal_txs(
-                                &chain_state,
-                                self.nc,
-                                self.peer,
-                                &compact_block,
-                            );
-                            self.relayer
-                                .reconstruct_block(&chain_state, &compact_block, Vec::new())
-                        };
-                        match ret {
-                            Ok(block) => {
-                                self.relayer
-                                    .accept_block(self.nc, self.peer, &Arc::new(block))
-                            }
-                            Err(missing) => {
-                                missing_indexes = missing;
-                                pending_compact_blocks
-                                    .insert(block_hash.clone(), compact_block);
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        debug!(target: "relay", "unexpected header verify failed: {}", err);
-                    }
+                let compact_block_verifier = CompactBlockVerifier::new();
+                header_verifier.verify(&resolver)?;
+                compact_block_verifier.verify(&compact_block)?;
+            }
+
+            // Reconstruct block
+            let ret = {
+                let chain_state = self.relayer.shared.chain_state().lock();
+                self.relayer
+                    .request_proposal_txs(&chain_state, self.nc, self.peer, &compact_block);
+                self.relayer
+                    .reconstruct_block(&chain_state, &compact_block, Vec::new())
+            };
+
+            // Accept block
+            // `relayer.accept_block` will make sure the validity of block before persisting
+            // into database
+            match ret {
+                Ok(block) => self
+                    .relayer
+                    .accept_block(self.nc, self.peer, &Arc::new(block)),
+                Err(missing) => {
+                    missing_indexes = missing;
+                    pending_compact_blocks.insert(block_hash.clone(), compact_block);
                 }
-            } else {
-                debug!(target: "relay", "already processed compact block {}", block_hash);
             }
         }
         if !missing_indexes.is_empty() {

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -111,7 +111,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                             Err(missing) => {
                                 missing_indexes = missing;
                                 pending_compact_blocks
-                                    .insert(block_hash.clone(), compact_block.clone());
+                                    .insert(block_hash.clone(), compact_block);
                             }
                         }
                     }
@@ -120,7 +120,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
                     }
                 }
             } else {
-                debug!(target: "relay", "Already processed compact block {}", block_hash);
+                debug!(target: "relay", "already processed compact block {}", block_hash);
             }
         }
         if !missing_indexes.is_empty() {

--- a/sync/src/relayer/compact_block_verifier.rs
+++ b/sync/src/relayer/compact_block_verifier.rs
@@ -1,0 +1,94 @@
+use crate::relayer::compact_block::CompactBlock;
+use crate::relayer::error::Error;
+use ckb_protocol::{short_transaction_id, short_transaction_id_keys};
+use std::collections::HashSet;
+
+pub struct CompactBlockVerifier {
+    prefilled: PrefilledVerifier,
+    short_ids: ShortIdsVerifier,
+}
+
+impl CompactBlockVerifier {
+    pub(crate) fn new() -> Self {
+        Self {
+            prefilled: PrefilledVerifier::new(),
+            short_ids: ShortIdsVerifier::new(),
+        }
+    }
+
+    pub(crate) fn verify(&self, block: &CompactBlock) -> Result<(), Error> {
+        self.prefilled.verify(block)?;
+        self.short_ids.verify(block)?;
+        Ok(())
+    }
+}
+
+pub struct PrefilledVerifier {}
+
+impl PrefilledVerifier {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    pub(crate) fn verify(&self, block: &CompactBlock) -> Result<(), Error> {
+        let prefilled_transactions = &block.prefilled_transactions;
+        let short_ids = &block.short_ids;
+        let txs_len = prefilled_transactions.len() + short_ids.len();
+
+        // Check indices order of prefilled transactions
+        let mut prev = prefilled_transactions
+            .get(0)
+            .and_then(|it| Some(it.index))
+            .unwrap_or(0);
+        for index_transaction in prefilled_transactions.iter().skip(1) {
+            if prev >= index_transaction.index {
+                return Err(Error::UnorderedPrefilledTransactions);
+            }
+            prev = index_transaction.index;
+        }
+
+        // Check highest prefilled index is less then length of block transactions
+        if prev >= txs_len {
+            return Err(Error::OverflowPrefilledTransactions);
+        }
+
+        Ok(())
+    }
+}
+
+pub struct ShortIdsVerifier {}
+
+impl ShortIdsVerifier {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    pub(crate) fn verify(&self, block: &CompactBlock) -> Result<(), Error> {
+        let prefilled_transactions = &block.prefilled_transactions;
+        let short_ids = &block.short_ids;
+        let short_ids_set: HashSet<[u8; 6]> = short_ids.iter().map(Clone::clone).collect();
+        let txs_len = prefilled_transactions.len() + short_ids.len();
+
+        // Check empty transactions
+        if txs_len == 0 {
+            return Err(Error::EmptyTransactions);
+        }
+
+        // Check duplicated short ids
+        if short_ids.len() != short_ids_set.len() {
+            return Err(Error::DuplicatedShortIds);
+        }
+
+        // Check intersection of prefilled transactions and short ids
+        let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
+        let is_intersect = prefilled_transactions.iter().any(|it| {
+            let short_id = short_transaction_id(key0, key1, &it.transaction.witness_hash());
+            short_ids_set.contains(&short_id)
+        });
+        if is_intersect {
+            return Err(Error::IntersectedPrefilledTransactions);
+        }
+
+        Ok(())
+    }
+}

--- a/sync/src/relayer/error.rs
+++ b/sync/src/relayer/error.rs
@@ -1,0 +1,15 @@
+use failure::Fail;
+
+#[derive(Debug, Fail, Eq, PartialEq)]
+pub enum Error {
+    #[fail(display = "CompactBlockError::EmptyTransactions")]
+    EmptyTransactions,
+    #[fail(display = "CompactBlockError::DuplicatedShortIds")]
+    DuplicatedShortIds,
+    #[fail(display = "CompactBlockError::UnorderedPrefilledTransactions")]
+    UnorderedPrefilledTransactions,
+    #[fail(display = "CompactBlockError::OverflowPrefilledTransactions")]
+    OverflowPrefilledTransactions,
+    #[fail(display = "CompactBlockError::IntersectedPrefilledTransactions")]
+    IntersectedPrefilledTransactions,
+}

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -1,11 +1,11 @@
 use crate::relayer::Relayer;
+use ckb_core::transaction::ProposalShortId;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, GetBlockProposal, RelayMessage};
 use ckb_store::ChainStore;
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
 use std::convert::TryInto;
-use ckb_core::transaction::ProposalShortId;
 
 pub struct GetBlockProposalProcess<'a, CS> {
     message: &'a GetBlockProposal<'a>,

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -5,6 +5,7 @@ use ckb_store::ChainStore;
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
 use std::convert::TryInto;
+use ckb_core::transaction::ProposalShortId;
 
 pub struct GetBlockProposalProcess<'a, CS> {
     message: &'a GetBlockProposal<'a>,
@@ -36,12 +37,12 @@ impl<'a, CS: ChainStore> GetBlockProposalProcess<'a, CS> {
             let chain_state = self.relayer.shared.chain_state().lock();
             let tx_pool = chain_state.tx_pool();
 
-            let proposals = proposals
+            let proposals: Vec<ProposalShortId> = proposals
                 .iter()
                 .map(TryInto::try_into)
-                .collect::<Result<Vec<_>, FailureError>>();
+                .collect::<Result<_, FailureError>>()?;
 
-            proposals?
+            proposals
                 .into_iter()
                 .filter_map(|short_id| {
                     tx_pool.get_tx(&short_id).or({

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -2,9 +2,13 @@ mod block_proposal_process;
 mod block_transactions_process;
 pub mod compact_block;
 mod compact_block_process;
+mod compact_block_verifier;
+mod error;
 mod get_block_proposal_process;
 mod get_block_transactions_process;
 mod get_transaction_process;
+#[cfg(test)]
+mod tests;
 mod transaction_hash_process;
 mod transaction_process;
 
@@ -12,6 +16,7 @@ use self::block_proposal_process::BlockProposalProcess;
 use self::block_transactions_process::BlockTransactionsProcess;
 use self::compact_block::CompactBlock;
 use self::compact_block_process::CompactBlockProcess;
+pub use self::error::Error;
 use self::get_block_proposal_process::GetBlockProposalProcess;
 use self::get_block_transactions_process::GetBlockTransactionsProcess;
 use self::get_transaction_process::GetTransactionProcess;

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -239,8 +239,8 @@ impl<CS: ChainStore> Relayer<CS> {
     ) -> Result<Block, Vec<usize>> {
         let (key0, key1) =
             short_transaction_id_keys(compact_block.header.nonce(), compact_block.nonce);
-        let mut short_ids_set: HashSet<[u8; 6]> =
-            compact_block.short_ids.iter().map(Clone::clone).collect();
+        let mut short_ids_set: HashSet<&ShortTransactionID> =
+            compact_block.short_ids.iter().collect();
 
         let mut txs_map: FnvHashMap<ShortTransactionID, Transaction> = transactions
             .into_iter()

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -164,7 +164,8 @@ impl<CS: ChainStore> Relayer<CS> {
     }
 
     fn process(&self, nc: &CKBProtocolContext, peer: PeerIndex, message: RelayMessage) {
-        if self.try_process(nc, peer, message).is_err() {
+        if let Err(err) = self.try_process(nc, peer, message) {
+            debug!(target: "relay", "try_process error {}", err);
             nc.ban_peer(peer, BAD_MESSAGE_BAN_TIME);
         }
     }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -249,10 +249,12 @@ impl<CS: ChainStore> Relayer<CS> {
             .collect();
 
         {
+            let short_ids_set: HashSet<[u8; 6]> =
+                compact_block.short_ids.iter().map(Clone::clone).collect();
             let tx_pool = chain_state.tx_pool();
             let iter = tx_pool.staging_txs_iter().filter_map(|entry| {
                 let short_id = short_transaction_id(key0, key1, &entry.transaction.witness_hash());
-                if compact_block.short_ids.contains(&short_id) {
+                if short_ids_set.contains(&short_id) {
                     Some((short_id, entry.transaction.clone()))
                 } else {
                     None

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -1,4 +1,4 @@
-use crate::relayer::compact_block::CompactBlock;
+use crate::relayer::compact_block::{CompactBlock, ShortTransactionID};
 use crate::{Relayer, SyncSharedState};
 use ckb_chain::chain::ChainBuilder;
 use ckb_chain_spec::consensus::Consensus;
@@ -128,7 +128,7 @@ fn test_reconstruct_block() {
             .iter()
             .map(|tx| short_transaction_id(key0, key1, &tx.witness_hash()))
             .collect();
-        let transactions: Vec<Transaction> = prepare.iter().skip(1).map(Clone::clone).collect();
+        let transactions: Vec<Transaction> = prepare.iter().skip(1).cloned().collect();
         compact.short_ids = short_ids;
         assert_eq!(
             relayer.reconstruct_block(&chain_state, &compact, transactions),
@@ -147,12 +147,7 @@ fn test_reconstruct_block() {
             .iter()
             .map(|tx| short_transaction_id(key0, key1, &tx.witness_hash()))
             .collect();
-        let transactions: Vec<Transaction> = prepare
-            .iter()
-            .skip(1)
-            .step_by(2)
-            .map(Clone::clone)
-            .collect();
+        let transactions: Vec<Transaction> = prepare.iter().skip(1).step_by(2).cloned().collect();
         let missing = prepare
             .iter()
             .enumerate()
@@ -174,8 +169,7 @@ fn test_reconstruct_block() {
         };
         let (key0, key1) = short_transaction_id_keys(compact.header.nonce(), compact.nonce);
         let (short_transactions, prefilled) = {
-            let short_transactions: Vec<Transaction> =
-                prepare.iter().step_by(2).map(Clone::clone).collect();
+            let short_transactions: Vec<Transaction> = prepare.iter().step_by(2).cloned().collect();
             let prefilled: Vec<IndexTransaction> = prepare
                 .iter()
                 .enumerate()
@@ -188,7 +182,7 @@ fn test_reconstruct_block() {
                 .collect();
             (short_transactions, prefilled)
         };
-        let short_ids: Vec<[u8; 6]> = short_transactions
+        let short_ids: Vec<ShortTransactionID> = short_transactions
             .iter()
             .map(|tx| short_transaction_id(key0, key1, &tx.witness_hash()))
             .collect();
@@ -198,8 +192,7 @@ fn test_reconstruct_block() {
         // Split first 2 short transactions and move into pool. These pool transactions are not
         // staging, so it will not be acquired inside `reconstruct_block`
         let (pool_transactions, short_transactions) = short_transactions.split_at(2);
-        let short_transactions: Vec<Transaction> =
-            short_transactions.iter().map(Clone::clone).collect();
+        let short_transactions: Vec<Transaction> = short_transactions.to_vec();
         pool_transactions.iter().for_each(|tx| {
             // `tx` is added into pool but not be staging, since `tx` has not been proposal yet
             chain_state

--- a/sync/src/relayer/tests/compact_block_verifier.rs
+++ b/sync/src/relayer/tests/compact_block_verifier.rs
@@ -1,0 +1,114 @@
+use crate::relayer::compact_block::CompactBlock;
+use crate::relayer::compact_block_verifier::{PrefilledVerifier, ShortIdsVerifier};
+use crate::relayer::error::Error;
+use ckb_core::transaction::{CellOutput, IndexTransaction, TransactionBuilder};
+use ckb_core::Capacity;
+use ckb_protocol::{short_transaction_id, short_transaction_id_keys};
+
+fn new_index_transaction(index: usize) -> IndexTransaction {
+    let transaction = TransactionBuilder::default()
+        .output(CellOutput::new(
+            Capacity::bytes(index).unwrap(),
+            Default::default(),
+            Default::default(),
+            None,
+        ))
+        .build();
+    IndexTransaction { index, transaction }
+}
+
+#[test]
+fn test_unordered_prefilled() {
+    let mut block = CompactBlock::default();
+    let prefilled: Vec<IndexTransaction> = (0..5).rev().map(new_index_transaction).collect();
+    block.prefilled_transactions = prefilled;
+    assert_eq!(
+        PrefilledVerifier::new().verify(&block),
+        Err(Error::UnorderedPrefilledTransactions),
+    );
+}
+
+#[test]
+fn test_ordered_prefilled() {
+    let mut block = CompactBlock::default();
+    let prefilled: Vec<IndexTransaction> = (0..5).map(new_index_transaction).collect();
+    block.prefilled_transactions = prefilled;
+    assert_eq!(PrefilledVerifier::new().verify(&block), Ok(()),);
+}
+
+#[test]
+fn test_overflow_prefilled() {
+    let mut block = CompactBlock::default();
+    let prefilled: Vec<IndexTransaction> = (1..5).map(new_index_transaction).collect();
+    block.prefilled_transactions = prefilled;
+    assert_eq!(
+        PrefilledVerifier::new().verify(&block),
+        Err(Error::OverflowPrefilledTransactions),
+    );
+}
+
+#[test]
+fn test_empty_transactions() {
+    let block = CompactBlock::default();
+    assert_eq!(
+        ShortIdsVerifier::new().verify(&block),
+        Err(Error::EmptyTransactions)
+    );
+}
+
+#[test]
+fn test_duplicated_short_ids() {
+    let mut block = CompactBlock::default();
+    let mut short_ids: Vec<[u8; 6]> = (1..5)
+        .map(new_index_transaction)
+        .map(|tx| {
+            let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
+            short_transaction_id(key0, key1, &tx.transaction.witness_hash())
+        })
+        .collect();
+    short_ids.push(short_ids[0]);
+    block.short_ids = short_ids;
+    assert_eq!(
+        ShortIdsVerifier::new().verify(&block),
+        Err(Error::DuplicatedShortIds),
+    );
+}
+
+#[test]
+fn test_intersected_short_ids() {
+    let mut block = CompactBlock::default();
+    let prefilled: Vec<IndexTransaction> = (0..=5).map(new_index_transaction).collect();
+    let short_ids: Vec<[u8; 6]> = (5..9)
+        .map(new_index_transaction)
+        .map(|tx| {
+            let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
+            short_transaction_id(key0, key1, &tx.transaction.witness_hash())
+        })
+        .collect();
+    block.prefilled_transactions = prefilled;
+    block.short_ids = short_ids;
+    assert_eq!(
+        ShortIdsVerifier::new().verify(&block),
+        Err(Error::IntersectedPrefilledTransactions),
+    );
+}
+
+#[test]
+fn test_normal() {
+    let mut block = CompactBlock::default();
+    let prefilled: Vec<IndexTransaction> = vec![1, 2, 5]
+        .into_iter()
+        .map(new_index_transaction)
+        .collect();
+    let short_ids: Vec<[u8; 6]> = vec![0, 3, 4]
+        .into_iter()
+        .map(new_index_transaction)
+        .map(|tx| {
+            let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
+            short_transaction_id(key0, key1, &tx.transaction.witness_hash())
+        })
+        .collect();
+    block.prefilled_transactions = prefilled;
+    block.short_ids = short_ids;
+    assert_eq!(ShortIdsVerifier::new().verify(&block), Ok(()),);
+}

--- a/sync/src/relayer/tests/compact_block_verifier.rs
+++ b/sync/src/relayer/tests/compact_block_verifier.rs
@@ -1,4 +1,4 @@
-use crate::relayer::compact_block::CompactBlock;
+use crate::relayer::compact_block::{CompactBlock, ShortTransactionID};
 use crate::relayer::compact_block_verifier::{PrefilledVerifier, ShortIdsVerifier};
 use crate::relayer::error::Error;
 use ckb_core::transaction::{CellOutput, IndexTransaction, TransactionBuilder};
@@ -59,7 +59,7 @@ fn test_empty_transactions() {
 #[test]
 fn test_duplicated_short_ids() {
     let mut block = CompactBlock::default();
-    let mut short_ids: Vec<[u8; 6]> = (1..5)
+    let mut short_ids: Vec<ShortTransactionID> = (1..5)
         .map(new_index_transaction)
         .map(|tx| {
             let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
@@ -78,7 +78,7 @@ fn test_duplicated_short_ids() {
 fn test_intersected_short_ids() {
     let mut block = CompactBlock::default();
     let prefilled: Vec<IndexTransaction> = (0..=5).map(new_index_transaction).collect();
-    let short_ids: Vec<[u8; 6]> = (5..9)
+    let short_ids: Vec<ShortTransactionID> = (5..9)
         .map(new_index_transaction)
         .map(|tx| {
             let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
@@ -100,7 +100,7 @@ fn test_normal() {
         .into_iter()
         .map(new_index_transaction)
         .collect();
-    let short_ids: Vec<[u8; 6]> = vec![0, 3, 4]
+    let short_ids: Vec<ShortTransactionID> = vec![0, 3, 4]
         .into_iter()
         .map(new_index_transaction)
         .map(|tx| {

--- a/sync/src/relayer/tests/mod.rs
+++ b/sync/src/relayer/tests/mod.rs
@@ -1,0 +1,2 @@
+mod compact_block_process;
+mod compact_block_verifier;

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -142,7 +142,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
     }
 
     fn process(&self, nc: &CKBProtocolContext, peer: PeerIndex, message: SyncMessage) {
-        if self.try_process(nc, peer, message).is_err() {
+        if let Err(err) = self.try_process(nc, peer, message) {
+            debug!(target: "sync", "try_process error: {}", err);
             nc.ban_peer(peer, BAD_MESSAGE_BAN_TIME);
         }
     }


### PR DESCRIPTION
* Implement `CompactBlockVerifier` to verify the validity of CompactBlock, which be passed to `Relayer::reconstruct_block` function. The correctness of reconstructed block will be verified by `BlockVerifier` and `TransactionsVerifier`.
* test: Add unit tests for `Relayer::reconstruct_block` and `CompactBlockVerifier`
* perf: Use `HashSet::contains` to check whether a short id be contained in staging pool. It will decrease the time-complexity.