### PR TITLE
[ᚬrc/v0.15.z] feat: allow providing extra sentry info in config

### DIFF
--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -29,6 +29,9 @@ log_to_stdout = true # {{
 dsn = "" # {{
 # testnet => dsn = "https://48c6a88d92e246478e2d53b5917a887c@sentry.io/1422795"
 # }}
+# if you are willing to help us to improve,
+# please leave a way to contact you when we have troubles to reproduce the errors.
+# org_contact = ""
 
 [miner.client]
 rpc_url = "http://127.0.0.1:8114/" # {{

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -31,6 +31,9 @@ log_to_stdout = true # {{
 dsn = "" # {{
 # testnet => dsn = "https://48c6a88d92e246478e2d53b5917a887c@sentry.io/1422795"
 # }}
+# if you are willing to help us to improve,
+# please leave a way to contact you when we have troubles to reproduce the errors.
+# org_contact = ""
 
 [network]
 listen_addresses = ["/ip4/0.0.0.0/tcp/8115"] # {{

--- a/util/app-config/src/sentry_config.rs
+++ b/util/app-config/src/sentry_config.rs
@@ -67,8 +67,10 @@ fn before_send(mut event: Event<'static>) -> Option<Event<'static>> {
     // Group events via fingerprint, or ignore
 
     if ex.starts_with("DBError failed to open the database") {
+        event.level = Level::Warning;
         event.fingerprint = Cow::Borrowed(DB_OPEN_FINGERPRINT);
     } else if ex.contains("SqliteFailure") {
+        event.level = Level::Warning;
         event.fingerprint = Cow::Borrowed(SQLITE_FINGERPRINT);
     } else if ex.starts_with("DBError the database version")
         || ex.contains("kind: AddrInUse")

--- a/util/app-config/src/sentry_config.rs
+++ b/util/app-config/src/sentry_config.rs
@@ -4,7 +4,7 @@ use sentry::{
     integrations::panic::register_panic_handler,
     internals::{ClientInitGuard, Dsn},
     protocol::Event,
-    ClientOptions,
+    ClientOptions, Level,
 };
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -13,6 +13,8 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SentryConfig {
     pub dsn: String,
+    pub org_ident: Option<String>,
+    pub org_contact: Option<String>,
 }
 
 impl SentryConfig {
@@ -22,6 +24,12 @@ impl SentryConfig {
             configure_scope(|scope| {
                 scope.set_tag("release.pre", version.is_pre());
                 scope.set_tag("release.dirty", version.is_dirty());
+                if let Some(org_ident) = &self.org_ident {
+                    scope.set_tag("org_ident", org_ident);
+                }
+                if let Some(org_contact) = &self.org_contact {
+                    scope.set_extra("org_contact", org_contact.clone().into());
+                }
             });
 
             register_panic_handler();


### PR DESCRIPTION
```toml
[sentry]
dsn = "https://48c6a88d92e246478e2d53b5917a887c@sentry.io/1422795"
org_ident = "ckb-dev"
# org_ident = "ckb-testnet"
# org_ident = "ckb-test"
org_contact = "test@example.org"
```
