### PR TITLE
feat: upgrade VM to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "ckb-db 0.12.0-pre",
  "ckb-protocol 0.12.0-pre",
  "ckb-store 0.12.0-pre",
- "ckb-vm 0.9.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207)",
+ "ckb-vm 0.9.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5)",
  "crypto 0.12.0-pre",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -813,11 +813,12 @@ dependencies = [
 [[package]]
 name = "ckb-vm"
 version = "0.9.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207#2e41207dcd7310d5c86448921154fe38acf32357"
+source = "git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5#17addb5b63f7348b9899b8c49ad631447bfcabb9"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207)",
+ "ckb-vm-definitions 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5)",
  "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -825,7 +826,7 @@ dependencies = [
 [[package]]
 name = "ckb-vm-definitions"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207#2e41207dcd7310d5c86448921154fe38acf32357"
+source = "git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5#17addb5b63f7348b9899b8c49ad631447bfcabb9"
 
 [[package]]
 name = "clang-sys"
@@ -3630,8 +3631,8 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum ckb-vm 0.9.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207)" = "<none>"
-"checksum ckb-vm-definitions 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=2e41207)" = "<none>"
+"checksum ckb-vm 0.9.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5)" = "<none>"
+"checksum ckb-vm-definitions 0.1.0 (git+https://github.com/nervosnetwork/ckb-vm?rev=17addb5)" = "<none>"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -12,7 +12,7 @@ crypto = {path = "../util/crypto"}
 ckb-core = { path = "../core" }
 ckb-store = { path = "../store" }
 hash = {path = "../util/hash"}
-ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "2e41207", features = ["asm"] }
+ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "17addb5", features = ["asm"] }
 faster-hex = "0.3"
 fnv = "1.0.3"
 flatbuffers = "0.6.0"

--- a/script/src/cost_model.rs
+++ b/script/src/cost_model.rs
@@ -3,10 +3,8 @@ use ckb_vm::{
     Instruction,
 };
 
-// TODO: adjust the API in CKB VM repo, then fix this.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub fn instruction_cycles(i: &Instruction) -> u64 {
-    match extract_opcode(*i) {
+pub fn instruction_cycles(i: Instruction) -> u64 {
+    match extract_opcode(i) {
         insts::OP_JALR => 3,
         insts::OP_LD => 2,
         insts::OP_LW => 3,

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -31,7 +31,7 @@ pub enum ScriptError {
     NoScript,
     InvalidReferenceIndex,
     ArgumentError,
-    ValidationFailure(u8),
+    ValidationFailure(i8),
     VMError(VMInternalError),
     ExceededMaximumCycles,
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -174,15 +174,9 @@ impl<'a, CS: LazyLoadCellOutput> TransactionScriptsVerifier<'a, CS> {
         if script.code_hash == ALWAYS_SUCCESS_HASH {
             return Ok(0);
         }
-        let mut args = vec![b"verify".to_vec()];
+        let mut args = vec!["verify".into()];
         self.extract_script(script).and_then(|script_binary| {
-            args.extend_from_slice(
-                &script
-                    .args
-                    .iter()
-                    .map(|b| b[..].to_vec())
-                    .collect::<Vec<Vec<u8>>>(),
-            );
+            args.extend_from_slice(&script.args);
 
             let mut appended_arguments = vec![];
             // TODO: change CKB VM to use Bytes in its API, then we can simplify the
@@ -200,12 +194,7 @@ impl<'a, CS: LazyLoadCellOutput> TransactionScriptsVerifier<'a, CS> {
             }
 
             let current_script_hash = script.hash_with_appended_arguments(&appended_arguments);
-            args.extend_from_slice(
-                &appended_arguments
-                    .iter()
-                    .map(|a| a[..].to_vec())
-                    .collect::<Vec<Vec<u8>>>(),
-            );
+            args.extend_from_slice(&appended_arguments);
 
             self.run(
                 &script_binary,
@@ -268,8 +257,8 @@ impl<'a, CS: LazyLoadCellOutput> TransactionScriptsVerifier<'a, CS> {
 
     fn run(
         &self,
-        program: &[u8],
-        args: &[Vec<u8>],
+        program: &Bytes,
+        args: &[Bytes],
         prefix: &str,
         max_cycles: Cycle,
         current_script_hash: &[u8],


### PR DESCRIPTION
Noticeable changes here include:

* Shrink VM memory from 16MB to 4MB now for both resource usage and performance
* Use Bytes in VM API to avoid unnecessary copying
* Use i8 as VM return code for better debugging