### PR TITLE
chore: improve command line messages

### DIFF
--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -167,7 +167,7 @@ fn init() -> App<'static, 'static> {
             Arg::with_name(ARG_FORCE)
                 .short("f")
                 .long(ARG_FORCE)
-                .help("Force overwrits existing files"),
+                .help("Forces overwriting existing files"),
         )
         .arg(
             Arg::with_name(ARG_RPC_PORT)

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -39,7 +39,7 @@ pub fn get_matches(version: &Version) -> ArgMatches<'static> {
                 .value_name("path")
                 .takes_value(true)
                 .help(
-                    "Run as if ckb was started in <path> instead of the current working directory.",
+                    "Runs as if ckb was started in <path> instead of the current working directory.",
                 ),
         )
         .subcommand(run())
@@ -53,17 +53,17 @@ pub fn get_matches(version: &Version) -> ArgMatches<'static> {
 }
 
 fn run() -> App<'static, 'static> {
-    SubCommand::with_name(CMD_RUN).about("Running ckb node")
+    SubCommand::with_name(CMD_RUN).about("Runs ckb node")
 }
 
 fn miner() -> App<'static, 'static> {
-    SubCommand::with_name(CMD_MINER).about("Running ckb miner")
+    SubCommand::with_name(CMD_MINER).about("Runs ckb miner")
 }
 
 fn prof() -> App<'static, 'static> {
     SubCommand::with_name(CMD_PROF)
         .about(
-            "Profling ckb node\n\
+            "Profiles ckb node\n\
              Example: Process 1..500 blocks then output flagme graph\n\
              cargo flamegraph --bin ckb -- -C <dir> prof 1 500",
         )
@@ -71,13 +71,13 @@ fn prof() -> App<'static, 'static> {
             Arg::with_name("from")
                 .required(true)
                 .index(1)
-                .help("from block number."),
+                .help("Specifies from block number."),
         )
         .arg(
             Arg::with_name("to")
                 .required(true)
                 .index(2)
-                .help("to block number."),
+                .help("Specifies to block number."),
         )
 }
 
@@ -88,12 +88,12 @@ fn arg_format() -> Arg<'static, 'static> {
         .possible_values(&["bin", "json"])
         .required(true)
         .takes_value(true)
-        .help("Specify the format.")
+        .help("Specifies the format.")
 }
 
 fn export() -> App<'static, 'static> {
     SubCommand::with_name(CMD_EXPORT)
-        .about("Export ckb data")
+        .about("Exports ckb data")
         .arg(arg_format())
         .arg(
             Arg::with_name(ARG_TARGET)
@@ -102,13 +102,13 @@ fn export() -> App<'static, 'static> {
                 .value_name("path")
                 .required(true)
                 .index(1)
-                .help("Specify the export target path."),
+                .help("Specifies the export target path."),
         )
 }
 
 fn import() -> App<'static, 'static> {
     SubCommand::with_name(CMD_IMPORT)
-        .about("Import ckb data")
+        .about("Imports ckb data")
         .arg(arg_format())
         .arg(
             Arg::with_name(ARG_SOURCE)
@@ -117,7 +117,7 @@ fn import() -> App<'static, 'static> {
                 .value_name("path")
                 .required(true)
                 .index(1)
-                .help("Specify the exported data path."),
+                .help("Specifies the exported data path."),
         )
 }
 
@@ -125,16 +125,16 @@ fn cli() -> App<'static, 'static> {
     SubCommand::with_name(CMD_CLI)
         .about("CLI tools")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(SubCommand::with_name(CMD_KEYGEN).about("Generate new key"))
+        .subcommand(SubCommand::with_name(CMD_KEYGEN).about("Generates new key"))
         .subcommand(
             SubCommand::with_name(CMD_HASHES)
-                .about("List well known hashes")
+                .about("Lists well known hashes")
                 .arg(
                     Arg::with_name(ARG_BUNDLED)
                         .short("b")
                         .long(ARG_BUNDLED)
                         .help(
-                            "List hashes of the bundled chain specs instead of the current effective one.",
+                            "Lists hashes of the bundled chain specs instead of the current effective one.",
                         ),
                 ),
         )
@@ -142,19 +142,19 @@ fn cli() -> App<'static, 'static> {
 
 fn init() -> App<'static, 'static> {
     SubCommand::with_name(CMD_INIT)
-        .about("Create a CKB direcotry or reinitialize an existing one")
+        .about("Creates a CKB direcotry or reinitialize an existing one")
         .arg(
             Arg::with_name(ARG_LIST_SPECS)
                 .short("l")
                 .long(ARG_LIST_SPECS)
-                .help("List available chain specs"),
+                .help("Lists available chain specs"),
         )
         .arg(
             Arg::with_name(ARG_SPEC)
                 .short("s")
                 .long(ARG_SPEC)
                 .default_value(DEFAULT_SPEC)
-                .help("Export config files for <spec>"),
+                .help("Exports config files for <spec>"),
         )
         .arg(
             Arg::with_name(ARG_LOG_TO)
@@ -167,24 +167,24 @@ fn init() -> App<'static, 'static> {
             Arg::with_name(ARG_FORCE)
                 .short("f")
                 .long(ARG_FORCE)
-                .help("Force overwriting existing files"),
+                .help("Force overwrits existing files"),
         )
         .arg(
             Arg::with_name(ARG_RPC_PORT)
                 .long(ARG_RPC_PORT)
                 .default_value(DEFAULT_RPC_PORT)
-                .help("Replace CKB RPC port in the exported config file"),
+                .help("Replaces CKB RPC port in the exported config file"),
         )
         .arg(
             Arg::with_name(ARG_P2P_PORT)
                 .long(ARG_P2P_PORT)
                 .default_value(DEFAULT_P2P_PORT)
-                .help("Replace CKB P2P port in the exported config file"),
+                .help("Replaces CKB P2P port in the exported config file"),
         )
         .arg(
             Arg::with_name(ARG_EXPORT_SPECS)
                 .long(ARG_EXPORT_SPECS)
                 .hidden(true)
-                .help("Export spec files as well"),
+                .help("Exports spec files as well"),
         )
 }


### PR DESCRIPTION
* Fix typos
* Display messages in the 3rd person

This is an attempt to unify the message style. Personally I like to NOT use the 3rd parson, but `clap`'s `help` and `version` uses that. (Anyway to override that?)

BTW, would `perf` be a better subcommand name than `prof`? @jjyr 

## Before

Specifically, now we have three styles: `Prints`, `Import`, `Profling` (should be `Profiling`).

```shell
ckb 0.13.0-pre
Nervos Core Dev <dev@nervos.org>
Nervos CKB - The Common Knowledge Base

USAGE:
    ckb [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -C <path>        Runs as if ckb was started in <path> instead of the current working directory.

SUBCOMMANDS:
    cli       CLI tools
    export    Export ckb data
    help      Prints this message or the help of the given subcommand(s)
    import    Import ckb data
    init      Create a CKB direcotry or reinitialize an existing one
    miner     Run ckb miner
    prof      Profling ckb node
              Example: Process 1..500 blocks then output flagme graph
              cargo flamegraph --bin ckb -- -C <dir> prof 1 500
    run       Run ckb node
```

## After

```shell
ckb 0.13.0-pre
Nervos Core Dev <dev@nervos.org>
Nervos CKB - The Common Knowledge Base

USAGE:
    ckb [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -C <path>        Run as if ckb was started in <path> instead of the current working directory.

SUBCOMMANDS:
    cli       CLI tools
    export    Exports ckb data
    help      Prints this message or the help of the given subcommand(s)
    import    Imports ckb data
    init      Creates a CKB direcotry or reinitialize an existing one
    miner     Runs ckb miner
    prof      Profiles ckb node
              Example: Process 1..500 blocks then output flagme graph
              cargo flamegraph --bin ckb -- -C <dir> prof 1 500
    run       Runs ckb node
```