### PR TITLE
chore: change dev default pow engine to `Dummy`

### DIFF
--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -40,11 +40,9 @@ block_on_submit = true
 poll_interval = 1000
 
 [[miner.workers]]
-worker_type = "CuckooSimple"
-threads     = 1
-
-# Below is an example dummy worker configuration for development:
-# [[miner.workers]]
-# worker_type = "Dummy"
-# delay_type  = "Constant"
-# value       = 5000
+worker_type = "CuckooSimple" # {{
+# dev => worker_type = "Dummy"
+# }}
+threads     = 1 # {{
+# dev => delay_type = "Constant"\nvalue = 5000
+# }}

--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -44,13 +44,4 @@ max_block_cycles = 10_000_000_000
 cellbase_maturity = 0
 
 [pow]
-func = "Cuckoo"
-
-[pow.params]
-# the 2-log of the graph size, which is the size in bits of the node
-# identifiers
-edge_bits = 15
-
-# length of the cycle to be found, must be an even number, a minimum of 12 is
-# recommended
-cycle_length = 12
+func = "Dummy"


### PR DESCRIPTION
makes it easy to run dev chain