### PR TITLE
feat: Alert system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-alert-system"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-core 0.13.0-pre",
+ "ckb-network 0.13.0-pre",
+ "ckb-protocol 0.13.0-pre",
+ "ckb-util 0.13.0-pre",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-types 0.13.0-pre",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)",
+ "multisig 0.1.0",
+ "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-app-config"
 version = "0.13.0-pre"
 dependencies = [
@@ -364,6 +387,7 @@ name = "ckb-bin"
 version = "0.13.0-pre"
 dependencies = [
  "build-info 0.13.0-pre",
+ "ckb-alert-system 0.1.0",
  "ckb-app-config 0.13.0-pre",
  "ckb-chain 0.13.0-pre",
  "ckb-chain-spec 0.13.0-pre",
@@ -639,6 +663,7 @@ dependencies = [
 name = "ckb-rpc"
 version = "0.13.0-pre"
 dependencies = [
+ "ckb-alert-system 0.1.0",
  "ckb-chain 0.13.0-pre",
  "ckb-chain-spec 0.13.0-pre",
  "ckb-core 0.13.0-pre",
@@ -2003,6 +2028,17 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "multisig"
+version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ ckb-bin = { path = "ckb-bin" }
 
 [workspace]
 members = [
+    "util/alert-system",
+    "util/multisig",
     "util/logger",
     "util/hash",
     "util/merkle-tree",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -27,6 +27,7 @@ ckb-pow = { path = "../pow" }
 ckb-network = { path = "../network"}
 ckb-rpc = { path = "../rpc"}
 ckb-resource = { path = "../resource"}
+ckb-alert-system = { path = "../util/alert-system" }
 logger = { path = "../util/logger" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }

--- a/core/src/alert.rs
+++ b/core/src/alert.rs
@@ -1,0 +1,92 @@
+use crate::Bytes;
+use bincode::serialize;
+use hash::blake2b_256;
+use numext_fixed_hash::H256;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Alert {
+    pub id: u32,
+    // cancel id if cancel is greater than 0
+    pub cancel: u32,
+    // TODO use service flag to distinguish network
+    //network: String,
+    pub min_version: Option<String>,
+    pub max_version: Option<String>,
+    pub priority: u32,
+    pub notice_until: u64,
+    pub message: String,
+    pub signatures: Vec<Bytes>,
+}
+
+impl Alert {
+    pub fn hash(&self) -> H256 {
+        let alert = Self {
+            id: self.id,
+            cancel: self.cancel,
+            min_version: self.min_version.clone(),
+            max_version: self.max_version.clone(),
+            priority: self.priority,
+            notice_until: self.notice_until,
+            message: self.message.clone(),
+            signatures: Vec::new(),
+        };
+        blake2b_256(serialize(&alert).expect("serialize should not fail")).into()
+    }
+}
+
+#[derive(Default)]
+pub struct AlertBuilder {
+    inner: Alert,
+}
+
+impl AlertBuilder {
+    pub fn alert(mut self, alert: Alert) -> Self {
+        self.inner = alert;
+        self
+    }
+
+    pub fn id(mut self, id: u32) -> Self {
+        self.inner.id = id;
+        self
+    }
+
+    pub fn cancel(mut self, cancel: u32) -> Self {
+        self.inner.cancel = cancel;
+        self
+    }
+
+    pub fn min_version(mut self, min_version: Option<String>) -> Self {
+        self.inner.min_version = min_version;
+        self
+    }
+
+    pub fn max_version(mut self, max_version: Option<String>) -> Self {
+        self.inner.max_version = max_version;
+        self
+    }
+
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.inner.priority = priority;
+        self
+    }
+
+    pub fn signatures(mut self, signatures: Vec<Bytes>) -> Self {
+        self.inner.signatures.extend(signatures);
+        self
+    }
+
+    pub fn notice_until(mut self, notice_until: u64) -> Self {
+        self.inner.notice_until = notice_until;
+        self
+    }
+
+    pub fn message(mut self, message: String) -> Self {
+        self.inner.message = message;
+        self
+    }
+
+    pub fn build(self) -> Alert {
+        self.inner
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This Library provides the essential types for building ckb.
 
+pub mod alert;
 pub mod block;
 pub mod cell;
 pub mod difficulty;

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -353,3 +353,43 @@ impl<'a> TryFrom<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::
         })
     }
 }
+
+impl<'a> TryFrom<ckb_protocol::Alert<'a>> for ckb_core::alert::Alert {
+    type Error = FailureError;
+
+    fn try_from(alert: ckb_protocol::Alert<'a>) -> Result<Self, Self::Error> {
+        let message = String::from_utf8(cast!(alert.message().and_then(|m| m.seq()))?.to_owned())?;
+        let min_version: Option<String> = match alert
+            .min_version()
+            .and_then(|m| m.seq().map(|s| String::from_utf8(s.to_vec())))
+        {
+            Some(min_version) => Some(min_version?),
+            None => None,
+        };
+        let max_version: Option<String> = match alert
+            .max_version()
+            .and_then(|m| m.seq().map(|s| String::from_utf8(s.to_vec())))
+        {
+            Some(max_version) => Some(max_version?),
+            None => None,
+        };
+        let signatures: Result<Vec<ckb_core::Bytes>, FailureError> =
+            FlatbuffersVectorIterator::new(cast!(alert.signatures())?)
+                .map(|s| {
+                    cast!(s.seq())
+                        .map(ckb_core::Bytes::from)
+                        .map_err(Into::into)
+                })
+                .collect();
+        Ok(ckb_core::alert::AlertBuilder::default()
+            .id(alert.id())
+            .cancel(alert.cancel())
+            .min_version(min_version)
+            .max_version(max_version)
+            .priority(alert.priority())
+            .signatures(signatures?)
+            .notice_until(alert.notice_until())
+            .message(message)
+            .build())
+    }
+}

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -241,3 +241,19 @@ table TimeMessage {
 table Time {
     timestamp: uint64;
 }
+
+table AlertMessage {
+    payload:        Alert;
+}
+
+table Alert {
+    id: uint32;
+    cancel: uint32;
+    min_version: Bytes;
+    max_version: Bytes;
+    priority: uint32;
+    signatures: [Bytes];
+    notice_until: uint64;
+    message: Bytes;
+}
+

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -3591,6 +3591,242 @@ impl<'a: 'b, 'b> TimeBuilder<'a, 'b> {
   }
 }
 
+pub enum AlertMessageOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct AlertMessage<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for AlertMessage<'a> {
+    type Inner = AlertMessage<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> AlertMessage<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        AlertMessage {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args AlertMessageArgs<'args>) -> flatbuffers::WIPOffset<AlertMessage<'bldr>> {
+      let mut builder = AlertMessageBuilder::new(_fbb);
+      if let Some(x) = args.payload { builder.add_payload(x); }
+      builder.finish()
+    }
+
+    pub const VT_PAYLOAD: flatbuffers::VOffsetT = 4;
+
+  #[inline]
+  pub fn payload(&self) -> Option<Alert<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Alert<'a>>>(AlertMessage::VT_PAYLOAD, None)
+  }
+}
+
+pub struct AlertMessageArgs<'a> {
+    pub payload: Option<flatbuffers::WIPOffset<Alert<'a >>>,
+}
+impl<'a> Default for AlertMessageArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        AlertMessageArgs {
+            payload: None,
+        }
+    }
+}
+pub struct AlertMessageBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AlertMessageBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_payload(&mut self, payload: flatbuffers::WIPOffset<Alert<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Alert>>(AlertMessage::VT_PAYLOAD, payload);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AlertMessageBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AlertMessageBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<AlertMessage<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+pub enum AlertOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct Alert<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Alert<'a> {
+    type Inner = Alert<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> Alert<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Alert {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args AlertArgs<'args>) -> flatbuffers::WIPOffset<Alert<'bldr>> {
+      let mut builder = AlertBuilder::new(_fbb);
+      builder.add_notice_until(args.notice_until);
+      if let Some(x) = args.message { builder.add_message(x); }
+      if let Some(x) = args.signatures { builder.add_signatures(x); }
+      builder.add_priority(args.priority);
+      if let Some(x) = args.max_version { builder.add_max_version(x); }
+      if let Some(x) = args.min_version { builder.add_min_version(x); }
+      builder.add_cancel(args.cancel);
+      builder.add_id(args.id);
+      builder.finish()
+    }
+
+    pub const VT_ID: flatbuffers::VOffsetT = 4;
+    pub const VT_CANCEL: flatbuffers::VOffsetT = 6;
+    pub const VT_MIN_VERSION: flatbuffers::VOffsetT = 8;
+    pub const VT_MAX_VERSION: flatbuffers::VOffsetT = 10;
+    pub const VT_PRIORITY: flatbuffers::VOffsetT = 12;
+    pub const VT_SIGNATURES: flatbuffers::VOffsetT = 14;
+    pub const VT_NOTICE_UNTIL: flatbuffers::VOffsetT = 16;
+    pub const VT_MESSAGE: flatbuffers::VOffsetT = 18;
+
+  #[inline]
+  pub fn id(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_ID, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn cancel(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_CANCEL, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn min_version(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MIN_VERSION, None)
+  }
+  #[inline]
+  pub fn max_version(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MAX_VERSION, None)
+  }
+  #[inline]
+  pub fn priority(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_PRIORITY, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn signatures(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(Alert::VT_SIGNATURES, None)
+  }
+  #[inline]
+  pub fn notice_until(&self) -> u64 {
+    self._tab.get::<u64>(Alert::VT_NOTICE_UNTIL, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn message(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MESSAGE, None)
+  }
+}
+
+pub struct AlertArgs<'a> {
+    pub id: u32,
+    pub cancel: u32,
+    pub min_version: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub max_version: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub priority: u32,
+    pub signatures: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub notice_until: u64,
+    pub message: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+}
+impl<'a> Default for AlertArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        AlertArgs {
+            id: 0,
+            cancel: 0,
+            min_version: None,
+            max_version: None,
+            priority: 0,
+            signatures: None,
+            notice_until: 0,
+            message: None,
+        }
+    }
+}
+pub struct AlertBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AlertBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_id(&mut self, id: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_ID, id, 0);
+  }
+  #[inline]
+  pub fn add_cancel(&mut self, cancel: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_CANCEL, cancel, 0);
+  }
+  #[inline]
+  pub fn add_min_version(&mut self, min_version: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MIN_VERSION, min_version);
+  }
+  #[inline]
+  pub fn add_max_version(&mut self, max_version: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MAX_VERSION, max_version);
+  }
+  #[inline]
+  pub fn add_priority(&mut self, priority: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_PRIORITY, priority, 0);
+  }
+  #[inline]
+  pub fn add_signatures(&mut self, signatures: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Alert::VT_SIGNATURES, signatures);
+  }
+  #[inline]
+  pub fn add_notice_until(&mut self, notice_until: u64) {
+    self.fbb_.push_slot::<u64>(Alert::VT_NOTICE_UNTIL, notice_until, 0);
+  }
+  #[inline]
+  pub fn add_message(&mut self, message: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MESSAGE, message);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AlertBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AlertBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Alert<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
 #[inline]
 pub fn get_root_as_sync_message<'a>(buf: &'a [u8]) -> SyncMessage<'a> {
   flatbuffers::get_root::<SyncMessage<'a>>(buf)

--- a/protocol/src/protocol_generated_verifier.rs
+++ b/protocol/src/protocol_generated_verifier.rs
@@ -104,6 +104,254 @@ pub mod ckb {
             }
         }
 
+        impl<'a> Verify for reader::Alert<'a> {
+            fn verify(&self) -> Result {
+                let tab = self._tab;
+                let buf = tab.buf;
+                let buf_len = buf.len();
+
+                if tab.loc > MAX_OFFSET_LOC || tab.loc + flatbuffers::SIZE_SOFFSET > buf_len {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab_loc = {
+                    let soffset_slice = &buf[tab.loc..];
+                    let soffset = flatbuffers::read_scalar::<flatbuffers::SOffsetT>(soffset_slice);
+                    if soffset >= 0 {
+                        tab.loc.checked_sub(soffset as usize)
+                    } else {
+                        soffset
+                            .checked_neg()
+                            .and_then(|foffset| tab.loc.checked_add(foffset as usize))
+                    }
+                }
+                .ok_or(Error::OutOfBounds)?;
+                if vtab_loc
+                    .checked_add(flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab = tab.vtable();
+                let vtab_num_bytes = vtab.num_bytes();
+                let object_inline_num_bytes = vtab.object_inline_num_bytes();
+                if vtab_num_bytes < flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET
+                    || object_inline_num_bytes < flatbuffers::SIZE_SOFFSET
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if vtab_loc
+                    .checked_add(vtab_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if tab
+                    .loc
+                    .checked_add(object_inline_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                for i in 0..vtab.num_fields() {
+                    let voffset = vtab.get_field(i) as usize;
+                    if (voffset > 0 && voffset < flatbuffers::SIZE_SOFFSET)
+                        || voffset >= object_inline_num_bytes
+                    {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_ID as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_ID) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_CANCEL as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_CANCEL) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_MIN_VERSION as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MIN_VERSION) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.min_version() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                if Self::VT_MAX_VERSION as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MAX_VERSION) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.max_version() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                if Self::VT_PRIORITY as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_PRIORITY) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_SIGNATURES as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_SIGNATURES) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        let signatures_verifier = VectorVerifier::follow(
+                            buf,
+                            try_follow_uoffset(buf, tab.loc + voffset)?,
+                        );
+                        signatures_verifier
+                            .verify_reference_elements::<reader::Bytes>()?;
+                    }
+                }
+
+                if Self::VT_NOTICE_UNTIL as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_NOTICE_UNTIL) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 8 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_MESSAGE as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MESSAGE) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.message() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+
+        impl<'a> Verify for reader::AlertMessage<'a> {
+            fn verify(&self) -> Result {
+                let tab = self._tab;
+                let buf = tab.buf;
+                let buf_len = buf.len();
+
+                if tab.loc > MAX_OFFSET_LOC || tab.loc + flatbuffers::SIZE_SOFFSET > buf_len {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab_loc = {
+                    let soffset_slice = &buf[tab.loc..];
+                    let soffset = flatbuffers::read_scalar::<flatbuffers::SOffsetT>(soffset_slice);
+                    if soffset >= 0 {
+                        tab.loc.checked_sub(soffset as usize)
+                    } else {
+                        soffset
+                            .checked_neg()
+                            .and_then(|foffset| tab.loc.checked_add(foffset as usize))
+                    }
+                }
+                .ok_or(Error::OutOfBounds)?;
+                if vtab_loc
+                    .checked_add(flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab = tab.vtable();
+                let vtab_num_bytes = vtab.num_bytes();
+                let object_inline_num_bytes = vtab.object_inline_num_bytes();
+                if vtab_num_bytes < flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET
+                    || object_inline_num_bytes < flatbuffers::SIZE_SOFFSET
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if vtab_loc
+                    .checked_add(vtab_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if tab
+                    .loc
+                    .checked_add(object_inline_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                for i in 0..vtab.num_fields() {
+                    let voffset = vtab.get_field(i) as usize;
+                    if (voffset > 0 && voffset < flatbuffers::SIZE_SOFFSET)
+                        || voffset >= object_inline_num_bytes
+                    {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_PAYLOAD as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_PAYLOAD) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.payload() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+
         impl<'a> Verify for reader::Block<'a> {
             fn verify(&self) -> Result {
                 let tab = self._tab;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,6 +19,7 @@ ckb-chain = { path = "../chain" }
 ckb-miner = { path = "../miner" }
 ckb-protocol = { path = "../protocol" }
 ckb-pow = { path = "../pow"}
+ckb-alert-system = { path = "../util/alert-system" }
 jsonrpc-core = "10.1"
 jsonrpc-derive = "10.1"
 jsonrpc-http-server = { git = "https://github.com/nervosnetwork/jsonrpc", rev = "7c101f83a8fe34369c1b7a0e9b6721fcb0f91ee0" }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -10,6 +10,7 @@ pub enum Module {
     Experiment,
     Stats,
     IntegrationTest,
+    Alert,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -47,5 +48,9 @@ impl Config {
 
     pub fn integration_test_enable(&self) -> bool {
         self.modules.contains(&Module::IntegrationTest)
+    }
+
+    pub(crate) fn alert_enable(&self) -> bool {
+        self.modules.contains(&Module::Alert)
     }
 }

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -1,0 +1,65 @@
+use crate::error::RPCError;
+use ckb_alert_system::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
+use ckb_core::alert::Alert as CoreAlert;
+use ckb_network::NetworkController;
+use ckb_protocol::AlertMessage;
+use ckb_sync::NetworkProtocol;
+use flatbuffers::FlatBufferBuilder;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+use jsonrpc_types::Alert;
+use std::sync::Arc;
+
+#[rpc]
+pub trait AlertRpc {
+    // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"send_alert","params": [{}]}' -H 'content-type:application/json' 'http://localhost:8114'
+    #[rpc(name = "send_alert")]
+    fn send_alert(&self, _alert: Alert) -> Result<()>;
+}
+
+pub(crate) struct AlertRpcImpl {
+    network_controller: NetworkController,
+    verifier: Arc<AlertVerifier>,
+    notifier: Arc<AlertNotifier>,
+}
+
+impl AlertRpcImpl {
+    pub fn new(
+        verifier: Arc<AlertVerifier>,
+        notifier: Arc<AlertNotifier>,
+        network_controller: NetworkController,
+    ) -> Self {
+        AlertRpcImpl {
+            network_controller,
+            verifier,
+            notifier,
+        }
+    }
+}
+
+impl AlertRpc for AlertRpcImpl {
+    fn send_alert(&self, alert: Alert) -> Result<()> {
+        let alert: CoreAlert = alert.into();
+
+        let result = self.verifier.verify_signatures(&alert);
+
+        match result {
+            Ok(()) => {
+                let fbb = &mut FlatBufferBuilder::new();
+                let message = AlertMessage::build_alert(fbb, &alert);
+                fbb.finish(message, None);
+                let data = fbb.finished_data().into();
+                if let Err(err) = self
+                    .network_controller
+                    .broadcast(NetworkProtocol::ALERT.into(), data)
+                {
+                    log::error!(target: "rpc", "Broadcast alert failed: {:?}", err);
+                }
+                // set self node notifier
+                self.notifier.add(Arc::new(alert));
+                Ok(())
+            }
+            Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
+        }
+    }
+}

--- a/rpc/src/module/mod.rs
+++ b/rpc/src/module/mod.rs
@@ -1,3 +1,4 @@
+mod alert;
 mod chain;
 mod experiment;
 mod miner;
@@ -6,6 +7,7 @@ mod pool;
 mod stats;
 mod test;
 
+pub(crate) use self::alert::{AlertRpc, AlertRpcImpl};
 pub(crate) use self::chain::{ChainRpc, ChainRpcImpl};
 pub(crate) use self::experiment::{ExperimentRpc, ExperimentRpcImpl};
 pub(crate) use self::miner::{MinerRpc, MinerRpcImpl};

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,9 +1,10 @@
 use crate::config::Config;
 use crate::module::{
-    ChainRpc, ChainRpcImpl, ExperimentRpc, ExperimentRpcImpl, IntegrationTestRpc,
-    IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl, NetworkRpc, NetworkRpcImpl, PoolRpc,
-    PoolRpcImpl, StatsRpc, StatsRpcImpl,
+    AlertRpc, AlertRpcImpl, ChainRpc, ChainRpcImpl, ExperimentRpc, ExperimentRpcImpl,
+    IntegrationTestRpc, IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl, NetworkRpc, NetworkRpcImpl,
+    PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl,
 };
+use ckb_alert_system::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
 use ckb_chain::chain::ChainController;
 use ckb_miner::BlockAssemblerController;
 use ckb_network::NetworkController;
@@ -14,12 +15,14 @@ use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::{Server, ServerBuilder};
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
+use std::sync::Arc;
 
 pub struct RpcServer {
     pub(crate) server: Server,
 }
 
 impl RpcServer {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<CS: ChainStore + 'static>(
         config: Config,
         network_controller: NetworkController,
@@ -27,6 +30,8 @@ impl RpcServer {
         synchronizer: Synchronizer<CS>,
         chain: ChainController,
         block_assembler: Option<BlockAssemblerController>,
+        alert_notifier: Arc<AlertNotifier>,
+        alert_verifier: Arc<AlertVerifier>,
     ) -> RpcServer
     where
         CS: ChainStore,
@@ -76,6 +81,7 @@ impl RpcServer {
                 StatsRpcImpl {
                     shared: shared.clone(),
                     synchronizer: synchronizer.clone(),
+                    alert_notifier: Arc::clone(&alert_notifier),
                 }
                 .to_delegate(),
             );
@@ -93,11 +99,17 @@ impl RpcServer {
         if config.integration_test_enable() {
             io.extend_with(
                 IntegrationTestRpcImpl {
-                    network_controller,
+                    network_controller: network_controller.clone(),
                     shared,
                     chain,
                 }
                 .to_delegate(),
+            );
+        }
+
+        if config.alert_enable() {
+            io.extend_with(
+                AlertRpcImpl::new(alert_verifier, alert_notifier, network_controller).to_delegate(),
             );
         }
 

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -3,6 +3,7 @@ use crate::module::{
     PoolRpcImpl, StatsRpc, StatsRpcImpl,
 };
 use crate::RpcServer;
+use ckb_alert_system::{alert_relayer::AlertRelayer, config::Config as AlertSystemConfig};
 use ckb_chain::chain::{ChainController, ChainService};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::block::BlockBuilder;
@@ -164,10 +165,14 @@ fn setup_node(
         }
         .to_delegate(),
     );
+    let alert_relayer = AlertRelayer::new("0".to_string(), AlertSystemConfig::default());
+
+    let alert_notifier = alert_relayer.notifier();
     io.extend_with(
         StatsRpcImpl {
             shared: shared.clone(),
             synchronizer: synchronizer.clone(),
+            alert_notifier,
         }
         .to_delegate(),
     );

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -36,6 +36,7 @@ pub enum NetworkProtocol {
     SYNC = 100,
     RELAY = 101,
     TIME = 102,
+    ALERT = 110,
 }
 
 impl Into<ProtocolId> for NetworkProtocol {

--- a/util/alert-system/Cargo.toml
+++ b/util/alert-system/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ckb-alert-system"
+version = "0.1.0"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+toml = "0.5.0"
+multisig = { path = "../multisig" }
+ckb-core = { path = "../../core" }
+ckb-util = { path = "../../util" }
+ckb-network = { path = "../../network" }
+ckb-protocol = { path = "../../protocol" }
+jsonrpc-types = { path = "../jsonrpc-types" }
+log = "0.4"
+fnv = "1.0"
+faketime = "0.2.0"
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
+failure = "0.1.5"
+bytes = "0.4.12"
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "b36a4d1" }
+serde = "1.0"
+serde_derive = "1.0"
+flatbuffers = "0.6.0"
+

--- a/util/alert-system/src/alert.toml
+++ b/util/alert-system/src/alert.toml
@@ -1,0 +1,5 @@
+# need 2 signatures to send alert
+signatures_threshold = 2
+public_keys = [
+]
+

--- a/util/alert-system/src/alert_relayer.rs
+++ b/util/alert-system/src/alert_relayer.rs
@@ -1,0 +1,159 @@
+//! AlertRelayer
+//! We implment a Bitcoin like alert system, n of m alert key holders can decide to send alert
+//messages to all client
+//! to leave a space to reach consensus offline under critical bugs
+//!
+//! A cli to generate alert message,
+//! A config option to set alert messages to broard cast.
+//
+use crate::config::Config;
+use crate::notifier::Notifier;
+use crate::verifier::Verifier;
+use crate::BAD_MESSAGE_BAN_TIME;
+use ckb_core::alert::Alert;
+use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
+use ckb_protocol::{get_root, AlertMessage};
+use flatbuffers::FlatBufferBuilder;
+use fnv::{FnvHashMap, FnvHashSet};
+use log::{debug, info, trace};
+use lru_cache::LruCache;
+use std::convert::TryInto;
+use std::sync::Arc;
+
+const CANCEL_FILTER_SIZE: usize = 128;
+const KNOWN_LIST_SIZE: usize = 64;
+
+/// AlertRelayer
+/// relay alert messages
+#[derive(Clone)]
+pub struct AlertRelayer {
+    /// cancelled alerts
+    cancel_filter: LruCache<u32, ()>,
+    /// unexpired alerts we received
+    received_alerts: FnvHashMap<u32, Arc<Alert>>,
+    /// alerts that self node should notice
+    notifier: Arc<Notifier>,
+    verifier: Arc<Verifier>,
+    known_lists: LruCache<PeerIndex, FnvHashSet<u32>>,
+}
+
+impl AlertRelayer {
+    pub fn new(client_version: String, config: Config) -> Self {
+        AlertRelayer {
+            cancel_filter: LruCache::new(CANCEL_FILTER_SIZE),
+            received_alerts: Default::default(),
+            notifier: Arc::new(Notifier::new(client_version)),
+            verifier: Arc::new(Verifier::new(config)),
+            known_lists: LruCache::new(KNOWN_LIST_SIZE),
+        }
+    }
+
+    pub fn notifier(&self) -> Arc<Notifier> {
+        Arc::clone(&self.notifier)
+    }
+
+    pub fn verifier(&self) -> Arc<Verifier> {
+        Arc::clone(&self.verifier)
+    }
+
+    fn receive_new_alert(&mut self, alert: Arc<Alert>) {
+        // checkout cancel_id
+        if alert.cancel > 0 {
+            self.cancel_filter.insert(alert.cancel, ());
+            self.received_alerts.remove(&alert.cancel);
+            self.notifier.cancel(alert.cancel);
+        }
+        // add to received alerts
+        self.received_alerts.insert(alert.id, Arc::clone(&alert));
+        // set self node notice
+        self.notifier.add(alert);
+    }
+
+    fn clear_expired_alerts(&mut self) {
+        let now = faketime::unix_time_as_millis();
+        self.received_alerts
+            .retain(|_id, alert| alert.notice_until > now);
+        self.notifier.clear_expired_alerts(now);
+    }
+
+    // return true if it this first time the peer know this alert
+    fn mark_as_known(&mut self, peer: PeerIndex, alert_id: u32) -> bool {
+        match self.known_lists.get_refresh(&peer) {
+            Some(alert_ids) => alert_ids.insert(alert_id),
+            None => {
+                let mut alert_ids = FnvHashSet::default();
+                alert_ids.insert(alert_id);
+                self.known_lists.insert(peer, alert_ids);
+                true
+            }
+        }
+    }
+}
+
+impl CKBProtocolHandler for AlertRelayer {
+    fn init(&mut self, _nc: Arc<dyn CKBProtocolContext + Sync>) {}
+
+    fn connected(
+        &mut self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer_index: PeerIndex,
+        _version: &str,
+    ) {
+        self.clear_expired_alerts();
+        for alert in self.received_alerts.values() {
+            trace!(target: "alert", "send alert {} to peer {}", alert.id, peer_index);
+            let fbb = &mut FlatBufferBuilder::new();
+            let msg = AlertMessage::build_alert(fbb, &alert);
+            fbb.finish(msg, None);
+            nc.quick_send_message_to(peer_index, fbb.finished_data().into());
+        }
+    }
+
+    fn received(
+        &mut self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer_index: PeerIndex,
+        data: bytes::Bytes,
+    ) {
+        let alert: Arc<Alert> = match get_root::<AlertMessage>(&data)
+            .ok()
+            .and_then(|m| m.payload())
+            .map(TryInto::try_into)
+        {
+            Some(Ok(alert)) => Arc::new(alert),
+            Some(Err(_)) | None => {
+                info!(target: "network", "Peer {} sends us malformed message", peer_index);
+                nc.ban_peer(peer_index, BAD_MESSAGE_BAN_TIME);
+                return;
+            }
+        };
+        trace!(target: "alert", "receive alert {} from peer {}", alert.id, peer_index);
+        // ignore alert
+        if self.received_alerts.contains_key(&alert.id)
+            || self.cancel_filter.contains_key(&alert.id)
+        {
+            return;
+        }
+        // verify
+        if let Err(err) = self.verifier.verify_signatures(&alert) {
+            debug!(target: "network", "Peer {} sends us a alert with invalid signatures, error {:?}", peer_index, err);
+            nc.ban_peer(peer_index, BAD_MESSAGE_BAN_TIME);
+            return;
+        }
+        // mark sender as known
+        self.mark_as_known(peer_index, alert.id);
+        // broadcast message
+        let fbb = &mut FlatBufferBuilder::new();
+        let msg = AlertMessage::build_alert(fbb, &alert);
+        fbb.finish(msg, None);
+        let data = fbb.finished_data().into();
+        let selected_peers: Vec<PeerIndex> = nc
+            .connected_peers()
+            .into_iter()
+            .filter(|peer| self.mark_as_known(*peer, alert.id))
+            .collect();
+        nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data);
+        // add to received alerts
+        self.receive_new_alert(alert);
+    }
+}

--- a/util/alert-system/src/config.rs
+++ b/util/alert-system/src/config.rs
@@ -1,0 +1,15 @@
+use jsonrpc_types::JsonBytes;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub signatures_threshold: usize,
+    pub public_keys: Vec<JsonBytes>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let alert_config = include_bytes!("./alert.toml");
+        toml::from_slice(&alert_config[..]).expect("alert system config")
+    }
+}

--- a/util/alert-system/src/lib.rs
+++ b/util/alert-system/src/lib.rs
@@ -1,0 +1,17 @@
+//! Alert System
+//! See https://en.bitcoin.it/wiki/Alert_system to learn the history of Bitcoin alert system.
+//! We implement the alert system in CKB for urgent situation,
+//! In CKB early stage we may meet the same crisis bugs that Bitcoin meet,
+//! in urgent case, CKB core team can send an alert message across CKB P2P network,
+//! the client will show the alert message, the other behaviors of CKB node will not change.
+//!
+//! The Alert System will be removed soon once the CKB network is considered mature.
+//!
+pub mod alert_relayer;
+pub mod config;
+pub mod notifier;
+pub mod verifier;
+
+use std::time::Duration;
+
+pub(crate) const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);

--- a/util/alert-system/src/notifier.rs
+++ b/util/alert-system/src/notifier.rs
@@ -1,0 +1,58 @@
+use ckb_core::alert::Alert;
+use ckb_util::Mutex;
+use log::warn;
+use std::sync::Arc;
+
+pub struct Notifier {
+    alerts: Mutex<Vec<Arc<Alert>>>,
+    client_version: String,
+}
+
+impl Notifier {
+    pub fn new(client_version: String) -> Self {
+        Notifier {
+            alerts: Mutex::new(Vec::new()),
+            client_version,
+        }
+    }
+
+    pub fn add(&self, alert: Arc<Alert>) {
+        if alert
+            .min_version
+            .as_ref()
+            .map(|min_v| self.client_version < *min_v)
+            == Some(true)
+        {
+            return;
+        }
+
+        if alert
+            .max_version
+            .as_ref()
+            .map(|max_v| self.client_version > *max_v)
+            == Some(true)
+        {
+            return;
+        }
+        let mut alerts = self.alerts.lock();
+        if alerts.contains(&alert) {
+            return;
+        }
+        warn!(target: "alert", "receive a new alert: {}", alert.message);
+        alerts.push(alert);
+    }
+
+    pub fn cancel(&self, id: u32) {
+        let mut alerts = self.alerts.lock();
+        alerts.retain(|a| a.id == id);
+    }
+
+    pub fn clear_expired_alerts(&self, now: u64) {
+        let mut alerts = self.alerts.lock();
+        alerts.retain(|a| a.notice_until > now);
+    }
+
+    pub fn alerts(&self) -> Vec<Arc<Alert>> {
+        self.alerts.lock().clone()
+    }
+}

--- a/util/alert-system/src/verifier.rs
+++ b/util/alert-system/src/verifier.rs
@@ -1,0 +1,49 @@
+use crate::config::Config;
+use ckb_core::alert::Alert;
+use failure::Error;
+use log::{debug, trace};
+
+pub struct Verifier(Config);
+
+impl Verifier {
+    pub fn new(config: Config) -> Self {
+        Verifier(config)
+    }
+
+    pub fn verify_signatures(&self, alert: &Alert) -> Result<(), Error> {
+        trace!(target: "alert", "verify alert {:?}", alert);
+        use multisig::secp256k1::{verify_m_of_n, Message, PublicKey, Signature};
+        let message = Message::from_slice(alert.hash().as_bytes())?;
+        let signatures: Vec<Option<Signature>> = alert
+            .signatures
+            .iter()
+            .map(|sig| {
+                if sig.is_empty() {
+                    None
+                } else {
+                    match Signature::from_compact(sig) {
+                        Ok(i) => Some(i),
+                        Err(err) => {
+                            debug!(target: "alert", "signature error: {}", err);
+                            None
+                        }
+                    }
+                }
+            })
+            .collect();
+        let public_keys = self
+            .0
+            .public_keys
+            .iter()
+            .map(|raw| PublicKey::from_slice(raw.as_bytes()))
+            .collect::<Result<Vec<PublicKey>, _>>()?;
+        verify_m_of_n(
+            &message,
+            self.0.signatures_threshold,
+            signatures,
+            public_keys,
+        )
+        .map_err(|err| err.kind())?;
+        Ok(())
+    }
+}

--- a/util/jsonrpc-types/src/alert.rs
+++ b/util/jsonrpc-types/src/alert.rs
@@ -1,0 +1,77 @@
+use crate::{bytes::JsonBytes, string, Timestamp};
+use ckb_core::alert::{Alert as CoreAlert, AlertBuilder};
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct AlertId(#[serde(with = "string")] pub u32);
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct AlertPriority(#[serde(with = "string")] pub u32);
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct Alert {
+    pub id: AlertId,
+    pub cancel: AlertId,
+    pub min_version: Option<String>,
+    pub max_version: Option<String>,
+    pub priority: AlertPriority,
+    pub notice_until: Timestamp,
+    pub message: String,
+    pub signatures: Vec<JsonBytes>,
+}
+
+impl From<Alert> for CoreAlert {
+    fn from(json: Alert) -> Self {
+        let Alert {
+            id,
+            cancel,
+            min_version,
+            max_version,
+            priority,
+            notice_until,
+            message,
+            signatures,
+        } = json;
+
+        AlertBuilder::default()
+            .id(id.0)
+            .cancel(cancel.0)
+            .min_version(min_version)
+            .max_version(max_version)
+            .priority(priority.0)
+            .notice_until(notice_until.0)
+            .message(message)
+            .signatures(
+                signatures
+                    .into_iter()
+                    .map(JsonBytes::into_bytes)
+                    .collect::<Vec<_>>(),
+            )
+            .build()
+    }
+}
+
+impl From<CoreAlert> for Alert {
+    fn from(core: CoreAlert) -> Self {
+        let CoreAlert {
+            id,
+            cancel,
+            min_version,
+            max_version,
+            priority,
+            notice_until,
+            message,
+            signatures,
+        } = core;
+        Alert {
+            id: AlertId(id),
+            cancel: AlertId(cancel),
+            min_version,
+            max_version,
+            priority: AlertPriority(priority),
+            notice_until: Timestamp(notice_until),
+            message,
+            signatures: signatures.into_iter().map(JsonBytes::from_bytes).collect(),
+        }
+    }
+}

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -1,3 +1,4 @@
+mod alert;
 mod block_template;
 mod blockchain;
 mod bytes;
@@ -31,6 +32,7 @@ pub struct Timestamp(#[serde(with = "string")] pub u64);
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct Unsigned(#[serde(with = "string")] pub u64);
 
+pub use self::alert::Alert;
 pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "multisig"
+version = "0.1.0"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+secp256k1 = "0.12.2"
+lazy_static = "1.3.0"
+failure = "0.1.5"
+rand = "0.6.5"
+

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "multisig"
 version = "0.1.0"
+license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
@@ -8,5 +9,8 @@ edition = "2018"
 secp256k1 = "0.12.2"
 lazy_static = "1.3.0"
 failure = "0.1.5"
+log = "0.4"
+
+[dev-dependencies]
 rand = "0.6.5"
 

--- a/util/multisig/src/error.rs
+++ b/util/multisig/src/error.rs
@@ -1,0 +1,36 @@
+use failure::Context;
+
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "The count of sigs should less than pks.")]
+    SigCountOverflow,
+    #[fail(display = "The count of sigs less than threshold.")]
+    SigNotEnough,
+    #[fail(display = "Threshold not reach, sigs: {} required sigs: {}.", _0, _1)]
+    Threshold(usize, usize),
+}
+
+impl Error {
+    pub fn kind(&self) -> ErrorKind {
+        *self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner: inner }
+    }
+}

--- a/util/multisig/src/error.rs
+++ b/util/multisig/src/error.rs
@@ -31,6 +31,6 @@ impl From<ErrorKind> for Error {
 
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner: inner }
+        Error { inner }
     }
 }

--- a/util/multisig/src/lib.rs
+++ b/util/multisig/src/lib.rs
@@ -1,0 +1,7 @@
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate failure;
+
+pub mod error;
+pub mod secp256k1;

--- a/util/multisig/src/secp256k1.rs
+++ b/util/multisig/src/secp256k1.rs
@@ -1,0 +1,138 @@
+use crate::error::{Error, ErrorKind};
+pub use secp256k1::{
+    All, Error as Secp256k1Error, Message, PublicKey, RecoverableSignature, Secp256k1, SecretKey,
+    Signature,
+};
+
+lazy_static! {
+    pub static ref SECP256K1: Secp256k1<All> = Secp256k1::new();
+}
+
+pub fn sign(message: &Message, sk: &SecretKey) -> Signature {
+    SECP256K1.sign(message, sk)
+}
+
+/// position of each sigs must according to the pk that sined the sig
+/// Example 2 of 3 sigs: [s1, None, s3], pks: [pk1, pk2, pk3]
+pub fn verify_m_of_n(
+    message: &Message,
+    m_threshold: usize,
+    sigs: Vec<Option<Signature>>,
+    pks: Vec<PublicKey>,
+) -> Result<(), Error> {
+    if sigs.len() > pks.len() {
+        Err(ErrorKind::SigCountOverflow)?;
+    }
+    if m_threshold > sigs.len() {
+        Err(ErrorKind::SigNotEnough)?;
+    }
+    let verified_sig_count = sigs
+        .iter()
+        .zip(pks.iter())
+        .filter_map(|(sig, pk)| sig.and_then(|sig| SECP256K1.verify(&message, &sig, pk).ok()))
+        .take(m_threshold)
+        .count();
+    if verified_sig_count < m_threshold {
+        Err(ErrorKind::Threshold(verified_sig_count, m_threshold))?
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{thread_rng, Rng};
+
+    fn random_message() -> Message {
+        let mut data = [0; 32];
+        thread_rng().fill(&mut data[..]);
+        loop {
+            if let Ok(msg) = Message::from_slice(&data) {
+                return msg;
+            }
+        }
+    }
+
+    fn random_signature(message: &Message) -> Signature {
+        let secret_key = random_secret_key();
+        sign(message, &secret_key)
+    }
+
+    fn random_secret_key() -> SecretKey {
+        let mut data = [0; 32];
+        thread_rng().fill(&mut data[..]);
+        loop {
+            if let Ok(key) = SecretKey::from_slice(&data) {
+                return key;
+            }
+        }
+    }
+
+    #[test]
+    fn test_m_of_n() {
+        // (thresholds, sigs: [is_valid], pks, result)
+        let test_set = [
+            (2, vec![true, true], 3, Ok(())),
+            (2, vec![true, true, true], 3, Ok(())),
+            (3, vec![true, true, true], 3, Ok(())),
+            (3, vec![true, false, true, true], 4, Ok(())),
+            (
+                2,
+                vec![true, true, true],
+                1,
+                Err(ErrorKind::SigCountOverflow),
+            ),
+            (3, vec![true, true], 3, Err(ErrorKind::SigNotEnough)),
+            (
+                3,
+                vec![true, true, false],
+                3,
+                Err(ErrorKind::Threshold(2, 3)),
+            ),
+        ];
+        for (threshold, sigs, pks, result) in test_set.into_iter() {
+            let message = random_message();
+            let sks: Vec<SecretKey> = (0..sigs.len())
+                .into_iter()
+                .map(|_| random_secret_key())
+                .collect();
+            let pks: Vec<PublicKey> = sks
+                .iter()
+                .enumerate()
+                .map(|(_i, sk)| PublicKey::from_secret_key(&SECP256K1, sk))
+                .take(*pks)
+                .collect();
+            let sigs: Vec<Option<Signature>> = sigs
+                .into_iter()
+                .enumerate()
+                .map(|(i, valid)| {
+                    if *valid {
+                        Some(sign(&message, &sks[i]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let verify_result =
+                verify_m_of_n(&message, *threshold, sigs, pks).map_err(|err| err.kind());
+            assert_eq!(&verify_result, result);
+        }
+    }
+
+    #[test]
+    fn test_2_of_3_with_wrong_signature() {
+        let message = random_message();
+        let sks: Vec<SecretKey> = (0..3).into_iter().map(|_| random_secret_key()).collect();
+        let pks: Vec<PublicKey> = sks
+            .iter()
+            .map(|sk| PublicKey::from_secret_key(&SECP256K1, sk))
+            .collect();
+        let sigs: Vec<Option<Signature>> = vec![
+            Some(sign(&message, &sks[0])),
+            Some(random_signature(&message)),
+            Some(sign(&message, &sks[2])),
+        ];
+        let verify_result = verify_m_of_n(&message, 2, sigs, pks);
+        assert!(verify_result.is_ok());
+    }
+}


### PR DESCRIPTION
Introduce: 
https://en.bitcoin.it/wiki/Alert_system

Purpose: 
Implement the alert system in CKB for urgent situation,
In CKB early stage we may meet the same crisis bugs that Bitcoin meet,
in urgent case, CKB core team can send an alert message across CKB P2P network,
the client will show the alert message, the other behaviors of CKB node will not change.

The Alert System will be removed soon once the CKB network is considered mature.

Implement:
1. Add a new network protocol `alt`.
2. Add a default disabled RPC `send_alert`.