### PR TITLE
test: add code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ tags
 
 # tmp files
 *.pyc
+
+# code coverage report
+cobertura.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,12 @@ matrix:
     - name: Tests on Linux
       if: 'tag IS NOT present AND (type == pull_request OR branch = master OR branch =~ /^test/)'
       os: linux
+      install:
+        - cargo tarpaulin --version || cargo install cargo-tarpaulin
+      script:
+        - make cov
+        - bash <(curl -s https://codecov.io/bash)
+
     - name: Linters
       if: 'tag IS NOT present AND (type == pull_request OR branch = master OR branch =~ /^test/)'
       os: linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2945,7 +2945,7 @@ name = "sha2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3715,7 +3715,7 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
 "checksum blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9527b166a2d75fc95f72e09bc57030cd115960a5357cf55f6b7af7bffe678aab"
-"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum bloom-filters 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b233192e97c6e528c071bd83180c5d4f35846b9aff4670ea8e05e3ba0daa5e30"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use 
 test: ## Run all tests.
 	cargo test ${VERBOSE} --all -- --nocapture
 
+cov: ## Run code coverage.
+	# Tarpaulin only supports x86_64 processors running Linux.
+	# https://github.com/xd009642/tarpaulin/issues/161
+	# https://github.com/xd009642/tarpaulin/issues/190#issuecomment-473564880
+	RUSTC="$$(pwd)/devtools/cov/rustc-proptest-fix" taskset -c 0 cargo tarpaulin --all -v --out Xml
+
 setup-ckb-test:
 	cp -f Cargo.lock test/Cargo.lock
 	rm -rf test/target && ln -snf ../target/ test/target
@@ -136,7 +142,7 @@ help:  ## Display help message.
 
 .PHONY: build prod prod-test prod-docker docker docker-publish
 .PHONY: gen gen-clean clean clean-all check-cfbc-version
-.PHONY: fmt test clippy doc doc-deps gen-doc gen-hashes check stats check-dirty-doc
+.PHONY: fmt test clippy doc doc-deps gen-doc gen-hashes check stats check-dirty-doc cov
 .PHONY: ci security-audit
 .PHONY: integration integration-release setup-ckb-test
 .PHONY: setup-ckb-tools jsonfmt

--- a/devtools/cov/rustc-proptest-fix
+++ b/devtools/cov/rustc-proptest-fix
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+argv = sys.argv[1:]
+
+try:
+    pkg_name = os.environ['CARGO_PKG_NAME']
+except KeyError:
+    pass
+else:
+    if pkg_name == 'proptest':
+        try:
+            pos = list(zip(argv, argv[1:])).index(('-C', 'link-dead-code'))
+        except ValueError:
+            pass
+        else:
+            argv[pos:pos + 2] = []
+
+os.execv('/usr/bin/env', ['env', 'rustc'] + argv)


### PR DESCRIPTION
@quake 
There are many crates for code coverage in Rust: cargo-tarpaulin, grcov, cov, cargo-travis, but all are not matured.
I have investigated the most two popular crates: cargo-tarpaulin and grcov. There were some bugs for both of them. And finally, I figured cargo-tarpaulin out, and It's also newer and well maintained than others.

There are two features of tarpaulin, I think it's enough for us now:
- Line coverage
- Uploading coverage to https://coveralls.io or https://codecov.io

The result is as below:
```
[INFO tarpaulin] Coverage Results:
|| Uncovered Lines:
|| chain/src/chain.rs: 118-122, 124-125, 172, 181, 184, 188-190, 195, 213, 215-216, 228-229, 242, 244, 247, 249, 251, 257, 261, 268, 270, 273-274, 281, 309-311, 315, 321-322, 335, 344-347, 368, 373-376, 419, 421, 423-425, 428, 432, 434, 437-438, 442, 457, 459, 464-466, 471, 473, 476-477, 482, 507, 535-536, 544, 551, 555-557, 563, 567-568, 585, 589, 594-599, 603-604, 606, 608-611, 620-621, 627, 630, 634, 651, 657-658, 660-661, 663-665, 667, 670
|| chain/src/tests/basic.rs: 69, 106, 158, 166, 251, 343, 424, 518, 672, 734, 741, 836
|| chain/src/tests/delay_verify.rs: 203, 409
|| ckb-bin/src/helper.rs: 7-8, 11-13, 17-18, 21-26, 29-34
|| ckb-bin/src/lib.rs: 9, 13-21, 23-24, 26, 34-35, 37-42
|| ckb-bin/src/subcommand/cli/blake.rs: 7-11, 14-18
|| ckb-bin/src/subcommand/cli/hashes.rs: 30-35, 37-39, 44-45, 48-62, 65, 67-70, 75-76, 78-80, 82-84, 86-88, 91-99, 102, 104, 107-109
|| ckb-bin/src/subcommand/cli/secp256k1_lock.rs: 8-11, 13, 15, 18-20, 23-24, 26-32, 34-40, 45
|| ckb-bin/src/subcommand/export.rs: 6-9, 11-13, 15, 17-19
|| ckb-bin/src/subcommand/import.rs: 8-11, 13-15, 18-20, 22, 24-26
|| ckb-bin/src/subcommand/init.rs: 8-11, 13, 16-23, 26-29, 32, 34-35, 37, 39, 42-45, 47-49, 52
|| ckb-bin/src/subcommand/miner.rs: 8-9, 11, 13, 15, 17, 22-23
|| ckb-bin/src/subcommand/prof.rs: 12-17, 19-21, 24-29, 31, 33-35, 38-42, 44-45, 47, 49-53, 57, 59, 62, 68-69, 71-72, 74-75, 79
|| ckb-bin/src/subcommand/run.rs: 18, 21-26, 28-30, 34, 36-39, 42, 46-49, 52, 57, 61-62, 64-68, 71-74, 76, 78-85, 87-92, 94-99, 102-103, 106-112, 117, 119-121, 124-126, 128-130
|| core/src/block.rs: 56, 121-122, 124, 127-130, 137, 168, 173, 235, 240, 250, 255, 266
|| core/src/cell.rs: 46-54, 102, 109, 128-129, 148-149, 177, 181-182, 185-186, 189-190, 211-214, 218-219, 222-223, 226-227, 328, 330, 345-347, 349, 354-355, 365-366, 386, 440-441, 473-474, 476-479, 481-485, 488-489, 492, 494, 533-534, 563, 566, 585, 588, 594, 634-635, 642, 699-700, 704, 708, 964, 988, 1021, 1065
|| core/src/difficulty.rs: 16-18, 20-22
|| core/src/error.rs: 17-18
|| core/src/extras.rs: 59-60, 128, 136
|| core/src/header.rs: 20-21, 68-69, 72-73, 76-77, 80-81, 84-85, 88-89, 92-93, 137-138, 140-141, 150, 153, 157, 161-167, 169, 171-173, 175, 179-181, 185, 191-192, 226, 282-283, 310-311, 314-315
|| core/src/script.rs: 24-29, 33-37, 39, 41
|| core/src/transaction.rs: 40-41, 44-47, 65, 69-70, 83-84, 101-103, 114, 116-117, 129-130, 176, 178, 180-181, 183, 189-190, 192, 225, 228, 247-248, 279-282, 286, 291, 319, 335-336, 338-339, 342, 346-361, 364, 368-377, 379, 381-383, 385, 387-389, 391, 393-395, 397, 399-401, 403, 407-413, 417-418, 456, 467, 535-536, 549-552, 554-557, 559-562, 564-567, 581-589, 599-607, 632-634, 647-649, 662-664, 677-679, 683, 689, 698, 704, 735-737, 739, 745-746, 760-761
|| core/src/transaction_meta.rs: 59-60, 68-69, 72-73, 76-77
|| core/src/uncle.rs: 38-39, 56-57
|| db/src/cachedb.rs: 33, 37, 43-49, 52, 55-60, 63, 66-73, 76-79, 84, 100-103, 107, 118-122, 124, 126, 129-133, 136, 143, 146-147
|| db/src/memorydb.rs: 158, 168
|| db/src/rocksdb.rs: 40, 43, 46-52, 54-56, 58-61, 68, 70, 77-78, 80, 83, 85, 92-93, 96, 98, 101-102, 131, 139, 142, 146-149, 151, 174-177, 277, 287
|| miner/src/block_assembler.rs: 51-52, 55-57, 139, 142, 149-151, 154, 161, 165-167, 172, 220, 226, 228-230, 243, 245, 247, 281-282, 297, 300-301, 311-316, 324, 330, 332-336, 358-360, 400, 405, 422, 431, 446, 456
|| miner/src/client.rs: 40-42, 44-45, 47-49, 51-55, 57-61, 63-64, 67, 72, 76, 81, 83-87, 90-93, 95, 100-101, 114-115, 119, 125, 130-132, 134, 137-144, 146, 150-151, 153-154, 161-165, 169-177, 180-184, 186-187, 194-195, 199, 202-204, 206, 210-213, 215
|| miner/src/miner.rs: 22, 35-41, 44, 49-64, 68, 70-72, 75-81, 83-88, 90-95, 97-101, 103, 105, 107-112, 114-116, 120-124, 126-129, 131
|| network/src/behaviour.rs: 18, 20, 22, 24
|| network/src/compress.rs: 53-55, 65, 69-71, 90-91, 95-96
|| network/src/config.rs: 38, 62, 84, 98, 104, 114-117, 119, 121, 129-132, 134, 136
|| network/src/errors.rs: 43-44, 49-50, 55-56, 61-62, 67-68, 73-74, 79-80, 85-86, 91-92
|| network/src/network.rs: 90-91, 93, 95-96, 100, 107-109, 131, 137-138, 140-142, 146, 152-153, 159-164, 171, 177-178, 180-182, 186, 192-197, 202-203, 206-209, 213, 216, 220-224, 228-235, 238-239, 241, 245, 249, 253, 257, 276-277, 280-281, 284-285, 288-289, 301-303, 315, 321, 324-325, 328-329, 337-340, 342-343, 345-346, 348, 351-352, 354-356, 359-360, 362-363, 365, 367-371, 373, 376, 379, 382-383, 386-388, 390, 393, 400-401, 404-411, 413, 416-417, 423-425, 429-434, 444-457, 459-460, 463, 465-466, 468-475, 478-479, 481, 484-488, 490, 493-494, 496-500, 502, 505-506, 508-509, 511-512, 518, 520-522, 524, 526-530, 532, 534, 536, 538, 540, 542-545, 547, 549-550, 552, 556, 558, 560-561, 563, 565-566, 568, 575-576, 578, 580-584, 586-587, 589, 592-600, 602, 604-605, 609-610, 615, 617-626, 628, 630-638, 640, 642, 647, 650-657, 659, 661-666, 668, 670, 672, 675-677, 738, 746-747, 764, 809-811, 813, 815, 818, 820-821, 823-824, 826, 833-835, 843-845, 853, 863-865, 870-871, 876-877, 883, 887-890, 894-896, 899-901, 903, 923-924, 927-928, 931-932, 935-937, 940-945, 947-948, 953-960, 963-970, 972, 975, 987, 989-991, 995, 999-1002, 1004, 1006-1008, 1020-1023, 1026, 1032-1033
|| network/src/network_group.rs: 21, 29, 31-32, 57-60, 62-63
|| network/src/peer.rs: 68-69
|| network/src/peer_registry.rs: 88, 97-98, 101-102, 116, 118, 123-124, 127, 131, 140-141, 144, 148, 166, 170, 172-173, 183-184, 187-188, 191-192, 195-196, 211, 217-219, 236-237
|| network/src/peer_store/sqlite/db.rs: 57, 70, 76, 91-92, 94, 104, 112, 124, 130, 134, 140, 146, 151-152, 155, 160, 173, 186, 200, 204-205, 210, 213-214, 229, 234-235, 252-253, 257, 265, 355, 363, 394
|| network/src/peer_store/sqlite/peer_store.rs: 76, 85, 92, 112, 123, 128, 133, 137, 155-160, 162, 166-167, 170-172, 185, 200, 232-234, 256, 258-259, 265, 269-270, 294, 299, 336, 361
|| network/src/peer_store/sqlite.rs: 15-16
|| network/src/peer_store/types.rs: 64, 68, 74, 79-81, 84-85, 87
|| network/src/peer_store.rs: 90, 92, 105-106
|| network/src/protocols/discovery.rs: 49-50, 54-56, 58-60, 65, 69-71, 73, 75-77, 79-81, 84-89, 91, 93, 98-103, 105-106, 109-111, 113, 115-121, 123, 171-178, 182-189, 192-193, 195-196, 198-202, 208-212, 215-226, 228-232, 235-237, 249, 252, 254-256, 258, 270, 272-275, 279-284, 286-290, 294-298, 300-301
|| network/src/protocols/feeler.rs: 28-36, 38-40, 44-52, 54
|| network/src/protocols/identify.rs: 31-36, 46-47, 50-51, 53-54, 56-60, 65, 71, 73, 76, 78, 81-89, 91-93, 95, 98-101, 105, 108-109
|| network/src/protocols/mod.rs: 52, 60, 62, 70, 72, 86, 96-98, 106-107, 110-111, 114-115, 118-125, 157-161, 163-164, 167-171, 173-174, 177-181, 183-184, 187-188, 190-192, 194-197, 199-200, 203-210, 212, 216-220, 222, 233-236, 238, 241-242, 244-246, 248-250, 252, 255-256, 258-260, 262-264, 266, 269-272, 274, 277-279, 282-283, 285-287, 289-290, 293-294, 296-298, 300-302, 304, 307-310, 312, 315-317, 321-323, 325-327, 329-331, 333-335, 338-339
|| network/src/protocols/ping.rs: 36-37, 39-45, 50-54, 56-57, 61-65, 67-68, 72-74, 77
|| network/src/services/dns_seeding/mod.rs: 32, 36-37, 48, 50-51, 54-59, 61-63, 66-70, 72-76, 79-90, 92-93, 96-97, 102-103, 108-114, 117-118, 123, 132, 135-137, 139-142, 145-147, 149-152
|| network/src/services/dns_seeding/seed_record.rs: 51, 55, 59-61, 64, 72, 76-77, 79-80, 84-85, 88-89, 91-92, 95, 99, 101, 115-116, 120, 124-129, 133-138, 141, 188, 220
|| network/src/services/outbound_peer.rs: 44-45, 50-51, 58-60, 63-67, 69-71, 86-87, 94-95, 102-104, 106, 109-111
|| network/src/tests/peer_registry.rs: 65, 99
|| network/src/tests/sqlite_peer_store.rs: 83, 161, 180
|| notify/src/lib.rs: 78-80, 110, 172, 178, 244
|| pow/src/cuckoo.rs: 24-25, 36-37, 58, 67, 182, 186, 191, 210, 213, 221, 223, 225, 227, 232, 256-257, 260, 262, 264, 268-269, 274, 294, 311-312
|| pow/src/dummy.rs: 18-19, 27-28, 30-31, 33-34, 66-72, 74, 91-93, 98, 101, 104, 106-107, 110-111, 114-115, 119
|| pow/src/lib.rs: 25-28, 37, 52-55, 58-59, 62-63, 65-68, 72
|| protocol/src/builder.rs: 82-83, 85, 89-90, 92, 96-97, 99, 103-104, 106, 136, 157, 161-164, 169, 173-176, 186-188, 191-193, 196-198, 219-220, 222, 240, 242, 264, 275-276, 278, 282-283, 285, 289-292, 305, 309-315, 317-320, 330, 332, 346-348, 366-368, 377-380, 429, 434-438, 443, 448, 450, 452-459, 461-468, 471-478, 481-482, 484-488, 490, 506-507, 515, 522-525, 534-535, 537, 540-543, 558, 563-567, 582, 586-590, 593, 597-601, 604, 609-615, 618-621, 624, 629-635, 637-640, 643-646, 649, 654-663, 666-669, 672, 676-681, 683-685, 688-691, 696, 700-703
|| protocol/src/convert.rs: 65-66, 68-69, 77-88, 90, 100-101, 103, 105, 108, 110-111, 121, 128-134, 136-138, 163, 168, 170, 172, 182-183, 185, 187, 190, 192, 195, 197, 206, 215-218, 225-227, 234-236, 243-246, 248, 255-259, 261, 263-265, 267, 276-277, 281, 286-288, 300-301, 340-344
|| protocol/src/lib.rs: 44, 87
|| protocol/src/protocol_generated.rs: 103-105, 131-132, 144-147, 185-187, 210-211, 217-218, 224-226, 228, 235-237, 239, 245, 247-256, 260-261, 263-264, 266-267, 269-270, 272-273, 275-276, 278-279, 281-282, 284-285, 287-288, 348, 359, 522, 528, 531-534, 553-554, 563-564, 573-574, 583, 590-594, 600-604, 610-614, 620-624, 636, 690, 696, 699-701, 717, 757, 759, 772, 775-779, 787-788, 795-796, 807, 829-830, 857, 859, 872, 875-877, 893, 948, 951-953, 969, 1018, 1024, 1027-1041, 1129, 1244, 1247-1252, 1286, 1341, 1343, 1350, 1356, 1359-1362, 1369-1370, 1373-1374, 1384, 1397-1398, 1401-1402, 1405-1406, 1413-1415, 1438, 1444, 1447-1453, 1493, 1553, 1555, 1562, 1568, 1571-1573, 1579-1580, 1589, 1629, 1631, 1638, 1644, 1647-1651, 1659-1660, 1663-1664, 1667-1668, 1679, 1693-1694, 1738, 1744, 1747-1752, 1769-1770, 1786, 1850, 1856, 1859-1864, 1898, 1925-1926, 1962, 1968, 1971-1974, 1996, 2041, 2043, 2050, 2056, 2059-2062, 2069-2070, 2073-2074, 2078-2082, 2088-2092, 2098-2102, 2108-2112, 2118-2122, 2128-2132, 2138-2142, 2148-2152, 2164, 2218, 2224, 2227-2234, 2245-2246, 2249-2250, 2253-2254, 2261-2262, 2265-2266, 2280, 2345, 2347, 2354, 2360, 2363-2366, 2373-2374, 2377-2378, 2388, 2433, 2435, 2442, 2448, 2451-2453, 2459-2460, 2469, 2481-2482, 2485-2486, 2493-2495, 2509, 2511, 2518, 2524, 2527-2529, 2535-2536, 2545, 2557-2558, 2561-2562, 2569-2571, 2585, 2587, 2594, 2600, 2603-2606, 2613-2614, 2617-2618, 2628, 2673, 2675, 2682, 2688, 2691-2694, 2701-2702, 2705-2706, 2716, 2729-2730, 2733-2734, 2737-2738, 2745-2747, 2761, 2763, 2770, 2776, 2779-2782, 2789-2790, 2793-2794, 2804, 2817-2818, 2821-2822, 2825-2826, 2833-2835, 2849, 2851, 2858, 2864, 2867-2870, 2877-2878, 2881-2882, 2892, 2905-2906, 2909-2910, 2913-2914, 2921-2923, 2937, 2939, 2946, 2952, 2955-2957, 2963-2964, 2973, 2985-2986, 2989-2990, 2997-2999, 3013, 3015, 3022, 3028, 3031-3035, 3043-3044, 3047-3048, 3051-3052, 3063, 3077-3078, 3081-3082, 3085-3086, 3089-3090, 3097-3099, 3113, 3115, 3122, 3128, 3131-3133, 3139-3140, 3149, 3161-3162, 3165-3166, 3173-3175, 3189, 3191, 3198, 3204, 3207-3208, 3217, 3228-3229, 3236-3238, 3252, 3254, 3261, 3267, 3270-3274, 3282-3283, 3286-3287, 3290-3291, 3302, 3316-3317, 3320-3321, 3324-3325, 3328-3329, 3336-3338, 3352, 3354, 3361, 3367, 3370-3373, 3380-3381, 3384-3385, 3395, 3408-3409, 3412-3413, 3416-3417, 3424-3426, 3440, 3442, 3449, 3455, 3458-3460, 3466-3467, 3476, 3488-3489, 3492-3493, 3500-3502, 3516, 3518, 3525, 3531, 3534-3536, 3542-3543, 3552, 3564-3565, 3568-3569, 3576-3578, 3583-3584, 3588-3589, 3593, 3596, 3600-3601
|| protocol/src/protocol_generated_verifier.rs: 24-27, 29-30, 33-41, 44-45, 50, 53-57, 59, 61, 66, 68, 74, 77-80, 82, 86-87, 89-92, 95-97, 99, 103, 114, 122-125, 134, 143, 150, 158, 166, 171, 176, 186, 191, 199, 204, 209, 217, 222, 227, 243-246, 248-249, 252-260, 263-264, 269, 272-276, 278, 280, 285, 287, 293, 296-299, 301, 305-306, 308-311, 314-316, 318-319, 323, 328-331, 333-334, 337-345, 348-349, 354, 357-361, 363, 365, 370, 372, 378, 381-384, 386, 390-391, 393-395, 399-400, 402-405, 408-410, 412-413, 417, 428, 436, 438, 448, 457, 464, 472, 480, 485, 490, 512, 520-523, 532, 541, 548, 556, 564, 569, 573, 578, 582, 587, 591, 596, 600, 615, 623-626, 635, 644, 651, 659, 667, 672, 676, 681, 686, 696, 701, 711, 713-716, 719-720, 730-733, 735-736, 739-747, 750-751, 756, 759-763, 765, 767, 772, 774, 780, 783-786, 788, 792, 797-800, 802-803, 806-814, 817-818, 823, 826-830, 832, 834, 839, 841, 847, 850-853, 855, 859-860, 862-865, 868-869, 874-875, 877-879, 883-884, 886-889, 892-894, 896-897, 901-902, 904-907, 910-912, 914-915, 919-920, 922-925, 928-930, 932-933, 937-938, 940-943, 946-948, 950, 954, 959-962, 964-965, 968-976, 979-980, 985, 988-992, 994, 996, 1001, 1003, 1009, 1012-1015, 1017, 1021-1022, 1024-1027, 1030-1031, 1036-1037, 1039-1042, 1045-1047, 1049-1050, 1054-1055, 1057-1060, 1063-1064, 1069, 1074-1077, 1079-1080, 1083-1091, 1094-1095, 1100, 1103-1107, 1109, 1111, 1116, 1118, 1124, 1127-1130, 1132, 1136-1137, 1139-1141, 1145-1146, 1148-1151, 1154-1156, 1158, 1162, 1167-1170, 1172-1173, 1176-1184, 1187-1188, 1193, 1196-1200, 1202, 1204, 1209, 1211, 1217, 1220-1223, 1225, 1229-1230, 1232-1234, 1238-1239, 1241-1244, 1247-1249, 1251, 1255, 1266, 1274-1277, 1286, 1295, 1302, 1310, 1318, 1323, 1328, 1350, 1358-1361, 1370, 1379, 1386, 1394, 1402, 1407, 1411, 1416, 1421, 1433, 1435-1437, 1446-1449, 1451-1452, 1455-1463, 1466-1467, 1472, 1475-1479, 1481, 1483, 1488, 1490, 1496, 1499-1502, 1504, 1508-1509, 1511-1513, 1517, 1528, 1536, 1538, 1548, 1557, 1564, 1572, 1580, 1585, 1589, 1594, 1598, 1603, 1607, 1612, 1616, 1621, 1625, 1630, 1634, 1639, 1643, 1648, 1653, 1663, 1667, 1672, 1677, 1687, 1691, 1696, 1698-1700, 1705, 1707-1709, 1724, 1732, 1734, 1744, 1753, 1760, 1768, 1776, 1781, 1786, 1794, 1803-1806, 1808-1809, 1812-1820, 1823-1824, 1829, 1832-1836, 1838, 1840, 1845, 1847, 1853, 1856-1859, 1861, 1865-1866, 1868-1870, 1874-1875, 1877-1880, 1883-1884, 1889, 1894-1897, 1899-1900, 1903-1911, 1914-1915, 1920, 1923-1927, 1929, 1931, 1936, 1938, 1944, 1947-1950, 1952, 1956-1957, 1959-1962, 1965-1967, 1969, 1973-1974, 1976-1979, 1982-1984, 1986, 1990, 1995-1998, 2000-2001, 2004-2012, 2015-2016, 2021, 2024-2028, 2030, 2032, 2037, 2039, 2045, 2048-2051, 2053, 2057-2058, 2060-2062, 2066-2067, 2069-2071, 2075-2076, 2078-2080, 2084, 2089-2092, 2094-2095, 2098-2106, 2109-2110, 2115, 2118-2122, 2124, 2126, 2131, 2133, 2139, 2142-2145, 2147, 2151-2152, 2154-2156, 2160-2161, 2163-2166, 2169-2202, 2207, 2212-2215, 2217-2218, 2221-2229, 2232-2233, 2238, 2241-2245, 2247, 2249, 2254, 2256, 2262, 2265-2268, 2270, 2274-2275, 2277-2279, 2283-2284, 2286-2289, 2292-2293, 2298, 2303-2306, 2308-2309, 2312-2320, 2323-2324, 2329, 2332-2336, 2338, 2340, 2345, 2347, 2353, 2356-2359, 2361, 2365-2366, 2368-2370, 2374, 2385, 2393-2396, 2405, 2414, 2421, 2429, 2437, 2442, 2447, 2455, 2460, 2464, 2473-2476, 2478-2479, 2482-2490, 2493-2494, 2499, 2502-2506, 2508, 2510, 2515, 2517, 2523, 2526-2529, 2531, 2535-2536, 2538-2541, 2544-2546, 2548, 2552-2553, 2555-2557, 2561-2562, 2564-2566, 2570, 2581, 2589-2592, 2601, 2610, 2617, 2625, 2633, 2638, 2642, 2647, 2652, 2657, 2659, 2661, 2663, 2665, 2667, 2669, 2671-2688, 2698-2701, 2703-2704, 2707-2715, 2718-2719, 2724, 2727-2731, 2733, 2735, 2740, 2742, 2748, 2751-2754, 2756, 2760-2761, 2763-2765, 2769, 2774-2777, 2779-2780, 2783-2791, 2794-2795, 2800, 2803-2807, 2809, 2811, 2816, 2818, 2824, 2827-2830, 2832, 2836-2837, 2839-2842, 2845-2846, 2851, 2862, 2870-2873, 2882, 2891, 2898, 2906, 2914, 2919, 2923, 2928, 2933, 2941, 2946, 2951, 2959, 2964, 2969, 2977, 2982, 2987, 2995, 3004-3007, 3009-3010, 3013-3021, 3024-3025, 3030, 3033-3037, 3039, 3041, 3046, 3048, 3054, 3057-3060, 3062, 3066-3067, 3069-3072, 3075-3076, 3081-3082, 3084-3087, 3090-3092, 3094, 3098, 3103-3106, 3108-3109, 3112-3120, 3123-3124, 3129, 3132-3136, 3138, 3140, 3145, 3147, 3153, 3156-3159, 3161, 3165-3166, 3168-3171, 3174-3176, 3178-3179, 3183
|| resource/src/lib.rs: 32-35, 44, 62-65, 147, 154-155, 157, 174-175, 252, 257, 261, 282, 286, 305, 322
|| resource/src/template.rs: 69, 77, 89, 98-101
|| rpc/src/config.rs: 24-25, 28-29, 32-33, 36-37, 40-41, 44-45, 48-49
|| rpc/src/error.rs: 9, 11
|| rpc/src/module/chain.rs: 66, 74, 79-80, 84, 101-106, 111-115, 120-121, 138-140, 143-145, 152, 157-159, 187-188, 194, 196
|| rpc/src/module/experiment.rs: 67-73, 91, 95, 100-115, 117-120, 122, 134, 176, 179
|| rpc/src/module/miner.rs: 45, 51-53, 56-58, 61, 63-65, 69, 73-74, 76-83, 85, 87-90, 92-94, 98-104, 106, 108-114, 116, 118-119, 121, 123
|| rpc/src/module/net.rs: 24-35, 37, 41-51, 53-57, 59, 61
|| rpc/src/module/pool.rs: 58, 61, 65
|| rpc/src/module/stats.rs: 32, 50, 52-59
|| rpc/src/module/test.rs: 34-37, 39, 42-45, 48-55
|| rpc/src/server.rs: 23, 34, 36-39, 41, 45-47, 51-58, 60, 65-68, 70, 74-78, 80, 84-87, 89, 93-98, 100, 104-107, 109-115, 117, 122-123
|| rpc/src/test.rs: 251, 254, 256-257, 264-265, 270-273, 316
|| script/src/cost_model.rs: 11, 26, 39, 43, 48, 50-53, 55-56
|| script/src/lib.rs: 20-23, 28-30, 42-43
|| script/src/syscalls/debugger.rs: 23-26, 29-30, 32-38, 40-41, 44-46
|| script/src/syscalls/load_cell.rs: 46, 52, 70, 74-75, 116, 120, 126-132, 134, 140, 142-147, 151-156, 158, 190
|| script/src/syscalls/load_header.rs: 35, 40-41, 47, 56-58, 78-79
|| script/src/syscalls/load_input.rs: 28-31, 33-35, 39-43, 45-46, 50, 60-63, 65-66, 69, 74, 76-83, 85-89, 92, 104, 108-109, 111-114, 116, 118-121, 124-125
|| script/src/syscalls/load_witness.rs: 28, 34, 46, 54-55
|| script/src/syscalls/mod.rs: 55, 58-59, 71-75, 103, 132
|| script/src/verify.rs: 98-101, 109, 116-117, 122, 128, 231-232, 247, 252, 260, 266-269, 277, 292, 297, 300, 310, 314, 316, 319-320, 324, 328, 332, 337, 341, 344, 349, 361, 365, 369, 373-374, 377, 396-397, 418-419, 428, 431, 435, 439, 443-444, 447, 449-450, 459, 462, 466, 470, 477, 483, 489-496, 498-503, 505-508, 510-512, 514-515, 517-527, 534-535, 540, 1317, 1424, 1526, 1625, 1731, 1827, 1934
|| shared/src/cell_set.rs: 56, 97-98, 104-108, 115-119, 139, 147-150, 152-154, 167, 183, 190-195
|| shared/src/chain_state.rs: 56, 60-67, 70-72, 78-79, 96, 100-101, 135, 153-156, 162, 164, 197-198, 205-206, 218-219, 239, 244, 249, 252-269, 271, 275, 278, 280, 283, 294, 310, 330, 334, 348, 356-360, 362-366, 368, 370, 377, 388, 394, 399-401, 413, 418-419, 422-431, 433-435, 444-450, 452-453, 456-457, 467, 474-475, 477-483, 485-486, 488-491, 493-494, 496, 499-502, 507, 510-511, 515, 522-526, 529, 534, 541-544, 574-580, 582-583, 585, 587-589, 591-592, 606-608, 614-619, 625-630, 635-638, 640-641, 647-648, 650, 652, 680-681, 683-685, 687-688, 696-697, 730, 732, 736, 740-741, 757-758, 761-762, 765, 767, 780, 783-788, 790-791, 797, 806-807, 819, 821, 825-826
|| shared/src/config.rs: 22, 25, 27-28, 31, 36-44, 46-48, 53-54
|| shared/src/shared.rs: 55, 94-95, 134-135, 147, 154-155, 160, 192, 216, 220-222, 234-236, 239-241, 244-246
|| shared/src/tx_pool/orphan.rs: 23-24, 39-40, 86, 110-111, 208
|| shared/src/tx_pool/pending.rs: 48-49, 52-53, 69, 72, 74-76, 78, 80, 83-84
|| shared/src/tx_pool/pool.rs: 54-55, 86-92, 94, 96-101, 103, 105-106, 113, 119-120, 123, 130-131, 134, 141-143, 146-147, 150-151, 154-158, 161-162, 184-188, 192-193, 221, 223, 230-231, 233-234
|| shared/src/tx_pool/proposed.rs: 31-32, 59-60, 71-72, 75-77, 80-81, 83-85, 88-89, 103, 106-109, 111-113, 117-118, 129-130, 133-134, 145-149, 153-155, 157, 159-167, 171-172, 175-177, 180-182, 187, 190, 193-194, 220-221, 223, 251-252, 262, 264, 276, 280-281
|| shared/src/tx_pool/types.rs: 58-61, 67-68, 159-160, 165-166
|| shared/src/tx_proposal_table.rs: 41-42, 45-46, 61, 63, 66, 69-70, 74, 77-79, 81, 84, 86-88, 91, 93-95
|| shared/tx-pool-executor/src/tx_pool_executor.rs: 18-19, 22-27, 30-31, 56, 72, 107, 120, 129, 132, 140, 144, 148, 150, 153, 158, 161
|| spec/src/consensus.rs: 86, 164-166, 203, 207, 294-295, 298, 300, 308, 311, 314, 320, 324, 328, 340, 345
|| spec/src/lib.rs: 97-98, 101-102, 105-106, 113-117, 119, 121-122, 124, 138, 144, 148-151, 157, 164-165, 172-174, 185, 187, 227, 245, 260-264, 314
|| src/main.rs: 8-11, 15-16, 19, 22, 26-28, 30, 34, 37-38
|| store/src/flat_block_body.rs: 163
|| store/src/store.rs: 149, 177, 187-188, 200-202, 223, 244, 247, 249-250, 253-254, 258, 260-261, 268, 274, 277-282, 284, 315, 343, 353, 380-381, 394-395, 400, 406, 408-410, 425, 466, 471, 474, 476, 487, 489-490, 496, 541, 557
|| sync/src/net_time_checker.rs: 51, 70-71, 81, 83, 89-93, 100-101, 107, 109, 116-121, 125, 131-132, 135-138, 140-144, 148-154
|| sync/src/relayer/block_proposal_process.rs: 20, 32-36, 38-45, 48-50, 52, 54-57, 59-62, 65-74, 77, 80
|| sync/src/relayer/block_transactions_process.rs: 19, 33-42, 44-47, 52-55, 60
|| sync/src/relayer/compact_block.rs: 37-43, 45-52, 54-61, 63-66
|| sync/src/relayer/compact_block_process.rs: 28, 42-44, 46-52, 54-55, 57-60, 62, 66-72, 74-76, 78, 82-87, 89-91, 93, 95, 100, 103-108, 110-111, 113, 115-121, 124-126, 128-132, 134, 136-139, 141, 143, 145, 149-155, 157-158, 164-168, 170-172, 176, 180-186, 188-189, 191-192, 194, 197-204, 206-208, 210, 224-225, 233-234, 237-241
|| sync/src/relayer/compact_block_verifier.rs: 12, 14-15, 19-22, 45-46
|| sync/src/relayer/get_block_proposal_process.rs: 19, 33-35, 37-39, 41-44, 46-54, 57, 60-62, 64-66
|| sync/src/relayer/get_block_transactions_process.rs: 19, 33-36, 38, 41, 43-52, 54-55, 58
|| sync/src/relayer/get_transaction_process.rs: 20, 34-37, 39-40, 42-48, 50-58, 60-61, 64
|| sync/src/relayer/mod.rs: 68, 70-74, 95, 101-107, 109, 111-116, 118, 120-125, 127, 129-134, 136, 138-143, 145, 147-152, 154, 156-161, 163, 165-167, 169-170, 173, 176, 182-184, 188, 195-202, 204-208, 210, 214-215, 217-219, 221-222, 224-229, 231-236, 238-243, 245, 258, 262, 267-268, 271, 274-278, 281-282, 309-318, 320-321, 323-324, 326, 331-334, 336-342, 345, 349-350, 353-358, 363-370, 372, 374, 376-379, 381-382, 385-390, 397-399, 402, 409-410, 413-419, 421-422, 426-427, 429-430, 432-435, 437-439, 443, 449-450, 452-453, 458-460, 462, 467, 469-470, 473-477, 480-481, 483-484, 510-512, 515-516
|| sync/src/relayer/tests/compact_block_process.rs: 156, 182, 229
|| sync/src/relayer/transaction_hash_process.rs: 20, 34-39, 41-42, 44, 52-53, 55-56, 58-61, 63-64, 66-79, 81, 85, 89
|| sync/src/relayer/transaction_process.rs: 25, 39-41, 43-45, 47, 49, 54, 56-57, 60, 62-70, 72-80, 82-83, 86-90, 92-99, 101, 103-110, 112-115, 117, 119-126, 131, 134
|| sync/src/synchronizer/block_fetcher.rs: 56, 58-60, 66-67, 83-84, 88, 91, 93-94, 103, 105, 107, 112-115, 117, 123, 125-126, 128, 132, 146-147, 168-169, 179-180
|| sync/src/synchronizer/block_pool.rs: 31, 50-51, 54-55
|| sync/src/synchronizer/block_process.rs: 35, 37-38
|| sync/src/synchronizer/filter_process.rs: 18, 30, 32-38, 41, 55, 67-70, 72-73, 86, 90-93
|| sync/src/synchronizer/get_blocks_process.rs: 43, 47-49, 56, 63-64, 69
|| sync/src/synchronizer/get_headers_process.rs: 40, 42, 44, 50, 52, 54, 59-61, 64-65, 70-71, 76-77, 88-90, 93
|| sync/src/synchronizer/headers_process.rs: 40, 46, 74-76, 81-82, 84, 88-89, 129, 131-132, 134, 153, 164-166, 178-180, 182-183, 189-190, 193-195, 200-201, 203, 205, 207, 209, 219, 224-225, 227, 229-230, 236-238, 240-241, 243, 245-247, 249-250, 252-255, 257-258, 260, 269-270, 272, 278-281, 284, 289-290, 342, 346-347, 356-360, 362, 364-368, 370, 372-376, 378, 385-387, 395-396, 400, 402, 404-406, 410, 412, 414-416, 420-423, 431-433, 468-469, 472-475
|| sync/src/synchronizer/mod.rs: 48, 125, 127, 129, 131, 133, 135, 138-139, 141-142, 150-151, 159, 163-164, 181, 198, 200, 202, 223-224, 231-232, 234, 255, 260, 262-263, 265-266, 272-273, 279, 282, 286-287, 289-291, 293, 296-297, 310, 313, 361-364, 389, 393, 400-403, 418-421, 424-425, 427, 440-441, 449, 451, 472-474, 477, 520-523, 533-535, 549-551, 555-556, 570, 573, 577, 582-583, 585-586, 876, 880, 918, 986, 990, 996, 999-1000, 1002-1003, 1005-1006, 1010-1011, 1021, 1024-1025, 1027, 1124, 1160, 1213, 1242
|| sync/src/tests/inflight_blocks.rs: 22, 35, 57, 64, 75, 82, 113, 120, 127
|| sync/src/tests/mod.rs: 154, 160, 163-164, 166-167, 169-170, 182-185, 187-189, 192, 197, 202-203, 205-206, 208-209
|| sync/src/tests/synchronizer.rs: 64
|| sync/src/types.rs: 118-119, 121, 137-138, 141, 146-148, 150, 152, 154-156, 158, 160, 163-165, 167, 169, 173-176, 179-181, 184-185, 188-194, 196-197, 199-200, 202, 215-222, 277-278, 285-289, 296-297, 333, 335, 375-377, 380-381, 383, 439-440, 444, 454, 456-457, 491-492, 546, 577-578, 583-584, 586-587, 592-593, 601, 663-664, 681-682, 687, 698, 710, 727, 750, 754, 759-760, 763, 786, 815-816, 819-820, 822, 824-826, 828, 838-839
|| test/src/net.rs: 24, 30-40, 43, 45-48, 50-68, 71-72, 74-83, 86, 88-92, 99-105, 109-110, 112, 115-119, 125-133, 136-137, 141-142, 150-151, 154-155, 166, 172
|| test/src/node.rs: 36-39, 45, 48-49, 55-56, 60-61, 64-65, 68, 73, 76-85, 87-97, 99-100, 102-103, 111-112, 114-118, 121-123, 126-127, 131-132, 134-136, 138-140, 143-144, 148-151, 153-156, 159-160, 162, 167-168, 171-172, 177-178, 183-184, 188-189, 193-194, 198-204, 207-208, 211-214, 221, 227, 231, 237-245, 250-251, 253-255, 258-264, 266, 289, 292-293, 296-298, 300, 312, 317-322, 324-327, 329-333, 337-338, 342, 348-354, 356-359, 362-365, 367-368, 372, 377-378, 380-390, 392-393, 395-398, 401-404, 407-410
|| test/src/rpc.rs: 19-22, 25, 29-30, 33-34, 41-42, 49-50, 57-58, 65-66, 73, 79, 86-87, 94-100, 103-104, 111-112, 119-120, 127-128, 135, 141-144, 151-152, 159-160, 167-168, 175-176, 179-180, 187-188, 195-196, 203-204
|| test/src/specs/mining/basic.rs: 13-15, 17-18, 21-22, 29-33, 35, 37-48, 50-54, 56-60, 63-64, 66-70, 72-73, 77-78, 81-84, 86-91, 95-101
|| test/src/specs/mining/size_limit.rs: 7-9, 11-12, 14-17, 19-22, 25, 28-30, 32-33, 36-37
|| test/src/specs/mod.rs: 22-23, 26-27, 30-31, 34-35, 38-41, 45-46, 49-50, 54-55, 58, 69, 71-73, 77, 79-81
|| test/src/specs/p2p/disconnect.rs: 8-9, 11-13, 15-18, 20-21, 26-27
|| test/src/specs/p2p/discovery.rs: 8-12, 14-19, 21-22
|| test/src/specs/p2p/malformed_message.rs: 10-11, 13-15, 17-20, 22-26, 28-31, 33-35, 37-39, 42-43, 46-47
|| test/src/specs/relay/block_relay.rs: 8-12, 14-17, 19-20, 22-24, 26-28
|| test/src/specs/relay/compact_block.rs: 19, 25-26, 28-36, 38-39, 41-45, 51-53, 55-59, 61-62, 64, 68-70, 73-78, 80, 83-90, 92-94, 98, 103, 105-110, 112, 115-116, 120-127, 129-130, 132-136, 140, 143, 150-156, 159, 162-164, 167, 170-173, 177-180, 182-188, 193-194, 199-200, 202-208, 210, 212-217, 220-221, 224-225, 228-230
|| test/src/specs/relay/transaction_relay.rs: 10-14, 16-19, 21-23, 25-31, 34, 36-41, 44, 54-55, 57, 59-61, 64-66, 68-74, 76-81, 83-85, 89-95, 97-98, 101-104, 106-107, 109-112, 117-118
|| test/src/specs/sync/block_sync.rs: 17-20, 22-23, 26, 28-31, 33-34, 40-43, 45-52, 55-59, 61-62, 65-69, 73-79, 81-84, 88-92, 95, 98-106, 108, 113-115, 121-123, 125-136, 138, 142-145, 148, 150-156, 159-163, 165, 168-169, 173, 176-178, 180-181, 184-186, 191-196, 199-200, 203-204, 207-208
|| test/src/specs/sync/chain_forks.rs: 16-19, 21-22, 24-28, 30-33, 35-37, 40-41, 44-45, 57-61, 63-64, 66-71, 73-78, 80-84, 86-91, 94-95, 98-99, 103-104, 116-120, 122-123, 125-128, 130-131, 133-138, 140-150, 152-153, 155-156, 158-163, 166-167, 170-171, 175-176, 188-192, 194-195, 197-200, 202-203, 205-210, 212-222, 224-225, 227-228, 230-235, 238-239, 242-243, 247-248, 260-264, 266-275, 277-278, 280-285, 287-301, 303-304, 306-311, 314-315, 318-319, 323-324, 336-340, 342-343, 345-348, 350-351, 353-358, 360-369, 371-372, 374-379, 382-383, 386-387, 391-392, 404-408, 410-411, 413-416, 418-419, 421-426, 428-435, 437-445, 447-448, 450-455, 458-459, 462-463, 467-468
|| test/src/specs/sync/invalid_locator_size.rs: 12-13, 15-17, 19, 21, 23-30, 33-35, 37-39, 42-43, 46-47
|| test/src/specs/sync/sync_timeout.rs: 8-14, 16-17, 19-24, 26-27, 29-30, 32, 34-35, 37-38, 40-45, 47-48, 51-52, 55-56, 60-61
|| test/src/specs/tx_pool/cellbase_maturity.rs: 11-13, 15-16, 18-20, 22-26, 29, 31, 33-35, 37, 39, 41-42, 45-47, 50-51, 54-56
|| test/src/specs/tx_pool/depend_tx_in_same_block.rs: 8-10, 12-17, 19-28, 30, 32-39, 41-42, 45-46
|| test/src/specs/tx_pool/different_txs_with_same_input.rs: 9-11, 13-17, 19-26, 28-29, 31-39, 41-42, 45-46
|| test/src/specs/tx_pool/limit.rs: 8-10, 12-13, 15-18, 20-23, 26-27, 29-33, 37-39, 41-42, 45-46, 49-52, 60-62, 64-65, 67-70, 72-75, 78-79, 81-85, 89-91, 93-94, 97-98, 101-104
|| test/src/specs/tx_pool/pool_reconcile.rs: 7-10, 12-13, 15-16, 18-19, 21-28, 30-31, 33-34, 36, 38-45, 48-49, 52-53
|| test/src/specs/tx_pool/pool_resurrect.rs: 7-10, 12-13, 15-18, 20-23, 26-27, 29-31, 33-34, 36-38, 40-41, 43-45, 47-49, 52-53, 56-57
|| test/src/specs/tx_pool/valid_since.rs: 18-23, 29-30, 33-36, 42-43, 46-52, 56-58, 62-64, 68-74, 79-86, 90-92, 96-99, 103-109, 114-118, 120-122, 126-135, 137-139, 142, 144-146, 149-157, 163-168, 172-182, 184-186, 189, 191-193, 196-204, 211-212, 215-220, 222-226, 229, 231, 233-235, 237, 239, 241-242, 244, 246-247, 250-251, 253, 255-259, 261-265, 268, 270, 272-274, 276, 278, 280-281, 283, 285-286
|| util/app-config/src/app_config.rs: 74-75, 94, 107-110, 114-117, 121-124, 126-128, 135-137, 145-147, 190, 233, 253, 277, 291, 314, 323, 346, 360, 383, 398, 424, 438
|| util/app-config/src/cli.rs: 30-31, 57-58, 61-62, 65-66, 79, 86-87, 96-97, 101, 111-112, 116, 126-127, 133, 136-137, 140, 149-150, 159-160, 162, 165-166, 168, 171-172, 183, 194-195, 242
|| util/app-config/src/exit_code.rs: 14-15, 20-22, 27-29, 34-36, 41-43
|| util/app-config/src/lib.rs: 37-42, 46-50, 53, 55-59, 63, 67, 69-70, 72-78, 81, 83-84, 87-90, 93-95, 99-101, 103, 106-109, 111-113, 117-121, 123-127, 131-135, 137-141, 145-149, 151-155, 159-161, 165-166, 168-169, 172-179, 181-187, 190-198, 202-205, 207, 210-216, 221, 224-225, 227-230, 235, 239-243, 247-250
|| util/app-config/src/sentry_config.rs: 10-15, 21, 24-25, 28, 30-31
|| util/build-info/src/lib.rs: 14-15, 17, 21-22, 25-26, 29-33, 39-43, 46-54, 57, 61-62, 66-67, 69, 73-74, 79-80, 82
|| util/crypto/src/bech32/error.rs: 25-26
|| util/crypto/src/bech32/mod.rs: 63, 67-69, 71-77, 79, 81, 84, 86-89, 93-94, 97-101, 104-107, 109-110, 113-114, 117-118, 120-122, 125, 129-130, 132-133, 136-137, 140-141, 145-146, 148-150, 153, 157-158, 162-163, 167-168, 170-172
|| util/crypto/src/secp/error.rs: 21-27
|| util/crypto/src/secp/generator.rs: 29, 39
|| util/crypto/src/secp/privkey.rs: 45, 51-52, 59-62, 69-70, 83-84
|| util/crypto/src/secp/pubkey.rs: 22, 39, 48-49, 60, 66-67, 74-75, 91-92
|| util/crypto/src/secp/signature.rs: 23-24, 28-29, 33-34, 45-50, 54-58, 62-65, 68, 93-94, 103-104, 113-114, 119-120, 125-128, 135-136, 138
|| util/dao/src/lib.rs: 22
|| util/dao/utils/src/lib.rs: 76
|| util/instrument/src/export.rs: 25, 34-35, 39-40, 43-47, 52-58, 60-64, 66, 70-76, 78-83, 85-89, 91-92
|| util/instrument/src/format.rs: 11-14, 22-26
|| util/instrument/src/import.rs: 24, 32-35, 40-42, 44-48, 53, 57-65, 67-71, 75, 77-78
|| util/instrument/src/iter.rs: 15-17, 25-26, 33-34, 36-41, 44, 46, 49-52
|| util/jsonrpc-types/src/block_template.rs: 38-41, 44-45, 62-64, 78-80
|| util/jsonrpc-types/src/blockchain.rs: 66, 71, 89-90, 93, 152, 155, 218, 224, 237-238, 251, 253-254, 259, 261-262, 294, 301, 392, 405, 425-426, 452, 454-455, 471-472, 474-475, 520, 525, 537-543, 545, 567, 590-599, 601-607
|| util/jsonrpc-types/src/bytes.rs: 32-33, 46-47, 55, 83
|| util/jsonrpc-types/src/cell.rs: 25-27
|| util/jsonrpc-types/src/proposal_short_id.rs: 35-36, 44, 48, 52, 56, 69
|| util/jsonrpc-types/src/sync.rs: 16, 18-20
|| util/logger/src/lib.rs: 122-123, 125-126, 129-130, 133-141, 143-152, 156-163, 165-166, 169-170, 175, 179-180, 184-185, 199, 202, 211-212, 215, 217-219, 221-231, 234, 238-241, 245, 247, 249, 257, 262, 265-267, 270-271, 277-287, 290, 294-295, 299
|| util/merkle-tree/src/lib.rs: 31-32, 35-36
|| util/multisig/src/error.rs: 33
|| util/multisig/src/secp256k1.rs: 31-32, 36-38
|| util/occupied-capacity/core/src/traits.rs: 12-13, 15-16, 63-64
|| util/occupied-capacity/core/src/units.rs: 27-28, 53, 64, 71
|| util/occupied-capacity/macros/src/lib.rs: 13, 15-20, 22, 26, 28, 31, 34-35, 37, 39, 49, 53-56, 58, 61, 64-69, 71, 79, 81-83, 100-104, 108, 117, 127-131, 135, 146
|| util/src/lib.rs: 61-64
|| util/src/linked_hash_set.rs: 18, 20, 46, 48, 62, 77, 79, 93-94, 97-98, 101-102, 105-106, 163, 165, 177-178, 180-181, 186-187
|| util/stop-handler/src/lib.rs: 19, 22-24, 54-56, 62
|| verification/src/block_verifier.rs: 55-56, 58, 90, 95, 111, 115, 119, 139, 189, 217
|| verification/src/contextual_block_verifier.rs: 30-31, 35, 40-41, 44-48, 51-52, 56, 76, 80-81, 83, 85-86, 88, 111, 139, 147, 150, 156-158, 177-182, 188, 190-191, 195, 197, 200, 202, 237, 239, 242, 244-245, 252, 288-290, 301, 304, 319, 328-329, 337, 378, 381
|| verification/src/error.rs: 69-72, 173-174, 181, 183-186, 192-194, 200-202
|| verification/src/header_verifier.rs: 44, 64, 88, 93, 96-98, 103-105, 124-126, 140-141, 144-146, 151-153, 176-177
|| verification/src/tests/commit_verifier.rs: 171
|| verification/src/tests/dummy.rs: 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 87
|| verification/src/tests/transaction_verifier.rs: 178
|| verification/src/tests/uncle_verifier.rs: 171, 243, 267, 344, 515
|| verification/src/transaction_verifier.rs: 106, 129-130, 161, 177, 207-210, 216-218, 223-225, 231, 252, 276-278, 284, 286, 292-295, 354, 390, 392, 394, 400, 402, 404-405, 423-425, 428-431, 434-435, 451, 455-456, 469, 471, 477-478, 487-489, 493
|| verification/src/uncles_verifier.rs: 63-65, 81, 117-120, 122
|| Tested/Total Lines:
|| chain/src/chain.rs: 252/361
|| chain/src/tests/basic.rs: 545/557
|| chain/src/tests/delay_verify.rs: 264/266
|| chain/src/tests/find_fork.rs: 165/165
|| chain/src/tests/util.rs: 36/36
|| ckb-bin/src/helper.rs: 0/19
|| ckb-bin/src/lib.rs: 0/21
|| ckb-bin/src/subcommand/cli/blake.rs: 0/10
|| ckb-bin/src/subcommand/cli/hashes.rs: 0/56
|| ckb-bin/src/subcommand/cli/mod.rs: 21/21
|| ckb-bin/src/subcommand/cli/secp256k1_lock.rs: 0/26
|| ckb-bin/src/subcommand/export.rs: 0/11
|| ckb-bin/src/subcommand/import.rs: 0/14
|| ckb-bin/src/subcommand/init.rs: 0/30
|| ckb-bin/src/subcommand/miner.rs: 0/8
|| ckb-bin/src/subcommand/prof.rs: 0/42
|| ckb-bin/src/subcommand/run.rs: 0/73
|| core/src/block.rs: 108/124
|| core/src/cell.rs: 342/420
|| core/src/difficulty.rs: 8/14
|| core/src/error.rs: 0/2
|| core/src/extras.rs: 39/43
|| core/src/header.rs: 112/160
|| core/src/script.rs: 40/53
|| core/src/service.rs: 6/6
|| core/src/transaction.rs: 196/354
|| core/src/transaction_meta.rs: 42/50
|| core/src/uncle.rs: 25/29
|| db/src/cachedb.rs: 0/51
|| db/src/memorydb.rs: 74/76
|| db/src/rocksdb.rs: 120/163
|| miner/src/block_assembler.rs: 287/338
|| miner/src/client.rs: 0/90
|| miner/src/miner.rs: 0/74
|| network/src/behaviour.rs: 4/8
|| network/src/compress.rs: 37/48
|| network/src/config.rs: 47/64
|| network/src/errors.rs: 0/18
|| network/src/network.rs: 147/532
|| network/src/network_group.rs: 15/25
|| network/src/peer.rs: 9/11
|| network/src/peer_registry.rs: 88/121
|| network/src/peer_store/sqlite/db.rs: 129/164
|| network/src/peer_store/sqlite/peer_store.rs: 142/177
|| network/src/peer_store/sqlite.rs: 0/2
|| network/src/peer_store/types.rs: 10/19
|| network/src/peer_store.rs: 8/12
|| network/src/protocols/discovery.rs: 21/147
|| network/src/protocols/feeler.rs: 2/24
|| network/src/protocols/identify.rs: 2/44
|| network/src/protocols/mod.rs: 0/139
|| network/src/protocols/ping.rs: 3/30
|| network/src/services/dns_seeding/mod.rs: 9/77
|| network/src/services/dns_seeding/seed_record.rs: 78/116
|| network/src/services/outbound_peer.rs: 27/53
|| network/src/tests/peer_registry.rs: 119/121
|| network/src/tests/sqlite_peer_store.rs: 122/125
|| notify/src/lib.rs: 39/46
|| pow/src/cuckoo.rs: 160/187
|| pow/src/dummy.rs: 8/37
|| pow/src/lib.rs: 14/32
|| protocol/src/builder.rs: 235/442
|| protocol/src/convert.rs: 119/205
|| protocol/src/lib.rs: 26/28
|| protocol/src/protocol_generated.rs: 429/1032
|| protocol/src/protocol_generated_verifier.rs: 467/1703
|| resource/src/lib.rs: 118/140
|| resource/src/template.rs: 36/43
|| rpc/src/config.rs: 0/14
|| rpc/src/error.rs: 0/2
|| rpc/src/module/chain.rs: 65/97
|| rpc/src/module/experiment.rs: 36/69
|| rpc/src/module/miner.rs: 0/50
|| rpc/src/module/net.rs: 0/31
|| rpc/src/module/pool.rs: 24/27
|| rpc/src/module/stats.rs: 17/27
|| rpc/src/module/test.rs: 0/17
|| rpc/src/server.rs: 0/56
|| rpc/src/test.rs: 125/136
|| script/src/cost_model.rs: 41/52
|| script/src/lib.rs: 2/11
|| script/src/syscalls/debugger.rs: 3/21
|| script/src/syscalls/load_cell.rs: 57/87
|| script/src/syscalls/load_header.rs: 22/31
|| script/src/syscalls/load_input.rs: 7/58
|| script/src/syscalls/load_script_hash.rs: 9/9
|| script/src/syscalls/load_tx_hash.rs: 9/9
|| script/src/syscalls/load_witness.rs: 21/26
|| script/src/syscalls/mod.rs: 622/632
|| script/src/syscalls/utils.rs: 12/12
|| script/src/verify.rs: 1197/1300
|| shared/src/cell_set.rs: 58/87
|| shared/src/chain_state.rs: 235/455
|| shared/src/config.rs: 0/19
|| shared/src/shared.rs: 85/108
|| shared/src/tests/proposal_table.rs: 44/44
|| shared/src/tests/shared.rs: 35/35
|| shared/src/tx_pool/orphan.rs: 101/109
|| shared/src/tx_pool/pending.rs: 23/36
|| shared/src/tx_pool/pool.rs: 38/91
|| shared/src/tx_pool/proposed.rs: 198/268
|| shared/src/tx_pool/types.rs: 4/14
|| shared/src/tx_proposal_table.rs: 45/67
|| shared/tx-pool-executor/src/tx_pool_executor.rs: 168/191
|| spec/src/consensus.rs: 140/158
|| spec/src/lib.rs: 102/139
|| src/main.rs: 1/16
|| store/src/flat_block_body.rs: 94/95
|| store/src/lazy_load_cell_output.rs: 4/4
|| store/src/store.rs: 306/355
|| sync/src/config.rs: 1/1
|| sync/src/lib.rs: 2/2
|| sync/src/net_time_checker.rs: 43/82
|| sync/src/relayer/block_proposal_process.rs: 0/38
|| sync/src/relayer/block_transactions_process.rs: 0/20
|| sync/src/relayer/compact_block.rs: 7/34
|| sync/src/relayer/compact_block_process.rs: 0/124
|| sync/src/relayer/compact_block_verifier.rs: 29/38
|| sync/src/relayer/get_block_proposal_process.rs: 0/27
|| sync/src/relayer/get_block_transactions_process.rs: 0/20
|| sync/src/relayer/get_transaction_process.rs: 0/26
|| sync/src/relayer/mod.rs: 35/264
|| sync/src/relayer/tests/compact_block_process.rs: 111/114
|| sync/src/relayer/tests/compact_block_verifier.rs: 68/68
|| sync/src/relayer/transaction_hash_process.rs: 0/37
|| sync/src/relayer/transaction_process.rs: 0/70
|| sync/src/synchronizer/block_fetcher.rs: 61/92
|| sync/src/synchronizer/block_pool.rs: 41/46
|| sync/src/synchronizer/block_process.rs: 6/9
|| sync/src/synchronizer/filter_process.rs: 0/22
|| sync/src/synchronizer/get_blocks_process.rs: 15/23
|| sync/src/synchronizer/get_headers_process.rs: 21/40
|| sync/src/synchronizer/headers_process.rs: 111/228
|| sync/src/synchronizer/mod.rs: 575/686
|| sync/src/tests/inflight_blocks.rs: 70/79
|| sync/src/tests/mod.rs: 77/100
|| sync/src/tests/synchronizer.rs: 78/79
|| sync/src/types.rs: 245/355
|| test/src/net.rs: 0/88
|| test/src/node.rs: 0/194
|| test/src/rpc.rs: 0/57
|| test/src/specs/mining/basic.rs: 0/63
|| test/src/specs/mining/size_limit.rs: 0/21
|| test/src/specs/mod.rs: 0/27
|| test/src/specs/p2p/disconnect.rs: 0/13
|| test/src/specs/p2p/discovery.rs: 0/13
|| test/src/specs/p2p/malformed_message.rs: 0/28
|| test/src/specs/relay/block_relay.rs: 0/17
|| test/src/specs/relay/compact_block.rs: 0/131
|| test/src/specs/relay/transaction_relay.rs: 0/73
|| test/src/specs/sync/block_sync.rs: 0/124
|| test/src/specs/sync/chain_forks.rs: 0/295
|| test/src/specs/sync/invalid_locator_size.rs: 0/25
|| test/src/specs/sync/sync_timeout.rs: 0/38
|| test/src/specs/tx_pool/cellbase_maturity.rs: 0/30
|| test/src/specs/tx_pool/depend_tx_in_same_block.rs: 0/32
|| test/src/specs/tx_pool/different_txs_with_same_input.rs: 0/31
|| test/src/specs/tx_pool/limit.rs: 0/62
|| test/src/specs/tx_pool/pool_reconcile.rs: 0/35
|| test/src/specs/tx_pool/pool_resurrect.rs: 0/36
|| test/src/specs/tx_pool/valid_since.rs: 0/173
|| traits/src/block_median_time_context.rs: 10/10
|| util/app-config/src/app_config.rs: 161/198
|| util/app-config/src/cli.rs: 0/37
|| util/app-config/src/exit_code.rs: 0/14
|| util/app-config/src/lib.rs: 0/139
|| util/app-config/src/sentry_config.rs: 0/12
|| util/build-info/src/lib.rs: 0/37
|| util/crypto/src/bech32/error.rs: 0/2
|| util/crypto/src/bech32/mod.rs: 0/62
|| util/crypto/src/secp/error.rs: 0/7
|| util/crypto/src/secp/generator.rs: 13/15
|| util/crypto/src/secp/mod.rs: 18/18
|| util/crypto/src/secp/privkey.rs: 22/33
|| util/crypto/src/secp/pubkey.rs: 24/35
|| util/crypto/src/secp/signature.rs: 21/58
|| util/dao/src/lib.rs: 105/106
|| util/dao/utils/src/lib.rs: 7/8
|| util/hash/src/lib.rs: 12/12
|| util/instrument/src/export.rs: 0/43
|| util/instrument/src/format.rs: 0/9
|| util/instrument/src/import.rs: 0/31
|| util/instrument/src/iter.rs: 0/19
|| util/jsonrpc-types/src/block_template.rs: 0/12
|| util/jsonrpc-types/src/blockchain.rs: 167/225
|| util/jsonrpc-types/src/bytes.rs: 31/37
|| util/jsonrpc-types/src/cell.rs: 5/8
|| util/jsonrpc-types/src/proposal_short_id.rs: 21/28
|| util/jsonrpc-types/src/string.rs: 4/4
|| util/jsonrpc-types/src/sync.rs: 0/4
|| util/logger/src/lib.rs: 0/91
|| util/merkle-tree/src/lib.rs: 9/13
|| util/multisig/src/error.rs: 4/5
|| util/multisig/src/secp256k1.rs: 78/83
|| util/occupied-capacity/core/src/traits.rs: 15/21
|| util/occupied-capacity/core/src/units.rs: 18/23
|| util/occupied-capacity/macros/src/lib.rs: 0/47
|| util/occupied-capacity/tests/tests.rs: 16/16
|| util/src/lib.rs: 2/6
|| util/src/linked_hash_set.rs: 39/62
|| util/stop-handler/src/lib.rs: 14/22
|| util/test-chain-utils/src/lib.rs: 12/12
|| verification/src/block_verifier.rs: 68/79
|| verification/src/contextual_block_verifier.rs: 118/175
|| verification/src/error.rs: 0/17
|| verification/src/header_verifier.rs: 42/65
|| verification/src/tests/block_verifier.rs: 83/83
|| verification/src/tests/commit_verifier.rs: 134/135
|| verification/src/tests/dummy.rs: 0/17
|| verification/src/tests/transaction_verifier.rs: 200/201
|| verification/src/tests/uncle_verifier.rs: 313/318
|| verification/src/transaction_verifier.rs: 147/201
|| verification/src/uncles_verifier.rs: 43/52
|| 
58.26% coverage, 12874/22097 lines covered
```
If we need to upload the coverage to codecov, we should register it firstly.