### PR TITLE
[ᚬrc/v0.13.0] fix: cuckoo cycle max edge verification

### DIFF
--- a/pow/src/cuckoo.rs
+++ b/pow/src/cuckoo.rs
@@ -167,6 +167,7 @@ pub struct Cuckoo {
 
 impl Cuckoo {
     pub fn new(edge_bits: u8, cycle_length: usize) -> Self {
+        assert!(cycle_length > 0, "cycle_length must be larger than 0");
         Self {
             max_edge: 1 << edge_bits,
             edge_mask: (1 << edge_bits) - 1,
@@ -181,22 +182,11 @@ impl Cuckoo {
             return false;
         }
 
-        // Check if proof values are in valid range
-        // Should be monotonically increasing
-        let is_monotonous = proof
-            .iter()
-            .rev()
-            .try_fold(
-                self.max_edge as u32,
-                |x, y| {
-                    if x > *y {
-                        Ok(*y)
-                    } else {
-                        Err(())
-                    }
-                },
-            )
-            .is_ok();
+        if u64::from(proof[self.cycle_length - 1]) > self.max_edge {
+            return false;
+        }
+
+        let is_monotonous = proof.windows(2).all(|w| w[0] < w[1]);
         if !is_monotonous {
             return false;
         }


### PR DESCRIPTION
The last point can be equal to the max edge.