### PR TITLE
feat: network alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "ckb-logger 0.15.0-pre",
  "ckb-miner 0.15.0-pre",
  "ckb-network 0.15.0-pre",
+ "ckb-network-alert 0.1.0",
  "ckb-notify 0.15.0-pre",
  "ckb-pow 0.15.0-pre",
  "ckb-resource 0.15.0-pre",
@@ -597,6 +598,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-network-alert"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-core 0.15.0-pre",
+ "ckb-logger 0.15.0-pre",
+ "ckb-network 0.15.0-pre",
+ "ckb-protocol 0.15.0-pre",
+ "ckb-util 0.15.0-pre",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-types 0.15.0-pre",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)",
+ "multisig 0.15.0-pre",
+ "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-notify"
 version = "0.15.0-pre"
 dependencies = [
@@ -662,6 +686,7 @@ dependencies = [
  "ckb-logger 0.15.0-pre",
  "ckb-miner 0.15.0-pre",
  "ckb-network 0.15.0-pre",
+ "ckb-network-alert 0.1.0",
  "ckb-notify 0.15.0-pre",
  "ckb-pow 0.15.0-pre",
  "ckb-protocol 0.15.0-pre",
@@ -1879,6 +1904,15 @@ dependencies = [
 name = "lru-cache"
 version = "0.1.0"
 source = "git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8#a35fdb81a309dd494c8edc02c0ff44e0597a4be4"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.0"
+source = "git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1#b36a4d1d16137f065d2b6ccdc676f901f80188a8"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3836,6 +3870,7 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)" = "<none>"
+"checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)" = "<none>"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "ckb-logger 0.15.0-pre",
  "ckb-miner 0.15.0-pre",
  "ckb-network 0.15.0-pre",
+ "ckb-network-alert 0.1.0",
  "ckb-pow 0.15.0-pre",
  "ckb-resource 0.15.0-pre",
  "ckb-rpc 0.15.0-pre",
@@ -612,7 +613,7 @@ dependencies = [
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-types 0.15.0-pre",
- "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",
  "multisig 0.15.0-pre",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1904,15 +1905,6 @@ dependencies = [
 name = "lru-cache"
 version = "0.1.0"
 source = "git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8#a35fdb81a309dd494c8edc02c0ff44e0597a4be4"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1#b36a4d1d16137f065d2b6ccdc676f901f80188a8"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3870,7 +3862,6 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)" = "<none>"
-"checksum lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=b36a4d1)" = "<none>"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ckb-bin = { path = "ckb-bin" }
 
 [workspace]
 members = [
+    "util/network-alert",
     "util/multisig",
     "util/logger",
     "util/hash",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -27,6 +27,7 @@ ckb-pow = { path = "../pow" }
 ckb-network = { path = "../network"}
 ckb-rpc = { path = "../rpc"}
 ckb-resource = { path = "../resource"}
+ckb-network-alert = { path = "../util/network-alert" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 ctrlc = { version = "3.1", features = ["termination"] }

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -126,7 +126,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             block_assembler_controller,
         )
         .enable_net(network_controller.clone())
-        .enable_stats(shared.clone(), synchronizer, alert_notifier.clone())
+        .enable_stats(shared.clone(), synchronizer, Arc::clone(&alert_notifier))
         .enable_experiment(shared.clone())
         .enable_integration_test(
             shared.clone(),

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -6,7 +6,7 @@ use ckb_db::RocksDB;
 use ckb_logger::info_target;
 use ckb_miner::BlockAssembler;
 use ckb_network::{CKBProtocol, NetworkService, NetworkState};
-use ckb_network_alert::{alert_relayer::AlertRelayer, config::Config as AlertConfig};
+use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_notify::NotifyService;
 use ckb_rpc::RpcServer;
 use ckb_shared::shared::{Shared, SharedBuilder};
@@ -75,7 +75,8 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         Arc::clone(synchronizer.peers()),
     );
     let net_timer = NetTimeProtocol::default();
-    let alert_relayer = AlertRelayer::new(version.to_string(), AlertConfig::default());
+    let alert_config = args.config.alert.unwrap_or_default();
+    let alert_relayer = AlertRelayer::new(version.to_string(), alert_config);
 
     let alert_notifier = alert_relayer.notifier();
     let alert_verifier = alert_relayer.verifier();

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -78,8 +78,8 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let alert_config = args.config.alert.unwrap_or_default();
     let alert_relayer = AlertRelayer::new(version.to_string(), alert_config);
 
-    let alert_notifier = alert_relayer.notifier();
-    let alert_verifier = alert_relayer.verifier();
+    let alert_notifier = Arc::clone(alert_relayer.notifier());
+    let alert_verifier = Arc::clone(alert_relayer.verifier());
 
     let synchronizer_clone = synchronizer.clone();
     let protocols = vec![

--- a/core/src/alert.rs
+++ b/core/src/alert.rs
@@ -1,0 +1,92 @@
+use crate::Bytes;
+use bincode::serialize;
+use hash::blake2b_256;
+use numext_fixed_hash::H256;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Alert {
+    pub id: u32,
+    // cancel id if cancel is greater than 0
+    pub cancel: u32,
+    // TODO use service flag to distinguish network
+    //network: String,
+    pub min_version: Option<String>,
+    pub max_version: Option<String>,
+    pub priority: u32,
+    pub notice_until: u64,
+    pub message: String,
+    pub signatures: Vec<Bytes>,
+}
+
+impl Alert {
+    pub fn hash(&self) -> H256 {
+        let alert = Self {
+            id: self.id,
+            cancel: self.cancel,
+            min_version: self.min_version.clone(),
+            max_version: self.max_version.clone(),
+            priority: self.priority,
+            notice_until: self.notice_until,
+            message: self.message.clone(),
+            signatures: Vec::new(),
+        };
+        blake2b_256(serialize(&alert).expect("serialize should not fail")).into()
+    }
+}
+
+#[derive(Default)]
+pub struct AlertBuilder {
+    inner: Alert,
+}
+
+impl AlertBuilder {
+    pub fn alert(mut self, alert: Alert) -> Self {
+        self.inner = alert;
+        self
+    }
+
+    pub fn id(mut self, id: u32) -> Self {
+        self.inner.id = id;
+        self
+    }
+
+    pub fn cancel(mut self, cancel: u32) -> Self {
+        self.inner.cancel = cancel;
+        self
+    }
+
+    pub fn min_version(mut self, min_version: Option<String>) -> Self {
+        self.inner.min_version = min_version;
+        self
+    }
+
+    pub fn max_version(mut self, max_version: Option<String>) -> Self {
+        self.inner.max_version = max_version;
+        self
+    }
+
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.inner.priority = priority;
+        self
+    }
+
+    pub fn signatures(mut self, signatures: Vec<Bytes>) -> Self {
+        self.inner.signatures.extend(signatures);
+        self
+    }
+
+    pub fn notice_until(mut self, notice_until: u64) -> Self {
+        self.inner.notice_until = notice_until;
+        self
+    }
+
+    pub fn message(mut self, message: String) -> Self {
+        self.inner.message = message;
+        self
+    }
+
+    pub fn build(self) -> Alert {
+        self.inner
+    }
+}

--- a/core/src/alert.rs
+++ b/core/src/alert.rs
@@ -4,7 +4,7 @@ use hash::blake2b_256;
 use numext_fixed_hash::H256;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Alert {
     pub id: u32,
     // cancel id if cancel is greater than 0

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This Library provides the essential types for building ckb.
 
+pub mod alert;
 pub mod block;
 pub mod cell;
 pub mod difficulty;

--- a/protocol/src/builder.rs
+++ b/protocol/src/builder.rs
@@ -1,9 +1,10 @@
 use crate::protocol_generated::ckb::protocol::{
-    Block as FbsBlock, BlockBuilder, BlockProposalBuilder, BlockTransactionsBuilder,
-    Bytes as FbsBytes, BytesBuilder, CellInput as FbsCellInput, CellInputBuilder,
-    CellOutput as FbsCellOutput, CellOutputBuilder, CompactBlock, CompactBlockBuilder,
-    FilteredBlock, FilteredBlockBuilder, GetBlockProposalBuilder, GetBlockTransactionsBuilder,
-    GetBlocks as FbsGetBlocks, GetBlocksBuilder, GetHeaders as FbsGetHeaders, GetHeadersBuilder,
+    Alert as FbsAlert, AlertBuilder, AlertMessage, AlertMessageBuilder, Block as FbsBlock,
+    BlockBuilder, BlockProposalBuilder, BlockTransactionsBuilder, Bytes as FbsBytes, BytesBuilder,
+    CellInput as FbsCellInput, CellInputBuilder, CellOutput as FbsCellOutput, CellOutputBuilder,
+    CompactBlock, CompactBlockBuilder, FilteredBlock, FilteredBlockBuilder,
+    GetBlockProposalBuilder, GetBlockTransactionsBuilder, GetBlocks as FbsGetBlocks,
+    GetBlocksBuilder, GetHeaders as FbsGetHeaders, GetHeadersBuilder,
     GetRelayTransaction as FbsGetRelayTransaction, GetRelayTransactionBuilder, Header as FbsHeader,
     HeaderBuilder, Headers as FbsHeaders, HeadersBuilder, IndexTransactionBuilder,
     MerkleProofBuilder, OutPoint as FbsOutPoint, OutPointBuilder,
@@ -16,6 +17,7 @@ use crate::protocol_generated::ckb::protocol::{
     WitnessBuilder, H256 as FbsH256,
 };
 use crate::{short_transaction_id, short_transaction_id_keys};
+use ckb_core::alert::Alert;
 use ckb_core::block::Block;
 use ckb_core::header::{BlockNumber, Header};
 use ckb_core::script::Script;
@@ -700,6 +702,54 @@ impl<'a> TimeMessage<'a> {
         let fbs_time = FbsTime::build(fbb, timestamp);
         let mut builder = TimeMessageBuilder::new(fbb);
         builder.add_payload(fbs_time);
+        builder.finish()
+    }
+}
+
+impl<'a> FbsAlert<'a> {
+    pub fn build<'b>(fbb: &mut FlatBufferBuilder<'b>, alert: &Alert) -> WIPOffset<FbsAlert<'b>> {
+        let min_version = alert
+            .min_version
+            .as_ref()
+            .map(|min_ver| FbsBytes::build(fbb, min_ver.as_bytes()));
+        let max_version = alert
+            .max_version
+            .as_ref()
+            .map(|max_ver| FbsBytes::build(fbb, max_ver.as_bytes()));
+        let signatures = {
+            let signatures: Vec<_> = alert
+                .signatures
+                .iter()
+                .map(|sig| FbsBytes::build(fbb, sig))
+                .collect();
+            fbb.create_vector(&signatures)
+        };
+        let message = FbsBytes::build(fbb, alert.message.as_bytes());
+        let mut builder = AlertBuilder::new(fbb);
+        builder.add_id(alert.id);
+        builder.add_cancel(alert.cancel);
+        if let Some(min_version) = min_version {
+            builder.add_min_version(min_version);
+        }
+        if let Some(max_version) = max_version {
+            builder.add_max_version(max_version);
+        }
+        builder.add_priority(alert.priority);
+        builder.add_signatures(signatures);
+        builder.add_notice_until(alert.notice_until);
+        builder.add_message(message);
+        builder.finish()
+    }
+}
+
+impl<'a> AlertMessage<'a> {
+    pub fn build_alert<'b>(
+        fbb: &mut FlatBufferBuilder<'b>,
+        alert: &Alert,
+    ) -> WIPOffset<AlertMessage<'b>> {
+        let fbs_alert = FbsAlert::build(fbb, alert);
+        let mut builder = AlertMessageBuilder::new(fbb);
+        builder.add_payload(fbs_alert);
         builder.finish()
     }
 }

--- a/protocol/src/convert.rs
+++ b/protocol/src/convert.rs
@@ -345,3 +345,43 @@ impl<'a> TryFrom<ckb_protocol::IndexTransaction<'a>> for ckb_core::transaction::
         })
     }
 }
+
+impl<'a> TryFrom<ckb_protocol::Alert<'a>> for ckb_core::alert::Alert {
+    type Error = FailureError;
+
+    fn try_from(alert: ckb_protocol::Alert<'a>) -> Result<Self, Self::Error> {
+        let message = String::from_utf8(cast!(alert.message().and_then(|m| m.seq()))?.to_owned())?;
+        let min_version: Option<String> = match alert
+            .min_version()
+            .and_then(|m| m.seq().map(|s| String::from_utf8(s.to_vec())))
+        {
+            Some(min_version) => Some(min_version?),
+            None => None,
+        };
+        let max_version: Option<String> = match alert
+            .max_version()
+            .and_then(|m| m.seq().map(|s| String::from_utf8(s.to_vec())))
+        {
+            Some(max_version) => Some(max_version?),
+            None => None,
+        };
+        let signatures: Result<Vec<ckb_core::Bytes>, FailureError> =
+            FlatbuffersVectorIterator::new(cast!(alert.signatures())?)
+                .map(|s| {
+                    cast!(s.seq())
+                        .map(ckb_core::Bytes::from)
+                        .map_err(Into::into)
+                })
+                .collect();
+        Ok(ckb_core::alert::AlertBuilder::default()
+            .id(alert.id())
+            .cancel(alert.cancel())
+            .min_version(min_version)
+            .max_version(max_version)
+            .priority(alert.priority())
+            .signatures(signatures?)
+            .notice_until(alert.notice_until())
+            .message(message)
+            .build())
+    }
+}

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -240,3 +240,19 @@ table TimeMessage {
 table Time {
     timestamp: uint64;
 }
+
+table AlertMessage {
+    payload:        Alert;
+}
+
+table Alert {
+    id: uint32;
+    cancel: uint32;
+    min_version: Bytes;
+    max_version: Bytes;
+    priority: uint32;
+    signatures: [Bytes];
+    notice_until: uint64;
+    message: Bytes;
+}
+

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -3579,6 +3579,242 @@ impl<'a: 'b, 'b> TimeBuilder<'a, 'b> {
   }
 }
 
+pub enum AlertMessageOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct AlertMessage<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for AlertMessage<'a> {
+    type Inner = AlertMessage<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> AlertMessage<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        AlertMessage {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args AlertMessageArgs<'args>) -> flatbuffers::WIPOffset<AlertMessage<'bldr>> {
+      let mut builder = AlertMessageBuilder::new(_fbb);
+      if let Some(x) = args.payload { builder.add_payload(x); }
+      builder.finish()
+    }
+
+    pub const VT_PAYLOAD: flatbuffers::VOffsetT = 4;
+
+  #[inline]
+  pub fn payload(&self) -> Option<Alert<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Alert<'a>>>(AlertMessage::VT_PAYLOAD, None)
+  }
+}
+
+pub struct AlertMessageArgs<'a> {
+    pub payload: Option<flatbuffers::WIPOffset<Alert<'a >>>,
+}
+impl<'a> Default for AlertMessageArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        AlertMessageArgs {
+            payload: None,
+        }
+    }
+}
+pub struct AlertMessageBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AlertMessageBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_payload(&mut self, payload: flatbuffers::WIPOffset<Alert<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Alert>>(AlertMessage::VT_PAYLOAD, payload);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AlertMessageBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AlertMessageBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<AlertMessage<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+pub enum AlertOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct Alert<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Alert<'a> {
+    type Inner = Alert<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> Alert<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Alert {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args AlertArgs<'args>) -> flatbuffers::WIPOffset<Alert<'bldr>> {
+      let mut builder = AlertBuilder::new(_fbb);
+      builder.add_notice_until(args.notice_until);
+      if let Some(x) = args.message { builder.add_message(x); }
+      if let Some(x) = args.signatures { builder.add_signatures(x); }
+      builder.add_priority(args.priority);
+      if let Some(x) = args.max_version { builder.add_max_version(x); }
+      if let Some(x) = args.min_version { builder.add_min_version(x); }
+      builder.add_cancel(args.cancel);
+      builder.add_id(args.id);
+      builder.finish()
+    }
+
+    pub const VT_ID: flatbuffers::VOffsetT = 4;
+    pub const VT_CANCEL: flatbuffers::VOffsetT = 6;
+    pub const VT_MIN_VERSION: flatbuffers::VOffsetT = 8;
+    pub const VT_MAX_VERSION: flatbuffers::VOffsetT = 10;
+    pub const VT_PRIORITY: flatbuffers::VOffsetT = 12;
+    pub const VT_SIGNATURES: flatbuffers::VOffsetT = 14;
+    pub const VT_NOTICE_UNTIL: flatbuffers::VOffsetT = 16;
+    pub const VT_MESSAGE: flatbuffers::VOffsetT = 18;
+
+  #[inline]
+  pub fn id(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_ID, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn cancel(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_CANCEL, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn min_version(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MIN_VERSION, None)
+  }
+  #[inline]
+  pub fn max_version(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MAX_VERSION, None)
+  }
+  #[inline]
+  pub fn priority(&self) -> u32 {
+    self._tab.get::<u32>(Alert::VT_PRIORITY, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn signatures(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(Alert::VT_SIGNATURES, None)
+  }
+  #[inline]
+  pub fn notice_until(&self) -> u64 {
+    self._tab.get::<u64>(Alert::VT_NOTICE_UNTIL, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn message(&self) -> Option<Bytes<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Bytes<'a>>>(Alert::VT_MESSAGE, None)
+  }
+}
+
+pub struct AlertArgs<'a> {
+    pub id: u32,
+    pub cancel: u32,
+    pub min_version: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub max_version: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+    pub priority: u32,
+    pub signatures: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub notice_until: u64,
+    pub message: Option<flatbuffers::WIPOffset<Bytes<'a >>>,
+}
+impl<'a> Default for AlertArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        AlertArgs {
+            id: 0,
+            cancel: 0,
+            min_version: None,
+            max_version: None,
+            priority: 0,
+            signatures: None,
+            notice_until: 0,
+            message: None,
+        }
+    }
+}
+pub struct AlertBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AlertBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_id(&mut self, id: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_ID, id, 0);
+  }
+  #[inline]
+  pub fn add_cancel(&mut self, cancel: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_CANCEL, cancel, 0);
+  }
+  #[inline]
+  pub fn add_min_version(&mut self, min_version: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MIN_VERSION, min_version);
+  }
+  #[inline]
+  pub fn add_max_version(&mut self, max_version: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MAX_VERSION, max_version);
+  }
+  #[inline]
+  pub fn add_priority(&mut self, priority: u32) {
+    self.fbb_.push_slot::<u32>(Alert::VT_PRIORITY, priority, 0);
+  }
+  #[inline]
+  pub fn add_signatures(&mut self, signatures: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Alert::VT_SIGNATURES, signatures);
+  }
+  #[inline]
+  pub fn add_notice_until(&mut self, notice_until: u64) {
+    self.fbb_.push_slot::<u64>(Alert::VT_NOTICE_UNTIL, notice_until, 0);
+  }
+  #[inline]
+  pub fn add_message(&mut self, message: flatbuffers::WIPOffset<Bytes<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Bytes>>(Alert::VT_MESSAGE, message);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AlertBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AlertBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Alert<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
 #[inline]
 pub fn get_root_as_sync_message<'a>(buf: &'a [u8]) -> SyncMessage<'a> {
   flatbuffers::get_root::<SyncMessage<'a>>(buf)

--- a/protocol/src/protocol_generated_verifier.rs
+++ b/protocol/src/protocol_generated_verifier.rs
@@ -104,6 +104,254 @@ pub mod ckb {
             }
         }
 
+        impl<'a> Verify for reader::Alert<'a> {
+            fn verify(&self) -> Result {
+                let tab = self._tab;
+                let buf = tab.buf;
+                let buf_len = buf.len();
+
+                if tab.loc > MAX_OFFSET_LOC || tab.loc + flatbuffers::SIZE_SOFFSET > buf_len {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab_loc = {
+                    let soffset_slice = &buf[tab.loc..];
+                    let soffset = flatbuffers::read_scalar::<flatbuffers::SOffsetT>(soffset_slice);
+                    if soffset >= 0 {
+                        tab.loc.checked_sub(soffset as usize)
+                    } else {
+                        soffset
+                            .checked_neg()
+                            .and_then(|foffset| tab.loc.checked_add(foffset as usize))
+                    }
+                }
+                .ok_or(Error::OutOfBounds)?;
+                if vtab_loc
+                    .checked_add(flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab = tab.vtable();
+                let vtab_num_bytes = vtab.num_bytes();
+                let object_inline_num_bytes = vtab.object_inline_num_bytes();
+                if vtab_num_bytes < flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET
+                    || object_inline_num_bytes < flatbuffers::SIZE_SOFFSET
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if vtab_loc
+                    .checked_add(vtab_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if tab
+                    .loc
+                    .checked_add(object_inline_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                for i in 0..vtab.num_fields() {
+                    let voffset = vtab.get_field(i) as usize;
+                    if (voffset > 0 && voffset < flatbuffers::SIZE_SOFFSET)
+                        || voffset >= object_inline_num_bytes
+                    {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_ID as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_ID) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_CANCEL as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_CANCEL) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_MIN_VERSION as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MIN_VERSION) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.min_version() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                if Self::VT_MAX_VERSION as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MAX_VERSION) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.max_version() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                if Self::VT_PRIORITY as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_PRIORITY) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 4 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_SIGNATURES as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_SIGNATURES) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        let signatures_verifier = VectorVerifier::follow(
+                            buf,
+                            try_follow_uoffset(buf, tab.loc + voffset)?,
+                        );
+                        signatures_verifier
+                            .verify_reference_elements::<reader::Bytes>()?;
+                    }
+                }
+
+                if Self::VT_NOTICE_UNTIL as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_NOTICE_UNTIL) as usize;
+                    if voffset > 0 && object_inline_num_bytes - voffset < 8 {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_MESSAGE as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_MESSAGE) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.message() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+
+        impl<'a> Verify for reader::AlertMessage<'a> {
+            fn verify(&self) -> Result {
+                let tab = self._tab;
+                let buf = tab.buf;
+                let buf_len = buf.len();
+
+                if tab.loc > MAX_OFFSET_LOC || tab.loc + flatbuffers::SIZE_SOFFSET > buf_len {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab_loc = {
+                    let soffset_slice = &buf[tab.loc..];
+                    let soffset = flatbuffers::read_scalar::<flatbuffers::SOffsetT>(soffset_slice);
+                    if soffset >= 0 {
+                        tab.loc.checked_sub(soffset as usize)
+                    } else {
+                        soffset
+                            .checked_neg()
+                            .and_then(|foffset| tab.loc.checked_add(foffset as usize))
+                    }
+                }
+                .ok_or(Error::OutOfBounds)?;
+                if vtab_loc
+                    .checked_add(flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                let vtab = tab.vtable();
+                let vtab_num_bytes = vtab.num_bytes();
+                let object_inline_num_bytes = vtab.object_inline_num_bytes();
+                if vtab_num_bytes < flatbuffers::SIZE_VOFFSET + flatbuffers::SIZE_VOFFSET
+                    || object_inline_num_bytes < flatbuffers::SIZE_SOFFSET
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if vtab_loc
+                    .checked_add(vtab_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+                if tab
+                    .loc
+                    .checked_add(object_inline_num_bytes)
+                    .filter(|loc| *loc <= buf_len)
+                    .is_none()
+                {
+                    return Err(Error::OutOfBounds);
+                }
+
+                for i in 0..vtab.num_fields() {
+                    let voffset = vtab.get_field(i) as usize;
+                    if (voffset > 0 && voffset < flatbuffers::SIZE_SOFFSET)
+                        || voffset >= object_inline_num_bytes
+                    {
+                        return Err(Error::OutOfBounds);
+                    }
+                }
+
+                if Self::VT_PAYLOAD as usize + flatbuffers::SIZE_VOFFSET
+                    <= vtab_num_bytes
+                {
+                    let voffset = vtab.get(Self::VT_PAYLOAD) as usize;
+                    if voffset > 0 {
+                        if voffset + 4 > object_inline_num_bytes {
+                            return Err(Error::OutOfBounds);
+                        }
+
+                        if let Some(f) = self.payload() {
+                            f.verify()?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+
         impl<'a> Verify for reader::Block<'a> {
             fn verify(&self) -> Result {
                 let tab = self._tab;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,6 +20,7 @@ ckb-miner = { path = "../miner" }
 ckb-protocol = { path = "../protocol" }
 ckb-pow = { path = "../pow"}
 ckb-logger = { path = "../util/logger"}
+ckb-network-alert = { path = "../util/network-alert" }
 jsonrpc-core = "10.1"
 jsonrpc-derive = "10.1"
 jsonrpc-http-server = { git = "https://github.com/nervosnetwork/jsonrpc", rev = "7c101f83a8fe34369c1b7a0e9b6721fcb0f91ee0" }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1022,12 +1022,12 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
+        "alerts": [],
         "chain": "main",
         "difficulty": "0x3e8",
         "epoch": "0",
         "is_initial_block_download": true,
-        "median_time": "1557311762",
-        "warnings": ""
+        "median_time": "1557311762"
     }
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -318,12 +318,12 @@
         "module": "stats",
         "params": [],
         "result": {
+            "alerts": [],
             "chain": "main",
             "difficulty": "0x3e8",
             "epoch": "0",
             "is_initial_block_download": true,
-            "median_time": "1557311762",
-            "warnings": ""
+            "median_time": "1557311762"
         }
     },
     {

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -10,6 +10,7 @@ pub enum Module {
     Experiment,
     Stats,
     IntegrationTest,
+    Alert,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -47,5 +48,9 @@ impl Config {
 
     pub fn integration_test_enable(&self) -> bool {
         self.modules.contains(&Module::IntegrationTest)
+    }
+
+    pub(crate) fn alert_enable(&self) -> bool {
+        self.modules.contains(&Module::Alert)
     }
 }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -6,7 +6,6 @@ pub enum Module {
     Chain,
     Miner,
     Pool,
-    Trace,
     Experiment,
     Stats,
     IntegrationTest,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -2,8 +2,10 @@ pub(crate) mod config;
 pub(crate) mod error;
 pub(crate) mod module;
 pub(crate) mod server;
+pub(crate) mod service_builder;
 #[cfg(test)]
 mod test;
 
 pub use crate::config::{Config, Module};
 pub use crate::server::RpcServer;
+pub use crate::service_builder::ServiceBuilder;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -5,5 +5,5 @@ pub(crate) mod server;
 #[cfg(test)]
 mod test;
 
-pub use crate::config::Config;
+pub use crate::config::{Config, Module};
 pub use crate::server::RpcServer;

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -5,6 +5,7 @@ use ckb_network::NetworkController;
 use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
 use ckb_protocol::AlertMessage;
 use ckb_sync::NetworkProtocol;
+use ckb_util::Mutex;
 use flatbuffers::FlatBufferBuilder;
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
@@ -21,13 +22,13 @@ pub trait AlertRpc {
 pub(crate) struct AlertRpcImpl {
     network_controller: NetworkController,
     verifier: Arc<AlertVerifier>,
-    notifier: Arc<AlertNotifier>,
+    notifier: Arc<Mutex<AlertNotifier>>,
 }
 
 impl AlertRpcImpl {
     pub fn new(
         verifier: Arc<AlertVerifier>,
-        notifier: Arc<AlertNotifier>,
+        notifier: Arc<Mutex<AlertNotifier>>,
         network_controller: NetworkController,
     ) -> Self {
         AlertRpcImpl {
@@ -57,7 +58,7 @@ impl AlertRpc for AlertRpcImpl {
                     error!("Broadcast alert failed: {:?}", err);
                 }
                 // set self node notifier
-                self.notifier.add(Arc::new(alert));
+                self.notifier.lock().add(Arc::new(alert));
                 Ok(())
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -1,0 +1,66 @@
+use crate::error::RPCError;
+use ckb_core::alert::Alert as CoreAlert;
+use ckb_logger::error;
+use ckb_network::NetworkController;
+use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
+use ckb_protocol::AlertMessage;
+use ckb_sync::NetworkProtocol;
+use flatbuffers::FlatBufferBuilder;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+use jsonrpc_types::Alert;
+use std::sync::Arc;
+
+#[rpc]
+pub trait AlertRpc {
+    // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"send_alert","params": [{}]}' -H 'content-type:application/json' 'http://localhost:8114'
+    #[rpc(name = "send_alert")]
+    fn send_alert(&self, _alert: Alert) -> Result<()>;
+}
+
+pub(crate) struct AlertRpcImpl {
+    network_controller: NetworkController,
+    verifier: Arc<AlertVerifier>,
+    notifier: Arc<AlertNotifier>,
+}
+
+impl AlertRpcImpl {
+    pub fn new(
+        verifier: Arc<AlertVerifier>,
+        notifier: Arc<AlertNotifier>,
+        network_controller: NetworkController,
+    ) -> Self {
+        AlertRpcImpl {
+            network_controller,
+            verifier,
+            notifier,
+        }
+    }
+}
+
+impl AlertRpc for AlertRpcImpl {
+    fn send_alert(&self, alert: Alert) -> Result<()> {
+        let alert: CoreAlert = alert.into();
+
+        let result = self.verifier.verify_signatures(&alert);
+
+        match result {
+            Ok(()) => {
+                let fbb = &mut FlatBufferBuilder::new();
+                let message = AlertMessage::build_alert(fbb, &alert);
+                fbb.finish(message, None);
+                let data = fbb.finished_data().into();
+                if let Err(err) = self
+                    .network_controller
+                    .broadcast(NetworkProtocol::ALERT.into(), data)
+                {
+                    error!("Broadcast alert failed: {:?}", err);
+                }
+                // set self node notifier
+                self.notifier.add(Arc::new(alert));
+                Ok(())
+            }
+            Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
+        }
+    }
+}

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -42,6 +42,16 @@ impl AlertRpcImpl {
 impl AlertRpc for AlertRpcImpl {
     fn send_alert(&self, alert: Alert) -> Result<()> {
         let alert: CoreAlert = alert.into();
+        let now_ms = faketime::unix_time_as_millis();
+        if alert.notice_until < now_ms {
+            Err(RPCError::custom(
+                RPCError::Invalid,
+                format!(
+                    "expired alert, notice_until: {} server: {}",
+                    alert.notice_until, now_ms
+                ),
+            ))?;
+        }
 
         let result = self.verifier.verify_signatures(&alert);
 

--- a/rpc/src/module/mod.rs
+++ b/rpc/src/module/mod.rs
@@ -1,3 +1,4 @@
+mod alert;
 mod chain;
 mod experiment;
 mod miner;
@@ -6,6 +7,7 @@ mod pool;
 mod stats;
 mod test;
 
+pub(crate) use self::alert::{AlertRpc, AlertRpcImpl};
 pub(crate) use self::chain::{ChainRpc, ChainRpcImpl};
 pub(crate) use self::experiment::{ExperimentRpc, ExperimentRpcImpl};
 pub(crate) use self::miner::{MinerRpc, MinerRpcImpl};

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -3,6 +3,7 @@ use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_sync::Synchronizer;
 use ckb_traits::BlockMedianTimeContext;
+use ckb_util::Mutex;
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use jsonrpc_types::{ChainInfo, EpochNumber, PeerState, Timestamp};
@@ -23,7 +24,7 @@ where
 {
     pub shared: Shared<CS>,
     pub synchronizer: Synchronizer<CS>,
-    pub alert_notifier: Arc<AlertNotifier>,
+    pub alert_notifier: Arc<Mutex<AlertNotifier>>,
 }
 
 impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
@@ -41,7 +42,8 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         let is_initial_block_download = self.synchronizer.shared.is_initial_block_download();
         let warnings = self
             .alert_notifier
-            .alerts()
+            .lock()
+            .noticed_alerts()
             .into_iter()
             .map(|alert| alert.message.clone())
             .collect::<Vec<String>>()

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -1,3 +1,4 @@
+use ckb_network_alert::notifier::Notifier as AlertNotifier;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_sync::Synchronizer;
@@ -5,6 +6,7 @@ use ckb_traits::BlockMedianTimeContext;
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use jsonrpc_types::{ChainInfo, EpochNumber, PeerState, Timestamp};
+use std::sync::Arc;
 
 #[rpc]
 pub trait StatsRpc {
@@ -21,6 +23,7 @@ where
 {
     pub shared: Shared<CS>,
     pub synchronizer: Synchronizer<CS>,
+    pub alert_notifier: Arc<AlertNotifier>,
 }
 
 impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
@@ -36,6 +39,13 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         let epoch = tip_header.epoch();
         let difficulty = tip_header.difficulty().clone();
         let is_initial_block_download = self.synchronizer.shared.is_initial_block_download();
+        let warnings = self
+            .alert_notifier
+            .alerts()
+            .into_iter()
+            .map(|alert| alert.message.clone())
+            .collect::<Vec<String>>()
+            .join("\n");
 
         Ok(ChainInfo {
             chain,
@@ -43,7 +53,7 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
             epoch: EpochNumber(epoch),
             difficulty,
             is_initial_block_download,
-            warnings: String::new(),
+            warnings,
         })
     }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,120 +1,16 @@
 use crate::config::Config;
-use crate::module::{
-    AlertRpc, AlertRpcImpl, ChainRpc, ChainRpcImpl, ExperimentRpc, ExperimentRpcImpl,
-    IntegrationTestRpc, IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl, NetworkRpc, NetworkRpcImpl,
-    PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl,
-};
-use ckb_chain::chain::ChainController;
-use ckb_miner::BlockAssemblerController;
-use ckb_network::NetworkController;
-use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
-use ckb_shared::shared::Shared;
-use ckb_store::ChainStore;
-use ckb_sync::Synchronizer;
-use ckb_util::Mutex;
 use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::{Server, ServerBuilder};
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
-use std::sync::Arc;
 
 pub struct RpcServer {
     pub(crate) server: Server,
 }
 
 impl RpcServer {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new<CS: ChainStore + 'static>(
-        config: Config,
-        network_controller: NetworkController,
-        shared: Shared<CS>,
-        synchronizer: Synchronizer<CS>,
-        chain: ChainController,
-        block_assembler: Option<BlockAssemblerController>,
-        alert_notifier: Arc<Mutex<AlertNotifier>>,
-        alert_verifier: Arc<AlertVerifier>,
-    ) -> RpcServer
-    where
-        CS: ChainStore,
-    {
-        let mut io = IoHandler::new();
-
-        if config.chain_enable() {
-            io.extend_with(
-                ChainRpcImpl {
-                    shared: shared.clone(),
-                }
-                .to_delegate(),
-            );
-        }
-
-        if config.pool_enable() {
-            io.extend_with(
-                PoolRpcImpl::new(shared.clone(), network_controller.clone()).to_delegate(),
-            );
-        }
-
-        if config.miner_enable() {
-            if let Some(block_assembler) = block_assembler {
-                io.extend_with(
-                    MinerRpcImpl {
-                        shared: shared.clone(),
-                        block_assembler,
-                        chain: chain.clone(),
-                        network_controller: network_controller.clone(),
-                    }
-                    .to_delegate(),
-                );
-            }
-        }
-
-        if config.net_enable() {
-            io.extend_with(
-                NetworkRpcImpl {
-                    network_controller: network_controller.clone(),
-                }
-                .to_delegate(),
-            );
-        }
-
-        if config.stats_enable() {
-            io.extend_with(
-                StatsRpcImpl {
-                    shared: shared.clone(),
-                    synchronizer: synchronizer.clone(),
-                    alert_notifier: Arc::clone(&alert_notifier),
-                }
-                .to_delegate(),
-            );
-        }
-
-        if config.experiment_enable() {
-            io.extend_with(
-                ExperimentRpcImpl {
-                    shared: shared.clone(),
-                }
-                .to_delegate(),
-            );
-        }
-
-        if config.integration_test_enable() {
-            io.extend_with(
-                IntegrationTestRpcImpl {
-                    network_controller: network_controller.clone(),
-                    shared,
-                    chain,
-                }
-                .to_delegate(),
-            );
-        }
-
-        if config.alert_enable() {
-            io.extend_with(
-                AlertRpcImpl::new(alert_verifier, alert_notifier, network_controller).to_delegate(),
-            );
-        }
-
-        let server = ServerBuilder::new(io)
+    pub fn new(config: Config, io_handler: IoHandler) -> RpcServer {
+        let server = ServerBuilder::new(io_handler)
             .cors(DomainsValidation::AllowOnly(vec![
                 AccessControlAllowOrigin::Null,
                 AccessControlAllowOrigin::Any,

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -11,6 +11,7 @@ use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier 
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_sync::Synchronizer;
+use ckb_util::Mutex;
 use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::{Server, ServerBuilder};
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
@@ -30,7 +31,7 @@ impl RpcServer {
         synchronizer: Synchronizer<CS>,
         chain: ChainController,
         block_assembler: Option<BlockAssemblerController>,
-        alert_notifier: Arc<AlertNotifier>,
+        alert_notifier: Arc<Mutex<AlertNotifier>>,
         alert_verifier: Arc<AlertVerifier>,
     ) -> RpcServer
     where

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -1,0 +1,147 @@
+use crate::config::Config;
+use crate::module::{
+    AlertRpc, AlertRpcImpl, ChainRpc, ChainRpcImpl, ExperimentRpc, ExperimentRpcImpl,
+    IntegrationTestRpc, IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl, NetworkRpc, NetworkRpcImpl,
+    PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl,
+};
+use ckb_chain::chain::ChainController;
+use ckb_miner::BlockAssemblerController;
+use ckb_network::NetworkController;
+use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
+use ckb_shared::shared::Shared;
+use ckb_store::ChainStore;
+use ckb_sync::Synchronizer;
+use ckb_util::Mutex;
+use jsonrpc_core::IoHandler;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+pub struct ServiceBuilder<'a, CS> {
+    config: &'a Config,
+    io_handler: IoHandler,
+    _phantom: PhantomData<CS>,
+}
+
+impl<'a, CS: ChainStore + 'static> ServiceBuilder<'a, CS> {
+    pub fn new(config: &'a Config) -> Self {
+        Self {
+            config,
+            io_handler: IoHandler::new(),
+            _phantom: PhantomData,
+        }
+    }
+    pub fn enable_chain(mut self, shared: Shared<CS>) -> Self {
+        if self.config.chain_enable() {
+            self.io_handler
+                .extend_with(ChainRpcImpl { shared }.to_delegate());
+        }
+        self
+    }
+
+    pub fn enable_pool(
+        mut self,
+        shared: Shared<CS>,
+        network_controller: NetworkController,
+    ) -> Self {
+        if self.config.pool_enable() {
+            self.io_handler
+                .extend_with(PoolRpcImpl::new(shared, network_controller).to_delegate());
+        }
+        self
+    }
+
+    pub fn enable_miner(
+        mut self,
+        shared: Shared<CS>,
+        network_controller: NetworkController,
+        chain: ChainController,
+        block_assembler: Option<BlockAssemblerController>,
+    ) -> Self {
+        if let Some(block_assembler) = block_assembler {
+            if self.config.pool_enable() {
+                self.io_handler.extend_with(
+                    MinerRpcImpl {
+                        shared: shared.clone(),
+                        block_assembler,
+                        chain: chain.clone(),
+                        network_controller: network_controller.clone(),
+                    }
+                    .to_delegate(),
+                );
+            }
+        }
+        self
+    }
+
+    pub fn enable_net(mut self, network_controller: NetworkController) -> Self {
+        if self.config.net_enable() {
+            self.io_handler
+                .extend_with(NetworkRpcImpl { network_controller }.to_delegate());
+        }
+        self
+    }
+
+    pub fn enable_stats(
+        mut self,
+        shared: Shared<CS>,
+        synchronizer: Synchronizer<CS>,
+        alert_notifier: Arc<Mutex<AlertNotifier>>,
+    ) -> Self {
+        if self.config.net_enable() {
+            self.io_handler.extend_with(
+                StatsRpcImpl {
+                    shared,
+                    synchronizer,
+                    alert_notifier,
+                }
+                .to_delegate(),
+            );
+        }
+        self
+    }
+
+    pub fn enable_experiment(mut self, shared: Shared<CS>) -> Self {
+        if self.config.experiment_enable() {
+            self.io_handler
+                .extend_with(ExperimentRpcImpl { shared }.to_delegate());
+        }
+        self
+    }
+
+    pub fn enable_integration_test(
+        mut self,
+        shared: Shared<CS>,
+        network_controller: NetworkController,
+        chain: ChainController,
+    ) -> Self {
+        if self.config.integration_test_enable() {
+            self.io_handler.extend_with(
+                IntegrationTestRpcImpl {
+                    shared,
+                    network_controller,
+                    chain,
+                }
+                .to_delegate(),
+            );
+        }
+        self
+    }
+
+    pub fn enable_alert(
+        mut self,
+        alert_verifier: Arc<AlertVerifier>,
+        alert_notifier: Arc<Mutex<AlertNotifier>>,
+        network_controller: NetworkController,
+    ) -> Self {
+        if self.config.alert_enable() {
+            self.io_handler.extend_with(
+                AlertRpcImpl::new(alert_verifier, alert_notifier, network_controller).to_delegate(),
+            )
+        }
+        self
+    }
+
+    pub fn build(self) -> IoHandler {
+        self.io_handler
+    }
+}

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -167,7 +167,7 @@ fn setup_node(
     );
     let alert_relayer = AlertRelayer::new("0".to_string(), AlertConfig::default());
 
-    let alert_notifier = alert_relayer.notifier();
+    let alert_notifier = Arc::clone(alert_relayer.notifier());
     io.extend_with(
         StatsRpcImpl {
             shared: shared.clone(),

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -12,6 +12,7 @@ use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, Transa
 use ckb_core::{capacity_bytes, BlockNumber, Bytes, Capacity};
 use ckb_db::MemoryKeyValueDB;
 use ckb_network::{NetworkConfig, NetworkService, NetworkState};
+use ckb_network_alert::{alert_relayer::AlertRelayer, config::Config as AlertConfig};
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
@@ -164,10 +165,14 @@ fn setup_node(
         }
         .to_delegate(),
     );
+    let alert_relayer = AlertRelayer::new("0".to_string(), AlertConfig::default());
+
+    let alert_notifier = alert_relayer.notifier();
     io.extend_with(
         StatsRpcImpl {
             shared: shared.clone(),
             synchronizer: synchronizer.clone(),
+            alert_notifier,
         }
         .to_delegate(),
     );

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -38,6 +38,7 @@ pub enum NetworkProtocol {
     SYNC = 100,
     RELAY = 101,
     TIME = 102,
+    ALERT = 110,
 }
 
 impl Into<ProtocolId> for NetworkProtocol {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -30,6 +30,7 @@ bytes = "0.4.12"
 crossbeam-channel = "0.3"
 flatbuffers = "0.6.0"
 regex = "1"
+faketime = "0.2"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -17,6 +17,9 @@ ckb-protocol = { path = "../protocol"}
 ckb-util = { path = "../util" }
 ckb-chain-spec = { path = "../spec" }
 ckb-resource = { path = "../resource" }
+ckb-rpc= { path = "../rpc" }
+ckb-network-alert = { path = "../util/network-alert" }
+crypto = { path = "../util/crypto" }
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 tempfile = "3.0"
 jsonrpc-client-core = "0.5.0"

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -55,6 +55,7 @@ fn main() {
     specs.insert("invalid_locator_size", Box::new(InvalidLocatorSize));
     specs.insert("tx_pool_size_limit", Box::new(SizeLimit));
     specs.insert("tx_pool_cycles_limit", Box::new(CyclesLimit));
+    specs.insert("alert_propagation", Box::new(AlertPropagation::default()));
 
     if let Some(spec_name) = env::args().nth(3) {
         if let Some(spec) = specs.get(spec_name.as_str()) {

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -5,7 +5,7 @@ use ckb_util::Mutex;
 use jsonrpc_client_core::{expand_params, jsonrpc_client, Result as JsonRpcResult};
 use jsonrpc_client_http::{HttpHandle, HttpTransport};
 use jsonrpc_types::{
-    Block, BlockNumber, BlockTemplate, BlockView, CellOutputWithOutPoint, CellWithStatus,
+    Alert, Block, BlockNumber, BlockTemplate, BlockView, CellOutputWithOutPoint, CellWithStatus,
     ChainInfo, DryRunResult, EpochExt, EpochNumber, HeaderView, Node, OutPoint, PeerState,
     Transaction, TransactionWithStatus, TxPoolInfo, Unsigned, Version,
 };
@@ -176,6 +176,14 @@ impl RpcClient {
         self.inner.lock().send_transaction(tx).call()
     }
 
+    pub fn send_alert(&self, alert: Alert) {
+        self.inner
+            .lock()
+            .send_alert(alert)
+            .call()
+            .expect("rpc call send_alert")
+    }
+
     pub fn tx_pool_info(&self) -> TxPoolInfo {
         self.inner
             .lock()
@@ -240,6 +248,8 @@ jsonrpc_client!(pub struct Inner {
     pub fn dry_run_transaction(&mut self, _tx: Transaction) -> RpcRequest<DryRunResult>;
     pub fn send_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
     pub fn tx_pool_info(&mut self) -> RpcRequest<TxPoolInfo>;
+
+    pub fn send_alert(&mut self, alert: Alert) -> RpcRequest<()>;
 
     pub fn add_node(&mut self, peer_id: String, address: String) -> RpcRequest<()>;
     pub fn remove_node(&mut self, peer_id: String) -> RpcRequest<()>;

--- a/test/src/specs/alert/alert_propagation.rs
+++ b/test/src/specs/alert/alert_propagation.rs
@@ -1,0 +1,116 @@
+use super::new_alert_config;
+use crate::utils::wait_until;
+use crate::{Net, Spec};
+use ckb_app_config::CKBAppConfig;
+use ckb_core::{alert::AlertBuilder, Bytes};
+use ckb_network_alert::config::Config as AlertConfig;
+use ckb_rpc::Module as RPCModule;
+use crypto::secp::{Message, Privkey};
+use log::info;
+
+pub struct AlertPropagation {
+    alert_config: AlertConfig,
+    privkeys: Vec<Privkey>,
+}
+
+impl Default for AlertPropagation {
+    fn default() -> Self {
+        let (alert_config, privkeys) = new_alert_config(2, 3);
+        Self {
+            alert_config,
+            privkeys,
+        }
+    }
+}
+
+impl Spec for AlertPropagation {
+    fn run(&self, net: Net) {
+        info!("Running AlertPropagation");
+
+        let node0 = &net.nodes[0];
+        let warning1 = "pretend we are in dangerous status";
+
+        // send alert
+        let mut alert = AlertBuilder::default()
+            .id(42)
+            .message(warning1.to_string())
+            .build();
+        let msg: Message = alert.hash();
+        let signatures = self
+            .privkeys
+            .iter()
+            .take(2)
+            .map(|key| key.sign_recoverable(&msg))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("sign alert");
+        alert.signatures = signatures
+            .iter()
+            .map(|s| Bytes::from(s.serialize()))
+            .collect();
+        // send alert
+        node0.rpc_client().send_alert(alert.clone().into());
+        info!("Waiting for alert relay");
+        let ret = wait_until(10, || {
+            net.nodes
+                .iter()
+                .all(|node| !node.rpc_client().get_blockchain_info().warnings.is_empty())
+        });
+        assert!(ret, "alert is relayed");
+        for node in net.nodes.iter() {
+            let received = node.rpc_client().get_blockchain_info().warnings;
+            assert_eq!(&received, warning1);
+        }
+
+        // cancel previous alert
+        let warning2 = "alert is canceled";
+        let mut alert2 = AlertBuilder::default()
+            .id(2)
+            .cancel(42)
+            .message(warning2.to_string())
+            .build();
+        let msg: Message = alert2.hash();
+        let signatures = self
+            .privkeys
+            .iter()
+            .map(|key| key.sign_recoverable(&msg))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("sign alert");
+        alert2.signatures = signatures
+            .iter()
+            .map(|s| Bytes::from(s.serialize()))
+            .collect();
+        node0.rpc_client().send_alert(alert2.into());
+        info!("Waiting for alert relay");
+        let ret = wait_until(10, || {
+            net.nodes
+                .iter()
+                .all(|node| node.rpc_client().get_blockchain_info().warnings != warning1)
+        });
+        assert!(ret, "alert is relayed");
+        for node in net.nodes.iter() {
+            let received = node.rpc_client().get_blockchain_info().warnings;
+            assert_eq!(&received, warning2);
+        }
+
+        // send canceled alert again, should ignore by all nodes
+        node0.rpc_client().send_alert(alert.into());
+        let received = node0.rpc_client().get_blockchain_info().warnings;
+        assert_eq!(&received, warning2);
+    }
+
+    fn num_nodes(&self) -> usize {
+        3
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        let alert_config = self.alert_config.to_owned();
+        Box::new(move |config| {
+            config.network.connect_outbound_interval_secs = 1;
+            config.network.discovery_local_address = true;
+            // set test alert config
+            config.alert = Some(alert_config.clone());
+            // enable alert RPC
+            config.rpc.modules.push(RPCModule::Alert);
+        })
+    }
+}

--- a/test/src/specs/alert/alert_propagation.rs
+++ b/test/src/specs/alert/alert_propagation.rs
@@ -29,11 +29,13 @@ impl Spec for AlertPropagation {
 
         let node0 = &net.nodes[0];
         let warning1 = "pretend we are in dangerous status";
+        let notice_until = faketime::unix_time_as_millis() + 100_000;
 
         // send alert
         let mut alert = AlertBuilder::default()
             .id(42)
             .message(warning1.to_string())
+            .notice_until(notice_until)
             .build();
         let msg: Message = alert.hash();
         let signatures = self
@@ -67,6 +69,7 @@ impl Spec for AlertPropagation {
             .id(2)
             .cancel(42)
             .message(warning2.to_string())
+            .notice_until(notice_until)
             .build();
         let msg: Message = alert2.hash();
         let signatures = self

--- a/test/src/specs/alert/alert_propagation.rs
+++ b/test/src/specs/alert/alert_propagation.rs
@@ -50,7 +50,7 @@ impl Spec for AlertPropagation {
         // send alert
         node0.rpc_client().send_alert(alert.clone().into());
         info!("Waiting for alert relay");
-        let ret = wait_until(10, || {
+        let ret = wait_until(20, || {
             net.nodes
                 .iter()
                 .all(|node| !node.rpc_client().get_blockchain_info().warnings.is_empty())
@@ -81,7 +81,7 @@ impl Spec for AlertPropagation {
             .collect();
         node0.rpc_client().send_alert(alert2.into());
         info!("Waiting for alert relay");
-        let ret = wait_until(10, || {
+        let ret = wait_until(20, || {
             net.nodes
                 .iter()
                 .all(|node| node.rpc_client().get_blockchain_info().warnings != warning1)

--- a/test/src/specs/alert/mod.rs
+++ b/test/src/specs/alert/mod.rs
@@ -1,0 +1,38 @@
+mod alert_propagation;
+
+pub use alert_propagation::AlertPropagation;
+
+use ckb_network_alert::config::Config as AlertConfig;
+use crypto::secp::Privkey;
+use jsonrpc_types::JsonBytes;
+use rand::{thread_rng, Rng};
+
+pub(crate) fn random_privkey() -> Privkey {
+    let mut rng = thread_rng();
+    let mut raw = [0; 32];
+    loop {
+        rng.fill(&mut raw);
+        let privkey = Privkey::from_slice(&raw[..]);
+        if privkey.pubkey().is_ok() {
+            return privkey;
+        }
+    }
+}
+
+pub(crate) fn new_alert_config(
+    signatures_threshold: usize,
+    key_num: usize,
+) -> (AlertConfig, Vec<Privkey>) {
+    let privkeys: Vec<_> = (0..key_num).map(|_| random_privkey()).collect();
+    let alert_config = AlertConfig {
+        signatures_threshold,
+        public_keys: privkeys
+            .iter()
+            .map(|privkey| {
+                let pubkey = privkey.pubkey().expect("pubkey");
+                JsonBytes::from_vec(pubkey.serialize())
+            })
+            .collect(),
+    };
+    (alert_config, privkeys)
+}

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -1,9 +1,11 @@
+mod alert;
 mod mining;
 mod p2p;
 mod relay;
 mod sync;
 mod tx_pool;
 
+pub use alert::*;
 pub use mining::*;
 pub use p2p::*;
 pub use relay::*;

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -23,6 +23,7 @@ ckb-instrument = { path = "../instrument", features = ["progress_bar"] }
 ckb-shared = { path = "../../shared" }
 ckb-sync = { path = "../../sync"}
 ckb-store = { path = "../../store" }
+ckb-network-alert = { path = "../network-alert" }
 build-info = { path = "../build-info" }
 ckb-script = { path = "../../script" }
 

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -15,6 +15,7 @@ use ckb_logger::Config as LogConfig;
 use ckb_miner::BlockAssemblerConfig;
 use ckb_miner::MinerConfig;
 use ckb_network::NetworkConfig;
+use ckb_network_alert::config::Config as AlertConfig;
 use ckb_resource::{Resource, ResourceLocator};
 use ckb_rpc::Config as RpcConfig;
 use ckb_script::ScriptConfig;
@@ -52,6 +53,7 @@ pub struct CKBAppConfig {
     pub tx_pool: TxPoolConfig,
     pub script: ScriptConfig,
     pub store: StoreConfig,
+    pub alert: Option<AlertConfig>,
 }
 
 // change the order of fields will break integration test, see module doc.

--- a/util/crypto/src/secp/privkey.rs
+++ b/util/crypto/src/secp/privkey.rs
@@ -7,7 +7,7 @@ use secp256k1::Message as SecpMessage;
 use std::str::FromStr;
 use std::{fmt, ops};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Privkey {
     /// ECDSA key.
     inner: H256,

--- a/util/crypto/src/secp/signature.rs
+++ b/util/crypto/src/secp/signature.rs
@@ -50,6 +50,15 @@ impl Signature {
         Signature(sig)
     }
 
+    pub fn from_slice(data: &[u8]) -> Result<Self, Error> {
+        if data.len() != 65 {
+            Err(Error::InvalidSignature)?;
+        }
+        let mut sig = [0u8; 65];
+        sig[..].copy_from_slice(data);
+        Ok(Signature(sig))
+    }
+
     /// Check if each component of the signature is in range.
     pub fn is_valid(&self) -> bool {
         let h_r = match H256::from_slice(self.r()) {

--- a/util/jsonrpc-types/src/alert.rs
+++ b/util/jsonrpc-types/src/alert.rs
@@ -20,6 +20,14 @@ pub struct Alert {
     pub signatures: Vec<JsonBytes>,
 }
 
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct AlertMessage {
+    pub id: AlertId,
+    pub priority: AlertPriority,
+    pub notice_until: Timestamp,
+    pub message: String,
+}
+
 impl From<Alert> for CoreAlert {
     fn from(json: Alert) -> Self {
         let Alert {
@@ -72,6 +80,24 @@ impl From<CoreAlert> for Alert {
             notice_until: Timestamp(notice_until),
             message,
             signatures: signatures.into_iter().map(JsonBytes::from_bytes).collect(),
+        }
+    }
+}
+
+impl From<&CoreAlert> for AlertMessage {
+    fn from(core: &CoreAlert) -> Self {
+        let CoreAlert {
+            id,
+            priority,
+            notice_until,
+            message,
+            ..
+        } = core;
+        AlertMessage {
+            id: AlertId(*id),
+            priority: AlertPriority(*priority),
+            notice_until: Timestamp(*notice_until),
+            message: message.to_owned(),
         }
     }
 }

--- a/util/jsonrpc-types/src/alert.rs
+++ b/util/jsonrpc-types/src/alert.rs
@@ -1,0 +1,77 @@
+use crate::{bytes::JsonBytes, string, Timestamp};
+use ckb_core::alert::{Alert as CoreAlert, AlertBuilder};
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct AlertId(#[serde(with = "string")] pub u32);
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct AlertPriority(#[serde(with = "string")] pub u32);
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct Alert {
+    pub id: AlertId,
+    pub cancel: AlertId,
+    pub min_version: Option<String>,
+    pub max_version: Option<String>,
+    pub priority: AlertPriority,
+    pub notice_until: Timestamp,
+    pub message: String,
+    pub signatures: Vec<JsonBytes>,
+}
+
+impl From<Alert> for CoreAlert {
+    fn from(json: Alert) -> Self {
+        let Alert {
+            id,
+            cancel,
+            min_version,
+            max_version,
+            priority,
+            notice_until,
+            message,
+            signatures,
+        } = json;
+
+        AlertBuilder::default()
+            .id(id.0)
+            .cancel(cancel.0)
+            .min_version(min_version)
+            .max_version(max_version)
+            .priority(priority.0)
+            .notice_until(notice_until.0)
+            .message(message)
+            .signatures(
+                signatures
+                    .into_iter()
+                    .map(JsonBytes::into_bytes)
+                    .collect::<Vec<_>>(),
+            )
+            .build()
+    }
+}
+
+impl From<CoreAlert> for Alert {
+    fn from(core: CoreAlert) -> Self {
+        let CoreAlert {
+            id,
+            cancel,
+            min_version,
+            max_version,
+            priority,
+            notice_until,
+            message,
+            signatures,
+        } = core;
+        Alert {
+            id: AlertId(id),
+            cancel: AlertId(cancel),
+            min_version,
+            max_version,
+            priority: AlertPriority(priority),
+            notice_until: Timestamp(notice_until),
+            message,
+            signatures: signatures.into_iter().map(JsonBytes::from_bytes).collect(),
+        }
+    }
+}

--- a/util/jsonrpc-types/src/chain_info.rs
+++ b/util/jsonrpc-types/src/chain_info.rs
@@ -1,4 +1,4 @@
-use crate::{EpochNumber, Timestamp};
+use crate::{AlertMessage, EpochNumber, Timestamp};
 use numext_fixed_uint::U256;
 use serde_derive::{Deserialize, Serialize};
 
@@ -15,5 +15,5 @@ pub struct ChainInfo {
     // estimate of whether this node is in InitialBlockDownload mode
     pub is_initial_block_download: bool,
     // any network and blockchain warnings
-    pub warnings: String,
+    pub alerts: Vec<AlertMessage>,
 }

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Timestamp(#[serde(with = "string")] pub u64);
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct Unsigned(#[serde(with = "string")] pub u64);
 
-pub use self::alert::Alert;
+pub use self::alert::{Alert, AlertMessage};
 pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -1,3 +1,4 @@
+mod alert;
 mod block_template;
 mod blockchain;
 mod bytes;
@@ -31,6 +32,7 @@ pub struct Timestamp(#[serde(with = "string")] pub u64);
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct Unsigned(#[serde(with = "string")] pub u64);
 
+pub use self::alert::Alert;
 pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -19,7 +19,7 @@ faketime = "0.2.0"
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 failure = "0.1.5"
 bytes = "0.4.12"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "b36a4d1" }
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
 serde = "1.0"
 serde_derive = "1.0"
 flatbuffers = "0.6.0"

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ckb-network-alert"
+version = "0.1.0"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+toml = "0.5.0"
+multisig = { path = "../multisig" }
+ckb-core = { path = "../../core" }
+ckb-util = { path = "../../util" }
+ckb-network = { path = "../../network" }
+ckb-protocol = { path = "../../protocol" }
+jsonrpc-types = { path = "../jsonrpc-types" }
+ckb-logger = { path = "../logger"}
+fnv = "1.0"
+faketime = "0.2.0"
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
+failure = "0.1.5"
+bytes = "0.4.12"
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "b36a4d1" }
+serde = "1.0"
+serde_derive = "1.0"
+flatbuffers = "0.6.0"
+

--- a/util/network-alert/src/alert.toml
+++ b/util/network-alert/src/alert.toml
@@ -1,0 +1,5 @@
+# need 2 signatures to send alert
+signatures_threshold = 2
+public_keys = [
+]
+

--- a/util/network-alert/src/alert_relayer.rs
+++ b/util/network-alert/src/alert_relayer.rs
@@ -41,12 +41,12 @@ impl AlertRelayer {
         }
     }
 
-    pub fn notifier(&self) -> Arc<Mutex<Notifier>> {
-        Arc::clone(&self.notifier)
+    pub fn notifier(&self) -> &Arc<Mutex<Notifier>> {
+        &self.notifier
     }
 
-    pub fn verifier(&self) -> Arc<Verifier> {
-        Arc::clone(&self.verifier)
+    pub fn verifier(&self) -> &Arc<Verifier> {
+        &self.verifier
     }
 
     fn clear_expired_alerts(&mut self) {

--- a/util/network-alert/src/alert_relayer.rs
+++ b/util/network-alert/src/alert_relayer.rs
@@ -1,0 +1,162 @@
+//! AlertRelayer
+//! We implment a Bitcoin like alert system, n of m alert key holders can decide to send alert
+//messages to all client
+//! to leave a space to reach consensus offline under critical bugs
+//!
+//! A cli to generate alert message,
+//! A config option to set alert messages to broard cast.
+//
+use crate::config::Config;
+use crate::notifier::Notifier;
+use crate::verifier::Verifier;
+use crate::BAD_MESSAGE_BAN_TIME;
+use ckb_core::alert::Alert;
+use ckb_logger::{debug, info, trace};
+use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
+use ckb_protocol::{get_root, AlertMessage};
+use flatbuffers::FlatBufferBuilder;
+use fnv::{FnvHashMap, FnvHashSet};
+use lru_cache::LruCache;
+use std::convert::TryInto;
+use std::sync::Arc;
+
+const CANCEL_FILTER_SIZE: usize = 128;
+const KNOWN_LIST_SIZE: usize = 64;
+
+/// AlertRelayer
+/// relay alert messages
+#[derive(Clone)]
+pub struct AlertRelayer {
+    /// cancelled alerts
+    cancel_filter: LruCache<u32, ()>,
+    /// unexpired alerts we received
+    received_alerts: FnvHashMap<u32, Arc<Alert>>,
+    /// alerts that self node should notice
+    notifier: Arc<Notifier>,
+    verifier: Arc<Verifier>,
+    known_lists: LruCache<PeerIndex, FnvHashSet<u32>>,
+}
+
+impl AlertRelayer {
+    pub fn new(client_version: String, config: Config) -> Self {
+        AlertRelayer {
+            cancel_filter: LruCache::new(CANCEL_FILTER_SIZE),
+            received_alerts: Default::default(),
+            notifier: Arc::new(Notifier::new(client_version)),
+            verifier: Arc::new(Verifier::new(config)),
+            known_lists: LruCache::new(KNOWN_LIST_SIZE),
+        }
+    }
+
+    pub fn notifier(&self) -> Arc<Notifier> {
+        Arc::clone(&self.notifier)
+    }
+
+    pub fn verifier(&self) -> Arc<Verifier> {
+        Arc::clone(&self.verifier)
+    }
+
+    fn receive_new_alert(&mut self, alert: Arc<Alert>) {
+        // checkout cancel_id
+        if alert.cancel > 0 {
+            self.cancel_filter.insert(alert.cancel, ());
+            self.received_alerts.remove(&alert.cancel);
+            self.notifier.cancel(alert.cancel);
+        }
+        // add to received alerts
+        self.received_alerts.insert(alert.id, Arc::clone(&alert));
+        // set self node notice
+        self.notifier.add(alert);
+    }
+
+    fn clear_expired_alerts(&mut self) {
+        let now = faketime::unix_time_as_millis();
+        self.received_alerts
+            .retain(|_id, alert| alert.notice_until > now);
+        self.notifier.clear_expired_alerts(now);
+    }
+
+    // return true if it this first time the peer know this alert
+    fn mark_as_known(&mut self, peer: PeerIndex, alert_id: u32) -> bool {
+        match self.known_lists.get_refresh(&peer) {
+            Some(alert_ids) => alert_ids.insert(alert_id),
+            None => {
+                let mut alert_ids = FnvHashSet::default();
+                alert_ids.insert(alert_id);
+                self.known_lists.insert(peer, alert_ids);
+                true
+            }
+        }
+    }
+}
+
+impl CKBProtocolHandler for AlertRelayer {
+    fn init(&mut self, _nc: Arc<dyn CKBProtocolContext + Sync>) {}
+
+    fn connected(
+        &mut self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer_index: PeerIndex,
+        _version: &str,
+    ) {
+        self.clear_expired_alerts();
+        for alert in self.received_alerts.values() {
+            trace!("send alert {} to peer {}", alert.id, peer_index);
+            let fbb = &mut FlatBufferBuilder::new();
+            let msg = AlertMessage::build_alert(fbb, &alert);
+            fbb.finish(msg, None);
+            nc.quick_send_message_to(peer_index, fbb.finished_data().into());
+        }
+    }
+
+    fn received(
+        &mut self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer_index: PeerIndex,
+        data: bytes::Bytes,
+    ) {
+        let alert: Arc<Alert> = match get_root::<AlertMessage>(&data)
+            .ok()
+            .and_then(|m| m.payload())
+            .map(TryInto::try_into)
+        {
+            Some(Ok(alert)) => Arc::new(alert),
+            Some(Err(_)) | None => {
+                info!("Peer {} sends us malformed message", peer_index);
+                nc.ban_peer(peer_index, BAD_MESSAGE_BAN_TIME);
+                return;
+            }
+        };
+        trace!("receive alert {} from peer {}", alert.id, peer_index);
+        // ignore alert
+        if self.received_alerts.contains_key(&alert.id)
+            || self.cancel_filter.contains_key(&alert.id)
+        {
+            return;
+        }
+        // verify
+        if let Err(err) = self.verifier.verify_signatures(&alert) {
+            debug!(
+                "Peer {} sends us a alert with invalid signatures, error {:?}",
+                peer_index, err
+            );
+            nc.ban_peer(peer_index, BAD_MESSAGE_BAN_TIME);
+            return;
+        }
+        // mark sender as known
+        self.mark_as_known(peer_index, alert.id);
+        // broadcast message
+        let fbb = &mut FlatBufferBuilder::new();
+        let msg = AlertMessage::build_alert(fbb, &alert);
+        fbb.finish(msg, None);
+        let data = fbb.finished_data().into();
+        let selected_peers: Vec<PeerIndex> = nc
+            .connected_peers()
+            .into_iter()
+            .filter(|peer| self.mark_as_known(*peer, alert.id))
+            .collect();
+        nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data);
+        // add to received alerts
+        self.receive_new_alert(alert);
+    }
+}

--- a/util/network-alert/src/config.rs
+++ b/util/network-alert/src/config.rs
@@ -1,0 +1,15 @@
+use jsonrpc_types::JsonBytes;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub signatures_threshold: usize,
+    pub public_keys: Vec<JsonBytes>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let alert_config = include_bytes!("./alert.toml");
+        toml::from_slice(&alert_config[..]).expect("alert system config")
+    }
+}

--- a/util/network-alert/src/lib.rs
+++ b/util/network-alert/src/lib.rs
@@ -1,0 +1,17 @@
+//! Network Alert
+//! See https://en.bitcoin.it/wiki/Alert_system to learn the history of Bitcoin alert system.
+//! We implement the alert system in CKB for urgent situation,
+//! In CKB early stage we may meet the same crisis bugs that Bitcoin meet,
+//! in urgent case, CKB core team can send an alert message across CKB P2P network,
+//! the client will show the alert message, the other behaviors of CKB node will not change.
+//!
+//! Network Alert will be removed soon once the CKB network is considered mature.
+//!
+pub mod alert_relayer;
+pub mod config;
+pub mod notifier;
+pub mod verifier;
+
+use std::time::Duration;
+
+pub(crate) const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);

--- a/util/network-alert/src/notifier.rs
+++ b/util/network-alert/src/notifier.rs
@@ -60,6 +60,9 @@ impl Notifier {
         }
         warn!("receive a new alert: {}", alert.message);
         self.noticed_alerts.push(alert);
+        // sort by priority
+        self.noticed_alerts
+            .sort_by_key(|a| std::u32::MAX - a.priority);
     }
 
     pub fn cancel(&mut self, cancel_id: u32) {

--- a/util/network-alert/src/notifier.rs
+++ b/util/network-alert/src/notifier.rs
@@ -1,0 +1,58 @@
+use ckb_core::alert::Alert;
+use ckb_logger::warn;
+use ckb_util::Mutex;
+use std::sync::Arc;
+
+pub struct Notifier {
+    alerts: Mutex<Vec<Arc<Alert>>>,
+    client_version: String,
+}
+
+impl Notifier {
+    pub fn new(client_version: String) -> Self {
+        Notifier {
+            alerts: Mutex::new(Vec::new()),
+            client_version,
+        }
+    }
+
+    pub fn add(&self, alert: Arc<Alert>) {
+        if alert
+            .min_version
+            .as_ref()
+            .map(|min_v| self.client_version < *min_v)
+            == Some(true)
+        {
+            return;
+        }
+
+        if alert
+            .max_version
+            .as_ref()
+            .map(|max_v| self.client_version > *max_v)
+            == Some(true)
+        {
+            return;
+        }
+        let mut alerts = self.alerts.lock();
+        if alerts.contains(&alert) {
+            return;
+        }
+        warn!("receive a new alert: {}", alert.message);
+        alerts.push(alert);
+    }
+
+    pub fn cancel(&self, id: u32) {
+        let mut alerts = self.alerts.lock();
+        alerts.retain(|a| a.id == id);
+    }
+
+    pub fn clear_expired_alerts(&self, now: u64) {
+        let mut alerts = self.alerts.lock();
+        alerts.retain(|a| a.notice_until > now);
+    }
+
+    pub fn alerts(&self) -> Vec<Arc<Alert>> {
+        self.alerts.lock().clone()
+    }
+}

--- a/util/network-alert/src/notifier.rs
+++ b/util/network-alert/src/notifier.rs
@@ -1,22 +1,43 @@
 use ckb_core::alert::Alert;
 use ckb_logger::warn;
-use ckb_util::Mutex;
+use fnv::FnvHashMap;
+use lru_cache::LruCache;
 use std::sync::Arc;
 
+const CANCEL_FILTER_SIZE: usize = 128;
+
 pub struct Notifier {
-    alerts: Mutex<Vec<Arc<Alert>>>,
+    /// cancelled alerts
+    cancel_filter: LruCache<u32, ()>,
+    /// alerts we received
+    received_alerts: FnvHashMap<u32, Arc<Alert>>,
+    /// alerts that self node should notice
+    noticed_alerts: Vec<Arc<Alert>>,
     client_version: String,
 }
 
 impl Notifier {
     pub fn new(client_version: String) -> Self {
         Notifier {
-            alerts: Mutex::new(Vec::new()),
+            cancel_filter: LruCache::new(CANCEL_FILTER_SIZE),
+            received_alerts: Default::default(),
+            noticed_alerts: Vec::new(),
             client_version,
         }
     }
 
-    pub fn add(&self, alert: Arc<Alert>) {
+    pub fn add(&mut self, alert: Arc<Alert>) {
+        if self.has_received(alert.id) {
+            return;
+        }
+        // checkout cancel_id
+        if alert.cancel > 0 {
+            self.cancel(alert.cancel);
+        }
+        // add to received alerts
+        self.received_alerts.insert(alert.id, Arc::clone(&alert));
+
+        // check conditions, figure out do we need to notice this alert
         if alert
             .min_version
             .as_ref()
@@ -34,25 +55,36 @@ impl Notifier {
         {
             return;
         }
-        let mut alerts = self.alerts.lock();
-        if alerts.contains(&alert) {
+        if self.noticed_alerts.contains(&alert) {
             return;
         }
         warn!("receive a new alert: {}", alert.message);
-        alerts.push(alert);
+        self.noticed_alerts.push(alert);
     }
 
-    pub fn cancel(&self, id: u32) {
-        let mut alerts = self.alerts.lock();
-        alerts.retain(|a| a.id == id);
+    pub fn cancel(&mut self, cancel_id: u32) {
+        self.cancel_filter.insert(cancel_id, ());
+        self.received_alerts.remove(&cancel_id);
+        self.noticed_alerts.retain(|a| a.id != cancel_id);
     }
 
-    pub fn clear_expired_alerts(&self, now: u64) {
-        let mut alerts = self.alerts.lock();
-        alerts.retain(|a| a.notice_until > now);
+    pub fn clear_expired_alerts(&mut self, now: u64) {
+        self.received_alerts
+            .retain(|_id, alert| alert.notice_until > now);
+        self.noticed_alerts.retain(|a| a.notice_until > now);
     }
 
-    pub fn alerts(&self) -> Vec<Arc<Alert>> {
-        self.alerts.lock().clone()
+    pub fn has_received(&self, id: u32) -> bool {
+        self.received_alerts.contains_key(&id) || self.cancel_filter.contains_key(&id)
+    }
+
+    // all unexpired alerts
+    pub fn received_alerts(&self) -> Vec<Arc<Alert>> {
+        self.received_alerts.values().cloned().collect()
+    }
+
+    // alerts that self node should noticed
+    pub fn noticed_alerts(&self) -> Vec<Arc<Alert>> {
+        self.noticed_alerts.clone()
     }
 }

--- a/util/network-alert/src/verifier.rs
+++ b/util/network-alert/src/verifier.rs
@@ -1,0 +1,47 @@
+use crate::config::Config;
+use ckb_core::alert::Alert;
+use ckb_logger::{debug, trace};
+use failure::Error;
+use fnv::FnvHashSet;
+use multisig::secp256k1::{verify_m_of_n, Message, Pubkey, Signature};
+
+pub struct Verifier {
+    config: Config,
+    pubkeys: FnvHashSet<Pubkey>,
+}
+
+impl Verifier {
+    pub fn new(config: Config) -> Self {
+        let pubkeys = config
+            .public_keys
+            .iter()
+            .map(|raw| Pubkey::from_slice(raw.as_bytes()))
+            .collect::<Result<FnvHashSet<Pubkey>, _>>()
+            .expect("builtin pubkeys");
+        Verifier { config, pubkeys }
+    }
+
+    pub fn verify_signatures(&self, alert: &Alert) -> Result<(), Error> {
+        trace!("verify alert {:?}", alert);
+        let message = Message::from_slice(alert.hash().as_bytes())?;
+        let signatures: Vec<Signature> = alert
+            .signatures
+            .iter()
+            .filter_map(|sig_data| match Signature::from_slice(sig_data) {
+                Ok(sig) => Some(sig),
+                Err(err) => {
+                    debug!("signature error: {}", err);
+                    None
+                }
+            })
+            .collect();
+        verify_m_of_n(
+            &message,
+            self.config.signatures_threshold,
+            &signatures,
+            &self.pubkeys,
+        )
+        .map_err(|err| err.kind())?;
+        Ok(())
+    }
+}

--- a/util/network-alert/src/verifier.rs
+++ b/util/network-alert/src/verifier.rs
@@ -28,7 +28,14 @@ impl Verifier {
             .signatures
             .iter()
             .filter_map(|sig_data| match Signature::from_slice(sig_data) {
-                Ok(sig) => Some(sig),
+                Ok(sig) => {
+                    if sig.is_valid() {
+                        Some(sig)
+                    } else {
+                        debug!("invalid signature: {:?}", sig);
+                        None
+                    }
+                }
                 Err(err) => {
                     debug!("signature error: {}", err);
                     None


### PR DESCRIPTION
Introduce: 
https://en.bitcoin.it/wiki/Alert_system

Purpose: 
Implement the alert system in CKB for urgent situation,
In CKB early stage we may meet the same crisis bugs that Bitcoin meet,
in urgent case, CKB core team can send an alert message across CKB P2P network,
the client will show the alert message, the other behaviors of CKB node will not change.

The Network Alert will be removed soon once the CKB network is considered mature.

Implement:
1. Add a new network protocol `alt`.
2. Add a default disabled RPC `send_alert`.