### PR TITLE
feat: includes full version in RPC `local_node_info`

### DIFF
--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -23,7 +23,7 @@ pub(crate) struct NetworkRpcImpl {
 impl NetworkRpc for NetworkRpcImpl {
     fn local_node_info(&self) -> Result<Node> {
         Ok(Node {
-            version: self.network_controller.node_version().to_string(),
+            version: self.network_controller.node_version().long(),
             is_outbound: None,
             node_id: self.network_controller.node_id(),
             addresses: self


### PR DESCRIPTION
This is a breaking change for clients and SDKs that rely on the version
detailed content.