### PR TITLE
Ignore staled block

### DIFF
--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -34,8 +34,13 @@ where
         let block: Block = (*self.message).try_into()?;
         debug!(target: "sync", "BlockProcess received block {} {:x}", block.header().number(), block.header().hash());
 
-        self.synchronizer.peers.block_received(self.peer, &block);
-        self.synchronizer.process_new_block(self.peer, block);
+        if self
+            .synchronizer
+            .peers
+            .new_block_received(self.peer, &block)
+        {
+            self.synchronizer.process_new_block(self.peer, block);
+        }
         Ok(())
     }
 }

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -1,10 +1,12 @@
 use crate::synchronizer::Synchronizer;
+use crate::BLOCK_DOWNLOAD_WINDOW;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, GetBlocks, SyncMessage};
 use ckb_store::ChainStore;
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
-use log::debug;
+use log::{debug, warn};
+use std::cmp::min;
 use std::convert::TryInto;
 
 pub struct GetBlocksProcess<'a, CS: ChainStore + 'a> {
@@ -35,7 +37,9 @@ where
     pub fn execute(self) -> Result<(), FailureError> {
         let block_hashes = cast!(self.message.block_hashes())?;
 
-        for fbs_h256 in block_hashes {
+        // bitcoin limits 500
+        let n_limit = min(BLOCK_DOWNLOAD_WINDOW as usize, block_hashes.len());
+        for fbs_h256 in block_hashes.iter().take(n_limit) {
             let block_hash = fbs_h256.try_into()?;
             debug!(target: "sync", "get_blocks {:x}", block_hash);
             if let Some(block) = self.synchronizer.shared.get_block(&block_hash) {
@@ -48,7 +52,17 @@ where
             } else {
                 // TODO response not found
                 // TODO add timeout check in synchronizer
+
+                // We expect that `block_hashes` is sorted descending by height.
+                // So if we cannot find the current one from local, we cannot find
+                // the next either.
+                debug!(target: "sync", "getblocks stopping since {} is not found", block_hash);
+                break;
             }
+        }
+
+        if n_limit < block_hashes.len() {
+            warn!(target: "sync", "getblocks stopping at limit {}", n_limit);
         }
 
         Ok(())

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -278,13 +278,18 @@ impl Peers {
         self.last_common_headers.write().remove(&peer);
     }
 
-    pub fn block_received(&self, peer: PeerIndex, block: &Block) {
+    // Return true when the block is that we have requested and received first time.
+    pub fn new_block_received(&self, peer: PeerIndex, block: &Block) -> bool {
         let mut blocks_inflight = self.blocks_inflight.write();
+        let mut is_new = false;
         debug!(target: "sync", "block_received from peer {} {} {:x}", peer, block.header().number(), block.header().hash());
         blocks_inflight.entry(peer).and_modify(|inflight| {
-            inflight.remove(&block.header().hash());
-            inflight.update_timestamp();
+            if inflight.remove(&block.header().hash()) {
+                is_new = true;
+                inflight.update_timestamp();
+            }
         });
+        is_new
     }
 
     pub fn set_last_common_header(&self, peer: PeerIndex, header: &Header) {


### PR DESCRIPTION
* Ignore "block" message if we are not interested (never requested before or already processed)
* Limit length of "getblocks" message