### PR TITLE
fix: uncle block serialized_size

### DIFF
--- a/core/src/uncle.rs
+++ b/core/src/uncle.rs
@@ -49,6 +49,7 @@ impl UncleBlock {
 
     pub fn serialized_size(&self, proof_size: usize) -> usize {
         Header::serialized_size(proof_size)
+            + self.proposals.len() * ProposalShortId::serialized_size()
     }
 }
 
@@ -82,13 +83,16 @@ mod tests {
     use crate::block::BlockBuilder;
 
     #[test]
-    fn block_size_should_not_include_uncles_proposal_zones() {
+    fn block_size_should_include_uncles_proposal_zones() {
         let uncle1: UncleBlock = BlockBuilder::default()
             .proposal(ProposalShortId::zero())
             .build()
             .into();
         let uncle2: UncleBlock = BlockBuilder::default().build().into();
 
-        assert_eq!(uncle1.serialized_size(0), uncle2.serialized_size(0));
+        assert_eq!(
+            uncle1.serialized_size(0) - uncle2.serialized_size(0),
+            ProposalShortId::serialized_size()
+        );
     }
 }


### PR DESCRIPTION
I am just confused.
```
#[derive(Clone, Serialize, Deserialize, Eq, Debug)]
pub struct UncleBlock {
    pub header: Header,
    pub proposals: Vec<ProposalShortId>,
}

    pub fn serialized_size(&self, proof_size: usize) -> usize {
        Header::serialized_size(proof_size)
    }
```
Is it inconsistence?
I checked the paper:
```
The total size of the first four fields should be no larger than
the hard-coded block size limit. The uncle blocks’ proposal
zones do not count in the limit as they are usually already
synchronized. The number of txpids in a proposal zone also
has a hard-coded upper bound.
```

We should store the uncle proposals?
