### PR TITLE
ci: [only integration] control CI checks by the last commit message

### DIFF
--- a/devtools/ci/script.sh
+++ b/devtools/ci/script.sh
@@ -8,13 +8,27 @@ RUN_TEST=false
 # Run integration only in master, develop and rc branches
 RUN_INTEGRATION=false
 if [ "$TRAVIS_PULL_REQUEST" != false ]; then
-  RUN_TEST=true
+  LAST_COMMIT_MSG="$(git log --max-count 1 --skip 1 --format="%s")"
+  echo "Last commit message is \"${LAST_COMMIT_MSG}\""
+  if [[ "${LAST_COMMIT_MSG}" =~ ^[a-z]+:\ \[skip\ tests\]\  ]]; then
+      :
+  elif [[ "${LAST_COMMIT_MSG}" =~ ^[a-z]+:\ \[only\ integration\]\  ]]; then
+    RUN_INTEGRATION=true
+  elif [[ "${LAST_COMMIT_MSG}" =~ ^[a-z]+:\ \[all\ tests\]\  ]]; then
+    RUN_TEST=true
+    RUN_INTEGRATION=true
+  else
+    RUN_TEST=true
+  fi
 else
   RUN_INTEGRATION=true
   if [ "$TRAVIS_BRANCH" = master ]; then
     RUN_TEST=true
   fi
 fi
+
+echo "\${RUN_TEST} = ${RUN_TEST}"
+echo "\${RUN_INTEGRATION} = ${RUN_INTEGRATION}"
 
 if [ "$RUN_TEST" = true ]; then
   if [ "$FMT" = true ]; then


### PR DESCRIPTION
### Why Need This

For example, #541 and #646 don't have to run unit tests, and both of them should have to run integration tests.

Now, each reviewers have to run integration tests in his own laptop (not in CI) for reviewing (or approving).

### Solution

Use the last commit message to control CI checks.

#### Format

- Only one tag is allowed for **only one** commit message.

  There are only few tags at present:

  - `[only integration]`: only run integration tests

  - `[skip tests]`: skip all tests

  - `[all tests]`: run all tests

- The tag should be written **at start** of the commit message, so reviewers can see it clearly.

  Examples:

  - `ci: [only integration] control CI checks by the last commit message`