### PR TITLE
docs: Add missing container name in run-ckb-with-docker.md

### DIFF
--- a/docs/run-ckb-with-docker.md
+++ b/docs/run-ckb-with-docker.md
@@ -39,6 +39,7 @@ Create a container `ckb-testnet-node` to run a node:
 ```bash
 docker create -it \
   -v ckb-testnet:/var/lib/ckb \
+  --name ckb-testnet-node \
   nervos/ckb:latest run
 ```
 


### PR DESCRIPTION
fix doc bug