### PR TITLE
chore: fix travis condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
   depth: 2
   submodules: false
 
-if: 'branch IN (master, develop) OR branch =~ /^rc\// OR type != push OR fork = true OR tag IS present'
+if: 'branch IN (master, develop) OR branch =~ /^rc\// OR type != push OR repo != nervosnetwork/ckb OR tag IS present'
 
 env:
   global:


### PR DESCRIPTION
Allow building any branch in fork repository.

The `fork` condition does not work like what Travis doc says.