### PR TITLE
feat: add rpc dry_run_transaction

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -732,3 +732,104 @@ curl -H 'content-type:application/json' \
     "id": 2
 }
 ```
+
+### dry_run_transaction
+
+Dry run transaction and return the execution cycles.
+
+This method will not check the transaction validaty, but only run the lock script
+and type script and than return the execution cycles.
+
+#### Parameters
+
+transaction - The transaction object.
+
+    version - Transaction version.
+    deps - Dependent cells.
+    inputs - Transaction inputs.
+    outputs - Transaction outputs.
+    witnesses - Witnesses.
+
+#### Examples
+
+
+```bash
+echo '{
+   "id" : 2,
+   "method" : "dry_run_transaction",
+   "jsonrpc" : "2.0",
+   "params" : [
+      {
+         "deps" : [
+            {
+               "tx_hash" : "0x4974d7ab2d9c548447e12a5488965352bf3d72ef7e6b09445be228be40b73dfe",
+               "index" : 0
+            }
+         ],
+         "inputs" : [
+            {
+               "args" : [
+                  "0x303234613530316566643332386530363263383637356632333635393730373238633835396335393262656565666436626538656164336439303133333062633031",
+                  "0x33303435303232313030643066313935343561656635633463336565306564633066666439633635303165623864303363393831626236313235623335323130616533666134663635373032323034616331353230333134386364346438373566353436323134343661656437353164326466646339666536653464313431663164306231613763393630613337",
+                  "0x31"
+               ],
+               "since" : "0",
+               "previous_output" : {
+                  "index" : 1,
+                  "tx_hash" : "0x98427f95a11fe26b42e7e29ef9ac14b0b84b0a8359b05fd0824b84e09d41c9ea"
+               }
+            }
+         ],
+         "outputs" : [
+            {
+               "capacity" : "1000000000000",
+               "type" : {
+                  "args" : [
+                     "0x31202b202032202b2033202b20340a",
+                     "0x546f6b656e2031",
+                     "0x303234613530316566643332386530363263383637356632333635393730373238633835396335393262656565666436626538656164336439303133333062633031"
+                  ],
+                  "code_hash" : "0x8c3b24e83d111d3a8430416df6a16e33d729273be82cfe0fc994bf147cd8a4ee"
+               },
+               "data" : "0x80969800000000003044022052de9ce28c28c0c2f8b4819b30d8d936718998808e3d74aca73fdae7bd0904ed022024f9556fa1ea1e8921df0931daf2016f0fb75bbe8bcda5ef625ffb779ad2853c",
+               "lock" : {
+                  "args" : [
+                     "0x31202b202032202b2033202b20340a",
+                     "0x546f6b656e2031",
+                     "0x303234613530316566643332386530363263383637356632333635393730373238633835396335393262656565666436626538656164336439303133333062633031"
+                  ],
+                  "code_hash" : "0x8c3b24e83d111d3a8430416df6a16e33d729273be82cfe0fc994bf147cd8a4ee"
+               }
+            },
+            {
+               "capacity" : "28000000000000",
+               "type" : null,
+               "data" : "0x",
+               "lock" : {
+                  "code_hash" : "0x8c3b24e83d111d3a8430416df6a16e33d729273be82cfe0fc994bf147cd8a4ee",
+                  "args" : [
+                     "0x31202b2032202b2033202b20340a",
+                     "0x65646134626639666336373064656339636663663831333839393966613437353835313731633966636166313162336364616439363939656233633435343766"
+                  ]
+               }
+            }
+         ],
+         "witnesses" : [],
+         "version" : 0
+      }
+   ]
+}' \
+    | tr -d '\n' \
+    | curl -H 'content-type:application/json' -d @- \
+    http://localhost:8114
+```
+
+```json
+{
+   "jsonrpc" : "2.0",
+   "id" : 2,
+   "result" : {
+      "cycles" : "20650838"
+   }
+}
+```

--- a/rpc/src/module/trace.rs
+++ b/rpc/src/module/trace.rs
@@ -1,11 +1,16 @@
-use ckb_core::transaction::Transaction as CoreTransaction;
+use crate::error::RPCError;
+use ckb_core::cell::{resolve_transaction, CellProvider, CellStatus};
+use ckb_core::transaction::{OutPoint, Transaction as CoreTransaction};
 use ckb_network::NetworkController;
+use ckb_shared::chain_state::ChainState;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
+use ckb_verification::ScriptVerifier;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_types::{Transaction, TxTrace};
 use numext_fixed_hash::H256;
+use serde_derive::Serialize;
 use std::convert::TryInto;
 
 #[rpc]
@@ -15,6 +20,9 @@ pub trait TraceRpc {
 
     #[rpc(name = "get_transaction_trace")]
     fn get_transaction_trace(&self, _hash: H256) -> Result<Option<Vec<TxTrace>>>;
+
+    #[rpc(name = "dry_run_transaction")]
+    fn dry_run_transaction(&self, _tx: Transaction) -> Result<DryRunResult>;
 }
 
 pub(crate) struct TraceRpcImpl<CS> {
@@ -35,5 +43,54 @@ impl<CS: ChainStore + 'static> TraceRpc for TraceRpcImpl<CS> {
         let chain_state = self.shared.chain_state().lock();
         let tx_pool = chain_state.tx_pool();
         Ok(tx_pool.get_tx_traces(&hash).cloned())
+    }
+
+    fn dry_run_transaction(&self, tx: Transaction) -> Result<DryRunResult> {
+        let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
+        let chain_state = self.shared.chain_state().lock();
+        DryRunner::new(&chain_state).run(tx)
+    }
+}
+
+#[derive(Serialize)]
+pub struct DryRunResult {
+    pub cycles: String,
+}
+
+// DryRunner dry run given transaction, and return the result, including execution cycles.
+pub(crate) struct DryRunner<'a, CS> {
+    chain_state: &'a ChainState<CS>,
+}
+
+impl<'a, CS: ChainStore> CellProvider for DryRunner<'a, CS> {
+    fn cell(&self, o: &OutPoint) -> CellStatus {
+        self
+            .chain_state
+            .get_store()
+            .get_cell_meta(&o.tx_hash, o.index)
+            .map(CellStatus::live_cell)  // treat as live cell, regardless of live or dead
+            .unwrap_or(CellStatus::Unknown)
+    }
+}
+
+impl<'a, CS: ChainStore> DryRunner<'a, CS> {
+    pub(crate) fn new(chain_state: &'a ChainState<CS>) -> Self {
+        Self { chain_state }
+    }
+
+    pub(crate) fn run(&self, tx: CoreTransaction) -> Result<DryRunResult> {
+        match resolve_transaction(&tx, &mut Default::default(), self) {
+            Ok(resolved) => {
+                let max_cycles = self.chain_state.consensus().max_block_cycles;
+                let store = self.chain_state.get_store();
+                match ScriptVerifier::new(&resolved, store).verify(max_cycles) {
+                    Ok(cycles) => Ok(DryRunResult {
+                        cycles: cycles.to_string(),
+                    }),
+                    Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
+                }
+            }
+            Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
+        }
     }
 }

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -98,6 +98,10 @@ impl<CS: ChainStore> ChainState<CS> {
         })
     }
 
+    pub fn get_store(&self) -> Arc<CS> {
+        Arc::clone(&self.store)
+    }
+
     fn init_proposal_ids(
         store: &CS,
         proposal_window: ProposalWindow,
@@ -274,7 +278,7 @@ impl<CS: ChainStore> ChainState<CS> {
                 let max_cycles = self.consensus.max_block_cycles();
                 let cycles = TransactionVerifier::new(
                     &rtx,
-                    Arc::clone(&self.store),
+                    self.get_store(),
                     &self,
                     self.tip_number(),
                     self.consensus().cellbase_maturity,
@@ -441,7 +445,7 @@ impl<CS: ChainStore> ChainState<CS> {
     ) -> ChainCellSetOverlay<'a, CS> {
         ChainCellSetOverlay {
             overlay: self.cell_set.new_overlay(diff),
-            store: Arc::clone(&self.store),
+            store: self.get_store(),
             outputs,
         }
     }

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -9,7 +9,9 @@ mod tests;
 pub use crate::block_verifier::{BlockVerifier, HeaderResolverWrapper, TransactionsVerifier};
 pub use crate::error::{Error, TransactionError};
 pub use crate::header_verifier::{HeaderResolver, HeaderVerifier};
-pub use crate::transaction_verifier::{PoolTransactionVerifier, TransactionVerifier};
+pub use crate::transaction_verifier::{
+    PoolTransactionVerifier, ScriptVerifier, TransactionVerifier,
+};
 
 pub const ALLOWED_FUTURE_BLOCKTIME: u64 = 15 * 1000; // 15 Second
 


### PR DESCRIPTION
* Add rpc `dry_run_transaction`

I place the code inside `rpc/src/module/trace.rs`, together with `trace_transaction`. Since I think `dry_run_transaction` is a kind of interfaces used only at development/testing. 