### PR TITLE
[HOLD] feat: ban relaying invalid compact blocks

### DIFF
--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -52,7 +52,7 @@ impl<'a, CS: ChainStore + 'static> BlockTransactionsProcess<'a, CS> {
                 if let Ok(block) = ret {
                     pending.remove();
                     self.relayer
-                        .accept_block(self.nc.as_ref(), self.peer, &Arc::new(block));
+                        .accept_block(self.nc.as_ref(), self.peer, &Arc::new(block))?;
                 }
             }
         }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -165,7 +165,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                 Ok(block) => {
                     pending_compact_blocks.remove(&block_hash);
                     self.relayer
-                        .accept_block(self.nc.as_ref(), self.peer, &Arc::new(block))
+                        .accept_block(self.nc.as_ref(), self.peer, &Arc::new(block))?;
                 }
                 Err(missing) => {
                     missing_indexes = missing;

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -211,7 +211,12 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         }
     }
 
-    pub fn accept_block(&self, nc: &CKBProtocolContext, peer: PeerIndex, block: &Arc<Block>) {
+    pub fn accept_block(
+        &self,
+        nc: &CKBProtocolContext,
+        peer: PeerIndex,
+        block: &Arc<Block>,
+    ) -> Result<(), FailureError> {
         let ret = self.chain.process_block(Arc::clone(&block), true);
 
         if ret.is_ok() {
@@ -245,6 +250,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                 ret
             );
         }
+        ret
     }
 
     pub fn reconstruct_block(

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
         Box::new(DifferentTxsWithSameInput),
     );
     specs.insert("compact_block_basic", Box::new(CompactBlockBasic));
+    specs.insert("relay_block_transactions", Box::new(RelayBlockTransactions));
     specs.insert("invalid_locator_size", Box::new(InvalidLocatorSize));
     specs.insert("tx_pool_size_limit", Box::new(SizeLimit));
     specs.insert("tx_pool_cycles_limit", Box::new(CyclesLimit));

--- a/test/src/specs/relay/block_transactions.rs
+++ b/test/src/specs/relay/block_transactions.rs
@@ -1,0 +1,104 @@
+use crate::{
+    utils::{build_block_transactions, build_compact_block, clear_messages},
+    Net, Node, Spec, TestProtocol,
+};
+use ckb_chain_spec::ChainSpec;
+use ckb_network::PeerIndex;
+use ckb_protocol::{get_root, RelayMessage, RelayPayload};
+use ckb_sync::NetworkProtocol;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub struct RelayBlockTransactions;
+
+impl RelayBlockTransactions {
+    pub fn test_compact_block_contains_invalid_missing_transactions(
+        &self,
+        net: &Net,
+        node: &Node,
+        peer_id: PeerIndex,
+    ) {
+        node.generate_block();
+        let _ = net.receive();
+
+        // Construct a new block contains a invalid transaction
+        let tip_block = node.get_tip_block();
+        let new_tx = node.new_transaction(tip_block.transactions()[0].hash().clone());
+        let new_block = node
+            .new_block_builder(None, None, None)
+            .transaction(new_tx)
+            .build();
+
+        // Net send the compact block to node0, but dose not send the corresponding missing
+        // block transactions. It will make node0 unable to reconstruct the complete block
+        net.send(
+            NetworkProtocol::RELAY.into(),
+            peer_id,
+            build_compact_block(&new_block),
+        );
+        let (_, _, data) = net
+            .receive_timeout(Duration::from_secs(10))
+            .expect("receive GetBlockTransactions");
+        let message = get_root::<RelayMessage>(&data).unwrap();
+        assert_eq!(
+            message.payload_type(),
+            RelayPayload::GetBlockTransactions,
+            "Node should send GetBlockTransactions message for missing transactions",
+        );
+
+        // Net send the corresponding invalid transactions to node
+        // And then, we should be banned by node
+        net.send(
+            NetworkProtocol::RELAY.into(),
+            peer_id,
+            build_block_transactions(&new_block),
+        );
+
+        // Let's attempt to confirm that we were baned by node
+        sleep(Duration::from_secs(5));
+        node.generate_block();
+        assert!(
+            net.receive_timeout(Duration::from_secs(5)).is_err(),
+            "Node should ban us, so we cannot receive node's new block"
+        );
+    }
+}
+
+impl Spec for RelayBlockTransactions {
+    fn run(&self, net: Net) {
+        log::info!("Running RelayBlockTransactions");
+        let peer_ids = net
+            .nodes
+            .iter()
+            .map(|node| {
+                net.connect(node);
+                let (peer_id, _, _) = net.receive();
+                peer_id
+            })
+            .collect::<Vec<PeerIndex>>();
+        clear_messages(&net);
+
+        // node0 ban us in this case
+        self.test_compact_block_contains_invalid_missing_transactions(
+            &net,
+            &net.nodes[0],
+            peer_ids[0],
+        );
+    }
+
+    fn test_protocols(&self) -> Vec<TestProtocol> {
+        vec![TestProtocol::sync(), TestProtocol::relay()]
+    }
+
+    fn connect_all(&self) -> bool {
+        false
+    }
+
+    fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
+        Box::new(|mut spec_config| {
+            // Test cases of relaying block transactions care about the validity of transactions,
+            // so here give the realistic parameters
+            spec_config.params.cellbase_maturity = 12;
+        })
+    }
+}

--- a/test/src/specs/relay/mod.rs
+++ b/test/src/specs/relay/mod.rs
@@ -1,7 +1,9 @@
 mod block_relay;
+mod block_transactions;
 mod compact_block;
 mod transaction_relay;
 
 pub use block_relay::BlockRelayBasic;
+pub use block_transactions::RelayBlockTransactions;
 pub use compact_block::CompactBlockBasic;
 pub use transaction_relay::{TransactionRelayBasic, TransactionRelayMultiple};

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -38,6 +38,14 @@ pub fn build_compact_block(block: &Block) -> Bytes {
     fbb.finished_data().into()
 }
 
+pub fn build_block_transactions(block: &Block) -> Bytes {
+    let fbb = &mut FlatBufferBuilder::new();
+    let message =
+        RelayMessage::build_block_transactions(fbb, block.header().hash(), block.transactions());
+    fbb.finish(message, None);
+    fbb.finished_data().into()
+}
+
 pub fn build_header(header: &Header) -> Bytes {
     let headers = vec![header.clone()];
     let fbb = &mut FlatBufferBuilder::new();


### PR DESCRIPTION
* feat: Ban relaying invalid compact blocks. Treat a compact block as invalid when `Relayer::accept_block` returns an error, and ban the corresponding sourced peer.

---

NOTE: Currently, when `Synchronizer::accept_block` returns an error, we just log a message but not ban the sourced peer. Maybe we should ban the sourced peer when the error is not "unknown parent".