### PR TITLE
feat: Add syscall to load current script hash

### DIFF
--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -61,11 +61,21 @@ impl Script {
     }
 
     pub fn hash(&self) -> H256 {
+        self.hash_with_appended_arguments(&[])
+    }
+
+    // This calculates the script hash with provided arguments appended
+    // to the script's own argument list. This way we can calculate the
+    // script hash on &Script struct without needing to clone it.
+    pub fn hash_with_appended_arguments(&self, args: &[Bytes]) -> H256 {
         let mut bytes = vec![];
         bytes
             .write_all(self.code_hash.as_bytes())
             .expect(VEC_WRITE_ALL_EXPECT);
         for argument in &self.args {
+            bytes.write_all(argument).expect(VEC_WRITE_ALL_EXPECT);
+        }
+        for argument in args {
             bytes.write_all(argument).expect(VEC_WRITE_ALL_EXPECT);
         }
         blake2b_256(bytes).into()

--- a/script/src/common.rs
+++ b/script/src/common.rs
@@ -1,12 +1,6 @@
 use ckb_core::{cell::CellMeta, transaction::CellOutput};
 use ckb_store::ChainStore;
 
-#[derive(Debug, Clone, Copy)]
-pub enum CurrentCell {
-    Input(usize),
-    Output(usize),
-}
-
 /// Extend ChainStore
 /// Lazy load cell output from chain store
 pub trait LazyLoadCellOutput {

--- a/script/src/syscalls/load_cell.rs
+++ b/script/src/syscalls/load_cell.rs
@@ -1,4 +1,4 @@
-use crate::common::{CurrentCell, LazyLoadCellOutput};
+use crate::common::LazyLoadCellOutput;
 use crate::syscalls::{Source, ITEM_MISSING, LOAD_CELL_SYSCALL_NUMBER, SUCCESS};
 use ckb_core::cell::{CellMeta, ResolvedOutPoint};
 use ckb_protocol::CellOutput as FbsCellOutput;
@@ -14,7 +14,6 @@ pub struct LoadCell<'a, CS> {
     store: Arc<CS>,
     outputs: &'a [CellMeta],
     resolved_inputs: &'a [&'a ResolvedOutPoint],
-    current: CurrentCell,
     resolved_deps: &'a [&'a ResolvedOutPoint],
 }
 
@@ -23,14 +22,12 @@ impl<'a, CS: LazyLoadCellOutput + 'a> LoadCell<'a, CS> {
         store: Arc<CS>,
         outputs: &'a [CellMeta],
         resolved_inputs: &'a [&'a ResolvedOutPoint],
-        current: CurrentCell,
         resolved_deps: &'a [&'a ResolvedOutPoint],
     ) -> LoadCell<'a, CS> {
         LoadCell {
             store,
             outputs,
             resolved_inputs,
-            current,
             resolved_deps,
         }
     }
@@ -39,10 +36,6 @@ impl<'a, CS: LazyLoadCellOutput + 'a> LoadCell<'a, CS> {
         match source {
             Source::Input => self.resolved_inputs.get(index).and_then(|r| r.cell()),
             Source::Output => self.outputs.get(index),
-            Source::Current => match self.current {
-                CurrentCell::Input(index) => self.resolved_inputs.get(index).and_then(|r| r.cell()),
-                CurrentCell::Output(index) => self.outputs.get(index),
-            },
             Source::Dep => self.resolved_deps.get(index).and_then(|r| r.cell()),
         }
     }

--- a/script/src/syscalls/load_cell_by_field.rs
+++ b/script/src/syscalls/load_cell_by_field.rs
@@ -1,4 +1,4 @@
-use crate::common::{CurrentCell, LazyLoadCellOutput};
+use crate::common::LazyLoadCellOutput;
 use crate::syscalls::{
     utils::store_data, CellField, Source, ITEM_MISSING, LOAD_CELL_BY_FIELD_SYSCALL_NUMBER, SUCCESS,
 };
@@ -17,7 +17,6 @@ pub struct LoadCellByField<'a, CS> {
     store: Arc<CS>,
     outputs: &'a [CellMeta],
     resolved_inputs: &'a [&'a ResolvedOutPoint],
-    current: CurrentCell,
     resolved_deps: &'a [&'a ResolvedOutPoint],
 }
 
@@ -26,14 +25,12 @@ impl<'a, CS: LazyLoadCellOutput> LoadCellByField<'a, CS> {
         store: Arc<CS>,
         outputs: &'a [CellMeta],
         resolved_inputs: &'a [&'a ResolvedOutPoint],
-        current: CurrentCell,
         resolved_deps: &'a [&'a ResolvedOutPoint],
     ) -> LoadCellByField<'a, CS> {
         LoadCellByField {
             store,
             outputs,
             resolved_inputs,
-            current,
             resolved_deps,
         }
     }
@@ -42,10 +39,6 @@ impl<'a, CS: LazyLoadCellOutput> LoadCellByField<'a, CS> {
         match source {
             Source::Input => self.resolved_inputs.get(index).and_then(|r| r.cell()),
             Source::Output => self.outputs.get(index),
-            Source::Current => match self.current {
-                CurrentCell::Input(index) => self.resolved_inputs.get(index).and_then(|r| r.cell()),
-                CurrentCell::Output(index) => self.outputs.get(index),
-            },
             Source::Dep => self.resolved_deps.get(index).and_then(|r| r.cell()),
         }
     }

--- a/script/src/syscalls/load_header.rs
+++ b/script/src/syscalls/load_header.rs
@@ -1,4 +1,3 @@
-use crate::common::CurrentCell;
 use crate::syscalls::{Source, ITEM_MISSING, LOAD_HEADER_SYSCALL_NUMBER, SUCCESS};
 use ckb_core::cell::ResolvedOutPoint;
 use ckb_core::header::Header;
@@ -13,19 +12,16 @@ use std::cmp;
 #[derive(Debug)]
 pub struct LoadHeader<'a> {
     resolved_inputs: &'a [&'a ResolvedOutPoint],
-    current: CurrentCell,
     resolved_deps: &'a [&'a ResolvedOutPoint],
 }
 
 impl<'a> LoadHeader<'a> {
     pub fn new(
         resolved_inputs: &'a [&'a ResolvedOutPoint],
-        current: CurrentCell,
         resolved_deps: &'a [&'a ResolvedOutPoint],
     ) -> LoadHeader<'a> {
         LoadHeader {
             resolved_inputs,
-            current,
             resolved_deps,
         }
     }
@@ -34,12 +30,6 @@ impl<'a> LoadHeader<'a> {
         match source {
             Source::Input => self.resolved_inputs.get(index).and_then(|r| r.header()),
             Source::Output => None,
-            Source::Current => match self.current {
-                CurrentCell::Input(index) => {
-                    self.resolved_inputs.get(index).and_then(|r| r.header())
-                }
-                CurrentCell::Output(_) => None,
-            },
             Source::Dep => self.resolved_deps.get(index).and_then(|r| r.header()),
         }
     }

--- a/script/src/syscalls/load_input_by_field.rs
+++ b/script/src/syscalls/load_input_by_field.rs
@@ -13,22 +13,17 @@ use flatbuffers::FlatBufferBuilder;
 #[derive(Debug)]
 pub struct LoadInputByField<'a> {
     inputs: &'a [&'a CellInput],
-    current: Option<&'a CellInput>,
 }
 
 impl<'a> LoadInputByField<'a> {
-    pub fn new(
-        inputs: &'a [&'a CellInput],
-        current: Option<&'a CellInput>,
-    ) -> LoadInputByField<'a> {
-        LoadInputByField { inputs, current }
+    pub fn new(inputs: &'a [&'a CellInput]) -> LoadInputByField<'a> {
+        LoadInputByField { inputs }
     }
 
     fn fetch_input(&self, source: Source, index: usize) -> Option<&CellInput> {
         match source {
             Source::Input => self.inputs.get(index).cloned(),
             Source::Output => None,
-            Source::Current => self.current,
             Source::Dep => None,
         }
     }

--- a/script/src/syscalls/load_script_hash.rs
+++ b/script/src/syscalls/load_script_hash.rs
@@ -1,0 +1,34 @@
+use crate::syscalls::{utils::store_data, LOAD_SCRIPT_HASH_SYSCALL_NUMBER, SUCCESS};
+use ckb_vm::{
+    registers::{A0, A7},
+    Error as VMError, Register, SupportMachine, Syscalls,
+};
+
+#[derive(Debug)]
+pub struct LoadScriptHash<'a> {
+    hash: &'a [u8],
+}
+
+impl<'a> LoadScriptHash<'a> {
+    pub fn new(hash: &'a [u8]) -> LoadScriptHash<'a> {
+        LoadScriptHash { hash }
+    }
+}
+
+impl<'a, Mac: SupportMachine> Syscalls<Mac> for LoadScriptHash<'a> {
+    fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
+        Ok(())
+    }
+
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, VMError> {
+        if machine.registers()[A7].to_u64() != LOAD_SCRIPT_HASH_SYSCALL_NUMBER {
+            return Ok(false);
+        }
+
+        store_data(machine, &self.hash)?;
+
+        machine.set_register(A0, Mac::REG::from_u8(SUCCESS));
+        machine.add_cycles((self.hash.len() as u64 + 1) * 10)?;
+        Ok(true)
+    }
+}


### PR DESCRIPTION
All the other methods to load current cell's information, such as
capacity, data, etc. are also removed in this commit. This way we can
enable group based transaction validation which saves cycles for
duplicate scripts.

TODO:

* [x] RFC: https://github.com/nervosnetwork/rfcs/pull/112