### PR TITLE
feat: move DryRuResult into jsonrpc-types

### DIFF
--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -7,9 +7,8 @@ use ckb_store::ChainStore;
 use ckb_verification::ScriptVerifier;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
-use jsonrpc_types::Transaction;
+use jsonrpc_types::{Cycle, DryRunResult, Transaction};
 use numext_fixed_hash::H256;
-use serde_derive::Serialize;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -37,11 +36,6 @@ impl<CS: ChainStore + 'static> ExperimentRpc for ExperimentRpcImpl<CS> {
         let chain_state = self.shared.chain_state().lock();
         DryRunner::new(&chain_state).run(tx)
     }
-}
-
-#[derive(Serialize)]
-pub struct DryRunResult {
-    pub cycles: String,
 }
 
 // DryRunner dry run given transaction, and return the result, including execution cycles.
@@ -94,7 +88,7 @@ impl<'a, CS: ChainStore> DryRunner<'a, CS> {
                     .verify(max_cycles)
                 {
                     Ok(cycles) => Ok(DryRunResult {
-                        cycles: cycles.to_string(),
+                        cycles: Cycle(cycles),
                     }),
                     Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
                 }

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -8,7 +8,7 @@ use ckb_core::script::Script;
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
 use ckb_core::{capacity_bytes, BlockNumber, Bytes, Capacity};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
-use jsonrpc_types::{BlockTemplate, CellbaseTemplate};
+use jsonrpc_types::{BlockTemplate, CellbaseTemplate, Unsigned, Version};
 use log::info;
 use numext_fixed_hash::{h256, H256};
 use rand;
@@ -178,10 +178,13 @@ impl Node {
 
     pub fn new_block(
         &self,
-        bytes_limit: Option<String>,
-        proposals_limit: Option<String>,
+        bytes_limit: Option<u64>,
+        proposals_limit: Option<u64>,
         max_version: Option<u32>,
     ) -> Block {
+        let bytes_limit = bytes_limit.map(Unsigned);
+        let proposals_limit = proposals_limit.map(Unsigned);
+        let max_version = max_version.map(Version);
         let template = self
             .rpc_client()
             .get_block_template(bytes_limit, proposals_limit, max_version)

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,32 +1,42 @@
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_types::{
-    Block, BlockTemplate, BlockView, HeaderView, Node, Transaction, TransactionWithStatus,
-    TxPoolInfo,
+    Block, BlockNumber, BlockTemplate, BlockView, CellOutputWithOutPoint, CellWithStatus,
+    ChainInfo, DryRunResult, EpochExt, EpochNumber, HeaderView, Node, OutPoint, PeerState,
+    Transaction, TransactionWithStatus, TxPoolInfo, Unsigned, Version,
 };
 use numext_fixed_hash::H256;
 
 jsonrpc_client!(pub struct RpcClient {
+    pub fn get_block(&mut self, _hash: H256) -> RpcRequest<Option<BlockView>>;
+    pub fn get_block_by_number(&mut self, _number: BlockNumber) -> RpcRequest<Option<BlockView>>;
+    pub fn get_transaction(&mut self, _hash: H256) -> RpcRequest<Option<TransactionWithStatus>>;
+    pub fn get_block_hash(&mut self, _number: BlockNumber) -> RpcRequest<Option<H256>>;
+    pub fn get_tip_header(&mut self) -> RpcRequest<HeaderView>;
+    pub fn get_cells_by_lock_hash(
+        &mut self,
+        _lock_hash: H256,
+        _from: BlockNumber,
+        _to: BlockNumber
+    ) -> RpcRequest<Vec<CellOutputWithOutPoint>>;
+    pub fn get_live_cell(&mut self, _out_point: OutPoint) -> RpcRequest<CellWithStatus>;
+    pub fn get_tip_block_number(&mut self) -> RpcRequest<BlockNumber>;
+    pub fn get_current_epoch(&mut self) -> RpcRequest<EpochExt>;
+    pub fn get_epoch_by_number(&mut self, number: EpochNumber) -> RpcRequest<Option<EpochExt>>;
     pub fn local_node_info(&mut self) -> RpcRequest<Node>;
     pub fn get_peers(&mut self) -> RpcRequest<Vec<Node>>;
-
-    pub fn add_node(&mut self, peer_id: String, address: String) -> RpcRequest<()>;
-
     pub fn get_block_template(
         &mut self,
-        bytes_limit: Option<String>,
-        proposals_limit: Option<String>,
-        max_version: Option<u32>
+        bytes_limit: Option<Unsigned>,
+        proposals_limit: Option<Unsigned>,
+        max_version: Option<Version>
     ) -> RpcRequest<BlockTemplate>;
-
-    pub fn submit_block(&mut self, work_id: String, data: Block) -> RpcRequest<Option<H256>>;
-
+    pub fn submit_block(&mut self, _work_id: String, _data: Block) -> RpcRequest<Option<H256>>;
+    pub fn get_blockchain_info(&mut self) -> RpcRequest<ChainInfo>;
+    pub fn get_peers_state(&mut self) -> RpcRequest<Vec<PeerState>>;
+    pub fn compute_transaction_hash(&mut self, tx: Transaction) -> RpcRequest<H256>;
+    pub fn dry_run_transaction(&mut self, _tx: Transaction) -> RpcRequest<DryRunResult>;
     pub fn send_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
     pub fn tx_pool_info(&mut self) -> RpcRequest<TxPoolInfo>;
-
-    pub fn get_block(&mut self, hash: H256) -> RpcRequest<Option<BlockView>>;
-    pub fn get_transaction(&mut self, hash: H256) -> RpcRequest<Option<TransactionWithStatus>>;
-    pub fn get_block_hash(&mut self, number: String) -> RpcRequest<Option<H256>>;
-    pub fn get_tip_header(&mut self) -> RpcRequest<HeaderView>;
-    pub fn get_tip_block_number(&mut self) -> RpcRequest<String>;
+    pub fn add_node(&mut self, peer_id: String, address: String) -> RpcRequest<()>;
     pub fn enqueue_test_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
 });

--- a/test/src/specs/mining/size_limit.rs
+++ b/test/src/specs/mining/size_limit.rs
@@ -33,7 +33,7 @@ impl Spec for TemplateSizeLimit {
         assert_eq!(new_block.serialized_size(0), 1036);
         assert_eq!(new_block.transactions().len(), 7);
 
-        let new_block = node.new_block(Some("1000".to_string()), None, None);
+        let new_block = node.new_block(Some(1000), None, None);
         assert_eq!(new_block.transactions().len(), 6);
     }
 

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -20,8 +20,8 @@ impl Spec for BlockSyncBasic {
         net.waiting_for_sync(10);
 
         info!("Node1 should be synced to same block number with node0");
-        let number0 = node0.rpc_client().get_tip_block_number().call().unwrap();
-        let number1 = node0.rpc_client().get_tip_block_number().call().unwrap();
+        let number0 = node0.rpc_client().get_tip_block_number().call().unwrap().0;
+        let number1 = node0.rpc_client().get_tip_block_number().call().unwrap().0;
         assert_eq!(number0, number1);
     }
 

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -57,13 +57,7 @@ impl Spec for ValidSince {
         node.assert_tx_pool_size(0, 0);
 
         // test absolute block number since
-        let tip_number: BlockNumber = node
-            .rpc_client()
-            .get_tip_block_number()
-            .call()
-            .unwrap()
-            .parse()
-            .unwrap();
+        let tip_number: BlockNumber = node.rpc_client().get_tip_block_number().call().unwrap().0;
         info!(
             "Use tip block {} cellbase as tx input with an absolute block number since",
             tip_number

--- a/util/jsonrpc-types/src/experiment.rs
+++ b/util/jsonrpc-types/src/experiment.rs
@@ -1,0 +1,7 @@
+use crate::Cycle;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct DryRunResult {
+    pub cycles: Cycle,
+}

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -3,6 +3,7 @@ mod blockchain;
 mod bytes;
 mod cell;
 mod chain_info;
+mod experiment;
 mod net;
 mod pool;
 mod proposal_short_id;
@@ -41,6 +42,7 @@ pub use self::blockchain::{
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};
 pub use self::chain_info::ChainInfo;
+pub use self::experiment::DryRunResult;
 pub use self::net::{Node, NodeAddress};
 pub use self::pool::TxPoolInfo;
 pub use self::proposal_short_id::ProposalShortId;


### PR DESCRIPTION
* Move `DryRunResult` into jsonrpc-types
* Complete rpc-client used in integration testing