### PR TITLE
fix: Information is inconsistent with the transaction pool display

### DIFF
--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -80,7 +80,11 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
             tx_pool
                 .get_tx_from_staging(&id)
                 .map(TransactionWithStatus::with_proposed)
-                .or_else(|| tx_pool.get_tx(&id).map(TransactionWithStatus::with_pending))
+                .or_else(|| {
+                    tx_pool
+                        .get_tx_without_conflict(&id)
+                        .map(TransactionWithStatus::with_pending)
+                })
         };
 
         Ok(tx.or_else(|| {

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -151,6 +151,14 @@ impl TxPool {
             .cloned()
     }
 
+    pub fn get_tx_without_conflict(&self, id: &ProposalShortId) -> Option<Transaction> {
+        self.pending
+            .get_tx(id)
+            .or_else(|| self.staging.get_tx(id))
+            .or_else(|| self.orphan.get_tx(id))
+            .cloned()
+    }
+
     pub fn get_tx_from_staging(&self, id: &ProposalShortId) -> Option<Transaction> {
         self.staging.get_tx(id).cloned()
     }


### PR DESCRIPTION
`get_transaction` RPC information is inconsistent with the transaction pool display