### PR TITLE
[ᚬrc/v0.12.0] chore: print warning about default miner key

### DIFF
--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -46,5 +46,11 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         args.locator.export_specs()?;
     }
 
+    eprintln!(
+        "**Notice**: \
+         If you want to mine CKB, please make sure to create your own \
+         private key and change the block_assembler config in ckb.toml."
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Print the warning when running `ckb init`. Remind user to change the default
block assembler config before mining.