### PR TITLE
fix: Check new block based on orphan block pool

### DIFF
--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -58,7 +58,9 @@ impl OrphanBlockPool {
     pub fn contains(&self, block: &Block) -> bool {
         self.blocks
             .read()
-            .contains_key(block.header().parent_hash())
+            .get(block.header().parent_hash())
+            .map(|blocks| blocks.contains(block))
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
* `orphan_block_pool` use `ParentHash` rather than `BlockHash` as key. So when we want to check whether we have received the same block as the arrived one, based `orphan_block_pool`, we should check deeply.