### PR TITLE
fix: fix confusing JsonBytes deserializing error message

### DIFF
--- a/util/jsonrpc-types/src/bytes.rs
+++ b/util/jsonrpc-types/src/bytes.rs
@@ -51,9 +51,14 @@ impl<'b> serde::de::Visitor<'b> for BytesVisitor {
     where
         E: serde::de::Error,
     {
-        if v.len() < 2 || &v[0..2] != "0x" || v.len() & 1 != 0 {
+        if v.len() < 2 || &v[0..2] != "0x" {
             return Err(E::invalid_value(serde::de::Unexpected::Str(v), &self));
         }
+
+        if v.len() & 1 != 0 {
+            return Err(E::invalid_length(v.len(), &"even length"));
+        }
+
         let bytes = &v.as_bytes()[2..];
         if bytes.is_empty() {
             return Ok(JsonBytes::default());

--- a/util/jsonrpc-types/src/bytes.rs
+++ b/util/jsonrpc-types/src/bytes.rs
@@ -98,3 +98,37 @@ impl<'de> serde::Deserialize<'de> for JsonBytes {
         deserializer.deserialize_str(BytesVisitor)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::JsonBytes;
+    use serde_derive::{Deserialize, Serialize};
+    use serde_json;
+
+    #[test]
+    fn test_toml_de_error() {
+        #[derive(Deserialize, Serialize, Debug)]
+        struct Test {
+            bytes: JsonBytes,
+        }
+
+        let invalid_prefixed = r#"{"bytes": "2143"}"#;
+        let invalid_length = r#"{"bytes" : "0x0"}"#;
+        let illegal_char = r#"{"bytes":"0xgh"}"#;
+
+        let e = serde_json::from_str::<Test>(invalid_prefixed);
+        assert_eq!(r#"invalid value: string "2143", expected a 0x-prefixed hex string at line 1 column 16"#, format!("{}", e.unwrap_err()));
+
+        let e = serde_json::from_str::<Test>(invalid_length);
+        assert_eq!(
+            r#"invalid length 3, expected even length at line 1 column 16"#,
+            format!("{}", e.unwrap_err())
+        );
+
+        let e = serde_json::from_str::<Test>(illegal_char);
+        assert_eq!(
+            r#"Invalid character at line 1 column 15"#,
+            format!("{}", e.unwrap_err())
+        );
+    }
+}


### PR DESCRIPTION
fix #974 

1. Not 0x-prefixed hex string, error message:
```
Config Error: Error { inner: ErrorInner { kind: Custom, line: None, col: 0, message: "invalid value: string \"7f52f0fccdd1d11391c441adfb174f87bca612b0\", expected a 0x-prefixed hex string", key: ["block_assembler", "args"] } }
```

2. The illegal 0x-prefixed hex string
```
Config Error: Error { inner: ErrorInner { kind: Custom, line: None, col: 0, message: "invalid length 43, expected even length", key: ["block_assembler", "args"] } }
```