### PR TITLE
[ᚬrc/v0.14.0] feat: `ckb init` supports setting block assembler

### DIFF
--- a/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
+++ b/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
@@ -25,26 +25,21 @@ pub fn secp256k1_lock<'m>(matches: &ArgMatches<'m>) -> Result<(), ExitCode> {
     let pubkey_blake160 = H160::from_slice(&pubkey_hash[0..20]).unwrap();
 
     match matches.value_of(cli::ARG_FORMAT).unwrap() {
-        "block_assembler" => {
+        "toml" => {
             println!("[block_assembler]");
-            println!("# secp256k1_sighash_all");
+            println!("# secp256k1_blake160_sighash_all");
             println!(
                 "code_hash = \"{:#x}\"",
                 CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL
             );
-            println!("# args = [ \"blake160(compressed_pubkey)\" ]");
+            println!("# args = [ \"ckb cli blake160 <compressed-pubkey>\" ]");
             println!("args = [ \"{:#x}\" ]", pubkey_blake160);
         }
-        "json" => {
-            println!("{{");
+        "cmd" => {
             println!(
-                "    \"code_hash\": \"{:#x}\",",
-                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL
+                "--ba-code-hash {:#x} --ba-arg {:#x}",
+                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL, pubkey_blake160
             );
-            println!("    \"args\": [");
-            println!("        \"{:#x}\"", pubkey_blake160);
-            println!("    ]");
-            println!("}}");
         }
         _ => unreachable!(),
     }

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -115,10 +115,16 @@ cell_output_cache_size  = 128
 #
 #     ckb cli secp256k1-lock <pubkey>
 #
-# Below is an example block assembler configuration section:
+# The command `ckb init` also accepts options to generate the block assembler
+# directly. See `ckb init --help` for details. And `ckb cli secp256k1-lock` can
+# also prints the command line options for `ckb init`.
 #
-# [block_assembler]
+#     ckb cli secp256k1-lock <pubkey> --format cmd
+#
+# The two commands can be combined together:
+#
+#     ckb init $(ckb cli secp256k1-lock <pubkey> --format cmd)
+#
 # # {{
-# _ => # code_hash = "{code_hash}"
+# _ => {block_assembler}
 # }}
-# args = ["ckb cli blake160 <pubkey>"]

--- a/resource/src/template.rs
+++ b/resource/src/template.rs
@@ -7,7 +7,6 @@ const START_MARKER: &str = " # {{";
 const END_MAKER: &str = "# }}";
 const WILDCARD_BRANCH: &str = "# _ => ";
 
-use crate::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use std::io;
 
 pub struct Template<T>(T);
@@ -19,6 +18,7 @@ pub struct TemplateContext<'a> {
     pub log_to_file: bool,
     pub log_to_stdout: bool,
     pub runner: &'a str,
+    pub block_assembler: &'a str,
 }
 
 impl<T> Template<T> {
@@ -39,10 +39,7 @@ fn writeln<W: io::Write>(w: &mut W, s: &str, context: &TemplateContext) -> io::R
             .replace("{log_to_file}", &format!("{}", context.log_to_file))
             .replace("{log_to_stdout}", &format!("{}", context.log_to_stdout))
             .replace("{runner}", &context.runner.to_string())
-            .replace(
-                "{code_hash}",
-                &format!("{:#x}", CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL)
-            )
+            .replace("{block_assembler}", context.block_assembler)
     )
 }
 

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -270,6 +270,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             runner: "Rust",
+            block_assembler: "",
         };
         {
             locator.export_ckb(&context).expect("export config files");
@@ -307,6 +308,7 @@ mod tests {
             log_to_file: false,
             log_to_stdout: true,
             runner: "Rust",
+            block_assembler: "",
         };
         {
             locator.export_ckb(&context).expect("export config files");
@@ -339,6 +341,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             runner: "Rust",
+            block_assembler: "",
         };
         locator.export_ckb(&context).expect("export config files");
         {
@@ -376,6 +379,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             runner: "Rust",
+            block_assembler: "",
         };
         locator.export_ckb(&context).expect("export config files");
         {
@@ -417,6 +421,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             runner: "Assembly",
+            block_assembler: "",
         };
         {
             locator.export_ckb(&context).expect("export config files");

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -47,4 +47,6 @@ pub struct InitArgs {
     pub log_to_stdout: bool,
     pub list_chains: bool,
     pub force: bool,
+    pub block_assembler_code_hash: Option<String>,
+    pub block_assembler_args: Vec<String>,
 }

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -26,6 +26,8 @@ pub const ARG_RPC_PORT: &str = "rpc-port";
 pub const ARG_FORCE: &str = "force";
 pub const ARG_LOG_TO: &str = "log-to";
 pub const ARG_BUNDLED: &str = "bundled";
+pub const ARG_BA_CODE_HASH: &str = "ba-code-hash";
+pub const ARG_BA_ARG: &str = "ba-arg";
 
 pub fn get_matches(version: &Version) -> ArgMatches<'static> {
     App::new("ckb")
@@ -183,11 +185,11 @@ fn cli_secp256k1_lock() -> App<'static, 'static> {
             Arg::with_name(ARG_FORMAT)
                 .long(ARG_FORMAT)
                 .short("s")
-                .possible_values(&["block_assembler", "json"])
-                .default_value("block_assembler")
+                .possible_values(&["toml", "cmd"])
+                .default_value("toml")
                 .required(true)
                 .takes_value(true)
-                .help("Output format: `block_assembler` is used in ckb.toml."),
+                .help("Output format. toml: ckb.toml, cmd: command line options for `ckb init`"),
         )
 }
 
@@ -231,6 +233,21 @@ fn init() -> App<'static, 'static> {
                 .long(ARG_P2P_PORT)
                 .default_value(DEFAULT_P2P_PORT)
                 .help("Replaces CKB P2P port in the created config file"),
+        )
+        .arg(
+            Arg::with_name(ARG_BA_CODE_HASH)
+                .long(ARG_BA_CODE_HASH)
+                .value_name("code_hash")
+                .takes_value(true)
+                .help("Set code_hash in [block_assembler]"),
+        )
+        .arg(
+            Arg::with_name(ARG_BA_ARG)
+                .long(ARG_BA_ARG)
+                .value_name("arg")
+                .multiple(true)
+                .number_of_values(1)
+                .help("Set args in [block_assembler]"),
         )
         .arg(
             Arg::with_name("export-specs")

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -187,6 +187,13 @@ impl Setup {
             _ => unreachable!(),
         };
 
+        let block_assembler_code_hash = matches.value_of(cli::ARG_BA_CODE_HASH).map(str::to_string);
+        let block_assembler_args: Vec<_> = matches
+            .values_of(cli::ARG_BA_ARG)
+            .unwrap_or_default()
+            .map(str::to_string)
+            .collect();
+
         Ok(InitArgs {
             locator,
             chain,
@@ -196,6 +203,8 @@ impl Setup {
             force,
             log_to_file,
             log_to_stdout,
+            block_assembler_code_hash,
+            block_assembler_args,
         })
     }
 


### PR DESCRIPTION
- `ckb init` accepts options `--ba-code-hash` and `--ba-arg` (which can
repeat multiple times) to set block assembler.
- `ckb cli secp256k1-lock` adds an output format `cmd` to prints the
command line options for `ckb init` to set block assembler.

The two commands can combine into one to init the directory with a secp256k1 compressed pub key:

    ckb init $(ckb cli secp256k1-lock <pubkey> --format cmd)

Depends on: #999