### PR TITLE
tests: share one rpc client in tests

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut specs: HashMap<&str, Box<dyn Spec>> = HashMap::new();
     specs.insert("block_relay_basic", Box::new(BlockRelayBasic));
     specs.insert("block_sync_basic", Box::new(BlockSyncBasic));
-    // specs.insert("sync_timeout", Box::new(SyncTimeout));
+    specs.insert("sync_timeout", Box::new(SyncTimeout));
     specs.insert("chain_fork_1", Box::new(ChainFork1));
     specs.insert("chain_fork_2", Box::new(ChainFork2));
     specs.insert("chain_fork_3", Box::new(ChainFork3));

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,6 +1,7 @@
 use ckb_core::{
     BlockNumber as CoreBlockNumber, EpochNumber as CoreEpochNumber, Version as CoreVersion,
 };
+use ckb_util::Mutex;
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
 use jsonrpc_types::{
@@ -11,7 +12,7 @@ use jsonrpc_types::{
 use numext_fixed_hash::H256;
 
 pub struct RpcClient {
-    inner: Inner<HttpHandle>,
+    inner: Mutex<Inner<HttpHandle>>,
 }
 
 impl RpcClient {
@@ -21,103 +22,118 @@ impl RpcClient {
             .handle(uri)
             .expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
         Self {
-            inner: Inner::new(transport),
+            inner: Mutex::new(Inner::new(transport)),
         }
     }
 
-    pub fn inner(&mut self) -> &mut Inner<HttpHandle> {
-        &mut self.inner
+    pub fn inner(&self) -> &Mutex<Inner<HttpHandle>> {
+        &self.inner
     }
 
-    pub fn get_block(&mut self, hash: H256) -> Option<BlockView> {
+    pub fn get_block(&self, hash: H256) -> Option<BlockView> {
         self.inner
+            .lock()
             .get_block(hash)
             .call()
             .expect("rpc call get_block")
     }
 
-    pub fn get_block_by_number(&mut self, number: CoreBlockNumber) -> Option<BlockView> {
+    pub fn get_block_by_number(&self, number: CoreBlockNumber) -> Option<BlockView> {
         self.inner
+            .lock()
             .get_block_by_number(BlockNumber(number))
             .call()
             .expect("rpc call get_block_by_number")
     }
 
-    pub fn get_transaction(&mut self, hash: H256) -> Option<TransactionWithStatus> {
+    pub fn get_transaction(&self, hash: H256) -> Option<TransactionWithStatus> {
         self.inner
+            .lock()
             .get_transaction(hash)
             .call()
             .expect("rpc call get_transaction")
     }
 
-    pub fn get_block_hash(&mut self, number: CoreBlockNumber) -> Option<H256> {
+    pub fn get_block_hash(&self, number: CoreBlockNumber) -> Option<H256> {
         self.inner
+            .lock()
             .get_block_hash(BlockNumber(number))
             .call()
             .expect("rpc call get_block_hash")
     }
 
-    pub fn get_tip_header(&mut self) -> HeaderView {
+    pub fn get_tip_header(&self) -> HeaderView {
         self.inner
+            .lock()
             .get_tip_header()
             .call()
             .expect("rpc call get_block_hash")
     }
 
     pub fn get_cells_by_lock_hash(
-        &mut self,
+        &self,
         lock_hash: H256,
         from: CoreBlockNumber,
         to: CoreBlockNumber,
     ) -> Vec<CellOutputWithOutPoint> {
         self.inner
+            .lock()
             .get_cells_by_lock_hash(lock_hash, BlockNumber(from), BlockNumber(to))
             .call()
             .expect("rpc call get_cells_by_lock_hash")
     }
 
-    pub fn get_live_cell(&mut self, out_point: OutPoint) -> CellWithStatus {
+    pub fn get_live_cell(&self, out_point: OutPoint) -> CellWithStatus {
         self.inner
+            .lock()
             .get_live_cell(out_point)
             .call()
             .expect("rpc call get_live_cell")
     }
 
-    pub fn get_tip_block_number(&mut self) -> CoreBlockNumber {
+    pub fn get_tip_block_number(&self) -> CoreBlockNumber {
         self.inner
+            .lock()
             .get_tip_block_number()
             .call()
             .expect("rpc call get_tip_block_number")
             .0
     }
 
-    pub fn get_current_epoch(&mut self) -> EpochExt {
+    pub fn get_current_epoch(&self) -> EpochExt {
         self.inner
+            .lock()
             .get_current_epoch()
             .call()
             .expect("rpc call get_current_epoch")
     }
 
-    pub fn get_epoch_by_number(&mut self, number: CoreEpochNumber) -> Option<EpochExt> {
+    pub fn get_epoch_by_number(&self, number: CoreEpochNumber) -> Option<EpochExt> {
         self.inner
+            .lock()
             .get_epoch_by_number(EpochNumber(number))
             .call()
             .expect("rpc call get_epoch_by_number")
     }
 
-    pub fn local_node_info(&mut self) -> Node {
+    pub fn local_node_info(&self) -> Node {
         self.inner
+            .lock()
             .local_node_info()
             .call()
             .expect("rpc call local_node_info")
     }
 
-    pub fn get_peers(&mut self) -> Vec<Node> {
-        self.inner.get_peers().call().expect("rpc call get_peers")
+    pub fn get_peers(&self) -> Vec<Node> {
+        self.inner
+            .lock()
+            .get_peers()
+            .call()
+            .expect("rpc call get_peers")
     }
 
     pub fn get_block_template(
-        &mut self,
+        &self,
         bytes_limit: Option<u64>,
         proposals_limit: Option<u64>,
         max_version: Option<CoreVersion>,
@@ -126,55 +142,63 @@ impl RpcClient {
         let proposals_limit = proposals_limit.map(Unsigned);
         let max_version = max_version.map(Version);
         self.inner
+            .lock()
             .get_block_template(bytes_limit, proposals_limit, max_version)
             .call()
             .expect("rpc call get_block_template")
     }
 
-    pub fn submit_block(&mut self, work_id: String, block: Block) -> Option<H256> {
+    pub fn submit_block(&self, work_id: String, block: Block) -> Option<H256> {
         self.inner
+            .lock()
             .submit_block(work_id, block)
             .call()
             .expect("rpc call submit_block")
     }
 
-    pub fn get_blockchain_info(&mut self) -> ChainInfo {
+    pub fn get_blockchain_info(&self) -> ChainInfo {
         self.inner
+            .lock()
             .get_blockchain_info()
             .call()
             .expect("rpc call get_blockchain_info")
     }
 
-    pub fn send_transaction(&mut self, tx: Transaction) -> H256 {
+    pub fn send_transaction(&self, tx: Transaction) -> H256 {
         self.inner
+            .lock()
             .send_transaction(tx)
             .call()
             .expect("rpc call send_transaction")
     }
 
-    pub fn tx_pool_info(&mut self) -> TxPoolInfo {
+    pub fn tx_pool_info(&self) -> TxPoolInfo {
         self.inner
+            .lock()
             .tx_pool_info()
             .call()
             .expect("rpc call tx_pool_info")
     }
 
-    pub fn add_node(&mut self, peer_id: String, address: String) {
+    pub fn add_node(&self, peer_id: String, address: String) {
         self.inner
+            .lock()
             .add_node(peer_id, address)
             .call()
             .expect("rpc call add_node");
     }
 
-    pub fn remove_node(&mut self, peer_id: String) {
+    pub fn remove_node(&self, peer_id: String) {
         self.inner
+            .lock()
             .remove_node(peer_id)
             .call()
             .expect("rpc call remove_node")
     }
 
-    pub fn process_block_without_verify(&mut self, block: Block) -> Option<H256> {
+    pub fn process_block_without_verify(&self, block: Block) -> Option<H256> {
         self.inner
+            .lock()
             .process_block_without_verify(block)
             .call()
             .expect("rpc call process_block_without verify")

--- a/test/src/specs/mining/basic.rs
+++ b/test/src/specs/mining/basic.rs
@@ -78,7 +78,7 @@ impl MiningBasic {
             std::mem::swap(&mut block1, &mut block2);
         }
 
-        let mut rpc_client = node.rpc_client();
+        let rpc_client = node.rpc_client();
         let block_hash1 = block1.header().hash().clone();
         assert_eq!(block_hash1, node.submit_block(&block1));
         assert_eq!(block_hash1, rpc_client.get_tip_header().hash);

--- a/test/src/specs/p2p/disconnect.rs
+++ b/test/src/specs/p2p/disconnect.rs
@@ -12,7 +12,7 @@ impl Spec for Disconnect {
         let node1 = net.nodes.pop().unwrap();
         std::mem::drop(node1);
 
-        let mut rpc_client = net.nodes[0].rpc_client();
+        let rpc_client = net.nodes[0].rpc_client();
         let ret = wait_until(10, || {
             let peers = rpc_client.get_peers();
             peers.is_empty()

--- a/test/src/specs/p2p/discovery.rs
+++ b/test/src/specs/p2p/discovery.rs
@@ -7,9 +7,9 @@ pub struct Discovery;
 impl Spec for Discovery {
     fn run(&self, net: Net) {
         info!("Running Discovery");
-        let node0_id = &net.nodes[0].node_id.clone().unwrap();
+        let node0_id = &net.nodes[0].node_id().clone().unwrap();
         let node2 = &net.nodes[2];
-        let mut rpc_client = node2.rpc_client();
+        let rpc_client = node2.rpc_client();
 
         info!("Waiting for discovering");
         let ret = wait_until(10, || {

--- a/test/src/specs/p2p/malformed_message.rs
+++ b/test/src/specs/p2p/malformed_message.rs
@@ -30,7 +30,7 @@ impl Spec for MalformedMessage {
             peer_id,
             vec![0, 1, 2, 3].into(),
         );
-        let mut rpc_client = net.nodes[0].rpc_client();
+        let rpc_client = net.nodes[0].rpc_client();
         let ret = wait_until(10, || rpc_client.get_peers().is_empty());
         assert!(ret, "Node0 should disconnect test node");
 

--- a/test/src/specs/relay/block_relay.rs
+++ b/test/src/specs/relay/block_relay.rs
@@ -19,11 +19,11 @@ impl Spec for BlockRelayBasic {
         info!("Generate new block on node1");
         let hash = node1.generate_block();
 
-        let mut rpc_client = node0.rpc_client();
+        let rpc_client = node0.rpc_client();
         let ret = wait_until(10, || rpc_client.get_block(hash.clone()).is_some());
         assert!(ret, "Block should be relayed to node0");
 
-        let mut rpc_client = node2.rpc_client();
+        let rpc_client = node2.rpc_client();
         let ret = wait_until(10, || rpc_client.get_block(hash.clone()).is_some());
         assert!(ret, "Block should be relayed to node2");
     }

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -23,7 +23,7 @@ impl Spec for TransactionRelayBasic {
         let hash = node1.generate_transaction();
 
         info!("Waiting for relay");
-        let mut rpc_client = node0.rpc_client();
+        let rpc_client = node0.rpc_client();
         let ret = wait_until(10, || {
             if let Some(transaction) = rpc_client.get_transaction(hash.clone()) {
                 transaction.tx_status.block_hash.is_none()
@@ -33,7 +33,7 @@ impl Spec for TransactionRelayBasic {
         });
         assert!(ret, "Transaction should be relayed to node0");
 
-        let mut rpc_client = node2.rpc_client();
+        let rpc_client = node2.rpc_client();
         let ret = wait_until(10, || {
             if let Some(transaction) = rpc_client.get_transaction(hash.clone()) {
                 transaction.tx_status.block_hash.is_none()

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -15,7 +15,7 @@ pub struct BlockSyncBasic;
 impl BlockSyncBasic {
     // NOTE: ENSURE node0 and nodes1 is in genesis state.
     fn test_sync_from_one(&self, _net: &Net, node0: &Node, node1: &Node) {
-        let (mut rpc_client0, mut rpc_client1) = (node0.rpc_client(), node1.rpc_client());
+        let (rpc_client0, rpc_client1) = (node0.rpc_client(), node1.rpc_client());
         assert_eq!(0, rpc_client0.get_tip_block_number());
         assert_eq!(0, rpc_client1.get_tip_block_number());
 
@@ -38,7 +38,7 @@ impl BlockSyncBasic {
 
     // NOTE: ENSURE node0 and nodes1 is in genesis state.
     fn test_sync_forks(&self, _net: &Net, node0: &Node, node1: &Node) {
-        let (mut rpc_client0, mut rpc_client1) = (node0.rpc_client(), node1.rpc_client());
+        let (rpc_client0, rpc_client1) = (node0.rpc_client(), node1.rpc_client());
         assert_eq!(0, rpc_client0.get_tip_block_number());
         assert_eq!(0, rpc_client1.get_tip_block_number());
 
@@ -141,7 +141,7 @@ impl BlockSyncBasic {
         // Sync corresponding block entity, `node` should accept the block as tip block
         sync_block(net, peer_id, &block);
         let hash = block.header().hash().clone();
-        let mut rpc_client = node.rpc_client();
+        let rpc_client = node.rpc_client();
         wait_until(10, || rpc_client.get_tip_header().hash == hash);
     }
 
@@ -152,7 +152,7 @@ impl BlockSyncBasic {
         let (peer_id, _, _) = net
             .receive_timeout(Duration::new(10, 0))
             .expect("net receive timeout");
-        let mut rpc_client = node0.rpc_client();
+        let rpc_client = node0.rpc_client();
         let tip_number = rpc_client.get_tip_block_number();
 
         // Generate some blocks from node1
@@ -210,7 +210,7 @@ impl Spec for BlockSyncBasic {
 }
 
 fn build_forks(node: &Node, offsets: &[u64]) {
-    let mut rpc_client = node.rpc_client();
+    let rpc_client = node.rpc_client();
     for offset in offsets.iter() {
         let mut template = rpc_client.get_block_template(None, None, None);
         template.current_time = Timestamp(template.current_time.0 + offset);

--- a/test/src/specs/sync/invalid_locator_size.rs
+++ b/test/src/specs/sync/invalid_locator_size.rs
@@ -30,7 +30,7 @@ impl Spec for InvalidLocatorSize {
             fbb.finished_data().into(),
         );
 
-        let mut rpc_client = net.nodes[0].rpc_client();
+        let rpc_client = net.nodes[0].rpc_client();
         let ret = wait_until(10, || rpc_client.get_peers().is_empty());
         assert!(ret, "Node0 should disconnect test node");
 


### PR DESCRIPTION
* Enable "sync_timeout" test case
* Refactor RpcClient, test cases can share the same RpcClient instance, to avoid wasting connections resource.