### PR TITLE
chore(ci): force job Linters using its own cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
       if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
       os: linux
     - name: Linters
+      env: CACHE_NAME=linters
       if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
       os: linux
       install:


### PR DESCRIPTION
This PR tries to fix the following error in CI:

    found possibly newer version of crate `*` which `*` depends on

Travis separate cache via OS, Language and Env. So the new env option added to
job Linters can force it to use its own cache.