### PR TITLE
fix: clean corresponding cache when receive proposals

### DIFF
--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -1,4 +1,5 @@
 use crate::relayer::Relayer;
+use ckb_core::transaction::Transaction;
 use ckb_protocol::{cast, BlockProposal, FlatbuffersVectorIterator};
 use ckb_store::ChainStore;
 use failure::Error as FailureError;
@@ -17,11 +18,15 @@ impl<'a, CS: ChainStore> BlockProposalProcess<'a, CS> {
 
     pub fn execute(self) -> Result<(), FailureError> {
         let chain_state = self.relayer.shared.chain_state().lock();
+        let mut inflight = self.relayer.state.inflight_proposals.lock();
         let txs = FlatbuffersVectorIterator::new(cast!(self.message.transactions())?);
-        for tx in txs {
-            let ret = chain_state.add_tx_to_pool(TryInto::try_into(tx)?);
-            if ret.is_err() {
-                warn!(target: "relay", "BlockProposal add_tx_to_pool error {:?}", ret)
+        for ftx in txs {
+            let tx: Transaction = TryInto::try_into(ftx)?;
+            if inflight.remove(&tx.proposal_short_id()) {
+                let ret = chain_state.add_tx_to_pool(tx);
+                if ret.is_err() {
+                    warn!(target: "relay", "BlockProposal add_tx_to_pool error {:?}", ret)
+                }
             }
         }
         Ok(())

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -52,7 +52,7 @@ pub const TX_ASKED_SIZE: usize = TX_FILTER_SIZE;
 pub struct Relayer<CS> {
     chain: ChainController,
     pub(crate) shared: Arc<SyncSharedState<CS>>,
-    state: Arc<RelayState>,
+    pub(crate) state: Arc<RelayState>,
     // TODO refactor shared Peers struct with Synchronizer
     peers: Arc<Peers>,
 }


### PR DESCRIPTION
* Clean relayer's `inflight_proposals` after received the corresponding proposal transactions