### PR TITLE
chore: rename the target in log for rpc module

### DIFF
--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -16,7 +16,7 @@ spec = "specs/dev.toml" # {{
 
 [logger]
 filter = "info" # {{
-# integration => filter = "info,network=trace,rpc=debug,sync=debug,relay=debug"
+# integration => filter = "info,network=trace,sync=debug,relay=debug"
 # }}
 color = true
 log_to_file = true # {{

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -16,7 +16,7 @@ spec = "specs/dev.toml" # {{
 
 [logger]
 filter = "info" # {{
-# integration => filter = "info,network=trace,rpc=debug,sync=debug,relay=debug,tx_pool=debug"
+# integration => filter = "info,network=trace,rpc-server=debug,sync=debug,relay=debug,tx_pool=debug"
 # }}
 color = true
 log_to_file = true # {{

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -70,7 +70,7 @@ impl<CS: ChainStore + 'static> ExperimentRpc for ExperimentRpcImpl<CS> {
         match DaoWithdrawCalculator::new(&chain_state).calculate(out_point.clone().into(), hash) {
             Ok(capacity) => Ok(capacity),
             Err(err) => {
-                error!(target: "rpc", "calculate_dao_maximum_withdraw error {:?}", err);
+                error!(target: "rpc-server", "calculate_dao_maximum_withdraw error {:?}", err);
                 Err(Error::internal_error())
             }
         }

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -57,7 +57,7 @@ impl<CS: ChainStore + 'static> PoolRpc for PoolRpcImpl<CS> {
                     .network_controller
                     .broadcast(NetworkProtocol::RELAY.into(), data)
                 {
-                    log::error!(target: "rpc", "Broadcast transaction failed: {:?}", err);
+                    log::error!(target: "rpc-server", "Broadcast transaction failed: {:?}", err);
                 }
                 Ok(tx.hash().to_owned())
             }

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -51,7 +51,7 @@ impl<CS: ChainStore + 'static> IntegrationTestRpc for IntegrationTestRpcImpl<CS>
         if ret.is_ok() {
             Ok(Some(block.header().hash().to_owned()))
         } else {
-            error!(target: "rpc", "process_block_without_verify error: {:?}", ret);
+            error!(target: "rpc-server", "process_block_without_verify error: {:?}", ret);
             Ok(None)
         }
     }


### PR DESCRIPTION
The old target is same as the target in [`jsonrpc-core`](https://github.com/paritytech/jsonrpc/blob/master/core/src/io.rs#L177).

I rename it to `rpc-server` since we have `rpc` client in some tests.