### PR TITLE
fix: calculate the current median time from tip

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     specs.insert("depent_tx_in_same_block", Box::new(DepentTxInSameBlock));
     // TODO enable these after proposed/pending pool tip verfiry logic changing
     // specs.insert("cellbase_maturity", Box::new(CellbaseMaturity));
-    // specs.insert("valid_since", Box::new(ValidSince));
+    specs.insert("valid_since", Box::new(ValidSince));
     specs.insert(
         "different_txs_with_same_input",
         Box::new(DifferentTxsWithSameInput),

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -1,16 +1,214 @@
-use crate::{assert_regex_match, Net, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use crate::utils::{
+    since_from_absolute_block_number, since_from_absolute_timestamp,
+    since_from_relative_block_number, since_from_relative_timestamp, MEDIAN_TIME_BLOCK_COUNT,
+};
+use crate::{assert_regex_match, Net, Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use ckb_chain_spec::ChainSpec;
+use ckb_core::transaction::Transaction;
 use ckb_core::BlockNumber;
 use log::info;
+use std::cmp::max;
+use std::thread::sleep;
+use std::time::Duration;
 
 pub struct ValidSince;
 
-#[allow(clippy::identity_op)]
+// TODO add cases verify compact block(forks) including transaction of which since != 0
 impl Spec for ValidSince {
     fn run(&self, net: Net) {
         info!("Running ValidSince");
-        let node = &net.nodes[0];
+        self.test_since_relative_block_number(&net.nodes[0]);
+        self.test_since_absolute_block_number(&net.nodes[0]);
+        self.test_since_relative_median_time(&net.nodes[0]);
+        self.test_since_absolute_median_time(&net.nodes[0]);
 
-        info!("Generate 1 block");
+        // TODO: Uncomment this case after proposed/pending pool tip verfiry logic changing
+        // self.test_since_and_proposal(&net.nodes[1]);
+    }
+
+    fn num_nodes(&self) -> usize {
+        2
+    }
+
+    fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
+        let cellbase_maturity = self.cellbase_maturity();
+        Box::new(move |spec_config: &mut ChainSpec| {
+            spec_config.params.cellbase_maturity = cellbase_maturity;
+        })
+    }
+}
+
+impl ValidSince {
+    pub fn cellbase_maturity(&self) -> u64 {
+        DEFAULT_TX_PROPOSAL_WINDOW.0 + 2
+    }
+
+    pub fn test_since_relative_block_number(&self, node: &Node) {
+        node.generate_block();
+        let relative: BlockNumber = self.cellbase_maturity() + 5;
+        let since = since_from_relative_block_number(relative);
+        let transaction = {
+            let cellbase = node.get_tip_block().transactions()[0].clone();
+            node.new_transaction_with_since(cellbase.hash().to_owned(), since)
+        };
+
+        // Failed to send transaction since CellbaseImmaturity
+        for _ in 0..self.cellbase_maturity() {
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(CellbaseImmaturity)");
+            node.generate_block();
+        }
+
+        // Failed to send transaction since SinceImmaturity
+        for _ in self.cellbase_maturity()..relative {
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(Immature)");
+            node.generate_block();
+        }
+
+        // Success to send transaction after cellbase immaturity and since immaturity
+        assert!(
+            node.rpc_client()
+                .inner()
+                .lock()
+                .send_transaction((&transaction).into())
+                .call()
+                .is_ok(),
+            "transaction is ok, tip is equal to relative since block number",
+        );
+    }
+
+    pub fn test_since_absolute_block_number(&self, node: &Node) {
+        node.generate_block();
+        let absolute: BlockNumber =
+            node.rpc_client().get_tip_block_number() + self.cellbase_maturity() + 5;
+        let since = since_from_absolute_block_number(absolute);
+        let transaction = {
+            let cellbase = node.get_tip_block().transactions()[0].clone();
+            node.new_transaction_with_since(cellbase.hash().to_owned(), since)
+        };
+
+        // Failed to send transaction since CellbaseImmaturity
+        for _ in 0..self.cellbase_maturity() {
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(CellbaseImmaturity)");
+            node.generate_block();
+        }
+
+        // Failed to send transaction since SinceImmaturity
+        let tip_number = node.rpc_client().get_tip_block_number();
+        for _ in tip_number..absolute {
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(Immature)");
+            node.generate_block();
+        }
+
+        // Success to send transaction after cellbase immaturity and since immaturity
+        assert!(
+            node.rpc_client()
+                .inner()
+                .lock()
+                .send_transaction((&transaction).into())
+                .call()
+                .is_ok(),
+            "transaction is ok, tip is equal to absolute since block number",
+        );
+    }
+
+    pub fn test_since_relative_median_time(&self, node: &Node) {
+        node.generate_block();
+        let cellbase = node.get_tip_block().transactions()[0].clone();
+        let old_median_time = node.rpc_client().get_blockchain_info().median_time.0;
+        sleep(Duration::from_secs(2));
+
+        let n = max(self.cellbase_maturity(), MEDIAN_TIME_BLOCK_COUNT);
+        (0..n).for_each(|_| {
+            node.generate_block();
+        });
+
+        // Calculate the current block median time
+        let tip_number = node.rpc_client().get_tip_block_number();
+        let mut timestamps: Vec<u64> = (tip_number - MEDIAN_TIME_BLOCK_COUNT + 1..=tip_number)
+            .map(|block_number| {
+                node.rpc_client()
+                    .get_block_by_number(block_number)
+                    .unwrap()
+                    .header
+                    .inner
+                    .timestamp
+                    .0
+            })
+            .collect();
+        timestamps.sort();
+        let median_time = timestamps[timestamps.len() / 2];
+
+        // Absolute since timestamp in seconds
+        let median_time_seconds = (median_time - old_median_time) / 1000;
+        {
+            let since = since_from_relative_timestamp(median_time_seconds + 1);
+            let transaction = node.new_transaction_with_since(cellbase.hash().to_owned(), since);
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(Immature)");
+        }
+        {
+            let since = since_from_relative_timestamp(median_time_seconds - 1);
+            let transaction = node.new_transaction_with_since(cellbase.hash().to_owned(), since);
+            assert!(
+                node.rpc_client()
+                    .inner()
+                    .lock()
+                    .send_transaction((&transaction).into())
+                    .call()
+                    .is_ok(),
+                "transaction's since is greater than tip's median time",
+            );
+        }
+    }
+
+    pub fn test_since_absolute_median_time(&self, node: &Node) {
+        node.generate_block();
+        let cellbase = node.get_tip_block().transactions()[0].clone();
+        let n = max(self.cellbase_maturity(), MEDIAN_TIME_BLOCK_COUNT);
+        (0..n).for_each(|_| {
+            node.generate_block();
+        });
+
+        // Calculate current block median time
+        let tip_number = node.rpc_client().get_tip_block_number();
+        let mut timestamps: Vec<u64> = (tip_number.saturating_sub(MEDIAN_TIME_BLOCK_COUNT + 1)
+            ..=tip_number)
+            .map(|block_number| {
+                node.rpc_client()
+                    .get_block_by_number(block_number)
+                    .unwrap()
+                    .header
+                    .inner
+                    .timestamp
+                    .0
+            })
+            .collect();
+        timestamps.sort();
+        let median_time = timestamps[timestamps.len() / 2];
+
+        // Absolute since timestamp in seconds
+        let median_time_seconds = median_time / 1000;
+        {
+            let since = since_from_absolute_timestamp(median_time_seconds + 1);
+            let transaction = node.new_transaction_with_since(cellbase.hash().to_owned(), since);
+            assert_send_transaction_fail(node, &transaction, "InvalidTx(Immature)");
+        }
+        {
+            let since = since_from_absolute_timestamp(median_time_seconds - 1);
+            let transaction = node.new_transaction_with_since(cellbase.hash().to_owned(), since);
+            assert!(
+                node.rpc_client()
+                    .inner()
+                    .lock()
+                    .send_transaction((&transaction).into())
+                    .call()
+                    .is_ok(),
+                "transaction's since is greater than tip's median time",
+            );
+        }
+    }
+
+    #[allow(clippy::identity_op)]
+    pub fn test_since_and_proposal(&self, node: &Node) {
         node.generate_block();
 
         // test relative block number since
@@ -87,8 +285,21 @@ impl Spec for ValidSince {
         node.generate_block();
         node.assert_tx_pool_size(0, 0);
     }
+}
 
-    fn num_nodes(&self) -> usize {
-        1
-    }
+fn assert_send_transaction_fail(node: &Node, transaction: &Transaction, message: &str) {
+    let result = node
+        .rpc_client()
+        .inner()
+        .lock()
+        .send_transaction(transaction.into())
+        .call();
+    let error = result.expect_err(&format!("transaction is invalid since {}", message));
+    let error_string = error.to_string();
+    assert!(
+        error_string.contains(message),
+        "expect error \"{}\" but got \"{}\"",
+        message,
+        error_string,
+    );
 }

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -2,6 +2,7 @@ use crate::Net;
 use bytes::Bytes;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::header::{Header, HeaderBuilder, Seal};
+use ckb_core::BlockNumber;
 use ckb_protocol::{RelayMessage, SyncMessage};
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_types::BlockTemplate;
@@ -9,6 +10,16 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+
+pub const MEDIAN_TIME_BLOCK_COUNT: u64 = 11;
+pub const FLAG_SINCE_RELATIVE: u64 =
+    0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+pub const FLAG_SINCE_BLOCK_NUMBER: u64 =
+    0b000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+// pub const FLAG_SINCE_EPOCH_NUMBER: u64 =
+//    0b010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+pub const FLAG_SINCE_TIMESTAMP: u64 =
+    0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
 
 // Build compact block based on core block, and specific prefilled indices
 pub fn build_compact_block_with_prefilled(block: &Block, prefilled: Vec<usize>) -> Bytes {
@@ -99,4 +110,28 @@ where
 // Clear net message channel
 pub fn clear_messages(net: &Net) {
     while let Ok(_) = net.receive_timeout(Duration::new(0, 100)) {}
+}
+
+pub fn since_from_relative_block_number(block_number: BlockNumber) -> u64 {
+    FLAG_SINCE_RELATIVE | FLAG_SINCE_BLOCK_NUMBER | block_number
+}
+
+pub fn since_from_absolute_block_number(block_number: BlockNumber) -> u64 {
+    FLAG_SINCE_BLOCK_NUMBER | block_number
+}
+
+// pub fn since_from_relative_epoch_number(epoch_number: EpochNumber) -> u64 {
+//     FLAG_SINCE_RELATIVE | FLAG_SINCE_EPOCH_NUMBER | epoch_number
+// }
+//
+// pub fn since_from_absolute_epoch_number(epoch_number: EpochNumber) -> u64 {
+//     FLAG_SINCE_EPOCH_NUMBER | epoch_number
+// }
+
+pub fn since_from_relative_timestamp(timestamp: u64) -> u64 {
+    FLAG_SINCE_RELATIVE | FLAG_SINCE_TIMESTAMP | timestamp
+}
+
+pub fn since_from_absolute_timestamp(timestamp: u64) -> u64 {
+    FLAG_SINCE_TIMESTAMP | timestamp
 }

--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -31,7 +31,7 @@ pub trait BlockMedianTimeContext {
         }
 
         // return greater one if count is even.
-        timestamps.sort_by(|a, b| a.cmp(b));
+        timestamps.sort();
         timestamps[timestamps.len() / 2]
     }
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -423,7 +423,7 @@ where
                     }
                 }
                 Some(SinceMetric::Timestamp(timestamp)) => {
-                    let tip_timestamp = self.block_median_time(self.tip_number.saturating_sub(1));
+                    let tip_timestamp = self.block_median_time(self.tip_number);
                     if tip_timestamp < timestamp {
                         return Err(TransactionError::Immature);
                     }
@@ -459,9 +459,13 @@ where
                     }
                 }
                 Some(SinceMetric::Timestamp(timestamp)) => {
-                    let tip_timestamp = self.block_median_time(self.tip_number.saturating_sub(1));
+                    // pass_median_time(current_block) starts with tip block, which is the
+                    // parent of current block.
+                    // pass_median_time(input_cell's block) starts with cell_block_number - 1,
+                    // which is the parent of input_cell's block
                     let median_timestamp =
                         self.block_median_time(cell_block_number.saturating_sub(1));
+                    let tip_timestamp = self.block_median_time(self.tip_number);
                     if tip_timestamp < median_timestamp + timestamp {
                         return Err(TransactionError::Immature);
                     }


### PR DESCRIPTION
**BREAKING CHANGE**: Original implementation use `[Tip-BlockMedianCount .. Tip-1]` to calculate the current block median time. According to the notion of BlockMedianTime in [bip-0113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki#specification) , here change to use `[Tip-BlockMedianCount+1 .. Tip]` instead.