### PR TITLE
✋ test: integration test code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,24 @@ matrix:
         - make cov
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+    - name: Code Coverage
+      if: 'tag IS NOT present AND branch = master'
+      os: linux
+      install:
+        wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz &&
+        tar xzf v36.tar.gz &&
+        cd kcov-36 &&
+        mkdir build &&
+        cd build &&
+        cmake .. &&
+        make &&
+        sudo make install &&
+        cd ../.. &&
+        rm -rf kcov-36 v36.tar.gz &&
+      script:
+        - make integration-cov
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
 
     - name: Package for macOS
       if: 'tag IS present AND env(GITHUB_TOKEN) IS present'

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ cov: ## Run code coverage.
 	# https://github.com/xd009642/tarpaulin/issues/190#issuecomment-473564880
 	RUSTC="$$(pwd)/devtools/cov/rustc-proptest-fix" taskset -c 0 cargo tarpaulin --exclude-files protocol/src/protocol_generated* test/* */tests/ --all -v --out Xml
 
+integration-cov: setup-ckb-test
+	cargo build ${VERBOSE} --release
+	mkdir -p target/cov/ckb-test
+	cd test && kcov --exclude-pattern=/.cargo,/usr/lib,/usr/include/,../test --verify ../target/cov/ckb-test cargo run
+
 setup-ckb-test:
 	cp -f Cargo.lock test/Cargo.lock
 	rm -rf test/target && ln -snf ../target/ test/target


### PR DESCRIPTION
I do not know where is the best place for Integration Code coverage.
If we want a different report we could update the integration code coverage report to another website.
If we want a total coverage report including unit tests and integration test, we should put them together, but it is not friendly to CI.

The make integration-cov will fail locally.

```
2019-06-19 00:48:43.598 +08:00 main ERROR panic  thread 'main' panicked at 'timeout to wait for sync, tip_numbers: {299, 274, 402, 244}': src/net.rs:161stack backtrace:
   0: ckb_logger::setup_panic_logger::{{closure}}::habf90c747c498e69 (0x555557250167)
             at /home/u2/nervos/ckb/util/logger/src/lib.rs:279
   1: rust_panic_with_hook (0x55555756e848)
             at src/libstd/panicking.rs:482
   2: continue_panic_fmt (0x55555756e2e1)
             at src/libstd/panicking.rs:385
   3: begin_panic_fmt (0x55555756e22e)
             at src/libstd/panicking.rs:340
   4: ckb_test::net::Net::waiting_for_sync::hdcd1f1be3ec6fcce (0x555555dd7cd1)
             at src/net.rs:161
   5: <ckb_test::specs::sync::sync_timeout::SyncTimeout as ckb_test::specs::Spec>::run::h8cbe4fea3007a80a (0x555555fe746e)
             at src/specs/sync/sync_timeout.rs:46
   6: ckb_test::main::{{closure}}::habae5e1cc6c4c152 (0x555555c7d488)
             at src/main.rs:70
   7: core::iter::traits::iterator::Iterator::for_each::{{closure}}::h56b208b34f280e74 (0x555555c7c846)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libcore/iter/traits/iterator.rs:604
   8: core::iter::traits::iterator::Iterator::fold::{{closure}}::h5500a57f4f47f5a1 (0x555555c7c604)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libcore/iter/traits/iterator.rs:1684
   9: core::iter::traits::iterator::Iterator::try_fold::h0687bd89c754e20d (0x555555c80818)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libcore/iter/traits/iterator.rs:1572
  10: core::iter::traits::iterator::Iterator::fold::hb6c4088ef9bebf50 (0x555555c80700)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libcore/iter/traits/iterator.rs:1684
  11: core::iter::traits::iterator::Iterator::for_each::he3c9d43e7365e1ae (0x555555c80786)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libcore/iter/traits/iterator.rs:604
  12: ckb_test::main::h6466cecdb90bac33 (0x555555c7c264)
             at src/main.rs:68
  13: std::rt::lang_start::{{closure}}::h09299407aaf0fe8b (0x555555c90eff)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libstd/rt.rs:64
  14: {{closure}} (0x55555756e162)
             at src/libstd/rt.rs:49
      do_call<closure,i32>
             at src/libstd/panicking.rs:297
  15: __rust_maybe_catch_panic (0x555557578119)
             at src/libpanic_unwind/lib.rs:87
  16: try<i32,closure> (0x55555756ec6c)
             at src/libstd/panicking.rs:276
      catch_unwind<closure,i32>
             at src/libstd/panic.rs:388
      lang_start_internal
             at src/libstd/rt.rs:48
  17: std::rt::lang_start::hfb6b48329fc0ae95 (0x555555c90ed8)
             at /rustc/6c2484dc3c532c052f159264e970278d8b77cdc9/src/libstd/rt.rs:64
  18: main (0x555555c7c5a9)
  19: __libc_start_main (0x7ffff742a82f)
  20: _start (0x555555c7a428)
  21: <unknown> (0x0)
2019-06-19 00:48:43.646 +08:00 main INFO ckb_test::node  Successfully killed ckb process
2019-06-19 00:48:43.682 +08:00 main INFO ckb_test::node  Successfully killed ckb process
2019-06-19 00:48:43.686 +08:00 main INFO ckb_test::node  Successfully killed ckb process
2019-06-19 00:48:43.697 +08:00 main INFO ckb_test::node  Successfully killed ckb process
2019-06-19 00:48:43.708 +08:00 main INFO ckb_test::node  Successfully killed ckb process
Makefile:19: recipe for target 'integration-cov' failed

```

But when using the release version, it's ok.

```
integration-cov: setup-ckb-test
	cargo build ${VERBOSE} --release
	mkdir -p target/cov/ckb-test
	cd test && kcov --exclude-pattern=/.cargo,/usr/lib,/usr/include/,../test --verify ../target/cov/ckb-test cargo run
```
