### PR TITLE
feat: simplify git describe info in version

### DIFF
--- a/util/build-info/src/lib.rs
+++ b/util/build-info/src/lib.rs
@@ -60,7 +60,7 @@ impl std::fmt::Display for Version {
 
 pub fn get_commit_describe() -> Option<String> {
     std::process::Command::new("git")
-        .args(&["describe", "--dirty"])
+        .args(&["describe", "--dirty", "--always", "--exclude", "*"])
         .output()
         .ok()
         .and_then(|r| {


### PR DESCRIPTION
The full `git describe` output easily cause confusion, this change will only
show the 7 hex digests commit sha and the dirty flag, such as

    ckb 0.15.0-pre (rylai-v4 d7d3baca-dirty 2019-06-06)