### PR TITLE
fix: RPC doc for deindex_lock_hash

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -798,7 +798,7 @@ http://localhost:8114
 
 ### `deindex_lock_hash`
 
-Remove index for live cells and transaction by the hash of lock script. Returns empty array when the `lock_hash` not indexed yet.
+Remove index for live cells and transactions by the hash of lock script.
 
 #### Parameters
 
@@ -900,8 +900,7 @@ http://localhost:8114
 
 ### `get_lock_hash_index_states`
 
-Get lock hash index states
-
+Get lock hash index states.
 
 #### Examples
 
@@ -933,7 +932,7 @@ http://localhost:8114
 
 ### `get_transactions_by_lock_hash`
 
-Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` not indexed yet.
+Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` has not been indexed yet.
 
 #### Parameters
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -900,7 +900,8 @@ http://localhost:8114
 
 ### `get_lock_hash_index_states`
 
-Get lock hash index states.
+Get lock hash index states
+
 
 #### Examples
 

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -723,7 +723,7 @@
         ]
     },
     {
-        "description": "Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` not indexed yet.",
+        "description": "Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` has not been indexed yet.",
         "method": "get_transactions_by_lock_hash",
         "module": "indexer",
         "params": [
@@ -765,7 +765,7 @@
         ]
     },
     {
-        "description": "Remove index for live cells and transaction by the hash of lock script. Returns empty array when the `lock_hash` not indexed yet.",
+        "description": "Remove index for live cells and transactions by the hash of lock script.",
         "method": "deindex_lock_hash",
         "module": "indexer",
         "params": [


### PR DESCRIPTION
It always returns `null`, instead of empty array.