### PR TITLE
chore: use large timeout value for integration test

### DIFF
--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -122,10 +122,11 @@ impl Net {
         });
     }
 
-    pub fn waiting_for_sync(&self, target: BlockNumber, timeout: u64) {
+    pub fn waiting_for_sync(&self, target: BlockNumber) {
         let rpc_clients: Vec<_> = self.nodes.iter().map(Node::rpc_client).collect();
         let mut tip_numbers: HashSet<BlockNumber> = HashSet::with_capacity(self.nodes.len());
-        let result = wait_until(timeout, || {
+        // 60 seconds is a reasonable timeout to sync, even for poor CI server
+        let result = wait_until(60, || {
             tip_numbers = rpc_clients
                 .iter()
                 .map(|rpc_client| rpc_client.get_tip_block_number())

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -145,12 +145,12 @@ impl Node {
         }
     }
 
-    pub fn waiting_for_sync(&self, node: &Node, target: BlockNumber, timeout: u64) {
+    pub fn waiting_for_sync(&self, node: &Node, target: BlockNumber) {
         let self_rpc_client = self.rpc_client();
         let node_rpc_client = node.rpc_client();
         let (mut self_tip_number, mut node_tip_number) = (0, 0);
-
-        let result = wait_until(timeout, || {
+        // 60 seconds is a reasonable timeout to sync, even for poor CI server
+        let result = wait_until(60, || {
             self_tip_number = self_rpc_client.get_tip_block_number();
             node_tip_number = node_rpc_client.get_tip_block_number();
             self_tip_number == node_tip_number && target == self_tip_number

--- a/test/src/specs/relay/compact_block.rs
+++ b/test/src/specs/relay/compact_block.rs
@@ -161,7 +161,7 @@ impl CompactBlockBasic {
         // Make node0 and node1 reach the same height
         node1.generate_block();
         node0.connect(node1);
-        node0.waiting_for_sync(node1, node0.get_tip_block().header().number(), 20);
+        node0.waiting_for_sync(node1, node0.get_tip_block().header().number());
 
         // Net consume and ignore the recent blocks
         clear_messages(net);
@@ -191,7 +191,7 @@ impl CompactBlockBasic {
 
         // Submit the new block to node1. We expect node1 will relay the new block to node0.
         node1.submit_block(&block);
-        node1.waiting_for_sync(node0, node1.get_tip_block().header().number(), 20);
+        node1.waiting_for_sync(node0, node1.get_tip_block().header().number());
     }
 }
 

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -78,7 +78,7 @@ impl Spec for TransactionRelayMultiple {
         node0.generate_block();
         node0.generate_block();
         node0.generate_block();
-        net.waiting_for_sync(4, 10);
+        net.waiting_for_sync(4);
 
         info!("Send multiple transactions to node0");
         let tx_hash = transaction.hash().to_owned();
@@ -101,7 +101,7 @@ impl Spec for TransactionRelayMultiple {
         node0.generate_block();
         node0.generate_block();
         node0.generate_block();
-        net.waiting_for_sync(7, 30);
+        net.waiting_for_sync(7);
 
         info!("All transactions should be relayed and mined");
         node0.assert_tx_pool_size(0, 0);

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -23,7 +23,7 @@ impl Spec for ChainFork1 {
 
         info!("Connect node0 to node1");
         node0.connect(node1);
-        node0.waiting_for_sync(node1, 2, 10);
+        node0.waiting_for_sync(node1, 2);
         info!("Disconnect node1");
         node0.disconnect(node1);
 
@@ -34,7 +34,7 @@ impl Spec for ChainFork1 {
 
         info!("Reconnect node0 to node1");
         node0.connect(node1);
-        net.waiting_for_sync(4, 10);
+        net.waiting_for_sync(4);
     }
 
     fn num_nodes(&self) -> usize {
@@ -66,14 +66,14 @@ impl Spec for ChainFork2 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
         info!("Disconnect all nodes");
         net.disconnect_all();
 
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -81,14 +81,14 @@ impl Spec for ChainFork2 {
         node1.generate_blocks(2);
         info!("Reconnect node1");
         node0.connect(node1);
-        node0.waiting_for_sync(node1, 4, 10);
+        node0.waiting_for_sync(node1, 4);
 
         info!("Generate 2 blocks (F, G) on node2");
         node2.generate_blocks(2);
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        net.waiting_for_sync(5, 10);
+        net.waiting_for_sync(5);
     }
 
     fn num_nodes(&self) -> usize {
@@ -125,7 +125,7 @@ impl Spec for ChainFork3 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -133,7 +133,7 @@ impl Spec for ChainFork3 {
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -160,7 +160,7 @@ impl Spec for ChainFork3 {
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        node0.waiting_for_sync(node2, 4, 10);
+        node0.waiting_for_sync(node2, 4);
     }
 
     fn num_nodes(&self) -> usize {
@@ -197,7 +197,7 @@ impl Spec for ChainFork4 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -205,7 +205,7 @@ impl Spec for ChainFork4 {
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -232,7 +232,7 @@ impl Spec for ChainFork4 {
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        node0.waiting_for_sync(node2, 4, 10);
+        node0.waiting_for_sync(node2, 4);
     }
 
     fn num_nodes(&self) -> usize {
@@ -272,7 +272,7 @@ impl Spec for ChainFork5 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -280,7 +280,7 @@ impl Spec for ChainFork5 {
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -308,7 +308,7 @@ impl Spec for ChainFork5 {
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        node0.waiting_for_sync(node2, 4, 10);
+        node0.waiting_for_sync(node2, 4);
     }
 
     fn num_nodes(&self) -> usize {
@@ -345,7 +345,7 @@ impl Spec for ChainFork6 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -353,7 +353,7 @@ impl Spec for ChainFork6 {
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -376,7 +376,7 @@ impl Spec for ChainFork6 {
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        node0.waiting_for_sync(node2, 4, 10);
+        node0.waiting_for_sync(node2, 4);
     }
 
     fn num_nodes(&self) -> usize {
@@ -413,7 +413,7 @@ impl Spec for ChainFork7 {
         info!("Connect all nodes");
         node0.connect(node1);
         node0.connect(node2);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -421,7 +421,7 @@ impl Spec for ChainFork7 {
         info!("Generate 1 block (C) on node0");
         node0.generate_blocks(1);
         node0.connect(node2);
-        node0.waiting_for_sync(node2, 3, 10);
+        node0.waiting_for_sync(node2, 3);
         info!("Disconnect node2");
         node0.disconnect(node2);
 
@@ -452,7 +452,7 @@ impl Spec for ChainFork7 {
         info!("Reconnect node2");
         node0.connect(node2);
         node1.connect(node2);
-        node0.waiting_for_sync(node2, 4, 10);
+        node0.waiting_for_sync(node2, 4);
     }
 
     fn num_nodes(&self) -> usize {

--- a/test/src/specs/sync/sync_timeout.rs
+++ b/test/src/specs/sync/sync_timeout.rs
@@ -21,7 +21,7 @@ impl Spec for SyncTimeout {
         node0.connect(node2);
         node0.connect(node3);
         node0.connect(node4);
-        net.waiting_for_sync(2, 10);
+        net.waiting_for_sync(2);
 
         info!("Disconnect all nodes");
         net.disconnect_all();
@@ -30,9 +30,8 @@ impl Spec for SyncTimeout {
         node0.generate_blocks(200);
 
         node0.connect(node1);
-        // 60 seconds is a reasonable timeout to sync, even for poor CI server
         info!("Waiting for node0 and node1 sync");
-        node0.waiting_for_sync(node1, 202, 60);
+        node0.waiting_for_sync(node1, 202);
 
         info!("Generate 200 blocks on node1");
         node1.generate_blocks(200);
@@ -43,9 +42,8 @@ impl Spec for SyncTimeout {
         node3.connect(node1);
         node4.connect(node0);
         node4.connect(node1);
-        // 60 seconds is a reasonable timeout to sync, even for poor CI server
         info!("Waiting for all nodes sync");
-        net.waiting_for_sync(402, 60);
+        net.waiting_for_sync(402);
     }
 
     fn num_nodes(&self) -> usize {

--- a/test/src/specs/tx_pool/pool_reconcile.rs
+++ b/test/src/specs/tx_pool/pool_reconcile.rs
@@ -33,7 +33,7 @@ impl Spec for PoolReconcile {
         info!("Connect node0 to node1");
         node0.connect(node1);
 
-        net.waiting_for_sync(5, 10);
+        net.waiting_for_sync(5);
 
         info!("Tx should be re-added to node0's pool");
         assert!(node0

--- a/test/src/specs/tx_pool/pool_resurrect.rs
+++ b/test/src/specs/tx_pool/pool_resurrect.rs
@@ -35,7 +35,7 @@ impl Spec for PoolResurrect {
 
         info!("Connect node0 to node1, waiting for sync");
         node0.connect(node1);
-        net.waiting_for_sync(5, 10);
+        net.waiting_for_sync(5);
 
         info!("6 txs should be returned to node0 pending pool");
         node0.assert_tx_pool_size(txs_hash.len() as u64, 0);


### PR DESCRIPTION
Change all `waiting_for_sync` timeout value to 60 seconds, resolve integration test fail issue on poor CI server.