### PR TITLE
[ᚬrc/v0.12.0] fix: load_script_hash should use script's own hash for lock script

### DIFF
--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -55,20 +55,10 @@ impl Script {
     }
 
     pub fn hash(&self) -> H256 {
-        self.hash_with_appended_arguments(&[])
-    }
-
-    // This calculates the script hash with provided arguments appended
-    // to the script's own argument list. This way we can calculate the
-    // script hash on &Script struct without needing to clone it.
-    pub fn hash_with_appended_arguments(&self, args: &[Bytes]) -> H256 {
         let mut ret = [0u8; 32];
         let mut blake2b = new_blake2b();
         blake2b.update(self.code_hash.as_bytes());
         for argument in &self.args {
-            blake2b.update(argument);
-        }
-        for argument in args {
             blake2b.update(argument);
         }
         blake2b.finalize(&mut ret);

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -873,4 +873,56 @@ mod tests {
             _test_load_current_script_hash(data)?;
         }
     }
+
+    fn _test_load_input_lock_script_hash(data: &[u8]) -> Result<(), TestCaseError> {
+        let mut machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::default();
+        let size_addr: u64 = 0;
+        let addr: u64 = 100;
+
+        machine.set_register(A0, addr); // addr
+        machine.set_register(A1, size_addr); // size_addr
+        machine.set_register(A2, 0); // offset
+        machine.set_register(A3, 0); //index
+        machine.set_register(A4, Source::Input as u64); //source: 1 input
+        machine.set_register(A5, CellField::LockHash as u64); //field: 2 lock hash
+        machine.set_register(A7, LOAD_CELL_BY_FIELD_SYSCALL_NUMBER); // syscall number
+
+        let script = Script::new(vec![Bytes::from(data)], H256::zero());
+        let h = script.hash();
+        let hash = h.as_bytes();
+
+        let input_cell = build_resolved_outpoint(CellOutput::new(
+            capacity_bytes!(1000),
+            Bytes::default(),
+            script,
+            None,
+        ));
+        let outputs = vec![];
+        let resolved_inputs = vec![&input_cell];
+        let resolved_deps = vec![];
+        let store = Arc::new(new_memory_store());
+        let mut load_cell = LoadCell::new(store, &outputs, &resolved_inputs, &resolved_deps);
+
+        prop_assert!(machine.memory_mut().store64(&size_addr, &64).is_ok());
+
+        prop_assert!(load_cell.ecall(&mut machine).is_ok());
+        prop_assert_eq!(machine.registers()[A0], u64::from(SUCCESS));
+
+        prop_assert_eq!(
+            machine.memory_mut().load64(&size_addr),
+            Ok(hash.len() as u64)
+        );
+
+        for (i, addr) in (addr..addr + hash.len() as u64).enumerate() {
+            prop_assert_eq!(machine.memory_mut().load8(&addr), Ok(u64::from(hash[i])));
+        }
+        Ok(())
+    }
+
+    proptest! {
+        #[test]
+        fn test_load_input_lock_script_hash(ref data in any_with::<Vec<u8>>(size_range(1000).lift())) {
+            _test_load_input_lock_script_hash(data)?;
+        }
+    }
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -176,7 +176,7 @@ impl<'a, CS: ChainStore> TransactionScriptsVerifier<'a, CS> {
         appended_arguments: &[Bytes],
         max_cycles: Cycle,
     ) -> Result<Cycle, ScriptError> {
-        let current_script_hash = script.hash_with_appended_arguments(&appended_arguments);
+        let current_script_hash = script.hash();
         let mut args = vec!["verify".into()];
         args.extend_from_slice(&script.args);
         args.extend_from_slice(&appended_arguments);


### PR DESCRIPTION
NOTE: this is a breaking change.