### PR TITLE
style: use more handsome constructors for hashes

### DIFF
--- a/core/src/difficulty.rs
+++ b/core/src/difficulty.rs
@@ -26,14 +26,14 @@ pub fn difficulty_to_boundary(difficulty: &U256) -> H256 {
 #[cfg(test)]
 mod tests {
     use super::boundary_to_difficulty;
-    use numext_fixed_hash::H256;
-    use numext_fixed_uint::U256;
+    use numext_fixed_hash::{h256, H256};
+    use numext_fixed_uint::{u256, U256};
 
     #[test]
     fn test_boundary_to_difficulty() {
-        let h1 = H256::from_trimmed_hex_str("1000").unwrap();
+        let h1 = h256!("0x1000");
         let h2: U256 = boundary_to_difficulty(&h1);
 
-        assert_eq!(boundary_to_difficulty(&h2.into()), U256::from(4096u64));
+        assert_eq!(boundary_to_difficulty(&h2.into()), u256!("4096"));
     }
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -340,7 +340,7 @@ mod tests {
     use crypto::secp::Generator;
     use faster_hex::hex_encode;
     use hash::{blake2b_256, sha3_256};
-    use numext_fixed_hash::H256;
+    use numext_fixed_hash::{h256, H256};
     use std::fs::File;
     use std::io::{Read, Write};
     use std::path::Path;
@@ -422,7 +422,7 @@ mod tests {
         witness_data.insert(0, hex_pubkey);
 
         let code_hash: H256 = (&blake2b_256(&buffer)).into();
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let output = CellOutput::new(
             Capacity::bytes(buffer.len()).unwrap(),
             Bytes::from(buffer),
@@ -503,7 +503,7 @@ mod tests {
         witness_data.insert(0, hex_pubkey);
 
         let code_hash: H256 = (&blake2b_256(&buffer)).into();
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let output = CellOutput::new(
             Capacity::bytes(buffer.len()).unwrap(),
             Bytes::from(buffer),
@@ -584,7 +584,7 @@ mod tests {
         witness_data.insert(0, hex_pubkey);
 
         let code_hash: H256 = (&blake2b_256(&buffer)).into();
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let output = CellOutput::new(
             Capacity::bytes(buffer.len()).unwrap(),
             Bytes::from(buffer),
@@ -668,7 +668,7 @@ mod tests {
         witness_data.insert(0, hex_pubkey);
 
         let code_hash: H256 = (&blake2b_256(&buffer)).into();
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let output = CellOutput::new(
             Capacity::bytes(buffer.len()).unwrap(),
             Bytes::from(buffer),
@@ -741,7 +741,7 @@ mod tests {
         hex_encode(&signature_der, &mut hex_signature).expect("hex privkey");
         witness_data.insert(0, hex_signature);
 
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
 
         let pubkey = privkey.pubkey().unwrap().serialize();
         let mut hex_pubkey = vec![0; pubkey.len() * 2];
@@ -834,7 +834,7 @@ mod tests {
             Some(script),
         );
 
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let dep_cell = {
             let output = CellOutput::new(
                 Capacity::bytes(buffer.len()).unwrap(),
@@ -928,7 +928,7 @@ mod tests {
             Some(script),
         );
 
-        let dep_out_point = OutPoint::new_cell(H256::from_trimmed_hex_str("123").unwrap(), 8);
+        let dep_out_point = OutPoint::new_cell(h256!("0x123"), 8);
         let dep_cell = {
             let output = CellOutput::new(
                 Capacity::bytes(buffer.len()).unwrap(),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -10,7 +10,7 @@ use ckb_core::{capacity_bytes, BlockNumber, Bytes, Capacity};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
 use jsonrpc_types::{BlockTemplate, CellbaseTemplate};
 use log::info;
-use numext_fixed_hash::H256;
+use numext_fixed_hash::{h256, H256};
 use rand;
 use std::convert::TryInto;
 use std::fs;
@@ -259,14 +259,12 @@ impl Node {
     pub fn new_transaction(&self, hash: H256) -> Transaction {
         // OutPoint and Script reference hash values are from spec#always_success_type_hash test
         let out_point = OutPoint::new_cell(
-            H256::from_hex_str("f8532f2ed92aad146878dca1d5ad9840e9c803ab85d1361652500eaee09c9038")
-                .unwrap(),
+            h256!("0xf8532f2ed92aad146878dca1d5ad9840e9c803ab85d1361652500eaee09c9038"),
             0,
         );
         let script = Script::new(
             vec![],
-            H256::from_hex_str("28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5")
-                .unwrap(),
+            h256!("0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"),
         );
 
         TransactionBuilder::default()

--- a/util/crypto/src/secp/signature.rs
+++ b/util/crypto/src/secp/signature.rs
@@ -147,19 +147,3 @@ impl FromStr for Signature {
             .map_err(|_| Error::InvalidSignature)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn test_n() {
-        let half: H256 =
-            H256::from_hex_str("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0")
-                .unwrap();
-        let n: H256 =
-            H256::from_hex_str("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141")
-                .unwrap();
-        assert_eq!(half, HALF_N);
-        assert_eq!(n, N);
-    }
-}

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -8,7 +8,7 @@ use ckb_core::transaction::{
     CellInput, CellOutput, OutPoint, ProposalShortId, Transaction, TransactionBuilder,
 };
 use ckb_core::{capacity_bytes, Bytes, Capacity};
-use numext_fixed_hash::H256;
+use numext_fixed_hash::{h256, H256};
 
 fn create_cellbase_transaction_with_capacity(capacity: Capacity) -> Transaction {
     TransactionBuilder::default()
@@ -29,7 +29,7 @@ fn create_cellbase_transaction() -> Transaction {
 fn create_normal_transaction() -> Transaction {
     TransactionBuilder::default()
         .input(CellInput::new(
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
             0,
             Default::default(),
         ))

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -7,7 +7,7 @@ use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, TransactionBuilder};
 use ckb_core::{capacity_bytes, Bytes, Capacity};
 use ckb_traits::BlockMedianTimeContext;
-use numext_fixed_hash::H256;
+use numext_fixed_hash::{h256, H256};
 
 #[test]
 pub fn test_empty() {
@@ -133,8 +133,8 @@ pub fn test_capacity_invalid() {
 pub fn test_duplicate_deps() {
     let transaction = TransactionBuilder::default()
         .deps(vec![
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
         ])
         .build();
 
@@ -167,7 +167,7 @@ pub fn test_since() {
     // use remain flags
     let transaction = TransactionBuilder::default()
         .inputs(vec![CellInput::new(
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
             0x2000_0000_0000_0000,
             Default::default(),
         )])
@@ -199,7 +199,7 @@ pub fn test_since() {
     // absolute lock
     let transaction = TransactionBuilder::default()
         .inputs(vec![CellInput::new(
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
             0x0000_0000_0000_000a,
             Default::default(),
         )])
@@ -231,7 +231,7 @@ pub fn test_since() {
     // relative lock
     let transaction = TransactionBuilder::default()
         .inputs(vec![CellInput::new(
-            OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+            OutPoint::new_cell(h256!("0x1"), 0),
             0xc000_0000_0000_0002,
             Default::default(),
         )])
@@ -265,12 +265,12 @@ pub fn test_since() {
     let transaction = TransactionBuilder::default()
         .inputs(vec![
             CellInput::new(
-                OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+                OutPoint::new_cell(h256!("0x1"), 0),
                 0x0000_0000_0000_000a,
                 Default::default(),
             ),
             CellInput::new(
-                OutPoint::new_cell(H256::from_trimmed_hex_str("1").unwrap(), 0),
+                OutPoint::new_cell(h256!("0x1"), 0),
                 0xc000_0000_0000_0002,
                 Default::default(),
             ),


### PR DESCRIPTION
Remove a useless test. Initially, some const hashes are constructed by `[u8; N]`, so there need some tests to ensure correctness. Now, they are constructed in the same way as the tests, so the tests are redundant.