### PR TITLE
[ᚬrc/v0.13.0] feat: upgrade CKB VM to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
  "ckb-protocol 0.13.0-pre",
  "ckb-resource 0.13.0-pre",
  "ckb-store 0.13.0-pre",
- "ckb-vm 0.12.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc)",
+ "ckb-vm 0.13.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0)",
  "crypto 0.13.0-pre",
  "dao 0.13.0-pre",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,21 +865,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.12.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc#5c443bc4cc79e28d1e7b5a813eeb492ba908c59e"
+version = "0.13.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0#85e38f07ed3de5334ebc06d74b18702d0ec87bdc"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.12.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc)",
+ "ckb-vm-definitions 0.13.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0)",
  "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.12.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc#5c443bc4cc79e28d1e7b5a813eeb492ba908c59e"
+version = "0.13.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0#85e38f07ed3de5334ebc06d74b18702d0ec87bdc"
 
 [[package]]
 name = "clang-sys"
@@ -3724,8 +3724,8 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum ckb-vm 0.12.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc)" = "<none>"
-"checksum ckb-vm-definitions 0.12.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=5c443bc)" = "<none>"
+"checksum ckb-vm 0.13.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0)" = "<none>"
+"checksum ckb-vm-definitions 0.13.0-pre (git+https://github.com/nervosnetwork/ckb-vm?rev=85e38f0)" = "<none>"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -12,7 +12,7 @@ crypto = {path = "../util/crypto"}
 ckb-core = { path = "../core" }
 ckb-store = { path = "../store" }
 hash = {path = "../util/hash"}
-ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "5c443bc", features = ["asm"] }
+ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm", rev = "85e38f0", features = ["asm"] }
 faster-hex = "0.3"
 fnv = "1.0.3"
 flatbuffers = "0.6.0"


### PR DESCRIPTION
This upgrade contains the following changes:

# Refactors

* #57 calculate address first before cond operation @xxuejie

# Bug fixes

* #60 fix broken bench tests @mohanson
* #61 VM panics when ELF uses invalid file offset @xxuejie
* #63 out of bound read check in assembly VM

# Chore

* #59 fix a bad way to using machine @mohanson
* #61 add an example named is13 @mohanson