### PR TITLE
feat: Use snappy to compress large messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,12 +571,13 @@ dependencies = [
  "sentry 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stop-handler 0.13.0-pre",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-discovery 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-identify 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-ping 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-discovery 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-identify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-ping 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2974,6 +2975,15 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "snap"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.2.0-alpha.18"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3069,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tentacle-discovery"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3080,26 +3090,26 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-identify"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers-verifier 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-ping"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3108,7 +3118,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3932,6 +3942,7 @@ dependencies = [
 "checksum sized-chunks 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "882678bcc6f62ef6bb83ce1b7dbbec316f24a2be7f3033acc107d3b11735cb50"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
@@ -3941,10 +3952,10 @@ dependencies = [
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
-"checksum tentacle 0.2.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0471908d0dd4be91fcff04647e004b7fd8c596cc0d7b78b6a5c7f985f27d7962"
-"checksum tentacle-discovery 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "48f049945da9545ef3208a10a28a33ca64e9672dab762ad28cfc861262f9a770"
-"checksum tentacle-identify 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "345d23968098e355e3e01973c3531886c0f1631723aa46774fc3ebfb8f1e714c"
-"checksum tentacle-ping 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b70c3cca0a78b4661039f257d849993009a5f4bcd32203fffc9b5d755001613"
+"checksum tentacle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088112e5f3f5ebe287852a9c9ce29bd168586d9338489d49d5aa9639c3d1cbaa"
+"checksum tentacle-discovery 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66079c177dba4f89cc882d74a16b037774059cf5be4fe9179b12937d7b4ffe40"
+"checksum tentacle-identify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "510f23842a73416bf478515081c49e6ba09d9d4d75d71b0892ffeb496612395e"
+"checksum tentacle-ping 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad0c0e23ab0c103ce91f6d5c19554fce95f82abc542739360b273e1bc46edbe"
 "checksum tentacle-secio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1f7e6cfc62a132bec2b68c0827dcbfbe7b54744783aeaf15219acaeb8e07e8cd"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,10 +20,10 @@ bytes = "0.4.12"
 tokio = "0.1.18"
 futures = "0.1"
 crossbeam-channel = "0.3"
-p2p = { version="0.2.0-alpha.18", package="tentacle" }
-p2p-ping = { version="0.3.4", package="tentacle-ping" }
-p2p-discovery = { version="0.2.4", package="tentacle-discovery" }
-p2p-identify = { version="0.2.4", package="tentacle-identify" }
+p2p = { version="0.2.0", package="tentacle" }
+p2p-ping = { version="0.3.5", package="tentacle-ping" }
+p2p-discovery = { version="0.2.5", package="tentacle-discovery" }
+p2p-identify = { version="0.2.5", package="tentacle-identify" }
 faketime = "0.2.0"
 rusqlite = {version = "0.18.0", features = ["bundled"]}
 lazy_static = "1.3.0"
@@ -36,6 +36,7 @@ secp256k1 = {version = "0.12.2" }
 resolve = "0.2.0"
 build-info = {path = "../util/build-info"}
 num_cpus = "1.10"
+snap = "0.2"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/network/src/compress.rs
+++ b/network/src/compress.rs
@@ -1,0 +1,178 @@
+use bytes::{Bytes, BytesMut};
+use snap::{Decoder as SnapDecoder, Encoder as SnapEncoder};
+use tokio::codec::{Decoder, Encoder, LengthDelimitedCodec};
+
+use std::io;
+
+const SKIP_COMPRESS_SIZE: usize = 40 * 1024;
+
+/// Compressed decompression structure
+///
+/// If you want to support multiple compression formats in the future,
+/// you can simply think that 0b1000 is in snappy format and 0b0000 is in uncompressed format.
+///
+/// # Message in Bytes:
+///
+/// +---------------------------------------------------------------+
+/// | Bytes | Type | Function                                       |
+/// |-------+------+------------------------------------------------|
+/// |   0   |  u1  | Compress: true 1, false 0                      |
+/// |       |  u7  | Reserved                                       |
+/// +-------+------+------------------------------------------------+
+/// |  1~   |      | Payload (Serialized Data with Compress)        |
+/// +-------+------+------------------------------------------------+
+#[derive(Clone, Debug)]
+struct Message {
+    inner: BytesMut,
+}
+
+impl Message {
+    /// Init
+    fn init() -> Self {
+        Message {
+            inner: BytesMut::from(&[0u8][..]),
+        }
+    }
+
+    /// Compress message
+    fn compress(&mut self, input: Bytes) {
+        if input.len() > SKIP_COMPRESS_SIZE {
+            match SnapEncoder::new().compress_vec(&input) {
+                Ok(res) => {
+                    self.inner.unsplit(BytesMut::from(res));
+                    self.set_compress_flag(true);
+                }
+                Err(_) => {
+                    self.inner.unsplit(BytesMut::from(input));
+                    self.set_compress_flag(false);
+                }
+            }
+        } else {
+            self.set_compress_flag(false);
+            self.inner.unsplit(BytesMut::from(input));
+        }
+    }
+
+    /// Decompress message
+    fn decompress(mut self) -> Option<BytesMut> {
+        if self.inner.len() <= 1 {
+            None
+        } else if self.compress_flag() {
+            match SnapDecoder::new().decompress_vec(&self.inner[1..]) {
+                Ok(res) => Some(BytesMut::from(res)),
+                Err(_) => None,
+            }
+        } else {
+            self.inner.split_to(1);
+            Some(self.inner.take())
+        }
+    }
+
+    fn set_compress_flag(&mut self, flag: bool) {
+        let compress_flag = if flag { 0b1000_0000 } else { 0b0000_0000 };
+        self.inner[0] = (self.inner[0] & 0b0111_1111) + (compress_flag & 0b1000_0000);
+    }
+
+    fn compress_flag(&self) -> bool {
+        (self.inner[0] & 0b1000_0000) != 0
+    }
+
+    fn into_inner(self) -> Bytes {
+        self.inner.freeze()
+    }
+}
+
+impl From<BytesMut> for Message {
+    fn from(src: BytesMut) -> Self {
+        Message { inner: src }
+    }
+}
+
+impl From<Bytes> for Message {
+    fn from(src: Bytes) -> Self {
+        Message {
+            inner: BytesMut::from(src),
+        }
+    }
+}
+
+/// Compress data
+pub fn compress(src: Bytes) -> Bytes {
+    let mut msg = Message::init();
+    msg.compress(src);
+    msg.into_inner()
+}
+
+/// Decompression structure for Codec
+pub struct LengthDelimited(LengthDelimitedCodec);
+
+impl LengthDelimited {
+    pub fn new(codec: LengthDelimitedCodec) -> Self {
+        LengthDelimited(codec)
+    }
+}
+
+impl Encoder for LengthDelimited {
+    type Item = bytes::Bytes;
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
+        self.0.encode(item, dst)
+    }
+}
+
+impl Decoder for LengthDelimited {
+    type Item = bytes::BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.0
+            .decode(src)
+            .map(|item| item.and_then(|item| Into::<Message>::into(item).decompress()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Bytes, Message, SKIP_COMPRESS_SIZE};
+
+    #[test]
+    fn test_no_need_compress() {
+        let mut msg = Message::init();
+        msg.compress(Bytes::from("1222"));
+
+        assert!(!msg.compress_flag());
+
+        let demsg = msg.decompress().unwrap();
+
+        assert_eq!(Bytes::from("1222"), demsg)
+    }
+
+    #[test]
+    fn test_compress_and_decompress() {
+        let mut msg = Message::init();
+        let data = Bytes::from(vec![1; SKIP_COMPRESS_SIZE + 1]);
+        msg.compress(data.clone());
+
+        assert!(msg.compress_flag());
+
+        let demsg = msg.decompress().unwrap();
+
+        assert_eq!(data, demsg)
+    }
+
+    #[test]
+    fn test_compress_and_decompress_use_another_message() {
+        let mut msg = Message::init();
+        let data = Bytes::from(vec![1; SKIP_COMPRESS_SIZE + 1]);
+        msg.compress(data.clone());
+
+        assert!(msg.compress_flag());
+
+        let cmp_msg = msg.into_inner();
+
+        let demsg = Into::<Message>::into(cmp_msg).decompress().unwrap();
+
+        assert_eq!(data, demsg)
+    }
+}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -1,4 +1,5 @@
 mod behaviour;
+mod compress;
 mod config;
 pub mod errors;
 pub mod network;

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -10,8 +10,7 @@ use crate::protocols::{
 use crate::services::{dns_seeding::DnsSeedingService, outbound_peer::OutboundPeerService};
 use crate::Peer;
 use crate::{
-    compress::compress, Behaviour, CKBProtocol, NetworkConfig, ProtocolId, ProtocolVersion,
-    PublicKey, ServiceControl,
+    Behaviour, CKBProtocol, NetworkConfig, ProtocolId, ProtocolVersion, PublicKey, ServiceControl,
 };
 use build_info::Version;
 use ckb_util::{Mutex, RwLock};
@@ -980,14 +979,13 @@ impl NetworkController {
         data: Bytes,
     ) -> Result<(), P2pError> {
         let now = Instant::now();
-        let cmp_data = compress(data);
         loop {
             let result = if quick {
                 self.p2p_control
-                    .quick_filter_broadcast(target.clone(), proto_id, cmp_data.clone())
+                    .quick_filter_broadcast(target.clone(), proto_id, data.clone())
             } else {
                 self.p2p_control
-                    .filter_broadcast(target.clone(), proto_id, cmp_data.clone())
+                    .filter_broadcast(target.clone(), proto_id, data.clone())
             };
             match result {
                 Ok(()) => {

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -10,7 +10,8 @@ use crate::protocols::{
 use crate::services::{dns_seeding::DnsSeedingService, outbound_peer::OutboundPeerService};
 use crate::Peer;
 use crate::{
-    Behaviour, CKBProtocol, NetworkConfig, ProtocolId, ProtocolVersion, PublicKey, ServiceControl,
+    compress::compress, Behaviour, CKBProtocol, NetworkConfig, ProtocolId, ProtocolVersion,
+    PublicKey, ServiceControl,
 };
 use build_info::Version;
 use ckb_util::{Mutex, RwLock};
@@ -979,13 +980,14 @@ impl NetworkController {
         data: Bytes,
     ) -> Result<(), P2pError> {
         let now = Instant::now();
+        let cmp_data = compress(data);
         loop {
             let result = if quick {
                 self.p2p_control
-                    .quick_filter_broadcast(target.clone(), proto_id, data.clone())
+                    .quick_filter_broadcast(target.clone(), proto_id, cmp_data.clone())
             } else {
                 self.p2p_control
-                    .filter_broadcast(target.clone(), proto_id, data.clone())
+                    .filter_broadcast(target.clone(), proto_id, cmp_data.clone())
             };
             match result {
                 Ok(()) => {

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -19,7 +19,10 @@ use tokio::codec::length_delimited;
 
 pub type PeerIndex = SessionId;
 
-use crate::{Behaviour, NetworkState, Peer, PeerRegistry, ProtocolVersion, MAX_FRAME_LENGTH};
+use crate::{
+    compress::{compress, LengthDelimited},
+    Behaviour, NetworkState, Peer, PeerRegistry, ProtocolVersion, MAX_FRAME_LENGTH,
+};
 
 pub trait CKBProtocolContext: Send {
     // Interact with underlying p2p service
@@ -123,11 +126,11 @@ impl CKBProtocol {
             .id(self.id)
             .name(move |_| protocol_name.clone())
             .codec(|| {
-                Box::new(
+                Box::new(LengthDelimited::new(
                     length_delimited::Builder::new()
                         .max_frame_length(MAX_FRAME_LENGTH)
                         .new_codec(),
-                )
+                ))
             })
             .support_versions(supported_versions)
             .service_handle(move || {
@@ -230,26 +233,26 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
     }
     fn quick_send_message(&self, proto_id: ProtocolId, peer_index: PeerIndex, data: Bytes) {
         trace!(target: "network", "[send message]: {}, to={}, length={}", proto_id, peer_index, data.len());
-        if let Err(err) = self
-            .p2p_control
-            .quick_send_message_to(peer_index, proto_id, data)
+        if let Err(err) =
+            self.p2p_control
+                .quick_send_message_to(peer_index, proto_id, compress(data))
         {
             debug!(target: "network", "p2p service quick_send_message error: {:?}", err);
         }
     }
     fn quick_send_message_to(&self, peer_index: PeerIndex, data: Bytes) {
         trace!(target: "network", "[send message to]: {}, to={}, length={}", self.proto_id, peer_index, data.len());
-        if let Err(err) = self
-            .p2p_control
-            .quick_send_message_to(peer_index, self.proto_id, data)
+        if let Err(err) =
+            self.p2p_control
+                .quick_send_message_to(peer_index, self.proto_id, compress(data))
         {
             debug!(target: "network", "p2p service quick_send_message_to error: {:?}", err);
         }
     }
     fn quick_filter_broadcast(&self, target: TargetSession, data: Bytes) {
-        if let Err(err) = self
-            .p2p_control
-            .quick_filter_broadcast(target, self.proto_id, data)
+        if let Err(err) =
+            self.p2p_control
+                .quick_filter_broadcast(target, self.proto_id, compress(data))
         {
             debug!(target: "network", "p2p service quick_filter_broadcast error: {:?}", err);
         }
@@ -267,9 +270,9 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
     }
     fn send_message_to(&self, peer_index: PeerIndex, data: Bytes) {
         trace!(target: "network", "[send message to]: {}, to={}, length={}", self.proto_id, peer_index, data.len());
-        if let Err(err) = self
-            .p2p_control
-            .send_message_to(peer_index, self.proto_id, data)
+        if let Err(err) =
+            self.p2p_control
+                .send_message_to(peer_index, self.proto_id, compress(data))
         {
             debug!(target: "network", "p2p service send_message_to error: {:?}", err);
         }
@@ -277,7 +280,7 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
     fn filter_broadcast(&self, target: TargetSession, data: Bytes) {
         if let Err(err) = self
             .p2p_control
-            .filter_broadcast(target, self.proto_id, data)
+            .filter_broadcast(target, self.proto_id, compress(data))
         {
             debug!(target: "network", "p2p service filter_broadcast error: {:?}", err);
         }


### PR DESCRIPTION
BREAKING CHANGE: protocol communication break

On the test net monitoring, the bandwidth usage is often in a full state. We try to use the snappy compression algorithm to reduce network transmission consumption.

After testing, the compression yield of flatbuffer format is very high, cpu consumption is relatively acceptable.

The following is the data transmission on the test net:

```
2019-05-20 16:27:41.875 +08:00 tokio-runtime-worker-7 DEBUG compress  raw_data len: 625400, compress used time: 3.635121ms, compress_data size: 335401, compression ratio: 0.536298369043812, decompress used time: 1.496667ms
2019-05-20 16:27:42.128 +08:00 tokio-runtime-worker-6 DEBUG compress  raw_data len: 633544, compress used time: 3.789752ms, compress_data size: 335462, compression ratio: 0.5295007134468955, decompress used time: 1.490144ms
2019-05-20 16:27:42.340 +08:00 tokio-runtime-worker-6 DEBUG compress  raw_data len: 633216, compress used time: 3.998678ms, compress_data size: 333458, compression ratio: 0.5266101930462906, decompress used time: 1.593165ms
2019-05-20 16:27:42.558 +08:00 tokio-runtime-worker-5 DEBUG compress  raw_data len: 632992, compress used time: 3.453616ms, compress_data size: 333552, compression ratio: 0.5269450482786512, decompress used time: 1.052606ms
2019-05-20 16:27:42.740 +08:00 tokio-runtime-worker-2 DEBUG compress  raw_data len: 633760, compress used time: 1.256847ms, compress_data size: 340022, compression ratio: 0.5365154001514769, decompress used time: 545.473µs
2019-05-20 16:37:43.934 +08:00 tokio-runtime-worker-1 DEBUG compress  raw_data len: 186912, compress used time: 659.317µs, compress_data size: 42640, compression ratio: 0.22812874507789763, decompress used time: 515.287µs
2019-05-20 16:37:47.338 +08:00 tokio-runtime-worker-3 DEBUG compress  raw_data len: 186520, compress used time: 189.079µs, compress_data size: 42334, compression ratio: 0.22696761741368218, decompress used time: 150.644µs
2019-05-20 16:37:50.729 +08:00 tokio-runtime-worker-3 DEBUG compress  raw_data len: 186520, compress used time: 197.656µs, compress_data size: 42336, compression ratio: 0.22697834012438345, decompress used time: 145.5µs
2019-05-20 16:38:52.549 +08:00 tokio-runtime-worker-4 DEBUG compress  raw_data len: 95904, compress used time: 217.968µs, compress_data size: 33801, compression ratio: 0.3524461961961962, decompress used time: 95.818µs
2019-05-20 16:39:32.522 +08:00 tokio-runtime-worker-0 DEBUG compress  raw_data len: 47320, compress used time: 418.183µs, compress_data size: 17183, compression ratio: 0.363123415046492, decompress used time: 252.148µs
```

Note that this is a **break change**, the data is modified as follows:

By default, data above 40k enters compressed mode.

From the current point of view, the high bit 1 is the compressed format and the high bit 0 is the uncompressed format.

If you want to support multiple compression formats in the future, you can simply think that 0b1000 is in snappy format and 0b0000 is in uncompressed format.

```
 # Message in Bytes:

 +---------------------------------------------------------------+
 | Bytes | Type | Function                                       |
 |-------+------+------------------------------------------------|
 |   0   |  u1  | Compress: true 1, false 0                      |
 |       |  u7  | Reserved                                       |
 +-------+------+------------------------------------------------+
 |  1~   |      | Payload (Serialized Data with Compress)        |
 +-------+------+------------------------------------------------+
```