### PR TITLE
fix: use Rust VM runner in bundled config file

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -78,7 +78,7 @@ max_cycles = 200_000_000_000
 max_verfify_cache_size = 100_000
 
 [script]
-runner = "Assembly" # {{
+runner = "Rust" # {{
 # _ => runner = "{runner}"
 # }}
 

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -282,7 +282,6 @@ impl SystemCells {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use ckb_core::script::Script;
     use serde_derive::{Deserialize, Serialize};
     use std::collections::HashMap;
 

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -223,6 +223,17 @@ mod tests {
     }
 
     #[test]
+    fn test_bundled_config_files() {
+        let resource = Resource::bundled_ckb_config();
+        toml::from_slice::<CKBAppConfig>(&resource.get().expect("read bundled file"))
+            .expect("deserialize config");
+
+        let resource = Resource::bundled_miner_config();
+        toml::from_slice::<MinerAppConfig>(&resource.get().expect("read bundled file"))
+            .expect("deserialize config");
+    }
+
+    #[test]
     fn test_export_dev_config_files() {
         let dir = mkdir();
         let context = TemplateContext {


### PR DESCRIPTION
Some command still uses the bundled config file, for example, following
command will fail in Windows when `ckb.toml` not found in current directory:

    ckb cli hashes