### PR TITLE
 perf: calculate some hashes when constructing

### DIFF
--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -259,7 +259,7 @@ fn gen_block(
         .proposals(proposals)
         .header_builder(
             HeaderBuilder::default()
-                .parent_hash(p_block.header().hash())
+                .parent_hash(p_block.header().hash().to_owned())
                 .number(number)
                 .timestamp(timestamp)
                 .difficulty(difficulty)

--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -164,7 +164,7 @@ fn new_chain(
         .output(cell_output)
         .build();
 
-    let system_cell_hash = cellbase.hash();
+    let system_cell_hash = cellbase.hash().to_owned();
 
     // create genesis block with N txs
     let transactions: Vec<Transaction> = (0..txs_size)
@@ -270,15 +270,23 @@ fn gen_block(
     blocks.push(block);
 }
 
-fn create_transaction(parent_hash: H256, system_cell_hash: &H256, data_hash: &H256) -> Transaction {
+fn create_transaction(
+    parent_hash: &H256,
+    system_cell_hash: &H256,
+    data_hash: &H256,
+) -> Transaction {
     TransactionBuilder::default()
         .output(CellOutput::new(
             capacity_bytes!(50_000),
             (0..255).collect(),
-            Script::new(vec![(0..255).collect()], data_hash.clone()),
+            Script::new(vec![(0..255).collect()], data_hash.to_owned()),
             None,
         ))
-        .input(CellInput::new(OutPoint::new(parent_hash, 0), 0, vec![]))
-        .dep(OutPoint::new(system_cell_hash.clone(), 0))
+        .input(CellInput::new(
+            OutPoint::new(parent_hash.to_owned(), 0),
+            0,
+            vec![],
+        ))
+        .dep(OutPoint::new(system_cell_hash.to_owned(), 0))
         .build()
 }

--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -184,7 +184,8 @@ fn new_chain(
     let genesis_block = BlockBuilder::default()
         .transaction(cellbase)
         .transactions(transactions)
-        .with_header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)));
+        .header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)))
+        .build();
 
     let mut consensus = Consensus::default().set_genesis_block(genesis_block);
     consensus.tx_proposal_window = ProposalWindow(1, 10);
@@ -256,14 +257,15 @@ fn gen_block(
         .transaction(cellbase)
         .transactions(transactions)
         .proposals(proposals)
-        .with_header_builder(
+        .header_builder(
             HeaderBuilder::default()
                 .parent_hash(p_block.header().hash())
                 .number(number)
                 .timestamp(timestamp)
                 .difficulty(difficulty)
                 .nonce(random()),
-        );
+        )
+        .build();
 
     blocks.push(block);
 }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -501,7 +501,11 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
 
         for b in attached_blocks_iter.take(unverified_len) {
             cell_set_diff.push_new(b);
-            outputs.extend(b.transactions().iter().map(|tx| (tx.hash(), tx.outputs())));
+            outputs.extend(
+                b.transactions()
+                    .iter()
+                    .map(|tx| (tx.hash().to_owned(), tx.outputs())),
+            );
         }
 
         // The verify function
@@ -559,7 +563,9 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                                 Ok(_) => {
                                     cell_set_diff.push_new(b);
                                     outputs.extend(
-                                        b.transactions().iter().map(|tx| (tx.hash(), tx.outputs())),
+                                        b.transactions()
+                                            .iter()
+                                            .map(|tx| (tx.hash().to_owned(), tx.outputs())),
                                     );
                                     ext.txs_verified = Some(true);
                                 }
@@ -586,7 +592,11 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                 }
             } else {
                 cell_set_diff.push_new(b);
-                outputs.extend(b.transactions().iter().map(|tx| (tx.hash(), tx.outputs())));
+                outputs.extend(
+                    b.transactions()
+                        .iter()
+                        .map(|tx| (tx.hash().to_owned(), tx.outputs())),
+                );
                 ext.txs_verified = Some(true);
             }
         }

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -33,7 +33,8 @@ fn test_genesis_transaction_spend() {
 
     let genesis_block = BlockBuilder::default()
         .transaction(tx)
-        .with_header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)));
+        .header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)))
+        .build();
 
     let consensus = Consensus::default().set_genesis_block(genesis_block);
     let (chain_controller, shared) = start_chain(Some(consensus), false);
@@ -379,7 +380,8 @@ fn test_genesis_transaction_fetch() {
 
     let genesis_block = BlockBuilder::default()
         .transaction(tx)
-        .with_header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)));
+        .header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)))
+        .build();
 
     let consensus = Consensus::default().set_genesis_block(genesis_block);
     let (_chain_controller, shared) = start_chain(Some(consensus), false);
@@ -577,7 +579,8 @@ fn test_chain_get_ancestor() {
 #[test]
 fn test_next_epoch_ext() {
     let genesis_block = BlockBuilder::default()
-        .with_header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)));
+        .header_builder(HeaderBuilder::default().difficulty(U256::from(1000u64)))
+        .build();
     let mut consensus = Consensus::default().set_genesis_block(genesis_block);
     consensus.genesis_epoch_ext.set_length(400);
     let epoch = consensus.genesis_epoch_ext.clone();

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -441,7 +441,7 @@ fn test_chain_fork_by_total_difficulty() {
     }
     assert_eq!(
         shared.block_hash(8),
-        chain2.get(7).map(|b| b.header().hash())
+        chain2.get(7).map(|b| b.header().hash().to_owned())
     );
 }
 
@@ -506,10 +506,13 @@ fn test_chain_fork_by_hash() {
     } else {
         chain2
     };
-    assert_eq!(shared.block_hash(8), best.get(7).map(|b| b.header().hash()));
+    assert_eq!(
+        shared.block_hash(8),
+        best.get(7).map(|b| b.header().hash().to_owned())
+    );
     assert_eq!(
         shared.block_hash(19),
-        best.get(18).map(|b| b.header().hash())
+        best.get(18).map(|b| b.header().hash().to_owned())
     );
 }
 

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -46,9 +46,9 @@ fn test_dead_cell_in_same_block() {
 
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
-    let tx1_hash = tx1.hash();
-    let tx2 = create_transaction(tx1_hash.clone(), 2);
-    let tx3 = create_transaction(tx1_hash.clone(), 3);
+    let tx1_hash = tx1.hash().to_owned();
+    let tx2 = create_transaction(&tx1_hash, 2);
+    let tx3 = create_transaction(&tx1_hash, 3);
     let txs = vec![tx1, tx2, tx3];
     for i in switch_fork_number..final_number {
         let difficulty = parent.difficulty().to_owned();
@@ -146,8 +146,8 @@ fn test_dead_cell_in_different_block() {
     let last_cell_base = &chain2.last().unwrap().transactions()[0];
     let tx1 = create_transaction(last_cell_base.hash(), 1);
     let tx1_hash = tx1.hash();
-    let tx2 = create_transaction(tx1_hash.clone(), 2);
-    let tx3 = create_transaction(tx1_hash.clone(), 3);
+    let tx2 = create_transaction(tx1_hash, 2);
+    let tx3 = create_transaction(tx1_hash, 3);
     for i in switch_fork_number..final_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = if i == switch_fork_number {
@@ -201,7 +201,7 @@ fn test_dead_cell_in_different_block() {
 
     assert_eq!(
         SharedError::UnresolvableTransaction(UnresolvableError::Dead(OutPoint {
-            tx_hash: tx1_hash,
+            tx_hash: tx1_hash.to_owned(),
             index: 0,
         })),
         chain_controller

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -70,7 +70,8 @@ pub(crate) fn gen_block(
                 .map(Transaction::proposal_short_id)
                 .collect(),
         )
-        .with_header_builder(header_builder)
+        .header_builder(header_builder)
+        .build()
 }
 
 pub(crate) fn create_transaction(parent: H256, unique_data: u8) -> Transaction {

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -74,7 +74,7 @@ pub(crate) fn gen_block(
         .build()
 }
 
-pub(crate) fn create_transaction(parent: H256, unique_data: u8) -> Transaction {
+pub(crate) fn create_transaction(parent: &H256, unique_data: u8) -> Transaction {
     TransactionBuilder::default()
         .output(CellOutput::new(
             capacity_bytes!(5000),
@@ -82,6 +82,10 @@ pub(crate) fn create_transaction(parent: H256, unique_data: u8) -> Transaction {
             Script::always_success(),
             None,
         ))
-        .input(CellInput::new(OutPoint::new(parent, 0), 0, vec![]))
+        .input(CellInput::new(
+            OutPoint::new(parent.to_owned(), 0),
+            0,
+            vec![],
+        ))
         .build()
 }

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -55,7 +55,7 @@ pub(crate) fn gen_block(
     let number = parent_header.number() + 1;
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash())
+        .parent_hash(parent_header.hash().to_owned())
         .timestamp(parent_header.timestamp() + 20_000)
         .number(number)
         .difficulty(difficulty);

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -6,7 +6,22 @@ use fnv::FnvHashSet;
 use numext_fixed_hash::H256;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize, Eq, Default, Debug)]
+fn cal_transactions_root(vec: &[Transaction]) -> H256 {
+    merkle_root(&vec.iter().map(Transaction::hash).collect::<Vec<_>>())
+}
+
+fn cal_proposals_root(vec: &[ProposalShortId]) -> H256 {
+    merkle_root(&vec.iter().map(ProposalShortId::hash).collect::<Vec<_>>())
+}
+
+fn cal_witnesses_root(vec: &[Transaction]) -> H256 {
+    // The witness hash of cellbase transaction is assumed to be zero 0x0000....0000
+    let mut witnesses = vec![H256::zero()];
+    witnesses.extend(vec.iter().skip(1).map(Transaction::witness_hash));
+    merkle_root(&witnesses[..])
+}
+
+#[derive(Clone, Serialize, Deserialize, Eq, Debug)]
 pub struct Block {
     header: Header,
     uncles: Vec<UncleBlock>,
@@ -66,35 +81,15 @@ impl Block {
     }
 
     pub fn cal_witnesses_root(&self) -> H256 {
-        // The witness hash of cellbase transaction is assumed to be zero 0x0000....0000
-        let mut witnesses = vec![H256::zero()];
-        witnesses.extend(
-            self.transactions()
-                .iter()
-                .skip(1)
-                .map(Transaction::witness_hash),
-        );
-        merkle_root(&witnesses[..])
+        cal_witnesses_root(self.transactions())
     }
 
     pub fn cal_transactions_root(&self) -> H256 {
-        merkle_root(
-            &self
-                .transactions
-                .iter()
-                .map(Transaction::hash)
-                .collect::<Vec<_>>(),
-        )
+        cal_transactions_root(self.transactions())
     }
 
     pub fn cal_proposals_root(&self) -> H256 {
-        merkle_root(
-            &self
-                .proposals
-                .iter()
-                .map(ProposalShortId::hash)
-                .collect::<Vec<_>>(),
-        )
+        cal_proposals_root(self.proposals())
     }
 
     pub fn serialized_size(&self, proof_size: usize) -> usize {
@@ -131,67 +126,100 @@ impl PartialEq for Block {
 
 #[derive(Default)]
 pub struct BlockBuilder {
-    inner: Block,
+    header_builder: HeaderBuilder,
+    uncles: Vec<UncleBlock>,
+    transactions: Vec<Transaction>,
+    proposals: Vec<ProposalShortId>,
 }
 
 impl BlockBuilder {
-    pub fn block(mut self, block: Block) -> Self {
-        self.inner = block;
+    pub fn from_block(block: Block) -> Self {
+        let Block {
+            header,
+            uncles,
+            transactions,
+            proposals,
+        } = block;
+        Self {
+            header_builder: HeaderBuilder::from_header(header),
+            uncles,
+            transactions,
+            proposals,
+        }
+    }
+
+    pub fn from_header_builder(header_builder: HeaderBuilder) -> Self {
+        Self {
+            header_builder,
+            uncles: Vec::new(),
+            transactions: Vec::new(),
+            proposals: Vec::new(),
+        }
+    }
+
+    pub fn header_builder(mut self, header_builder: HeaderBuilder) -> Self {
+        self.header_builder = header_builder;
         self
     }
 
     pub fn header(mut self, header: Header) -> Self {
-        self.inner.header = header;
+        self.header_builder = HeaderBuilder::from_header(header);
         self
     }
 
     pub fn uncle(mut self, uncle: UncleBlock) -> Self {
-        self.inner.uncles.push(uncle);
+        self.uncles.push(uncle);
         self
     }
 
     pub fn uncles(mut self, uncles: Vec<UncleBlock>) -> Self {
-        self.inner.uncles.extend(uncles);
+        self.uncles.extend(uncles);
         self
     }
 
     pub fn transaction(mut self, transaction: Transaction) -> Self {
-        self.inner.transactions.push(transaction);
+        self.transactions.push(transaction);
         self
     }
 
     pub fn transactions(mut self, transactions: Vec<Transaction>) -> Self {
-        self.inner.transactions.extend(transactions);
+        self.transactions.extend(transactions);
         self
     }
 
     pub fn proposal(mut self, proposal_short_id: ProposalShortId) -> Self {
-        self.inner.proposals.push(proposal_short_id);
+        self.proposals.push(proposal_short_id);
         self
     }
 
     pub fn proposals(mut self, proposal_short_ids: Vec<ProposalShortId>) -> Self {
-        self.inner.proposals.extend(proposal_short_ids);
+        self.proposals.extend(proposal_short_ids);
         self
     }
 
     pub fn build(self) -> Block {
-        self.inner
-    }
-
-    pub fn with_header_builder(mut self, header_builder: HeaderBuilder) -> Block {
-        let transactions_root = self.inner.cal_transactions_root();
-        let witnesses_root = self.inner.cal_witnesses_root();
-        let proposals_root = self.inner.cal_proposals_root();
-        let uncles_hash = self.inner.cal_uncles_hash();
-
-        self.inner.header = header_builder
+        let Self {
+            header_builder,
+            uncles,
+            transactions,
+            proposals,
+        } = self;
+        let transactions_root = cal_transactions_root(&transactions);
+        let witnesses_root = cal_witnesses_root(&transactions);
+        let proposals_root = cal_proposals_root(&proposals);
+        let uncles_hash = uncles_hash(&uncles);
+        let header = header_builder
             .transactions_root(transactions_root)
             .proposals_root(proposals_root)
             .witnesses_root(witnesses_root)
             .uncles_hash(uncles_hash)
-            .uncles_count(self.inner.uncles.len() as u32)
+            .uncles_count(uncles.len() as u32)
             .build();
-        self.inner
+        Block {
+            header,
+            uncles,
+            transactions,
+            proposals,
+        }
     }
 }

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -5,9 +5,15 @@ use ckb_merkle_tree::merkle_root;
 use fnv::FnvHashSet;
 use numext_fixed_hash::H256;
 use serde_derive::{Deserialize, Serialize};
+use std::borrow::ToOwned;
 
 fn cal_transactions_root(vec: &[Transaction]) -> H256 {
-    merkle_root(&vec.iter().map(Transaction::hash).collect::<Vec<_>>())
+    merkle_root(
+        &vec.iter()
+            .map(Transaction::hash)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>(),
+    )
 }
 
 fn cal_proposals_root(vec: &[ProposalShortId]) -> H256 {
@@ -17,7 +23,12 @@ fn cal_proposals_root(vec: &[ProposalShortId]) -> H256 {
 fn cal_witnesses_root(vec: &[Transaction]) -> H256 {
     // The witness hash of cellbase transaction is assumed to be zero 0x0000....0000
     let mut witnesses = vec![H256::zero()];
-    witnesses.extend(vec.iter().skip(1).map(Transaction::witness_hash));
+    witnesses.extend(
+        vec.iter()
+            .skip(1)
+            .map(Transaction::witness_hash)
+            .map(ToOwned::to_owned),
+    );
     merkle_root(&witnesses[..])
 }
 

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -197,6 +197,21 @@ impl BlockBuilder {
         self
     }
 
+    pub fn unsafe_build(self) -> Block {
+        let Self {
+            header_builder,
+            uncles,
+            transactions,
+            proposals,
+        } = self;
+        Block {
+            header: header_builder.build(),
+            uncles,
+            transactions,
+            proposals,
+        }
+    }
+
     pub fn build(self) -> Block {
         let Self {
             header_builder,

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -118,7 +118,7 @@ impl<'a> BlockCellProvider<'a> {
             .transactions()
             .iter()
             .enumerate()
-            .map(|(idx, tx)| (tx.hash(), idx))
+            .map(|(idx, tx)| (tx.hash().to_owned(), idx))
             .collect();
         Self {
             output_indices,

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -258,8 +258,8 @@ impl Header {
         self.seal.nonce
     }
 
-    pub fn hash(&self) -> H256 {
-        self.hash.clone()
+    pub fn hash(&self) -> &H256 {
+        &self.hash
     }
 
     pub fn pow_hash(&self) -> H256 {

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -222,6 +222,17 @@ impl Header {
         header
     }
 
+    pub fn from_bytes_with_hash(bytes: &[u8], hash: H256) -> Self {
+        #[derive(Deserialize)]
+        struct HeaderKernel {
+            raw: RawHeader,
+            seal: Seal,
+        }
+        let HeaderKernel { raw, seal } =
+            deserialize(bytes).expect("header kernel deserializing should be ok");
+        Self { raw, seal, hash }
+    }
+
     pub fn serialized_size(proof_size: usize) -> usize {
         RawHeader::serialized_size() + proof_size + mem::size_of::<u64>()
     }
@@ -316,12 +327,6 @@ pub struct HeaderBuilder {
 }
 
 impl HeaderBuilder {
-    pub fn new(bytes: &[u8]) -> Self {
-        let Header { raw, seal, .. } =
-            deserialize(bytes).expect("header deserializing should be ok");
-        Self { raw, seal }
-    }
-
     pub fn from_header(header: Header) -> Self {
         let Header { raw, seal, .. } = header;
         Self { raw, seal }

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -71,10 +71,7 @@ impl RawHeader {
     }
 
     pub fn with_seal(self, seal: Seal) -> Header {
-        let builder = HeaderBuilder {
-            inner: Header { raw: self, seal },
-        };
-        builder.build()
+        HeaderBuilder { raw: self, seal }.build()
     }
 
     pub fn number(&self) -> BlockNumber {
@@ -107,11 +104,80 @@ impl RawHeader {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Default, Eq)]
+#[derive(Clone, Serialize, Eq)]
 pub struct Header {
     raw: RawHeader,
     /// proof seal
     seal: Seal,
+    #[serde(skip)]
+    hash: H256,
+}
+
+impl<'de> serde::de::Deserialize<'de> for Header {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Raw,
+            Seal,
+        }
+
+        struct InnerVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for InnerVisitor {
+            type Value = Header;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Header")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let raw = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let seal = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                Ok(Self::Value::new(raw, seal))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut raw = None;
+                let mut seal = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Raw => {
+                            if raw.is_some() {
+                                return Err(serde::de::Error::duplicate_field("raw"));
+                            }
+                            raw = Some(map.next_value()?);
+                        }
+                        Field::Seal => {
+                            if seal.is_some() {
+                                return Err(serde::de::Error::duplicate_field("seal"));
+                            }
+                            seal = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let raw = raw.ok_or_else(|| serde::de::Error::missing_field("raw"))?;
+                let seal = seal.ok_or_else(|| serde::de::Error::missing_field("seal"))?;
+                Ok(Self::Value::new(raw, seal))
+            }
+        }
+
+        const FIELDS: &[&str] = &["raw", "seal"];
+        deserializer.deserialize_struct("Header", FIELDS, InnerVisitor)
+    }
 }
 
 impl fmt::Debug for Header {
@@ -144,6 +210,18 @@ impl fmt::Debug for Header {
 }
 
 impl Header {
+    pub(crate) fn new(raw: RawHeader, seal: Seal) -> Self {
+        let mut header = Self {
+            raw,
+            seal,
+            hash: H256::zero(),
+        };
+        let hash =
+            blake2b_256(serialize(&header).expect("Header serialize should not fail")).into();
+        header.hash = hash;
+        header
+    }
+
     pub fn serialized_size(proof_size: usize) -> usize {
         RawHeader::serialized_size() + proof_size + mem::size_of::<u64>()
     }
@@ -181,7 +259,7 @@ impl Header {
     }
 
     pub fn hash(&self) -> H256 {
-        blake2b_256(serialize(&self).expect("Header serialize should not fail")).into()
+        self.hash.clone()
     }
 
     pub fn pow_hash(&self) -> H256 {
@@ -233,92 +311,94 @@ impl PartialEq for Header {
 
 #[derive(Default)]
 pub struct HeaderBuilder {
-    inner: Header,
+    raw: RawHeader,
+    seal: Seal,
 }
 
 impl HeaderBuilder {
     pub fn new(bytes: &[u8]) -> Self {
-        HeaderBuilder {
-            inner: deserialize(bytes).expect("header deserializing should be ok"),
-        }
+        let Header { raw, seal, .. } =
+            deserialize(bytes).expect("header deserializing should be ok");
+        Self { raw, seal }
     }
 
-    pub fn header(mut self, header: Header) -> Self {
-        self.inner = header;
-        self
+    pub fn from_header(header: Header) -> Self {
+        let Header { raw, seal, .. } = header;
+        Self { raw, seal }
     }
 
     pub fn seal(mut self, seal: Seal) -> Self {
-        self.inner.seal = seal;
+        self.seal = seal;
         self
     }
 
     pub fn version(mut self, version: u32) -> Self {
-        self.inner.raw.version = version;
+        self.raw.version = version;
         self
     }
 
     pub fn number(mut self, number: BlockNumber) -> Self {
-        self.inner.raw.number = number;
+        self.raw.number = number;
         self
     }
 
     pub fn epoch(mut self, number: EpochNumber) -> Self {
-        self.inner.raw.epoch = number;
+        self.raw.epoch = number;
         self
     }
 
     pub fn difficulty(mut self, difficulty: U256) -> Self {
-        self.inner.raw.difficulty = difficulty;
+        self.raw.difficulty = difficulty;
         self
     }
 
     pub fn timestamp(mut self, timestamp: u64) -> Self {
-        self.inner.raw.timestamp = timestamp;
+        self.raw.timestamp = timestamp;
         self
     }
 
     pub fn proof(mut self, proof: Vec<u8>) -> Self {
-        self.inner.seal.proof = proof;
+        self.seal.proof = proof;
         self
     }
 
     pub fn nonce(mut self, nonce: u64) -> Self {
-        self.inner.seal.nonce = nonce;
+        self.seal.nonce = nonce;
         self
     }
 
     pub fn parent_hash(mut self, hash: H256) -> Self {
-        self.inner.raw.parent_hash = hash;
+        self.raw.parent_hash = hash;
         self
     }
 
     pub fn transactions_root(mut self, hash: H256) -> Self {
-        self.inner.raw.transactions_root = hash;
+        self.raw.transactions_root = hash;
         self
     }
 
     pub fn proposals_root(mut self, hash: H256) -> Self {
-        self.inner.raw.proposals_root = hash;
+        self.raw.proposals_root = hash;
         self
     }
 
     pub fn witnesses_root(mut self, hash: H256) -> Self {
-        self.inner.raw.witnesses_root = hash;
+        self.raw.witnesses_root = hash;
         self
     }
 
     pub fn uncles_hash(mut self, hash: H256) -> Self {
-        self.inner.raw.uncles_hash = hash;
+        self.raw.uncles_hash = hash;
         self
     }
 
     pub fn uncles_count(mut self, uncles_count: u32) -> Self {
-        self.inner.raw.uncles_count = uncles_count;
+        self.raw.uncles_count = uncles_count;
         self
     }
 
     pub fn build(self) -> Header {
-        self.inner
+        let Self { raw, seal } = self;
+        Header::new(raw, seal)
     }
 }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -375,12 +375,12 @@ impl Transaction {
             && self.inputs[0].since == 0
     }
 
-    pub fn hash(&self) -> H256 {
-        self.hash.clone()
+    pub fn hash(&self) -> &H256 {
+        &self.hash
     }
 
-    pub fn witness_hash(&self) -> H256 {
-        self.witness_hash.clone()
+    pub fn witness_hash(&self) -> &H256 {
+        &self.witness_hash
     }
 
     pub fn out_points_iter(&self) -> impl Iterator<Item = &OutPoint> {

--- a/core/src/uncle.rs
+++ b/core/src/uncle.rs
@@ -8,7 +8,7 @@ use hash::blake2b_256;
 use numext_fixed_hash::H256;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct UncleBlock {
     pub header: Header,
     pub proposals: Vec<ProposalShortId>,

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -637,7 +637,8 @@ mod tests {
                     .collect::<Result<_, _>>()
                     .unwrap(),
             )
-            .with_header_builder(header_builder);
+            .header_builder(header_builder)
+            .build();
 
         let resolver = HeaderResolverWrapper::new(block.header(), shared.clone());
         let header_verify_result = {
@@ -668,7 +669,7 @@ mod tests {
             .header(header)
             .transaction(cellbase)
             .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-            .build()
+            .unsafe_build()
     }
 
     fn create_cellbase(number: BlockNumber, epoch: &EpochExt) -> Transaction {

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -209,7 +209,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
                     recv(new_uncle_receiver) -> msg => match msg {
                         Ok(uncle_block) => {
                             let hash = uncle_block.header().hash();
-                            self.candidate_uncles.insert(hash, uncle_block);
+                            self.candidate_uncles.insert(hash.to_owned(), uncle_block);
                             self.last_uncles_updated_at
                                 .store(unix_time_as_millis(), Ordering::SeqCst);
                         }
@@ -261,7 +261,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         let UncleBlock { header, proposals } = uncle;
 
         UncleTemplate {
-            hash: header.hash(),
+            hash: header.hash().to_owned(),
             required: false,
             proposals: proposals.into_iter().map(Into::into).collect(),
             header: (&header).into(),
@@ -383,7 +383,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
             current_time: current_time.to_string(),
             number: number.to_string(),
             epoch: current_epoch.number().to_string(),
-            parent_hash: header.hash(),
+            parent_hash: header.hash().to_owned(),
             cycles_limit: cycles_limit.to_string(),
             bytes_limit: bytes_limit.to_string(),
             uncles_count_limit,
@@ -457,13 +457,13 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         // tip.p^4  -----------/  6
         // tip.p^5  -------------/
         // tip.p^6
-        let mut block_hash = tip.hash();
+        let mut block_hash = tip.hash().to_owned();
         excluded.insert(block_hash.clone());
         for _depth in 0..max_uncles_age {
             if let Some(block) = self.shared.block(&block_hash) {
                 excluded.insert(block.header().parent_hash().to_owned());
                 for uncle in block.uncles() {
-                    excluded.insert(uncle.header.hash());
+                    excluded.insert(uncle.header.hash().to_owned());
                 }
 
                 block_hash = block.header().parent_hash().to_owned();
@@ -657,7 +657,7 @@ mod tests {
         let number = parent_header.number() + 1;
         let cellbase = create_cellbase(number, epoch);
         let header = HeaderBuilder::default()
-            .parent_hash(parent_header.hash())
+            .parent_hash(parent_header.hash().to_owned())
             .timestamp(parent_header.timestamp() + 10)
             .number(number)
             .epoch(epoch.number())
@@ -726,7 +726,7 @@ mod tests {
         let block_template = block_assembler_controller
             .get_block_template(None, None, None)
             .unwrap();
-        assert_eq!(block_template.uncles[0].hash, block0_0.header().hash());
+        assert_eq!(&block_template.uncles[0].hash, block0_0.header().hash());
 
         let last_epoch = epoch.clone();
         let epoch = shared

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -63,7 +63,7 @@ impl TemplateCache {
 struct FeeCalculator<'a> {
     txs: &'a [PoolEntry],
     provider: &'a dyn ChainProvider,
-    txs_map: FnvHashMap<H256, usize>,
+    txs_map: FnvHashMap<&'a H256, usize>,
 }
 
 impl<'a> FeeCalculator<'a> {
@@ -270,7 +270,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
 
     fn transform_cellbase(tx: &Transaction, cycles: Option<Cycle>) -> CellbaseTemplate {
         CellbaseTemplate {
-            hash: tx.hash(),
+            hash: tx.hash().to_owned(),
             cycles: cycles.map(|c| c.to_string()),
             data: tx.into(),
         }
@@ -282,7 +282,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         depends: Option<Vec<u32>>,
     ) -> TransactionTemplate {
         TransactionTemplate {
-            hash: tx.transaction.hash(),
+            hash: tx.transaction.hash().to_owned(),
             required,
             cycles: tx.cycles.map(|c| c.to_string()),
             depends,

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -81,7 +81,7 @@ impl Miner {
                 .timestamp(current_time.parse::<u64>()?)
                 .parent_hash(parent_hash);
 
-            let block = BlockBuilder::default()
+            let block = BlockBuilder::from_header_builder(header_builder)
                 .uncles(
                     uncles
                         .into_iter()
@@ -101,15 +101,14 @@ impl Miner {
                         .map(TryInto::try_into)
                         .collect::<Result<_, _>>()?,
                 )
-                .with_header_builder(header_builder);
+                .build();
 
             let raw_header = block.header().raw().to_owned();
 
             Ok(self
                 .mine_loop(&raw_header)
                 .map(|seal| {
-                    BlockBuilder::default()
-                        .block(block)
+                    BlockBuilder::from_block(block)
                         .header(raw_header.with_seal(seal))
                         .build()
                 })

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -27,6 +27,7 @@ use flatbuffers::{FlatBufferBuilder, WIPOffset};
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
 use rand::{thread_rng, Rng};
+use std::borrow::ToOwned;
 use std::collections::HashSet;
 
 fn uint_to_bytes(uint: &U256) -> [u8; 32] {
@@ -439,6 +440,7 @@ impl<'a> FilteredBlock<'a> {
                     .transactions()
                     .iter()
                     .map(Transaction::hash)
+                    .map(ToOwned::to_owned)
                     .collect::<Vec<_>>(),
                 transactions_index,
             );

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -165,7 +165,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
                     if output.lock.hash() == lock_hash && (!transaction_meta.is_dead(i)) {
                         result.push(CellOutputWithOutPoint {
                             out_point: OutPoint {
-                                tx_hash: transaction.hash(),
+                                tx_hash: transaction.hash().to_owned(),
                                 index: i as u32,
                             },
                             capacity: output.capacity.to_string(),

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -94,7 +94,7 @@ impl<CS: ChainStore + 'static> MinerRpc for MinerRpcImpl<CS> {
                 let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
-                Ok(Some(block.header().hash()))
+                Ok(Some(block.header().hash().to_owned()))
             } else {
                 error!(target: "rpc", "[{}] submit_block process_block {:?}", work_id, ret);
                 sentry::capture_event(sentry::protocol::Event {

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -45,7 +45,7 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
                 let data = fbb.finished_data().into();
                 self.network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data);
-                Ok(tx.hash())
+                Ok(tx.hash().to_owned())
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
         }

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -35,7 +35,7 @@ impl<CS: ChainStore + 'static> IntegrationTestRpc for IntegrationTestRpcImpl<CS>
     fn enqueue_test_transaction(&self, tx: Transaction) -> Result<H256> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
         let mut chain_state = self.shared.chain_state().lock();
-        let tx_hash = tx.hash();
+        let tx_hash = tx.hash().to_owned();
         chain_state.mut_tx_pool().enqueue_tx(None, tx);
         Ok(tx_hash)
     }

--- a/rpc/src/module/trace.rs
+++ b/rpc/src/module/trace.rs
@@ -25,7 +25,7 @@ pub(crate) struct TraceRpcImpl<CS> {
 impl<CS: ChainStore + 'static> TraceRpc for TraceRpcImpl<CS> {
     fn trace_transaction(&self, tx: Transaction) -> Result<H256> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
-        let tx_hash = tx.hash();
+        let tx_hash = tx.hash().to_owned();
         let mut chain_state = self.shared.chain_state().lock();
         chain_state.mut_tx_pool().trace_tx(tx);
         Ok(tx_hash)

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -56,7 +56,7 @@ impl<'a, CS: LazyLoadCellOutput> TransactionScriptsVerifier<'a, CS> {
                 |(index, output)| CellMeta {
                     cell_output: Some(output.clone()),
                     out_point: OutPoint {
-                        tx_hash: tx_hash.clone(),
+                        tx_hash: tx_hash.to_owned(),
                         index: index as u32,
                     },
                     block_number: None,
@@ -103,7 +103,7 @@ impl<'a, CS: LazyLoadCellOutput> TransactionScriptsVerifier<'a, CS> {
             dep_cells,
             witnesses,
             vm,
-            hash: tx_hash,
+            hash: tx_hash.to_owned(),
         }
     }
 

--- a/shared/src/cell_set.rs
+++ b/shared/src/cell_set.rs
@@ -21,7 +21,7 @@ impl CellSetDiff {
             let output_len = tx.outputs().len();
             self.new_inputs.extend(input_pts);
             self.new_outputs.insert(
-                tx_hash,
+                tx_hash.to_owned(),
                 (block.header().number(), tx.is_cellbase(), output_len),
             );
         }
@@ -33,7 +33,7 @@ impl CellSetDiff {
             let tx_hash = tx.hash();
 
             self.old_inputs.extend(input_pts);
-            self.old_outputs.insert(tx_hash);
+            self.old_outputs.insert(tx_hash.to_owned());
         }
     }
 }

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -149,7 +149,7 @@ impl<CS: ChainStore> ChainState<CS> {
         self.tip_header.number()
     }
 
-    pub fn tip_hash(&self) -> H256 {
+    pub fn tip_hash(&self) -> &H256 {
         self.tip_header.hash()
     }
 

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -138,7 +138,7 @@ impl<CS: ChainStore> ChainState<CS> {
                     cell_set.mark_dead(&o);
                 }
 
-                cell_set.insert(tx.hash(), n, tx.is_cellbase(), output_len);
+                cell_set.insert(tx.hash().to_owned(), n, tx.is_cellbase(), output_len);
             }
         }
 
@@ -292,7 +292,7 @@ impl<CS: ChainStore> ChainState<CS> {
         let entries = tx_pool.orphan.remove_by_ancestor(tx);
         for entry in entries {
             if self.contains_proposal_id(&tx.proposal_short_id()) {
-                let tx_hash = entry.transaction.hash();
+                let tx_hash = entry.transaction.hash().to_owned();
                 let ret = self.staging_tx(tx_pool, entry.cycles, entry.transaction);
                 if ret.is_err() {
                     trace!(target: "tx_pool", "staging tx {:x} failed {:?}", tx_hash, ret);

--- a/shared/src/tests/shared.rs
+++ b/shared/src/tests/shared.rs
@@ -14,7 +14,7 @@ where
 {
     let mut blocks = Vec::with_capacity(timestamps.len());
     let tip_header = store.get_tip_header().expect("tip");
-    let mut parent_hash = tip_header.hash();
+    let mut parent_hash = tip_header.hash().to_owned();
     let mut parent_number = tip_header.number();
     for timestamp in timestamps {
         let header = HeaderBuilder::default()
@@ -22,7 +22,7 @@ where
             .parent_hash(parent_hash.clone())
             .number(parent_number + 1)
             .build();
-        parent_hash = header.hash();
+        parent_hash = header.hash().to_owned();
         parent_number += 1;
         blocks.push(BlockBuilder::default().header(header).build());
     }

--- a/shared/src/tx_pool/orphan.rs
+++ b/shared/src/tx_pool/orphan.rs
@@ -122,13 +122,13 @@ mod tests {
     use ckb_core::{Bytes, Capacity};
     use numext_fixed_hash::H256;
 
-    fn build_tx(inputs: Vec<(H256, u32)>, outputs_len: usize) -> Transaction {
+    fn build_tx(inputs: Vec<(&H256, u32)>, outputs_len: usize) -> Transaction {
         TransactionBuilder::default()
             .inputs(
                 inputs
                     .into_iter()
                     .map(|(txid, index)| {
-                        CellInput::new(OutPoint::new(txid, index), 0, Default::default())
+                        CellInput::new(OutPoint::new(txid.to_owned(), index), 0, Default::default())
                     })
                     .collect(),
             )
@@ -151,7 +151,7 @@ mod tests {
     fn test_orphan_pool_remove_by_ancestor1() {
         let mut pool = OrphanPool::new();
 
-        let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
+        let tx1 = build_tx(vec![(&H256::zero(), 0)], 1);
         let tx1_hash = tx1.hash();
 
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);
@@ -183,10 +183,10 @@ mod tests {
     fn test_orphan_pool_remove_by_ancestor2() {
         let mut pool = OrphanPool::new();
 
-        let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
+        let tx1 = build_tx(vec![(&H256::zero(), 0)], 1);
         let tx1_hash = tx1.hash();
 
-        let tx2 = build_tx(vec![(H256::zero(), 1)], 1);
+        let tx2 = build_tx(vec![(&H256::zero(), 1)], 1);
         let tx2_hash = tx2.hash();
 
         let tx3 = build_tx(vec![(tx1_hash, 0), (tx2_hash, 1)], 1);
@@ -218,7 +218,7 @@ mod tests {
     fn test_orphan_pool_recursion_remove() {
         let mut pool = OrphanPool::new();
 
-        let tx1 = build_tx(vec![(H256::zero(), 0)], 1);
+        let tx1 = build_tx(vec![(&H256::zero(), 0)], 1);
         let tx1_hash = tx1.hash();
 
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);

--- a/shared/src/tx_pool/staging.rs
+++ b/shared/src/tx_pool/staging.rs
@@ -310,15 +310,15 @@ mod tests {
     use ckb_core::script::Script;
     use ckb_core::transaction::{CellInput, CellOutput, Transaction, TransactionBuilder};
     use ckb_core::{Bytes, Capacity};
-    use numext_fixed_hash::H256;
+    use numext_fixed_hash::{h256, H256};
 
-    fn build_tx(inputs: Vec<(H256, u32)>, outputs_len: usize) -> Transaction {
+    fn build_tx(inputs: Vec<(&H256, u32)>, outputs_len: usize) -> Transaction {
         TransactionBuilder::default()
             .inputs(
                 inputs
                     .into_iter()
                     .map(|(txid, index)| {
-                        CellInput::new(OutPoint::new(txid, index), 0, Default::default())
+                        CellInput::new(OutPoint::new(txid.to_owned(), index), 0, Default::default())
                     })
                     .collect(),
             )
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn test_add_entry() {
-        let tx1 = build_tx(vec![(H256::zero(), 1), (H256::zero(), 2)], 1);
+        let tx1 = build_tx(vec![(&H256::zero(), 1), (&H256::zero(), 2)], 1);
         let tx1_hash = tx1.hash();
         let tx2 = build_tx(vec![(tx1_hash, 0)], 1);
 
@@ -368,14 +368,8 @@ mod tests {
 
     #[test]
     fn test_add_roots() {
-        let tx1 = build_tx(vec![(H256::zero(), 1), (H256::zero(), 2)], 1);
-        let tx2 = build_tx(
-            vec![
-                (H256::from_trimmed_hex_str("2").unwrap(), 1),
-                (H256::from_trimmed_hex_str("3").unwrap(), 2),
-            ],
-            3,
-        );
+        let tx1 = build_tx(vec![(&H256::zero(), 1), (&H256::zero(), 2)], 1);
+        let tx2 = build_tx(vec![(&h256!("0x2"), 1), (&h256!("0x3"), 2)], 3);
 
         let mut pool = StagingPool::new();
 
@@ -414,16 +408,16 @@ mod tests {
     #[test]
     #[allow(clippy::cyclomatic_complexity)]
     fn test_add_no_roots() {
-        let tx1 = build_tx(vec![(H256::zero(), 1)], 3);
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 3);
         let tx2 = build_tx(vec![], 4);
         let tx1_hash = tx1.hash();
         let tx2_hash = tx2.hash();
 
-        let tx3 = build_tx(vec![(tx1_hash.clone(), 0), (H256::zero(), 2)], 2);
-        let tx4 = build_tx(vec![(tx1_hash.clone(), 1), (tx2_hash.clone(), 0)], 2);
+        let tx3 = build_tx(vec![(tx1_hash, 0), (&H256::zero(), 2)], 2);
+        let tx4 = build_tx(vec![(tx1_hash, 1), (tx2_hash, 0)], 2);
 
         let tx3_hash = tx3.hash();
-        let tx5 = build_tx(vec![(tx1_hash.clone(), 2), (tx3_hash.clone(), 0)], 2);
+        let tx5 = build_tx(vec![(tx1_hash, 2), (tx3_hash, 0)], 2);
 
         let id1 = tx1.proposal_short_id();
         let id3 = tx3.proposal_short_id();

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -91,7 +91,7 @@ impl Default for Consensus {
         );
 
         Consensus {
-            genesis_hash: genesis_block.header().hash(),
+            genesis_hash: genesis_block.header().hash().to_owned(),
             genesis_block,
             id: "main".to_owned(),
             max_uncles_age: MAX_UNCLE_AGE,
@@ -122,7 +122,7 @@ impl Consensus {
     pub fn set_genesis_block(mut self, genesis_block: Block) -> Self {
         self.genesis_epoch_ext
             .set_difficulty(genesis_block.header().difficulty().clone());
-        self.genesis_hash = genesis_block.header().hash();
+        self.genesis_hash = genesis_block.header().hash().to_owned();
         self.genesis_block = genesis_block;
         self
     }
@@ -316,7 +316,7 @@ impl Consensus {
                     last_epoch.number() + 1, // number
                     block_reward,
                     remainder_reward,        // remainder_reward
-                    header.hash(),           // last_block_hash_in_previous_epoch
+                    header.hash().to_owned(),           // last_block_hash_in_previous_epoch
                     header.number() + 1,     // start
                     next_epoch_length,       // length
                     difficulty               // difficulty,
@@ -333,7 +333,7 @@ impl Consensus {
                     last_epoch.number() + 1, // number
                     block_reward,
                     remainder_reward,        // remainder_reward
-                    header.hash(),           // last_block_hash_in_previous_epoch
+                    header.hash().to_owned(),           // last_block_hash_in_previous_epoch
                     header.number() + 1,     // start
                     next_epoch_length,       // length
                     difficulty               // difficulty,

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -76,8 +76,9 @@ pub struct Consensus {
 // genesis difficulty should not be zero
 impl Default for Consensus {
     fn default() -> Self {
-        let genesis_block = BlockBuilder::default()
-            .with_header_builder(HeaderBuilder::default().difficulty(U256::one()));
+        let genesis_block =
+            BlockBuilder::from_header_builder(HeaderBuilder::default().difficulty(U256::one()))
+                .build();
 
         let genesis_epoch_ext = EpochExt::new(
             0, // number

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -199,9 +199,9 @@ impl ChainSpec {
     fn verify_genesis_hash(&self, genesis: &Block) -> Result<(), Box<Error>> {
         if let Some(ref expect) = self.genesis.hash {
             let actual = genesis.header().hash();
-            if &actual != expect {
+            if actual != expect {
                 return Err(GenesisError {
-                    actual,
+                    actual: actual.clone(),
                     expect: expect.clone(),
                 }
                 .boxed());

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -220,9 +220,9 @@ impl ChainSpec {
             .proof(self.genesis.seal.proof.to_vec())
             .uncles_hash(self.genesis.uncles_hash.clone());
 
-        let genesis_block = BlockBuilder::default()
+        let genesis_block = BlockBuilder::from_header_builder(header_builder)
             .transaction(self.build_system_cells_transaction()?)
-            .with_header_builder(header_builder);
+            .build();
 
         self.verify_genesis_hash(&genesis_block)?;
 

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -312,7 +312,7 @@ pub mod test {
             let block = consensus.genesis_block();
             let cells_tx = &block.transactions()[0];
 
-            assert_eq!(spec_hashes.system_cells_transaction, cells_tx.hash());
+            assert_eq!(&spec_hashes.system_cells_transaction, cells_tx.hash());
 
             for (output, cell_hashes) in cells_tx
                 .outputs()

--- a/src/subcommand/cli/hashes.rs
+++ b/src/subcommand/cli/hashes.rs
@@ -37,7 +37,7 @@ impl TryFrom<ChainSpec> for SpecHashes {
             .zip(cells_tx.outputs())
             .map(|(resource, output)| {
                 let code_hash = output.data_hash();
-                let script_hash = Script::new(vec![], code_hash.clone()).hash();
+                let script_hash = Script::new(vec![], code_hash.to_owned()).hash();
                 SystemCellHashes {
                     path: format!("{}", resource),
                     code_hash,
@@ -47,8 +47,8 @@ impl TryFrom<ChainSpec> for SpecHashes {
             .collect();
 
         Ok(SpecHashes {
-            genesis: consensus.genesis_hash().clone(),
-            system_cells_transaction: cells_tx.hash(),
+            genesis: consensus.genesis_hash().to_owned(),
+            system_cells_transaction: cells_tx.hash().to_owned(),
             system_cells: cells_hashes,
         })
     }

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -9,7 +9,7 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::cell::CellMeta;
 use ckb_core::extras::{BlockExt, EpochExt, TransactionAddress};
-use ckb_core::header::{BlockNumber, Header, HeaderBuilder};
+use ckb_core::header::{BlockNumber, Header};
 use ckb_core::transaction::{
     CellOutput, OutPoint, ProposalShortId, Transaction, TransactionBuilder,
 };
@@ -135,7 +135,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
 
     fn get_header(&self, h: &H256) -> Option<Header> {
         self.get(COLUMN_BLOCK_HEADER, h.as_bytes())
-            .map(|ref raw| HeaderBuilder::new(raw).build())
+            .map(|ref raw| Header::from_bytes_with_hash(raw, h.to_owned()))
     }
 
     fn get_block_uncles(&self, h: &H256) -> Option<Vec<UncleBlock>> {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -484,7 +484,7 @@ mod tests {
         let block = consensus.genesis_block();
         let hash = block.header().hash();
         store.init(&consensus).unwrap();
-        assert_eq!(&hash, &store.get_block_hash(0).unwrap());
+        assert_eq!(hash, &store.get_block_hash(0).unwrap());
 
         assert_eq!(
             block.header().difficulty(),

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -30,7 +30,7 @@ impl<'a, CS: ChainStore> BlockProposalProcess<'a, CS> {
                 if self.relayer.state.already_known(&tx_hash) {
                     None
                 } else {
-                    Some((tx_hash, tx))
+                    Some((tx_hash.to_owned(), tx))
                 }
             })
             .collect();

--- a/sync/src/relayer/compact_block.rs
+++ b/sync/src/relayer/compact_block.rs
@@ -1,4 +1,4 @@
-use ckb_core::header::Header;
+use ckb_core::header::{Header, HeaderBuilder};
 use ckb_core::transaction::{IndexTransaction, ProposalShortId};
 use ckb_core::uncle::UncleBlock;
 use ckb_protocol::{self, cast, FlatbuffersVectorIterator};
@@ -7,7 +7,7 @@ use std::convert::{TryFrom, TryInto};
 
 pub type ShortTransactionID = [u8; 6];
 
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CompactBlock {
     pub header: Header,
     pub uncles: Vec<UncleBlock>,
@@ -15,6 +15,20 @@ pub struct CompactBlock {
     pub short_ids: Vec<ShortTransactionID>,
     pub prefilled_transactions: Vec<IndexTransaction>,
     pub proposals: Vec<ProposalShortId>,
+}
+
+impl Default for CompactBlock {
+    fn default() -> Self {
+        let header = HeaderBuilder::default().build();
+        Self {
+            header,
+            uncles: Default::default(),
+            nonce: Default::default(),
+            short_ids: Default::default(),
+            prefilled_transactions: Default::default(),
+            proposals: Default::default(),
+        }
+    }
 }
 
 impl<'a> TryFrom<ckb_protocol::CompactBlock<'a>> for CompactBlock {

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -40,7 +40,7 @@ impl<'a, CS: ChainStore> CompactBlockProcess<'a, CS> {
 
     pub fn execute(self) -> Result<(), FailureError> {
         let compact_block: CompactBlock = (*self.message).try_into()?;
-        let block_hash = compact_block.header.hash();
+        let block_hash = compact_block.header.hash().to_owned();
         if let Some(parent_header_view) = self
             .relayer
             .shared

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -29,7 +29,7 @@ fn new_header_builder(
         .next_epoch_ext(&parent_epoch, parent.header())
         .unwrap_or(parent_epoch);
     HeaderBuilder::default()
-        .parent_hash(parent_hash)
+        .parent_hash(parent_hash.to_owned())
         .number(parent.header().number() + 1)
         .timestamp(parent.header().timestamp() + 1)
         .epoch(epoch.number())

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -65,11 +65,12 @@ fn new_transaction(relayer: &Relayer<ChainKVStore<MemoryKeyValueDB>>, index: usi
 
 fn build_chain(tip: BlockNumber) -> Relayer<ChainKVStore<MemoryKeyValueDB>> {
     let shared = {
-        let genesis = BlockBuilder::default().with_header_builder(
+        let genesis = BlockBuilder::from_header_builder(
             HeaderBuilder::default()
                 .timestamp(unix_time_as_millis())
                 .difficulty(U256::from(1000u64)),
-        );
+        )
+        .build();
         let consensus = Consensus::default()
             .set_genesis_block(genesis)
             .set_cellbase_maturity(0);
@@ -101,9 +102,9 @@ fn build_chain(tip: BlockNumber) -> Relayer<ChainKVStore<MemoryKeyValueDB>> {
                 None,
             ))
             .build();
-        let block = BlockBuilder::default()
+        let block = BlockBuilder::from_header_builder(new_header_builder(&shared, &parent))
             .transaction(cellbase)
-            .with_header_builder(new_header_builder(&shared, &parent));
+            .build();
         chain_controller
             .process_block(Arc::new(block))
             .expect("processing block should be ok");

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -185,15 +185,16 @@ where
                     .get_ancestor(&best_known_header.hash(), n_height)?;
                 let to_fetch_hash = to_fetch.hash();
 
-                let block_status = self.synchronizer.get_block_status(&to_fetch_hash);
-                if block_status == BlockStatus::VALID_MASK && inflight.insert(to_fetch_hash.clone())
+                let block_status = self.synchronizer.get_block_status(to_fetch_hash);
+                if block_status == BlockStatus::VALID_MASK
+                    && inflight.insert(to_fetch_hash.to_owned())
                 {
                     trace!(
                         target: "sync", "[Synchronizer] inflight insert {:?}------------{:x}",
                         to_fetch.number(),
                         to_fetch_hash
                     );
-                    v_fetch.push(to_fetch_hash);
+                    v_fetch.push(to_fetch_hash.to_owned());
                 }
             }
         }

--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -40,7 +40,7 @@ impl OrphanBlockPool {
         while let Some(parent_hash) = queue.pop_front() {
             if let Entry::Occupied(entry) = guard.entry(parent_hash) {
                 let (_, orphaned) = entry.remove_entry();
-                queue.extend(orphaned.iter().map(|b| b.header().hash()));
+                queue.extend(orphaned.iter().map(|b| b.header().hash().to_owned()));
                 removed.extend(orphaned.into_iter());
             }
         }
@@ -74,7 +74,7 @@ mod tests {
 
     fn gen_block(parent_header: &Header) -> Block {
         let header = HeaderBuilder::default()
-            .parent_hash(parent_header.hash())
+            .parent_hash(parent_header.hash().to_owned())
             .timestamp(unix_time_as_millis())
             .number(parent_header.number() + 1)
             .nonce(parent_header.nonce() + 1)

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -134,7 +134,7 @@ where
     fn is_continuous(&self, headers: &[Header]) -> bool {
         for window in headers.windows(2) {
             if let [parent, header] = &window {
-                if header.parent_hash() != &parent.hash() {
+                if header.parent_hash() != parent.hash() {
                     debug!(
                         target: "sync",
                         "header.parent_hash {:?} parent.hash {:?}",
@@ -395,21 +395,21 @@ where
         if self.prev_block_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} prev_block", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_MASK);
             return result;
         }
 
         if self.non_contextual_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} non_contextual", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_MASK);
             return result;
         }
 
         if self.version_check(&mut result).is_err() {
             debug!(target: "sync", "HeadersProcess accept {:?} version", self.header.number());
             self.synchronizer
-                .insert_block_status(self.header.hash(), BlockStatus::FAILED_MASK);
+                .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_MASK);
             return result;
         }
 
@@ -423,7 +423,7 @@ where
                 .clone(),
         );
         self.synchronizer
-            .insert_block_status(self.header.hash(), BlockStatus::VALID_MASK);
+            .insert_block_status(self.header.hash().to_owned(), BlockStatus::VALID_MASK);
         result
     }
 }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -663,7 +663,8 @@ mod tests {
 
         BlockBuilder::default()
             .transaction(cellbase)
-            .with_header_builder(header_builder)
+            .header_builder(header_builder)
+            .build()
     }
 
     fn insert_block<CS: ChainStore>(

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -52,7 +52,7 @@ fn relay_compact_block_with_one_tx() {
             // building tx and broadcast it
             let tx = TransactionBuilder::default()
                 .input(CellInput::new(
-                    OutPoint::new(last_cellbase.hash(), 0),
+                    OutPoint::new(last_cellbase.hash().to_owned(), 0),
                     0,
                     vec![],
                 ))
@@ -213,7 +213,7 @@ fn relay_compact_block_with_missing_indexs() {
                 .map(|i| {
                     TransactionBuilder::default()
                         .input(CellInput::new(
-                            OutPoint::new(last_cellbase.hash(), u32::from(i)),
+                            OutPoint::new(last_cellbase.hash().to_owned(), u32::from(i)),
                             0,
                             vec![],
                         ))

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -100,7 +100,8 @@ fn relay_compact_block_with_one_tx() {
                 BlockBuilder::default()
                     .transaction(cellbase)
                     .proposal(tx.proposal_short_id())
-                    .with_header_builder(header_builder)
+                    .header_builder(header_builder)
+                    .build()
             };
 
             {
@@ -141,7 +142,8 @@ fn relay_compact_block_with_one_tx() {
                 BlockBuilder::default()
                     .transaction(cellbase)
                     .transaction(tx)
-                    .with_header_builder(header_builder)
+                    .header_builder(header_builder)
+                    .build()
             };
 
             {
@@ -264,7 +266,8 @@ fn relay_compact_block_with_missing_indexs() {
                 BlockBuilder::default()
                     .transaction(cellbase)
                     .proposals(txs.iter().map(Transaction::proposal_short_id).collect())
-                    .with_header_builder(header_builder)
+                    .header_builder(header_builder)
+                    .build()
             };
 
             {
@@ -305,7 +308,8 @@ fn relay_compact_block_with_missing_indexs() {
                 BlockBuilder::default()
                     .transaction(cellbase)
                     .transactions(txs)
-                    .with_header_builder(header_builder)
+                    .header_builder(header_builder)
+                    .build()
             };
 
             {
@@ -348,11 +352,13 @@ fn setup_node(
     Shared<ChainKVStore<MemoryKeyValueDB>>,
     ChainController,
 ) {
-    let mut block = BlockBuilder::default().with_header_builder(
-        HeaderBuilder::default()
-            .timestamp(unix_time_as_millis())
-            .difficulty(U256::from(1000u64)),
-    );
+    let mut block = BlockBuilder::default()
+        .header_builder(
+            HeaderBuilder::default()
+                .timestamp(unix_time_as_millis())
+                .difficulty(U256::from(1000u64)),
+        )
+        .build();
     let consensus = Consensus::default()
         .set_genesis_block(block.clone())
         .set_cellbase_maturity(0);
@@ -402,7 +408,8 @@ fn setup_node(
 
         block = BlockBuilder::default()
             .transaction(cellbase)
-            .with_header_builder(header_builder);
+            .header_builder(header_builder)
+            .build();
 
         chain_controller
             .process_block(Arc::new(block.clone()))

--- a/sync/src/tests/relayer.rs
+++ b/sync/src/tests/relayer.rs
@@ -91,7 +91,7 @@ fn relay_compact_block_with_one_tx() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash())
+                    .parent_hash(last_block.header().hash().to_owned())
                     .number(number)
                     .epoch(epoch.number())
                     .timestamp(timestamp)
@@ -133,7 +133,7 @@ fn relay_compact_block_with_one_tx() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash())
+                    .parent_hash(last_block.header().hash().to_owned())
                     .number(number)
                     .epoch(epoch.number())
                     .timestamp(timestamp)
@@ -257,7 +257,7 @@ fn relay_compact_block_with_missing_indexs() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash())
+                    .parent_hash(last_block.header().hash().to_owned())
                     .epoch(epoch.number())
                     .number(number)
                     .timestamp(timestamp)
@@ -299,7 +299,7 @@ fn relay_compact_block_with_missing_indexs() {
                     .build();
 
                 let header_builder = HeaderBuilder::default()
-                    .parent_hash(last_block.header().hash())
+                    .parent_hash(last_block.header().hash().to_owned())
                     .number(number)
                     .epoch(epoch.number())
                     .timestamp(timestamp)
@@ -400,7 +400,7 @@ fn setup_node(
             .build();
 
         let header_builder = HeaderBuilder::default()
-            .parent_hash(block.header().hash())
+            .parent_hash(block.header().hash().to_owned())
             .number(number)
             .epoch(epoch.number())
             .timestamp(timestamp)

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -67,11 +67,13 @@ fn setup_node(
     thread_name: &str,
     height: u64,
 ) -> (TestNode, Shared<ChainKVStore<MemoryKeyValueDB>>) {
-    let mut block = BlockBuilder::default().with_header_builder(
-        HeaderBuilder::default()
-            .timestamp(unix_time_as_millis())
-            .difficulty(U256::from(1000u64)),
-    );
+    let mut block = BlockBuilder::default()
+        .header_builder(
+            HeaderBuilder::default()
+                .timestamp(unix_time_as_millis())
+                .difficulty(U256::from(1000u64)),
+        )
+        .build();
 
     let consensus = Consensus::default().set_genesis_block(block.clone());
     let shared = SharedBuilder::<MemoryKeyValueDB>::new()
@@ -108,7 +110,8 @@ fn setup_node(
 
         block = BlockBuilder::default()
             .transaction(cellbase)
-            .with_header_builder(header_builder);
+            .header_builder(header_builder)
+            .build();
 
         chain_controller
             .process_block(Arc::new(block.clone()))

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -102,7 +102,7 @@ fn setup_node(
             .build();
 
         let header_builder = HeaderBuilder::default()
-            .parent_hash(block.header().hash())
+            .parent_hash(block.header().hash().to_owned())
             .number(number)
             .epoch(epoch.number())
             .timestamp(timestamp)

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -302,7 +302,7 @@ impl Peers {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HeaderView {
     inner: Header,
     total_difficulty: U256,

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -322,7 +322,7 @@ impl HeaderView {
         self.inner.number()
     }
 
-    pub fn hash(&self) -> H256 {
+    pub fn hash(&self) -> &H256 {
         self.inner.hash()
     }
 
@@ -478,7 +478,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     pub fn insert_epoch(&self, header: &Header, epoch: EpochExt) {
         let mut epoch_map = self.epoch_map.write();
         epoch_map.insert_index(
-            header.hash(),
+            header.hash().to_owned(),
             epoch.last_block_hash_in_previous_epoch().clone(),
         );
         epoch_map.insert_epoch(epoch.last_block_hash_in_previous_epoch().clone(), epoch);
@@ -522,12 +522,12 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         let mut step = 1;
         let mut locator = Vec::with_capacity(32);
         let mut index = start.number();
-        let mut base = start.hash();
+        let mut base = start.hash().to_owned();
         loop {
             let header = self
                 .get_ancestor(&base, index)
                 .expect("index calculated in get_locator");
-            locator.push(header.hash());
+            locator.push(header.hash().to_owned());
 
             if locator.len() >= 10 {
                 step <<= 1;
@@ -541,7 +541,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
                 break;
             }
             index -= step;
-            base = header.hash();
+            base = header.hash().to_owned();
         }
         locator
     }
@@ -645,7 +645,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         if let Some(last_time) = self
             .get_headers_cache
             .write()
-            .get_refresh(&(peer, header.hash()))
+            .get_refresh(&(peer, header.hash().to_owned()))
         {
             if Instant::now() < *last_time + GET_HEADERS_TIMEOUT {
                 debug!(
@@ -666,7 +666,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         }
         self.get_headers_cache
             .write()
-            .insert((peer, header.hash()), Instant::now());
+            .insert((peer, header.hash().to_owned()), Instant::now());
 
         debug!(target: "sync", "send_getheaders_to_peer peer={}, hash={}", peer, header.hash());
         let locator_hash = self.get_locator(header);

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -252,7 +252,8 @@ impl Node {
                     .collect::<Result<_, _>>()
                     .expect("parse proposal transactions failed"),
             )
-            .with_header_builder(header_builder)
+            .header_builder(header_builder)
+            .build()
     }
 
     pub fn new_transaction(&self, hash: H256) -> Transaction {

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -152,7 +152,7 @@ impl Node {
             .try_into()
             .expect("parse cellbase transaction failed");
         let mut rpc = self.rpc_client();
-        rpc.send_transaction((&self.new_transaction(cellbase.hash())).into())
+        rpc.send_transaction((&self.new_transaction(cellbase.hash().to_owned())).into())
             .call()
             .expect("rpc call send_transaction failed")
     }
@@ -164,7 +164,7 @@ impl Node {
             .try_into()
             .expect("parse cellbase transaction failed");
         let mut rpc = self.rpc_client();
-        rpc.trace_transaction((&self.new_transaction(cellbase.hash())).into())
+        rpc.trace_transaction((&self.new_transaction(cellbase.hash().to_owned())).into())
             .call()
             .expect("rpc call send_transaction failed")
     }

--- a/test/src/specs/tx_pool/cellbase_immature_tx.rs
+++ b/test/src/specs/tx_pool/cellbase_immature_tx.rs
@@ -15,7 +15,7 @@ impl Spec for CellbaseImmatureTx {
 
         info!("Use generated block's cellbase as tx input");
         let tip_block = node.get_tip_block();
-        let tx = node.new_transaction(tip_block.transactions()[0].hash());
+        let tx = node.new_transaction(tip_block.transactions()[0].hash().to_owned());
         let transaction_hash = tx.hash();
         node.rpc_client()
             .enqueue_test_transaction((&tx).into())

--- a/test/src/specs/tx_pool/depend_tx_in_same_block.rs
+++ b/test/src/specs/tx_pool/depend_tx_in_same_block.rs
@@ -42,8 +42,8 @@ impl Spec for DepentTxInSameBlock {
             .map(Transaction::hash)
             .collect();
 
-        assert!(commit_txs_hash.contains(&tx_hash_0));
-        assert!(commit_txs_hash.contains(&tx_hash_1));
+        assert!(commit_txs_hash.contains(&&tx_hash_0));
+        assert!(commit_txs_hash.contains(&&tx_hash_1));
     }
 
     fn num_nodes(&self) -> usize {

--- a/test/src/specs/tx_pool/different_txs_with_same_input.rs
+++ b/test/src/specs/tx_pool/different_txs_with_same_input.rs
@@ -18,8 +18,7 @@ impl Spec for DifferentTxsWithSameInput {
         // Set tx2 fee to a higher value
         let mut output = tx2_temp.outputs()[0].clone();
         output.capacity = capacity_bytes!(40_000);
-        let tx2 = TransactionBuilder::default()
-            .transaction(tx2_temp)
+        let tx2 = TransactionBuilder::from_transaction(tx2_temp)
             .outputs_clear()
             .output(output)
             .build();

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -368,7 +368,7 @@ impl<'a> From<&'a CoreHeader> for Header {
             uncles_hash: core.uncles_hash().to_owned(),
             uncles_count: core.uncles_count(),
             seal: core.seal().to_owned().into(),
-            hash: core.hash(),
+            hash: core.hash().to_owned(),
         }
     }
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -181,15 +181,13 @@ pub struct Transaction {
 
 impl<'a> From<&'a CoreTransaction> for Transaction {
     fn from(core: &CoreTransaction) -> Transaction {
-        let hash = core.hash();
-
         Transaction {
             version: core.version(),
             deps: core.deps().iter().cloned().map(Into::into).collect(),
             inputs: core.inputs().iter().cloned().map(Into::into).collect(),
             outputs: core.outputs().iter().cloned().map(Into::into).collect(),
             witnesses: core.witnesses().iter().map(Into::into).collect(),
-            hash,
+            hash: core.hash().to_owned(),
         }
     }
 }

--- a/util/occupied-capacity/tests/tests.rs
+++ b/util/occupied-capacity/tests/tests.rs
@@ -1,0 +1,44 @@
+use occupied_capacity::{capacity_bytes, Capacity, HasOccupiedCapacity, OccupiedCapacity};
+
+#[derive(HasOccupiedCapacity)]
+struct StructA {
+    f1: u32,
+    f2: Vec<u8>,
+}
+
+#[derive(HasOccupiedCapacity)]
+struct StructB(u32, Vec<u8>);
+
+#[derive(HasOccupiedCapacity)]
+struct StructA1 {
+    f1: u32,
+    f2: Vec<u8>,
+    #[free_capacity]
+    _f3: Vec<u8>,
+}
+
+#[derive(HasOccupiedCapacity)]
+struct StructB1(u32, Vec<u8>, #[free_capacity] Vec<u8>);
+
+#[test]
+pub fn capacity() {
+    let v = vec![0u8; 7];
+    assert_eq!(v.occupied_capacity().unwrap(), capacity_bytes!(7));
+    let u = 0u32;
+    assert_eq!(u.occupied_capacity().unwrap(), capacity_bytes!(4));
+    let a = StructA {
+        f1: 1,
+        f2: v.clone(),
+    };
+    assert_eq!(a.occupied_capacity().unwrap(), capacity_bytes!(11));
+    let a1 = StructA1 {
+        f1: 2,
+        f2: v.clone(),
+        _f3: v.clone(),
+    };
+    assert_eq!(a1.occupied_capacity().unwrap(), capacity_bytes!(11));
+    let b = StructB(3, v.clone());
+    assert_eq!(b.occupied_capacity().unwrap(), capacity_bytes!(11));
+    let b1 = StructB1(4, v.clone(), v.clone());
+    assert_eq!(b1.occupied_capacity().unwrap(), capacity_bytes!(11));
+}

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -302,7 +302,7 @@ where
         // TODO: cache context
         let mut excluded = FnvHashSet::default();
         let mut included = FnvHashSet::default();
-        excluded.insert(block.header().hash());
+        excluded.insert(block.header().hash().to_owned());
         let mut block_hash = block.header().parent_hash().to_owned();
         excluded.insert(block_hash.clone());
         for _ in 0..max_uncles_age {
@@ -311,7 +311,7 @@ where
                 excluded.insert(parent_hash.clone());
                 if let Some(uncles) = self.provider.uncles(&block_hash) {
                     uncles.iter().for_each(|uncle| {
-                        excluded.insert(uncle.header.hash());
+                        excluded.insert(uncle.header.hash().to_owned());
                     });
                 };
                 block_hash = parent_hash;
@@ -331,13 +331,15 @@ where
 
             let uncle_header = uncle.header.clone();
 
-            let uncle_hash = uncle_header.hash();
+            let uncle_hash = uncle_header.hash().to_owned();
             if included.contains(&uncle_hash) {
-                return Err(Error::Uncles(UnclesError::Duplicate(uncle_hash)));
+                return Err(Error::Uncles(UnclesError::Duplicate(uncle_hash.clone())));
             }
 
             if excluded.contains(&uncle_hash) {
-                return Err(Error::Uncles(UnclesError::InvalidInclude(uncle_hash)));
+                return Err(Error::Uncles(UnclesError::InvalidInclude(
+                    uncle_hash.clone(),
+                )));
             }
 
             if uncle_header.proposals_root() != &uncle.cal_proposals_root() {
@@ -453,7 +455,7 @@ impl<CP: ChainProvider + Clone> CommitVerifier<CP> {
         let mut block_hash = self
             .provider
             .get_ancestor(&block.header().parent_hash(), proposal_end)
-            .map(|h| h.hash())
+            .map(|h| h.hash().to_owned())
             .ok_or_else(|| Error::Commit(CommitError::AncestorNotFound))?;
 
         let mut proposal_txs_ids = FnvHashSet::default();

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -31,7 +31,7 @@ fn gen_block(
     let difficulty = parent_header.difficulty() + U256::from(1u64);
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash())
+        .parent_hash(parent_header.hash().to_owned())
         .timestamp(now)
         .number(number)
         .difficulty(difficulty)

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -110,7 +110,7 @@ fn setup_env() -> (
             100
         ])
         .build();
-    let tx_hash = tx.hash();
+    let tx_hash = tx.hash().to_owned();
     let genesis_block = BlockBuilder::default().transaction(tx).build();
     let consensus = Consensus::default().set_genesis_block(genesis_block);
     let (chain_controller, shared) = start_chain(Some(consensus));
@@ -125,7 +125,7 @@ fn test_proposal() {
     for _ in 0..20 {
         let tx = create_transaction(&prev_tx_hash);
         txs20.push(tx.clone());
-        prev_tx_hash = tx.hash();
+        prev_tx_hash = tx.hash().to_owned();
     }
 
     let proposal_window = shared.consensus().tx_proposal_window();
@@ -186,7 +186,7 @@ fn test_uncle_proposal() {
     for _ in 0..20 {
         let tx = create_transaction(&prev_tx_hash);
         txs20.push(tx.clone());
-        prev_tx_hash = tx.hash();
+        prev_tx_hash = tx.hash().to_owned();
     }
 
     let proposal_window = shared.consensus().tx_proposal_window();

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -42,7 +42,8 @@ fn gen_block(
         .transactions(transactions)
         .proposals(proposals)
         .uncles(uncles)
-        .with_header_builder(header_builder)
+        .header_builder(header_builder)
+        .build()
 }
 
 fn create_transaction(parent: &H256) -> Transaction {

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -26,7 +26,7 @@ fn gen_block(parent_header: &Header, nonce: u64, epoch: &EpochExt) -> Block {
     let number = parent_header.number() + 1;
     let cellbase = create_cellbase(number);
     let header_builder = HeaderBuilder::default()
-        .parent_hash(parent_header.hash())
+        .parent_hash(parent_header.hash().to_owned())
         .timestamp(now)
         .epoch(epoch.number())
         .number(number)
@@ -263,7 +263,7 @@ from_block(chain1[block_number].to_owned())          // block.number 10 epoch 1
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::InvalidInclude(
-                block.uncles()[0].header().hash()
+                block.uncles()[0].header().hash().to_owned()
             )))
         );
     }
@@ -359,7 +359,7 @@ from_block(chain1.get(block_number).cloned().unwrap())          // epoch 1
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::Duplicate(
-                block.uncles()[1].header().hash()
+                block.uncles()[1].header().hash().to_owned()
             )))
         );
     }


### PR DESCRIPTION
### Issue

#549

### Commits

1. feat: add an attribute allow to skip some fields when computing occupied capacity
   **WHY-NEED-THIS**: If adding the hash field to some structs, the hash field should be skipped when computing occupied capacity.
2. perf: calculate Header hash when constructing
3. test: correct existing tests for the modification of Header hash
4. perf: return a reference to replace an owned struct of `Header::hash()`
5. perf: calculate Transaction hash when constructing
6. perf: return a reference to replace an owned struct of `Transaction::hash()`
7. perf: do not calculate Header hash when fetching header from database

### Summary

1st commit, 2nd commit, 5th commit, 7th commit are important, other commits are just apply the core commits to tests.