### PR TITLE
[ᚬrc/v0.12.0]  feat: peer_store support retry and refresh

### DIFF
--- a/network/src/benches/sqlite_peer_store.rs
+++ b/network/src/benches/sqlite_peer_store.rs
@@ -59,7 +59,7 @@ fn random_order_benchmark(c: &mut Criterion) {
             for _ in 0..8000 {
                 let peer_id = PeerId::random();
                 peer_store.add_connected_peer(&peer_id, addr.clone(), SessionType::Outbound);
-                let _ = peer_store.add_discovered_addr(&peer_id, addr.clone());
+                peer_store.add_discovered_addr(&peer_id, addr.clone());
             }
         }
         c.bench_function("random order 1000 / 8000 peer_info", {
@@ -77,7 +77,7 @@ fn random_order_benchmark(c: &mut Criterion) {
             for _ in 0..8000 {
                 let peer_id = PeerId::random();
                 peer_store.add_connected_peer(&peer_id, addr.clone(), SessionType::Outbound);
-                let _ = peer_store.add_discovered_addr(&peer_id, addr.clone());
+                peer_store.add_discovered_addr(&peer_id, addr.clone());
             }
         }
         c.bench_function("random order 2000 / 8000 peer_info", {
@@ -100,7 +100,7 @@ fn random_order_benchmark(c: &mut Criterion) {
                 for _ in 0..8000 {
                     let peer_id = PeerId::random();
                     peer_store.add_connected_peer(&peer_id, addr.clone(), SessionType::Outbound);
-                    let _ = peer_store.add_discovered_addr(&peer_id, addr.clone());
+                    peer_store.add_discovered_addr(&peer_id, addr.clone());
                 }
                 move || {
                     let count = 1000;

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -84,7 +84,7 @@ impl PeerRegistry {
                 return Err(PeerError::NonReserved);
             }
             // ban_list lock acquired
-            if peer_store.is_banned(&peer_id) {
+            if peer_store.is_banned(&remote_addr) {
                 return Err(PeerError::Banned);
             }
 

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -118,17 +118,6 @@ impl PeerRegistry {
                 .collect::<Vec<_>>()
         };
         // Protect peers based on characteristics that an attacker hard to simulate or manipulate
-        // Protect peers which has the highest score
-        // sort_then_drop(
-        //     &mut candidate_peers,
-        //     EVICTION_PROTECT_PEERS,
-        //     |peer1, peer2| {
-        //         let peer1_score = peer_store.peer_score(&peer1.peer_id).unwrap_or_default();
-        //         let peer2_score = peer_store.peer_score(&peer2.peer_id).unwrap_or_default();
-        //         peer1_score.cmp(&peer2_score)
-        //     },
-        // );
-
         // Protect peers which has the lowest ping
         sort_then_drop(
             &mut candidate_peers,
@@ -186,7 +175,7 @@ impl PeerRegistry {
         let mut rng = thread_rng();
         evict_group.shuffle(&mut rng);
 
-        // randomly evict a lowest scored peer
+        // randomly evict a peer
         evict_group.get(0).map(|peer| {
             debug!(target: "network", "evict inbound peer {:?}", peer.peer_id);
             peer.session_id

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -110,7 +110,7 @@ impl PeerRegistry {
 
     // When have inbound connection, we try evict a inbound peer
     // TODO: revisit this after find out what's bitcoin way
-    fn try_evict_inbound_peer(&self, peer_store: &PeerStore) -> Option<SessionId> {
+    fn try_evict_inbound_peer(&self, _peer_store: &PeerStore) -> Option<SessionId> {
         let mut candidate_peers = {
             self.peers
                 .values()
@@ -119,15 +119,15 @@ impl PeerRegistry {
         };
         // Protect peers based on characteristics that an attacker hard to simulate or manipulate
         // Protect peers which has the highest score
-        sort_then_drop(
-            &mut candidate_peers,
-            EVICTION_PROTECT_PEERS,
-            |peer1, peer2| {
-                let peer1_score = peer_store.peer_score(&peer1.peer_id).unwrap_or_default();
-                let peer2_score = peer_store.peer_score(&peer2.peer_id).unwrap_or_default();
-                peer1_score.cmp(&peer2_score)
-            },
-        );
+        // sort_then_drop(
+        //     &mut candidate_peers,
+        //     EVICTION_PROTECT_PEERS,
+        //     |peer1, peer2| {
+        //         let peer1_score = peer_store.peer_score(&peer1.peer_id).unwrap_or_default();
+        //         let peer2_score = peer_store.peer_score(&peer2.peer_id).unwrap_or_default();
+        //         peer1_score.cmp(&peer2_score)
+        //     },
+        // );
 
         // Protect peers which has the lowest ping
         sort_then_drop(
@@ -187,13 +187,10 @@ impl PeerRegistry {
         evict_group.shuffle(&mut rng);
 
         // randomly evict a lowest scored peer
-        evict_group
-            .iter()
-            .min_by_key(|peer| peer_store.peer_score(&peer.peer_id).unwrap_or_default())
-            .map(|peer| {
-                debug!(target: "network", "evict inbound peer {:?}", peer.peer_id);
-                peer.session_id
-            })
+        evict_group.get(0).map(|peer| {
+            debug!(target: "network", "evict inbound peer {:?}", peer.peer_id);
+            peer.session_id
+        })
     }
 
     pub fn add_feeler(&mut self, peer_id: PeerId) {

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -158,7 +158,7 @@ impl PeerRegistry {
         });
 
         // Grop peers by network group
-        let mut evict_group = candidate_peers
+        let evict_group = candidate_peers
             .into_iter()
             .fold(FnvHashMap::default(), |mut groups, peer| {
                 groups
@@ -172,11 +172,9 @@ impl PeerRegistry {
             .cloned()
             .unwrap_or_else(Vec::new);
 
-        let mut rng = thread_rng();
-        evict_group.shuffle(&mut rng);
-
         // randomly evict a peer
-        evict_group.get(0).map(|peer| {
+        let mut rng = thread_rng();
+        evict_group.choose(&mut rng).map(|peer| {
             debug!(target: "network", "evict inbound peer {:?}", peer.peer_id);
             peer.session_id
         })

--- a/network/src/peer_store.rs
+++ b/network/src/peer_store.rs
@@ -1,9 +1,22 @@
 pub mod sqlite;
+pub mod types;
 
+use self::types::PeerAddr;
 pub use crate::{peer_store::sqlite::SqlitePeerStore, SessionType};
 pub(crate) use crate::{Behaviour, PeerId};
 use p2p::multiaddr::Multiaddr;
 use std::time::Duration;
+
+/// After this limitation, peer store will try to eviction peers
+pub const PEER_STORE_LIMIT: u32 = 8192;
+/// Clear banned list if the list reach this size
+pub const BAN_LIST_CLEAR_EXPIRES_SIZE: usize = 1024;
+pub const DEFAULT_ADDRS: u32 = 3;
+pub const MAX_ADDRS: u32 = 3;
+/// Consider we never seen a peer if peer's last_connected_at beyond this timeout
+pub const ADDR_TIMEOUT_MS: u64 = 7 * 24 * 3600 * 1000;
+pub const ADDR_MAX_RETRIES: u32 = 3;
+pub const ADDR_MAX_FAILURES: u32 = 10;
 
 pub type Score = i32;
 
@@ -33,9 +46,9 @@ pub trait PeerStore: Send {
     fn add_connected_peer(&mut self, peer_id: &PeerId, address: Multiaddr, endpoint: SessionType);
     /// Add discovered peer addresses
     /// this method will assume peer and addr is untrust since we have not connected to it.
-    fn add_discovered_addr(&mut self, peer_id: &PeerId, address: Multiaddr) -> bool;
-    /// Delete peer by peer_id (TODO: remove later?)
-    fn delete_peer(&mut self, peer_id: &PeerId);
+    fn add_discovered_addr(&mut self, peer_id: &PeerId, address: Multiaddr);
+    // Update PeerAddr
+    fn update_peer_addr(&mut self, peer_addr: &PeerAddr);
     /// Report peer behaviours
     fn report(&mut self, peer_id: &PeerId, behaviour: Behaviour) -> ReportResult;
     /// Update peer status
@@ -47,14 +60,14 @@ pub trait PeerStore: Send {
     /// This method randomly return peers, it return bootnodes if no other peers in PeerStore.
     fn bootnodes(&self, count: u32) -> Vec<(PeerId, Multiaddr)>;
     /// Get addrs of a peer, note a peer may have multiple addrs
-    fn peer_addrs(&self, peer_id: &PeerId, count: u32) -> Option<Vec<Multiaddr>>;
+    fn peer_addrs(&self, peer_id: &PeerId, count: u32) -> Vec<PeerAddr>;
     /// Get peers for outbound connection, this method randomly return non-connected peer addrs
-    fn peers_to_attempt(&self, count: u32) -> Vec<(PeerId, Multiaddr)>;
+    fn peers_to_attempt(&self, count: u32) -> Vec<PeerAddr>;
     /// Get peers for feeler connection, this method randomly return peer addrs that we never
     /// connected to.
-    fn peers_to_feeler(&self, count: u32) -> Vec<(PeerId, Multiaddr)>;
+    fn peers_to_feeler(&self, count: u32) -> Vec<PeerAddr>;
     /// Randomly get peers
-    fn random_peers(&self, count: u32) -> Vec<(PeerId, Multiaddr)>;
+    fn random_peers(&self, count: u32) -> Vec<PeerAddr>;
     /// Ban a peer
     fn ban_peer(&mut self, peer_id: &PeerId, timeout: Duration);
     /// Check peer ban status

--- a/network/src/peer_store.rs
+++ b/network/src/peer_store.rs
@@ -54,7 +54,6 @@ pub trait PeerStore: Send {
     /// Update peer status
     fn update_status(&self, peer_id: &PeerId, status: Status);
     fn peer_status(&self, peer_id: &PeerId) -> Status;
-    fn peer_score(&self, peer_id: &PeerId) -> Option<Score>;
     /// Add bootnode
     fn add_bootnode(&mut self, peer_id: PeerId, addr: Multiaddr);
     /// This method randomly return peers, it return bootnodes if no other peers in PeerStore.

--- a/network/src/peer_store.rs
+++ b/network/src/peer_store.rs
@@ -67,10 +67,10 @@ pub trait PeerStore: Send {
     fn peers_to_feeler(&self, count: u32) -> Vec<PeerAddr>;
     /// Randomly get peers
     fn random_peers(&self, count: u32) -> Vec<PeerAddr>;
-    /// Ban a peer
-    fn ban_peer(&mut self, peer_id: &PeerId, timeout: Duration);
+    /// Ban a addr
+    fn ban_addr(&mut self, addr: &Multiaddr, timeout: Duration);
     /// Check peer ban status
-    fn is_banned(&self, peer_id: &PeerId) -> bool;
+    fn is_banned(&self, addr: &Multiaddr) -> bool;
     /// peer score config
     fn peer_score_config(&self) -> PeerScoreConfig;
 }

--- a/network/src/peer_store/sqlite/db.rs
+++ b/network/src/peer_store/sqlite/db.rs
@@ -1,5 +1,6 @@
 use crate::network_group::{Group, NetworkGroup};
 use crate::peer_store::sqlite::DBError;
+use crate::peer_store::types::{PeerAddr, PeerInfo};
 use crate::peer_store::{Multiaddr, PeerId, Score, Status};
 use crate::SessionType;
 use rusqlite::types::ToSql;
@@ -7,7 +8,6 @@ use rusqlite::OptionalExtension;
 use rusqlite::{Connection, NO_PARAMS};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
-use std::time::Duration;
 
 type DBResult<T> = Result<T, DBError>;
 
@@ -21,62 +21,57 @@ pub fn create_tables(conn: &Connection) -> DBResult<()> {
     score INTEGER NOT NULL,
     status INTEGER NOT NULL,
     endpoint INTEGER NOT NULL,
-    ban_time INTEGER NOT NULL,
-    last_connected_at INTEGER NOT NULL
+    ban_time_ms INTEGER NOT NULL,
+    last_connected_at_ms INTEGER NOT NULL
     );
     "#;
     conn.execute_batch(sql)?;
     let sql = r#"
     CREATE TABLE IF NOT EXISTS peer_addr (
     id INTEGER PRIMARY KEY NOT NULL,
-    peer_info_id INTEGER NOT NULL,
+    peer_id BINARY NOT NULL,
     addr BINARY NOT NULL,
-    last_connected_at INTEGER NOT NULL
+    last_connected_at_ms INTEGER NOT NULL,
+    last_tried_at_ms INTEGER NOT NULL,
+    attempts_count INTEGER NOT NULL
     );
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_peer_info_id_addr_on_peer_addr ON peer_addr (peer_info_id, addr);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_peer_id_addr_on_peer_addr ON peer_addr (peer_id, addr);
     "#;
     conn.execute_batch(sql)?;
     let sql = r#"
     CREATE TABLE IF NOT EXISTS ban_list (
     id INTEGER PRIMARY KEY NOT NULL,
     ip BINARY UNIQUE NOT NULL,
-    ban_time INTEGER NOT NULL
+    ban_time_ms INTEGER NOT NULL
     );
     "#;
     conn.execute_batch(sql).map_err(Into::into)
 }
 
-#[derive(Debug)]
-pub struct PeerInfo {
-    pub id: u32,
-    pub peer_id: PeerId,
-    pub connected_addr: Multiaddr,
-    pub score: Score,
-    pub status: Status,
-    pub endpoint: SessionType,
-    pub ban_time: Duration,
-    pub last_connected_at: Duration,
-}
+pub struct PeerInfoDB;
 
-impl PeerInfo {
+impl PeerInfoDB {
     pub fn insert(
         conn: &Connection,
         peer_id: &PeerId,
         connected_addr: &Multiaddr,
         endpoint: SessionType,
         score: Score,
-        last_connected_at: Duration,
+        last_connected_at_ms: u64,
     ) -> DBResult<usize> {
         let network_group = connected_addr.network_group();
-        let mut stmt = conn.prepare("INSERT OR REPLACE INTO peer_info (peer_id, connected_addr, score, status, endpoint, last_connected_at, network_group, ban_time) 
-                                    VALUES(:peer_id, :connected_addr, :score, :status, :endpoint, :last_connected_at, :network_group, 0)").expect("prepare");
+        let mut stmt = conn.prepare("INSERT OR REPLACE INTO peer_info (peer_id, connected_addr, score, status, endpoint, last_connected_at_ms, network_group, ban_time_ms) 
+                                    VALUES(:peer_id, :connected_addr, :score, :status, :endpoint, :last_connected_at_ms, :network_group, 0)").expect("prepare");
         stmt.execute_named(&[
             (":peer_id", &peer_id.as_bytes()),
             (":connected_addr", &connected_addr.as_ref()),
             (":score", &score),
             (":status", &status_to_u8(Status::Unknown)),
             (":endpoint", &endpoint_to_bool(endpoint)),
-            (":last_connected_at", &duration_to_secs(last_connected_at)),
+            (
+                ":last_connected_at_ms",
+                &millis_to_secs(last_connected_at_ms),
+            ),
             (":network_group", &network_group_to_bytes(&network_group)),
         ])
         .map_err(Into::into)
@@ -88,12 +83,19 @@ impl PeerInfo {
         addr: &Multiaddr,
         session_type: SessionType,
         score: Score,
-        last_connected_at: Duration,
+        last_connected_at_ms: u64,
     ) -> DBResult<Option<PeerInfo>> {
         match Self::get_by_peer_id(conn, peer_id)? {
             Some(peer) => Ok(Some(peer)),
             None => {
-                Self::insert(conn, peer_id, addr, session_type, score, last_connected_at)?;
+                Self::insert(
+                    conn,
+                    peer_id,
+                    addr,
+                    session_type,
+                    score,
+                    last_connected_at_ms,
+                )?;
                 Self::get_by_peer_id(conn, peer_id)
             }
         }
@@ -104,50 +106,59 @@ impl PeerInfo {
         peer_id: &PeerId,
         connected_addr: &Multiaddr,
         endpoint: SessionType,
-        last_connected_at: Duration,
+        last_connected_at_ms: u64,
     ) -> DBResult<usize> {
         let mut stmt = conn
             .prepare(
-                "UPDATE peer_info SET connected_addr=:connected_addr, endpoint=:endpoint, last_connected_at=:last_connected_at WHERE peer_id=:peer_id",
+                "UPDATE peer_info SET connected_addr=:connected_addr, endpoint=:endpoint, last_connected_at_ms=:last_connected_at_ms WHERE peer_id=:peer_id",
                 )
             .expect("prepare");
         stmt.execute_named(&[
             (":connected_addr", &connected_addr.as_ref()),
             (":endpoint", &endpoint_to_bool(endpoint)),
-            (":last_connected_at", &duration_to_secs(last_connected_at)),
+            (
+                ":last_connected_at_ms",
+                &millis_to_secs(last_connected_at_ms),
+            ),
             (":peer_id", &peer_id.as_bytes()),
         ])
         .map_err(Into::into)
     }
 
-    pub fn delete(conn: &Connection, id: u32) -> DBResult<usize> {
-        conn.execute("DELETE FROM peer_info WHERE id=?1", &[id])
-            .map_err(Into::into)
+    pub fn delete(conn: &Connection, peer_id: &PeerId) -> DBResult<usize> {
+        conn.execute(
+            "DELETE FROM peer_info WHERE peer_id=?1",
+            &[peer_id.as_bytes()],
+        )
+        .map_err(Into::into)
     }
 
     pub fn get_by_peer_id(conn: &Connection, peer_id: &PeerId) -> DBResult<Option<PeerInfo>> {
-        conn.query_row("SELECT id, peer_id, connected_addr, score, status, endpoint, ban_time, last_connected_at FROM peer_info WHERE peer_id=?1 LIMIT 1", &[&peer_id.as_bytes()], |row| Ok(PeerInfo {
-            id: row.get(0)?,
-            peer_id: PeerId::from_bytes(row.get(1)?).expect("parse peer_id"),
-            connected_addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(2)?).expect("parse multiaddr"),
-            score: row.get(3)?,
-            status: u8_to_status(row.get::<_, u8>(4)?),
-            endpoint: bool_to_endpoint(row.get::<_, bool>(5)?),
-            ban_time: secs_to_duration(row.get(6)?),
-            last_connected_at: secs_to_duration(row.get(7)?),
+        conn.query_row("SELECT peer_id, connected_addr, score, status, endpoint, ban_time_ms, last_connected_at_ms FROM peer_info WHERE peer_id=?1 LIMIT 1", &[&peer_id.as_bytes()], |row| Ok(PeerInfo {
+            peer_id: PeerId::from_bytes(row.get(0)?).expect("parse peer_id"),
+            connected_addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(1)?).expect("parse multiaddr"),
+            score: row.get(2)?,
+            status: u8_to_status(row.get::<_, u8>(3)?),
+            endpoint: bool_to_endpoint(row.get::<_, bool>(4)?),
+            ban_time_ms: secs_to_millis(row.get(5)?),
+            last_connected_at_ms: secs_to_millis(row.get(6)?),
         })).optional().map_err(Into::into)
     }
 
-    pub fn update_score(conn: &Connection, id: u32, score: Score) -> DBResult<usize> {
-        let mut stmt = conn.prepare("UPDATE peer_info SET score=:score WHERE id=:id")?;
-        stmt.execute_named(&[(":score", &score), (":id", &id)])
+    pub fn update_score(conn: &Connection, peer_id: &PeerId, score: Score) -> DBResult<usize> {
+        let mut stmt = conn.prepare("UPDATE peer_info SET score=:score WHERE peer_id=:peer_id")?;
+        stmt.execute_named(&[(":score", &score), (":peer_id", &peer_id.as_bytes())])
             .map_err(Into::into)
     }
 
-    pub fn update_status(conn: &Connection, id: u32, status: Status) -> DBResult<usize> {
-        let mut stmt = conn.prepare("UPDATE peer_info SET status=:status WHERE id=:id")?;
-        stmt.execute_named(&[(":status", &status_to_u8(status)), (":id", &id)])
-            .map_err(Into::into)
+    pub fn update_status(conn: &Connection, peer_id: &PeerId, status: Status) -> DBResult<usize> {
+        let mut stmt =
+            conn.prepare("UPDATE peer_info SET status=:status WHERE peer_id=:peer_id")?;
+        stmt.execute_named(&[
+            (":status", &status_to_u8(status) as &ToSql),
+            (":peer_id", &peer_id.as_bytes()),
+        ])
+        .map_err(Into::into)
     }
 
     pub fn reset_status(conn: &Connection) -> DBResult<usize> {
@@ -161,19 +172,18 @@ impl PeerInfo {
             .query_row::<(Vec<u8>, u32), _, _>("SELECT network_group, COUNT(network_group) AS network_group_count FROM peer_info
                                                GROUP BY network_group ORDER BY network_group_count DESC LIMIT 1",
                                                NO_PARAMS, |r| Ok((r.get(0)?, r.get(1)?)))?;
-        let mut stmt = conn.prepare("SELECT id, peer_id, connected_addr, score, status, endpoint, ban_time, last_connected_at FROM peer_info
+        let mut stmt = conn.prepare("SELECT peer_id, connected_addr, score, status, endpoint, ban_time_ms, last_connected_at_ms FROM peer_info
                                     WHERE network_group=:network_group")?;
         let rows = stmt.query_map_named(&[(":network_group", &network_group)], |row| {
             Ok(PeerInfo {
-                id: row.get(0)?,
-                peer_id: PeerId::from_bytes(row.get(1)?).expect("parse peer_id"),
-                connected_addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(2)?)
+                peer_id: PeerId::from_bytes(row.get(0)?).expect("parse peer_id"),
+                connected_addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(1)?)
                     .expect("parse multiaddr"),
-                score: row.get(3)?,
-                status: u8_to_status(row.get::<_, u8>(4)?),
-                endpoint: bool_to_endpoint(row.get::<_, bool>(5)?),
-                ban_time: secs_to_duration(row.get(6)?),
-                last_connected_at: secs_to_duration(row.get(7)?),
+                score: row.get(2)?,
+                status: u8_to_status(row.get::<_, u8>(3)?),
+                endpoint: bool_to_endpoint(row.get::<_, bool>(4)?),
+                ban_time_ms: secs_to_millis(row.get(5)?),
+                last_connected_at_ms: secs_to_millis(row.get(6)?),
             })
         })?;
         Result::from_iter(rows).map_err(Into::into)
@@ -185,101 +195,127 @@ impl PeerInfo {
     }
 }
 
-pub struct PeerAddr;
+pub struct PeerAddrDB;
 
-impl PeerAddr {
-    pub fn insert(
+impl PeerAddrDB {
+    pub fn count(conn: &Connection, peer_id: &PeerId) -> DBResult<u32> {
+        conn.query_row::<u32, _, _>(
+            "SELECT COUNT(*) FROM peer_addr WHERE peer_id=?1",
+            &[&peer_id.as_bytes()],
+            |r| r.get(0),
+        )
+        .map_err(Into::into)
+    }
+
+    pub fn get(
         conn: &Connection,
-        peer_info_id: u32,
+        peer_id: &PeerId,
         addr: &Multiaddr,
-        last_connected_at: Duration,
-    ) -> DBResult<usize> {
+    ) -> DBResult<Option<PeerAddr>> {
+        conn.query_row("SELECT peer_id, addr, last_connected_at_ms, last_tried_at_ms, last_tried_at_ms, attempts_count FROM peer_addr WHERE peer_id=?1 AND addr=?2 LIMIT 1", &[&peer_id.as_bytes(), &addr.as_ref()], |row| Ok(PeerAddr {
+            peer_id: PeerId::from_bytes(row.get(0)?).expect("parse peer_id"),
+            addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(1)?).expect("parse multiaddr"),
+            last_connected_at_ms: secs_to_millis(row.get(2)?),
+            last_tried_at_ms: secs_to_millis(row.get(3)?),
+            attempts_count: row.get(4)?,
+        })).optional().map_err(Into::into)
+    }
+    pub fn insert_or_update(conn: &Connection, peer_addr: &PeerAddr) -> DBResult<usize> {
         let mut stmt = conn.prepare(
-            "INSERT OR IGNORE INTO peer_addr (peer_info_id, addr, last_connected_at)
-                     VALUES(:peer_info_id, :addr, :last_connected_at)",
+            "INSERT OR REPLACE INTO peer_addr (peer_id, addr, last_connected_at_ms, last_tried_at_ms, attempts_count)
+                     VALUES(:peer_id, :addr, :last_connected_at_ms, :last_tried_at_ms, :attempts_count)",
         )?;
         stmt.execute_named(&[
-            (":peer_info_id", &peer_info_id),
-            (":addr", &addr.as_ref()),
-            (":last_connected_at", &duration_to_secs(last_connected_at)),
+            (":peer_id", &peer_addr.peer_id.as_bytes()),
+            (":addr", &peer_addr.addr.as_ref()),
+            (
+                ":last_connected_at_ms",
+                &millis_to_secs(peer_addr.last_connected_at_ms),
+            ),
+            (
+                ":last_tried_at_ms",
+                &millis_to_secs(peer_addr.last_tried_at_ms),
+            ),
+            (":attempts_count", &peer_addr.attempts_count),
         ])
         .map_err(Into::into)
     }
 
-    pub fn update_connected_at(
-        conn: &Connection,
-        peer_info_id: u32,
-        addr: Multiaddr,
-        last_connected_at: Duration,
-    ) -> DBResult<usize> {
+    pub fn get_addrs(conn: &Connection, peer_id: &PeerId, count: u32) -> DBResult<Vec<PeerAddr>> {
         let mut stmt = conn.prepare(
-            "UPDATE peer_addr SET last_connected_at=:last_connected_at
-                    WHERE peer_info_id=:peer_info_id AND addr=:addr",
+            "SELECT peer_id, addr, last_connected_at_ms, last_tried_at_ms, attempts_count FROM peer_addr 
+            WHERE peer_id == :peer_id
+            ORDER BY last_connected_at_ms DESC LIMIT :count",
         )?;
-        stmt.execute_named(&[
-            (":peer_info_id", &peer_info_id),
-            (":addr", &addr.as_ref()),
-            (":last_connected_at", &duration_to_secs(last_connected_at)),
-        ])
-        .map_err(Into::into)
-    }
-
-    pub fn get_addrs(conn: &Connection, id: u32, count: u32) -> DBResult<Vec<Multiaddr>> {
-        let mut stmt = conn.prepare(
-            "SELECT addr FROM peer_addr WHERE peer_info_id == :id 
-                         ORDER BY last_connected_at DESC LIMIT :count",
+        let rows = stmt.query_map_named(
+            &[(":peer_id", &peer_id.as_bytes()), (":count", &count)],
+            |row| {
+                Ok(PeerAddr {
+                    peer_id: PeerId::from_bytes(row.get(0)?).expect("parse peer_id"),
+                    addr: Multiaddr::try_from(row.get::<_, Vec<u8>>(1)?).expect("parse multiaddr"),
+                    last_connected_at_ms: secs_to_millis(row.get(2)?),
+                    last_tried_at_ms: secs_to_millis(row.get(3)?),
+                    attempts_count: row.get(4)?,
+                })
+            },
         )?;
-        let rows = stmt.query_map_named(&[(":id", &id), (":count", &count)], |row| {
-            Ok(Multiaddr::try_from(row.get::<_, Vec<u8>>(0)?).expect("parse multiaddr"))
-        })?;
         Result::from_iter(rows).map_err(Into::into)
     }
 
-    pub fn delete_by_peer_id(conn: &Connection, id: u32) -> DBResult<usize> {
-        conn.execute("DELETE FROM peer_addr WHERE peer_info_id=?1", &[id])
-            .map_err(Into::into)
+    pub fn delete(conn: &Connection, peer_id: &PeerId, addr: &Multiaddr) -> DBResult<usize> {
+        conn.execute(
+            "DELETE FROM peer_addr WHERE peer_id=?1 AND addr=?2",
+            &[&peer_id.as_bytes(), &addr.as_ref()],
+        )
+        .map_err(Into::into)
+    }
+
+    pub fn delete_by_peer_id(conn: &Connection, peer_id: &PeerId) -> DBResult<usize> {
+        conn.execute(
+            "DELETE FROM peer_addr WHERE peer_id=?1",
+            &[peer_id.as_bytes()],
+        )
+        .map_err(Into::into)
     }
 }
 
 pub fn get_random_peers(
     conn: &Connection,
     count: u32,
-    expired_at: Duration,
-) -> DBResult<Vec<(PeerId, Multiaddr)>> {
+    expired_at_ms: u64,
+) -> DBResult<Vec<PeerAddr>> {
     // random select peers that we have connect to recently.
     let mut stmt = conn.prepare(
-        "SELECT id, peer_id FROM peer_info 
-                                WHERE ban_time < strftime('%s','now') 
-                                AND last_connected_at > :time 
+        "SELECT peer_id FROM peer_info 
+                                WHERE ban_time_ms < strftime('%s','now') 
+                                AND last_connected_at_ms > :time 
                                 ORDER BY RANDOM() LIMIT :count",
     )?;
     let rows = stmt.query_map_named(
-        &[(":count", &count), (":time", &duration_to_secs(expired_at))],
-        |row| {
-            Ok((
-                row.get::<_, u32>(0)?,
-                PeerId::from_bytes(row.get(1)?).expect("parse peer_id"),
-            ))
-        },
+        &[
+            (":count", &count),
+            (":time", &millis_to_secs(expired_at_ms)),
+        ],
+        |row| Ok(PeerId::from_bytes(row.get(0)?).expect("parse peer_id")),
     )?;
 
     let mut peers = Vec::with_capacity(count as usize);
     for row in rows {
-        let (id, peer_id) = row?;
-        let mut addrs = PeerAddr::get_addrs(conn, id, 1)?;
+        let peer_id = row?;
+        let mut addrs = PeerAddrDB::get_addrs(conn, &peer_id, 1)?;
         if let Some(addr) = addrs.pop() {
-            peers.push((peer_id, addr));
+            peers.push(addr);
         }
     }
     Ok(peers)
 }
 
-pub fn get_peers_to_attempt(conn: &Connection, count: u32) -> DBResult<Vec<(u32, PeerId)>> {
+pub fn get_peers_to_attempt(conn: &Connection, count: u32) -> DBResult<Vec<PeerId>> {
     // random select peers
     let mut stmt = conn.prepare(
-        "SELECT id, peer_id FROM peer_info 
+        "SELECT peer_id FROM peer_info 
                                 WHERE status != :connected_status 
-                                AND ban_time < strftime('%s','now') 
+                                AND ban_time_ms < strftime('%s','now') 
                                 ORDER BY RANDOM() LIMIT :count",
     )?;
     let rows = stmt.query_map_named(
@@ -290,12 +326,7 @@ pub fn get_peers_to_attempt(conn: &Connection, count: u32) -> DBResult<Vec<(u32,
             ),
             (":count", &count),
         ],
-        |row| {
-            Ok((
-                row.get::<_, u32>(0)?,
-                PeerId::from_bytes(row.get(1)?).expect("parse peer_id"),
-            ))
-        },
+        |row| Ok(PeerId::from_bytes(row.get(0)?).expect("parse peer_id")),
     )?;
 
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
@@ -304,14 +335,14 @@ pub fn get_peers_to_attempt(conn: &Connection, count: u32) -> DBResult<Vec<(u32,
 pub fn get_peers_to_feeler(
     conn: &Connection,
     count: u32,
-    expired_at: Duration,
-) -> DBResult<Vec<(u32, PeerId)>> {
+    expired_at_ms: u64,
+) -> DBResult<Vec<PeerId>> {
     // random select peers
     let mut stmt = conn.prepare(
-        "SELECT id, peer_id FROM peer_info 
+        "SELECT peer_id FROM peer_info 
                                 WHERE status != :connected_status 
-                                AND last_connected_at < :time 
-                                AND ban_time < strftime('%s','now') 
+                                AND last_connected_at_ms < :time 
+                                AND ban_time_ms < strftime('%s','now') 
                                 ORDER BY RANDOM() LIMIT :count",
     )?;
     let rows = stmt.query_map_named(
@@ -320,41 +351,36 @@ pub fn get_peers_to_feeler(
                 ":connected_status",
                 &status_to_u8(Status::Connected) as &ToSql,
             ),
-            (":time", &duration_to_secs(expired_at)),
+            (":time", &millis_to_secs(expired_at_ms)),
             (":count", &count),
         ],
-        |row| {
-            Ok((
-                row.get::<_, u32>(0)?,
-                PeerId::from_bytes(row.get(1)?).expect("parse peer_id"),
-            ))
-        },
+        |row| Ok(PeerId::from_bytes(row.get(0)?).expect("parse peer_id")),
     )?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
-pub fn insert_ban_record(conn: &Connection, ip: &[u8], ban_time: Duration) -> DBResult<usize> {
-    let mut stmt =
-        conn.prepare("INSERT OR REPLACE INTO ban_list (ip, ban_time) VALUES(:ip, :ban_time);")?;
-    stmt.execute_named(&[(":ip", &ip), (":ban_time", &duration_to_secs(ban_time))])
+pub fn insert_ban_record(conn: &Connection, ip: &[u8], ban_time_ms: u64) -> DBResult<usize> {
+    let mut stmt = conn
+        .prepare("INSERT OR REPLACE INTO ban_list (ip, ban_time_ms) VALUES(:ip, :ban_time_ms);")?;
+    stmt.execute_named(&[(":ip", &ip), (":ban_time_ms", &millis_to_secs(ban_time_ms))])
         .map_err(Into::into)
 }
 
-pub fn get_ban_records(conn: &Connection, now: Duration) -> DBResult<Vec<(Vec<u8>, Duration)>> {
-    let mut stmt = conn.prepare("SELECT ip, ban_time FROM ban_list WHERE ban_time > :now")?;
-    let rows = stmt.query_map_named(&[(":now", &duration_to_secs(now))], |row| {
-        Ok((row.get::<_, Vec<u8>>(0)?, secs_to_duration(row.get(1)?)))
+pub fn get_ban_records(conn: &Connection, now_ms: u64) -> DBResult<Vec<(Vec<u8>, u64)>> {
+    let mut stmt = conn.prepare("SELECT ip, ban_time_ms FROM ban_list WHERE ban_time_ms > :now")?;
+    let rows = stmt.query_map_named(&[(":now", &millis_to_secs(now_ms))], |row| {
+        Ok((row.get::<_, Vec<u8>>(0)?, secs_to_millis(row.get(1)?)))
     })?;
     Result::from_iter(rows).map_err(Into::into)
 }
 
-pub fn clear_expires_banned_ip(conn: &Connection, now: Duration) -> DBResult<Vec<Vec<u8>>> {
-    let mut stmt = conn.prepare("SELECT ip FROM ban_list WHERE ban_time < :now")?;
-    let rows = stmt.query_map_named(&[(":now", &duration_to_secs(now))], |row| {
+pub fn clear_expires_banned_ip(conn: &Connection, now_ms: u64) -> DBResult<Vec<Vec<u8>>> {
+    let mut stmt = conn.prepare("SELECT ip FROM ban_list WHERE ban_time_ms < :now")?;
+    let rows = stmt.query_map_named(&[(":now", &millis_to_secs(now_ms))], |row| {
         row.get::<_, Vec<u8>>(0)
     })?;
-    let mut stmt = conn.prepare("DELETE FROM ban_list WHERE ban_time < :now")?;
-    stmt.execute_named(&[(":now", &duration_to_secs(now))])?;
+    let mut stmt = conn.prepare("DELETE FROM ban_list WHERE ban_time_ms < :now")?;
+    stmt.execute_named(&[(":now", &millis_to_secs(now_ms))])?;
     Result::from_iter(rows).map_err(Into::into)
 }
 
@@ -366,12 +392,12 @@ fn u8_to_status(i: u8) -> Status {
     Status::from(i)
 }
 
-fn secs_to_duration(secs: u32) -> Duration {
-    Duration::from_secs(secs.into())
+fn secs_to_millis(secs: u32) -> u64 {
+    u64::from(secs) * 1000
 }
 
-fn duration_to_secs(duration: Duration) -> u32 {
-    duration.as_secs() as u32
+fn millis_to_secs(millis: u64) -> u32 {
+    (millis / 1000) as u32
 }
 
 fn endpoint_to_bool(endpoint: SessionType) -> bool {

--- a/network/src/peer_store/sqlite/peer_store.rs
+++ b/network/src/peer_store/sqlite/peer_store.rs
@@ -1,16 +1,16 @@
-/// SqlitePeerStore
-/// Principles:
-/// 1. PeerId is easy to be generated, should never use a PeerId as an identity.
-/// 2. Peer's connected addr should be use as an identify to ban a peer, it is based on our
-///    assumption that IP is a limited resource.
-/// Solution:
-/// 1. Through PeerId to ban or score a peer.
-/// 2. When a peer get banned we also ban peer's connected addr.
-/// 3. A bad peer can always avoid punishment by change it's PeerId, but it can't get high
-///    score.
-/// 4. Good peers can get higher score than bad peers.
-///
-///
+//! SqlitePeerStore
+//! Principles:
+//! 1. PeerId is easy to be generated, should never use a PeerId as an identity.
+//! 2. Peer's connected addr should be use as an identify to ban a peer, it is based on our
+//!    assumption that IP is a limited resource.
+//! Solution:
+//! 1. Through PeerId to ban or score a peer.
+//! 2. When a peer get banned we also ban peer's connected addr.
+//! 3. A bad peer can always avoid punishment by change it's PeerId, but it can't get high
+//!    score.
+//! 4. Good peers can get higher score than bad peers.
+
+
 use crate::network_group::MultiaddrExt;
 use crate::peer_store::sqlite::{db, DBError};
 use crate::peer_store::types::{PeerAddr, PeerInfo};

--- a/network/src/peer_store/sqlite/peer_store.rs
+++ b/network/src/peer_store/sqlite/peer_store.rs
@@ -10,7 +10,6 @@
 //!    score.
 //! 4. Good peers can get higher score than bad peers.
 
-
 use crate::network_group::MultiaddrExt;
 use crate::peer_store::sqlite::{db, DBError};
 use crate::peer_store::types::{PeerAddr, PeerInfo};

--- a/network/src/peer_store/sqlite/peer_store.rs
+++ b/network/src/peer_store/sqlite/peer_store.rs
@@ -1,5 +1,3 @@
-use crate::network_group::MultiaddrExt;
-use crate::peer_store::sqlite::{db, DBError};
 /// SqlitePeerStore
 /// Principles:
 /// 1. PeerId is easy to be generated, should never use a PeerId as an identity.
@@ -11,27 +9,28 @@ use crate::peer_store::sqlite::{db, DBError};
 /// 3. A bad peer can always avoid punishment by change it's PeerId, but it can't get high
 ///    score.
 /// 4. Good peers can get higher score than bad peers.
+///
+///
+use crate::network_group::MultiaddrExt;
+use crate::peer_store::sqlite::{db, DBError};
+use crate::peer_store::types::{PeerAddr, PeerInfo};
 use crate::peer_store::{
     Behaviour, Multiaddr, PeerId, PeerScoreConfig, PeerStore, ReportResult, Score, Status,
 };
+use crate::peer_store::{
+    ADDR_TIMEOUT_MS, BAN_LIST_CLEAR_EXPIRES_SIZE, DEFAULT_ADDRS, MAX_ADDRS, PEER_STORE_LIMIT,
+};
 use crate::SessionType;
-use faketime::unix_time;
+use faketime::unix_time_as_millis;
 use fnv::FnvHashMap;
+use rand::{seq::SliceRandom, thread_rng};
 use rusqlite::Connection;
 use std::time::Duration;
-
-/// After this limitation, peer store will try to eviction peers
-pub(crate) const PEER_STORE_LIMIT: u32 = 8192;
-/// Consider we never seen a peer if peer's last_connected_at beyond this timeout
-pub(crate) const LAST_CONNECTED_TIMEOUT_SECS: u64 = 14 * 24 * 3600;
-/// Clear banned list if the list reach this size
-const BAN_LIST_CLEAR_EXPIRES_SIZE: usize = 1024;
-const DEFAULT_ADDRS: u32 = 3;
 
 pub struct SqlitePeerStore {
     bootnodes: Vec<(PeerId, Multiaddr)>,
     peer_score_config: PeerScoreConfig,
-    ban_list: FnvHashMap<Vec<u8>, Duration>,
+    ban_list: FnvHashMap<Vec<u8>, u64>,
     pub(crate) conn: Connection,
 }
 
@@ -73,12 +72,12 @@ impl SqlitePeerStore {
     }
 
     fn reset_status(&self) -> Result<usize, DBError> {
-        db::PeerInfo::reset_status(&self.conn)
+        db::PeerInfoDB::reset_status(&self.conn)
     }
 
     fn load_banlist(&mut self) -> Result<(), DBError> {
         self.clear_expires_banned_ip()?;
-        let now = unix_time();
+        let now = unix_time_as_millis();
         let ban_records = db::get_ban_records(&self.conn, now)?;
         for (ip, ban_time) in ban_records {
             self.ban_list.insert(ip, ban_time);
@@ -93,7 +92,7 @@ impl SqlitePeerStore {
                 None => return,
             }
         };
-        let ban_time = unix_time() + timeout;
+        let ban_time = unix_time_as_millis() + (timeout.as_millis() as u64);
         db::insert_ban_record(&self.conn, &ip, ban_time).expect("ban ip");
         self.ban_list.insert(ip, ban_time);
         if self.ban_list.len() > BAN_LIST_CLEAR_EXPIRES_SIZE {
@@ -106,7 +105,7 @@ impl SqlitePeerStore {
             Some(ip) => ip,
             None => return false,
         };
-        let now = unix_time();
+        let now = unix_time_as_millis();
         match self.ban_list.get(&ip) {
             Some(ban_time) => *ban_time > now,
             None => false,
@@ -114,7 +113,7 @@ impl SqlitePeerStore {
     }
 
     fn clear_expires_banned_ip(&mut self) -> Result<(), DBError> {
-        let now = unix_time();
+        let now = unix_time_as_millis();
         let ips = db::clear_expires_banned_ip(&self.conn, now)?;
         for ip in ips {
             self.ban_list.remove(&ip);
@@ -124,17 +123,17 @@ impl SqlitePeerStore {
 
     /// check and try delete peer_info if peer_infos reach limit
     fn check_store_limit(&mut self) -> Result<(), ()> {
-        let peer_info_count = db::PeerInfo::count(&self.conn).expect("peer info count");
+        let peer_info_count = db::PeerInfoDB::count(&self.conn).expect("peer info count");
         if peer_info_count < PEER_STORE_LIMIT {
             return Ok(());
         }
         let candidate_peers = {
-            let peers = db::PeerInfo::largest_network_group(&self.conn)
+            let peers = db::PeerInfoDB::largest_network_group(&self.conn)
                 .expect("query largest network group");
-            let not_seen_timeout = unix_time() - Duration::from_secs(LAST_CONNECTED_TIMEOUT_SECS);
+            let not_seen_timeout = unix_time_as_millis() - ADDR_TIMEOUT_MS;
             peers
                 .into_iter()
-                .filter(move |peer| peer.last_connected_at < not_seen_timeout)
+                .filter(move |peer| peer.last_connected_at_ms < not_seen_timeout)
         };
         let candidate_peer = match candidate_peers.min_by_key(|peer| peer.score) {
             Some(peer) => peer,
@@ -146,44 +145,59 @@ impl SqlitePeerStore {
         }
 
         let tx = self.conn.transaction().expect("db tx");
-        db::PeerInfo::delete(&tx, candidate_peer.id).expect("delete peer error");
-        db::PeerAddr::delete_by_peer_id(&tx, candidate_peer.id)
+        db::PeerInfoDB::delete(&tx, &candidate_peer.peer_id).expect("delete peer error");
+        db::PeerAddrDB::delete_by_peer_id(&tx, &candidate_peer.peer_id)
             .expect("delete peer by peer_id error");
         tx.commit().expect("delete peer error");
         Ok(())
     }
 
-    fn fetch_peer_info(&self, peer_id: &PeerId) -> db::PeerInfo {
+    /// check and try delete peer_addr if peer_addr reach limit
+    fn check_peer_addrs_limit(&mut self, peer_id: &PeerId) -> Result<(), ()> {
+        let now = unix_time_as_millis();
+        let peer_addrs_count = db::PeerAddrDB::count(&self.conn, peer_id).expect("peer info count");
+        if peer_addrs_count < MAX_ADDRS {
+            return Ok(());
+        }
+        let mut peer_addrs =
+            db::PeerAddrDB::get_addrs(&self.conn, peer_id, MAX_ADDRS).expect("peer addrs");
+        let mut terrible_addrs_count = 0;
+        for paddr in &peer_addrs {
+            if paddr.is_terrible(now) {
+                db::PeerAddrDB::delete(&self.conn, &paddr.peer_id, &paddr.addr)
+                    .expect("delete peer addr");
+                terrible_addrs_count += 1;
+            }
+        }
+        // have evict addrs
+        if terrible_addrs_count > 0 {
+            return Ok(());
+        }
+        // find oldest last_connected_at_ms addr
+        peer_addrs.sort_by(|a, b| a.last_connected_at_ms.cmp(&b.last_connected_at_ms));
+        if let Some(old_peer_addr) = peer_addrs.get(0) {
+            db::PeerAddrDB::delete(&self.conn, &old_peer_addr.peer_id, &old_peer_addr.addr)
+                .expect("evict peer addr");
+        }
+        Ok(())
+    }
+
+    fn fetch_peer_info(&self, peer_id: &PeerId) -> PeerInfo {
         let blank_addr = &Multiaddr::empty();
-        db::PeerInfo::get_or_insert(
+        db::PeerInfoDB::get_or_insert(
             &self.conn,
             peer_id,
             &blank_addr,
             SessionType::Inbound,
             self.peer_score_config.default_score,
-            Duration::from_secs(0),
+            0,
         )
         .expect("get or insert")
         .expect("must have peer info")
     }
 
-    fn get_peer_info(&self, peer_id: &PeerId) -> Option<db::PeerInfo> {
-        db::PeerInfo::get_by_peer_id(&self.conn, peer_id).expect("get peer info")
-    }
-
-    fn find_addrs_for_peers(
-        &self,
-        conn: &rusqlite::Connection,
-        peers: Vec<(u32, PeerId)>,
-    ) -> Result<Vec<(PeerId, Multiaddr)>, DBError> {
-        let mut peer_addrs = Vec::with_capacity(peers.len());
-        for (id, peer_id) in peers {
-            let addrs = db::PeerAddr::get_addrs(conn, id, DEFAULT_ADDRS)?;
-            if let Some(addr) = addrs.into_iter().find(|addr| !self.is_addr_banned(&addr)) {
-                peer_addrs.push((peer_id, addr));
-            }
-        }
-        Ok(peer_addrs)
+    fn get_peer_info(&self, peer_id: &PeerId) -> Option<PeerInfo> {
+        db::PeerInfoDB::get_by_peer_id(&self.conn, peer_id).expect("get peer info")
     }
 }
 
@@ -192,15 +206,15 @@ impl PeerStore for SqlitePeerStore {
         if self.check_store_limit().is_err() {
             return;
         }
-        let now = unix_time();
+        let now = unix_time_as_millis();
         let default_peer_score = self.peer_score_config().default_score;
         // upsert peer_info
-        db::PeerInfo::update(&self.conn, peer_id, &addr, endpoint, now)
+        db::PeerInfoDB::update(&self.conn, peer_id, &addr, endpoint, now)
             .and_then(|affected_lines| {
                 if affected_lines > 0 {
                     Ok(())
                 } else {
-                    db::PeerInfo::insert(
+                    db::PeerInfoDB::insert(
                         &self.conn,
                         peer_id,
                         &addr,
@@ -213,35 +227,44 @@ impl PeerStore for SqlitePeerStore {
             })
             .expect("update peer failed");
 
+        // update peer connected_info if outbound
         if endpoint.is_outbound() {
-            let peer = db::PeerInfo::get_by_peer_id(&self.conn, peer_id)
-                .expect("get_by_peer_id failed")
-                .expect("must have");
-            db::PeerAddr::update_connected_at(&self.conn, peer.id, addr, now)
-                .expect("update connected at");
-        }
-    }
-
-    fn add_discovered_addr(&mut self, peer_id: &PeerId, addr: Multiaddr) -> bool {
-        // peer store is full
-        if self.check_store_limit().is_err() {
-            return false;
-        }
-        let peer_info = self.fetch_peer_info(peer_id);
-        let inserted =
-            db::PeerAddr::insert(&self.conn, peer_info.id, &addr, Duration::from_secs(0))
+            // update peer_addr if addr already exists
+            if let Some(mut paddr) =
+                db::PeerAddrDB::get(&self.conn, &peer_id, &addr).expect("get peer addr")
+            {
+                paddr.mark_connected(now);
+                db::PeerAddrDB::insert_or_update(&self.conn, &paddr).expect("insert peer addr");
+            } else {
+                db::PeerAddrDB::insert_or_update(
+                    &self.conn,
+                    &PeerAddr::new(peer_id.to_owned(), addr, now),
+                )
                 .expect("insert addr");
-        inserted > 0
+            }
+        }
     }
 
-    fn delete_peer(&mut self, peer_id: &PeerId) {
-        let info = db::PeerInfo::get_by_peer_id(&self.conn, peer_id)
-            .expect("get peer info failed")
-            .expect("get peer info failed opt");
-        let tx = self.conn.transaction().expect("db tx");
-        db::PeerInfo::delete(&tx, info.id).expect("delete peer error");
-        db::PeerAddr::delete_by_peer_id(&tx, info.id).expect("delete peer by peer_id error");
-        tx.commit().expect("delete peer error");
+    fn add_discovered_addr(&mut self, peer_id: &PeerId, addr: Multiaddr) {
+        // peer store is full
+        if self.check_peer_addrs_limit(peer_id).is_err() {
+            return;
+        }
+        // insert a peer if peer not exists in db
+        let peer = self.fetch_peer_info(peer_id);
+        db::PeerAddrDB::insert_or_update(
+            &self.conn,
+            &PeerAddr::new(peer.peer_id.to_owned(), addr, 0),
+        )
+        .expect("insert addr");
+    }
+
+    fn update_peer_addr(&mut self, peer_addr: &PeerAddr) {
+        // peer store is full
+        if self.check_peer_addrs_limit(&peer_addr.peer_id).is_err() {
+            return;
+        }
+        db::PeerAddrDB::insert_or_update(&self.conn, peer_addr).expect("insert addr");
     }
 
     fn report(&mut self, peer_id: &PeerId, behaviour: Behaviour) -> ReportResult {
@@ -254,14 +277,12 @@ impl PeerStore for SqlitePeerStore {
             self.ban_peer(peer_id, self.peer_score_config.ban_timeout);
             return ReportResult::Banned;
         }
-        db::PeerInfo::update_score(&self.conn, peer.id, score).expect("update peer score");
+        db::PeerInfoDB::update_score(&self.conn, &peer.peer_id, score).expect("update peer score");
         ReportResult::Ok
     }
 
     fn update_status(&self, peer_id: &PeerId, status: Status) {
-        if let Some(peer) = self.get_peer_info(peer_id) {
-            db::PeerInfo::update_status(&self.conn, peer.id, status).expect("update status");
-        }
+        db::PeerInfoDB::update_status(&self.conn, &peer_id, status).expect("update status");
     }
 
     fn peer_status(&self, peer_id: &PeerId) -> Status {
@@ -277,9 +298,17 @@ impl PeerStore for SqlitePeerStore {
     fn add_bootnode(&mut self, peer_id: PeerId, addr: Multiaddr) {
         self.bootnodes.push((peer_id, addr));
     }
+
     // should return high scored nodes if possible, otherwise, return boostrap nodes
     fn bootnodes(&self, count: u32) -> Vec<(PeerId, Multiaddr)> {
-        let mut peers = self.peers_to_attempt(count);
+        let mut peers = self
+            .peers_to_attempt(count)
+            .into_iter()
+            .map(|paddr| {
+                let PeerAddr { peer_id, addr, .. } = paddr;
+                (peer_id, addr)
+            })
+            .collect::<Vec<_>>();
         if peers.len() < count as usize {
             for (peer_id, addr) in self.bootnodes.iter() {
                 let peer = (peer_id.to_owned(), addr.to_owned());
@@ -290,36 +319,62 @@ impl PeerStore for SqlitePeerStore {
         }
         peers
     }
-    fn peer_addrs<'a>(&'a self, peer_id: &'a PeerId, count: u32) -> Option<Vec<Multiaddr>> {
-        self.get_peer_info(peer_id).map(|peer| {
-            db::PeerAddr::get_addrs(&self.conn, peer.id, count).expect("get peer addrs")
-        })
+
+    fn peer_addrs<'a>(&'a self, peer_id: &'a PeerId, count: u32) -> Vec<PeerAddr> {
+        db::PeerAddrDB::get_addrs(&self.conn, peer_id, count).expect("get peer addrs")
     }
 
-    fn peers_to_attempt(&self, count: u32) -> Vec<(PeerId, Multiaddr)> {
+    fn peers_to_attempt(&self, count: u32) -> Vec<PeerAddr> {
+        let now_ms = unix_time_as_millis();
         let peers = db::get_peers_to_attempt(&self.conn, count).expect("get peers to attempt");
-        self.find_addrs_for_peers(&self.conn, peers)
-            .expect("find_addrs_for_peers failed")
+        peers
+            .into_iter()
+            .filter_map(|peer_id| {
+                let mut paddrs = db::PeerAddrDB::get_addrs(&self.conn, &peer_id, DEFAULT_ADDRS)
+                    .expect("get peer addr");
+                let mut rng = thread_rng();
+                paddrs.shuffle(&mut rng);
+                paddrs
+                    .into_iter()
+                    .find(|paddr| !self.is_addr_banned(&paddr.addr) && !paddr.is_terrible(now_ms))
+            })
+            .collect()
     }
 
-    fn peers_to_feeler(&self, count: u32) -> Vec<(PeerId, Multiaddr)> {
-        let peers = db::get_peers_to_feeler(
-            &self.conn,
-            count,
-            unix_time() - Duration::from_secs(LAST_CONNECTED_TIMEOUT_SECS),
-        )
-        .expect("get peers to feeler");
-        self.find_addrs_for_peers(&self.conn, peers)
-            .expect("find_addrs_for_peers failed")
+    fn peers_to_feeler(&self, count: u32) -> Vec<PeerAddr> {
+        let now_ms = unix_time_as_millis();
+        let peers =
+            db::get_peers_to_feeler(&self.conn, count, unix_time_as_millis() - ADDR_TIMEOUT_MS)
+                .expect("get peers to feeler");
+        peers
+            .into_iter()
+            .filter_map(|peer_id| {
+                let mut paddrs = db::PeerAddrDB::get_addrs(&self.conn, &peer_id, DEFAULT_ADDRS)
+                    .expect("get peer addr");
+                // find worst addr to feeler unless it is terrible or banned or already tried in one minute
+                paddrs.sort_by(|a, b| a.last_connected_at_ms.cmp(&b.last_connected_at_ms));
+                paddrs.into_iter().find(|paddr| {
+                    if paddr.is_terrible(now_ms) {
+                        // delete terrible addr
+                        db::PeerAddrDB::delete(&self.conn, &paddr.peer_id, &paddr.addr)
+                            .expect("delete peer addr");
+                        false
+                    } else {
+                        !self.is_addr_banned(&paddr.addr)
+                            && paddr.last_tried_at_ms < now_ms - 60_000
+                    }
+                })
+            })
+            .collect()
     }
 
-    fn random_peers(&self, count: u32) -> Vec<(PeerId, Multiaddr)> {
-        db::get_random_peers(
-            &self.conn,
-            count,
-            unix_time() - Duration::from_secs(LAST_CONNECTED_TIMEOUT_SECS),
-        )
-        .expect("get random peers")
+    fn random_peers(&self, count: u32) -> Vec<PeerAddr> {
+        let now_ms = unix_time_as_millis();
+        db::get_random_peers(&self.conn, count, unix_time_as_millis() - ADDR_TIMEOUT_MS)
+            .expect("get random peers")
+            .into_iter()
+            .filter(|paddr| !paddr.is_terrible(now_ms))
+            .collect()
     }
 
     fn ban_peer(&mut self, peer_id: &PeerId, timeout: Duration) {
@@ -334,6 +389,7 @@ impl PeerStore for SqlitePeerStore {
         }
         false
     }
+
     fn peer_score_config(&self) -> PeerScoreConfig {
         self.peer_score_config
     }

--- a/network/src/peer_store/sqlite/peer_store.rs
+++ b/network/src/peer_store/sqlite/peer_store.rs
@@ -15,7 +15,7 @@ use crate::network_group::MultiaddrExt;
 use crate::peer_store::sqlite::{db, DBError};
 use crate::peer_store::types::{PeerAddr, PeerInfo};
 use crate::peer_store::{
-    Behaviour, Multiaddr, PeerId, PeerScoreConfig, PeerStore, ReportResult, Score, Status,
+    Behaviour, Multiaddr, PeerId, PeerScoreConfig, PeerStore, ReportResult, Status,
 };
 use crate::peer_store::{
     ADDR_TIMEOUT_MS, BAN_LIST_CLEAR_EXPIRES_SIZE, DEFAULT_ADDRS, MAX_ADDRS, PEER_STORE_LIMIT,
@@ -289,10 +289,6 @@ impl PeerStore for SqlitePeerStore {
         self.get_peer_info(peer_id)
             .map(|peer| peer.status)
             .unwrap_or_else(|| Status::Unknown)
-    }
-
-    fn peer_score(&self, peer_id: &PeerId) -> Option<Score> {
-        self.get_peer_info(peer_id).map(|peer| peer.score)
     }
 
     fn add_bootnode(&mut self, peer_id: PeerId, addr: Multiaddr) {

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -1,0 +1,65 @@
+use crate::peer_store::{
+    Multiaddr, PeerId, Score, SessionType, Status, ADDR_MAX_FAILURES, ADDR_MAX_RETRIES,
+    ADDR_TIMEOUT_MS,
+};
+
+#[derive(Debug)]
+pub struct PeerInfo {
+    pub peer_id: PeerId,
+    pub connected_addr: Multiaddr,
+    pub score: Score,
+    pub status: Status,
+    pub endpoint: SessionType,
+    pub ban_time_ms: u64,
+    pub last_connected_at_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct PeerAddr {
+    pub peer_id: PeerId,
+    pub addr: Multiaddr,
+    pub last_connected_at_ms: u64,
+    pub last_tried_at_ms: u64,
+    pub attempts_count: u32,
+}
+
+impl PeerAddr {
+    pub fn new(peer_id: PeerId, addr: Multiaddr, last_connected_at_ms: u64) -> Self {
+        PeerAddr {
+            peer_id,
+            addr,
+            last_connected_at_ms,
+            last_tried_at_ms: 0,
+            attempts_count: 0,
+        }
+    }
+
+    pub fn is_terrible(&self, now_ms: u64) -> bool {
+        // do not remove addr tried in last minute
+        if self.last_tried_at_ms >= (now_ms - 60_000) {
+            return false;
+        }
+        // we give up if never connect to this addr
+        if self.last_connected_at_ms == 0 && self.attempts_count >= ADDR_MAX_RETRIES {
+            return true;
+        }
+        // consider addr is terrible if failed too many times
+        if (now_ms - self.last_connected_at_ms) > ADDR_TIMEOUT_MS
+            && (self.attempts_count >= ADDR_MAX_FAILURES)
+        {
+            return true;
+        }
+        false
+    }
+
+    pub fn mark_tried(&mut self, tried_at_ms: u64) {
+        self.last_tried_at_ms = tried_at_ms;
+        self.attempts_count = self.attempts_count.saturating_add(1);
+    }
+
+    pub fn mark_connected(&mut self, connected_at_ms: u64) {
+        self.last_connected_at_ms = connected_at_ms;
+        // reset attemps
+        self.attempts_count = 0;
+    }
+}

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -34,9 +34,13 @@ impl PeerAddr {
         }
     }
 
+    pub fn tried_in_last_minute(&self, now_ms: u64) -> bool {
+        self.last_tried_at_ms >= (now_ms - 60_000)
+    }
+
     pub fn is_terrible(&self, now_ms: u64) -> bool {
         // do not remove addr tried in last minute
-        if self.last_tried_at_ms >= (now_ms - 60_000) {
+        if self.tried_in_last_minute(now_ms) {
             return false;
         }
         // we give up if never connect to this addr

--- a/network/src/protocols/discovery.rs
+++ b/network/src/protocols/discovery.rs
@@ -1,4 +1,5 @@
 // use crate::peer_store::Behaviour;
+use crate::peer_store::types::PeerAddr;
 use crate::NetworkState;
 use fnv::FnvHashMap;
 use futures::{sync::mpsc, sync::oneshot, Async, Future, Stream};
@@ -207,9 +208,7 @@ impl DiscoveryService {
                                 .collect::<Multiaddr>();
 
                             self.network_state.with_peer_store_mut(|peer_store| {
-                                if !peer_store.add_discovered_addr(&peer_id, addr) {
-                                    trace!(target: "network", "add_discovered_addr failed {:?}", peer_id);
-                                }
+                                peer_store.add_discovered_addr(&peer_id, addr);
                             });
                         }
                     }
@@ -228,7 +227,10 @@ impl DiscoveryService {
                     .with_peer_store(|peer_store| peer_store.random_peers(n as u32));
                 let addrs = random_peers
                     .into_iter()
-                    .filter_map(|(peer_id, mut addr)| {
+                    .filter_map(|paddr| {
+                        let PeerAddr {
+                            mut addr, peer_id, ..
+                        } = paddr;
                         if !self.is_valid_addr(&addr) {
                             return None;
                         }

--- a/network/src/protocols/identify.rs
+++ b/network/src/protocols/identify.rs
@@ -58,9 +58,7 @@ impl Callback for IdentifyCallback {
             .insert(peer_id.clone(), addrs.clone());
         self.network_state.with_peer_store_mut(|peer_store| {
             for addr in addrs {
-                if !peer_store.add_discovered_addr(&peer_id, addr) {
-                    trace!(target: "network", "add_discovered_addr failed {:?}", peer_id);
-                }
+                peer_store.add_discovered_addr(&peer_id, addr);
             }
         })
     }
@@ -104,9 +102,7 @@ impl Callback for IdentifyCallback {
             debug!(target: "network", "identify add transformed addr: {:?}", transformed_addr);
             let local_peer_id = self.network_state.local_peer_id();
             self.network_state.with_peer_store_mut(|peer_store| {
-                if !peer_store.add_discovered_addr(local_peer_id, transformed_addr) {
-                    trace!(target: "network", "add_discovered_addr failed {:?}", local_peer_id);
-                }
+                peer_store.add_discovered_addr(local_peer_id, transformed_addr);
             });
         }
         // NOTE: for future usage

--- a/network/src/tests/peer_registry.rs
+++ b/network/src/tests/peer_registry.rs
@@ -3,7 +3,7 @@ use crate::{
     multiaddr::Multiaddr,
     peer_registry::{PeerRegistry, EVICTION_PROTECT_PEERS},
     peer_store::{PeerStore, SqlitePeerStore},
-    Behaviour, PeerId, SessionType,
+    PeerId, SessionType,
 };
 use std::time::{Duration, Instant};
 
@@ -113,24 +113,26 @@ fn test_accept_inbound_peer_until_full() {
 #[test]
 fn test_accept_inbound_peer_eviction() {
     // eviction inbound peer
-    // 1. should evict from largest network groups
-    // 2. should never evict reserved peer
-    // 3. should evict lowest scored peer
+    // We build an unprotected evict targets set
+    // PeerRegistry should
+    // 1. evict from largest network groups
+    // 2. never evict reserved peer
     let mut peer_store = new_peer_store();
     let reserved_peer = PeerId::random();
     let evict_target = PeerId::random();
-    let lowest_score_peer = PeerId::random();
+    let mut evict_targets = vec![evict_target.to_owned()];
     let addr1 = "/ip4/127.0.0.1".parse::<Multiaddr>().unwrap();
     let addr2 = "/ip4/192.168.0.1".parse::<Multiaddr>().unwrap();
     // prepare protected peers
     let longest_connection_time_peers_count = 5;
-    let protected_peers_count = 3 * EVICTION_PROTECT_PEERS + longest_connection_time_peers_count;
+    let protected_peers_count = 2 * (EVICTION_PROTECT_PEERS + longest_connection_time_peers_count);
     let mut peers_registry = PeerRegistry::new(
-        (protected_peers_count + longest_connection_time_peers_count) as u32,
+        (protected_peers_count) as u32,
         3,
         false,
         vec![reserved_peer.clone()],
     );
+    // prepare all peers
     for session_id in 0..protected_peers_count {
         assert!(peers_registry
             .accept_peer(
@@ -151,14 +153,6 @@ fn test_accept_inbound_peer_eviction() {
     };
 
     let mut peers_iter = peers.iter();
-    // higest scored peers
-    {
-        for _ in 0..EVICTION_PROTECT_PEERS {
-            let peer_id = peers_iter.next().unwrap();
-            peer_store.report(&peer_id, Behaviour::TestGood);
-            peer_store.report(&peer_id, Behaviour::TestGood);
-        }
-    }
     // lowest ping peers
     for _ in 0..EVICTION_PROTECT_PEERS {
         let peer_id = peers_iter.next().unwrap();
@@ -182,7 +176,7 @@ fn test_accept_inbound_peer_eviction() {
             peer.last_message_time = Some(now + Duration::from_secs(10));
         };
     }
-    // protect 5 peers which have the longest connection time
+    // protect half peers which have the longest connection time
     for _ in 0..longest_connection_time_peers_count {
         let peer_id = peers_iter.next().unwrap();
         let session_id = peers_registry
@@ -192,89 +186,18 @@ fn test_accept_inbound_peer_eviction() {
             peer.connected_time = now - Duration::from_secs(10);
         };
     }
-    let mut new_peer_ids = (0..3).map(|_| PeerId::random()).collect::<Vec<_>>();
-    // setup 3 node and 1 reserved node from addr1
-    peers_registry
-        .accept_peer(
-            reserved_peer.clone(),
-            addr1.clone(),
-            1000.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    peers_registry
-        .accept_peer(
-            evict_target.clone(),
-            addr1.clone(),
-            1001.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    peers_registry
-        .accept_peer(
-            new_peer_ids[0].clone(),
-            addr1.clone(),
-            1002.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    peers_registry
-        .accept_peer(
-            new_peer_ids[1].clone(),
-            addr1.clone(),
-            1003.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    // setup 2 node from addr2
-    peers_registry
-        .accept_peer(
-            lowest_score_peer.clone(),
-            addr2.clone(),
-            1004.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    peers_registry
-        .accept_peer(
-            new_peer_ids[2].clone(),
-            addr2.clone(),
-            1005.into(),
-            SessionType::Inbound,
-            peer_store.as_mut(),
-        )
-        .expect("accept");
-    // setup score
-    {
-        peer_store.report(&lowest_score_peer, Behaviour::TestBad);
-        peer_store.report(&lowest_score_peer, Behaviour::TestBad);
-        peer_store.report(&lowest_score_peer, Behaviour::TestBad);
-        peer_store.report(&reserved_peer, Behaviour::TestBad);
-        peer_store.report(&reserved_peer, Behaviour::TestBad);
-        peer_store.report(&evict_target, Behaviour::TestBad);
-    }
-    // make sure other peers should not protected by longest connection time rule
-    new_peer_ids.extend_from_slice(&[
-        reserved_peer.clone(),
-        evict_target.clone(),
-        lowest_score_peer.clone(),
-    ]);
-    for peer_id in new_peer_ids {
+    // thoses peers will not be protect, we add them to evict_targets
+    for _ in 0..longest_connection_time_peers_count {
+        let peer_id = peers_iter.next().unwrap();
+        evict_targets.push(peer_id.to_owned());
         let session_id = peers_registry
             .get_key_by_peer_id(&peer_id)
             .expect("get_key_by_peer_id failed");
         if let Some(peer) = peers_registry.get_peer_mut(session_id) {
-            // push the connected_time to make sure peer is unprotect
-            peer.connected_time = now + Duration::from_secs(10);
+            peer.connected_time = now - Duration::from_secs(10);
         };
     }
-    // should evict evict target
-    assert!(peers_registry.get_key_by_peer_id(&evict_target).is_some());
+
     peers_registry
         .accept_peer(
             PeerId::random(),
@@ -284,5 +207,10 @@ fn test_accept_inbound_peer_eviction() {
             peer_store.as_mut(),
         )
         .expect("accept");
-    assert!(peers_registry.get_key_by_peer_id(&evict_target).is_none());
+    let len_after_eviction = evict_targets
+        .iter()
+        .filter_map(|peer_id| peers_registry.get_key_by_peer_id(peer_id))
+        .count();
+    // should evict from one of evict_targets
+    assert_eq!(len_after_eviction, evict_targets.len() - 1);
 }

--- a/network/src/tests/sqlite_peer_store.rs
+++ b/network/src/tests/sqlite_peer_store.rs
@@ -33,10 +33,6 @@ fn test_report() {
     let mut peer_store: Box<dyn PeerStore> = Box::new(new_peer_store());
     let peer_id = PeerId::random();
     assert!(peer_store.report(&peer_id, Behaviour::TestGood).is_ok());
-    // assert!(
-    //     peer_store.peer_score(&peer_id).expect("peer score")
-    //         > peer_store.peer_score_config().default_score
-    // );
 }
 
 #[test]

--- a/network/src/tests/sqlite_peer_store.rs
+++ b/network/src/tests/sqlite_peer_store.rs
@@ -51,12 +51,10 @@ fn test_update_status() {
 fn test_ban_peer() {
     let mut peer_store: Box<dyn PeerStore> = Box::new(new_peer_store());
     let peer_id = PeerId::random();
-    peer_store.ban_peer(&peer_id, Duration::from_secs(10));
-    assert!(!peer_store.is_banned(&peer_id));
-    let addr = "/ip4/127.0.0.1".parse().unwrap();
-    peer_store.add_connected_peer(&peer_id, addr, SessionType::Inbound);
-    peer_store.ban_peer(&peer_id, Duration::from_secs(10));
-    assert!(peer_store.is_banned(&peer_id));
+    let addr: Multiaddr = "/ip4/127.0.0.1".parse().unwrap();
+    peer_store.add_connected_peer(&peer_id, addr.clone(), SessionType::Inbound);
+    peer_store.ban_addr(&addr, Duration::from_secs(10));
+    assert!(peer_store.is_banned(&addr));
 }
 
 #[test]
@@ -67,7 +65,7 @@ fn test_attepmt_ban() {
     peer_store.add_connected_peer(&peer_id, addr.clone(), SessionType::Inbound);
     peer_store.add_discovered_addr(&peer_id, addr.clone());
     assert_eq!(peer_store.peers_to_attempt(2).len(), 1);
-    peer_store.ban_peer(&peer_id, Duration::from_secs(10));
+    peer_store.ban_addr(&addr, Duration::from_secs(10));
     assert_eq!(peer_store.peers_to_attempt(2).len(), 0);
 }
 


### PR DESCRIPTION
1. Add retry and refresh address feature to peer_store
2. remove temp code
3. ban through addr instead peer_id

Discovery protocol will not return addresses which node can't reach to node's peers.
Feeler protocol will give up an address if reach a certain condition.

BREAKING CHANGE: peer store db file must be deleted manually.