### PR TITLE
[ᚬrc/v0.14.0] feat: avoid hard code code_hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,8 +642,10 @@ dependencies = [
 name = "ckb-resource"
 version = "0.14.0-pre"
 dependencies = [
+ "hash 0.14.0-pre",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
+++ b/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
@@ -1,5 +1,6 @@
 use super::parse_hex_data;
 use ckb_app_config::{cli, ExitCode};
+use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use clap::ArgMatches;
 use crypto::secp::Pubkey;
 use hash::blake2b_256;
@@ -27,13 +28,19 @@ pub fn secp256k1_lock<'m>(matches: &ArgMatches<'m>) -> Result<(), ExitCode> {
         "block_assembler" => {
             println!("[block_assembler]");
             println!("# secp256k1_sighash_all");
-            println!("code_hash = \"0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd\"");
+            println!(
+                "code_hash = \"{:#x}\"",
+                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL
+            );
             println!("# args = [ \"blake160(compressed_pubkey)\" ]");
             println!("args = [ \"{:#x}\" ]", pubkey_blake160);
         }
         "json" => {
             println!("{{");
-            println!("    \"code_hash\": \"0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd\",");
+            println!(
+                "    \"code_hash\": \"{:#x}\",",
+                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL
+            );
             println!("    \"args\": [");
             println!("        \"{:#x}\"", pubkey_blake160);
             println!("    ]");

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -11,7 +11,10 @@ include = ["/specs", "/ckb.toml", "/ckb-miner.toml"]
 phf = "0.7.21"
 includedir = "0.5.0"
 tempfile = "3.0"
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
+hash = { path = "../util/hash"}

--- a/resource/build.rs
+++ b/resource/build.rs
@@ -1,7 +1,20 @@
+use hash::new_blake2b;
 use includedir_codegen::Compression;
+use numext_fixed_hash::H256;
+use std::collections::BTreeMap;
+use std::env;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::Path;
 use walkdir::WalkDir;
 
+const BUF_SIZE: usize = 8 * 1024;
+
 fn main() {
+    let cells = Some(OsStr::new("cells"));
+    let mut buf = [0u8; BUF_SIZE];
+    let mut code_hashes = BTreeMap::new();
     let mut bundled = includedir_codegen::start("BUNDLED");
 
     for f in &["ckb.toml", "ckb-miner.toml"] {
@@ -9,6 +22,7 @@ fn main() {
             .add_file(f, Compression::Gzip)
             .expect("add files to resource bundle");
     }
+
     for entry in WalkDir::new("specs").follow_links(true).into_iter() {
         match entry {
             Ok(ref e)
@@ -17,10 +31,44 @@ fn main() {
                 bundled
                     .add_file(e.path(), Compression::Gzip)
                     .expect("add files to resource bundle");
+
+                if e.path().parent().and_then(|p| p.file_name()) == cells {
+                    let mut blake2b = new_blake2b();
+                    let mut fd = File::open(e.path()).expect("open file");
+                    loop {
+                        let read_bytes = fd.read(&mut buf).expect("read file");
+                        if read_bytes > 0 {
+                            blake2b.update(&buf[..read_bytes]);
+                        } else {
+                            break;
+                        }
+                    }
+                    let code_hash = {
+                        let mut result = [0u8; 32];
+                        blake2b.finalize(&mut result);
+                        H256::from_slice(&result).unwrap()
+                    };
+
+                    code_hashes.insert(
+                        format!(
+                            "CODE_HASH_{}",
+                            e.file_name().to_string_lossy().to_owned().to_uppercase()
+                        ),
+                        code_hash,
+                    );
+                }
             }
             _ => (),
         }
     }
 
     bundled.build("bundled.rs").expect("build resource bundle");
+
+    let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("code_hashes.rs");
+    let mut out_file = BufWriter::new(File::create(&out_path).expect("create code_hashes.rs"));
+
+    for (name, hash) in code_hashes {
+        write!(&mut out_file, "pub const {}: H256 = {:?};", name, hash)
+            .expect("write to code_hashes.rs");
+    }
 }

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -118,5 +118,7 @@ cell_output_cache_size  = 128
 # Below is an example block assembler configuration section:
 #
 # [block_assembler]
-# code_hash = "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd"
+# # {{
+# _ => # code_hash = "{code_hash}"
+# }}
 # args = ["ckb cli blake160 <pubkey>"]

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -9,6 +9,7 @@ pub use self::template::{
 pub use std::io::{Error, Result};
 
 use self::template::Template;
+use numext_fixed_hash::H256;
 use std::borrow::Cow;
 use std::fmt;
 use std::fs;
@@ -17,6 +18,7 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 include!(concat!(env!("OUT_DIR"), "/bundled.rs"));
+include!(concat!(env!("OUT_DIR"), "/code_hashes.rs"));
 
 pub const CKB_CONFIG_FILE_NAME: &str = "ckb.toml";
 pub const MINER_CONFIG_FILE_NAME: &str = "ckb-miner.toml";

--- a/resource/src/template.rs
+++ b/resource/src/template.rs
@@ -7,6 +7,7 @@ const START_MARKER: &str = " # {{";
 const END_MAKER: &str = "# }}";
 const WILDCARD_BRANCH: &str = "# _ => ";
 
+use crate::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use std::io;
 
 pub struct Template<T>(T);
@@ -38,6 +39,10 @@ fn writeln<W: io::Write>(w: &mut W, s: &str, context: &TemplateContext) -> io::R
             .replace("{log_to_file}", &format!("{}", context.log_to_file))
             .replace("{log_to_stdout}", &format!("{}", context.log_to_stdout))
             .replace("{runner}", &context.runner.to_string())
+            .replace(
+                "{code_hash}",
+                &format!("{:#x}", CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL)
+            )
     )
 }
 

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -12,9 +12,7 @@ pub fn new_blake2b() -> Blake2b {
 
 pub fn blake2b_256<T: AsRef<[u8]>>(s: T) -> [u8; 32] {
     let mut result = [0u8; 32];
-    let mut blake2b = Blake2bBuilder::new(32)
-        .personal(CKB_HASH_PERSONALIZATION)
-        .build();
+    let mut blake2b = new_blake2b();
     blake2b.update(s.as_ref());
     blake2b.finalize(&mut result);
     result


### PR DESCRIPTION
Generate the code hash constants in ckb-resource, and use the constants
instead of the hard code hash in different locations.