### PR TITLE
feat: limit TXO set memory usage

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -303,7 +303,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
             if new_epoch || fork.has_detached() {
                 chain_state.update_current_epoch_ext(epoch);
             }
-            chain_state.update_tip(tip_header, total_difficulty, cell_set_diff);
+            chain_state.update_tip(tip_header, total_difficulty, cell_set_diff)?;
             chain_state.update_tx_pool_for_reorg(
                 fork.detached_blocks().iter(),
                 fork.attached_blocks().iter(),

--- a/db/src/cachedb.rs
+++ b/db/src/cachedb.rs
@@ -136,6 +136,13 @@ where
         self.db.partial_read(col, key, range)
     }
 
+    fn traverse<F>(&self, col: Col, callback: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()>,
+    {
+        self.db.traverse(col, callback)
+    }
+
     fn batch(&self) -> Result<Self::Batch> {
         Ok(CacheDBBatch::new(self.db.batch()?, Arc::clone(&self.cache)))
     }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -31,6 +31,9 @@ pub trait KeyValueDB: Sync + Send {
     fn read(&self, col: Col, key: &[u8]) -> Result<Option<Vec<u8>>>;
     fn partial_read(&self, col: Col, key: &[u8], range: &Range<usize>) -> Result<Option<Vec<u8>>>;
     fn batch(&self) -> Result<Self::Batch>;
+    fn traverse<F>(&self, col: Col, callback: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()>;
 }
 
 pub trait DbBatch {

--- a/db/src/memorydb.rs
+++ b/db/src/memorydb.rs
@@ -50,6 +50,23 @@ impl KeyValueDB for MemoryKeyValueDB {
         }
     }
 
+    fn traverse<F>(&self, col: Col, mut callback: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()>,
+    {
+        let db = self.db.read();
+
+        match db.get(&col) {
+            None => Err(Error::DBError(format!("column {} not found ", col)))?,
+            Some(map) => {
+                for (key, val) in map {
+                    callback(key, val)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn batch(&self) -> Result<Self::Batch> {
         Ok(Self::Batch {
             operations: Vec::new(),

--- a/db/src/rocksdb.rs
+++ b/db/src/rocksdb.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 //      - If the data can be migrated manually: update "x.y1.z" to "x.y2.0".
 //      - If the data can not be migrated: update "x1.y.z" to "x2.0.0".
 pub(crate) const VERSION_KEY: &str = "db-version";
-pub(crate) const VERSION_VALUE: &str = "0.13.0";
+pub(crate) const VERSION_VALUE: &str = "0.14.0";
 
 pub struct RocksDB {
     inner: Arc<DB>,

--- a/db/src/rocksdb.rs
+++ b/db/src/rocksdb.rs
@@ -1,6 +1,6 @@
 use crate::{Col, DBConfig, DbBatch, Error, KeyValueDB, Result};
 use log::{info, warn};
-use rocksdb::{ColumnFamily, Error as RdbError, Options, WriteBatch, DB};
+use rocksdb::{ColumnFamily, Error as RdbError, IteratorMode, Options, WriteBatch, DB};
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -137,6 +137,18 @@ impl KeyValueDB for RocksDB {
             .get_pinned_cf(cf, &key)
             .map(|v| v.and_then(|vi| vi.get(range.start..range.end).map(|slice| slice.to_vec())))
             .map_err(Into::into)
+    }
+
+    fn traverse<F>(&self, col: Col, mut callback: F) -> Result<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<()>,
+    {
+        let cf = cf_handle(&self.inner, col)?;
+        let iter = self.inner.full_iterator_cf(cf, IteratorMode::Start)?;
+        for (key, val) in iter {
+            callback(&key, &val)?;
+        }
+        Ok(())
     }
 
     fn batch(&self) -> Result<Self::Batch> {

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -158,24 +158,23 @@ impl<CS: ChainStore + 'static> ChainRpc for ChainRpcImpl<CS> {
                 .block(&block_hash)
                 .ok_or_else(Error::internal_error)?;
             for transaction in block.transactions() {
-                let transaction_meta = chain_state
-                    .cell_set()
-                    .get(&transaction.hash())
-                    .ok_or_else(Error::internal_error)?;
-                for (i, output) in transaction.outputs().iter().enumerate() {
-                    if output.lock.hash() == lock_hash && transaction_meta.is_dead(i) == Some(false)
-                    {
-                        result.push(CellOutputWithOutPoint {
-                            out_point: OutPoint {
-                                cell: Some(CellOutPoint {
-                                    tx_hash: transaction.hash().to_owned(),
-                                    index: Unsigned(i as u64),
-                                }),
-                                block_hash: Some(block_hash.to_owned()),
-                            },
-                            capacity: Capacity(output.capacity),
-                            lock: output.lock.clone().into(),
-                        });
+                if let Some(transaction_meta) = chain_state.cell_set().get(&transaction.hash()) {
+                    for (i, output) in transaction.outputs().iter().enumerate() {
+                        if output.lock.hash() == lock_hash
+                            && transaction_meta.is_dead(i) == Some(false)
+                        {
+                            result.push(CellOutputWithOutPoint {
+                                out_point: OutPoint {
+                                    cell: Some(CellOutPoint {
+                                        tx_hash: transaction.hash().to_owned(),
+                                        index: Unsigned(i as u64),
+                                    }),
+                                    block_hash: Some(block_hash.to_owned()),
+                                },
+                                capacity: Capacity(output.capacity),
+                                lock: output.lock.clone().into(),
+                            });
+                        }
                     }
                 }
             }

--- a/shared/src/cell_set.rs
+++ b/shared/src/cell_set.rs
@@ -124,6 +124,10 @@ impl CellSet {
         self.inner.get(h)
     }
 
+    pub(crate) fn put(&mut self, tx_hash: H256, tx_meta: TransactionMeta) {
+        self.inner.insert(tx_hash, tx_meta);
+    }
+
     pub(crate) fn insert(
         &mut self,
         tx_hash: H256,

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -7,7 +7,7 @@ pub use store::{ChainKVStore, ChainStore, StoreBatch, StoreConfig};
 
 use ckb_db::Col;
 
-pub const COLUMNS: u32 = 12;
+pub const COLUMNS: u32 = 13;
 pub const COLUMN_INDEX: Col = 0;
 pub const COLUMN_BLOCK_HEADER: Col = 1;
 pub const COLUMN_BLOCK_BODY: Col = 2;
@@ -20,3 +20,4 @@ pub const COLUMN_BLOCK_PROPOSAL_IDS: Col = 8;
 pub const COLUMN_CELL_META: Col = 9;
 pub const COLUMN_BLOCK_EPOCH: Col = 10;
 pub const COLUMN_EPOCH: Col = 11;
+pub const COLUMN_CELL_SET: Col = 12;

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -78,6 +78,13 @@ impl<T: KeyValueDB> ChainKVStore<T> {
             .partial_read(col, key, range)
             .expect("db operation should be ok")
     }
+
+    pub fn traverse<F>(&self, col: Col, callback: F) -> Result<(), Error>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<(), Error>,
+    {
+        self.db.traverse(col, callback)
+    }
 }
 
 /// Store interface by chain

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -250,7 +250,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
                             .try_fold(Capacity::zero(), |capacity, output| {
                                 capacity.safe_add(output.capacity)
                             })
-                            .unwrap()
+                            .expect("accumulated capacity in genesis block should not overflow")
                     })
                     .unwrap_or_else(Capacity::zero)
                     .as_u64(),
@@ -301,7 +301,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
 
     fn get_block_number(&self, hash: &H256) -> Option<BlockNumber> {
         self.get(COLUMN_INDEX, hash.as_bytes())
-            .map(|raw| deserialize(&raw[..]).unwrap())
+            .map(|raw| deserialize(&raw[..]).expect("deserialize block number should be ok"))
     }
 
     fn get_tip_header(&self) -> Option<Header> {
@@ -367,7 +367,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
             COLUMN_CELL_META,
             CellKey::calculate(tx_hash, index).as_ref(),
         )
-        .map(|raw| deserialize(&raw[..]).unwrap())
+        .map(|raw| deserialize(&raw[..]).expect("deserialize cell meta should be ok"))
     }
 
     fn get_cell_output(&self, tx_hash: &H256, index: u32) -> Option<CellOutput> {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -4,8 +4,8 @@ use crate::flat_block_body::{
 };
 use crate::{
     COLUMN_BLOCK_BODY, COLUMN_BLOCK_EPOCH, COLUMN_BLOCK_HEADER, COLUMN_BLOCK_PROPOSAL_IDS,
-    COLUMN_BLOCK_TRANSACTION_ADDRESSES, COLUMN_BLOCK_UNCLE, COLUMN_CELL_META, COLUMN_EPOCH,
-    COLUMN_EXT, COLUMN_INDEX, COLUMN_META, COLUMN_TRANSACTION_ADDR,
+    COLUMN_BLOCK_TRANSACTION_ADDRESSES, COLUMN_BLOCK_UNCLE, COLUMN_CELL_META, COLUMN_CELL_SET,
+    COLUMN_EPOCH, COLUMN_EXT, COLUMN_INDEX, COLUMN_META, COLUMN_TRANSACTION_ADDR,
 };
 use bincode::{deserialize, serialize};
 use ckb_chain_spec::consensus::Consensus;
@@ -15,7 +15,8 @@ use ckb_core::extras::{
     BlockExt, DaoStats, EpochExt, TransactionAddress, DEFAULT_ACCUMULATED_RATE,
 };
 use ckb_core::header::{BlockNumber, Header};
-use ckb_core::transaction::{CellOutPoint, CellOutput, ProposalShortId, Transaction};
+use ckb_core::transaction::{CellKey, CellOutPoint, CellOutput, ProposalShortId, Transaction};
+use ckb_core::transaction_meta::TransactionMeta;
 use ckb_core::uncle::UncleBlock;
 use ckb_core::{Capacity, EpochNumber};
 use ckb_db::{Col, DbBatch, Error, KeyValueDB};
@@ -27,13 +28,6 @@ use std::sync::Mutex;
 
 const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
 const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";
-
-fn cell_store_key(tx_hash: &H256, index: u32) -> [u8; 36] {
-    let mut key: [u8; 36] = [0; 36];
-    key[..32].copy_from_slice(tx_hash.as_bytes());
-    key[32..36].copy_from_slice(&index.to_be_bytes());
-    key
-}
 
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
 pub struct StoreConfig {
@@ -143,6 +137,9 @@ pub trait StoreBatch {
 
     fn attach_block(&mut self, block: &Block) -> Result<(), Error>;
     fn detach_block(&mut self, block: &Block) -> Result<(), Error>;
+
+    fn update_cell_set(&mut self, tx_hash: &H256, meta: &TransactionMeta) -> Result<(), Error>;
+    fn delete_cell_set(&mut self, tx_hash: &H256) -> Result<(), Error>;
 
     fn commit(self) -> Result<(), Error>;
 }
@@ -259,11 +256,25 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
         let mut cells = Vec::with_capacity(genesis.transactions().len());
 
         for tx in genesis.transactions() {
+            let tx_meta;
             let ins = if tx.is_cellbase() {
+                tx_meta = TransactionMeta::new_cellbase(
+                    genesis.header().number(),
+                    genesis.header().epoch(),
+                    tx.outputs().len(),
+                    false,
+                );
                 Vec::new()
             } else {
+                tx_meta = TransactionMeta::new(
+                    genesis.header().number(),
+                    genesis.header().epoch(),
+                    tx.outputs().len(),
+                    false,
+                );
                 tx.input_pts_iter().cloned().collect()
             };
+            batch.update_cell_set(tx.hash(), &tx_meta)?;
             let outs = tx.output_pts();
 
             cells.push((ins, outs));
@@ -348,8 +359,11 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
     }
 
     fn get_cell_meta(&self, tx_hash: &H256, index: u32) -> Option<CellMeta> {
-        self.get(COLUMN_CELL_META, &cell_store_key(tx_hash, index))
-            .map(|raw| deserialize(&raw[..]).unwrap())
+        self.get(
+            COLUMN_CELL_META,
+            CellKey::calculate(tx_hash, index).as_ref(),
+        )
+        .map(|raw| deserialize(&raw[..]).unwrap())
     }
 
     fn get_cell_output(&self, tx_hash: &H256, index: u32) -> Option<CellOutput> {
@@ -468,7 +482,7 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
                     tx_hash: tx_hash.to_owned(),
                     index: index as u32,
                 };
-                let store_key = cell_store_key(&tx_hash, index as u32);
+                let store_key = out_point.cell_key();
                 let cell_meta = CellMeta {
                     cell_output: None,
                     out_point,
@@ -480,7 +494,7 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
                     capacity: output.capacity,
                     data_hash: Some(output.data_hash()),
                 };
-                self.insert_serialize(COLUMN_CELL_META, &store_key, &cell_meta)?;
+                self.insert_serialize(COLUMN_CELL_META, store_key.as_ref(), &cell_meta)?;
             }
         }
 
@@ -494,8 +508,8 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
             let tx_hash = tx.hash();
             self.delete(COLUMN_TRANSACTION_ADDR, tx_hash.as_bytes())?;
             for index in 0..tx.outputs().len() {
-                let store_key = cell_store_key(&tx_hash, index as u32);
-                self.delete(COLUMN_CELL_META, &store_key)?;
+                let store_key = CellKey::calculate(&tx_hash, index as u32);
+                self.delete(COLUMN_CELL_META, store_key.as_ref())?;
             }
         }
         self.delete(COLUMN_INDEX, &block.header().number().to_le_bytes())?;
@@ -527,6 +541,14 @@ impl<B: DbBatch> StoreBatch for DefaultStoreBatch<B> {
 
     fn insert_current_epoch_ext(&mut self, epoch: &EpochExt) -> Result<(), Error> {
         self.insert_serialize(COLUMN_META, META_CURRENT_EPOCH_KEY, epoch)
+    }
+
+    fn update_cell_set(&mut self, tx_hash: &H256, meta: &TransactionMeta) -> Result<(), Error> {
+        self.insert_serialize(COLUMN_CELL_SET, tx_hash.as_bytes(), meta)
+    }
+
+    fn delete_cell_set(&mut self, tx_hash: &H256) -> Result<(), Error> {
+        self.delete(COLUMN_CELL_SET, tx_hash.as_bytes())
     }
 
     fn commit(self) -> Result<(), Error> {


### PR DESCRIPTION
### Commits

- feat: add a function to traverse all keys for database

- feat: save cell set into database (but not used)

  BREAKING CHANGE: Add new column to store cell set into database.

- refactor: loading CellSet do not have to load all blocks

- perf: delete transactions whose all cells are dead

- fix: the order to apply cell set diff is very important

### Issue

#228

### Notes

- I insist on the opinion: save live cells is better than save transactions which include at least one live cell.

  We can use a only-key-and-no-value database (for example, Redis) to store live cells (`CellOutPoint` as key). 

  I tried, but it's too difficult to adapt to current logic, so I gave up.

- I didn't change current design about how to use `CellSet`, I just made them be persisted.

- **All transactions** which include at least one live cell, **are still kept in memory**.

  But **the transactions which don't have any live cells are removed from memory**.