### PR TITLE
fix: Use the String alias type EpochNumber

### DIFF
--- a/core/src/extras.rs
+++ b/core/src/extras.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumber, Capacity};
+use crate::{EpochNumber, BlockNumber, Capacity};
 use failure::Error as FailureError;
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
@@ -23,7 +23,7 @@ pub struct TransactionAddress {
 
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct EpochExt {
-    pub(crate) number: u64,
+    pub(crate) number: EpochNumber,
     pub(crate) block_reward: Capacity,
     pub(crate) remainder_reward: Capacity,
     pub(crate) last_block_hash_in_previous_epoch: H256,

--- a/core/src/extras.rs
+++ b/core/src/extras.rs
@@ -1,4 +1,4 @@
-use crate::{EpochNumber, BlockNumber, Capacity};
+use crate::{BlockNumber, Capacity, EpochNumber};
 use failure::Error as FailureError;
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -494,7 +494,7 @@ impl TryFrom<Block> for CoreBlock {
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct EpochExt {
-    pub number: String,
+    pub number: EpochNumber,
     pub block_reward: String,
     pub last_block_hash_in_previous_epoch: H256,
     pub start_number: BlockNumber,


### PR DESCRIPTION
Hide the real `String` type just as the way we use `BlockNumber`.