### PR TITLE
[ᚬrylai] feat: secp256k1 block assembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.12.1",
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash 0.12.1",
  "jemallocator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ckb-traits = { path = "traits" }
 sentry = "^0.15.4"
 ckb-verification = { path = "verification" }
 tempfile = "3.0"
+faster-hex = "0.3"
 
 [dev-dependencies]
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,7 +41,12 @@ curl -d '{"id": 1, "jsonrpc": "2.0", "method":"get_tip_header","params": []}' \
 
 ## Run Miner
 
-Run miner, gets a block template to mine.
+Miner is disabled by default, unless you have setup the miner lock
+to keep your mined CKB safe. See the comment of the section `[block_assember]`
+in `ckb.toml` how to configure it.
+
+After setting up the config file, restart the process `ckb run`, and start the
+miner process:
 
 ```shell
 ckb miner

--- a/docs/run-ckb-with-docker.md
+++ b/docs/run-ckb-with-docker.md
@@ -10,11 +10,11 @@ See other
 [tags](https://hub.docker.com/r/nervos/ckb/tags)
 listed in DockerHub.
 
-- Tag `latest` is always the latest release, which is built from the latest
-  master branch.
-- Tag `develop` is built from the latest develop branch.
-- Tags `vx.y.z` are history releases.
-- Tags `vx.y.z-rc` are the preview of the release candidates.
+-   Tag `latest` is always the latest release, which is built from the latest
+    master branch.
+-   Tag `develop` is built from the latest develop branch.
+-   Tags `vx.y.z` are history releases.
+-   Tags `vx.y.z-rc` are the preview of the release candidates.
 
 It is recommended to mount a volume at `/var/lib/ckb` in the container.
 Following is an example to mount a volume, generate config files in the volume
@@ -50,7 +50,7 @@ docker cp ckb-testnet-node:/var/lib/ckb/ckb-miner.toml .
 ```
 
 Edit the config files as you like. If you want to run a miner, remember to
-replace `block_assember` section in `ckb.toml`.
+replace `[block_assember]` section in `ckb.toml`.
 
 Copy back the edited config files back to container:
 

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -79,17 +79,25 @@ max_cache_size = 1000
 max_pending_size = 10000
 txs_verify_cache_size = 100000
 
-# This config is derived using 0x5c2514fb16b83259d3326a0acf05901c15a87dc46239b77b0a501cd58198dca0
-# as private key. If you want to mine CKB, please make sure to create your own
-# private key and change the config here, otherwise your CKB might be stolen by
-# someone else.
-[block_assembler]
-code_hash = "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"
-args = ["0x7f52f0fccdd1d11391c441adfb174f87bca612b0"]
-
 [script]
 runner = "Assembly"
 
 [store]
 header_cache_size       = 4096
 cell_output_cache_size  = 128
+
+# Set the lock script to protect mined CKB.
+#
+# The `code_hash` identifies different cryptography algorithm. Read the manual
+# of the lock script provider about how to generate this config.
+#
+# CKB provides an secp256k1 implementation, it requires a public key hash in
+# the args.
+#
+# See `ckb cli secp256k1 --help` about how to setup secp256k1 as block assembler lock.
+#
+# Following is an example output:
+#
+# [block_assembler]
+# code_hash = "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"
+# args = ["blake160(pubkey) here"]

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -100,4 +100,4 @@ cell_output_cache_size  = 128
 #
 # [block_assembler]
 # code_hash = "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"
-# args = ["blake160(pubkey) here"]
+# args = ["blake160(compressed_pubkey)"]

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -21,31 +21,31 @@ pub struct Config {
 }
 
 impl Config {
-    pub(crate) fn net_enable(&self) -> bool {
+    pub fn net_enable(&self) -> bool {
         self.modules.contains(&Module::Net)
     }
 
-    pub(crate) fn chain_enable(&self) -> bool {
+    pub fn chain_enable(&self) -> bool {
         self.modules.contains(&Module::Chain)
     }
 
-    pub(crate) fn miner_enable(&self) -> bool {
+    pub fn miner_enable(&self) -> bool {
         self.modules.contains(&Module::Miner)
     }
 
-    pub(crate) fn pool_enable(&self) -> bool {
+    pub fn pool_enable(&self) -> bool {
         self.modules.contains(&Module::Pool)
     }
 
-    pub(crate) fn experiment_enable(&self) -> bool {
+    pub fn experiment_enable(&self) -> bool {
         self.modules.contains(&Module::Experiment)
     }
 
-    pub(crate) fn stats_enable(&self) -> bool {
+    pub fn stats_enable(&self) -> bool {
         self.modules.contains(&Module::Stats)
     }
 
-    pub(crate) fn integration_test_enable(&self) -> bool {
+    pub fn integration_test_enable(&self) -> bool {
         self.modules.contains(&Module::IntegrationTest)
     }
 }

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -48,8 +48,8 @@ impl RpcServer {
             );
         }
 
-        match (config.miner_enable(), block_assembler) {
-            (true, Some(block_assembler)) => {
+        if config.miner_enable() {
+            if let Some(block_assembler) = block_assembler {
                 io.extend_with(
                     MinerRpcImpl {
                         shared: shared.clone(),
@@ -59,9 +59,6 @@ impl RpcServer {
                     }
                     .to_delegate(),
                 );
-            }
-            _ => {
-                // skip
             }
         }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -26,7 +26,7 @@ impl RpcServer {
         shared: Shared<CS>,
         synchronizer: Synchronizer<CS>,
         chain: ChainController,
-        block_assembler: BlockAssemblerController,
+        block_assembler: Option<BlockAssemblerController>,
     ) -> RpcServer
     where
         CS: ChainStore,
@@ -48,16 +48,21 @@ impl RpcServer {
             );
         }
 
-        if config.miner_enable() {
-            io.extend_with(
-                MinerRpcImpl {
-                    shared: shared.clone(),
-                    block_assembler,
-                    chain: chain.clone(),
-                    network_controller: network_controller.clone(),
-                }
-                .to_delegate(),
-            );
+        match (config.miner_enable(), block_assembler) {
+            (true, Some(block_assembler)) => {
+                io.extend_with(
+                    MinerRpcImpl {
+                        shared: shared.clone(),
+                        block_assembler,
+                        chain: chain.clone(),
+                        network_controller: network_controller.clone(),
+                    }
+                    .to_delegate(),
+                );
+            }
+            _ => {
+                // skip
+            }
         }
 
         if config.net_enable() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn run_app() -> Result<(), ExitCode> {
         (cli::CMD_INIT, Some(matches)) => return subcommand::init(Setup::init(&matches)?),
         (cli::CMD_CLI, Some(matches)) => {
             return match matches.subcommand() {
-                (cli::CMD_SECP256K1, _) => subcommand::cli::secp256k1(),
+                (cli::CMD_SECP256K1, Some(sub_matches)) => subcommand::cli::secp256k1(sub_matches),
                 (cli::CMD_HASHES, Some(sub_matches)) => {
                     subcommand::cli::hashes(Setup::locator_from_matches(&matches)?, sub_matches)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn run_app() -> Result<(), ExitCode> {
         (cli::CMD_INIT, Some(matches)) => return subcommand::init(Setup::init(&matches)?),
         (cli::CMD_CLI, Some(matches)) => {
             return match matches.subcommand() {
-                (cli::CMD_KEYGEN, _) => subcommand::cli::keygen(),
+                (cli::CMD_SECP256K1, _) => subcommand::cli::secp256k1(),
                 (cli::CMD_HASHES, Some(sub_matches)) => {
                     subcommand::cli::hashes(Setup::locator_from_matches(&matches)?, sub_matches)
                 }

--- a/src/subcommand/cli/mod.rs
+++ b/src/subcommand/cli/mod.rs
@@ -1,5 +1,5 @@
 mod hashes;
-mod keygen;
+mod secp256k1;
 
 pub use hashes::hashes;
-pub use keygen::keygen;
+pub use secp256k1::secp256k1;

--- a/src/subcommand/cli/secp256k1.rs
+++ b/src/subcommand/cli/secp256k1.rs
@@ -2,7 +2,7 @@ use ckb_app_config::ExitCode;
 use crypto::secp::Generator;
 use numext_fixed_hash::H256;
 
-pub fn keygen() -> Result<(), ExitCode> {
+pub fn secp256k1() -> Result<(), ExitCode> {
     let result: H256 = Generator::new().random_privkey().into();
     println!("{:#x}", result);
     Ok(())

--- a/src/subcommand/cli/secp256k1.rs
+++ b/src/subcommand/cli/secp256k1.rs
@@ -1,9 +1,110 @@
+use ckb_app_config::cli;
 use ckb_app_config::ExitCode;
-use crypto::secp::Generator;
-use numext_fixed_hash::H256;
+use clap::ArgMatches;
+use crypto::secp::{Generator, Privkey, Pubkey};
+use faster_hex::{hex_decode, hex_string};
+use hash::blake2b_256;
+use numext_fixed_hash::H160;
+use std::fs;
+use std::path::Path;
 
-pub fn secp256k1() -> Result<(), ExitCode> {
-    let result: H256 = Generator::new().random_privkey().into();
-    println!("{:#x}", result);
+pub fn secp256k1<'m>(matches: &ArgMatches<'m>) -> Result<(), ExitCode> {
+    let pubkey_vec = if matches.is_present(cli::ARG_GENERATE) {
+        generate(matches)?
+    } else {
+        load(matches)?
+    };
+
+    let pubkey_hash = blake2b_256(&pubkey_vec);
+    let pubkey_blake160 = H160::from_slice(&pubkey_hash[0..20]).unwrap();
+
+    println!("[block_assembler]");
+    println!("# secp256k1_sighash_all");
+    println!("code_hash = \"0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08\"");
+    println!("# args = [ \"blake160(compressed_pubkey)\" ]");
+    println!("args = [ \"{:#x}\" ]", pubkey_blake160);
+
     Ok(())
+}
+
+pub fn generate<'m>(matches: &ArgMatches<'m>) -> Result<Vec<u8>, ExitCode> {
+    let (privkey, pubkey) = Generator::new().random_keypair().unwrap();
+    let pubkey_vec = pubkey.serialize();
+
+    if let Some(path) = matches.value_of(cli::ARG_PRIVKEY) {
+        if Path::new(path).exists() {
+            eprintln!("Fail because privkey file already exists.");
+            return Err(ExitCode::IO);
+        }
+
+        fs::write(path, format!("0x{}\n", privkey))?;
+    }
+
+    if let Some(path) = matches.value_of(cli::ARG_PUBKEY) {
+        if Path::new(path).exists() {
+            eprintln!("Fail because pubkey file already exists.");
+            return Err(ExitCode::IO);
+        }
+
+        fs::write(path, format!("0x{}\n", hex_string(&pubkey_vec).unwrap()))?;
+    }
+
+    Ok(pubkey_vec)
+}
+
+pub fn load<'m>(matches: &ArgMatches<'m>) -> Result<Vec<u8>, ExitCode> {
+    let pubkey_from_privkey: Option<Pubkey> = if let Some(path) = matches.value_of(cli::ARG_PRIVKEY)
+    {
+        let file_content = fs::read_to_string(path)?;
+        let trimmed_content = file_content.trim();
+        if trimmed_content.len() != 66 || &trimmed_content[..2] != "0x" {
+            eprintln!("Privkey file corrupted: requires 32 bytes encoded in 0x prefix hex");
+            return Err(ExitCode::IO);
+        }
+
+        Some(
+            trimmed_content[2..]
+                .parse::<Privkey>()
+                .and_then(|key| key.pubkey())
+                .map_err(|err| {
+                    eprintln!("Privkey file corrupted: {}", err);
+                    ExitCode::IO
+                })?,
+        )
+    } else {
+        None
+    };
+
+    let pubkey: Pubkey = if let Some(path) = matches.value_of(cli::ARG_PUBKEY) {
+        let file_content = fs::read_to_string(path)?;
+        let trimmed_content = file_content.trim();
+        if trimmed_content.len() != 68 || &trimmed_content[..2] != "0x" {
+            eprintln!("Pubkey file corrupted: requires 33 bytes encoded in 0x prefix hex");
+            return Err(ExitCode::IO);
+        }
+
+        let mut pubkey_bytes = [0u8; 33];
+        hex_decode(&trimmed_content.as_bytes()[2..], &mut pubkey_bytes).map_err(|err| {
+            eprintln!("Pubkey file corrupted: {}", err);
+            ExitCode::IO
+        })?;
+
+        let pubkey = Pubkey::from_slice(&pubkey_bytes).map_err(|err| {
+            eprintln!("Pubkey file corrupted: {}", err);
+            ExitCode::IO
+        })?;
+
+        if let Some(pubkey_from_privkey) = pubkey_from_privkey {
+            if pubkey != pubkey_from_privkey {
+                eprintln!("Pubkey and privkey do not match");
+                return Err(ExitCode::Cli);
+            }
+        }
+
+        pubkey
+    } else {
+        pubkey_from_privkey.unwrap()
+    };
+
+    Ok(pubkey.serialize())
 }

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -46,11 +46,5 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         args.locator.export_specs()?;
     }
 
-    eprintln!(
-        "**Notice**: \
-         If you want to mine CKB, please make sure to create your own \
-         private key and change the block_assembler config in ckb.toml."
-    );
-
     Ok(())
 }

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -1,6 +1,6 @@
 use crate::rpc::RpcClient;
 use crate::utils::wait_until;
-use ckb_app_config::{CKBAppConfig, MinerAppConfig};
+use ckb_app_config::{BlockAssemblerConfig, CKBAppConfig, MinerAppConfig};
 use ckb_chain_spec::ChainSpec;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::{HeaderBuilder, Seal};
@@ -396,11 +396,10 @@ impl Node {
         let mut ckb_config: CKBAppConfig =
             toml::from_slice(&fs::read(&ckb_config_path)?).expect("ckb config");
         ckb_config.chain.spec = config_path.into();
-        ckb_config
-            .block_assembler
-            .code_hash
-            .clone_from(&self.always_success_code_hash);
-        ckb_config.block_assembler.args.clear();
+        ckb_config.block_assembler = Some(BlockAssemblerConfig {
+            code_hash: self.always_success_code_hash.clone(),
+            args: Default::default(),
+        });
         modify_ckb_config(&mut ckb_config);
         fs::write(
             &ckb_config_path,

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -43,7 +43,7 @@ pub struct CKBAppConfig {
     pub sentry: SentryConfig,
     pub chain: ChainConfig,
 
-    pub block_assembler: BlockAssemblerConfig,
+    pub block_assembler: Option<BlockAssemblerConfig>,
     #[serde(skip)]
     pub db: DBConfig,
     pub network: NetworkConfig,

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -24,6 +24,9 @@ pub const ARG_RPC_PORT: &str = "rpc-port";
 pub const ARG_FORCE: &str = "force";
 pub const ARG_LOG_TO: &str = "log-to";
 pub const ARG_BUNDLED: &str = "bundled";
+pub const ARG_GENERATE: &str = "generate";
+pub const ARG_PRIVKEY: &str = "privkey";
+pub const ARG_PUBKEY: &str = "pubkey";
 
 pub fn get_matches(version: &Version) -> ArgMatches<'static> {
     App::new("ckb")
@@ -125,17 +128,55 @@ fn cli() -> App<'static, 'static> {
     SubCommand::with_name(CMD_CLI)
         .about("CLI tools")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(SubCommand::with_name(CMD_SECP256K1).about("Setup secp256k1 as miner lock"))
-        .subcommand(
-            SubCommand::with_name(CMD_HASHES)
-                .about("List well known hashes")
-                .arg(
-                    Arg::with_name(ARG_BUNDLED)
-                        .short("b")
-                        .long(ARG_BUNDLED)
-                        .help(
-                            "List hashes of the bundled chain specs instead of the current effective one.",
-                        ),
+        .subcommand(cli_secp256k1())
+        .subcommand(cli_hashes())
+}
+
+fn cli_hashes() -> App<'static, 'static> {
+    SubCommand::with_name(CMD_HASHES)
+        .about("List well known hashes")
+        .arg(
+            Arg::with_name(ARG_BUNDLED)
+                .short("b")
+                .long(ARG_BUNDLED)
+                .help(
+                    "List hashes of the bundled chain specs instead of the current effective one.",
+                ),
+        )
+}
+
+fn cli_secp256k1() -> App<'static, 'static> {
+    SubCommand::with_name(CMD_SECP256K1)
+        .about("Use secp256k1 in [block_assember]")
+        .arg(
+            Arg::with_name(ARG_GENERATE)
+                .long(ARG_GENERATE)
+                .short("g")
+                .requires(ARG_PRIVKEY)
+                .help(
+                    "Generate the privkey and save it into the file. \
+                     Then print [block_assember] from the privkey",
+                ),
+        )
+        .arg(
+            Arg::with_name(ARG_PRIVKEY)
+                .long(ARG_PRIVKEY)
+                .value_name("path")
+                .takes_value(true)
+                .help(
+                    "Read privkey from the file, or write generated privkey into the file \
+                     when `--generate` is specified.",
+                ),
+        )
+        .arg(
+            Arg::with_name(ARG_PUBKEY)
+                .long(ARG_PUBKEY)
+                .value_name("path")
+                .takes_value(true)
+                .required_unless(ARG_PRIVKEY)
+                .help(
+                    "Read pubkey from the file, or write generated pubkey into the file \
+                     when `--generate` is specified",
                 ),
         )
 }

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -9,7 +9,7 @@ pub const CMD_IMPORT: &str = "import";
 pub const CMD_INIT: &str = "init";
 pub const CMD_PROF: &str = "prof";
 pub const CMD_CLI: &str = "cli";
-pub const CMD_KEYGEN: &str = "keygen";
+pub const CMD_SECP256K1: &str = "secp256k1";
 pub const CMD_HASHES: &str = "hashes";
 
 pub const ARG_CONFIG_DIR: &str = "config-dir";
@@ -125,7 +125,7 @@ fn cli() -> App<'static, 'static> {
     SubCommand::with_name(CMD_CLI)
         .about("CLI tools")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(SubCommand::with_name(CMD_KEYGEN).about("Generate new key"))
+        .subcommand(SubCommand::with_name(CMD_SECP256K1).about("Setup secp256k1 as miner lock"))
         .subcommand(
             SubCommand::with_name(CMD_HASHES)
                 .about("List well known hashes")

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -6,6 +6,7 @@ mod sentry_config;
 
 pub use app_config::{AppConfig, CKBAppConfig, MinerAppConfig};
 pub use args::{ExportArgs, ImportArgs, InitArgs, MinerArgs, ProfArgs, RunArgs};
+pub use ckb_miner::BlockAssemblerConfig;
 pub use exit_code::ExitCode;
 
 use build_info::Version;

--- a/util/crypto/src/secp/pubkey.rs
+++ b/util/crypto/src/secp/pubkey.rs
@@ -44,6 +44,10 @@ impl Pubkey {
         let pubkey = key::PublicKey::from_slice(&prefix_key).unwrap();
         Vec::from(&pubkey.serialize()[..])
     }
+
+    pub fn from_slice(data: &[u8]) -> Result<Self, Error> {
+        Ok(key::PublicKey::from_slice(data)?.into())
+    }
 }
 
 impl From<[u8; 64]> for Pubkey {


### PR DESCRIPTION
- Remove the default block assembler config. If user want to mine, they must configure it.
- Add subcommand `ckb cli secp256k1` to generate block assembler config