### PR TITLE
refactor: Remove redundant interface from ChainProvider

### DIFF
--- a/benches/benches/process_block.rs
+++ b/benches/benches/process_block.rs
@@ -10,7 +10,7 @@ use ckb_core::{capacity_bytes, Bytes, Capacity};
 use ckb_db::{DBConfig, RocksDB};
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
-use ckb_store::ChainKVStore;
+use ckb_store::{ChainKVStore, ChainStore};
 use ckb_traits::chain_provider::ChainProvider;
 use criterion::{criterion_group, criterion_main, Criterion};
 use numext_fixed_hash::H256;
@@ -30,7 +30,8 @@ fn bench(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let (chain, shared, dir, system_cell_hash, data_hash) = new_chain(*txs_size);
-                    let mut blocks = vec![shared.block(&shared.genesis_hash()).unwrap()];
+                    let mut blocks =
+                        vec![shared.store().get_block(&shared.genesis_hash()).unwrap()];
                     (0..20).for_each(|_| {
                         let parent_index = blocks.len() - 1;
                         gen_block(&mut blocks, parent_index, &system_cell_hash, &data_hash);
@@ -59,7 +60,8 @@ fn bench(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let (chain, shared, dir, system_cell_hash, data_hash) = new_chain(*txs_size);
-                    let mut blocks = vec![shared.block(&shared.genesis_hash()).unwrap()];
+                    let mut blocks =
+                        vec![shared.store().get_block(&shared.genesis_hash()).unwrap()];
                     (0..5).for_each(|_| {
                         let parent_index = blocks.len() - 1;
                         gen_block(&mut blocks, parent_index, &system_cell_hash, &data_hash);
@@ -102,7 +104,8 @@ fn bench(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let (chain, shared, dir, system_cell_hash, data_hash) = new_chain(*txs_size);
-                    let mut blocks = vec![shared.block(&shared.genesis_hash()).unwrap()];
+                    let mut blocks =
+                        vec![shared.store().get_block(&shared.genesis_hash()).unwrap()];
                     (0..5).for_each(|_| {
                         let parent_index = blocks.len() - 1;
                         gen_block(&mut blocks, parent_index, &system_cell_hash, &data_hash);

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -5,6 +5,7 @@ use ckb_core::block::Block;
 use ckb_core::cell::UnresolvableError;
 use ckb_core::transaction::OutPoint;
 use ckb_shared::error::SharedError;
+use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 use numext_fixed_uint::U256;
 use std::sync::Arc;
@@ -18,7 +19,10 @@ fn test_dead_cell_in_same_block() {
     let mut chain1: Vec<Block> = Vec::new();
     let mut chain2: Vec<Block> = Vec::new();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..final_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -32,7 +36,10 @@ fn test_dead_cell_in_same_block() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..switch_fork_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -116,7 +123,10 @@ fn test_dead_cell_in_different_block() {
     let mut chain1: Vec<Block> = Vec::new();
     let mut chain2: Vec<Block> = Vec::new();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..final_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -130,7 +140,10 @@ fn test_dead_cell_in_different_block() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..switch_fork_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -222,7 +235,10 @@ fn test_invalid_out_point_index_in_same_block() {
     let mut chain1: Vec<Block> = Vec::new();
     let mut chain2: Vec<Block> = Vec::new();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..final_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -236,7 +252,10 @@ fn test_invalid_out_point_index_in_same_block() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..switch_fork_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -321,7 +340,10 @@ fn test_invalid_out_point_index_in_different_blocks() {
     let mut chain1: Vec<Block> = Vec::new();
     let mut chain2: Vec<Block> = Vec::new();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..final_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(
@@ -335,7 +357,10 @@ fn test_invalid_out_point_index_in_different_blocks() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for _ in 1..switch_fork_number {
         let difficulty = parent.difficulty().to_owned();
         let new_block = gen_block(

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -6,6 +6,7 @@ use ckb_core::extras::{BlockExt, DaoStats, DEFAULT_ACCUMULATED_RATE};
 use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::SharedBuilder;
+use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 use faketime::unix_time_as_millis;
 use numext_fixed_uint::U256;
@@ -23,7 +24,10 @@ fn test_find_fork_case1() {
     let shared = builder.consensus(Consensus::default()).build().unwrap();
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainService::new(shared.clone(), notify);
-    let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     let mut fork1: Vec<Block> = Vec::new();
     let mut fork2: Vec<Block> = Vec::new();
@@ -101,7 +105,10 @@ fn test_find_fork_case2() {
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainService::new(shared.clone(), notify);
 
-    let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     let mut fork1: Vec<Block> = Vec::new();
     let mut fork2: Vec<Block> = Vec::new();
@@ -186,7 +193,10 @@ fn test_find_fork_case3() {
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainService::new(shared.clone(), notify);
 
-    let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     let mut fork1: Vec<Block> = Vec::new();
     let mut fork2: Vec<Block> = Vec::new();
@@ -263,7 +273,10 @@ fn test_find_fork_case4() {
     let notify = NotifyService::default().start::<&str>(None);
     let mut chain_service = ChainService::new(shared.clone(), notify);
 
-    let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     let mut fork1: Vec<Block> = Vec::new();
     let mut fork2: Vec<Block> = Vec::new();

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -652,7 +652,10 @@ mod tests {
         let new_uncle_receiver = notify.subscribe_new_uncle("test_prepare_uncles");
         let block_assembler_controller = block_assembler.start(Some("test"), &notify.clone());
 
-        let genesis = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+        let genesis = shared
+            .store()
+            .get_block_header(&shared.store().get_block_hash(0).unwrap())
+            .unwrap();
 
         let block0_0 = gen_block(&genesis, 11, &epoch);
         let block0_1 = gen_block(&genesis, 10, &epoch);

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -151,7 +151,7 @@ impl<'a, CS: ChainStore> HeaderProvider for DryRunner<'a, CS> {
         let block_hash = o.block_hash.as_ref().expect("checked below");
         self.chain_state
             .store()
-            .get_header(&block_hash)
+            .get_block_header(&block_hash)
             .map(|header| HeaderStatus::Live(Box::new(header)))
             .unwrap_or(HeaderStatus::Unknown)
     }

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -746,7 +746,7 @@ impl<CS: ChainStore> CellProvider for ChainState<CS> {
 impl<CS: ChainStore> HeaderProvider for ChainState<CS> {
     fn header(&self, out_point: &OutPoint) -> HeaderStatus {
         if let Some(block_hash) = &out_point.block_hash {
-            match self.store.get_header(&block_hash) {
+            match self.store.get_block_header(&block_hash) {
                 Some(header) => {
                     if let Some(cell_out_point) = &out_point.cell {
                         self.store
@@ -817,7 +817,7 @@ impl<CS: ChainStore> BlockMedianTimeContext for &ChainState<CS> {
     fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
         let header = self
             .store
-            .get_header(&block_hash)
+            .get_block_header(&block_hash)
             .expect("[ChainState] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -2,11 +2,8 @@ use crate::chain_state::ChainState;
 use crate::error::SharedError;
 use crate::tx_pool::TxPoolConfig;
 use ckb_chain_spec::consensus::Consensus;
-use ckb_core::block::Block;
-use ckb_core::extras::{BlockExt, EpochExt};
+use ckb_core::extras::EpochExt;
 use ckb_core::header::{BlockNumber, Header};
-use ckb_core::transaction::{ProposalShortId, Transaction};
-use ckb_core::uncle::UncleBlock;
 use ckb_core::Cycle;
 use ckb_db::{DBConfig, KeyValueDB, MemoryKeyValueDB, RocksDB};
 use ckb_script::ScriptConfig;
@@ -87,60 +84,25 @@ impl<CS: ChainStore> ChainProvider for Shared<CS> {
         &self.script_config
     }
 
-    fn block(&self, hash: &H256) -> Option<Block> {
-        self.store.get_block(hash)
-    }
-
-    fn block_body(&self, hash: &H256) -> Option<Vec<Transaction>> {
-        self.store.get_block_body(hash)
-    }
-
-    fn block_header(&self, hash: &H256) -> Option<Header> {
-        self.store.get_header(hash)
-    }
-
-    fn block_proposal_txs_ids(&self, hash: &H256) -> Option<Vec<ProposalShortId>> {
-        self.store.get_block_proposal_txs_ids(hash)
-    }
-
-    fn uncles(&self, hash: &H256) -> Option<Vec<UncleBlock>> {
-        self.store.get_block_uncles(hash)
-    }
-
-    fn block_hash(&self, number: BlockNumber) -> Option<H256> {
-        self.store.get_block_hash(number)
-    }
-
-    fn block_ext(&self, hash: &H256) -> Option<BlockExt> {
-        self.store.get_block_ext(hash)
-    }
-
-    fn block_number(&self, hash: &H256) -> Option<BlockNumber> {
-        self.store.get_block_number(hash)
-    }
-
     fn genesis_hash(&self) -> &H256 {
         self.consensus.genesis_hash()
     }
 
-    fn get_transaction(&self, hash: &H256) -> Option<(Transaction, H256)> {
-        self.store.get_transaction(hash)
-    }
-
     fn get_ancestor(&self, base: &H256, number: BlockNumber) -> Option<Header> {
         // if base in the main chain
-        if let Some(n_number) = self.block_number(base) {
+        if let Some(n_number) = self.store.get_block_number(base) {
             if number > n_number {
                 return None;
             } else {
                 return self
-                    .block_hash(number)
-                    .and_then(|hash| self.block_header(&hash));
+                    .store
+                    .get_block_hash(number)
+                    .and_then(|hash| self.store.get_block_header(&hash));
             }
         }
 
         // if base in the fork
-        if let Some(header) = self.block_header(base) {
+        if let Some(header) = self.store.get_block_header(base) {
             let mut n_number = header.number();
             let mut index_walk = header;
             if number > n_number {
@@ -148,7 +110,7 @@ impl<CS: ChainStore> ChainProvider for Shared<CS> {
             }
 
             while n_number > number {
-                if let Some(header) = self.block_header(&index_walk.parent_hash()) {
+                if let Some(header) = self.store.get_block_header(&index_walk.parent_hash()) {
                     index_walk = header;
                     n_number -= 1;
                 } else {
@@ -170,8 +132,12 @@ impl<CS: ChainStore> ChainProvider for Shared<CS> {
         self.consensus.next_epoch_ext(
             last_epoch,
             header,
-            |hash| self.block_header(hash),
-            |hash| self.block_ext(hash).map(|ext| ext.total_uncles_count),
+            |hash| self.store.get_block_header(hash),
+            |hash| {
+                self.store
+                    .get_block_ext(hash)
+                    .map(|ext| ext.total_uncles_count)
+            },
         )
     }
 

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -22,7 +22,7 @@ impl<CS: ChainStore> BlockMedianTimeContext for StoreBlockMedianTimeContext<CS> 
     fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
         let header = self
             .store
-            .get_header(block_hash)
+            .get_block_header(block_hash)
             .expect("[StoreBlockMedianTimeContext] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
@@ -286,7 +286,10 @@ mod tests {
     #[test]
     fn test_verify_and_add_tx_to_pool() {
         let (shared, always_success_out_point) = setup(10);
-        let last_block = shared.block(&shared.lock_chain_state().tip_hash()).unwrap();
+        let last_block = shared
+            .store()
+            .get_block(&shared.lock_chain_state().tip_hash())
+            .unwrap();
         let last_cellbase = last_block.transactions().first().unwrap();
 
         // building 10 txs and broadcast some

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -271,7 +271,7 @@ impl Consensus {
         &self,
         last_epoch: &EpochExt,
         header: &Header,
-        get_header: A,
+        get_block_header: A,
         total_uncles_count: B,
     ) -> Option<EpochExt>
     where
@@ -292,7 +292,7 @@ impl Consensus {
         let last_block_header_in_previous_epoch = if last_epoch.is_genesis() {
             self.genesis_block().header().clone()
         } else {
-            get_header(last_epoch.last_block_hash_in_previous_epoch())?
+            get_block_header(last_epoch.last_block_hash_in_previous_epoch())?
         };
 
         let start_total_uncles_count =

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -40,7 +40,7 @@ impl<'a, CS: ChainStore> GetBlockTransactionsProcess<'a, CS> {
 
         let indexes = cast!(self.message.indexes())?;
 
-        if let Some(block) = self.relayer.shared.get_block(&block_hash) {
+        if let Some(block) = self.relayer.shared.store().get_block(&block_hash) {
             let transactions = indexes
                 .safe_slice()
                 .iter()

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -55,8 +55,15 @@ where
             if let Some(header) = self.synchronizer.peers().get_last_common_header(self.peer) {
                 Some(header)
             } else if best.number() < self.tip_header.number() {
-                let last_common_hash = self.synchronizer.shared.block_hash(best.number())?;
-                self.synchronizer.shared.block_header(&last_common_hash)
+                let last_common_hash = self
+                    .synchronizer
+                    .shared
+                    .store()
+                    .get_block_hash(best.number())?;
+                self.synchronizer
+                    .shared
+                    .store()
+                    .get_block_header(&last_common_hash)
             } else {
                 Some(self.tip_header.clone())
             }

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -41,7 +41,7 @@ where
         for fbs_h256 in block_hashes.iter().take(n_limit) {
             let block_hash = fbs_h256.try_into()?;
             debug!("get_blocks {:x} from peer {:?}", block_hash, self.peer);
-            if let Some(block) = self.synchronizer.shared.get_block(&block_hash) {
+            if let Some(block) = self.synchronizer.shared.store().get_block(&block_hash) {
                 debug!(
                     "respond_block {} {:x} to peer {:?}",
                     block.header().number(),

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -86,7 +86,10 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
     }
 
     fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        self.synchronizer.shared.block_hash(block_number)
+        self.synchronizer
+            .shared
+            .store()
+            .get_block_hash(block_number)
     }
 }
 

--- a/traits/src/chain_provider.rs
+++ b/traits/src/chain_provider.rs
@@ -1,9 +1,6 @@
 use ckb_chain_spec::consensus::Consensus;
-use ckb_core::block::Block;
-use ckb_core::extras::{BlockExt, EpochExt};
+use ckb_core::extras::EpochExt;
 use ckb_core::header::{BlockNumber, Header};
-use ckb_core::transaction::{ProposalShortId, Transaction};
-use ckb_core::uncle::UncleBlock;
 use ckb_script::ScriptConfig;
 use ckb_store::ChainStore;
 use numext_fixed_hash::H256;
@@ -16,25 +13,7 @@ pub trait ChainProvider: Sync + Send {
 
     fn script_config(&self) -> &ScriptConfig;
 
-    fn block_body(&self, hash: &H256) -> Option<Vec<Transaction>>;
-
-    fn block_header(&self, hash: &H256) -> Option<Header>;
-
-    fn block_proposal_txs_ids(&self, hash: &H256) -> Option<Vec<ProposalShortId>>;
-
-    fn uncles(&self, hash: &H256) -> Option<Vec<UncleBlock>>;
-
-    fn block_hash(&self, number: BlockNumber) -> Option<H256>;
-
-    fn block_ext(&self, hash: &H256) -> Option<BlockExt>;
-
-    fn block_number(&self, hash: &H256) -> Option<BlockNumber>;
-
-    fn block(&self, hash: &H256) -> Option<Block>;
-
     fn genesis_hash(&self) -> &H256;
-
-    fn get_transaction(&self, hash: &H256) -> Option<(Transaction, H256)>;
 
     fn get_ancestor(&self, base: &H256, number: BlockNumber) -> Option<Header>;
 

--- a/util/instrument/src/iter.rs
+++ b/util/instrument/src/iter.rs
@@ -13,7 +13,10 @@ pub struct ChainIterator<CS> {
 
 impl<CS: ChainStore> ChainIterator<CS> {
     pub fn new(shared: Shared<CS>) -> Self {
-        let current = shared.block_hash(0).and_then(|h| shared.block(&h));
+        let current = shared
+            .store()
+            .get_block_hash(0)
+            .and_then(|h| shared.store().get_block(&h));
         let tip = shared.lock_chain_state().tip_number();
         ChainIterator {
             shared,
@@ -35,8 +38,10 @@ impl<CS: ChainStore> Iterator for ChainIterator<CS> {
 
         self.current = match current {
             Some(ref b) => {
-                if let Some(block_hash) = self.shared.block_hash(b.header().number() + 1) {
-                    self.shared.block(&block_hash)
+                if let Some(block_hash) =
+                    self.shared.store().get_block_hash(b.header().number() + 1)
+                {
+                    self.shared.store().get_block(&block_hash)
                 } else {
                     None
                 }

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -5,6 +5,7 @@ use ckb_core::block::Block;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
 use ckb_core::transaction::CellInput;
+use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 use std::collections::HashSet;
 
@@ -134,7 +135,7 @@ impl<'a> HeaderResolverWrapper<'a> {
     where
         CP: ChainProvider,
     {
-        let parent = provider.block_header(&header.parent_hash());
+        let parent = provider.store().get_block_header(&header.parent_hash());
         let epoch = parent
             .as_ref()
             .and_then(|parent| {

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -14,6 +14,7 @@ use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
+use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
@@ -154,7 +155,10 @@ fn test_proposal() {
 
     let proposal_window = shared.consensus().tx_proposal_window();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     //proposal in block(1)
     let proposed = 1;
@@ -224,7 +228,10 @@ fn test_uncle_proposal() {
 
     let proposal_window = shared.consensus().tx_proposal_window();
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     //proposal in block(1)
     let proposed = 1;

--- a/verification/src/tests/dummy.rs
+++ b/verification/src/tests/dummy.rs
@@ -1,10 +1,8 @@
 use ckb_chain_spec::consensus::Consensus;
-use ckb_core::block::Block;
 use ckb_core::cell::{CellProvider, CellStatus};
-use ckb_core::extras::{BlockExt, EpochExt};
+use ckb_core::extras::EpochExt;
 use ckb_core::header::{BlockNumber, Header};
-use ckb_core::transaction::{OutPoint, ProposalShortId, Transaction};
-use ckb_core::uncle::UncleBlock;
+use ckb_core::transaction::OutPoint;
 use ckb_db::MemoryKeyValueDB;
 use ckb_script::ScriptConfig;
 use ckb_store::ChainKVStore;
@@ -26,47 +24,11 @@ impl ChainProvider for DummyChainProvider {
         unimplemented!();
     }
 
-    fn block_ext(&self, _hash: &H256) -> Option<BlockExt> {
-        unimplemented!();
-    }
-
     fn genesis_hash(&self) -> &H256 {
         unimplemented!();
     }
 
-    fn block_body(&self, _hash: &H256) -> Option<Vec<Transaction>> {
-        unimplemented!();
-    }
-
-    fn block_header(&self, _hash: &H256) -> Option<Header> {
-        unimplemented!();
-    }
-
-    fn block_proposal_txs_ids(&self, _hash: &H256) -> Option<Vec<ProposalShortId>> {
-        unimplemented!();
-    }
-
-    fn block_hash(&self, _height: u64) -> Option<H256> {
-        unimplemented!();
-    }
-
     fn get_ancestor(&self, _base: &H256, _number: BlockNumber) -> Option<Header> {
-        unimplemented!();
-    }
-
-    fn block_number(&self, _hash: &H256) -> Option<BlockNumber> {
-        unimplemented!();
-    }
-
-    fn uncles(&self, _hash: &H256) -> Option<Vec<UncleBlock>> {
-        unimplemented!();
-    }
-
-    fn block(&self, _hash: &H256) -> Option<Block> {
-        unimplemented!();
-    }
-
-    fn get_transaction(&self, _hash: &H256) -> Option<(Transaction, H256)> {
         unimplemented!();
     }
 

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -16,6 +16,7 @@ use ckb_db::memorydb::MemoryKeyValueDB;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
+use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 #[cfg(not(disable_faketime))]
 use faketime;
@@ -92,7 +93,10 @@ fn test_uncle_verifier() {
 
     faketime::write_millis(&faketime_file, 10).expect("write millis");
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for i in 1..number {
         let parent_epoch = shared.get_block_epoch(&parent.hash()).unwrap();
         let epoch = shared
@@ -106,7 +110,10 @@ fn test_uncle_verifier() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     // if block_number < 11 { chain1 == chain2 } else { chain1 != chain2 }
     for i in 1..number {
@@ -457,7 +464,10 @@ fn test_uncle_verifier_with_fork_context() {
 
     faketime::write_millis(&faketime_file, 10).expect("write millis");
 
-    let mut parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    let mut parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
     for i in 1..20 {
         let parent_epoch = shared.get_block_epoch(&parent.hash()).unwrap();
         let epoch = shared
@@ -471,7 +481,10 @@ fn test_uncle_verifier_with_fork_context() {
         parent = new_block.header().to_owned();
     }
 
-    parent = shared.block_header(&shared.block_hash(0).unwrap()).unwrap();
+    parent = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
 
     // if block_number < 11 { chain1 == chain2 } else { chain1 != chain2 }
     for i in 1..19 {


### PR DESCRIPTION
  
```diff
pub trait ChainProvider: Sync + Send {
    type Store: ChainStore;

    fn store(&self) -> &Arc<Self::Store>;
    ...
-    fn block_body(&self, hash: &H256) -> Option<Vec<Transaction>>;
-    fn block_header(&self, hash: &H256) -> Option<Header>;
-    fn block_proposal_txs_ids(&self, hash: &H256) -> Option<Vec<ProposalShortId>>;
-    fn uncles(&self, hash: &H256) -> Option<Vec<UncleBlock>>;
-    fn block_hash(&self, number: BlockNumber) -> Option<H256>;
-    fn block_ext(&self, hash: &H256) -> Option<BlockExt>;
-    fn block_number(&self, hash: &H256) -> Option<BlockNumber>;
-    fn block(&self, hash: &H256) -> Option<Block>;
-    fn get_transaction(&self, hash: &H256) -> Option<(Transaction, H256)>;
    ...
}
```