### PR TITLE
refactor: change db cache to store cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "ckb-rpc 0.12.0-pre",
  "ckb-script 0.12.0-pre",
  "ckb-shared 0.12.0-pre",
+ "ckb-store 0.12.0-pre",
  "ckb-sync 0.12.0-pre",
  "ckb-verification 0.12.0-pre",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +735,6 @@ dependencies = [
  "ckb-chain-spec 0.12.0-pre",
  "ckb-core 0.12.0-pre",
  "ckb-db 0.12.0-pre",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1834,15 +1834,6 @@ dependencies = [
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/lru-cache#b36a4d1d16137f065d2b6ccdc676f901f80188a8"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3790,7 +3781,6 @@ dependencies = [
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)" = "<none>"
 "checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)" = "<none>"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
  "ckb-core 0.12.0-pre",
  "ckb-db 0.12.0-pre",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,8 @@ dependencies = [
  "ckb-chain-spec 0.12.0-pre",
  "ckb-core 0.12.0-pre",
  "ckb-db 0.12.0-pre",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1832,6 +1834,15 @@ dependencies = [
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.0"
+source = "git+https://github.com/nervosnetwork/lru-cache#b36a4d1d16137f065d2b6ccdc676f901f80188a8"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3779,6 +3790,7 @@ dependencies = [
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache)" = "<none>"
 "checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)" = "<none>"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -7,7 +7,7 @@ use ckb_core::transaction::{
     CellInput, CellOutput, OutPoint, ProposalShortId, Transaction, TransactionBuilder,
 };
 use ckb_core::{capacity_bytes, Bytes, Capacity};
-use ckb_db::{CacheDB, DBConfig, RocksDB};
+use ckb_db::{DBConfig, RocksDB};
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
@@ -147,7 +147,7 @@ fn new_chain(
     txs_size: usize,
 ) -> (
     ChainController,
-    Shared<ChainKVStore<CacheDB<RocksDB>>>,
+    Shared<ChainKVStore<RocksDB>>,
     TempDir,
     H256,
     H256,
@@ -192,7 +192,7 @@ fn new_chain(
     consensus.cellbase_maturity = 0;
 
     let db_dir = tempdir().unwrap();
-    let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+    let shared = SharedBuilder::<RocksDB>::default()
         .db(&DBConfig {
             path: db_dir.path().to_owned(),
             options: None,

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -84,3 +84,7 @@ args = []
 
 [script]
 runner = "Assembly"
+
+[store]
+header_cache_size       = 4096
+cell_output_cache_size  = 128

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -60,18 +60,16 @@ impl<'a, CS: ChainStore> TransactionScriptsVerifier<'a, CS> {
             .outputs()
             .iter()
             .enumerate()
-            .map({
-                |(index, output)| CellMeta {
-                    cell_output: Some(output.clone()),
-                    out_point: CellOutPoint {
-                        tx_hash: tx_hash.to_owned(),
-                        index: index as u32,
-                    },
-                    block_info: None,
-                    cellbase: false,
-                    capacity: output.capacity,
-                    data_hash: None,
-                }
+            .map(|(index, output)| CellMeta {
+                cell_output: Some(output.clone()),
+                out_point: CellOutPoint {
+                    tx_hash: tx_hash.to_owned(),
+                    index: index as u32,
+                },
+                block_info: None,
+                cellbase: false,
+                capacity: output.capacity,
+                data_hash: None,
             })
             .collect();
         let witnesses: FnvHashMap<u32, &'a [Bytes]> = rtx

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -8,9 +8,9 @@ use ckb_core::header::{BlockNumber, Header};
 use ckb_core::transaction::{ProposalShortId, Transaction};
 use ckb_core::uncle::UncleBlock;
 use ckb_core::Cycle;
-use ckb_db::{CacheDB, DBConfig, KeyValueDB, MemoryKeyValueDB, RocksDB};
+use ckb_db::{DBConfig, KeyValueDB, MemoryKeyValueDB, RocksDB};
 use ckb_script::ScriptConfig;
-use ckb_store::{ChainKVStore, ChainStore, COLUMNS, COLUMN_BLOCK_HEADER};
+use ckb_store::{ChainKVStore, ChainStore, COLUMNS};
 use ckb_traits::ChainProvider;
 use ckb_util::{lock_or_panic, Mutex, MutexGuard};
 use lru_cache::LruCache;
@@ -209,16 +209,13 @@ impl SharedBuilder<MemoryKeyValueDB> {
     }
 }
 
-impl SharedBuilder<CacheDB<RocksDB>> {
+impl SharedBuilder<RocksDB> {
     pub fn new() -> Self {
         Default::default()
     }
 
     pub fn db(mut self, config: &DBConfig) -> Self {
-        self.db = Some(CacheDB::new(
-            RocksDB::open(config, COLUMNS),
-            &[(COLUMN_BLOCK_HEADER, 4096)],
-        ));
+        self.db = Some(RocksDB::open(config, COLUMNS));
         self
     }
 }

--- a/src/subcommand/export.rs
+++ b/src/subcommand/export.rs
@@ -1,10 +1,10 @@
 use ckb_app_config::{ExitCode, ExportArgs};
-use ckb_db::{CacheDB, RocksDB};
+use ckb_db::RocksDB;
 use ckb_instrument::Export;
 use ckb_shared::shared::SharedBuilder;
 
 pub fn export(args: ExportArgs) -> Result<(), ExitCode> {
-    let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+    let shared = SharedBuilder::<RocksDB>::default()
         .consensus(args.consensus)
         .db(&args.config.db)
         .build()

--- a/src/subcommand/import.rs
+++ b/src/subcommand/import.rs
@@ -1,12 +1,12 @@
 use ckb_app_config::{ExitCode, ImportArgs};
 use ckb_chain::chain::ChainService;
-use ckb_db::{CacheDB, RocksDB};
+use ckb_db::RocksDB;
 use ckb_instrument::Import;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::SharedBuilder;
 
 pub fn import(args: ImportArgs) -> Result<(), ExitCode> {
-    let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+    let shared = SharedBuilder::<RocksDB>::default()
         .consensus(args.consensus)
         .db(&args.config.db)
         .build()

--- a/src/subcommand/prof.rs
+++ b/src/subcommand/prof.rs
@@ -1,6 +1,6 @@
 use ckb_app_config::{ExitCode, ProfArgs};
 use ckb_chain::chain::ChainService;
-use ckb_db::{CacheDB, DBConfig, RocksDB};
+use ckb_db::{DBConfig, RocksDB};
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainStore;
@@ -9,7 +9,7 @@ use log::info;
 use std::sync::Arc;
 
 pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
-    let shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+    let shared = SharedBuilder::<RocksDB>::default()
         .consensus(args.consensus.clone())
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool.clone())
@@ -20,7 +20,7 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
         })?;
 
     let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
-    let tmp_shared = SharedBuilder::<CacheDB<RocksDB>>::default()
+    let tmp_shared = SharedBuilder::<RocksDB>::default()
         .consensus(args.consensus)
         .db(&DBConfig {
             path: tmp_dir.as_ref().to_path_buf(),

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -2,7 +2,7 @@ use crate::helper::{deadlock_detection, wait_for_exit};
 use build_info::Version;
 use ckb_app_config::{ExitCode, RunArgs};
 use ckb_chain::chain::ChainService;
-use ckb_db::{CacheDB, RocksDB};
+use ckb_db::RocksDB;
 use ckb_miner::BlockAssembler;
 use ckb_network::{CKBProtocol, NetworkService, NetworkState};
 use ckb_notify::NotifyService;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     deadlock_detection();
 
-    let shared = SharedBuilder::<CacheDB<RocksDB>>::new()
+    let shared = SharedBuilder::<RocksDB>::new()
         .consensus(args.consensus)
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool)

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -23,6 +23,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         .db(&args.config.db)
         .tx_pool_config(args.config.tx_pool)
         .script_config(args.config.script)
+        .store_config(args.config.store)
         .build()
         .map_err(|err| {
             eprintln!("Run error: {:?}", err);

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -14,7 +14,7 @@ ckb-db = { path = "../db" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 ckb-chain-spec = { path = "../spec" }
 lazy_static = "1.3"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache" }
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "b36a4d1" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -13,7 +13,6 @@ ckb-core = { path = "../core" }
 ckb-db = { path = "../db" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 ckb-chain-spec = { path = "../spec" }
-lazy_static = "1.3"
 lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "b36a4d1" }
 
 [dev-dependencies]

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -13,6 +13,8 @@ ckb-core = { path = "../core" }
 ckb-db = { path = "../db" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 ckb-chain-spec = { path = "../spec" }
+lazy_static = "1.3"
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -3,7 +3,7 @@ mod lazy_load_cell_output;
 mod store;
 
 pub use lazy_load_cell_output::LazyLoadCellOutput;
-pub use store::{ChainKVStore, ChainStore, DefaultStoreBatch, StoreBatch};
+pub use store::{ChainKVStore, ChainStore, StoreBatch, StoreConfig};
 
 use ckb_db::Col;
 

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -19,18 +19,11 @@ use ckb_core::transaction::{CellOutPoint, CellOutput, ProposalShortId, Transacti
 use ckb_core::uncle::UncleBlock;
 use ckb_core::EpochNumber;
 use ckb_db::{Col, DbBatch, Error, KeyValueDB};
-use lazy_static::lazy_static;
 use lru_cache::LruCache;
 use numext_fixed_hash::H256;
-use serde::Serialize;
+use serde_derive::{Deserialize, Serialize};
 use std::ops::Range;
 use std::sync::Mutex;
-
-lazy_static! {
-    static ref HEADER_CACHE: Mutex<LruCache<H256, Header>> = Mutex::new(LruCache::new(4096));
-    static ref CELL_OUTPUT_CACHE: Mutex<LruCache<(H256, u32), CellOutput>> =
-        Mutex::new(LruCache::new(128));
-}
 
 const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
 const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";
@@ -42,13 +35,38 @@ fn cell_store_key(tx_hash: &H256, index: u32) -> Vec<u8> {
     key.to_vec()
 }
 
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
+pub struct StoreConfig {
+    pub header_cache_size: usize,
+    pub cell_output_cache_size: usize,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            header_cache_size: 4096,
+            cell_output_cache_size: 128,
+        }
+    }
+}
+
 pub struct ChainKVStore<T> {
     db: T,
+    header_cache: Mutex<LruCache<H256, Header>>,
+    cell_output_cache: Mutex<LruCache<(H256, u32), CellOutput>>,
 }
 
 impl<T: KeyValueDB> ChainKVStore<T> {
     pub fn new(db: T) -> Self {
-        ChainKVStore { db }
+        Self::with_config(db, StoreConfig::default())
+    }
+
+    pub fn with_config(db: T, config: StoreConfig) -> Self {
+        ChainKVStore {
+            db,
+            header_cache: Mutex::new(LruCache::new(config.header_cache_size)),
+            cell_output_cache: Mutex::new(LruCache::new(config.cell_output_cache_size)),
+        }
     }
 
     pub fn get(&self, col: Col, key: &[u8]) -> Option<Vec<u8>> {
@@ -152,7 +170,10 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
     }
 
     fn get_header(&self, hash: &H256) -> Option<Header> {
-        let mut header_cache_unlocked = HEADER_CACHE.lock().expect("poisoned header cache lock");
+        let mut header_cache_unlocked = self
+            .header_cache
+            .lock()
+            .expect("poisoned header cache lock");
         if let Some(header) = header_cache_unlocked.get_refresh(hash) {
             return Some(header.clone());
         }
@@ -162,8 +183,10 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
         self.get(COLUMN_BLOCK_HEADER, hash.as_bytes())
             .map(|ref raw| unsafe { Header::from_bytes_with_hash_unchecked(raw, hash.to_owned()) })
             .and_then(|header| {
-                let mut header_cache_unlocked =
-                    HEADER_CACHE.lock().expect("poisoned header cache lock");
+                let mut header_cache_unlocked = self
+                    .header_cache
+                    .lock()
+                    .expect("poisoned header cache lock");
                 header_cache_unlocked.insert(hash.clone(), header.clone());
                 Some(header)
             })
@@ -313,7 +336,8 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
     }
 
     fn get_cell_output(&self, tx_hash: &H256, index: u32) -> Option<CellOutput> {
-        let mut cell_output_cache_unlocked = CELL_OUTPUT_CACHE
+        let mut cell_output_cache_unlocked = self
+            .cell_output_cache
             .lock()
             .expect("poisoned cell output cache lock");
         if let Some(cell_output) = cell_output_cache_unlocked.get_refresh(&(tx_hash.clone(), index))
@@ -340,7 +364,8 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
                         .map(|ref serialized_cell_output| {
                             let cell_output: CellOutput = deserialize(serialized_cell_output)
                                 .expect("flat deserialize cell output should be ok");
-                            let mut cell_output_cache_unlocked = CELL_OUTPUT_CACHE
+                            let mut cell_output_cache_unlocked = self
+                                .cell_output_cache
                                 .lock()
                                 .expect("poisoned cell output cache lock");
                             cell_output_cache_unlocked
@@ -362,7 +387,7 @@ impl<B: DbBatch> DefaultStoreBatch<B> {
         self.inner.insert(col, key, value)
     }
 
-    fn insert_serialize<T: Serialize + ?Sized>(
+    fn insert_serialize<T: serde::ser::Serialize + ?Sized>(
         &mut self,
         col: Col,
         key: &[u8],

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -19,9 +19,16 @@ use ckb_core::transaction::{CellOutPoint, CellOutput, ProposalShortId, Transacti
 use ckb_core::uncle::UncleBlock;
 use ckb_core::EpochNumber;
 use ckb_db::{Col, DbBatch, Error, KeyValueDB};
+use lazy_static::lazy_static;
+use lru_cache::LruCache;
 use numext_fixed_hash::H256;
 use serde::Serialize;
 use std::ops::Range;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref HEADER_CACHE: Mutex<LruCache<H256, Header>> = Mutex::new(LruCache::new(4096));
+}
 
 const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
 const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";
@@ -142,9 +149,22 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
         })
     }
 
-    fn get_header(&self, h: &H256) -> Option<Header> {
-        self.get(COLUMN_BLOCK_HEADER, h.as_bytes())
-            .map(|ref raw| unsafe { Header::from_bytes_with_hash_unchecked(raw, h.to_owned()) })
+    fn get_header(&self, hash: &H256) -> Option<Header> {
+        let mut header_cache_unlocked = HEADER_CACHE.lock().expect("poisoned header cache lock");
+        if let Some(header) = header_cache_unlocked.get_refresh(hash) {
+            return Some(header.clone());
+        }
+        // release lock asap
+        drop(header_cache_unlocked);
+
+        self.get(COLUMN_BLOCK_HEADER, hash.as_bytes())
+            .map(|ref raw| unsafe { Header::from_bytes_with_hash_unchecked(raw, hash.to_owned()) })
+            .and_then(|header| {
+                let mut header_cache_unlocked =
+                    HEADER_CACHE.lock().expect("poisoned header cache lock");
+                header_cache_unlocked.insert(hash.clone(), header.clone());
+                Some(header)
+            })
     }
 
     fn get_block_uncles(&self, h: &H256) -> Option<Vec<UncleBlock>> {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -28,6 +28,8 @@ use std::sync::Mutex;
 
 lazy_static! {
     static ref HEADER_CACHE: Mutex<LruCache<H256, Header>> = Mutex::new(LruCache::new(4096));
+    static ref CELL_OUTPUT_CACHE: Mutex<LruCache<(H256, u32), CellOutput>> =
+        Mutex::new(LruCache::new(128));
 }
 
 const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
@@ -311,24 +313,39 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
     }
 
     fn get_cell_output(&self, tx_hash: &H256, index: u32) -> Option<CellOutput> {
+        let mut cell_output_cache_unlocked = CELL_OUTPUT_CACHE
+            .lock()
+            .expect("poisoned cell output cache lock");
+        if let Some(cell_output) = cell_output_cache_unlocked.get_refresh(&(tx_hash.clone(), index))
+        {
+            return Some(cell_output.clone());
+        }
+        // release lock asap
+        drop(cell_output_cache_unlocked);
+
         self.get(COLUMN_TRANSACTION_ADDR, tx_hash.as_bytes())
             .map(|raw| deserialize(&raw[..]).expect("deserialize tx address should be ok"))
             .and_then(|stored: TransactionAddressStored| {
-                let tx_offset = stored.inner.offset;
                 stored
                     .inner
                     .outputs_addresses
                     .get(index as usize)
                     .and_then(|addr| {
-                        let output_offset = tx_offset + addr.offset;
+                        let output_offset = stored.inner.offset + addr.offset;
                         self.partial_get(
                             COLUMN_BLOCK_BODY,
                             stored.block_hash.as_bytes(),
                             &(output_offset..(output_offset + addr.length)),
                         )
                         .map(|ref serialized_cell_output| {
-                            deserialize(serialized_cell_output)
-                                .expect("flat deserialize cell output should be ok")
+                            let cell_output: CellOutput = deserialize(serialized_cell_output)
+                                .expect("flat deserialize cell output should be ok");
+                            let mut cell_output_cache_unlocked = CELL_OUTPUT_CACHE
+                                .lock()
+                                .expect("poisoned cell output cache lock");
+                            cell_output_cache_unlocked
+                                .insert((tx_hash.clone(), index), cell_output.clone());
+                            cell_output.to_owned()
                         })
                     })
             })

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -23,6 +23,7 @@ ckb-resource = { path = "../../resource"}
 ckb-instrument = { path = "../instrument", features = ["progress_bar"] }
 ckb-shared = { path = "../../shared" }
 ckb-sync = { path = "../../sync"}
+ckb-store = { path = "../../store" }
 build-info = { path = "../build-info" }
 ckb-verification = { path = "../../verification" }
 ckb-script = { path = "../../script" }

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -18,6 +18,7 @@ use ckb_resource::{Resource, ResourceLocator};
 use ckb_rpc::Config as RpcConfig;
 use ckb_script::ScriptConfig;
 use ckb_shared::tx_pool::TxPoolConfig;
+use ckb_store::StoreConfig;
 use ckb_sync::Config as SyncConfig;
 use logger::Config as LogConfig;
 
@@ -50,6 +51,7 @@ pub struct CKBAppConfig {
     pub sync: SyncConfig,
     pub tx_pool: TxPoolConfig,
     pub script: ScriptConfig,
+    pub store: StoreConfig,
 }
 
 // change the order of fields will break integration test, see module doc.


### PR DESCRIPTION
Use lru cache to replace CacheDB, add CellOutput and Header cache, need to run bench on testnet.

Run the simple bench on current develop branch ( commit c212e5caae309e4751e9706fb4cfdb2c569980f2 ) on my machine:
```
fetch_cell_output_from_1        time:   [3.7808 us 3.8320 us 3.8897 us]
fetch_cell_output_from_50       time:   [207.07 us 210.38 us 213.78 us]
fetch_cell_output_from_100      time:   [450.58 us 457.00 us 463.63 us]
fetch_cell_output_from_300      time:   [1.8685 ms 1.9008 ms 1.9332 ms]

main_branch/100                 time:   [396.98 ms 417.18 ms 433.43 ms]                          
main_branch/200                 time:   [807.37 ms 860.79 ms 932.32 ms]
main_branch/500                 time:   [3.4735 s 3.6176 s 3.7493 s]
```

Run this PR:
```
fetch_cell_output_from_1        time:   [123.32 ns 124.53 ns 125.90 ns]
                                change: [-96.817% -96.732% -96.643%] (p = 0.00 < 0.05)
fetch_cell_output_from_50       time:   [6.2367 us 6.2929 us 6.3569 us]
                                change: [-97.051% -97.016% -96.981%] (p = 0.00 < 0.05)
fetch_cell_output_from_100      time:   [12.708 us 12.769 us 12.831 us]
                                change: [-97.219% -97.179% -97.141%] (p = 0.00 < 0.05)
fetch_cell_output_from_300      time:   [1.9551 ms 1.9706 ms 1.9901 ms]
                                change: [+6.2674% +8.0554% +9.9104%] (p = 0.00 < 0.05)


main_branch/100                 time:   [333.55 ms 341.84 ms 350.45 ms]                          
                                change: [-19.245% -14.530% -9.5650%] (p = 0.00 < 0.05)
main_branch/200                 time:   [699.51 ms 709.13 ms 723.16 ms]                          
                                change: [-21.607% -16.549% -11.225%] (p = 0.00 < 0.05)
main_branch/500                 time:   [2.8819 s 2.9392 s 2.9854 s]   
                                change: [-22.821% -19.802% -16.656%] (p = 0.00 < 0.05)
```

Performance of `fetch_cell_output_from_300` has regressed due to default small cache size, performance of other cases has improved.