### PR TITLE
[ᚬrc/v0.12.0] docs: no rustup override in docs

### DIFF
--- a/docs/get-ckb.md
+++ b/docs/get-ckb.md
@@ -20,16 +20,10 @@ We also provides docker images, see [how to run CKB with docker](run-ckb-with-do
 
 ### Install Build Dependencies
 
-CKB is currently tested mainly with `stable-1.34.2` on Linux and macOS.
+CKB requires Rust to build. We recommend installing [rustup](https://www.rustup.rs/) to manage Rust versions.
 
-We recommend installing Rust through [rustup](https://www.rustup.rs/)
-
-```bash
-# Get rustup from rustup.rs, then in your `ckb` folder:
-rustup override set 1.34.2
-```
-
-Report new breakage is welcome.
+The required Rust version is saved in the file `rust-toolchain`. If rustup is
+available, it will pick the right version automatically.
 
 You also need to get the following packages：
 
@@ -51,7 +45,7 @@ sudo pacman -Sy git gcc pkgconf clang
 brew install autoconf libtool
 ```
 
-### Adding Environment Variables
+### Add Environment Variables
 
 If your OS contains pre-compiled `rocksdb` or `snappy` libraries,
 you may setup `ROCKSDB_LIB_DIR` and/or `SNAPPY_LIB_DIR` environment variable


### PR DESCRIPTION
`rustup override` locks the version in the directory. It will cause problems
when the required Rust version has changed, but user forget to override the
new version.