### PR TITLE
feat: remove script_hash from docs/hashes.toml

### DIFF
--- a/ckb-bin/src/subcommand/cli/hashes.rs
+++ b/ckb-bin/src/subcommand/cli/hashes.rs
@@ -1,6 +1,5 @@
 use ckb_app_config::{cli, CKBAppConfig, ExitCode};
 use ckb_chain_spec::ChainSpec;
-use ckb_core::script::Script;
 use ckb_resource::Resource;
 use clap::ArgMatches;
 use numext_fixed_hash::H256;
@@ -14,7 +13,6 @@ struct SystemCell {
     pub path: String,
     pub index: usize,
     pub code_hash: H256,
-    pub script_hash: H256,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -54,12 +52,10 @@ impl TryFrom<ChainSpec> for SpecHashes {
             .enumerate()
             .map(|(index_minus_one, (resource, output))| {
                 let code_hash = output.data_hash();
-                let script_hash = Script::new(vec![], code_hash.to_owned()).hash();
                 SystemCell {
                     path: resource.to_string(),
                     index: index_minus_one + 1,
                     code_hash,
-                    script_hash,
                 }
             })
             .collect();

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -7,7 +7,6 @@ cellbase = "0xfa90ec4417d8d96b180926e273e52284e90b2b87b8988606090687f0c84a0341"
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
 index = 1
 code_hash = "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd"
-script_hash = "0xc0dd96594cf5af5e521340672c1e8d19cc1dde13117ef5a5b4f5cd658d159211"
 
 [ckb_testnet]
 genesis = "0x8d40c56b87b3772dba8802f825e396d25ff26bd5516acb69577f082aca563141"
@@ -17,4 +16,3 @@ cellbase = "0x4761362a804a39c51410d25f622da2fcfd2fb1ed72d46b1b7cf9a09b167470dd"
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
 index = 1
 code_hash = "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd"
-script_hash = "0xc0dd96594cf5af5e521340672c1e8d19cc1dde13117ef5a5b4f5cd658d159211"

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -282,7 +282,6 @@ impl SystemCells {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use ckb_core::script::Script;
     use serde_derive::{Deserialize, Serialize};
     use std::collections::HashMap;
 
@@ -291,7 +290,6 @@ pub mod test {
         pub path: String,
         pub index: usize,
         pub code_hash: H256,
-        pub script_hash: H256,
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -347,10 +345,8 @@ pub mod test {
                 .enumerate()
             {
                 let code_hash = output.data_hash();
-                let script_hash = Script::new(vec![], code_hash.clone()).hash();
                 assert_eq!(index_minus_one + 1, cell.index, "{}", bundled_spec_err);
                 assert_eq!(cell.code_hash, code_hash, "{}", bundled_spec_err);
-                assert_eq!(cell.script_hash, script_hash, "{}", bundled_spec_err);
             }
         }
     }


### PR DESCRIPTION
It makes no sense since most system cells require args to work.