### PR TITLE
chore: remove some unsafe

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -231,7 +231,7 @@ impl BlockBuilder {
     /// # Warning
     ///
     /// For testing purpose only, this method is used to construct a incorrect Block.
-    pub unsafe fn build_unchecked(self) -> Block {
+    pub fn build_unchecked(self) -> Block {
         let Self {
             header_builder,
             uncles,

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -694,7 +694,7 @@ impl TransactionBuilder {
     ///
     /// When using this method, the caller should ensure the input hashes is right, or the caller
     /// will get a incorrect Transaction.
-    pub unsafe fn build_unchecked(self, hash: H256, witness_hash: H256) -> Transaction {
+    pub fn build_unchecked(self, hash: H256, witness_hash: H256) -> Transaction {
         let Self {
             version,
             deps,

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -616,13 +616,11 @@ mod tests {
             .nonce(nonce)
             .build();
 
-        unsafe {
-            BlockBuilder::default()
-                .header(header)
-                .transaction(cellbase)
-                .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-                .build_unchecked()
-        }
+        BlockBuilder::default()
+            .header(header)
+            .transaction(cellbase)
+            .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
+            .build_unchecked()
     }
 
     fn create_cellbase(number: BlockNumber, epoch: &EpochExt) -> Transaction {

--- a/store/src/flat_block_body.rs
+++ b/store/src/flat_block_body.rs
@@ -139,15 +139,13 @@ pub(crate) fn deserialize_transaction(
     let witnesses: Vec<Witness> = config.deserialize(&tx[header[5]..])?;
     let hash: H256 = config.deserialize(&tx[header[6]..])?;
     let witness_hash: H256 = config.deserialize(&tx[header[7]..])?;
-    unsafe {
-        Ok(TransactionBuilder::default()
-            .version(version)
-            .deps(deps)
-            .inputs(inputs)
-            .outputs(outputs)
-            .witnesses(witnesses)
-            .build_unchecked(hash, witness_hash))
-    }
+    Ok(TransactionBuilder::default()
+        .version(version)
+        .deps(deps)
+        .inputs(inputs)
+        .outputs(outputs)
+        .witnesses(witnesses)
+        .build_unchecked(hash, witness_hash))
 }
 
 pub(crate) fn serialize_block_body_size(

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -134,11 +134,9 @@ fn test_uncle_verifier() {
         let epoch = shared
             .next_epoch_ext(&parent_epoch, chain1[chain1.len() - 2].header())
             .unwrap_or(parent_epoch);
-        let block = unsafe {
-            BlockBuilder::from_block(chain1.last().cloned().unwrap())
-                .uncle(chain2.last().cloned().unwrap().into())
-                .build_unchecked()
-        };
+        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
+            .uncle(chain2.last().cloned().unwrap().into())
+            .build_unchecked();
 
         let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch, &block);
         let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
@@ -160,12 +158,10 @@ fn test_uncle_verifier() {
             .next_epoch_ext(&parent_epoch, chain1[chain1.len() - 2].header())
             .unwrap_or(parent_epoch);
         // header has 1 uncle, but body has empty uncles
-        let block = unsafe {
-            BlockBuilder::from_block(chain1.last().cloned().unwrap())
-                .header(HeaderBuilder::default().uncles_count(1).build())
-                .uncle(chain2.last().cloned().unwrap().into())
-                .build_unchecked()
-        };
+        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
+            .header(HeaderBuilder::default().uncles_count(1).build())
+            .uncle(chain2.last().cloned().unwrap().into())
+            .build_unchecked();
         let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch, &block);
         let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
         assert_eq!(
@@ -178,16 +174,14 @@ fn test_uncle_verifier() {
 
         // header has empty uncles, but body has 1 uncle
         let uncles_hash = uncles_hash(&[chain2.last().cloned().unwrap().into()]);
-        let block = unsafe {
-            BlockBuilder::from_block(chain1.last().cloned().unwrap())
-                .header(
-                    HeaderBuilder::from_header(chain1.last().cloned().unwrap().header().to_owned())
-                        .uncles_count(0)
-                        .uncles_hash(uncles_hash.clone())
-                        .build(),
-                )
-                .build_unchecked()
-        };
+        let block = BlockBuilder::from_block(chain1.last().cloned().unwrap())
+            .header(
+                HeaderBuilder::from_header(chain1.last().cloned().unwrap().header().to_owned())
+                    .uncles_count(0)
+                    .uncles_hash(uncles_hash.clone())
+                    .build(),
+            )
+            .build_unchecked();
         let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch, &block);
         let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
         assert_eq!(
@@ -280,11 +274,9 @@ fn test_uncle_verifier() {
             .next_epoch_ext(&parent_epoch, chain2[17].header())
             .unwrap_or(parent_epoch);
 
-        let uncle = unsafe {
-            BlockBuilder::from_block(chain1[16].to_owned())
-                .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
-                .build_unchecked()
-        };
+        let uncle = BlockBuilder::from_block(chain1[16].to_owned())
+            .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
+            .build_unchecked();
         let block = BlockBuilder::from_block(chain2[18].to_owned())
             .uncle(uncle.into())
             .header_builder(HeaderBuilder::from_header(chain2[18].header().to_owned()))


### PR DESCRIPTION
Is the unsafe necessary?

I tried to add `#[cfg(test)]` for `build_unchecked` of `Block`, but the compiling failed.