### PR TITLE
refactor: flatten fields into shared

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -69,11 +69,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         args.config.sync,
     );
 
-    let relayer = Relayer::new(
-        chain_controller.clone(),
-        sync_shared_state,
-        Arc::clone(synchronizer.peers()),
-    );
+    let relayer = Relayer::new(chain_controller.clone(), sync_shared_state);
     let net_timer = NetTimeProtocol::default();
     let alert_config = args.config.alert.unwrap_or_default();
     let alert_relayer = AlertRelayer::new(version.to_string(), alert_config);

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -65,9 +65,8 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         // deprecated
         Ok(self
             .synchronizer
-            .peers()
-            .blocks_inflight
-            .read()
+            .shared()
+            .read_inflight_blocks()
             .blocks_iter()
             .map(|(peer, blocks)| PeerState::new(peer.value(), 0, blocks.len()))
             .collect())

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -39,7 +39,7 @@ impl<'a, CS: ChainStore + 'static> BlockProposalProcess<'a, CS> {
             .into_iter()
             .filter_map(|tx| {
                 let tx_hash = tx.hash();
-                if self.relayer.state.already_known_tx(&tx_hash) {
+                if self.relayer.shared().already_known_tx(&tx_hash) {
                     None
                 } else {
                     Some((tx_hash.to_owned(), tx))
@@ -49,14 +49,14 @@ impl<'a, CS: ChainStore + 'static> BlockProposalProcess<'a, CS> {
         if unknown_txs.is_empty() {
             return Ok(());
         }
-        let mut inflight = self.relayer.state.inflight_proposals.lock();
+        let mut inflight = self.relayer.shared().inflight_proposals();
         // filter txs that we ask for download
         let asked_txs = unknown_txs
             .into_iter()
             .filter_map(|(tx_hash, tx)| {
                 if inflight.remove(&ProposalShortId::from_tx_hash(&tx_hash)) {
                     // mark as known
-                    self.relayer.state.mark_as_known_tx(tx_hash);
+                    self.relayer.shared().mark_as_known_tx(tx_hash);
                     Some(tx)
                 } else {
                     None

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -32,8 +32,12 @@ impl<'a, CS: ChainStore + 'static> BlockTransactionsProcess<'a, CS> {
 
     pub fn execute(self) -> Result<(), FailureError> {
         let block_hash = cast!(self.message.block_hash())?.try_into()?;
-        let pending_compact_blocks = &self.relayer.state.pending_compact_blocks;
-        if let Entry::Occupied(mut pending) = pending_compact_blocks.lock().entry(block_hash) {
+        if let Entry::Occupied(mut pending) = self
+            .relayer
+            .shared()
+            .pending_compact_blocks()
+            .entry(block_hash)
+        {
             let (compact_block, peers_set) = pending.get_mut();
             if peers_set.remove(&self.peer) {
                 let transactions: Vec<Transaction> =

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -100,7 +100,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
         let mut missing_indexes: Vec<usize> = Vec::new();
         {
             // Verify compact block
-            let mut pending_compact_blocks = self.relayer.state.pending_compact_blocks.lock();
+            let mut pending_compact_blocks = self.relayer.shared().pending_compact_blocks();
             if pending_compact_blocks
                 .get(&block_hash)
                 .map(|(_, peers_set)| peers_set.contains(&self.peer))

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -224,7 +224,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             fbb.finish(message, None);
             let data = fbb.finished_data().into();
 
-            let mut known_blocks = self.peers.known_blocks.lock();
+            let mut known_blocks = self.shared().known_blocks();
             let selected_peers: Vec<PeerIndex> = nc
                 .connected_peers()
                 .into_iter()

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -27,7 +27,7 @@ use crate::types::{Peers, SyncSharedState};
 use crate::BAD_MESSAGE_BAN_TIME;
 use ckb_chain::chain::ChainController;
 use ckb_core::block::{Block, BlockBuilder};
-use ckb_core::transaction::{ProposalShortId, Transaction};
+use ckb_core::transaction::Transaction;
 use ckb_core::uncle::UncleBlock;
 use ckb_logger::{debug_target, info_target, trace_target};
 use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
@@ -37,13 +37,10 @@ use ckb_protocol::{
 use ckb_shared::chain_state::ChainState;
 use ckb_store::ChainStore;
 use ckb_tx_pool_executor::TxPoolExecutor;
-use ckb_util::Mutex;
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use flatbuffers::FlatBufferBuilder;
-use fnv::{FnvHashMap, FnvHashSet};
-use lru_cache::LruCache;
-use numext_fixed_hash::H256;
+use fnv::FnvHashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -52,13 +49,10 @@ pub const TX_PROPOSAL_TOKEN: u64 = 0;
 pub const ASK_FOR_TXS_TOKEN: u64 = 1;
 
 pub const MAX_RELAY_PEERS: usize = 128;
-pub const TX_FILTER_SIZE: usize = 50000;
-pub const TX_ASKED_SIZE: usize = TX_FILTER_SIZE;
 
 pub struct Relayer<CS> {
     chain: ChainController,
     pub(crate) shared: Arc<SyncSharedState<CS>>,
-    pub(crate) state: Arc<RelayState>,
     // TODO refactor shared Peers struct with Synchronizer
     peers: Arc<Peers>,
     pub(crate) tx_pool_executor: Arc<TxPoolExecutor<CS>>,
@@ -69,7 +63,6 @@ impl<CS: ChainStore> Clone for Relayer<CS> {
         Relayer {
             chain: self.chain.clone(),
             shared: Arc::clone(&self.shared),
-            state: Arc::clone(&self.state),
             peers: Arc::clone(&self.peers),
             tx_pool_executor: Arc::clone(&self.tx_pool_executor),
         }
@@ -86,10 +79,13 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         Relayer {
             chain,
             shared,
-            state: Arc::new(RelayState::default()),
             peers,
             tx_pool_executor,
         }
+    }
+
+    pub fn shared(&self) -> &Arc<SyncSharedState<CS>> {
+        &self.shared
     }
 
     fn try_process(
@@ -192,7 +188,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         peer: PeerIndex,
         block: &CompactBlock,
     ) {
-        let mut inflight = self.state.inflight_proposals.lock();
+        let mut inflight = self.shared().inflight_proposals();
         let unknown_ids = block
             .proposals
             .iter()
@@ -329,13 +325,13 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
     }
 
     fn prune_tx_proposal_request(&self, nc: &CKBProtocolContext) {
-        let mut pending_proposals_request = self.state.pending_proposals_request.lock();
+        let mut pending_get_block_proposals = self.shared().pending_get_block_proposals();
         let mut peer_txs = FnvHashMap::default();
         let mut remove_ids = Vec::new();
         {
             let chain_state = self.shared.lock_chain_state();
             let tx_pool = chain_state.tx_pool();
-            for (id, peer_indexs) in pending_proposals_request.iter() {
+            for (id, peer_indexs) in pending_get_block_proposals.iter() {
                 if let Some(tx) = tx_pool.get_tx(id) {
                     for peer_index in peer_indexs {
                         let tx_set = peer_txs.entry(*peer_index).or_insert_with(Vec::new);
@@ -347,7 +343,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
         }
 
         for id in remove_ids {
-            pending_proposals_request.remove(&id);
+            pending_get_block_proposals.remove(&id);
         }
 
         for (peer_index, txs) in peer_txs {
@@ -366,7 +362,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                 .pop_ask_for_txs()
                 .into_iter()
                 .filter(|tx_hash| {
-                    let already_known = self.state.already_known_tx(&tx_hash);
+                    let already_known = self.shared().already_known_tx(&tx_hash);
                     if already_known {
                         // Remove tx_hash from `tx_ask_for_set`
                         peer_state.remove_ask_for_tx(&tx_hash);
@@ -483,36 +479,5 @@ impl<CS: ChainStore + 'static> CKBProtocolHandler for Relayer<CS> {
             token,
             start_time.elapsed()
         );
-    }
-}
-
-pub struct RelayState {
-    pub pending_compact_blocks: Mutex<FnvHashMap<H256, (CompactBlock, FnvHashSet<PeerIndex>)>>,
-    pub inflight_proposals: Mutex<FnvHashSet<ProposalShortId>>,
-    pub pending_proposals_request: Mutex<FnvHashMap<ProposalShortId, FnvHashSet<PeerIndex>>>,
-    pub tx_filter: Mutex<LruCache<H256, ()>>,
-    pub tx_already_asked: Mutex<LruCache<H256, Instant>>,
-}
-
-impl Default for RelayState {
-    fn default() -> Self {
-        RelayState {
-            pending_compact_blocks: Mutex::new(FnvHashMap::default()),
-            inflight_proposals: Mutex::new(FnvHashSet::default()),
-            pending_proposals_request: Mutex::new(FnvHashMap::default()),
-            tx_filter: Mutex::new(LruCache::new(TX_FILTER_SIZE)),
-            tx_already_asked: Mutex::new(LruCache::new(TX_ASKED_SIZE)),
-        }
-    }
-}
-
-impl RelayState {
-    fn mark_as_known_tx(&self, hash: H256) {
-        self.tx_already_asked.lock().remove(&hash);
-        self.tx_filter.lock().insert(hash, ());
-    }
-
-    fn already_known_tx(&self, hash: &H256) -> bool {
-        self.tx_filter.lock().contains_key(hash)
     }
 }

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -125,11 +125,7 @@ fn build_chain(tip: BlockNumber) -> (Relayer<ChainKVStore<MemoryKeyValueDB>>, Ou
 
     let sync_shared_state = Arc::new(SyncSharedState::new(shared));
     (
-        Relayer::new(
-            chain_controller,
-            sync_shared_state,
-            Arc::new(Default::default()),
-        ),
+        Relayer::new(chain_controller, sync_shared_state),
         always_success_out_point,
     )
 }

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -71,7 +71,8 @@ impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
                 .cloned();
             if let Some(next_ask_timeout) = self
                 .relayer
-                .peers
+                .shared()
+                .peers()
                 .state
                 .write()
                 .get_mut(&self.peer)

--- a/sync/src/relayer/transaction_hash_process.rs
+++ b/sync/src/relayer/transaction_hash_process.rs
@@ -16,7 +16,7 @@ pub struct TransactionHashProcess<'a, CS> {
     peer: PeerIndex,
 }
 
-impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
+impl<'a, CS: ChainStore + 'static> TransactionHashProcess<'a, CS> {
     pub fn new(
         message: &'a FbsRelayTransactionHash,
         relayer: &'a Relayer<CS>,
@@ -34,7 +34,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
     pub fn execute(self) -> Result<(), FailureError> {
         let tx_hash: H256 = (*self.message).try_into()?;
         let short_id = ProposalShortId::from_tx_hash(&tx_hash);
-        if self.relayer.state.already_known_tx(&tx_hash) {
+        if self.relayer.shared().already_known_tx(&tx_hash) {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
                 "transaction({:#x}) from {} already known, ignore it",
@@ -55,7 +55,7 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 tx_hash,
                 self.peer,
             );
-            self.relayer.state.mark_as_known_tx(tx_hash.clone());
+            self.relayer.shared().mark_as_known_tx(tx_hash.clone());
         } else {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
@@ -65,9 +65,8 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
             );
             let last_ask_timeout = self
                 .relayer
-                .state
-                .tx_already_asked
-                .lock()
+                .shared()
+                .inflight_transactions()
                 .get(&tx_hash)
                 .cloned();
             if let Some(next_ask_timeout) = self
@@ -79,9 +78,8 @@ impl<'a, CS: ChainStore> TransactionHashProcess<'a, CS> {
                 .and_then(|peer_state| peer_state.add_ask_for_tx(tx_hash.clone(), last_ask_timeout))
             {
                 self.relayer
-                    .state
-                    .tx_already_asked
-                    .lock()
+                    .shared()
+                    .inflight_transactions()
                     .insert(tx_hash.clone(), next_ask_timeout);
             }
         }

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -62,7 +62,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
             let nc = Arc::clone(&self.nc);
             let self_peer = self.peer;
             let tx_pool_executor = Arc::clone(&self.relayer.tx_pool_executor);
-            let peers = Arc::clone(&self.relayer.peers);
+            let shared = Arc::clone(self.relayer.shared());
             let tx_hash = tx_hash.clone();
             let tx = tx.to_owned();
             Box::new(lazy(move || -> FutureResult<(), ()> {
@@ -72,7 +72,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
                 match tx_result {
                     Ok(cycles) if cycles == relay_cycles => {
                         let selected_peers: Vec<PeerIndex> = {
-                            let mut known_txs = peers.known_txs.lock();
+                            let mut known_txs = shared.known_txs();
                             nc.connected_peers()
                                 .into_iter()
                                 .filter(|target_peer| {

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -53,7 +53,14 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
         // Remove tx_hash from `tx_already_asked`
         self.relayer.shared().mark_as_known_tx(tx_hash.clone());
         // Remove tx_hash from `tx_ask_for_set`
-        if let Some(peer_state) = self.relayer.peers.state.write().get_mut(&self.peer) {
+        if let Some(peer_state) = self
+            .relayer
+            .shared()
+            .peers()
+            .state
+            .write()
+            .get_mut(&self.peer)
+        {
             peer_state.remove_ask_for_tx(&tx_hash);
         }
 

--- a/sync/src/relayer/transaction_process.rs
+++ b/sync/src/relayer/transaction_process.rs
@@ -40,7 +40,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
         let (tx, relay_cycles): (Transaction, Cycle) = (*self.message).try_into()?;
         let tx_hash = tx.hash();
 
-        if self.relayer.state.already_known_tx(&tx_hash) {
+        if self.relayer.shared().already_known_tx(&tx_hash) {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
                 "discarding already known transaction {:#x}",
@@ -51,7 +51,7 @@ impl<'a, CS: ChainStore + Sync + 'static> TransactionProcess<'a, CS> {
 
         // Insert tx_hash into `already_known`
         // Remove tx_hash from `tx_already_asked`
-        self.relayer.state.mark_as_known_tx(tx_hash.clone());
+        self.relayer.shared().mark_as_known_tx(tx_hash.clone());
         // Remove tx_hash from `tx_ask_for_set`
         if let Some(peer_state) = self.relayer.peers.state.write().get_mut(&self.peer) {
             peer_state.remove_ask_for_tx(&tx_hash);

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -36,7 +36,7 @@ where
         }
     }
     pub fn reached_inflight_limit(&self) -> bool {
-        let inflight = self.synchronizer.peers.blocks_inflight.read();
+        let inflight = self.synchronizer.shared().read_inflight_blocks();
 
         // Can't download any more from this peer
         inflight.peer_inflight_count(&self.peer) >= MAX_BLOCKS_IN_TRANSIT_PER_PEER
@@ -85,7 +85,7 @@ where
 
     // this peer's tip is wherethe the ancestor of global_best_known_header
     pub fn is_known_best(&self, header: &HeaderView) -> bool {
-        let global_best_known_header = self.synchronizer.shared.best_known_header();
+        let global_best_known_header = self.synchronizer.shared.shared_best_header();
         if let Some(ancestor) = self
             .synchronizer
             .shared
@@ -165,7 +165,7 @@ where
         let mut fetch = Vec::with_capacity(PER_FETCH_BLOCK_LIMIT);
 
         {
-            let mut inflight = self.synchronizer.peers.blocks_inflight.write();
+            let mut inflight = self.synchronizer.shared().write_inflight_blocks();
             let count = MAX_BLOCKS_IN_TRANSIT_PER_PEER
                 .saturating_sub(inflight.peer_inflight_count(&self.peer));
 

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -47,7 +47,7 @@ where
     }
 
     pub fn peer_best_known_header(&self) -> Option<HeaderView> {
-        self.synchronizer.peers.get_best_known_header(self.peer)
+        self.synchronizer.peers().get_best_known_header(self.peer)
     }
 
     pub fn last_common_header(&self, best: &HeaderView) -> Option<Header> {

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -38,7 +38,7 @@ where
             block.header().hash()
         );
 
-        if self.synchronizer.peers.new_block_received(&block) {
+        if self.synchronizer.shared().new_block_received(&block) {
             self.synchronizer.process_new_block(self.peer, block);
         }
         Ok(())

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -71,7 +71,7 @@ where
                 self.synchronizer.shared.tip_header().number(),
             );
 
-            self.synchronizer.peers.getheaders_received(self.peer);
+            self.synchronizer.peers().getheaders_received(self.peer);
             let headers: Vec<Header> = self
                 .synchronizer
                 .shared

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -237,7 +237,7 @@ where
 
         if log_enabled!(Level::Debug) {
             let chain_state = self.synchronizer.shared.lock_chain_state();
-            let peer_best_known = self.synchronizer.peers.get_best_known_header(self.peer);
+            let peer_best_known = self.synchronizer.peers().get_best_known_header(self.peer);
             debug!(
                 "chain: num={}, diff={:#x};",
                 chain_state.tip_number(),
@@ -279,7 +279,7 @@ where
         // chain. Disconnect peers that are on chains with insufficient work.
         let (is_outbound, is_protected) = self
             .synchronizer
-            .peers
+            .peers()
             .state
             .read()
             .get(&self.peer)

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -164,12 +164,12 @@ where
         let headers = cast!(self.message.headers())?;
 
         if headers.len() > MAX_HEADERS_LEN {
-            self.synchronizer.peers.misbehavior(self.peer, 20);
+            self.synchronizer.shared().misbehavior(self.peer, 20);
             warn!("HeadersProcess is_oversize");
             return Ok(());
         }
 
-        let shared_best_known = self.synchronizer.shared.best_known_header();
+        let shared_best_known = self.synchronizer.shared.shared_best_header();
         if headers.len() == 0 {
             // Update peer's best known header
             self.synchronizer
@@ -193,7 +193,7 @@ where
             .collect::<Result<Vec<Header>, FailureError>>()?;
 
         if !self.is_continuous(&headers) {
-            self.synchronizer.peers.misbehavior(self.peer, 20);
+            self.synchronizer.shared().misbehavior(self.peer, 20);
             debug!("HeadersProcess is not continuous");
             return Ok(());
         }
@@ -202,7 +202,7 @@ where
         if !result.is_valid() {
             if result.misbehavior > 0 {
                 self.synchronizer
-                    .peers
+                    .shared()
                     .misbehavior(self.peer, result.misbehavior);
             }
             debug!(
@@ -226,7 +226,7 @@ where
                 if !result.is_valid() {
                     if result.misbehavior > 0 {
                         self.synchronizer
-                            .peers
+                            .shared()
                             .misbehavior(self.peer, result.misbehavior);
                     }
                     debug!("HeadersProcess accept is invalid {:?}", result);


### PR DESCRIPTION
* Flatten some fields originally in `Synchronizer`, `Relayer` and `Peers` into `SyncSharedState`

----

This PR intends to make `Synchronizer` and `Relayer` share the same global state. So I try to move their fields into `SyncSharedState`.
Here only refactor around the "fields", and will refactor the "methods" in another PR.