### PR TITLE
feat: rpc get blockchain info

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -62,8 +62,8 @@ listen_address = "0.0.0.0:8114" # {{
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760
 
-# List of API modules: ["Net", "Pool", "Miner", "Chain", "Trace"]
-modules = ["Net", "Pool", "Miner", "Chain"] # {{
+# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Trace"]
+modules = ["Net", "Pool", "Miner", "Chain", "Stats"] # {{
 # integration => modules = ["Net", "Pool", "Miner", "Chain", "Trace", "IntegrationTest"]
 # }}
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -730,3 +730,54 @@ curl -H 'content-type:application/json' \
     "id": 2
 }
 ```
+
+### get_blochchain_info
+
+Return state info of blockchain
+
+#### Examples
+
+```bash
+curl -H 'content-type:application/json' \
+    -d '{"id": 2, "jsonrpc": "2.0", "method": "get_blochchain_info", "params": []}' \
+    http://localhost:8114'
+```
+
+```json
+{
+   "result" : {
+      "is_initial_block_download" : false,
+      "epoch" : "0",
+      "difficulty" : "0x100",
+      "median_time" : "1557287480008",
+      "chain" : "ckb_dev",
+      "warnings" : ""
+   },
+   "id" : 2,
+   "jsonrpc" : "2.0"
+}
+```
+
+### get_peers_state
+
+Return state info of peers
+
+```bash
+curl -H 'content-type:application/json' \
+    -d '{"id": 2, "jsonrpc": "2.0", "method": "get_peers_state", "params": []}' \
+    http://localhost:8114'
+```
+
+```json
+{
+   "result" : [
+      {
+         "last_updated" : "1557289448237",
+         "blocks_in_flight" : "86",
+         "peer" : "1"
+      }
+   ],
+   "jsonrpc" : "2.0",
+   "id" : 2
+}
+```

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -7,6 +7,7 @@ pub enum Module {
     Miner,
     Pool,
     Trace,
+    Stats,
     IntegrationTest,
 }
 
@@ -37,6 +38,10 @@ impl Config {
 
     pub(crate) fn trace_enable(&self) -> bool {
         self.modules.contains(&Module::Trace)
+    }
+
+    pub(crate) fn stats_enable(&self) -> bool {
+        self.modules.contains(&Module::Stats)
     }
 
     pub(crate) fn integration_test_enable(&self) -> bool {

--- a/rpc/src/module/mod.rs
+++ b/rpc/src/module/mod.rs
@@ -2,6 +2,7 @@ mod chain;
 mod miner;
 mod net;
 mod pool;
+mod stats;
 mod test;
 mod trace;
 
@@ -9,5 +10,6 @@ pub(crate) use self::chain::{ChainRpc, ChainRpcImpl};
 pub(crate) use self::miner::{MinerRpc, MinerRpcImpl};
 pub(crate) use self::net::{NetworkRpc, NetworkRpcImpl};
 pub(crate) use self::pool::{PoolRpc, PoolRpcImpl};
+pub(crate) use self::stats::{StatsRpc, StatsRpcImpl};
 pub(crate) use self::test::{IntegrationTestRpc, IntegrationTestRpcImpl};
 pub(crate) use self::trace::{TraceRpc, TraceRpcImpl};

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -1,0 +1,63 @@
+use ckb_shared::shared::Shared;
+use ckb_store::ChainStore;
+use ckb_sync::Synchronizer;
+use ckb_traits::BlockMedianTimeContext;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+use jsonrpc_types::{ChainInfo, PeerState};
+
+#[rpc]
+pub trait StatsRpc {
+    #[rpc(name = "get_blockchain_info")]
+    fn get_blockchain_info(&self) -> Result<ChainInfo>;
+
+    #[rpc(name = "get_peers_state")]
+    fn get_peers_state(&self) -> Result<Vec<PeerState>>;
+}
+
+pub(crate) struct StatsRpcImpl<CS>
+where
+    CS: ChainStore,
+{
+    pub shared: Shared<CS>,
+    pub synchronizer: Synchronizer<CS>,
+}
+
+impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
+    fn get_blockchain_info(&self) -> Result<ChainInfo> {
+        let chain = self.synchronizer.shared.consensus().id.clone();
+        let (tip_header, median_time) = {
+            let chain_state = self.shared.chain_state().lock();
+            let tip_header = chain_state.tip_header().clone();
+            let median_time = (&*chain_state)
+                .block_median_time(tip_header.number())
+                .expect("current block median time should exists");
+            (tip_header, median_time)
+        };
+        let epoch = tip_header.epoch();
+        let difficulty = tip_header.difficulty().clone();
+        let is_initial_block_download = self.synchronizer.shared.is_initial_block_download();
+
+        Ok(ChainInfo {
+            chain,
+            median_time: median_time.to_string(),
+            epoch: epoch.to_string(),
+            difficulty,
+            is_initial_block_download,
+            warnings: String::new(),
+        })
+    }
+
+    fn get_peers_state(&self) -> Result<Vec<PeerState>> {
+        Ok(self
+            .synchronizer
+            .peers()
+            .blocks_inflight
+            .read()
+            .iter()
+            .map(|(peer, in_flight)| {
+                PeerState::new(peer.value(), in_flight.timestamp, in_flight.blocks.len())
+            })
+            .collect())
+    }
+}

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,13 +1,15 @@
 use crate::config::Config;
 use crate::module::{
     ChainRpc, ChainRpcImpl, IntegrationTestRpc, IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl,
-    NetworkRpc, NetworkRpcImpl, PoolRpc, PoolRpcImpl, TraceRpc, TraceRpcImpl,
+    NetworkRpc, NetworkRpcImpl, PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl, TraceRpc,
+    TraceRpcImpl,
 };
 use ckb_chain::chain::ChainController;
 use ckb_miner::BlockAssemblerController;
 use ckb_network::NetworkController;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
+use ckb_sync::Synchronizer;
 use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::{Server, ServerBuilder};
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
@@ -22,6 +24,7 @@ impl RpcServer {
         config: Config,
         network_controller: NetworkController,
         shared: Shared<CS>,
+        synchronizer: Synchronizer<CS>,
         chain: ChainController,
         block_assembler: BlockAssemblerController,
     ) -> RpcServer
@@ -65,6 +68,16 @@ impl RpcServer {
             io.extend_with(
                 NetworkRpcImpl {
                     network_controller: network_controller.clone(),
+                }
+                .to_delegate(),
+            );
+        }
+
+        if config.stats_enable() {
+            io.extend_with(
+                StatsRpcImpl {
+                    shared: shared.clone(),
+                    synchronizer: synchronizer.clone(),
                 }
                 .to_delegate(),
             );

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -56,12 +56,13 @@ pub fn run(args: RunArgs) -> Result<(), ExitCode> {
     );
     let net_timer = NetTimeProtocol::default();
 
+    let synchronizer_clone = synchronizer.clone();
     let protocols = vec![
         CKBProtocol::new(
             "syn".to_string(),
             NetworkProtocol::SYNC.into(),
             &["1".to_string()][..],
-            move || Box::new(synchronizer.clone()),
+            move || Box::new(synchronizer_clone.clone()),
             Arc::clone(&network_state),
         ),
         CKBProtocol::new(
@@ -87,6 +88,7 @@ pub fn run(args: RunArgs) -> Result<(), ExitCode> {
         args.config.rpc,
         network_controller,
         shared,
+        synchronizer,
         chain_controller,
         block_assembler_controller,
     );

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -66,7 +66,7 @@ pub type BlockStatusMap = Arc<Mutex<HashMap<H256, BlockStatus>>>;
 
 pub struct Synchronizer<CS: ChainStore> {
     chain: ChainController,
-    shared: Arc<SyncSharedState<CS>>,
+    pub shared: Arc<SyncSharedState<CS>>,
     pub status_map: BlockStatusMap,
     pub n_sync: Arc<AtomicUsize>,
     pub peers: Arc<Peers>,

--- a/util/jsonrpc-types/src/chain_info.rs
+++ b/util/jsonrpc-types/src/chain_info.rs
@@ -1,0 +1,19 @@
+use crate::EpochNumber;
+use numext_fixed_uint::U256;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ChainInfo {
+    // network name
+    pub chain: String,
+    // median time for the current tip block
+    pub median_time: String,
+    // the current epoch number
+    pub epoch: EpochNumber,
+    // the current difficulty
+    pub difficulty: U256,
+    // estimate of whether this node is in InitialBlockDownload mode
+    pub is_initial_block_download: bool,
+    // any network and blockchain warnings
+    pub warnings: String,
+}

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -2,9 +2,11 @@ mod block_template;
 mod blockchain;
 mod bytes;
 mod cell;
+mod chain_info;
 mod net;
 mod pool;
 mod proposal_short_id;
+mod sync;
 mod trace;
 
 pub type BlockNumber = String;
@@ -22,9 +24,11 @@ pub use self::blockchain::{
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};
+pub use self::chain_info::ChainInfo;
 pub use self::net::{Node, NodeAddress};
 pub use self::pool::TxPoolInfo;
 pub use self::proposal_short_id::ProposalShortId;
+pub use self::sync::PeerState;
 pub use self::trace::{Action, TxTrace};
 pub use ckb_core::Version;
 pub use jsonrpc_core::types::{error, id, params, request, response, version};

--- a/util/jsonrpc-types/src/sync.rs
+++ b/util/jsonrpc-types/src/sync.rs
@@ -1,0 +1,22 @@
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PeerState {
+    // TODO use peer_id
+    // peer session id
+    peer: String,
+    // last updated timestamp
+    last_updated: String,
+    // blocks count has request but not receive response yet
+    blocks_in_flight: String,
+}
+
+impl PeerState {
+    pub fn new(peer: usize, last_updated: u64, blocks_in_flight: usize) -> Self {
+        Self {
+            peer: peer.to_string(),
+            last_updated: last_updated.to_string(),
+            blocks_in_flight: blocks_in_flight.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
* Add rpc `get_blockchain_info`
* Add rpc `get_peers_state`, currently only return the info of blocks synchronizing in flight.