### PR TITLE
perf: store transaction hashes into database to avoid computing them again

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -1,5 +1,5 @@
 use crate::header::{Header, HeaderBuilder};
-use crate::transaction::{ProposalShortId, Transaction};
+use crate::transaction::{ProposalShortId, Transaction, TransactionStored};
 use crate::uncle::{uncles_hash, UncleBlock};
 use ckb_merkle_tree::merkle_root;
 use fnv::FnvHashSet;
@@ -76,6 +76,13 @@ impl Block {
 
     pub fn transactions(&self) -> &[Transaction] {
         &self.transactions
+    }
+
+    pub fn stored_transactions(&self) -> Vec<TransactionStored> {
+        self.transactions
+            .iter()
+            .map(Transaction::to_stored)
+            .collect::<Vec<_>>()
     }
 
     pub fn proposals(&self) -> &[ProposalShortId] {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -226,7 +226,10 @@ impl BlockBuilder {
         self
     }
 
-    pub fn unsafe_build(self) -> Block {
+    /// # Warning
+    ///
+    /// For testing purpose only, this method is used to construct a incorrect Block.
+    pub unsafe fn build_unchecked(self) -> Block {
         let Self {
             header_builder,
             uncles,

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -113,13 +113,21 @@ pub struct Header {
     hash: H256,
 }
 
+// The order of fields should be same as Header deserialization
+#[derive(Deserialize)]
+struct HeaderKernel {
+    raw: RawHeader,
+    seal: Seal,
+}
+
+// The order of fields should be same as HeaderKernel deserialization
 impl<'de> serde::de::Deserialize<'de> for Header {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
         #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
+        #[serde(field_identifier, rename_all = "snake_case")]
         enum Field {
             Raw,
             Seal,
@@ -222,12 +230,11 @@ impl Header {
         header
     }
 
-    pub fn from_bytes_with_hash(bytes: &[u8], hash: H256) -> Self {
-        #[derive(Deserialize)]
-        struct HeaderKernel {
-            raw: RawHeader,
-            seal: Seal,
-        }
+    /// # Warning
+    ///
+    /// When using this method, the caller should ensure the input hash is right, or the caller
+    /// will get a incorrect Header.
+    pub unsafe fn from_bytes_with_hash_unchecked(bytes: &[u8], hash: H256) -> Self {
         let HeaderKernel { raw, seal } =
             deserialize(bytes).expect("header kernel deserializing should be ok");
         Self { raw, seal, hash }

--- a/db/src/rocksdb.rs
+++ b/db/src/rocksdb.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 //      - If the data can be migrated manually: update "x.y1.z" to "x.y2.0".
 //      - If the data can not be migrated: update "x1.y.z" to "x2.0.0".
 pub(crate) const VERSION_KEY: &str = "db-version";
-pub(crate) const VERSION_VALUE: &str = "0.3.0";
+pub(crate) const VERSION_VALUE: &str = "0.4.0";
 
 pub struct RocksDB {
     inner: Arc<DB>,

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -667,11 +667,13 @@ mod tests {
             .nonce(nonce)
             .build();
 
-        BlockBuilder::default()
-            .header(header)
-            .transaction(cellbase)
-            .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-            .unsafe_build()
+        unsafe {
+            BlockBuilder::default()
+                .header(header)
+                .transaction(cellbase)
+                .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
+                .build_unchecked()
+        }
     }
 
     fn create_cellbase(number: BlockNumber, epoch: &EpochExt) -> Transaction {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -140,7 +140,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
 
     fn get_header(&self, h: &H256) -> Option<Header> {
         self.get(COLUMN_BLOCK_HEADER, h.as_bytes())
-            .map(|ref raw| Header::from_bytes_with_hash(raw, h.to_owned()))
+            .map(|ref raw| unsafe { Header::from_bytes_with_hash_unchecked(raw, h.to_owned()) })
     }
 
     fn get_block_uncles(&self, h: &H256) -> Option<Vec<UncleBlock>> {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -10,9 +10,7 @@ use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::cell::CellMeta;
 use ckb_core::extras::{BlockExt, EpochExt, TransactionAddress};
 use ckb_core::header::{BlockNumber, Header};
-use ckb_core::transaction::{
-    CellOutPoint, CellOutput, ProposalShortId, Transaction, TransactionBuilder,
-};
+use ckb_core::transaction::{CellOutPoint, CellOutput, ProposalShortId, Transaction};
 use ckb_core::uncle::UncleBlock;
 use ckb_core::EpochNumber;
 use ckb_db::{Col, DbBatch, Error, KeyValueDB};
@@ -163,19 +161,20 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
                     deserialize(&serialized_addresses).expect("deserialize address should be ok");
                 self.get(COLUMN_BLOCK_BODY, h.as_bytes())
                     .map(|serialized_body| {
-                        let txs: Vec<TransactionBuilder> = addresses
+                        let txs: Vec<Transaction> = addresses
                             .iter()
                             .filter_map(|address| {
                                 serialized_body
                                     .get(address.offset..(address.offset + address.length))
-                                    .map(TransactionBuilder::new)
+                                    .map(|ref bytes| unsafe {
+                                        Transaction::from_bytes_unchecked(bytes)
+                                    })
                             })
                             .collect();
 
                         txs
                     })
             })
-            .map(|txs| txs.into_iter().map(TransactionBuilder::build).collect())
     }
 
     fn get_block_ext(&self, block_hash: &H256) -> Option<BlockExt> {
@@ -263,7 +262,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
             )
             .map(|ref serialized_transaction| {
                 (
-                    TransactionBuilder::new(serialized_transaction).build(),
+                    unsafe { Transaction::from_bytes_unchecked(serialized_transaction) },
                     d.block_hash,
                 )
             })
@@ -322,7 +321,7 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
         self.insert_serialize(COLUMN_BLOCK_UNCLE, hash.as_bytes(), b.uncles())?;
         self.insert_serialize(COLUMN_BLOCK_PROPOSAL_IDS, hash.as_bytes(), b.proposals())?;
         let (block_data, block_addresses) =
-            flat_serialize(b.transactions().iter()).expect("flat serialize should be ok");
+            flat_serialize(b.stored_transactions().iter()).expect("flat serialize should be ok");
         self.insert_raw(COLUMN_BLOCK_BODY, hash.as_bytes(), &block_data)?;
         self.insert_serialize(
             COLUMN_BLOCK_TRANSACTION_ADDRESSES,
@@ -337,11 +336,11 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
 
     fn attach_block(&mut self, block: &Block) -> Result<(), Error> {
         let hash = block.header().hash();
-        let addresses = serialized_addresses(block.transactions().iter())
+        let addresses = serialized_addresses(block.stored_transactions().iter())
             .expect("serialize addresses should be ok");
         for (id, tx) in block.transactions().iter().enumerate() {
             let address = TransactionAddress {
-                block_hash: hash.clone(),
+                block_hash: hash.to_owned(),
                 offset: addresses[id].offset,
                 length: addresses[id].length,
             };
@@ -350,7 +349,7 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
             let cellbase = id == 0;
             for (index, output) in tx.outputs().iter().enumerate() {
                 let out_point = CellOutPoint {
-                    tx_hash: tx_hash.clone(),
+                    tx_hash: tx_hash.to_owned(),
                     index: index as u32,
                 };
                 let store_key = cell_store_key(&tx_hash, index as u32);
@@ -422,6 +421,7 @@ mod tests {
     use super::*;
     use crate::store::StoreBatch;
     use ckb_chain_spec::consensus::Consensus;
+    use ckb_core::transaction::TransactionBuilder;
     use ckb_db::{DBConfig, RocksDB};
     use tempfile;
 

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -126,9 +126,11 @@ fn test_uncle_verifier() {
             .unwrap_or(parent_epoch);
         let verifier = UnclesVerifier::new(shared.clone(), &epoch);
 
-        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
-            .uncle(chain2.last().cloned().unwrap().into())
-            .unsafe_build();
+        let block = unsafe {
+            BlockBuilder::from_block(chain1.last().cloned().unwrap())
+                .uncle(chain2.last().cloned().unwrap().into())
+                .build_unchecked()
+        };
 
         assert_eq!(
             verifier.verify(&block),
@@ -149,10 +151,12 @@ fn test_uncle_verifier() {
             .unwrap_or(parent_epoch);
         let verifier = UnclesVerifier::new(shared.clone(), &epoch);
         // header has 1 uncle, but body has empty uncles
-        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
-            .header(HeaderBuilder::default().uncles_count(1).build())
-            .uncle(chain2.last().cloned().unwrap().into())
-            .unsafe_build();
+        let block = unsafe {
+            BlockBuilder::from_block(chain1.last().cloned().unwrap())
+                .header(HeaderBuilder::default().uncles_count(1).build())
+                .uncle(chain2.last().cloned().unwrap().into())
+                .build_unchecked()
+        };
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::InvalidHash {
@@ -163,14 +167,16 @@ fn test_uncle_verifier() {
 
         // header has empty uncles, but body has 1 uncle
         let uncles_hash = uncles_hash(&[chain2.last().cloned().unwrap().into()]);
-        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
-            .header(
-                HeaderBuilder::from_header(chain1.last().cloned().unwrap().header().to_owned())
-                    .uncles_count(0)
-                    .uncles_hash(uncles_hash.clone())
-                    .build(),
-            )
-            .unsafe_build();
+        let block = unsafe {
+            BlockBuilder::from_block(chain1.last().cloned().unwrap())
+                .header(
+                    HeaderBuilder::from_header(chain1.last().cloned().unwrap().header().to_owned())
+                        .uncles_count(0)
+                        .uncles_hash(uncles_hash.clone())
+                        .build(),
+                )
+                .build_unchecked()
+        };
         assert_eq!(
             verifier.verify(&block),
             Err(Error::Uncles(UnclesError::InvalidHash {
@@ -301,9 +307,11 @@ from_block(chain1.get(block_number).cloned().unwrap())          // epoch 1
             .unwrap_or(parent_epoch);
         let verifier = UnclesVerifier::new(shared.clone(), &epoch);
 
-        let uncle = BlockBuilder::from_block(chain2[6].to_owned())
-            .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-            .unsafe_build();
+        let uncle = unsafe {
+            BlockBuilder::from_block(chain2[6].to_owned())
+                .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
+                .build_unchecked()
+        };
         let block = BlockBuilder::from_block(chain1[8].to_owned())
             .uncle(uncle.into())
             .header_builder(HeaderBuilder::from_header(chain1[8].header().to_owned()))


### PR DESCRIPTION
### Commits

- perf: store transaction hashes into database to avoid computing them again

  **BREAKING CHANGE**: The format of block data in database is changed.

- chore: add `unsafe` to few constructors which may cause bugs and rename them to `xxx_unchecked`

### Associated Issue

#549