### PR TITLE
feat: enforce resolve txs order within block

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -549,7 +549,14 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                     let mut seen_inputs = FnvHashSet::default();
                     let cell_set_overlay =
                         chain_state.new_cell_set_overlay(&cell_set_diff, &outputs);
-                    let block_cp = BlockCellProvider::new(b);
+                    let block_cp = match BlockCellProvider::new(b) {
+                        Ok(block_cp) => block_cp,
+                        Err(err) => {
+                            found_error = Some(SharedError::UnresolvableTransaction(err));
+                            continue;
+                        }
+                    };
+
                     let cell_provider = OverlayCellProvider::new(&block_cp, &cell_set_overlay);
                     block_headers_provider.push_attached(b);
                     let header_provider =

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -364,6 +364,8 @@ impl<CS: ChainStore> ChainState<CS> {
                     UnresolvableError::Empty => (),
                     UnresolvableError::UnspecifiedInputCell(_) => (),
                     UnresolvableError::InvalidHeader(_) => (),
+                    // OutOfOrder should only appear in BlockCellProvider
+                    UnresolvableError::OutOfOrder(_) => (),
                 }
                 Err(PoolError::UnresolvableTransaction(err))
             }


### PR DESCRIPTION
Transactions are expected to be sorted within a block
Transactions have to appear after any transactions upon which they depend