### PR TITLE
fix: potential error in alert version compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -22,6 +22,7 @@ lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8
 serde = "1.0"
 serde_derive = "1.0"
 flatbuffers = "0.6.0"
+semver = "0.9"
 
 [dev-dependencies]
 ckb-crypto = { path = "../crypto" }

--- a/util/network-alert/src/notifier.rs
+++ b/util/network-alert/src/notifier.rs
@@ -27,6 +27,8 @@ impl Notifier {
     }
 
     pub fn add(&mut self, alert: Arc<Alert>) {
+        use semver::Version;
+
         if self.has_received(alert.id) {
             return;
         }
@@ -41,7 +43,7 @@ impl Notifier {
         if alert
             .min_version
             .as_ref()
-            .map(|min_v| self.client_version < *min_v)
+            .map(|min_v| Version::parse(&self.client_version) < Version::parse(min_v))
             == Some(true)
         {
             return;
@@ -50,7 +52,7 @@ impl Notifier {
         if alert
             .max_version
             .as_ref()
-            .map(|max_v| self.client_version > *max_v)
+            .map(|max_v| Version::parse(&self.client_version) > Version::parse(max_v))
             == Some(true)
         {
             return;

--- a/util/network-alert/src/tests/test_notifier.rs
+++ b/util/network-alert/src/tests/test_notifier.rs
@@ -4,18 +4,17 @@ use std::sync::Arc;
 
 #[test]
 fn test_notice_alerts_by_version() {
-    let mut notifier = Notifier::new("0.1.0".into());
+    let mut notifier = Notifier::new("0.9.0".into());
     let alert1 = Arc::new(
         AlertBuilder::default()
             .id(1)
-            .max_version(Some("0.2.0".into()))
-            .min_version(Some("0.1.0".into()))
+            .max_version(Some("0.10.0".into()))
             .build(),
     );
     let alert2 = Arc::new(
         AlertBuilder::default()
             .id(2)
-            .max_version(Some("0.0.2".into()))
+            .min_version(Some("0.10.0".into()))
             .build(),
     );
     notifier.add(alert1);


### PR DESCRIPTION
As @keroro520 mentioned, there is a potential bug in case like: `"0.10.0" < "0.9.10"`