### PR TITLE
chore(ci): skip integration in PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,15 @@ deploy:
 matrix:
   include:
     # We don't run tests, linters and quck check in fork branch, since they will be covered in PR.
-    # If you want to see the tests result in CI before submitting PR, name the branch with prefix "test".
     - name: Tests on macOS
-      if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
+      if: 'tag IS NOT present AND (type = pull_request OR branch = master)'
       os: osx
     - name: Tests on Linux
-      if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
+      if: 'tag IS NOT present AND (type = pull_request OR branch = master)'
       os: linux
     - name: Linters
       env: CACHE_NAME=linters
-      if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
+      if: 'tag IS NOT present AND (type = pull_request OR branch = master)'
       os: linux
       install:
         - cargo fmt --version || travis_retry rustup component add rustfmt
@@ -73,7 +72,7 @@ matrix:
         - make clippy
         - git diff --exit-code Cargo.lock
     - name: Quick Check
-      if: 'tag IS NOT present AND (type = pull_request OR branch = master OR branch =~ /^test/)'
+      if: 'tag IS NOT present AND (type = pull_request OR branch = master)'
       os: linux
       cache: false
       addons: { apt: { packages: [] } }
@@ -84,11 +83,11 @@ matrix:
         - make check-dirty-doc
 
     - name: Integration on macOS
-      if: 'tag IS NOT present AND type != pull_request'
+      if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, develop) OR branch =~ /^pr-mirror\// OR branch =~ /^rc\//)'
       os: osx
       script: make integration
     - name: Integration on Linux
-      if: 'tag IS NOT present AND type != pull_request'
+      if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, develop) OR branch =~ /^pr-mirror\// OR branch =~ /^rc\//)'
       os: linux
       script: make integration
     - name: Code Coverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,7 @@ jobs:
         not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')),
         or(
           eq(variables['Build.Reason'], 'PullRequest'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-          startsWith(variables['Build.SourceBranch'], 'refs/heads/test')
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
         )
       )
     pool:
@@ -30,7 +29,12 @@ jobs:
     condition: |
       and(
         not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')),
-        ne(variables['Build.Reason'], 'PullRequest')
+        ne(variables['Build.Reason'], 'PullRequest'),
+        or(
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/pr-mirror/'),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/rc/'),
+          in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/develop')
+        )
       )
     pool:
       vmImage: 'VS2017-Win2016'


### PR DESCRIPTION
Integration tests will become slower and slower, we don't want to run all the
test suites.

Later we may pick random n test specs to run in PR.