### PR TITLE
fix: random failure caused by dirty exit in RPC test

### DIFF
--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -333,4 +333,6 @@ fn test_rpc() {
     if print_mode {
         println!("{}", to_string_pretty(&Value::Array(outputs)).unwrap());
     }
+
+    server.close();
 }


### PR DESCRIPTION
Close the server before exit RPC test.