### PR TITLE
[ᚬrc/v0.12.0] fix: correct block_median_count

### DIFF
--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -9,7 +9,7 @@ pub trait BlockMedianTimeContext {
     /// ancestor timestamps from a block
     fn ancestor_timestamps(&self, block_number: BlockNumber) -> Vec<u64> {
         let count = self.median_block_count();
-        (block_number.saturating_sub(count)..=block_number)
+        (block_number.saturating_sub(count.saturating_sub(1))..=block_number)
             .filter_map(|n| self.timestamp(n))
             .collect()
     }


### PR DESCRIPTION
* Correct block_median_count when verifying a compact block