### PR TITLE
refactor: move VM config from chain spec to CKB config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "ckb-pow 0.12.0-pre",
  "ckb-resource 0.12.0-pre",
  "ckb-rpc 0.12.0-pre",
+ "ckb-script 0.12.0-pre",
  "ckb-shared 0.12.0-pre",
  "ckb-sync 0.12.0-pre",
  "ckb-verification 0.12.0-pre",
@@ -663,7 +664,6 @@ name = "ckb-script"
 version = "0.12.0-pre"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-chain-spec 0.12.0-pre",
  "ckb-core 0.12.0-pre",
  "ckb-db 0.12.0-pre",
  "ckb-protocol 0.12.0-pre",
@@ -677,6 +677,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -687,6 +689,7 @@ dependencies = [
  "ckb-core 0.12.0-pre",
  "ckb-db 0.12.0-pre",
  "ckb-protocol 0.12.0-pre",
+ "ckb-script 0.12.0-pre",
  "ckb-store 0.12.0-pre",
  "ckb-traits 0.12.0-pre",
  "ckb-util 0.12.0-pre",

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -515,7 +515,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
         // The verify function
         let txs_verifier = TransactionsVerifier::new(
             self.shared.consensus().max_block_cycles(),
-            self.shared.consensus().vm(),
+            self.shared.script_config(),
         );
 
         let mut found_error = None;

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -84,3 +84,6 @@ txs_verify_cache_size = 100000
 # value is set as always success binary hash
 code_hash = "0x0000000000000000000000000000000000000000000000000000000000000001"
 args = []
+
+[script]
+runner = "Assembly"

--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -17,9 +17,6 @@ epoch_reward = 5_000_000_000_000_000
 max_block_cycles = 20_000_000_000
 cellbase_maturity = 0
 
-[vm]
-runner = "Assembly"
-
 [pow]
 func = "Cuckoo"
 

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -17,9 +17,6 @@ epoch_reward = 5_000_000_000_000_000
 max_block_cycles = 20_000_000_000
 cellbase_maturity = 10
 
-[vm]
-runner = "Assembly"
-
 [pow]
 func = "Cuckoo"
 

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -18,7 +18,8 @@ fnv = "1.0.3"
 flatbuffers = "0.6.0"
 log = "0.4"
 ckb-protocol = { path = "../protocol" }
-ckb-chain-spec = { path = "../spec" }
+serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -4,8 +4,26 @@ mod syscalls;
 mod verify;
 
 use ckb_vm::Error as VMInternalError;
+use serde_derive::{Deserialize, Serialize};
 
 pub use crate::verify::TransactionScriptsVerifier;
+
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
+pub enum Runner {
+    Assembly,
+    Rust,
+}
+
+impl Default for Runner {
+    fn default() -> Runner {
+        Runner::Assembly
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug, Default)]
+pub struct ScriptConfig {
+    pub runner: Runner,
+}
 
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
 pub enum ScriptError {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -25,6 +25,7 @@ ckb-verification = { path = "../verification" }
 linked-hash-map = { git = "https://github.com/nervosnetwork/linked-hash-map", rev = "df27f21" }
 ckb-protocol = { path = "../protocol" }
 flatbuffers = "0.5.0"
+ckb-script = { path = "../script" }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -1,4 +1,3 @@
-use crate::Vm;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
@@ -55,7 +54,6 @@ pub struct Consensus {
     pub epoch_duration_target: u64,
     pub tx_proposal_window: ProposalWindow,
     pub pow: Pow,
-    pub vm: Vm,
     // For each input, if the referenced output transaction is cellbase,
     // it must have at least `cellbase_maturity` confirmations;
     // else reject this transaction.
@@ -100,7 +98,6 @@ impl Default for Consensus {
             orphan_rate_target_recip: ORPHAN_RATE_TARGET_RECIP,
             epoch_duration_target: EPOCH_DURATION_TARGET,
             tx_proposal_window: TX_PROPOSAL_WINDOW,
-            vm: Vm::Assembly,
             pow: Pow::Dummy(Default::default()),
             cellbase_maturity: CELLBASE_MATURITY,
             median_time_block_count: MEDIAN_TIME_BLOCK_COUNT,
@@ -152,11 +149,6 @@ impl Consensus {
 
     pub fn set_pow(mut self, pow: Pow) -> Self {
         self.pow = pow;
-        self
-    }
-
-    pub fn set_vm(mut self, vm: Vm) -> Self {
-        self.vm = vm;
         self
     }
 
@@ -344,9 +336,5 @@ impl Consensus {
         } else {
             None
         }
-    }
-
-    pub fn vm(&self) -> &Vm {
-        &self.vm
     }
 }

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -37,7 +37,6 @@ pub struct ChainSpec {
     pub params: Params,
     pub system_cells: Vec<Resource>,
     pub pow: Pow,
-    pub vm: Vm,
 }
 
 // change the order will break integration test, see module doc.
@@ -48,7 +47,6 @@ pub struct ChainSpecConfig {
     pub params: Params,
     pub system_cells: Vec<SystemCell>,
     pub pow: Pow,
-    pub vm: Vm,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -78,13 +76,6 @@ pub struct Seal {
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct SystemCell {
     pub path: PathBuf,
-}
-
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
-#[serde(tag = "runner")]
-pub enum Vm {
-    Assembly,
-    Rust,
 }
 
 #[derive(Debug)]
@@ -163,7 +154,6 @@ impl ChainSpec {
             genesis: spec_config.genesis,
             params: spec_config.params,
             pow: spec_config.pow,
-            vm: spec_config.vm,
         })
     }
 
@@ -248,8 +238,7 @@ impl ChainSpec {
             .set_cellbase_maturity(self.params.cellbase_maturity)
             .set_epoch_reward(self.params.epoch_reward)
             .set_max_block_cycles(self.params.max_block_cycles)
-            .set_pow(self.pow.clone())
-            .set_vm(self.vm.clone());
+            .set_pow(self.pow.clone());
 
         Ok(consensus)
     }

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -21,6 +21,7 @@ pub fn run(args: RunArgs) -> Result<(), ExitCode> {
         .consensus(args.consensus)
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool)
+        .script_config(args.config.script)
         .build()
         .map_err(|err| {
             eprintln!("Run error: {:?}", err);

--- a/test/integration.toml
+++ b/test/integration.toml
@@ -17,9 +17,6 @@ epoch_reward = 5_000_000_000_000_000
 max_block_cycles = 100000000
 cellbase_maturity = 0
 
-[vm]
-runner = "Assembly"
-
 [pow]
 func = "Dummy"
 

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -25,6 +25,7 @@ ckb-shared = { path = "../../shared" }
 ckb-sync = { path = "../../sync"}
 build-info = { path = "../build-info" }
 ckb-verification = { path = "../../verification" }
+ckb-script = { path = "../../script" }
 
 [build-dependencies]
 build-info = { path = "../build-info" }

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -16,6 +16,7 @@ use ckb_miner::MinerConfig;
 use ckb_network::NetworkConfig;
 use ckb_resource::{Resource, ResourceLocator};
 use ckb_rpc::Config as RpcConfig;
+use ckb_script::ScriptConfig;
 use ckb_shared::tx_pool::TxPoolConfig;
 use ckb_sync::Config as SyncConfig;
 use logger::Config as LogConfig;
@@ -48,6 +49,7 @@ pub struct CKBAppConfig {
     pub rpc: RpcConfig,
     pub sync: SyncConfig,
     pub tx_pool: TxPoolConfig,
+    pub script: ScriptConfig,
 }
 
 // change the order of fields will break integration test, see module doc.

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -1,13 +1,13 @@
 use crate::error::{CellbaseError, CommitError, Error, UnclesError};
 use crate::header_verifier::HeaderResolver;
 use crate::{TransactionVerifier, Verifier};
-use ckb_chain_spec::Vm;
 use ckb_core::cell::ResolvedTransaction;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
 use ckb_core::transaction::{Capacity, CellInput, Transaction};
 use ckb_core::Cycle;
 use ckb_core::{block::Block, BlockNumber};
+use ckb_script::ScriptConfig;
 use ckb_store::ChainStore;
 use ckb_traits::{BlockMedianTimeContext, ChainProvider};
 use fnv::FnvHashSet;
@@ -353,12 +353,15 @@ where
 #[derive(Clone)]
 pub struct TransactionsVerifier<'a> {
     max_cycles: Cycle,
-    vm: &'a Vm,
+    script_config: &'a ScriptConfig,
 }
 
 impl<'a> TransactionsVerifier<'a> {
-    pub fn new(max_cycles: Cycle, vm: &'a Vm) -> Self {
-        TransactionsVerifier { max_cycles, vm }
+    pub fn new(max_cycles: Cycle, script_config: &'a ScriptConfig) -> Self {
+        TransactionsVerifier {
+            max_cycles,
+            script_config,
+        }
     }
 
     pub fn verify<M, CS: ChainStore>(
@@ -397,7 +400,7 @@ impl<'a> TransactionsVerifier<'a> {
                     &block_median_time_context,
                     tip_number,
                     cellbase_maturity,
-                    self.vm,
+                    &self.script_config,
                 )
                 .verify(self.max_cycles)
                 .map_err(|e| Error::Transactions((index, e)))


### PR DESCRIPTION
#642 made a mistake: the flag for enabling assembly based VM is mistakenly put into chain spec. Since this shouldn't affect consensus, it should be a CKB config, not a chain spec config. This PR fixes this.