### PR TITLE
perf: Reveal network errors and involver handle it

### DIFF
--- a/network/src/errors.rs
+++ b/network/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::{peer_store::sqlite::DBError, ProtocolId};
-use p2p::{secio::PeerId, SessionId};
+use p2p::{error::Error as P2PError, secio::PeerId, SessionId};
 use std::fmt;
 use std::fmt::Display;
 use std::io::Error as IoError;
@@ -10,7 +10,7 @@ pub enum Error {
     Config(ConfigError),
     Protocol(ProtocolError),
     Io(IoError),
-    P2P(String),
+    P2P(P2PError),
     DB(DBError),
     Shutdown,
 }
@@ -60,6 +60,12 @@ impl From<ConfigError> for Error {
 impl From<ProtocolError> for Error {
     fn from(err: ProtocolError) -> Error {
         Error::Protocol(err)
+    }
+}
+
+impl From<P2PError> for Error {
+    fn from(err: P2PError) -> Error {
+        Error::P2P(err)
     }
 }
 

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod identify;
 pub(crate) mod ping;
 
 use crate::Error;
-use ckb_logger::{debug, error, trace};
+use ckb_logger::trace;
 use futures::Future;
 use p2p::{
     builder::MetaBuilder,
@@ -246,13 +246,8 @@ struct DefaultCKBProtocolContext {
 
 impl CKBProtocolContext for DefaultCKBProtocolContext {
     fn set_notify(&self, interval: Duration, token: u64) -> Result<(), Error> {
-        if let Err(err) = self
-            .p2p_control
-            .set_service_notify(self.proto_id, interval, token)
-        {
-            debug!("p2p service set_notify error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .set_service_notify(self.proto_id, interval, token)?;
         Ok(())
     }
     fn quick_send_message(
@@ -267,13 +262,8 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             peer_index,
             data.len()
         );
-        if let Err(err) = self
-            .p2p_control
-            .quick_send_message_to(peer_index, proto_id, data)
-        {
-            debug!("p2p service quick_send_message error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .quick_send_message_to(peer_index, proto_id, data)?;
         Ok(())
     }
     fn quick_send_message_to(&self, peer_index: PeerIndex, data: Bytes) -> Result<(), Error> {
@@ -283,33 +273,20 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             peer_index,
             data.len()
         );
-        if let Err(err) = self
-            .p2p_control
-            .quick_send_message_to(peer_index, self.proto_id, data)
-        {
-            debug!("p2p service quick_send_message_to error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .quick_send_message_to(peer_index, self.proto_id, data)?;
         Ok(())
     }
     fn quick_filter_broadcast(&self, target: TargetSession, data: Bytes) -> Result<(), Error> {
-        if let Err(err) = self
-            .p2p_control
-            .quick_filter_broadcast(target, self.proto_id, data)
-        {
-            debug!("p2p service quick_filter_broadcast error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .quick_filter_broadcast(target, self.proto_id, data)?;
         Ok(())
     }
     fn future_task(
         &self,
         task: Box<Future<Item = (), Error = ()> + 'static + Send>,
     ) -> Result<(), Error> {
-        if let Err(err) = self.p2p_control.future_task(task) {
-            error!("failed to spawn future task: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control.future_task(task)?;
         Ok(())
     }
     fn send_message(
@@ -324,10 +301,8 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             peer_index,
             data.len()
         );
-        if let Err(err) = self.p2p_control.send_message_to(peer_index, proto_id, data) {
-            debug!("p2p service send_message error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .send_message_to(peer_index, proto_id, data)?;
         Ok(())
     }
     fn send_message_to(&self, peer_index: PeerIndex, data: Bytes) -> Result<(), Error> {
@@ -337,30 +312,17 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
             peer_index,
             data.len()
         );
-        if let Err(err) = self
-            .p2p_control
-            .send_message_to(peer_index, self.proto_id, data)
-        {
-            debug!("p2p service send_message_to error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .send_message_to(peer_index, self.proto_id, data)?;
         Ok(())
     }
     fn filter_broadcast(&self, target: TargetSession, data: Bytes) -> Result<(), Error> {
-        if let Err(err) = self
-            .p2p_control
-            .filter_broadcast(target, self.proto_id, data)
-        {
-            debug!("p2p service filter_broadcast error: {:?}", err);
-            Err(err)?;
-        }
+        self.p2p_control
+            .filter_broadcast(target, self.proto_id, data)?;
         Ok(())
     }
     fn disconnect(&self, peer_index: PeerIndex) -> Result<(), Error> {
-        if let Err(err) = self.p2p_control.disconnect(peer_index) {
-            debug!("Disconnect failed {:?}, error: {:?}", peer_index, err);
-            Err(err)?;
-        }
+        self.p2p_control.disconnect(peer_index)?;
         Ok(())
     }
 

--- a/sync/src/net_time_checker.rs
+++ b/sync/src/net_time_checker.rs
@@ -118,7 +118,9 @@ impl CKBProtocolHandler for NetTimeProtocol {
             let fbb = &mut FlatBufferBuilder::new();
             let message = TimeMessage::build_time(fbb, now);
             fbb.finish(message, None);
-            nc.send_message_to(peer_index, fbb.finished_data().into());
+            if let Err(err) = nc.send_message_to(peer_index, fbb.finished_data().into()) {
+                debug!(target: "network", "net_time_checker send message error: {:?}", err);
+            }
         }
     }
 

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -1,6 +1,6 @@
 use crate::relayer::Relayer;
 use ckb_core::transaction::{ProposalShortId, Transaction};
-use ckb_logger::{debug_terget, warn_target};
+use ckb_logger::{debug_target, warn_target};
 use ckb_network::CKBProtocolContext;
 use ckb_protocol::{cast, BlockProposal, FlatbuffersVectorIterator};
 use ckb_store::ChainStore;

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -202,8 +202,12 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                     .collect::<Vec<_>>(),
             );
             fbb.finish(message, None);
-            self.nc
-                .send_message_to(self.peer, fbb.finished_data().into());
+            if let Err(err) = self
+                .nc
+                .send_message_to(self.peer, fbb.finished_data().into())
+            {
+                ckb_logger::debug!("relayer send get_block_transactions error: {:?}", err);
+            }
         }
         Ok(())
     }

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -1,5 +1,6 @@
 use crate::relayer::Relayer;
 use ckb_core::transaction::{ProposalShortId, Transaction};
+use ckb_logger::debug_target;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, GetBlockProposal, RelayMessage};
 use ckb_store::ChainStore;
@@ -70,8 +71,16 @@ impl<'a, CS: ChainStore + 'static> GetBlockProposalProcess<'a, CS> {
         let message = RelayMessage::build_block_proposal(fbb, &transactions);
         fbb.finish(message, None);
 
-        self.nc
-            .send_message_to(self.peer, fbb.finished_data().into());
+        if let Err(err) = self
+            .nc
+            .send_message_to(self.peer, fbb.finished_data().into())
+        {
+            debug_target!(
+                crate::LOG_TARGET_RELAY,
+                "relayer send GetBlockProposal error: {:?}",
+                err
+            );
+        }
         Ok(())
     }
 }

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -51,8 +51,16 @@ impl<'a, CS: ChainStore> GetBlockTransactionsProcess<'a, CS> {
             let message = RelayMessage::build_block_transactions(fbb, &block_hash, &transactions);
             fbb.finish(message, None);
 
-            self.nc
-                .send_message_to(self.peer, fbb.finished_data().into());
+            if let Err(err) = self
+                .nc
+                .send_message_to(self.peer, fbb.finished_data().into())
+            {
+                debug_target!(
+                    crate::LOG_TARGET_RELAY,
+                    "relayer send BlockTransactions error: {:?}",
+                    err
+                );
+            }
         }
 
         Ok(())

--- a/sync/src/relayer/get_transaction_process.rs
+++ b/sync/src/relayer/get_transaction_process.rs
@@ -52,7 +52,13 @@ impl<'a, CS: ChainStore> GetTransactionProcess<'a, CS> {
             let message = RelayMessage::build_transaction(fbb, &tx, cycles);
             fbb.finish(message, None);
             let data = fbb.finished_data().into();
-            self.nc.send_message_to(self.peer, data);
+            if let Err(err) = self.nc.send_message_to(self.peer, data) {
+                debug_target!(
+                    crate::LOG_TARGET_RELAY,
+                    "relayer send Transaction error: {:?}",
+                    err,
+                );
+            }
         } else {
             debug_target!(
                 crate::LOG_TARGET_RELAY,

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -404,6 +404,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                         "relayer send Transaction error: {:?}",
                         err,
                     );
+                    break;
                 }
             }
         }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -204,7 +204,14 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             );
             fbb.finish(message, None);
 
-            nc.send_message_to(peer, fbb.finished_data().into());
+            if let Err(err) = nc.send_message_to(peer, fbb.finished_data().into()) {
+                debug_target!(
+                    crate::LOG_TARGET_RELAY,
+                    "relayer send GetBlockProposal error {:?}",
+                    err,
+                );
+                self.shared().remove_inflight_proposals(&to_ask_proposals);
+            }
         }
     }
 
@@ -234,7 +241,14 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                 })
                 .take(MAX_RELAY_PEERS)
                 .collect();
-            nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data);
+            if let Err(err) = nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data)
+            {
+                debug_target!(
+                    crate::LOG_TARGET_RELAY,
+                    "relayer send block when accept block error: {:?}",
+                    err,
+                );
+            }
         } else {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
@@ -346,7 +360,13 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             let message =
                 RelayMessage::build_block_proposal(fbb, &txs.into_iter().collect::<Vec<_>>());
             fbb.finish(message, None);
-            nc.send_message_to(peer_index, fbb.finished_data().into());
+            if let Err(err) = nc.send_message_to(peer_index, fbb.finished_data().into()) {
+                debug_target!(
+                    crate::LOG_TARGET_RELAY,
+                    "relayer send BlockProposal error: {:?}",
+                    err,
+                );
+            }
         }
     }
 
@@ -378,7 +398,13 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
                 let message = RelayMessage::build_get_transaction(fbb, &tx_hash);
                 fbb.finish(message, None);
                 let data = fbb.finished_data().into();
-                nc.send_message_to(*peer, data);
+                if let Err(err) = nc.send_message_to(*peer, data) {
+                    debug_target!(
+                        crate::LOG_TARGET_RELAY,
+                        "relayer send Transaction error: {:?}",
+                        err,
+                    );
+                }
             }
         }
     }
@@ -386,8 +412,10 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
 
 impl<CS: ChainStore + 'static> CKBProtocolHandler for Relayer<CS> {
     fn init(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>) {
-        nc.set_notify(Duration::from_millis(100), TX_PROPOSAL_TOKEN);
-        nc.set_notify(Duration::from_millis(100), ASK_FOR_TXS_TOKEN);
+        nc.set_notify(Duration::from_millis(100), TX_PROPOSAL_TOKEN)
+            .expect("set_notify at init is ok");
+        nc.set_notify(Duration::from_millis(100), ASK_FOR_TXS_TOKEN)
+            .expect("set_notify at init is ok");
     }
 
     fn received(

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -51,8 +51,12 @@ where
                 let fbb = &mut FlatBufferBuilder::new();
                 let message = SyncMessage::build_block(fbb, &block);
                 fbb.finish(message, None);
-                self.nc
-                    .send_message_to(self.peer, fbb.finished_data().into());
+                if let Err(err) = self
+                    .nc
+                    .send_message_to(self.peer, fbb.finished_data().into())
+                {
+                    debug!("synchronizer send Block error: {:?}", err);
+                }
             } else {
                 // TODO response not found
                 // TODO add timeout check in synchronizer

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -56,6 +56,7 @@ where
                     .send_message_to(self.peer, fbb.finished_data().into())
                 {
                     debug!("synchronizer send Block error: {:?}", err);
+                    break;
                 }
             } else {
                 // TODO response not found

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -83,8 +83,12 @@ where
             let fbb = &mut FlatBufferBuilder::new();
             let message = SyncMessage::build_headers(fbb, &headers);
             fbb.finish(message, None);
-            self.nc
-                .send_message_to(self.peer, fbb.finished_data().into());
+            if let Err(err) = self
+                .nc
+                .send_message_to(self.peer, fbb.finished_data().into())
+            {
+                debug!("synchronizer send Headers error: {:?}", err);
+            }
         } else {
             for hash in &block_locator_hashes[..] {
                 warn!("unknown block headers from peer {} {:#x}", self.peer, hash);

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -290,7 +290,9 @@ where
             && (is_outbound && !is_protected)
         {
             debug!("Disconnect peer({}) is unprotected outbound", self.peer);
-            self.nc.disconnect(self.peer);
+            if let Err(err) = self.nc.disconnect(self.peer) {
+                debug!("synchronizer disconnect error: {:?}", err);
+            }
         }
 
         Ok(())

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -964,11 +964,13 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         let fbb = &mut FlatBufferBuilder::new();
         let message = SyncMessage::build_get_headers(fbb, &locator_hash);
         fbb.finish(message, None);
-        nc.send_message(
+        if let Err(err) = nc.send_message(
             NetworkProtocol::SYNC.into(),
             peer,
             fbb.finished_data().into(),
-        );
+        ) {
+            debug!("synchronizer send get_headers error: {:?}", err);
+        }
     }
 
     pub fn mark_as_known_tx(&self, hash: H256) {

--- a/util/network-alert/src/alert_relayer.rs
+++ b/util/network-alert/src/alert_relayer.rs
@@ -83,7 +83,9 @@ impl CKBProtocolHandler for AlertRelayer {
             let fbb = &mut FlatBufferBuilder::new();
             let msg = AlertMessage::build_alert(fbb, &alert);
             fbb.finish(msg, None);
-            nc.quick_send_message_to(peer_index, fbb.finished_data().into());
+            if let Err(err) = nc.quick_send_message_to(peer_index, fbb.finished_data().into()) {
+                debug!("alert_relayer send alert when connected error: {:?}", err);
+            }
         }
     }
 
@@ -131,7 +133,9 @@ impl CKBProtocolHandler for AlertRelayer {
             .into_iter()
             .filter(|peer| self.mark_as_known(*peer, alert.id))
             .collect();
-        nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data);
+        if let Err(err) = nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data) {
+            debug!("alert broadcast error: {:?}", err);
+        }
         // add to received alerts
         self.notifier.lock().add(alert);
     }


### PR DESCRIPTION
* feat: Reveal network errors. Currently, when `CKBProtocolContext` receives an error from p2p, it only logs the error and doesn't return to the caller. I change to `CKBProtocolContext` return the error to the caller, and caller handles it.

* perf: Short-circuiting break if occurs network error, `Synchronizer` responses `Blocks` and `Transactions`. This is the original intention of this PR. To achieve it, I have to make  `CKBProtocolContext` reveals the network errors, which introduces most of the change code.