### PR TITLE
fix: locate blocks by hash

### DIFF
--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -144,6 +144,18 @@ fn test_transaction_spend_in_same_block() {
     chain.gen_empty_block(100, &mut mock_store);
     // commit txs in block
     chain.gen_block_with_commit_txs(txs.clone(), &mut mock_store, false);
+    let (parent_hash4, parent_number4) = {
+        chain
+            .blocks()
+            .last()
+            .map(|block| {
+                (
+                    block.header().parent_hash().clone(),
+                    block.header().number(),
+                )
+            })
+            .unwrap()
+    };
 
     for block in chain.blocks() {
         chain_controller
@@ -178,7 +190,7 @@ fn test_transaction_spend_in_same_block() {
                 })
                 .data_hash(tx2_output.data_hash())
                 .capacity(tx2_output.capacity)
-                .block_info(BlockInfo::new(4, 0))
+                .block_info(BlockInfo::new(parent_number4, 0, parent_hash4))
                 .build()
         )
     );

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -148,12 +148,7 @@ fn test_transaction_spend_in_same_block() {
         chain
             .blocks()
             .last()
-            .map(|block| {
-                (
-                    block.header().parent_hash().clone(),
-                    block.header().number(),
-                )
-            })
+            .map(|block| (block.header().hash().clone(), block.header().number()))
             .unwrap()
     };
 

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -15,11 +15,16 @@ use std::fmt;
 pub struct BlockInfo {
     pub number: BlockNumber,
     pub epoch: EpochNumber,
+    pub hash: H256,
 }
 
 impl BlockInfo {
-    pub fn new(number: BlockNumber, epoch: EpochNumber) -> Self {
-        BlockInfo { number, epoch }
+    pub fn new(number: BlockNumber, epoch: EpochNumber, hash: H256) -> Self {
+        BlockInfo {
+            number,
+            epoch,
+            hash,
+        }
     }
 }
 
@@ -374,6 +379,7 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
                             block_info: Some(BlockInfo {
                                 number: self.block.header().number(),
                                 epoch: self.block.header().epoch(),
+                                hash: self.block.header().hash().to_owned(),
                             }),
                             cellbase: *i == 0,
                         })
@@ -691,6 +697,7 @@ mod tests {
             block_info: Some(BlockInfo {
                 number: 1,
                 epoch: 1,
+                hash: H256::zero(),
             }),
             capacity: cell_output.capacity,
             data_hash: Some(cell_output.data_hash()),

--- a/core/src/transaction_meta.rs
+++ b/core/src/transaction_meta.rs
@@ -1,5 +1,5 @@
-use crate::cell::BlockInfo;
 use bit_vec::BitVec;
+use numext_fixed_hash::H256;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -23,6 +23,7 @@ impl From<BitVecSerde> for BitVec {
 pub struct TransactionMeta {
     block_number: u64,
     epoch_number: u64,
+    block_hash: H256,
     cellbase: bool,
     /// each bits indicate if transaction has dead cells
     #[serde(with = "BitVecSerde")]
@@ -33,12 +34,14 @@ impl TransactionMeta {
     pub fn new(
         block_number: u64,
         epoch_number: u64,
+        block_hash: H256,
         outputs_count: usize,
         all_dead: bool,
     ) -> TransactionMeta {
         TransactionMeta {
             block_number,
             epoch_number,
+            block_hash,
             cellbase: false,
             dead_cell: BitVec::from_elem(outputs_count, all_dead),
         }
@@ -48,10 +51,17 @@ impl TransactionMeta {
     pub fn new_cellbase(
         block_number: u64,
         epoch_number: u64,
+        block_hash: H256,
         outputs_count: usize,
         all_dead: bool,
     ) -> Self {
-        let mut result = Self::new(block_number, epoch_number, outputs_count, all_dead);
+        let mut result = Self::new(
+            block_number,
+            epoch_number,
+            block_hash,
+            outputs_count,
+            all_dead,
+        );
         result.cellbase = true;
         result
     }
@@ -74,9 +84,8 @@ impl TransactionMeta {
         self.epoch_number
     }
 
-    pub fn block_info(&self) -> &BlockInfo {
-        // bilibili FIXME
-        unimplemented!()
+    pub fn block_hash(&self) -> &H256 {
+        &self.block_hash
     }
 
     pub fn is_empty(&self) -> bool {
@@ -103,12 +112,13 @@ impl TransactionMeta {
         }
     }
 
-    pub fn destruct(&self) -> (u64, u64, bool, Vec<u8>, usize) {
+    pub fn destruct(&self) -> (u64, u64, &H256, bool, Vec<u8>, usize) {
         let len = self.dead_cell.len();
         let bits = self.dead_cell.to_bytes();
         (
             self.block_number,
             self.epoch_number,
+            &self.block_hash,
             self.cellbase,
             bits,
             len,
@@ -120,6 +130,7 @@ impl TransactionMeta {
 pub struct TransactionMetaBuilder {
     block_number: u64,
     epoch_number: u64,
+    block_hash: H256,
     cellbase: bool,
     bits: Vec<u8>,
     len: usize,
@@ -133,6 +144,11 @@ impl TransactionMetaBuilder {
 
     pub fn epoch_number(mut self, epoch_number: u64) -> Self {
         self.epoch_number = epoch_number;
+        self
+    }
+
+    pub fn block_hash(mut self, block_hash: H256) -> Self {
+        self.block_hash = block_hash;
         self
     }
 
@@ -155,6 +171,7 @@ impl TransactionMetaBuilder {
         let TransactionMetaBuilder {
             block_number,
             epoch_number,
+            block_hash,
             cellbase,
             bits,
             len,
@@ -164,6 +181,7 @@ impl TransactionMetaBuilder {
         TransactionMeta {
             block_number,
             epoch_number,
+            block_hash,
             cellbase,
             dead_cell,
         }
@@ -174,10 +192,11 @@ impl TransactionMetaBuilder {
 mod tests {
     use super::*;
     use bincode;
+    use numext_fixed_hash::H256;
 
     #[test]
     fn transaction_meta_serde() {
-        let mut original = TransactionMeta::new(0, 0, 4, false);
+        let mut original = TransactionMeta::new(0, 0, H256::zero(), 4, false);
         original.set_dead(1);
         original.set_dead(3);
 
@@ -193,7 +212,7 @@ mod tests {
 
     #[test]
     fn set_unset_dead_out_of_bounds() {
-        let mut meta = TransactionMeta::new(0, 0, 4, false);
+        let mut meta = TransactionMeta::new(0, 0, H256::zero(), 4, false);
         meta.set_dead(3);
         assert!(meta.is_dead(3) == Some(true));
         meta.unset_dead(3);

--- a/core/src/transaction_meta.rs
+++ b/core/src/transaction_meta.rs
@@ -1,3 +1,4 @@
+use crate::cell::BlockInfo;
 use bit_vec::BitVec;
 use serde_derive::{Deserialize, Serialize};
 
@@ -71,6 +72,11 @@ impl TransactionMeta {
 
     pub fn epoch_number(&self) -> u64 {
         self.epoch_number
+    }
+
+    pub fn block_info(&self) -> &BlockInfo {
+        // bilibili FIXME
+        unimplemented!()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/protos/schemas/common.fbs
+++ b/protos/schemas/common.fbs
@@ -156,6 +156,7 @@ struct EpochExt {
 table TransactionMeta {
     block_number:   uint64;
     epoch_number:   uint64;
+    block_hash:     Bytes32;
     cellbase:       bool;
     bits:           Bytes;
     len:            uint32;

--- a/protos/src/convert/from_common.rs
+++ b/protos/src/convert/from_common.rs
@@ -382,6 +382,7 @@ impl TryFrom<&protos::EpochExt> for EpochExt {
 impl<'a> TryFrom<protos::TransactionMeta<'a>> for TransactionMeta {
     type Error = Error;
     fn try_from(proto: protos::TransactionMeta<'a>) -> Result<Self> {
+        let block_hash = proto.block_hash().unwrap_some()?;
         let bits = proto
             .bits()
             .and_then(|p| p.seq())
@@ -390,6 +391,7 @@ impl<'a> TryFrom<protos::TransactionMeta<'a>> for TransactionMeta {
         let ret = TransactionMetaBuilder::default()
             .block_number(proto.block_number())
             .epoch_number(proto.epoch_number())
+            .block_hash(block_hash.try_into()?)
             .cellbase(proto.cellbase())
             .bits(bits)
             .len(proto.len() as usize)

--- a/protos/src/convert/to_common.rs
+++ b/protos/src/convert/to_common.rs
@@ -410,11 +410,13 @@ impl<'a> CanBuild<'a> for protos::TransactionMeta<'a> {
         fbb: &mut FlatBufferBuilder<'b>,
         meta: &Self::Input,
     ) -> WIPOffset<protos::TransactionMeta<'b>> {
-        let (block_number, epoch_number, cellbase, bits, len) = meta.destruct();
+        let (block_number, epoch_number, block_hash, cellbase, bits, len) = meta.destruct();
+        let block_hash = block_hash.into();
         let bits = protos::Bytes::build(fbb, &bits);
         let mut builder = protos::TransactionMetaBuilder::new(fbb);
         builder.add_block_number(block_number);
         builder.add_epoch_number(epoch_number);
+        builder.add_block_hash(&block_hash);
         builder.add_cellbase(cellbase);
         builder.add_bits(bits);
         builder.add_len(len as u32);

--- a/protos/src/generated/common.rs
+++ b/protos/src/generated/common.rs
@@ -2276,15 +2276,19 @@ impl<'a> TransactionMeta<'a> {
         if let Some(x) = args.bits {
             builder.add_bits(x);
         }
+        if let Some(x) = args.block_hash {
+            builder.add_block_hash(x);
+        }
         builder.add_cellbase(args.cellbase);
         builder.finish()
     }
 
     pub const VT_BLOCK_NUMBER: flatbuffers::VOffsetT = 4;
     pub const VT_EPOCH_NUMBER: flatbuffers::VOffsetT = 6;
-    pub const VT_CELLBASE: flatbuffers::VOffsetT = 8;
-    pub const VT_BITS: flatbuffers::VOffsetT = 10;
-    pub const VT_LEN: flatbuffers::VOffsetT = 12;
+    pub const VT_BLOCK_HASH: flatbuffers::VOffsetT = 8;
+    pub const VT_CELLBASE: flatbuffers::VOffsetT = 10;
+    pub const VT_BITS: flatbuffers::VOffsetT = 12;
+    pub const VT_LEN: flatbuffers::VOffsetT = 14;
 
     #[inline]
     pub fn block_number(&self) -> u64 {
@@ -2297,6 +2301,11 @@ impl<'a> TransactionMeta<'a> {
         self._tab
             .get::<u64>(TransactionMeta::VT_EPOCH_NUMBER, Some(0))
             .unwrap()
+    }
+    #[inline]
+    pub fn block_hash(&self) -> Option<&'a Bytes32> {
+        self._tab
+            .get::<Bytes32>(TransactionMeta::VT_BLOCK_HASH, None)
     }
     #[inline]
     pub fn cellbase(&self) -> bool {
@@ -2320,6 +2329,7 @@ impl<'a> TransactionMeta<'a> {
 pub struct TransactionMetaArgs<'a> {
     pub block_number: u64,
     pub epoch_number: u64,
+    pub block_hash: Option<&'a Bytes32>,
     pub cellbase: bool,
     pub bits: Option<flatbuffers::WIPOffset<Bytes<'a>>>,
     pub len: u32,
@@ -2330,6 +2340,7 @@ impl<'a> Default for TransactionMetaArgs<'a> {
         TransactionMetaArgs {
             block_number: 0,
             epoch_number: 0,
+            block_hash: None,
             cellbase: false,
             bits: None,
             len: 0,
@@ -2350,6 +2361,11 @@ impl<'a: 'b, 'b> TransactionMetaBuilder<'a, 'b> {
     pub fn add_epoch_number(&mut self, epoch_number: u64) {
         self.fbb_
             .push_slot::<u64>(TransactionMeta::VT_EPOCH_NUMBER, epoch_number, 0);
+    }
+    #[inline]
+    pub fn add_block_hash(&mut self, block_hash: &'b Bytes32) {
+        self.fbb_
+            .push_slot_always::<&Bytes32>(TransactionMeta::VT_BLOCK_HASH, block_hash);
     }
     #[inline]
     pub fn add_cellbase(&mut self, cellbase: bool) {

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -475,12 +475,12 @@ mod tests {
 
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
         let always_success_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(always_success_cell.clone())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -539,7 +539,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.as_ref().unwrap().clone())
                 .build(),
@@ -556,7 +556,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -614,7 +614,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.clone().unwrap())
                 .build(),
@@ -631,7 +631,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -693,7 +693,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.clone().unwrap())
                 .build(),
@@ -710,7 +710,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -776,7 +776,7 @@ mod tests {
         let type_hash: H256 = output.type_.as_ref().unwrap().hash();
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.as_ref().unwrap().clone())
                 .build(),
@@ -793,7 +793,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -851,7 +851,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.as_ref().unwrap().clone())
                 .build(),
@@ -868,7 +868,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -930,7 +930,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .build(),
         );
@@ -946,7 +946,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -1008,7 +1008,7 @@ mod tests {
         let output = CellOutput::new(capacity_bytes!(100), Bytes::default(), script, None);
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -1066,12 +1066,12 @@ mod tests {
         );
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
         let always_success_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(always_success_cell.clone())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -1093,7 +1093,7 @@ mod tests {
             );
             ResolvedOutPoint::cell_only(
                 CellMetaBuilder::from_cell_output(output.to_owned())
-                    .block_info(BlockInfo::new(1, 0))
+                    .block_info(BlockInfo::new(1, 0, H256::zero()))
                     .out_point(dep_out_point.cell.as_ref().unwrap().clone())
                     .build(),
             )
@@ -1162,12 +1162,12 @@ mod tests {
         );
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
         let always_success_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(always_success_cell.to_owned())
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 
@@ -1189,7 +1189,7 @@ mod tests {
             );
             ResolvedOutPoint::cell_only(
                 CellMetaBuilder::from_cell_output(output)
-                    .block_info(BlockInfo::new(1, 0))
+                    .block_info(BlockInfo::new(1, 0, H256::zero()))
                     .build(),
             )
         };
@@ -1256,7 +1256,7 @@ mod tests {
         );
         let dep_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .data_hash(code_hash.to_owned())
                 .out_point(dep_out_point.cell.as_ref().unwrap().clone())
                 .build(),
@@ -1276,7 +1276,7 @@ mod tests {
         );
         let dummy_cell = ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output)
-                .block_info(BlockInfo::new(1, 0))
+                .block_info(BlockInfo::new(1, 0, H256::zero()))
                 .build(),
         );
 

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -6,8 +6,8 @@ use crate::tx_proposal_table::TxProposalTable;
 use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
 use ckb_core::block::Block;
 use ckb_core::cell::{
-    resolve_transaction, BlockInfo, CellMetaBuilder, CellProvider, CellStatus, HeaderProvider,
-    HeaderStatus, OverlayCellProvider, ResolvedTransaction, UnresolvableError,
+    resolve_transaction, CellMetaBuilder, CellProvider, CellStatus, HeaderProvider, HeaderStatus,
+    OverlayCellProvider, ResolvedTransaction, UnresolvableError,
 };
 use ckb_core::extras::EpochExt;
 use ckb_core::header::{BlockNumber, Header};
@@ -802,10 +802,7 @@ impl<'a, CS: ChainStore> CellProvider for ChainCellSetOverlay<'a, CS> {
                                 let output = &outputs[cell_out_point.index as usize];
                                 CellMetaBuilder::from_cell_output(output.to_owned())
                                     .out_point(cell_out_point.to_owned())
-                                    .block_info(BlockInfo::new(
-                                        tx_meta.block_number(),
-                                        tx_meta.epoch_number(),
-                                    ))
+                                    .block_info(tx_meta.block_info().clone())
                                     .cellbase(tx_meta.is_cellbase())
                                     .build()
                             })

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -425,8 +425,9 @@ impl<CS: ChainStore> ChainState<CS> {
                 ContextualTransactionVerifier::new(
                     &rtx,
                     &self,
-                    self.tx_verify_block_number(),
+                    self.tip_number() + 1,
                     self.current_epoch_ext().number(),
+                    self.tip_hash(),
                     &self.consensus(),
                 )
                 .verify()
@@ -438,8 +439,9 @@ impl<CS: ChainStore> ChainState<CS> {
                 let cycles = TransactionVerifier::new(
                     &rtx,
                     &self,
-                    self.tx_verify_block_number(),
+                    self.tip_number() + 1,
                     self.current_epoch_ext().number(),
+                    self.tip_hash(),
                     &self.consensus(),
                     &self.script_config,
                     &self.store,
@@ -471,11 +473,6 @@ impl<CS: ChainStore> ChainState<CS> {
                 tx_pool.enqueue_tx(entry.cycles, entry.size, entry.transaction);
             }
         }
-    }
-
-    // assume block_number = self.tip_number() + 1 when verify tx in tx_pool
-    pub(crate) fn tx_verify_block_number(&self) -> BlockNumber {
-        self.tip_number() + 1
     }
 
     pub(crate) fn proposed_tx(

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -837,8 +837,4 @@ impl<CS: ChainStore> BlockMedianTimeContext for &ChainState<CS> {
             .expect("[ChainState] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
-
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        self.store.get_block_hash(block_number)
-    }
 }

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -1,4 +1,4 @@
-use ckb_core::{transaction::Transaction, BlockNumber, Cycle};
+use ckb_core::{transaction::Transaction, Cycle};
 use ckb_shared::shared::Shared;
 use ckb_shared::tx_pool::PoolError;
 use ckb_store::ChainStore;

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -26,10 +26,6 @@ impl<CS: ChainStore> BlockMedianTimeContext for StoreBlockMedianTimeContext<CS> 
             .expect("[StoreBlockMedianTimeContext] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
-
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        self.store.get_block_hash(block_number)
-    }
 }
 
 /// TxPoolExecutor

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -399,6 +399,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
             let block_info = BlockInfo {
                 number: tx_info.block_number,
                 epoch: tx_info.block_epoch,
+                hash: tx_info.block_hash,
             };
             let (capacity, data_hash) = meta;
             CellMeta {

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -285,6 +285,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
                 tx_meta = TransactionMeta::new_cellbase(
                     genesis.header().number(),
                     genesis.header().epoch(),
+                    genesis.header().hash().to_owned(),
                     tx.outputs().len(),
                     false,
                 );
@@ -293,6 +294,7 @@ impl<T: KeyValueDB> ChainStore for ChainKVStore<T> {
                 tx_meta = TransactionMeta::new(
                     genesis.header().number(),
                     genesis.header().epoch(),
+                    genesis.header().hash().to_owned(),
                     tx.outputs().len(),
                     false,
                 );

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -2,7 +2,6 @@ use crate::relayer::compact_block::CompactBlock;
 use crate::relayer::compact_block_verifier::CompactBlockVerifier;
 use crate::relayer::Relayer;
 use ckb_core::header::Header;
-use ckb_core::BlockNumber;
 use ckb_logger::debug_target;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{CompactBlock as FbsCompactBlock, RelayMessage};
@@ -134,7 +133,6 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                 );
                 let header_verifier = HeaderVerifier::new(
                     CompactBlockMedianTimeView {
-                        anchor_hash: compact_block.header.hash(),
                         fn_get_pending_header: Box::new(fn_get_pending_header),
                         shared: self.relayer.shared.shared(),
                     },
@@ -222,7 +220,6 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
 }
 
 struct CompactBlockMedianTimeView<'a, CS> {
-    anchor_hash: &'a H256,
     fn_get_pending_header: Box<Fn(H256) -> Option<Header> + 'a>,
     shared: &'a Shared<CS>,
 }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -251,29 +251,4 @@ where
             .expect("[CompactBlockMedianTimeView] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
-
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        let mut hash = self.anchor_hash.to_owned();
-        while let Some(header) = self.get_header(&hash) {
-            if header.number() == block_number {
-                return Some(header.hash().to_owned());
-            }
-
-            // The current `hash` is the common ancestor of tip chain and `self.anchor_hash`,
-            // so we can get the target hash via `self.shared.store().get_block_hash`, since it is in tip chain
-            if self
-                .shared
-                .store()
-                .get_block_hash(header.number())
-                .expect("tip chain")
-                == hash
-            {
-                return self.shared.store().get_block_hash(block_number);
-            }
-
-            hash = header.parent_hash().to_owned();
-        }
-
-        unreachable!()
-    }
 }

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -84,13 +84,6 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
             .expect("[VerifierResolver] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
-
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        self.synchronizer
-            .shared
-            .store()
-            .get_block_hash(block_number)
-    }
 }
 
 impl<'a, CS: ChainStore> HeaderResolver for VerifierResolver<'a, CS> {

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -2,7 +2,6 @@ use crate::synchronizer::{BlockStatus, Synchronizer};
 use crate::MAX_HEADERS_LEN;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
-use ckb_core::BlockNumber;
 use ckb_logger::{debug, log_enabled, warn, Level};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, FlatbuffersVectorIterator, Headers};

--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -7,7 +7,7 @@ use std::cmp::min;
 pub trait BlockMedianTimeContext {
     fn median_block_count(&self) -> u64;
 
-    /// Return timestamp of the correspoding bloch_hash, and hash of parent block
+    /// Return timestamp of the corresponding bloch_hash, and hash of parent block
     ///
     /// Fake implementation:
     /// ```ignore
@@ -34,12 +34,4 @@ pub trait BlockMedianTimeContext {
         timestamps.sort();
         timestamps[timestamps.len() >> 1]
     }
-
-    /// Return the corresponding block_hash
-    ///
-    /// It's just a convenience way that constructing a BlockMedianContext, to get the
-    /// corresponding block_hash when you only know a block_number.
-    ///
-    /// Often used in verifying "since by block number".
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256>;
 }

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -302,6 +302,7 @@ struct BlockTxsVerifier<'a, P> {
     context: &'a ForkContext<'a, P>,
     block_number: BlockNumber,
     epoch_number: EpochNumber,
+    parent_hash: &'a H256,
     resolved: &'a [ResolvedTransaction<'a>],
 }
 
@@ -314,12 +315,14 @@ where
         context: &'a ForkContext<'a, P>,
         block_number: BlockNumber,
         epoch_number: EpochNumber,
+        parent_hash: &'a H256,
         resolved: &'a [ResolvedTransaction<'a>],
     ) -> BlockTxsVerifier<'a, P> {
         BlockTxsVerifier {
             context,
             block_number,
             epoch_number,
+            parent_hash,
             resolved,
         }
     }
@@ -338,6 +341,7 @@ where
                         self.context,
                         self.block_number,
                         self.epoch_number,
+                        self.parent_hash,
                         self.context.provider.consensus(),
                     )
                     .verify()
@@ -349,6 +353,7 @@ where
                         self.context,
                         self.block_number,
                         self.epoch_number,
+                        self.parent_hash,
                         self.context.provider.consensus(),
                         self.context.provider.script_config(),
                         self.context.provider.store(),
@@ -431,6 +436,7 @@ where
             self.context,
             block.header().number(),
             block.header().epoch(),
+            block.header().parent_hash(),
             resolved,
         )
         .verify(txs_verify_cache)?;

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -47,14 +47,6 @@ impl<'a, P: ChainProvider> BlockMedianTimeContext for ForkContext<'a, P> {
             .expect("[ForkContext] blocks used for median time exist");
         (header.timestamp(), header.parent_hash().to_owned())
     }
-
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
-        self.attached_blocks
-            .iter()
-            .find(|b| b.header().number() == block_number)
-            .and_then(|b| Some(b.header().hash().to_owned()))
-            .or_else(|| self.provider.store().get_block_hash(block_number))
-    }
 }
 
 pub(crate) struct UncleVerifierContext<'a, P> {

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -250,23 +250,22 @@ impl BlockMedianTimeContext for FakeMedianTime {
 
     fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
         for i in 0..self.timestamps.len() {
-            if &self.get_block_hash(i as u64).unwrap() == block_hash {
+            if &self.get_block_hash(i as u64) == block_hash {
                 if i == 0 {
                     return (self.timestamps[i], H256::zero());
                 } else {
-                    return (
-                        self.timestamps[i],
-                        self.get_block_hash(i as u64 - 1).unwrap(),
-                    );
+                    return (self.timestamps[i], self.get_block_hash(i as u64 - 1));
                 }
             }
         }
         unreachable!()
     }
+}
 
-    fn get_block_hash(&self, block_number: BlockNumber) -> Option<H256> {
+impl FakeMedianTime {
+    fn get_block_hash(&self, block_number: BlockNumber) -> H256 {
         let vec: Vec<u8> = (0..32).map(|_| block_number as u8).collect();
-        Some(H256::from_slice(vec.as_slice()).unwrap())
+        H256::from_slice(vec.as_slice()).unwrap()
     }
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -115,7 +115,7 @@ pub fn test_inputs_cellbase_maturity() {
         resolved_deps: Vec::new(),
         resolved_inputs: vec![ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.clone())
-                .block_info(BlockInfo::new(30, 0))
+                .block_info(BlockInfo::new(30, 0, H256::zero()))
                 .cellbase(true)
                 .build(),
         )],

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -6,7 +6,7 @@ use crate::error::TransactionError;
 use ckb_core::cell::{BlockInfo, CellMeta, CellMetaBuilder, ResolvedOutPoint, ResolvedTransaction};
 use ckb_core::script::{Script, ScriptHashType};
 use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
-use ckb_core::{capacity_bytes, BlockNumber, Bytes, Capacity, Version};
+use ckb_core::{capacity_bytes, BlockNumber, Bytes, Capacity, EpochNumber, Version};
 use ckb_db::MemoryKeyValueDB;
 use ckb_resource::CODE_HASH_DAO;
 use ckb_store::{ChainKVStore, COLUMNS};
@@ -115,7 +115,7 @@ pub fn test_inputs_cellbase_maturity() {
         resolved_deps: Vec::new(),
         resolved_inputs: vec![ResolvedOutPoint::cell_only(
             CellMetaBuilder::from_cell_output(output.clone())
-                .block_info(BlockInfo::new(30, 0, H256::zero()))
+                .block_info(make_block_info(30, 0))
                 .cellbase(true)
                 .build(),
         )],
@@ -147,13 +147,13 @@ pub fn test_deps_cellbase_maturity() {
         resolved_deps: vec![
             ResolvedOutPoint::cell_only(
                 CellMetaBuilder::from_cell_output(output.clone())
-                    .block_info(BlockInfo::new(30, 0))
+                    .block_info(make_block_info(30, 0))
                     .cellbase(true)
                     .build(),
             ),
             ResolvedOutPoint::cell_only(
                 CellMetaBuilder::from_cell_output(output.clone())
-                    .block_info(BlockInfo::new(40, 0))
+                    .block_info(make_block_info(40, 0))
                     .cellbase(false)
                     .build(),
             ),
@@ -250,11 +250,11 @@ impl BlockMedianTimeContext for FakeMedianTime {
 
     fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
         for i in 0..self.timestamps.len() {
-            if &self.get_block_hash(i as u64) == block_hash {
+            if &get_block_hash(i as u64) == block_hash {
                 if i == 0 {
                     return (self.timestamps[i], H256::zero());
                 } else {
-                    return (self.timestamps[i], self.get_block_hash(i as u64 - 1));
+                    return (self.timestamps[i], get_block_hash(i as u64 - 1));
                 }
             }
         }
@@ -262,11 +262,34 @@ impl BlockMedianTimeContext for FakeMedianTime {
     }
 }
 
-impl FakeMedianTime {
-    fn get_block_hash(&self, block_number: BlockNumber) -> H256 {
-        let vec: Vec<u8> = (0..32).map(|_| block_number as u8).collect();
-        H256::from_slice(vec.as_slice()).unwrap()
-    }
+fn get_block_hash(block_number: BlockNumber) -> H256 {
+    let vec: Vec<u8> = (0..32).map(|_| block_number as u8).collect();
+    H256::from_slice(vec.as_slice()).unwrap()
+}
+
+fn make_block_info(block_number: BlockNumber, epoch_number: EpochNumber) -> BlockInfo {
+    let block_hash = get_block_hash(block_number);
+    BlockInfo::new(block_number, epoch_number, block_hash)
+}
+
+fn verify_since<'a, M>(
+    rtx: &'a ResolvedTransaction,
+    block_median_time_context: &'a M,
+    block_number: BlockNumber,
+    epoch_number: BlockNumber,
+) -> Result<(), TransactionError>
+where
+    M: BlockMedianTimeContext,
+{
+    let parent_hash = Arc::new(get_block_hash(block_number - 1));
+    SinceVerifier::new(
+        rtx,
+        block_median_time_context,
+        block_number,
+        epoch_number,
+        &parent_hash,
+    )
+    .verify()
 }
 
 #[test]
@@ -330,14 +353,13 @@ fn create_resolve_tx_with_block_info(
 fn test_invalid_since_verify() {
     // use remain flags
     let tx = create_tx_with_lock(0x0100_0000_0000_0001);
-    let rtx = create_resolve_tx_with_block_info(&tx, BlockInfo::new(1, 0));
+    let rtx = create_resolve_tx_with_block_info(&tx, make_block_info(1, 0));
 
     let median_time_context = FakeMedianTime {
         timestamps: vec![0; 11],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 5, 1);
     assert_eq!(
-        verifier.verify().err(),
+        verify_since(&rtx, &median_time_context, 5, 1).err(),
         Some(TransactionError::InvalidSince)
     );
 }
@@ -346,70 +368,74 @@ fn test_invalid_since_verify() {
 pub fn test_absolute_block_number_lock() {
     // absolute lock until block number 0xa
     let tx = create_tx_with_lock(0x0000_0000_0000_000a);
-    let rtx = create_resolve_tx_with_block_info(&tx, BlockInfo::new(1, 0));
-
+    let rtx = create_resolve_tx_with_block_info(&tx, make_block_info(1, 0));
     let median_time_context = FakeMedianTime {
         timestamps: vec![0; 11],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 5, 1);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::Immature));
+
+    assert_eq!(
+        verify_since(&rtx, &median_time_context, 5, 1).err(),
+        Some(TransactionError::Immature)
+    );
     // spent after 10 height
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 10, 1);
-    assert!(verifier.verify().is_ok());
+    assert!(verify_since(&rtx, &median_time_context, 10, 1).is_ok());
 }
 
 #[test]
 pub fn test_absolute_epoch_number_lock() {
     // absolute lock until epoch number 0xa
     let tx = create_tx_with_lock(0x2000_0000_0000_000a);
-    let rtx = create_resolve_tx_with_block_info(&tx, BlockInfo::new(1, 0));
+    let rtx = create_resolve_tx_with_block_info(&tx, make_block_info(1, 0));
 
     let median_time_context = FakeMedianTime {
         timestamps: vec![0; 11],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 5, 1);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::Immature));
+    assert_eq!(
+        verify_since(&rtx, &median_time_context, 5, 1).err(),
+        Some(TransactionError::Immature)
+    );
     // spent after 10 epoch
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 100, 10);
-    assert!(verifier.verify().is_ok());
+    assert!(verify_since(&rtx, &median_time_context, 100, 10).is_ok());
 }
 
 #[test]
 pub fn test_relative_timestamp_lock() {
     // relative lock timestamp lock
     let tx = create_tx_with_lock(0xc000_0000_0000_0002);
-    let rtx = create_resolve_tx_with_block_info(&tx, BlockInfo::new(1, 0));
+    let rtx = create_resolve_tx_with_block_info(&tx, make_block_info(1, 0));
 
     let median_time_context = FakeMedianTime {
         timestamps: vec![0; 11],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 4, 1);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::Immature));
+    assert_eq!(
+        verify_since(&rtx, &median_time_context, 4, 1).err(),
+        Some(TransactionError::Immature)
+    );
 
     // spent after 1024 seconds
     // fake median time: 1124
     let median_time_context = FakeMedianTime {
         timestamps: vec![0, 100_000, 1_124_000, 2_000_000, 3_000_000],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 4, 1);
-    assert!(verifier.verify().is_ok());
+    assert!(verify_since(&rtx, &median_time_context, 4, 1).is_ok());
 }
 
 #[test]
 pub fn test_relative_epoch() {
     // next epoch
     let tx = create_tx_with_lock(0xa000_0000_0000_0001);
-    let rtx = create_resolve_tx_with_block_info(&tx, BlockInfo::new(1, 1));
+    let rtx = create_resolve_tx_with_block_info(&tx, make_block_info(1, 1));
 
     let median_time_context = FakeMedianTime {
         timestamps: vec![0; 11],
     };
 
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 4, 1);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::Immature));
+    assert_eq!(
+        verify_since(&rtx, &median_time_context, 4, 1).err(),
+        Some(TransactionError::Immature)
+    );
 
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 4, 2);
-    assert!(verifier.verify().is_ok());
+    assert!(verify_since(&rtx, &median_time_context, 4, 2).is_ok());
 }
 
 #[test]
@@ -425,15 +451,17 @@ pub fn test_since_both() {
         ])
         .build();
 
-    let rtx = create_resolve_tx_with_block_info(&transaction, BlockInfo::new(1, 0));
+    let rtx = create_resolve_tx_with_block_info(&transaction, make_block_info(1, 0));
     // spent after 1024 seconds and 4 blocks (less than 10 blocks)
     // fake median time: 1124
     let median_time_context = FakeMedianTime {
         timestamps: vec![0, 100_000, 1_124_000, 2_000_000, 3_000_000],
     };
 
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 4, 1);
-    assert_eq!(verifier.verify().err(), Some(TransactionError::Immature));
+    assert_eq!(
+        verify_since(&rtx, &median_time_context, 4, 1).err(),
+        Some(TransactionError::Immature)
+    );
     // spent after 1024 seconds and 10 blocks
     // fake median time: 1124
     let median_time_context = FakeMedianTime {
@@ -442,6 +470,5 @@ pub fn test_since_both() {
             6_000_000,
         ],
     };
-    let verifier = SinceVerifier::new(&rtx, &median_time_context, 10, 1);
-    assert!(verifier.verify().is_ok());
+    assert!(verify_since(&rtx, &median_time_context, 10, 1).is_ok());
 }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -388,7 +388,12 @@ where
         }
     }
 
-    fn block_median_time(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
+    // bilibili FIXME
+    fn block_median_time(&self, block_number: BlockNumber) -> u64 {
+        unimplemented!()
+    }
+
+    fn block_median_time2(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
         if let Some(median_time) = self.median_timestamps_cache.borrow().get(block_hash) {
             return *median_time;
         }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -5,7 +5,6 @@ use ckb_core::{
     transaction::{Transaction, TX_VERSION},
     BlockNumber, Cycle, EpochNumber,
 };
-use ckb_logger::info_target;
 use ckb_resource::CODE_HASH_DAO;
 use ckb_script::{ScriptConfig, TransactionScriptsVerifier};
 use ckb_script_data_loader::DataLoader;
@@ -30,11 +29,18 @@ where
         median_time_context: &'a M,
         block_number: BlockNumber,
         epoch_number: EpochNumber,
+        parent_hash: &'a H256,
         consensus: &'a Consensus,
     ) -> Self {
         ContextualTransactionVerifier {
             maturity: MaturityVerifier::new(&rtx, block_number, consensus.cellbase_maturity()),
-            since: SinceVerifier::new(rtx, median_time_context, block_number, epoch_number),
+            since: SinceVerifier::new(
+                rtx,
+                median_time_context,
+                block_number,
+                epoch_number,
+                parent_hash,
+            ),
         }
     }
 
@@ -61,11 +67,13 @@ where
     M: BlockMedianTimeContext,
     CS: ChainStore,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rtx: &'a ResolvedTransaction,
         median_time_context: &'a M,
         block_number: BlockNumber,
         epoch_number: EpochNumber,
+        parent_hash: &'a H256,
         consensus: &'a Consensus,
         script_config: &'a ScriptConfig,
         chain_store: &'a Arc<CS>,
@@ -78,7 +86,13 @@ where
             duplicate_deps: DuplicateDepsVerifier::new(&rtx.transaction),
             script: ScriptVerifier::new(rtx, chain_store, script_config),
             capacity: CapacityVerifier::new(rtx, chain_store),
-            since: SinceVerifier::new(rtx, median_time_context, block_number, epoch_number),
+            since: SinceVerifier::new(
+                rtx,
+                median_time_context,
+                block_number,
+                epoch_number,
+                parent_hash,
+            ),
         }
     }
 
@@ -365,6 +379,7 @@ pub struct SinceVerifier<'a, M> {
     block_median_time_context: &'a M,
     block_number: BlockNumber,
     epoch_number: EpochNumber,
+    parent_hash: &'a H256,
     median_timestamps_cache: RefCell<LruCache<H256, u64>>,
 }
 
@@ -377,6 +392,7 @@ where
         block_median_time_context: &'a M,
         block_number: BlockNumber,
         epoch_number: BlockNumber,
+        parent_hash: &'a H256,
     ) -> Self {
         let median_timestamps_cache = RefCell::new(LruCache::new(rtx.resolved_inputs.len()));
         SinceVerifier {
@@ -384,16 +400,19 @@ where
             block_median_time_context,
             block_number,
             epoch_number,
+            parent_hash,
             median_timestamps_cache,
         }
     }
 
-    // bilibili FIXME
-    fn block_median_time(&self, block_number: BlockNumber) -> u64 {
-        unimplemented!()
+    fn parent_median_time(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
+        let (_, parent_hash) = self
+            .block_median_time_context
+            .timestamp_and_parent(block_hash);
+        self.block_median_time(block_number - 1, &parent_hash)
     }
 
-    fn block_median_time2(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
+    fn block_median_time(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
         if let Some(median_time) = self.median_timestamps_cache.borrow().get(block_hash) {
             return *median_time;
         }
@@ -421,7 +440,8 @@ where
                     }
                 }
                 Some(SinceMetric::Timestamp(timestamp)) => {
-                    let tip_timestamp = self.block_median_time(self.block_number.saturating_sub(1));
+                    let tip_timestamp = self
+                        .block_median_time(self.block_number.saturating_sub(1), self.parent_hash);
                     if tip_timestamp < timestamp {
                         return Err(TransactionError::Immature);
                     }
@@ -440,19 +460,18 @@ where
         cell_meta: &CellMeta,
     ) -> Result<(), TransactionError> {
         if since.is_relative() {
-            // cell still in tx_pool
-            let (cell_block_number, cell_epoch_number) = match cell_meta.block_info {
-                Some(ref block_info) => (block_info.number, block_info.epoch),
+            let cell = match cell_meta.block_info {
+                Some(ref block_info) => block_info,
                 None => return Err(TransactionError::Immature),
             };
             match since.extract_metric() {
                 Some(SinceMetric::BlockNumber(block_number)) => {
-                    if self.block_number < cell_block_number + block_number {
+                    if self.block_number < cell.number + block_number {
                         return Err(TransactionError::Immature);
                     }
                 }
                 Some(SinceMetric::EpochNumber(epoch_number)) => {
-                    if self.epoch_number < cell_epoch_number + epoch_number {
+                    if self.epoch_number < cell.epoch + epoch_number {
                         return Err(TransactionError::Immature);
                     }
                 }
@@ -461,10 +480,9 @@ where
                     // parent of current block.
                     // pass_median_time(input_cell's block) starts with cell_block_number - 1,
                     // which is the parent of input_cell's block
-                    let cell_median_timestamp =
-                        self.block_median_time(cell_block_number.saturating_sub(1));
-                    let current_median_time =
-                        self.block_median_time(self.block_number.saturating_sub(1));
+                    let cell_median_timestamp = self.parent_median_time(cell.number, &cell.hash);
+                    let current_median_time = self
+                        .block_median_time(self.block_number.saturating_sub(1), self.parent_hash);
                     if current_median_time < cell_median_timestamp + timestamp {
                         return Err(TransactionError::Immature);
                     }


### PR DESCRIPTION
When calculates block_median_time, we need to locate the specific blocks.
Using block_hash instead block_number to locate the specific blocks is more accurate.

* feat: Add `hash: H256` into `BlockInfo`
* fix: Locate blocks by block_hash when calculate block_median_time

-------

**BREAKING CHANGE**: The format of `TransactionMeta`  is changed, which is affected by `BlockInfo`