### PR TITLE
[HOLD] refactor: Flatten sync states into SyncSharedState

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -61,11 +61,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         args.config.sync,
     );
 
-    let relayer = Relayer::new(
-        chain_controller.clone(),
-        sync_shared_state,
-        Arc::clone(synchronizer.peers()),
-    );
+    let relayer = Relayer::new(chain_controller.clone(), sync_shared_state);
     let net_timer = NetTimeProtocol::default();
 
     let synchronizer_clone = synchronizer.clone();

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -51,8 +51,7 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         // deprecated
         Ok(self
             .synchronizer
-            .peers()
-            .blocks_inflight
+            .inflight_blocks
             .read()
             .blocks_iter()
             .map(|(peer, blocks)| PeerState::new(peer.value(), 0, blocks.len()))

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -39,7 +39,7 @@ impl<'a, CS: ChainStore + 'static> BlockProposalProcess<'a, CS> {
             .into_iter()
             .filter_map(|tx| {
                 let tx_hash = tx.hash();
-                if self.relayer.state.already_known_tx(&tx_hash) {
+                if self.relayer.already_known_tx(&tx_hash) {
                     None
                 } else {
                     Some((tx_hash.to_owned(), tx))
@@ -49,14 +49,14 @@ impl<'a, CS: ChainStore + 'static> BlockProposalProcess<'a, CS> {
         if unknown_txs.is_empty() {
             return Ok(());
         }
-        let mut inflight = self.relayer.state.inflight_proposals.lock();
+        let mut inflight = self.relayer.inflight_proposals.lock();
         // filter txs that we ask for download
         let asked_txs = unknown_txs
             .into_iter()
             .filter_map(|(tx_hash, tx)| {
                 if inflight.remove(&ProposalShortId::from_tx_hash(&tx_hash)) {
                     // mark as known
-                    self.relayer.state.mark_as_known_tx(tx_hash);
+                    self.relayer.mark_as_known_tx(tx_hash);
                     Some(tx)
                 } else {
                     None

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -33,7 +33,6 @@ impl<'a, CS: ChainStore + 'static> BlockTransactionsProcess<'a, CS> {
         let block_hash = cast!(self.message.block_hash())?.try_into()?;
         if let Some(compact_block) = self
             .relayer
-            .state
             .pending_compact_blocks
             .lock()
             .remove(&block_hash)

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -31,12 +31,7 @@ impl<'a, CS: ChainStore + 'static> BlockTransactionsProcess<'a, CS> {
 
     pub fn execute(self) -> Result<(), FailureError> {
         let block_hash = cast!(self.message.block_hash())?.try_into()?;
-        if let Some(compact_block) = self
-            .relayer
-            .pending_compact_blocks
-            .lock()
-            .remove(&block_hash)
-        {
+        if let Some(compact_block) = self.relayer.remove_pending_compact_block(&block_hash) {
             let transactions: Vec<Transaction> =
                 FlatbuffersVectorIterator::new(cast!(self.message.transactions())?)
                     .map(TryInto::try_into)

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -43,13 +43,11 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
         let compact_block: CompactBlock = (*self.message).try_into()?;
         let block_hash = compact_block.header.hash().to_owned();
 
-        if self.relayer.state.already_known_compact_block(&block_hash) {
+        if self.relayer.already_known_compact_block(&block_hash) {
             debug!(target: "relay", "discarding already known compact block {:x}", block_hash);
             return Ok(());
         }
-        self.relayer
-            .state
-            .mark_as_known_compact_block(block_hash.clone());
+        self.relayer.mark_as_known_compact_block(block_hash.clone());
 
         if let Some(parent_header_view) = self
             .relayer
@@ -83,7 +81,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
         let mut missing_indexes: Vec<usize> = Vec::new();
         {
             // Verify compact block
-            let mut pending_compact_blocks = self.relayer.state.pending_compact_blocks.lock();
+            let mut pending_compact_blocks = self.relayer.pending_compact_blocks.lock();
             if pending_compact_blocks.get(&block_hash).is_some()
                 || self.relayer.shared.get_block(&block_hash).is_some()
             {

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -54,16 +54,16 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
             .shared
             .get_header_view(&compact_block.header.parent_hash())
         {
-            let best_known_header = self.relayer.shared.best_known_header();
+            let shared_best_header = self.relayer.shared.shared_best_header();
             let current_total_difficulty =
                 parent_header_view.total_difficulty() + compact_block.header.difficulty();
-            if current_total_difficulty <= *best_known_header.total_difficulty() {
+            if current_total_difficulty <= *shared_best_header.total_difficulty() {
                 debug!(
                     target: "relay",
                     "Received a compact block({:#x}), total difficulty {:#x} <= {:#x}, ignore it",
                     block_hash,
                     current_total_difficulty,
-                    best_known_header.total_difficulty(),
+                    shared_best_header.total_difficulty(),
                 );
                 return Ok(());
             }

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -1,5 +1,5 @@
 use crate::relayer::Relayer;
-use ckb_core::transaction::ProposalShortId;
+use ckb_core::transaction::{ProposalShortId, Transaction};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, GetBlockProposal, RelayMessage};
 use ckb_store::ChainStore;
@@ -31,31 +31,39 @@ impl<'a, CS: ChainStore> GetBlockProposalProcess<'a, CS> {
     }
 
     pub fn execute(self) -> Result<(), FailureError> {
-        let mut pending_proposals_request = self.relayer.state.pending_proposals_request.lock();
-        let proposals = cast!(self.message.proposals())?;
-
-        let transactions = {
-            let chain_state = self.relayer.shared.lock_chain_state();
-            let tx_pool = chain_state.tx_pool();
-
-            let proposals: Vec<ProposalShortId> = proposals
+        let proposals: Vec<ProposalShortId> = {
+            let proposals = cast!(self.message.proposals())?;
+            proposals
                 .iter()
                 .map(TryInto::try_into)
-                .collect::<Result<_, FailureError>>()?;
-
-            proposals
-                .into_iter()
-                .filter_map(|short_id| {
-                    tx_pool.get_tx(&short_id).or({
-                        pending_proposals_request
-                            .entry(short_id)
-                            .or_insert_with(Default::default)
-                            .insert(self.peer);
-                        None
-                    })
-                })
-                .collect::<Vec<_>>()
+                .collect::<Result<_, FailureError>>()?
         };
+        let pool_transactions: Vec<Option<Transaction>> = {
+            let chain_state = self.relayer.shared.lock_chain_state();
+            let tx_pool = chain_state.tx_pool();
+            proposals
+                .iter()
+                .map(|short_id| tx_pool.get_tx(short_id))
+                .collect()
+        };
+        let fresh_proposals: Vec<ProposalShortId> = proposals
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, short_id)| {
+                if pool_transactions[index].is_none() {
+                    Some(short_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let transactions: Vec<Transaction> = pool_transactions
+            .into_iter()
+            .filter_map(|pool_transaction| pool_transaction)
+            .collect();
+
+        self.relayer
+            .insert_get_block_proposals(fresh_proposals, self.peer);
 
         let fbb = &mut FlatBufferBuilder::new();
         let message = RelayMessage::build_block_proposal(fbb, &transactions);

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -41,7 +41,6 @@ use faketime::unix_time_as_millis;
 use flatbuffers::FlatBufferBuilder;
 use fnv::FnvHashMap;
 use log::{debug, info, trace};
-use numext_fixed_hash::H256;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -384,23 +383,6 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                 nc.send_message_to(*peer, data);
             }
         }
-    }
-
-    fn mark_as_known_tx(&self, hash: H256) {
-        self.tx_already_asked.lock().remove(&hash);
-        self.tx_filter.lock().insert(hash, ());
-    }
-
-    fn already_known_tx(&self, hash: &H256) -> bool {
-        self.tx_filter.lock().contains_key(hash)
-    }
-
-    fn already_known_compact_block(&self, hash: &H256) -> bool {
-        self.compact_block_filter.lock().contains_key(hash)
-    }
-
-    fn mark_as_known_compact_block(&self, hash: H256) {
-        self.compact_block_filter.lock().insert(hash, ());
     }
 }
 

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -27,7 +27,7 @@ use crate::types::SyncSharedState;
 use crate::BAD_MESSAGE_BAN_TIME;
 use ckb_chain::chain::ChainController;
 use ckb_core::block::{Block, BlockBuilder};
-use ckb_core::transaction::Transaction;
+use ckb_core::transaction::{ProposalShortId, Transaction};
 use ckb_core::uncle::UncleBlock;
 use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
 use ckb_protocol::{
@@ -192,19 +192,28 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         peer: PeerIndex,
         block: &CompactBlock,
     ) {
-        let mut inflight = self.inflight_proposals.lock();
-        let unknown_ids = block
+        let proposals = block
             .proposals
             .iter()
-            .chain(block.uncles.iter().flat_map(UncleBlock::proposals))
-            .filter(|x| !chain_state.contains_proposal_id(x) && inflight.insert(**x))
+            .chain(block.uncles.iter().flat_map(UncleBlock::proposals));
+        let fresh_proposals: Vec<ProposalShortId> = proposals
+            .filter(|id| !chain_state.contains_proposal_id(id))
             .cloned()
-            .collect::<Vec<_>>();
+            .collect();
+        let to_ask_proposals: Vec<ProposalShortId> = self
+            .insert_inflight_proposals(fresh_proposals.clone())
+            .into_iter()
+            .zip(fresh_proposals)
+            .filter_map(|(firstly_in, id)| if firstly_in { Some(id) } else { None })
+            .collect();
 
-        if !unknown_ids.is_empty() {
+        if !to_ask_proposals.is_empty() {
             let fbb = &mut FlatBufferBuilder::new();
-            let message =
-                RelayMessage::build_get_block_proposal(fbb, block.header.number(), &unknown_ids);
+            let message = RelayMessage::build_get_block_proposal(
+                fbb,
+                block.header.number(),
+                &to_ask_proposals,
+            );
             fbb.finish(message, None);
 
             nc.send_message_to(peer, fbb.finished_data().into());

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -23,7 +23,7 @@ use self::get_transaction_process::GetTransactionProcess;
 use self::transaction_hash_process::TransactionHashProcess;
 use self::transaction_process::TransactionProcess;
 use crate::relayer::compact_block::ShortTransactionID;
-use crate::types::{Peers, SyncSharedState};
+use crate::types::SyncSharedState;
 use crate::BAD_MESSAGE_BAN_TIME;
 use ckb_chain::chain::ChainController;
 use ckb_core::block::{Block, BlockBuilder};
@@ -45,6 +45,7 @@ use log::{debug, info, trace};
 use lru_cache::LruCache;
 use numext_fixed_hash::H256;
 use std::collections::HashSet;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -60,9 +61,21 @@ pub struct Relayer<CS> {
     chain: ChainController,
     pub(crate) shared: Arc<SyncSharedState<CS>>,
     pub(crate) state: Arc<RelayState>,
-    // TODO refactor shared Peers struct with Synchronizer
-    peers: Arc<Peers>,
     pub(crate) tx_pool_executor: Arc<TxPoolExecutor<CS>>,
+}
+
+impl<CS: ChainStore> Deref for Relayer<CS> {
+    type Target = Arc<SyncSharedState<CS>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared
+    }
+}
+
+impl<CS: ChainStore> DerefMut for Relayer<CS> {
+    fn deref_mut(&mut self) -> &mut Arc<SyncSharedState<CS>> {
+        &mut self.shared
+    }
 }
 
 impl<CS: ChainStore> Clone for Relayer<CS> {
@@ -71,24 +84,18 @@ impl<CS: ChainStore> Clone for Relayer<CS> {
             chain: self.chain.clone(),
             shared: Arc::clone(&self.shared),
             state: Arc::clone(&self.state),
-            peers: Arc::clone(&self.peers),
             tx_pool_executor: Arc::clone(&self.tx_pool_executor),
         }
     }
 }
 
 impl<CS: ChainStore + 'static> Relayer<CS> {
-    pub fn new(
-        chain: ChainController,
-        shared: Arc<SyncSharedState<CS>>,
-        peers: Arc<Peers>,
-    ) -> Self {
+    pub fn new(chain: ChainController, shared: Arc<SyncSharedState<CS>>) -> Self {
         let tx_pool_executor = Arc::new(TxPoolExecutor::new(shared.shared().clone()));
         Relayer {
             chain,
             shared,
             state: Arc::new(RelayState::default()),
-            peers,
             tx_pool_executor,
         }
     }
@@ -224,7 +231,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             fbb.finish(message, None);
             let data = fbb.finished_data().into();
 
-            let mut known_blocks = self.peers.known_blocks.lock();
+            let mut known_blocks = self.peers().known_blocks.lock();
             let selected_peers: Vec<PeerIndex> = nc
                 .connected_peers()
                 .into_iter()
@@ -353,7 +360,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
 
     // Ask for relay transaction by hash from all peers
     pub fn ask_for_txs(&self, nc: &CKBProtocolContext) {
-        for (peer, peer_state) in self.peers.state.write().iter_mut() {
+        for (peer, peer_state) in self.peers().state.write().iter_mut() {
             let tx_hashes = peer_state
                 .pop_ask_for_txs()
                 .into_iter()

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -232,7 +232,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             fbb.finish(message, None);
             let data = fbb.finished_data().into();
 
-            let mut known_blocks = self.peers().known_blocks.lock();
+            let mut known_blocks = self.known_blocks.lock();
             let selected_peers: Vec<PeerIndex> = nc
                 .connected_peers()
                 .into_iter()
@@ -355,7 +355,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
 
     // Ask for relay transaction by hash from all peers
     pub fn ask_for_txs(&self, nc: &CKBProtocolContext) {
-        for (peer, peer_state) in self.peers().state.write().iter_mut() {
+        for (peer, peer_state) in self.peers_state.write().iter_mut() {
             let tx_hashes = peer_state
                 .pop_ask_for_txs()
                 .into_iter()

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -123,11 +123,7 @@ fn build_chain(tip: BlockNumber) -> (Relayer<ChainKVStore<MemoryKeyValueDB>>, Ou
 
     let sync_shared_state = Arc::new(SyncSharedState::new(shared));
     (
-        Relayer::new(
-            chain_controller,
-            sync_shared_state,
-            Arc::new(Default::default()),
-        ),
+        Relayer::new(chain_controller, sync_shared_state),
         always_success_out_point,
     )
 }

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -66,8 +66,7 @@ impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
             let last_ask_timeout = self.relayer.tx_already_asked.lock().get(&tx_hash).cloned();
             if let Some(next_ask_timeout) = self
                 .relayer
-                .peers()
-                .state
+                .peers_state
                 .write()
                 .get_mut(&self.peer)
                 .and_then(|peer_state| peer_state.add_ask_for_tx(tx_hash.clone(), last_ask_timeout))

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -63,7 +63,12 @@ impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
                 tx_hash,
                 self.peer,
             );
-            let last_ask_timeout = self.relayer.tx_already_asked.lock().get(&tx_hash).cloned();
+            let last_ask_timeout = self
+                .relayer
+                .inflight_transactions
+                .lock()
+                .get(&tx_hash)
+                .cloned();
             if let Some(next_ask_timeout) = self
                 .relayer
                 .peers_state
@@ -72,7 +77,7 @@ impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
                 .and_then(|peer_state| peer_state.add_ask_for_tx(tx_hash.clone(), last_ask_timeout))
             {
                 self.relayer
-                    .tx_already_asked
+                    .inflight_transactions
                     .lock()
                     .insert(tx_hash.clone(), next_ask_timeout);
             }

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -16,7 +16,7 @@ pub struct TransactionHashProcess<'a, CS> {
     peer: PeerIndex,
 }
 
-impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
+impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
     pub fn new(
         message: &'a FbsRelayTransactionHash,
         relayer: &'a Relayer<CS>,
@@ -34,7 +34,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
     pub fn execute(self) -> Result<(), FailureError> {
         let tx_hash: H256 = (*self.message).try_into()?;
         let short_id = ProposalShortId::from_tx_hash(&tx_hash);
-        if self.relayer.state.already_known_tx(&tx_hash) {
+        if self.relayer.already_known_tx(&tx_hash) {
             debug!(
                 target: "relay",
                 "transaction({:#x}) from {} already known, ignore it",
@@ -55,7 +55,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 tx_hash,
                 self.peer,
             );
-            self.relayer.state.mark_as_known_tx(tx_hash.clone());
+            self.relayer.mark_as_known_tx(tx_hash.clone());
         } else {
             debug!(
                 target: "relay",
@@ -63,13 +63,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 tx_hash,
                 self.peer,
             );
-            let last_ask_timeout = self
-                .relayer
-                .state
-                .tx_already_asked
-                .lock()
-                .get(&tx_hash)
-                .cloned();
+            let last_ask_timeout = self.relayer.tx_already_asked.lock().get(&tx_hash).cloned();
             if let Some(next_ask_timeout) = self
                 .relayer
                 .peers()
@@ -79,7 +73,6 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 .and_then(|peer_state| peer_state.add_ask_for_tx(tx_hash.clone(), last_ask_timeout))
             {
                 self.relayer
-                    .state
                     .tx_already_asked
                     .lock()
                     .insert(tx_hash.clone(), next_ask_timeout);

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -72,7 +72,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 .cloned();
             if let Some(next_ask_timeout) = self
                 .relayer
-                .peers
+                .peers()
                 .state
                 .write()
                 .get_mut(&self.peer)

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -49,7 +49,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
         // Remove tx_hash from `tx_already_asked`
         self.relayer.mark_as_known_tx(tx_hash.clone());
         // Remove tx_hash from `tx_ask_for_set`
-        if let Some(peer_state) = self.relayer.peers().state.write().get_mut(&self.peer) {
+        if let Some(peer_state) = self.relayer.peers_state.write().get_mut(&self.peer) {
             peer_state.remove_ask_for_tx(&tx_hash);
         }
 
@@ -70,7 +70,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
                         match tx_result {
                             Ok(cycles) if cycles == relay_cycles => {
                                 let selected_peers: Vec<PeerIndex> = {
-                                    let mut known_txs = shared.peers().known_txs.lock();
+                                    let mut known_txs = shared.known_txs.lock();
                                     nc.connected_peers()
                                         .into_iter()
                                         .filter(|target_peer| {

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -40,14 +40,14 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
         let (tx, relay_cycles): (Transaction, Cycle) = (*self.message).try_into()?;
         let tx_hash = tx.hash();
 
-        if self.relayer.state.already_known_tx(&tx_hash) {
+        if self.relayer.already_known_tx(&tx_hash) {
             debug!(target: "relay", "discarding already known transaction {:#x}", tx_hash);
             return Ok(());
         }
 
         // Insert tx_hash into `already_known`
         // Remove tx_hash from `tx_already_asked`
-        self.relayer.state.mark_as_known_tx(tx_hash.clone());
+        self.relayer.mark_as_known_tx(tx_hash.clone());
         // Remove tx_hash from `tx_ask_for_set`
         if let Some(peer_state) = self.relayer.peers().state.write().get_mut(&self.peer) {
             peer_state.remove_ask_for_tx(&tx_hash);

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -49,7 +49,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
         // Remove tx_hash from `tx_already_asked`
         self.relayer.state.mark_as_known_tx(tx_hash.clone());
         // Remove tx_hash from `tx_ask_for_set`
-        if let Some(peer_state) = self.relayer.peers.state.write().get_mut(&self.peer) {
+        if let Some(peer_state) = self.relayer.peers().state.write().get_mut(&self.peer) {
             peer_state.remove_ask_for_tx(&tx_hash);
         }
 
@@ -58,7 +58,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
             let nc = Arc::clone(&self.nc);
             let self_peer = self.peer;
             let tx_pool_executor = Arc::clone(&self.relayer.tx_pool_executor);
-            let peers = Arc::clone(&self.relayer.peers);
+            let shared = Arc::clone(&self.relayer.shared);
             let tx_hash = tx_hash.clone();
             let tx = tx.to_owned();
             Box::new(
@@ -70,7 +70,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
                         match tx_result {
                             Ok(cycles) if cycles == relay_cycles => {
                                 let selected_peers: Vec<PeerIndex> = {
-                                    let mut known_txs = peers.known_txs.lock();
+                                    let mut known_txs = shared.peers().known_txs.lock();
                                     nc.connected_peers()
                                         .into_iter()
                                         .filter(|target_peer| {

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -1,5 +1,5 @@
-use crate::synchronizer::{BlockStatus, Synchronizer};
-use crate::types::HeaderView;
+use crate::synchronizer::Synchronizer;
+use crate::types::{BlockStatus, HeaderView};
 use crate::{BLOCK_DOWNLOAD_WINDOW, MAX_BLOCKS_IN_TRANSIT_PER_PEER, PER_FETCH_BLOCK_LIMIT};
 use ckb_core::header::Header;
 use ckb_network::PeerIndex;
@@ -36,7 +36,7 @@ where
         }
     }
     pub fn reached_inflight_limit(&self) -> bool {
-        let inflight = self.synchronizer.peers.blocks_inflight.read();
+        let inflight = self.synchronizer.peers().blocks_inflight.read();
 
         // Can't download any more from this peer
         inflight.peer_inflight_count(&self.peer) >= MAX_BLOCKS_IN_TRANSIT_PER_PEER
@@ -47,7 +47,7 @@ where
     }
 
     pub fn peer_best_known_header(&self) -> Option<HeaderView> {
-        self.synchronizer.peers.get_best_known_header(self.peer)
+        self.synchronizer.peers().get_best_known_header(self.peer)
     }
 
     pub fn last_common_header(&self, best: &HeaderView) -> Option<Header> {
@@ -76,7 +76,7 @@ where
         Some(fixed_last_common_header)
     }
 
-    // this peer's tip is wherethe the ancestor of global_best_known_header
+    // this peer's tip is where the the ancestor of global_best_known_header
     pub fn is_known_best(&self, header: &HeaderView) -> bool {
         let global_best_known_header = self.synchronizer.shared.best_known_header();
         if let Some(ancestor) = self
@@ -166,7 +166,7 @@ where
         let mut fetch = Vec::with_capacity(PER_FETCH_BLOCK_LIMIT);
 
         {
-            let mut inflight = self.synchronizer.peers.blocks_inflight.write();
+            let mut inflight = self.synchronizer.peers().blocks_inflight.write();
             let count = MAX_BLOCKS_IN_TRANSIT_PER_PEER
                 .saturating_sub(inflight.peer_inflight_count(&self.peer));
 

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -34,7 +34,7 @@ where
         let block: Block = (*self.message).try_into()?;
         debug!(target: "sync", "BlockProcess received block {} {:x}", block.header().number(), block.header().hash());
 
-        if self.synchronizer.peers().new_block_received(&block) {
+        if self.synchronizer.new_block_received(&block) {
             self.synchronizer.process_new_block(self.peer, block);
         }
         Ok(())

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -34,7 +34,7 @@ where
         let block: Block = (*self.message).try_into()?;
         debug!(target: "sync", "BlockProcess received block {} {:x}", block.header().number(), block.header().hash());
 
-        if self.synchronizer.peers.new_block_received(&block) {
+        if self.synchronizer.peers().new_block_received(&block) {
             self.synchronizer.process_new_block(self.peer, block);
         }
         Ok(())

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -66,7 +66,7 @@ where
                 self.synchronizer.shared.tip_header().number(),
             );
 
-            self.synchronizer.peers().getheaders_received(self.peer);
+            self.synchronizer.getheaders_received(self.peer);
             let headers: Vec<Header> = self
                 .synchronizer
                 .shared

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -66,7 +66,7 @@ where
                 self.synchronizer.shared.tip_header().number(),
             );
 
-            self.synchronizer.peers.getheaders_received(self.peer);
+            self.synchronizer.peers().getheaders_received(self.peer);
             let headers: Vec<Header> = self
                 .synchronizer
                 .shared

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -1,4 +1,5 @@
-use crate::synchronizer::{BlockStatus, Synchronizer};
+use crate::synchronizer::Synchronizer;
+use crate::types::BlockStatus;
 use crate::MAX_HEADERS_LEN;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
@@ -162,7 +163,7 @@ where
         let headers = cast!(self.message.headers())?;
 
         if headers.len() > MAX_HEADERS_LEN {
-            self.synchronizer.peers.misbehavior(self.peer, 20);
+            self.synchronizer.peers().misbehavior(self.peer, 20);
             warn!(target: "sync", "HeadersProcess is_oversize");
             return Ok(());
         }
@@ -191,7 +192,7 @@ where
             .collect::<Result<Vec<Header>, FailureError>>()?;
 
         if !self.is_continuous(&headers) {
-            self.synchronizer.peers.misbehavior(self.peer, 20);
+            self.synchronizer.peers().misbehavior(self.peer, 20);
             debug!(target: "sync", "HeadersProcess is not continuous");
             return Ok(());
         }
@@ -200,7 +201,7 @@ where
         if !result.is_valid() {
             if result.misbehavior > 0 {
                 self.synchronizer
-                    .peers
+                    .peers()
                     .misbehavior(self.peer, result.misbehavior);
             }
             debug!(target: "sync", "HeadersProcess accept_first is_valid {:?} headers = {:?}", result, headers[0]);
@@ -221,7 +222,7 @@ where
                 if !result.is_valid() {
                     if result.misbehavior > 0 {
                         self.synchronizer
-                            .peers
+                            .peers()
                             .misbehavior(self.peer, result.misbehavior);
                     }
                     debug!(target: "sync", "HeadersProcess accept is invalid {:?}", result);
@@ -232,7 +233,7 @@ where
 
         if log_enabled!(target: "sync", log::Level::Debug) {
             let chain_state = self.synchronizer.shared.lock_chain_state();
-            let peer_best_known = self.synchronizer.peers.get_best_known_header(self.peer);
+            let peer_best_known = self.synchronizer.peers().get_best_known_header(self.peer);
             debug!(
                 target: "sync",
                 "chain: num={}, diff={:#x};",
@@ -277,7 +278,7 @@ where
         // chain. Disconnect peers that are on chains with insufficient work.
         let (is_outbound, is_protected) = self
             .synchronizer
-            .peers
+            .peers()
             .state
             .read()
             .get(&self.peer)

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -12,28 +12,25 @@ use self::get_blocks_process::GetBlocksProcess;
 use self::get_headers_process::GetHeadersProcess;
 use self::headers_process::HeadersProcess;
 use crate::config::Config;
-use crate::types::{HeaderView, Peers, SyncSharedState};
+use crate::types::{BlockStatus, HeaderView, SyncSharedState};
 use crate::{
     BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
     HEADERS_DOWNLOAD_TIMEOUT_BASE, HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER, MAX_HEADERS_LEN,
     MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, POW_SPACE, PROTECT_STOP_SYNC_TIME,
 };
-use bitflags::bitflags;
 use ckb_chain::chain::ChainController;
 use ckb_core::block::Block;
 use ckb_core::header::Header;
 use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_protocol::{cast, get_root, SyncMessage, SyncPayload};
 use ckb_store::ChainStore;
-use ckb_util::Mutex;
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use flatbuffers::FlatBufferBuilder;
-use hashbrown::HashMap;
 use log::{debug, info, trace};
 use numext_fixed_hash::H256;
 use std::cmp::min;
-use std::sync::atomic::AtomicUsize;
+use std::ops::{Deref, DerefMut};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -45,37 +42,10 @@ pub const NO_PEER_CHECK_TOKEN: u64 = 255;
 const SYNC_NOTIFY_INTERVAL: Duration = Duration::from_millis(200);
 const BLOCK_FETCH_INTERVAL: Duration = Duration::from_millis(400);
 
-bitflags! {
-    pub struct BlockStatus: u32 {
-        const UNKNOWN            = 0;
-        const VALID_HEADER       = 1;
-        const VALID_TREE         = 2;
-        const VALID_TRANSACTIONS = 3;
-        const VALID_CHAIN        = 4;
-        const VALID_SCRIPTS      = 5;
-
-        const VALID_MASK         = Self::VALID_HEADER.bits | Self::VALID_TREE.bits | Self::VALID_TRANSACTIONS.bits |
-                                   Self::VALID_CHAIN.bits | Self::VALID_SCRIPTS.bits;
-        const BLOCK_HAVE_DATA    = 8;
-        const BLOCK_HAVE_UNDO    = 16;
-        const BLOCK_HAVE_MASK    = Self::BLOCK_HAVE_DATA.bits | Self::BLOCK_HAVE_UNDO.bits;
-        const FAILED_VALID       = 32;
-        const FAILED_CHILD       = 64;
-        const FAILED_MASK        = Self::FAILED_VALID.bits | Self::FAILED_CHILD.bits;
-    }
-}
-
-pub type BlockStatusMap = Arc<Mutex<HashMap<H256, BlockStatus>>>;
-
 pub struct Synchronizer<CS: ChainStore> {
     chain: ChainController,
     pub shared: Arc<SyncSharedState<CS>>,
-    pub status_map: BlockStatusMap,
-    pub peers: Arc<Peers>,
-    pub config: Arc<Config>,
     pub orphan_block_pool: Arc<OrphanBlockPool>,
-    pub n_sync_started: Arc<AtomicUsize>,
-    pub n_protected_outbound_peers: Arc<AtomicUsize>,
 }
 
 // https://github.com/rust-lang/rust/issues/40754
@@ -84,13 +54,22 @@ impl<CS: ChainStore> ::std::clone::Clone for Synchronizer<CS> {
         Synchronizer {
             chain: self.chain.clone(),
             shared: Arc::clone(&self.shared),
-            status_map: Arc::clone(&self.status_map),
-            n_sync_started: Arc::clone(&self.n_sync_started),
-            peers: Arc::clone(&self.peers),
-            config: Arc::clone(&self.config),
             orphan_block_pool: Arc::clone(&self.orphan_block_pool),
-            n_protected_outbound_peers: Arc::clone(&self.n_protected_outbound_peers),
         }
+    }
+}
+
+impl<CS: ChainStore> Deref for Synchronizer<CS> {
+    type Target = Arc<SyncSharedState<CS>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared
+    }
+}
+
+impl<CS: ChainStore> DerefMut for Synchronizer<CS> {
+    fn deref_mut(&mut self) -> &mut Arc<SyncSharedState<CS>> {
+        &mut self.shared
     }
 }
 
@@ -102,14 +81,9 @@ impl<CS: ChainStore> Synchronizer<CS> {
     ) -> Synchronizer<CS> {
         let orphan_block_limit = config.orphan_block_limit;
         Synchronizer {
-            config: Arc::new(config),
             chain,
             shared,
-            peers: Arc::new(Peers::default()),
             orphan_block_pool: Arc::new(OrphanBlockPool::with_capacity(orphan_block_limit)),
-            status_map: Arc::new(Mutex::new(HashMap::new())),
-            n_sync_started: Arc::new(AtomicUsize::new(0)),
-            n_protected_outbound_peers: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -152,29 +126,6 @@ impl<CS: ChainStore> Synchronizer<CS> {
         }
     }
 
-    pub fn get_block_status(&self, hash: &H256) -> BlockStatus {
-        let mut guard = self.status_map.lock();
-        match guard.get(hash).cloned() {
-            Some(s) => s,
-            None => {
-                if self.shared.block_header(hash).is_some() {
-                    guard.insert(hash.clone(), BlockStatus::BLOCK_HAVE_MASK);
-                    BlockStatus::BLOCK_HAVE_MASK
-                } else {
-                    BlockStatus::UNKNOWN
-                }
-            }
-        }
-    }
-
-    pub fn peers(&self) -> &Arc<Peers> {
-        &self.peers
-    }
-
-    pub fn insert_block_status(&self, hash: H256, status: BlockStatus) {
-        self.status_map.lock().insert(hash, status);
-    }
-
     pub fn predict_headers_sync_time(&self, header: &Header) -> u64 {
         let now = unix_time_as_millis();
         let expected_headers = min(
@@ -185,11 +136,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
     }
 
     pub fn mark_block_stored(&self, hash: H256) {
-        self.status_map
-            .lock()
-            .entry(hash)
-            .and_modify(|status| *status = BlockStatus::BLOCK_HAVE_MASK)
-            .or_insert_with(|| BlockStatus::BLOCK_HAVE_MASK);
+        self.shared
+            .insert_block_status(hash, BlockStatus::BLOCK_HAVE_MASK);
     }
 
     pub fn insert_header_view(&self, header: &Header, peer: PeerIndex) {
@@ -211,7 +159,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
                 header_view
             };
 
-            self.peers.new_header_received(peer, &header_view);
+            self.peers().new_header_received(peer, &header_view);
             self.shared
                 .insert_header_view(header.hash().to_owned(), header_view);
         }
@@ -238,7 +186,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
         self.chain.process_block(Arc::clone(&block), true)?;
         self.shared.remove_header_view(block.header().hash());
         self.mark_block_stored(block.header().hash().to_owned());
-        self.peers
+        self.peers()
             .set_last_common_header(peer, block.header().clone());
         Ok(())
     }
@@ -306,15 +254,15 @@ impl<CS: ChainStore> Synchronizer<CS> {
             .map(|peer| peer.is_outbound())
             .unwrap_or(false);
         let protect_outbound = is_outbound
-            && self.n_protected_outbound_peers.load(Ordering::Acquire)
+            && self.n_protected_outbound_peers().load(Ordering::Acquire)
                 < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT;
 
         if protect_outbound {
-            self.n_protected_outbound_peers
+            self.n_protected_outbound_peers()
                 .fetch_add(1, Ordering::Release);
         }
 
-        self.peers
+        self.peers()
             .on_connected(peer, None, protect_outbound, is_outbound);
     }
 
@@ -327,7 +275,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
     //     If their best known block is still behind when that new timeout is
     //     reached, disconnect.
     pub fn eviction(&self, nc: &CKBProtocolContext) {
-        let mut peer_states = self.peers.state.write();
+        let mut peer_states = self.peers().state.write();
         let is_initial_block_download = self.shared.is_initial_block_download();
         let mut eviction = Vec::new();
         for (peer, state) in peer_states.iter_mut() {
@@ -381,7 +329,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
                         if state.chain_sync.protect {
                             if state.sync_started {
                                 state.stop_sync(now + PROTECT_STOP_SYNC_TIME);
-                                self.n_sync_started.fetch_sub(1, Ordering::Release);
+                                self.n_sync_started().fetch_sub(1, Ordering::Release);
                             }
                         } else {
                             eviction.push(*peer);
@@ -412,7 +360,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
     fn start_sync_headers(&self, nc: &CKBProtocolContext) {
         let now = unix_time_as_millis();
         let peers: Vec<PeerIndex> = self
-            .peers
+            .peers()
             .state
             .read()
             .iter()
@@ -443,17 +391,17 @@ impl<CS: ChainStore> Synchronizer<CS> {
         for peer in peers {
             // Only sync with 1 peer if we're in IBD
             if self.shared.is_initial_block_download()
-                && self.n_sync_started.load(Ordering::Acquire) != 0
+                && self.n_sync_started().load(Ordering::Acquire) != 0
             {
                 break;
             }
             {
-                let mut state = self.peers.state.write();
+                let mut state = self.peers().state.write();
                 if let Some(peer_state) = state.get_mut(&peer) {
                     if !peer_state.sync_started {
                         let headers_sync_timeout = self.predict_headers_sync_time(&tip);
                         peer_state.start_sync(headers_sync_timeout);
-                        self.n_sync_started.fetch_add(1, Ordering::Release);
+                        self.n_sync_started().fetch_add(1, Ordering::Release);
                     }
                 }
             }
@@ -465,7 +413,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
     fn find_blocks_to_fetch(&self, nc: &CKBProtocolContext) {
         let peers: Vec<PeerIndex> = {
-            self.peers
+            self.peers()
                 .state
                 .read()
                 .iter()
@@ -477,7 +425,7 @@ impl<CS: ChainStore> Synchronizer<CS> {
 
         trace!(target: "sync", "poll find_blocks_to_fetch select peers");
         {
-            self.peers.blocks_inflight.write().prune();
+            self.peers().blocks_inflight.write().prune();
         }
         for peer in peers {
             if let Some(fetch) = self.get_blocks_to_fetch(peer) {
@@ -546,18 +494,19 @@ impl<CS: ChainStore> CKBProtocolHandler for Synchronizer<CS> {
 
     fn disconnected(&mut self, _nc: Arc<CKBProtocolContext + Sync>, peer_index: PeerIndex) {
         info!(target: "sync", "SyncProtocol.disconnected peer={}", peer_index);
-        if let Some(peer_state) = self.peers.disconnected(peer_index) {
+        if let Some(peer_state) = self.peers().disconnected(peer_index) {
             // It shouldn't happen
             // fetch_sub wraps around on overflow, we still check manually
             // panic here to prevent some bug be hidden silently.
-            if peer_state.sync_started && self.n_sync_started.fetch_sub(1, Ordering::Release) == 0 {
+            if peer_state.sync_started && self.n_sync_started().fetch_sub(1, Ordering::Release) == 0
+            {
                 panic!("Synchronizer n_sync overflow");
             }
         }
     }
 
     fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {
-        if !self.peers.state.read().is_empty() {
+        if !self.peers().state.read().is_empty() {
             let start_time = Instant::now();
             trace!(target: "sync", "start notify token={}", token);
 
@@ -615,7 +564,6 @@ mod tests {
     use fnv::{FnvHashMap, FnvHashSet};
     use futures::future::Future;
     use numext_fixed_uint::U256;
-    use std::ops::Deref;
     use std::time::Duration;
 
     fn start_chain(
@@ -1116,11 +1064,11 @@ mod tests {
             .execute()
             .expect("Process headers from peer2 failed");
         assert_eq!(
-            synchronizer1.peers.get_best_known_header(peer1),
-            synchronizer1.peers.get_best_known_header(peer2)
+            synchronizer1.peers().get_best_known_header(peer1),
+            synchronizer1.peers().get_best_known_header(peer2)
         );
 
-        let best_known_header = synchronizer1.peers.get_best_known_header(peer1);
+        let best_known_header = synchronizer1.peers().get_best_known_header(peer1);
 
         assert_eq!(best_known_header.unwrap().inner(), headers.last().unwrap());
 
@@ -1153,7 +1101,7 @@ mod tests {
 
         assert_eq!(
             synchronizer1
-                .peers
+                .peers()
                 .get_last_common_header(peer1)
                 .unwrap()
                 .hash(),
@@ -1234,7 +1182,9 @@ mod tests {
                 .get_mut(&sync_protected_peer)
                 .unwrap()
                 .start_sync(headers_sync_timeout);
-            synchronizer.n_sync_started.fetch_add(1, Ordering::Release);
+            synchronizer
+                .n_sync_started()
+                .fetch_add(1, Ordering::Release);
         }
         synchronizer.eviction(&network_context);
         {
@@ -1244,7 +1194,7 @@ mod tests {
                 peer_state.get(&sync_protected_peer).unwrap().sync_started,
                 true
             );
-            assert_eq!(synchronizer.n_sync_started.load(Ordering::Acquire), 1);
+            assert_eq!(synchronizer.n_sync_started().load(Ordering::Acquire), 1);
 
             assert!({ network_context.disconnected.lock().is_empty() });
             // start sync with protected peer
@@ -1330,7 +1280,7 @@ mod tests {
                 peer_state.get(&sync_protected_peer).unwrap().sync_started,
                 false
             );
-            assert_eq!(synchronizer.n_sync_started.load(Ordering::Acquire), 0);
+            assert_eq!(synchronizer.n_sync_started().load(Ordering::Acquire), 0);
 
             // Peer(3,4) run out of time to catch up!
             let disconnected = network_context.disconnected.lock();

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -220,6 +220,10 @@ impl KnownFilter {
             }
         }
     }
+
+    pub fn clear(&mut self, index: PeerIndex) {
+        self.inner.remove(&index);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -957,6 +961,8 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     pub fn disconnected(&self, peer: PeerIndex) -> Option<PeerState> {
         // self.misbehavior.write().remove(peer);
         self.inflight_blocks.write().remove_by_peer(&peer);
+        self.known_txs.lock().clear(peer);
+        self.known_blocks.lock().clear(peer);
         self.peers_state.write().remove(&peer)
     }
 

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -570,7 +570,7 @@ pub struct SyncSharedState<CS> {
     // reconstruct and process the complete block
     pub(crate) pending_compact_blocks: Mutex<FnvHashMap<H256, CompactBlock>>,
 
-    pub(crate) inflight_proposals: Mutex<FnvHashSet<ProposalShortId>>,
+    inflight_proposals: Mutex<FnvHashSet<ProposalShortId>>,
 
     // Records the processed result of blocks, so that avoid re-process same blocks
     block_status_map: Mutex<hashbrown::HashMap<H256, BlockStatus>>,
@@ -958,5 +958,15 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         for id in ids.into_iter() {
             locked.entry(id).or_default().insert(pi);
         }
+    }
+
+    pub fn remove_inflight_proposal(&self, ids: &[ProposalShortId]) -> Vec<bool> {
+        let mut locked = self.inflight_proposals.lock();
+        ids.iter().map(|id| locked.remove(id)).collect()
+    }
+
+    pub fn insert_inflight_proposals(&self, ids: Vec<ProposalShortId>) -> Vec<bool> {
+        let mut locked = self.inflight_proposals.lock();
+        ids.into_iter().map(|id| locked.insert(id)).collect()
     }
 }


### PR DESCRIPTION
* refactor: Flatten relayer's state and synchronizer's state into SyncSharedState.
* refactor: Flatten peers' state into SyncSharedState.
* feat: Hide locks, avoid taking locks too long outside (Not done yet, will continue in future)
* fix: Clear related state when peer disconnects