### PR TITLE
feat: Peers handle disconnect

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -64,7 +64,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let relayer = Relayer::new(
         chain_controller.clone(),
         sync_shared_state,
-        synchronizer.peers(),
+        Arc::clone(synchronizer.peers()),
     );
     let net_timer = NetTimeProtocol::default();
 

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -383,10 +383,6 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             }
         }
     }
-
-    pub fn peers(&self) -> Arc<Peers> {
-        Arc::clone(&self.peers)
-    }
 }
 
 impl<CS: ChainStore + 'static> CKBProtocolHandler for Relayer<CS> {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -167,8 +167,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
         }
     }
 
-    pub fn peers(&self) -> Arc<Peers> {
-        Arc::clone(&self.peers)
+    pub fn peers(&self) -> &Arc<Peers> {
+        &self.peers
     }
 
     pub fn insert_block_status(&self, hash: H256, status: BlockStatus) {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -71,11 +71,11 @@ pub struct Synchronizer<CS: ChainStore> {
     chain: ChainController,
     pub shared: Arc<SyncSharedState<CS>>,
     pub status_map: BlockStatusMap,
-    pub n_sync: Arc<AtomicUsize>,
     pub peers: Arc<Peers>,
     pub config: Arc<Config>,
     pub orphan_block_pool: Arc<OrphanBlockPool>,
-    pub outbound_peers_with_protect: Arc<AtomicUsize>,
+    pub n_sync_started: Arc<AtomicUsize>,
+    pub n_protected_outbound_peers: Arc<AtomicUsize>,
 }
 
 // https://github.com/rust-lang/rust/issues/40754
@@ -85,11 +85,11 @@ impl<CS: ChainStore> ::std::clone::Clone for Synchronizer<CS> {
             chain: self.chain.clone(),
             shared: Arc::clone(&self.shared),
             status_map: Arc::clone(&self.status_map),
-            n_sync: Arc::clone(&self.n_sync),
+            n_sync_started: Arc::clone(&self.n_sync_started),
             peers: Arc::clone(&self.peers),
             config: Arc::clone(&self.config),
             orphan_block_pool: Arc::clone(&self.orphan_block_pool),
-            outbound_peers_with_protect: Arc::clone(&self.outbound_peers_with_protect),
+            n_protected_outbound_peers: Arc::clone(&self.n_protected_outbound_peers),
         }
     }
 }
@@ -108,8 +108,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
             peers: Arc::new(Peers::default()),
             orphan_block_pool: Arc::new(OrphanBlockPool::with_capacity(orphan_block_limit)),
             status_map: Arc::new(Mutex::new(HashMap::new())),
-            n_sync: Arc::new(AtomicUsize::new(0)),
-            outbound_peers_with_protect: Arc::new(AtomicUsize::new(0)),
+            n_sync_started: Arc::new(AtomicUsize::new(0)),
+            n_protected_outbound_peers: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -305,11 +305,11 @@ impl<CS: ChainStore> Synchronizer<CS> {
             .map(|peer| peer.is_outbound())
             .unwrap_or(false);
         let protect_outbound = is_outbound
-            && self.outbound_peers_with_protect.load(Ordering::Acquire)
+            && self.n_protected_outbound_peers.load(Ordering::Acquire)
                 < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT;
 
         if protect_outbound {
-            self.outbound_peers_with_protect
+            self.n_protected_outbound_peers
                 .fetch_add(1, Ordering::Release);
         }
 
@@ -440,7 +440,9 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
         for peer in peers {
             // Only sync with 1 peer if we're in IBD
-            if self.shared.is_initial_block_download() && self.n_sync.load(Ordering::Acquire) != 0 {
+            if self.shared.is_initial_block_download()
+                && self.n_sync_started.load(Ordering::Acquire) != 0
+            {
                 break;
             }
             {
@@ -449,7 +451,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
                     if !peer_state.sync_started {
                         let headers_sync_timeout = self.predict_headers_sync_time(&tip);
                         peer_state.start_sync(headers_sync_timeout);
-                        self.n_sync.fetch_add(1, Ordering::Release);
+                        self.n_sync_started.fetch_add(1, Ordering::Release);
                     }
                 }
             }
@@ -547,7 +549,7 @@ impl<CS: ChainStore> CKBProtocolHandler for Synchronizer<CS> {
             // It shouldn't happen
             // fetch_sub wraps around on overflow, we still check manually
             // panic here to prevent some bug be hidden silently.
-            if peer_state.sync_started && self.n_sync.fetch_sub(1, Ordering::Release) == 0 {
+            if peer_state.sync_started && self.n_sync_started.fetch_sub(1, Ordering::Release) == 0 {
                 panic!("Synchronizer n_sync overflow");
             }
         }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -544,8 +544,7 @@ impl<CS: ChainStore> CKBProtocolHandler for Synchronizer<CS> {
 
     fn disconnected(&mut self, _nc: Arc<CKBProtocolContext + Sync>, peer_index: PeerIndex) {
         info!(target: "sync", "SyncProtocol.disconnected peer={}", peer_index);
-        let mut state = self.peers.state.write();
-        if let Some(peer_state) = state.get(&peer_index) {
+        if let Some(peer_state) = self.peers.disconnected(peer_index) {
             // It shouldn't happen
             // fetch_sub wraps around on overflow, we still check manually
             // panic here to prevent some bug be hidden silently.
@@ -553,8 +552,6 @@ impl<CS: ChainStore> CKBProtocolHandler for Synchronizer<CS> {
                 panic!("Synchronizer n_sync overflow");
             }
         }
-        state.remove(&peer_index);
-        self.peers.disconnected(peer_index);
     }
 
     fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -412,11 +412,12 @@ impl Peers {
         // TODO:
     }
 
-    pub fn disconnected(&self, peer: PeerIndex) {
+    pub fn disconnected(&self, peer: PeerIndex) -> Option<PeerState> {
         self.best_known_headers.write().remove(&peer);
         // self.misbehavior.write().remove(peer);
         self.blocks_inflight.write().remove_by_peer(&peer);
         self.last_common_headers.write().remove(&peer);
+        self.state.write().remove(&peer)
     }
 
     // Return true when the block is that we have requested and received first time.


### PR DESCRIPTION
* Handle disconnected inside `Peers`
* Rename `n_sync_started`/`n_protected_outbound_peers`
* Remove imlicitly clone for `Peers`