### PR TITLE
feat: apply tx_pool limit

### DIFF
--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -398,11 +398,8 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
             resolved_inputs: vec![],
         };
 
-        let script_verifier = ScriptVerifier::new(
-            &rtx,
-            Arc::clone(self.shared.store()),
-            self.shared.script_config(),
-        );
+        let script_verifier =
+            ScriptVerifier::new(&rtx, self.shared.store(), self.shared.script_config());
         let cycle = script_verifier.verify(self.shared.consensus().max_block_cycles())?;
         let serialized_size = tx.serialized_size();
         Ok((tx, serialized_size, cycle))

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -71,9 +71,9 @@ modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Experiment"] # {{
 orphan_block_limit = 1024
 
 [tx_pool]
-max_mem_szie = 20_000_000 # 20mb
+max_mem_size = 20_000_000 # 20mb
 max_cycles = 200_000_000_000
-max_cache_size = 100_000
+max_verfify_cache_size = 100_000
 
 # This config is derived using 0x5c2514fb16b83259d3326a0acf05901c15a87dc46239b77b0a501cd58198dca0
 # as private key. If you want to mine CKB, please make sure to create your own

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -71,12 +71,9 @@ modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Experiment"] # {{
 orphan_block_limit = 1024
 
 [tx_pool]
-max_pool_size = 10000
-max_orphan_size = 10000
-max_proposal_size = 10000
-max_cache_size = 1000
-max_pending_size = 10000
-txs_verify_cache_size = 100000
+max_mem_szie = 20_000_000 # 20mb
+max_cycles = 200_000_000_000
+max_cache_size = 100_000
 
 # This config is derived using 0x5c2514fb16b83259d3326a0acf05901c15a87dc46239b77b0a501cd58198dca0
 # as private key. If you want to mine CKB, please make sure to create your own

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1007,7 +1007,9 @@ http://localhost:8114
         "last_txs_updated_at": "0",
         "orphan": "0",
         "pending": "1",
-        "proposed": "0"
+        "proposed": "0",
+        "total_tx_cycles": "2",
+        "total_tx_size": "156"
     }
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -570,7 +570,9 @@
             "last_txs_updated_at": "0",
             "orphan": "0",
             "pending": "1",
-            "proposed": "0"
+            "proposed": "0",
+            "total_tx_cycles": "2",
+            "total_tx_size": "156"
         }
     },
     {

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -15,7 +15,6 @@ use jsonrpc_types::{Capacity, Cycle, DryRunResult, JsonBytes, OutPoint, Script, 
 use log::error;
 use numext_fixed_hash::H256;
 use serde_derive::Serialize;
-use std::sync::Arc;
 
 #[rpc]
 pub trait ExperimentRpc {
@@ -170,9 +169,7 @@ impl<'a, CS: ChainStore> DryRunner<'a, CS> {
                 let max_cycles = consensus.max_block_cycles;
                 let script_config = self.chain_state.script_config();
                 let store = self.chain_state.store();
-                match ScriptVerifier::new(&resolved, Arc::clone(store), script_config)
-                    .verify(max_cycles)
-                {
+                match ScriptVerifier::new(&resolved, &store, script_config).verify(max_cycles) {
                     Ok(cycles) => Ok(DryRunResult {
                         cycles: Cycle(cycles),
                     }),

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -72,6 +72,8 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
             pending: Unsigned(u64::from(tx_pool.pending_size())),
             proposed: Unsigned(u64::from(tx_pool.proposed_size())),
             orphan: Unsigned(u64::from(tx_pool.orphan_size())),
+            total_tx_size: Unsigned(tx_pool.total_tx_size() as u64),
+            total_tx_cycles: Unsigned(tx_pool.total_tx_cycles()),
             last_txs_updated_at: Timestamp(chain_state.get_last_txs_updated_at()),
         })
     }

--- a/shared/src/tx_pool/orphan.rs
+++ b/shared/src/tx_pool/orphan.rs
@@ -44,11 +44,12 @@ impl OrphanPool {
     pub(crate) fn add_tx(
         &mut self,
         cycles: Option<Cycle>,
+        size: usize,
         tx: Transaction,
         unknown: impl ExactSizeIterator<Item = OutPoint>,
     ) {
         let short_id = tx.proposal_short_id();
-        let entry = DefectEntry::new(tx, unknown.len(), cycles);
+        let entry = DefectEntry::new(tx, unknown.len(), cycles, size);
         for out_point in unknown {
             let edge = self.edges.entry(out_point).or_insert_with(Vec::new);
             edge.push(short_id);
@@ -151,6 +152,8 @@ mod tests {
             .build()
     }
 
+    const MOCK_SIZE: usize = 0;
+
     #[test]
     fn test_orphan_pool_remove_by_ancestor1() {
         let mut pool = OrphanPool::new();
@@ -166,9 +169,9 @@ mod tests {
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 
-        pool.add_tx(None, tx2.clone(), tx1.output_pts().into_iter());
-        pool.add_tx(None, tx3.clone(), tx2.output_pts().into_iter());
-        pool.add_tx(None, tx4.clone(), tx3.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx2.clone(), tx1.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx3.clone(), tx2.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx4.clone(), tx3.output_pts().into_iter());
 
         assert!(pool.contains(&tx2));
         assert!(pool.contains(&tx3));
@@ -198,8 +201,8 @@ mod tests {
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 
-        pool.add_tx(None, tx3.clone(), tx2.output_pts().into_iter());
-        pool.add_tx(None, tx4.clone(), tx3.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx3.clone(), tx2.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx4.clone(), tx3.output_pts().into_iter());
 
         assert!(pool.contains(&tx3));
 
@@ -233,9 +236,9 @@ mod tests {
 
         let tx4 = build_tx(vec![(tx3_hash, 0)], 1);
 
-        pool.add_tx(None, tx2.clone(), tx1.output_pts().into_iter());
-        pool.add_tx(None, tx3.clone(), tx2.output_pts().into_iter());
-        pool.add_tx(None, tx4.clone(), tx3.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx2.clone(), tx1.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx3.clone(), tx2.output_pts().into_iter());
+        pool.add_tx(None, MOCK_SIZE, tx4.clone(), tx3.output_pts().into_iter());
 
         assert!(pool.contains(&tx2));
         assert!(pool.contains(&tx3));

--- a/shared/src/tx_pool/orphan.rs
+++ b/shared/src/tx_pool/orphan.rs
@@ -47,14 +47,14 @@ impl OrphanPool {
         size: usize,
         tx: Transaction,
         unknown: impl ExactSizeIterator<Item = OutPoint>,
-    ) {
+    ) -> Option<DefectEntry> {
         let short_id = tx.proposal_short_id();
         let entry = DefectEntry::new(tx, unknown.len(), cycles, size);
         for out_point in unknown {
             let edge = self.edges.entry(out_point).or_insert_with(Vec::new);
             edge.push(short_id);
         }
-        self.vertices.insert(short_id, entry);
+        self.vertices.insert(short_id, entry)
     }
 
     pub(crate) fn recursion_remove(&mut self, id: &ProposalShortId) {

--- a/shared/src/tx_pool/pending.rs
+++ b/shared/src/tx_pool/pending.rs
@@ -25,10 +25,12 @@ impl PendingQueue {
     pub(crate) fn add_tx(
         &mut self,
         cycles: Option<Cycle>,
+        size: usize,
         tx: Transaction,
     ) -> Option<PendingEntry> {
         let short_id = tx.proposal_short_id();
-        self.inner.insert(short_id, PendingEntry::new(tx, cycles))
+        self.inner
+            .insert(short_id, PendingEntry::new(tx, cycles, size))
     }
 
     pub(crate) fn contains_key(&self, id: &ProposalShortId) -> bool {

--- a/shared/src/tx_pool/proposed.rs
+++ b/shared/src/tx_pool/proposed.rs
@@ -200,7 +200,7 @@ impl ProposedPool {
         }
     }
 
-    pub fn add_tx(&mut self, cycles: Cycle, fee: Capacity, tx: Transaction) {
+    pub fn add_tx(&mut self, cycles: Cycle, fee: Capacity, size: usize, tx: Transaction) {
         let inputs = tx.input_pts_iter();
         let outputs = tx.output_pts();
         let deps = tx.deps_iter();
@@ -234,7 +234,7 @@ impl ProposedPool {
         }
 
         self.vertices
-            .insert(id, ProposedEntry::new(tx, count, cycles, fee));
+            .insert(id, ProposedEntry::new(tx, count, cycles, fee, size));
     }
 
     pub fn remove_committed_tx(&mut self, tx: &Transaction) {
@@ -342,8 +342,9 @@ mod tests {
             .build()
     }
 
-    pub const MOCK_CYCLES: Cycle = 0;
-    pub const MOCK_FEE: Capacity = Capacity::zero();
+    const MOCK_CYCLES: Cycle = 0;
+    const MOCK_FEE: Capacity = Capacity::zero();
+    const MOCK_SIZE: usize = 0;
 
     #[test]
     fn test_add_entry() {
@@ -355,8 +356,8 @@ mod tests {
         let id1 = tx1.proposal_short_id();
         let id2 = tx2.proposal_short_id();
 
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx1.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx2.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx1.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx2.clone());
 
         assert_eq!(pool.vertices.len(), 2);
         assert_eq!(pool.edges.inner_len(), 2);
@@ -382,8 +383,8 @@ mod tests {
         let id1 = tx1.proposal_short_id();
         let id2 = tx2.proposal_short_id();
 
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx1.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx2.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx1.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx2.clone());
 
         assert_eq!(pool.get(&id1).unwrap().refs_count, 0);
         assert_eq!(pool.get(&id2).unwrap().refs_count, 0);
@@ -431,11 +432,11 @@ mod tests {
 
         let mut pool = ProposedPool::new();
 
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx1.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx2.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx3.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx4.clone());
-        pool.add_tx(MOCK_CYCLES, MOCK_FEE, tx5.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx1.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx2.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx3.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx4.clone());
+        pool.add_tx(MOCK_CYCLES, MOCK_FEE, MOCK_SIZE, tx5.clone());
 
         assert_eq!(pool.get(&id1).unwrap().refs_count, 0);
         assert_eq!(pool.get(&id3).unwrap().refs_count, 1);

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -14,18 +14,20 @@ use std::hash::{Hash, Hasher};
 /// Transaction pool configuration
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct TxPoolConfig {
-    /// Maximum capacity of the pool in number of transactions
-    pub max_mem_szie: usize,
-    pub max_cycles: usize,
-    pub max_cache_size: usize,
+    // Keep the transaction pool below <max_mem_size> mb
+    pub max_mem_size: usize,
+    // Keep the transaction pool below <max_cycles> cycles
+    pub max_cycles: Cycle,
+    // tx verfify cache capacity
+    pub max_verfify_cache_size: usize,
 }
 
 impl Default for TxPoolConfig {
     fn default() -> Self {
         TxPoolConfig {
-            max_mem_szie: 20_000_000, // 20mb
+            max_mem_size: 20_000_000, // 20mb
             max_cycles: 200_000_000_000,
-            max_cache_size: 100_000,
+            max_verfify_cache_size: 100_000,
         }
     }
 }
@@ -38,8 +40,8 @@ pub enum PoolError {
     UnresolvableTransaction(UnresolvableError),
     /// An invalid pool entry caused by underlying tx validation error
     InvalidTx(TransactionError),
-    /// Transaction pool is over capacity, can't accept more transactions
-    OverCapacity,
+    /// Transaction pool reach limit, can't accept more transactions
+    LimitReached,
     /// TimeOut
     TimeOut,
     /// BlockNumber is not right

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -12,24 +12,20 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 /// Transaction pool configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct TxPoolConfig {
     /// Maximum capacity of the pool in number of transactions
-    pub max_pool_size: usize,
-    pub max_orphan_size: usize,
-    pub max_proposal_size: usize,
+    pub max_mem_szie: usize,
+    pub max_cycles: usize,
     pub max_cache_size: usize,
-    pub max_pending_size: usize,
 }
 
 impl Default for TxPoolConfig {
     fn default() -> Self {
         TxPoolConfig {
-            max_pool_size: 10000,
-            max_orphan_size: 10000,
-            max_proposal_size: 10000,
-            max_cache_size: 1000,
-            max_pending_size: 10000,
+            max_mem_szie: 20_000_000, // 20mb
+            max_cycles: 200_000_000_000,
+            max_cache_size: 100_000,
         }
     }
 }
@@ -80,15 +76,23 @@ pub struct DefectEntry {
     pub refs_count: usize,
     /// Cycles
     pub cycles: Option<Cycle>,
+    /// tx size
+    pub size: usize,
 }
 
 impl DefectEntry {
     /// Create new transaction pool entry
-    pub fn new(tx: Transaction, refs_count: usize, cycles: Option<Cycle>) -> DefectEntry {
+    pub fn new(
+        tx: Transaction,
+        refs_count: usize,
+        cycles: Option<Cycle>,
+        size: usize,
+    ) -> DefectEntry {
         DefectEntry {
             transaction: tx,
             refs_count,
             cycles,
+            size,
         }
     }
 }
@@ -100,14 +104,17 @@ pub struct PendingEntry {
     pub transaction: Transaction,
     /// Cycles
     pub cycles: Option<Cycle>,
+    /// tx size
+    pub size: usize,
 }
 
 impl PendingEntry {
     /// Create new transaction pool entry
-    pub fn new(tx: Transaction, cycles: Option<Cycle>) -> PendingEntry {
+    pub fn new(tx: Transaction, cycles: Option<Cycle>, size: usize) -> PendingEntry {
         PendingEntry {
             transaction: tx,
             cycles,
+            size,
         }
     }
 }
@@ -123,16 +130,25 @@ pub struct ProposedEntry {
     pub cycles: Cycle,
     /// fee
     pub fee: Capacity,
+    /// tx size
+    pub size: usize,
 }
 
 impl ProposedEntry {
     /// Create new transaction pool entry
-    pub fn new(tx: Transaction, refs_count: usize, cycles: Cycle, fee: Capacity) -> ProposedEntry {
+    pub fn new(
+        tx: Transaction,
+        refs_count: usize,
+        cycles: Cycle,
+        fee: Capacity,
+        size: usize,
+    ) -> ProposedEntry {
         ProposedEntry {
             transaction: tx,
             refs_count,
             cycles,
             fee,
+            size,
         }
     }
 }

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -97,18 +97,19 @@ impl<CS: ChainStore> TxPoolExecutor<CS> {
             store: Arc::clone(&store),
             median_time_block_count: consensus.median_time_block_count() as u64,
         };
+
         // parallet verify txs
         let cycles_vec = resolved_txs
             .iter()
             .map(|(tx_hash, tx)| {
                 let verified_result = TransactionVerifier::new(
                     &tx,
-                    Arc::clone(&store),
                     &block_median_time_context,
                     tip_number,
                     epoch_number,
-                    consensus.cellbase_maturity(),
+                    &consensus,
                     self.shared.script_config(),
+                    &store,
                 )
                 .verify(max_block_cycles)
                 .map(|cycles| (tx, cycles))

--- a/src/subcommand/prof.rs
+++ b/src/subcommand/prof.rs
@@ -13,7 +13,7 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
     let shared = SharedBuilder::<RocksDB>::default()
         .consensus(args.consensus.clone())
         .db(&args.config.db)
-        .tx_pool_config(args.config.tx_pool.clone())
+        .tx_pool_config(args.config.tx_pool)
         .script_config(args.config.script)
         .build()
         .map_err(|err| {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -53,6 +53,8 @@ fn main() {
     );
     specs.insert("compact_block_basic", Box::new(CompactBlockBasic));
     specs.insert("invalid_locator_size", Box::new(InvalidLocatorSize));
+    specs.insert("tx_pool_size_limit", Box::new(SizeLimit));
+    specs.insert("tx_pool_cycles_limit", Box::new(CyclesLimit));
 
     if let Some(spec_name) = env::args().nth(3) {
         if let Some(spec) = specs.get(spec_name.as_str()) {

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -404,4 +404,10 @@ impl Node {
         assert_eq!(tx_pool_info.pending.0, pending_size);
         assert_eq!(tx_pool_info.proposed.0, proposed_size);
     }
+
+    pub fn assert_tx_pool_statics(&self, total_tx_size: u64, total_tx_cycles: u64) {
+        let tx_pool_info = self.rpc_client().tx_pool_info();
+        assert_eq!(tx_pool_info.total_tx_size.0, total_tx_size);
+        assert_eq!(tx_pool_info.total_tx_cycles.0, total_tx_cycles);
+    }
 }

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -2,7 +2,7 @@ use ckb_core::{
     BlockNumber as CoreBlockNumber, EpochNumber as CoreEpochNumber, Version as CoreVersion,
 };
 use ckb_util::Mutex;
-use jsonrpc_client_core::{expand_params, jsonrpc_client};
+use jsonrpc_client_core::{expand_params, jsonrpc_client, Result as JsonRpcResult};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
 use jsonrpc_types::{
     Block, BlockNumber, BlockTemplate, BlockView, CellOutputWithOutPoint, CellWithStatus,
@@ -170,6 +170,10 @@ impl RpcClient {
             .send_transaction(tx)
             .call()
             .expect("rpc call send_transaction")
+    }
+
+    pub fn send_transaction_result(&self, tx: Transaction) -> JsonRpcResult<H256> {
+        self.inner.lock().send_transaction(tx).call()
     }
 
     pub fn tx_pool_info(&self) -> TxPoolInfo {

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -1,0 +1,107 @@
+use crate::{assert_regex_match, Net, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use ckb_app_config::CKBAppConfig;
+use log::info;
+
+pub struct SizeLimit;
+
+impl Spec for SizeLimit {
+    fn run(&self, net: Net) {
+        info!("Running TxPoolSizeLimit");
+        let node = &net.nodes[0];
+
+        info!("Generate 1 block on node");
+        node.generate_block();
+
+        info!("Generate 5 txs on node");
+        let mut txs_hash = Vec::new();
+        let mut hash = node.generate_transaction();
+        txs_hash.push(hash.clone());
+
+        (0..4).for_each(|_| {
+            let tx = node.new_transaction(hash.clone());
+            hash = node.rpc_client().send_transaction((&tx).into());
+            txs_hash.push(hash.clone());
+        });
+
+        info!("No.6 tx reach size limit");
+        let tx = node.new_transaction(hash.clone());
+
+        let error = node
+            .rpc_client()
+            .send_transaction_result((&tx).into())
+            .unwrap_err();
+        assert_regex_match(&error.to_string(), r"LimitReached");
+
+        // 124 * 5
+        // 2 * 5
+        node.assert_tx_pool_statics(620, 10);
+        (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {
+            node.generate_block();
+        });
+        node.generate_block();
+        node.assert_tx_pool_statics(0, 0);
+    }
+
+    fn num_nodes(&self) -> usize {
+        1
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        Box::new(|config| {
+            config.tx_pool.max_mem_size = 620;
+            config.tx_pool.max_cycles = 200_000_000_000;
+        })
+    }
+}
+
+pub struct CyclesLimit;
+
+impl Spec for CyclesLimit {
+    fn run(&self, net: Net) {
+        info!("Running TxPoolCyclesLimit");
+        let node = &net.nodes[0];
+
+        info!("Generate 1 block on node");
+        node.generate_block();
+
+        info!("Generate 5 txs on node");
+        let mut txs_hash = Vec::new();
+        let mut hash = node.generate_transaction();
+        txs_hash.push(hash.clone());
+
+        (0..4).for_each(|_| {
+            let tx = node.new_transaction(hash.clone());
+            hash = node.rpc_client().send_transaction((&tx).into());
+            txs_hash.push(hash.clone());
+        });
+
+        info!("No.6 tx reach cycles limit");
+        let tx = node.new_transaction(hash.clone());
+
+        let error = node
+            .rpc_client()
+            .send_transaction_result((&tx).into())
+            .unwrap_err();
+        assert_regex_match(&error.to_string(), r"LimitReached");
+
+        // 124 * 5
+        // 2 * 5
+        node.assert_tx_pool_statics(620, 10);
+        (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {
+            node.generate_block();
+        });
+        node.generate_block();
+        node.assert_tx_pool_statics(0, 0);
+    }
+
+    fn num_nodes(&self) -> usize {
+        1
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        Box::new(|config| {
+            config.tx_pool.max_mem_size = 20_000_000;
+            config.tx_pool.max_cycles = 10;
+        })
+    }
+}

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -1,6 +1,7 @@
 mod cellbase_maturity;
 mod depend_tx_in_same_block;
 mod different_txs_with_same_input;
+mod limit;
 mod pool_reconcile;
 mod pool_resurrect;
 mod valid_since;
@@ -8,6 +9,7 @@ mod valid_since;
 pub use cellbase_maturity::CellbaseMaturity;
 pub use depend_tx_in_same_block::DepentTxInSameBlock;
 pub use different_txs_with_same_input::DifferentTxsWithSameInput;
+pub use limit::{CyclesLimit, SizeLimit};
 pub use pool_reconcile::PoolReconcile;
 pub use pool_resurrect::PoolResurrect;
 pub use valid_since::ValidSince;

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -6,5 +6,7 @@ pub struct TxPoolInfo {
     pub pending: Unsigned,
     pub proposed: Unsigned,
     pub orphan: Unsigned,
+    pub total_tx_size: Unsigned,
+    pub total_tx_cycles: Unsigned,
     pub last_txs_updated_at: Timestamp,
 }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -159,6 +159,7 @@ pub enum TransactionError {
     /// Invalid Since flags
     InvalidSince,
     CellbaseImmaturity,
+    ExceededMaximumBlockBytes,
 }
 
 impl StdError for TransactionError {}


### PR DESCRIPTION
### Features
1. apply tx_pool limit
2. tx size verify, enforce tx size below  block size limit

### BREAKING CHANGES

#### config ckb.toml

```diff
[tx_pool]
- max_pool_size = 10000
- max_orphan_size = 10000
- max_proposal_size = 10000
- max_cache_size = 1000
- max_pending_size = 10000
- txs_verify_cache_size = 100000
+ max_mem_size = 20_000_000 # 20mb
+ max_cycles = 200_000_000_000
+ max_verfify_cache_size = 100_000
```

#### rpc tx_pool_info

```diff
+ "total_tx_cycles": "2",
+ "total_tx_size": "156",
```