### PR TITLE
feat: Calculate median time by tracing parents

### DIFF
--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -29,9 +29,8 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         let (tip_header, median_time) = {
             let chain_state = self.shared.lock_chain_state();
             let tip_header = chain_state.tip_header().clone();
-            let median_time = (&*chain_state)
-                .block_median_time(tip_header.number())
-                .expect("current block median time should exists");
+            let median_time =
+                (&*chain_state).block_median_time(tip_header.number(), tip_header.hash());
             (tip_header, median_time)
         };
         let epoch = tip_header.epoch();

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -689,11 +689,11 @@ impl<CS: ChainStore> BlockMedianTimeContext for &ChainState<CS> {
         self.consensus.median_time_block_count() as u64
     }
 
-    fn timestamp(&self, number: BlockNumber) -> Option<u64> {
-        self.store.get_block_hash(number).and_then(|hash| {
-            self.store
-                .get_header(&hash)
-                .map(|header| header.timestamp())
-        })
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+        let header = self
+            .store
+            .get_header(&block_hash)
+            .expect("[ChainState] blocks used for median time exist");
+        (header.timestamp(), header.parent_hash().to_owned())
     }
 }

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -696,4 +696,8 @@ impl<CS: ChainStore> BlockMedianTimeContext for &ChainState<CS> {
             .expect("[ChainState] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
+        self.store.get_block_hash(block_number)
+    }
 }

--- a/shared/src/tests/shared.rs
+++ b/shared/src/tests/shared.rs
@@ -38,19 +38,15 @@ where
 fn test_block_median_time() {
     let shared = new_shared();
     let chain_state = shared.lock_chain_state();
-    assert_eq!((&*chain_state).block_median_time(0), Some(0));
+    let hash = shared.store().get_block_hash(0).unwrap();
+    assert_eq!((&*chain_state).block_median_time(0, &hash), 0);
     let now = faketime::unix_time_as_millis();
     insert_block_timestamps(shared.store(), &[now]);
-    assert_eq!(
-        (&*chain_state).block_median_time(1).expect("median time"),
-        now
-    );
+    let hash = shared.store().get_block_hash(1).unwrap();
+    assert_eq!((&*chain_state).block_median_time(1, &hash), now);
     let timestamps = (1..=22).collect::<Vec<_>>();
     insert_block_timestamps(shared.store(), &timestamps);
-    assert_eq!(
-        (&*chain_state)
-            .block_median_time(*timestamps.last().expect("last"))
-            .expect("median time"),
-        17
-    );
+    let block_number = *timestamps.last().expect("last");
+    let hash = shared.store().get_block_hash(block_number).unwrap();
+    assert_eq!((&*chain_state).block_median_time(block_number, &hash), 17);
 }

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -1,4 +1,4 @@
-use ckb_core::{transaction::Transaction, BlockNumber, Cycle};
+use ckb_core::{transaction::Transaction, Cycle};
 use ckb_shared::shared::Shared;
 use ckb_shared::tx_pool::PoolError;
 use ckb_store::ChainStore;
@@ -19,12 +19,12 @@ impl<CS: ChainStore> BlockMedianTimeContext for StoreBlockMedianTimeContext<CS> 
         self.median_time_block_count
     }
 
-    fn timestamp(&self, number: BlockNumber) -> Option<u64> {
-        self.store.get_block_hash(number).and_then(|hash| {
-            self.store
-                .get_header(&hash)
-                .map(|header| header.timestamp())
-        })
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+        let header = self
+            .store
+            .get_header(block_hash)
+            .expect("[StoreBlockMedianTimeContext] blocks used for median time exist");
+        (header.timestamp(), header.parent_hash().to_owned())
     }
 }
 

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -1,4 +1,4 @@
-use ckb_core::{transaction::Transaction, Cycle};
+use ckb_core::{transaction::Transaction, BlockNumber, Cycle};
 use ckb_shared::shared::Shared;
 use ckb_shared::tx_pool::PoolError;
 use ckb_store::ChainStore;
@@ -25,6 +25,10 @@ impl<CS: ChainStore> BlockMedianTimeContext for StoreBlockMedianTimeContext<CS> 
             .get_header(block_hash)
             .expect("[StoreBlockMedianTimeContext] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
+    }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
+        self.store.get_block_hash(block_number)
     }
 }
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -2,6 +2,7 @@ use crate::synchronizer::{BlockStatus, Synchronizer};
 use crate::MAX_HEADERS_LEN;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
+use ckb_core::BlockNumber;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, FlatbuffersVectorIterator, Headers};
 use ckb_store::ChainStore;
@@ -82,6 +83,10 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
             .get_header(&block_hash)
             .expect("[VerifierResolver] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
+    }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
+        self.synchronizer.shared.block_hash(block_number)
     }
 }
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -1,7 +1,7 @@
 use crate::synchronizer::{BlockStatus, Synchronizer};
 use crate::MAX_HEADERS_LEN;
 use ckb_core::extras::EpochExt;
-use ckb_core::{header::Header, BlockNumber};
+use ckb_core::header::Header;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, FlatbuffersVectorIterator, Headers};
 use ckb_store::ChainStore;
@@ -9,6 +9,7 @@ use ckb_traits::BlockMedianTimeContext;
 use ckb_verification::{Error as VerifyError, HeaderResolver, HeaderVerifier, Verifier};
 use failure::Error as FailureError;
 use log::{self, debug, log_enabled, warn};
+use numext_fixed_hash::H256;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -74,27 +75,13 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
             .median_time_block_count() as u64
     }
 
-    fn timestamp(&self, _n: BlockNumber) -> Option<u64> {
-        None
-    }
-
-    fn ancestor_timestamps(&self, block_number: BlockNumber) -> Vec<u64> {
-        if Some(block_number) != self.parent.and_then(|p| Some(p.number())) {
-            return Vec::new();
-        }
-        let parent = self.parent.expect("parent");
-        let count = std::cmp::min(self.median_block_count(), block_number + 1);
-        let mut block_hash = parent.hash().to_owned();
-        let mut timestamps: Vec<u64> = Vec::with_capacity(count as usize);
-        for _ in 0..count {
-            let header = match self.synchronizer.shared.get_header(&block_hash) {
-                Some(h) => h,
-                None => break,
-            };
-            timestamps.push(header.timestamp());
-            block_hash = header.parent_hash().to_owned();
-        }
-        timestamps
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+        let header = self
+            .synchronizer
+            .shared
+            .get_header(&block_hash)
+            .expect("[VerifierResolver] blocks used for median time exist");
+        (header.timestamp(), header.parent_hash().to_owned())
     }
 }
 

--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -1,24 +1,47 @@
 use ckb_core::BlockNumber;
+use numext_fixed_hash::H256;
+use std::cmp::min;
 
 /// The invoker should only rely on `block_median_time` function
 /// the other functions only use to help the default `block_median_time`, and maybe unimplemented.
 pub trait BlockMedianTimeContext {
     fn median_block_count(&self) -> u64;
-    /// block timestamp
-    fn timestamp(&self, block_number: BlockNumber) -> Option<u64>;
-    /// ancestor timestamps from a block
-    fn ancestor_timestamps(&self, block_number: BlockNumber) -> Vec<u64> {
-        let count = self.median_block_count();
-        (block_number.saturating_sub(count.saturating_sub(1))..=block_number)
-            .filter_map(|n| self.timestamp(n))
-            .collect()
+
+    /// Return timestamp of the correspoding bloch_hash, and hash of parent block
+    ///
+    /// Fake implementation:
+    /// ```ignore
+    /// let current_header = get_block_header(block_hash);
+    /// let parent_header = current_header.timestamp_and_parent().header();
+    /// return (parent_header.timestamp(), parent_header.hash());
+    /// ```
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256);
+
+    /// Return past block median time, **including the timestamp of the given one**
+    ///
+    /// It's duty for outside caller to ensure that the block_number and block_hash are matched
+    fn block_median_time(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
+        let median_time_span = min(block_number + 1, self.median_block_count());
+        let mut timestamps: Vec<u64> = Vec::with_capacity(median_time_span as usize);
+        let mut block_hash = block_hash.to_owned();
+        for _ in 0..median_time_span {
+            let (timestamp, parent_hash) = self.timestamp_and_parent(&block_hash);
+            timestamps.push(timestamp);
+            block_hash = parent_hash;
+        }
+
+        // return greater one if count is even.
+        timestamps.sort_by(|a, b| a.cmp(b));
+        timestamps[timestamps.len() / 2]
     }
 
-    /// get block median time
-    fn block_median_time(&self, block_number: BlockNumber) -> Option<u64> {
-        let mut timestamps: Vec<u64> = self.ancestor_timestamps(block_number);
-        timestamps.sort_by(|a, b| a.cmp(b));
-        // return greater one if count is even.
-        timestamps.get(timestamps.len() / 2).cloned()
+    /// Return the corresponding block_hash
+    ///
+    /// It's just a convenience way that constructing a BlockMedianContext, to get the
+    /// corresponding block_hash when you only know a block_number.
+    /// Most of time we know both the matched block_number and block_hash, so it's ok to give the
+    /// default implementation `unimplemented!()`. Implement it only when you really need it.
+    fn get_block_hash(&self, _block_number: BlockNumber) -> Option<H256> {
+        unimplemented!()
     }
 }

--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -39,9 +39,7 @@ pub trait BlockMedianTimeContext {
     ///
     /// It's just a convenience way that constructing a BlockMedianContext, to get the
     /// corresponding block_hash when you only know a block_number.
-    /// Most of time we know both the matched block_number and block_hash, so it's ok to give the
-    /// default implementation `unimplemented!()`. Implement it only when you really need it.
-    fn get_block_hash(&self, _block_number: BlockNumber) -> Option<H256> {
-        unimplemented!()
-    }
+    ///
+    /// Often used in verifying "since by block number".
+    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256>;
 }

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -47,6 +47,14 @@ impl<'a, CS: ChainStore> BlockMedianTimeContext for ForkContext<'a, CS> {
             .expect("[ForkContext] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
+        self.fork_attached_blocks
+            .iter()
+            .find(|b| b.header().number() == block_number)
+            .and_then(|b| Some(b.header().hash().to_owned()))
+            .or_else(|| self.store.get_block_hash(block_number))
+    }
 }
 
 #[derive(Clone)]

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -27,18 +27,12 @@ struct ForkContext<'a, CS> {
 }
 
 impl<'a, CS: ChainStore> ForkContext<'a, CS> {
-    fn get_header(&self, number: BlockNumber) -> Option<Header> {
-        match self
-            .fork_attached_blocks
+    fn get_header(&self, block_hash: &H256) -> Option<Header> {
+        self.fork_attached_blocks
             .iter()
-            .find(|b| b.header().number() == number)
-        {
-            Some(block) => Some(block.header().to_owned()),
-            None => self
-                .store
-                .get_block_hash(number)
-                .and_then(|hash| self.store.get_header(&hash)),
-        }
+            .find(|b| b.header().hash() == block_hash)
+            .and_then(|b| Some(b.header().to_owned()))
+            .or_else(|| self.store.get_header(block_hash))
     }
 }
 
@@ -47,8 +41,11 @@ impl<'a, CS: ChainStore> BlockMedianTimeContext for ForkContext<'a, CS> {
         self.consensus.median_time_block_count() as u64
     }
 
-    fn timestamp(&self, number: BlockNumber) -> Option<u64> {
-        self.get_header(number).map(|header| header.timestamp())
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+        let header = self
+            .get_header(block_hash)
+            .expect("[ForkContext] blocks used for median time exist");
+        (header.timestamp(), header.parent_hash().to_owned())
     }
 }
 
@@ -175,8 +172,8 @@ where
 struct BlockTxsVerifier<'a, M, P> {
     provider: &'a P,
     block_median_time_context: &'a M,
-    number: BlockNumber,
-    epoch: EpochNumber,
+    block_number: BlockNumber,
+    epoch_number: EpochNumber,
     resolved: &'a [ResolvedTransaction<'a>],
 }
 
@@ -189,15 +186,15 @@ where
     pub fn new(
         provider: &'a P,
         block_median_time_context: &'a M,
-        number: BlockNumber,
-        epoch: EpochNumber,
+        block_number: BlockNumber,
+        epoch_number: EpochNumber,
         resolved: &'a [ResolvedTransaction<'a>],
     ) -> BlockTxsVerifier<'a, M, P> {
         BlockTxsVerifier {
             provider,
             block_median_time_context,
-            number,
-            epoch,
+            block_number,
+            epoch_number,
             resolved,
         }
     }
@@ -214,8 +211,8 @@ where
                     ContextualTransactionVerifier::new(
                         &tx,
                         self.block_median_time_context,
-                        self.number,
-                        self.epoch,
+                        self.block_number,
+                        self.epoch_number,
                         self.provider.consensus(),
                     )
                     .verify()
@@ -225,8 +222,8 @@ where
                     TransactionVerifier::new(
                         &tx,
                         self.block_median_time_context,
-                        self.number,
-                        self.epoch,
+                        self.block_number,
+                        self.epoch_number,
                         self.provider.consensus(),
                         self.provider.script_config(),
                         self.provider.store(),

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -87,15 +87,11 @@ impl<'a, M: BlockMedianTimeContext> TimestampVerifier<'a, M> {
         if self.header.is_genesis() {
             return Ok(());
         }
-        let min = match self
-            .header
-            .number()
-            .checked_sub(1)
-            .and_then(|n| self.block_median_time_context.block_median_time(n))
-        {
-            Some(time) => time,
-            None => return Err(Error::UnknownParent(self.header.parent_hash().to_owned())),
-        };
+
+        let parent_number = self.header.number() - 1;
+        let min = self
+            .block_median_time_context
+            .block_median_time(parent_number, self.header.parent_hash());
         if self.header.timestamp() <= min {
             return Err(Error::Timestamp(TimestampError::BlockTimeTooOld {
                 min,


### PR DESCRIPTION
At present, the way calculating the passed median time is that collects block timestamps one by one by block_number. This PR change to collects blocks timestamps by tracing parents. The new way is more robust.

In addition to this, I use assert-style to rewrite the calculation of passed median time.