### PR TITLE
feat: panic if it's likely to reach a deadlock

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -220,7 +220,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
 
         let mut cell_set_diff = CellSetDiff::default();
         let mut fork = ForkChanges::default();
-        let mut chain_state = self.shared.chain_state().lock();
+        let mut chain_state = self.shared.lock_chain_state();
         let mut txs_verify_cache = self.shared.txs_verify_cache().lock();
 
         let parent_ext = self

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -221,7 +221,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
         let mut cell_set_diff = CellSetDiff::default();
         let mut fork = ForkChanges::default();
         let mut chain_state = self.shared.lock_chain_state();
-        let mut txs_verify_cache = self.shared.txs_verify_cache().lock();
+        let mut txs_verify_cache = self.shared.lock_txs_verify_cache();
 
         let parent_ext = self
             .shared

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -68,8 +68,7 @@ fn test_genesis_transaction_spend() {
 
     assert_eq!(
         shared
-            .chain_state()
-            .lock()
+            .lock_chain_state()
             .cell(&OutPoint::new_cell(genesis_tx_hash, 0)),
         CellStatus::Dead
     );
@@ -106,8 +105,7 @@ fn test_transaction_spend_in_same_block() {
     for hash in [&last_cell_base_hash, &tx1_hash, &tx2_hash].iter() {
         assert_eq!(
             shared
-                .chain_state()
-                .lock()
+                .lock_chain_state()
                 .cell(&OutPoint::new_cell(hash.to_owned().to_owned(), 0)),
             CellStatus::Unknown
         );
@@ -159,8 +157,7 @@ fn test_transaction_spend_in_same_block() {
     for hash in [&last_cell_base_hash, &tx1_hash].iter() {
         assert_eq!(
             shared
-                .chain_state()
-                .lock()
+                .lock_chain_state()
                 .cell(&OutPoint::new_cell(hash.to_owned().to_owned(), 0)),
             CellStatus::Dead
         );
@@ -168,8 +165,7 @@ fn test_transaction_spend_in_same_block() {
 
     assert_eq!(
         shared
-            .chain_state()
-            .lock()
+            .lock_chain_state()
             .cell(&OutPoint::new_cell(tx2_hash.to_owned(), 0)),
         CellStatus::live_cell(CellMeta {
             cell_output: None,
@@ -558,7 +554,7 @@ fn test_genesis_transaction_fetch() {
     let (_chain_controller, shared) = start_chain(Some(consensus));
 
     let out_point = OutPoint::new_cell(root_hash, 0);
-    let state = shared.chain_state().lock().cell(&out_point);
+    let state = shared.lock_chain_state().cell(&out_point);
     assert!(state.is_live());
 }
 
@@ -800,7 +796,7 @@ fn test_next_epoch_ext() {
         last_epoch = epoch;
     }
     {
-        let chain_state = shared.chain_state().lock();
+        let chain_state = shared.lock_chain_state();
         let tip = chain_state.tip_header().clone();
         let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
         assert_eq!(total_uncles_count, 25);
@@ -868,7 +864,7 @@ fn test_next_epoch_ext() {
     }
 
     {
-        let chain_state = shared.chain_state().lock();
+        let chain_state = shared.lock_chain_state();
         let tip = chain_state.tip_header().clone();
         let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
         assert_eq!(total_uncles_count, 10);
@@ -908,7 +904,7 @@ fn test_next_epoch_ext() {
     }
 
     {
-        let chain_state = shared.chain_state().lock();
+        let chain_state = shared.lock_chain_state();
         let tip = chain_state.tip_header().clone();
         let total_uncles_count = shared.block_ext(&tip.hash()).unwrap().total_uncles_count;
         assert_eq!(total_uncles_count, 150);

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -56,7 +56,7 @@ fn test_find_fork_case1() {
             .unwrap();
     }
 
-    let tip_number = { shared.chain_state().lock().tip_number() };
+    let tip_number = { shared.lock_chain_state().tip_number() };
 
     // fork2 total_difficulty 470
     let new_block = gen_block(&parent, U256::from(200u64), vec![], vec![], vec![]);
@@ -134,7 +134,7 @@ fn test_find_fork_case2() {
             .unwrap();
     }
 
-    let tip_number = { shared.chain_state().lock().tip_number() };
+    let tip_number = { shared.lock_chain_state().tip_number() };
 
     let difficulty = parent.difficulty().to_owned();
     let new_block = gen_block(
@@ -218,7 +218,7 @@ fn test_find_fork_case3() {
             .unwrap();
     }
 
-    let tip_number = { shared.chain_state().lock().tip_number() };
+    let tip_number = { shared.lock_chain_state().tip_number() };
 
     let new_block = gen_block(&parent, U256::from(100u64), vec![], vec![], vec![]);
     fork2.push(new_block.clone());
@@ -294,7 +294,7 @@ fn test_find_fork_case4() {
             .unwrap();
     }
 
-    let tip_number = { shared.chain_state().lock().tip_number() };
+    let tip_number = { shared.lock_chain_state().tip_number() };
 
     let new_block = gen_block(&parent, U256::from(100u64), vec![], vec![], vec![]);
     fork2.push(new_block.clone());

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -261,7 +261,7 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
         let uncles_count_limit = self.shared.consensus().max_uncles_num() as u32;
 
         let last_uncles_updated_at = self.last_uncles_updated_at.load(Ordering::SeqCst);
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         let last_txs_updated_at = chain_state.get_last_txs_updated_at();
 
         let header = chain_state.tip_header().to_owned();
@@ -608,7 +608,7 @@ mod tests {
 
         let resolver = HeaderResolverWrapper::new(block.header(), shared.clone());
         let header_verify_result = {
-            let chain_state = shared.chain_state().lock();
+            let chain_state = shared.lock_chain_state();
             let header_verifier =
                 HeaderVerifier::new(&*chain_state, Pow::Dummy(Default::default()).engine());
             header_verifier.verify(&resolver)

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -73,7 +73,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
         let id = ProposalShortId::from_tx_hash(&hash);
 
         let tx = {
-            let chan_state = self.shared.chain_state().lock();
+            let chan_state = self.shared.lock_chain_state();
 
             let tx_pool = chan_state.tx_pool();
             tx_pool
@@ -132,7 +132,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
         to: BlockNumber,
     ) -> Result<Vec<CellOutputWithOutPoint>> {
         let mut result = Vec::new();
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         let from = from.0;
         let to = to.0;
         if from > to {
@@ -185,7 +185,7 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
     }
 
     fn get_live_cell(&self, out_point: OutPoint) -> Result<CellWithStatus> {
-        let mut cell_status = self.shared.chain_state().lock().cell(
+        let mut cell_status = self.shared.lock_chain_state().cell(
             &(out_point
                 .clone()
                 .try_into()

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -42,12 +42,12 @@ impl<CS: ChainStore + 'static> ExperimentRpc for ExperimentRpcImpl<CS> {
 
     fn dry_run_transaction(&self, tx: Transaction) -> Result<DryRunResult> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         DryRunner::new(&chain_state).run(tx)
     }
 
     fn calculate_dao_maximum_withdraw(&self, out_point: OutPoint, hash: H256) -> Result<Capacity> {
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         match DaoWithdrawCalculator::new(&chain_state).calculate(
             out_point
                 .clone()

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -81,7 +81,7 @@ impl<CS: ChainStore + 'static> MinerRpc for MinerRpcImpl<CS> {
         );
         let resolver = HeaderResolverWrapper::new(block.header(), self.shared.clone());
         let header_verify_ret = {
-            let chain_state = self.shared.chain_state().lock();
+            let chain_state = self.shared.lock_chain_state();
             let header_verifier = HeaderVerifier::new(
                 &*chain_state,
                 Arc::clone(&self.shared.consensus().pow_engine()),

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -63,7 +63,7 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
     }
 
     fn tx_pool_info(&self) -> Result<TxPoolInfo> {
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         let tx_pool = chain_state.tx_pool();
         Ok(TxPoolInfo {
             pending: Unsigned(u64::from(tx_pool.pending_size())),

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -27,7 +27,7 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
     fn get_blockchain_info(&self) -> Result<ChainInfo> {
         let chain = self.synchronizer.shared.consensus().id.clone();
         let (tip_header, median_time) = {
-            let chain_state = self.shared.chain_state().lock();
+            let chain_state = self.shared.lock_chain_state();
             let tip_header = chain_state.tip_header().clone();
             let median_time = (&*chain_state)
                 .block_median_time(tip_header.number())

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -34,7 +34,7 @@ impl<CS: ChainStore + 'static> IntegrationTestRpc for IntegrationTestRpcImpl<CS>
 
     fn enqueue_test_transaction(&self, tx: Transaction) -> Result<H256> {
         let tx: CoreTransaction = tx.try_into().map_err(|_| Error::parse_error())?;
-        let mut chain_state = self.shared.chain_state().lock();
+        let mut chain_state = self.shared.lock_chain_state();
         let tx_hash = tx.hash().to_owned();
         chain_state.mut_tx_pool().enqueue_tx(None, tx);
         Ok(tx_hash)

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -273,7 +273,7 @@ fn test_rpc() {
         //// It is just a convenient way to get the json of `send_transaction`
         // if print_mode {
         //     let tip_header = {
-        //         let chain_state = shared.chain_state().lock();
+        //         let chain_state = shared.lock_chain_state();
         //         chain_state.tip_header().clone()
         //     };
         //     let cellbase = new_cellbase(tip_header.number());

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -75,8 +75,8 @@ impl<CS: ChainStore> Shared<CS> {
         &self.script_config
     }
 
-    pub fn txs_verify_cache(&self) -> &Mutex<LruCache<H256, Cycle>> {
-        &self.txs_verify_cache
+    pub fn lock_txs_verify_cache(&self) -> MutexGuard<LruCache<H256, Cycle>> {
+        lock_or_panic(&self.txs_verify_cache)
     }
 
     pub fn store(&self) -> &Arc<CS> {

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -12,7 +12,7 @@ use ckb_db::{CacheDB, DBConfig, KeyValueDB, MemoryKeyValueDB, RocksDB};
 use ckb_script::ScriptConfig;
 use ckb_store::{ChainKVStore, ChainStore, COLUMNS, COLUMN_BLOCK_HEADER};
 use ckb_traits::ChainProvider;
-use ckb_util::Mutex;
+use ckb_util::{lock_or_panic, Mutex, MutexGuard};
 use lru_cache::LruCache;
 use numext_fixed_hash::H256;
 use std::sync::Arc;
@@ -67,8 +67,8 @@ impl<CS: ChainStore> Shared<CS> {
         })
     }
 
-    pub fn chain_state(&self) -> &Mutex<ChainState<CS>> {
-        &self.chain_state
+    pub fn lock_chain_state(&self) -> MutexGuard<ChainState<CS>> {
+        lock_or_panic(&self.chain_state)
     }
 
     pub fn script_config(&self) -> &ScriptConfig {

--- a/shared/src/tests/shared.rs
+++ b/shared/src/tests/shared.rs
@@ -37,7 +37,7 @@ where
 #[test]
 fn test_block_median_time() {
     let shared = new_shared();
-    let chain_state = shared.chain_state().lock();
+    let chain_state = shared.lock_chain_state();
     assert_eq!((&*chain_state).block_median_time(0), Some(0));
     let now = faketime::unix_time_as_millis();
     insert_block_timestamps(shared.store(), &[now]);

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -54,7 +54,7 @@ impl<CS: ChainStore> TxPoolExecutor<CS> {
         // resolve txs
         // early release the chain_state lock because tx verification is slow
         let (resolved_txs, cached_txs, unresolvable_txs, consensus, tip_number) = {
-            let chain_state = self.shared.chain_state().lock();
+            let chain_state = self.shared.lock_chain_state();
             let txs_verify_cache = self.shared.txs_verify_cache().lock();
             let consensus = chain_state.consensus();
             let tip_number = chain_state.tip_number();
@@ -116,7 +116,7 @@ impl<CS: ChainStore> TxPoolExecutor<CS> {
 
         // Add verified txs to pool
         // must lock chain_state before txs_verify_cache to avoid dead lock.
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
         // write cache
         let cycles_vec = {
             let mut txs_verify_cache = self.shared.txs_verify_cache().lock();
@@ -279,9 +279,7 @@ mod tests {
     #[test]
     fn test_verify_and_add_tx_to_pool() {
         let (shared, always_success_out_point) = setup(10);
-        let last_block = shared
-            .block(&shared.chain_state().lock().tip_hash())
-            .unwrap();
+        let last_block = shared.block(&shared.lock_chain_state().tip_hash()).unwrap();
         let last_cellbase = last_block.transactions().first().unwrap();
 
         // building 10 txs and broadcast some

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -55,7 +55,7 @@ impl<CS: ChainStore> TxPoolExecutor<CS> {
         // early release the chain_state lock because tx verification is slow
         let (resolved_txs, cached_txs, unresolvable_txs, consensus, tip_number) = {
             let chain_state = self.shared.lock_chain_state();
-            let txs_verify_cache = self.shared.txs_verify_cache().lock();
+            let txs_verify_cache = self.shared.lock_txs_verify_cache();
             let consensus = chain_state.consensus();
             let tip_number = chain_state.tip_number();
             let mut resolved_txs = Vec::with_capacity(txs.len());
@@ -119,7 +119,7 @@ impl<CS: ChainStore> TxPoolExecutor<CS> {
         let chain_state = self.shared.lock_chain_state();
         // write cache
         let cycles_vec = {
-            let mut txs_verify_cache = self.shared.txs_verify_cache().lock();
+            let mut txs_verify_cache = self.shared.lock_txs_verify_cache();
             cycles_vec
                 .into_iter()
                 .map(|(i, result)| {

--- a/src/subcommand/prof.rs
+++ b/src/subcommand/prof.rs
@@ -33,7 +33,7 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
         })?;
 
     let from = std::cmp::max(1, args.from);
-    let to = std::cmp::min(shared.chain_state().lock().tip_number(), args.to);
+    let to = std::cmp::min(shared.lock_chain_state().tip_number(), args.to);
     info!("start profling, re-process blocks {}..{}:", from, to);
     let now = std::time::Instant::now();
     let tx_count = profile_block_process(shared, tmp_shared, from, to);

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -44,7 +44,7 @@ impl<'a, CS: ChainStore + 'static> BlockTransactionsProcess<'a, CS> {
                     .collect::<Result<_, FailureError>>()?;
 
             let ret = {
-                let chain_state = self.relayer.shared.chain_state().lock();
+                let chain_state = self.relayer.shared.lock_chain_state();
                 self.relayer
                     .reconstruct_block(&chain_state, &compact_block, transactions)
             };

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -73,7 +73,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
             self.relayer.shared.send_getheaders_to_peer(
                 self.nc.as_ref(),
                 self.peer,
-                self.relayer.shared.chain_state().lock().tip_header(),
+                self.relayer.shared.lock_chain_state().tip_header(),
             );
             return Ok(());
         }
@@ -111,7 +111,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
 
             // Reconstruct block
             let ret = {
-                let chain_state = self.relayer.shared.chain_state().lock();
+                let chain_state = self.relayer.shared.lock_chain_state();
                 self.relayer.request_proposal_txs(
                     &chain_state,
                     self.nc.as_ref(),

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -35,7 +35,7 @@ impl<'a, CS: ChainStore> GetBlockProposalProcess<'a, CS> {
         let proposals = cast!(self.message.proposals())?;
 
         let transactions = {
-            let chain_state = self.relayer.shared.chain_state().lock();
+            let chain_state = self.relayer.shared.lock_chain_state();
             let tx_pool = chain_state.tx_pool();
 
             let proposals: Vec<ProposalShortId> = proposals

--- a/sync/src/relayer/get_transaction_process.rs
+++ b/sync/src/relayer/get_transaction_process.rs
@@ -38,8 +38,7 @@ impl<'a, CS: ChainStore> GetTransactionProcess<'a, CS> {
             let short_id = ProposalShortId::from_tx_hash(&tx_hash);
             self.relayer
                 .shared
-                .chain_state()
-                .lock()
+                .lock_chain_state()
                 .get_tx_with_cycles_from_pool(&short_id)
                 .and_then(|(tx, cycles)| cycles.map(|cycles| (tx, cycles)))
         };

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -325,7 +325,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         let mut peer_txs = FnvHashMap::default();
         let mut remove_ids = Vec::new();
         {
-            let chain_state = self.shared.chain_state().lock();
+            let chain_state = self.shared.lock_chain_state();
             let tx_pool = chain_state.tx_pool();
             for (id, peer_indexs) in pending_proposals_request.iter() {
                 if let Some(tx) = tx_pool.get_tx(id) {

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -42,7 +42,7 @@ fn new_transaction(
     always_success_out_point: &OutPoint,
 ) -> Transaction {
     let previous_output = {
-        let chain_state = relayer.shared.shared().chain_state().lock();
+        let chain_state = relayer.shared.shared().lock_chain_state();
         let tip_hash = chain_state.tip_hash();
         let block = relayer
             .shared
@@ -152,7 +152,7 @@ fn test_reconstruct_block() {
             .collect();
         let transactions: Vec<Transaction> = prepare.iter().skip(1).cloned().collect();
         compact.short_ids = short_ids;
-        let chain_state = relayer.shared.chain_state().lock();
+        let chain_state = relayer.shared.lock_chain_state();
         assert_eq!(
             relayer.reconstruct_block(&chain_state, &compact, transactions),
             Err(vec![0]),
@@ -178,7 +178,7 @@ fn test_reconstruct_block() {
             .map(|(i, _)| i)
             .collect();
         compact.short_ids = short_ids;
-        let chain_state = relayer.shared.chain_state().lock();
+        let chain_state = relayer.shared.lock_chain_state();
         assert_eq!(
             relayer.reconstruct_block(&chain_state, &compact, transactions),
             Err(missing),
@@ -225,7 +225,7 @@ fn test_reconstruct_block() {
                 .expect("adding transaction into pool");
         });
 
-        let chain_state = relayer.shared.chain_state().lock();
+        let chain_state = relayer.shared.lock_chain_state();
         assert_eq!(
             relayer.reconstruct_block(&chain_state, &compact, short_transactions),
             Err(vec![0, 2]),

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -44,8 +44,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
         } else if self
             .relayer
             .shared
-            .chain_state()
-            .lock()
+            .lock_chain_state()
             .tx_pool()
             .get_tx_with_cycles(&short_id)
             .is_some()

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -27,7 +27,7 @@ where
 {
     pub fn new(synchronizer: Synchronizer<CS>, peer: PeerIndex) -> Self {
         let (tip_header, total_difficulty) = {
-            let chain_state = synchronizer.shared.chain_state().lock();
+            let chain_state = synchronizer.shared.lock_chain_state();
             (
                 chain_state.tip_header().to_owned(),
                 chain_state.total_difficulty().to_owned(),

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -241,7 +241,7 @@ where
         }
 
         if log_enabled!(target: "sync", log::Level::Debug) {
-            let chain_state = self.synchronizer.shared.chain_state().lock();
+            let chain_state = self.synchronizer.shared.lock_chain_state();
             let peer_state = self.synchronizer.peers.best_known_header(self.peer);
             debug!(
                 target: "sync",

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -349,7 +349,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
                 let best_known_header = best_known_headers.get(peer);
 
                 let (tip_header, local_total_difficulty) = {
-                    let chain_state = self.shared.chain_state().lock();
+                    let chain_state = self.shared.lock_chain_state();
                     (
                         chain_state.tip_header().to_owned(),
                         chain_state.total_difficulty().to_owned(),
@@ -424,7 +424,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
         let tip = {
             let (header, total_difficulty) = {
-                let chain_state = self.shared.chain_state().lock();
+                let chain_state = self.shared.lock_chain_state();
                 (
                     chain_state.tip_header().to_owned(),
                     chain_state.total_difficulty().to_owned(),
@@ -715,7 +715,7 @@ mod tests {
 
         let locator = synchronizer
             .shared
-            .get_locator(shared.chain_state().lock().tip_header());
+            .get_locator(shared.lock_chain_state().tip_header());
 
         let mut expect = Vec::new();
 
@@ -749,7 +749,7 @@ mod tests {
 
         let locator1 = synchronizer1
             .shared
-            .get_locator(shared1.chain_state().lock().tip_header());
+            .get_locator(shared1.lock_chain_state().tip_header());
 
         let latest_common = synchronizer2
             .shared
@@ -817,7 +817,7 @@ mod tests {
         let synchronizer2 = gen_synchronizer(chain_controller2.clone(), shared2.clone());
         let locator1 = synchronizer1
             .shared
-            .get_locator(shared1.chain_state().lock().tip_header());
+            .get_locator(shared1.lock_chain_state().tip_header());
 
         let latest_common = synchronizer2
             .shared
@@ -849,19 +849,19 @@ mod tests {
 
         let header = synchronizer
             .shared
-            .get_ancestor(&shared.chain_state().lock().tip_hash(), 100);
+            .get_ancestor(&shared.lock_chain_state().tip_hash(), 100);
         let tip = synchronizer
             .shared
-            .get_ancestor(&shared.chain_state().lock().tip_hash(), 199);
+            .get_ancestor(&shared.lock_chain_state().tip_hash(), 199);
         let noop = synchronizer
             .shared
-            .get_ancestor(&shared.chain_state().lock().tip_hash(), 200);
+            .get_ancestor(&shared.lock_chain_state().tip_hash(), 200);
         assert!(tip.is_some());
         assert!(header.is_some());
         assert!(noop.is_none());
         assert_eq!(
             tip.unwrap(),
-            shared.chain_state().lock().tip_header().to_owned()
+            shared.lock_chain_state().tip_header().to_owned()
         );
         assert_eq!(
             header.unwrap(),
@@ -903,7 +903,7 @@ mod tests {
         });
         assert_eq!(
             chain1_last_block.header(),
-            shared2.chain_state().lock().tip_header()
+            shared2.lock_chain_state().tip_header()
         );
     }
 
@@ -1036,7 +1036,7 @@ mod tests {
 
         let locator1 = synchronizer1
             .shared
-            .get_locator(&shared1.chain_state().lock().tip_header());
+            .get_locator(&shared1.lock_chain_state().tip_header());
 
         for i in 1..=num {
             let j = if i > 192 { i + 1 } else { i };
@@ -1190,7 +1190,7 @@ mod tests {
         let (chain_controller, shared, _notify) = start_chain(Some(consensus), None);
 
         assert_eq!(
-            shared.chain_state().lock().total_difficulty(),
+            shared.lock_chain_state().total_difficulty(),
             &U256::from(2u64)
         );
 
@@ -1231,7 +1231,7 @@ mod tests {
             // where we checked against our tip.
             // Either way, set a new timeout based on current tip.
             let (tip, total_difficulty) = {
-                let chain_state = shared.chain_state().lock();
+                let chain_state = shared.lock_chain_state();
                 let header = chain_state.tip_header().to_owned();
                 let total_difficulty = chain_state.total_difficulty().to_owned();
                 (header, total_difficulty)

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -60,10 +60,10 @@ fn basic_sync() {
     // Wait node1 receive block from node2
     let _ = signal_rx1.recv();
 
-    assert_eq!(shared1.chain_state().lock().tip_number(), 3);
+    assert_eq!(shared1.lock_chain_state().tip_number(), 3);
     assert_eq!(
-        shared1.chain_state().lock().tip_number(),
-        shared2.chain_state().lock().tip_number()
+        shared1.lock_chain_state().tip_number(),
+        shared2.lock_chain_state().tip_number()
     );
 }
 

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -453,8 +453,8 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     pub fn lock_chain_state(&self) -> MutexGuard<ChainState<CS>> {
         self.shared.lock_chain_state()
     }
-    pub fn txs_verify_cache(&self) -> &Mutex<LruCache<H256, Cycle>> {
-        self.shared.txs_verify_cache()
+    pub fn lock_txs_verify_cache(&self) -> MutexGuard<LruCache<H256, Cycle>> {
+        self.shared.lock_txs_verify_cache()
     }
     pub fn block_header(&self, hash: &H256) -> Option<Header> {
         self.shared.block_header(hash)

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -12,8 +12,8 @@ use ckb_shared::chain_state::ChainState;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
-use ckb_util::Mutex;
 use ckb_util::RwLock;
+use ckb_util::{Mutex, MutexGuard};
 use faketime::unix_time_as_millis;
 use flatbuffers::FlatBufferBuilder;
 use fnv::{FnvHashMap, FnvHashSet};
@@ -419,7 +419,7 @@ pub struct SyncSharedState<CS> {
 impl<CS: ChainStore> SyncSharedState<CS> {
     pub fn new(shared: Shared<CS>) -> SyncSharedState<CS> {
         let (total_difficulty, header, total_uncles_count) = {
-            let chain_state = shared.chain_state().lock();
+            let chain_state = shared.lock_chain_state();
             let block_ext = shared
                 .block_ext(&chain_state.tip_hash())
                 .expect("tip block_ext must exist");
@@ -450,8 +450,8 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     pub fn shared(&self) -> &Shared<CS> {
         &self.shared
     }
-    pub fn chain_state(&self) -> &Mutex<ChainState<CS>> {
-        self.shared.chain_state()
+    pub fn lock_chain_state(&self) -> MutexGuard<ChainState<CS>> {
+        self.shared.lock_chain_state()
     }
     pub fn txs_verify_cache(&self) -> &Mutex<LruCache<H256, Cycle>> {
         self.shared.txs_verify_cache()
@@ -469,14 +469,14 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         self.shared.block(hash)
     }
     pub fn tip_header(&self) -> Header {
-        self.shared.chain_state().lock().tip_header().to_owned()
+        self.shared.lock_chain_state().tip_header().to_owned()
     }
     pub fn consensus(&self) -> &Consensus {
         self.shared.consensus()
     }
     pub fn is_initial_block_download(&self) -> bool {
         unix_time_as_millis()
-            .saturating_sub(self.shared.chain_state().lock().tip_header().timestamp())
+            .saturating_sub(self.shared.lock_chain_state().tip_header().timestamp())
             > MAX_TIP_AGE
     }
 
@@ -669,7 +669,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
 
     pub fn get_locator_response(&self, block_number: BlockNumber, hash_stop: &H256) -> Vec<Header> {
         // Should not change chain state when get headers from it
-        let chain_state = self.shared.chain_state().lock();
+        let chain_state = self.shared.lock_chain_state();
 
         // NOTE: call `self.tip_header()` will cause deadlock
         let tip_number = chain_state.tip_header().number();

--- a/util/instrument/src/iter.rs
+++ b/util/instrument/src/iter.rs
@@ -14,7 +14,7 @@ pub struct ChainIterator<CS> {
 impl<CS: ChainStore> ChainIterator<CS> {
     pub fn new(shared: Shared<CS>) -> Self {
         let current = shared.block_hash(0).and_then(|h| shared.block(&h));
-        let tip = shared.chain_state().lock().tip_number();
+        let tip = shared.lock_chain_state().tip_number();
         ChainIterator {
             shared,
             current,

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,6 +1,7 @@
 mod linked_hash_set;
 
 use std::fmt;
+use std::time::Duration;
 
 pub use fnv::{FnvBuildHasher, FnvHashMap, FnvHashSet};
 pub use linked_hash_map::{Entries as LinkedHashMapEntries, LinkedHashMap};
@@ -13,6 +14,13 @@ pub type LinkedFnvHashSet<T> = LinkedHashSet<T, FnvBuildHasher>;
 pub use parking_lot::{
     self, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
+
+const TRY_LOCK_TIMEOUT: Duration = Duration::from_secs(300);
+
+pub fn lock_or_panic<T>(data: &Mutex<T>) -> MutexGuard<T> {
+    data.try_lock_for(TRY_LOCK_TIMEOUT)
+        .expect("please check if reach a deadlock")
+}
 
 /// Helper macro for reducing boilerplate code for matching `Option` together
 /// with early return.


### PR DESCRIPTION
### Commits

- chore: use `try_lock_for(...)` to replace `lock()` for ChainState

  `sed -i "s/[.]chain_state()[.]lock()/.lock_chain_state()/g" $(grep -rl "[.]chain_state()[.]lock()" [^t]*)`

- chore: use `try_lock_for(...)` to replace `lock()` in TxsVerifyCache

  `sed -i "s/[.]txs_verify_cache()[.]lock()/.lock_txs_verify_cache()/g" $(grep -rl "[.]txs_verify_cache()[.]lock()" [^t]*)`

### Summary

Panic if it's likely to reach a deadlock (wait for 300 seconds).

https://github.com/nervosnetwork/ckb/blob/4b890724d375f845773b57b5ee45b82bee9785f7/util/src/lib.rs#L18-L23