### PR TITLE
refactor: Use BlockStatus to filter things

### DIFF
--- a/sync/src/block_status.rs
+++ b/sync/src/block_status.rs
@@ -4,22 +4,23 @@ bitflags! {
     pub struct BlockStatus: u32 {
         const UNKNOWN                 =     0;
 
-        const HEADER_VERIFIED         =     1;
-        const BLOCK_RECEIVED          =     Self::HEADER_VERIFIED.bits | 2;
-        const BLOCK_STORED            =     Self::HEADER_VERIFIED.bits | Self::BLOCK_RECEIVED.bits | 16;
+        const HEADER_VALID            =     0b0000_0000_0000_0001;
+        const BLOCK_RECEIVED          =     Self::HEADER_VALID.bits | 0b0000_0000_0000_0010;
+        const BLOCK_STORED            =     Self::HEADER_VALID.bits | Self::BLOCK_RECEIVED.bits | 0b0000_0000_0000_1000;
 
-        const BLOCK_INVALID           =    32;
+        const BLOCK_INVALID           =     0b0010_0000_0000_0000;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::block_status::BlockStatus;
+    use std::collections::HashSet;
 
     fn all() -> Vec<BlockStatus> {
         vec![
             BlockStatus::UNKNOWN,
-            BlockStatus::HEADER_VERIFIED,
+            BlockStatus::HEADER_VALID,
             BlockStatus::BLOCK_RECEIVED,
             BlockStatus::BLOCK_STORED,
             BlockStatus::BLOCK_INVALID,
@@ -50,15 +51,21 @@ mod tests {
     }
 
     #[test]
+    fn test_all_different() {
+        let set: HashSet<_> = all().into_iter().collect();
+        assert_eq!(set.len(), all().len());
+    }
+
+    #[test]
     fn test_unknown() {
         assert!(BlockStatus::UNKNOWN.is_empty());
     }
 
     #[test]
-    fn test_header_verified() {
-        let target = BlockStatus::HEADER_VERIFIED;
+    fn test_header_valid() {
+        let target = BlockStatus::HEADER_VALID;
         let includes = vec![
-            BlockStatus::HEADER_VERIFIED,
+            BlockStatus::HEADER_VALID,
             BlockStatus::BLOCK_RECEIVED,
             BlockStatus::BLOCK_STORED,
         ];

--- a/sync/src/block_status.rs
+++ b/sync/src/block_status.rs
@@ -27,7 +27,7 @@ mod tests {
         ]
     }
 
-    fn assert_(includes: Vec<BlockStatus>, target: BlockStatus) {
+    fn assert_contain(includes: Vec<BlockStatus>, target: BlockStatus) {
         let excludes: Vec<BlockStatus> = all()
             .into_iter()
             .filter(|s1| !includes.iter().any(|s2| s2 == s1))
@@ -69,20 +69,20 @@ mod tests {
             BlockStatus::BLOCK_RECEIVED,
             BlockStatus::BLOCK_STORED,
         ];
-        assert_(includes, target);
+        assert_contain(includes, target);
     }
 
     #[test]
     fn test_block_received() {
         let target = BlockStatus::BLOCK_RECEIVED;
         let includes = vec![BlockStatus::BLOCK_RECEIVED, BlockStatus::BLOCK_STORED];
-        assert_(includes, target);
+        assert_contain(includes, target);
     }
 
     #[test]
     fn test_block_invalid() {
         let target = BlockStatus::BLOCK_INVALID;
         let includes = vec![BlockStatus::BLOCK_INVALID];
-        assert_(includes, target);
+        assert_contain(includes, target);
     }
 }

--- a/sync/src/block_status.rs
+++ b/sync/src/block_status.rs
@@ -1,0 +1,81 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct BlockStatus: u32 {
+        const UNKNOWN                 =     0;
+
+        const HEADER_VERIFIED         =     1;
+        const BLOCK_RECEIVED          =     Self::HEADER_VERIFIED.bits | 2;
+        const BLOCK_STORED            =     Self::HEADER_VERIFIED.bits | Self::BLOCK_RECEIVED.bits | 16;
+
+        const BLOCK_INVALID           =    32;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::block_status::BlockStatus;
+
+    fn all() -> Vec<BlockStatus> {
+        vec![
+            BlockStatus::UNKNOWN,
+            BlockStatus::HEADER_VERIFIED,
+            BlockStatus::BLOCK_RECEIVED,
+            BlockStatus::BLOCK_STORED,
+            BlockStatus::BLOCK_INVALID,
+        ]
+    }
+
+    fn assert_(includes: Vec<BlockStatus>, target: BlockStatus) {
+        let excludes: Vec<BlockStatus> = all()
+            .into_iter()
+            .filter(|s1| !includes.iter().any(|s2| s2 == s1))
+            .collect();
+        includes.into_iter().for_each(|status| {
+            assert!(
+                status.contains(target),
+                "{:?} should contains {:?}",
+                status,
+                target
+            )
+        });
+        excludes.into_iter().for_each(|status| {
+            assert!(
+                !status.contains(target),
+                "{:?} should not contains {:?}",
+                status,
+                target
+            )
+        });
+    }
+
+    #[test]
+    fn test_unknown() {
+        assert!(BlockStatus::UNKNOWN.is_empty());
+    }
+
+    #[test]
+    fn test_header_verified() {
+        let target = BlockStatus::HEADER_VERIFIED;
+        let includes = vec![
+            BlockStatus::HEADER_VERIFIED,
+            BlockStatus::BLOCK_RECEIVED,
+            BlockStatus::BLOCK_STORED,
+        ];
+        assert_(includes, target);
+    }
+
+    #[test]
+    fn test_block_received() {
+        let target = BlockStatus::BLOCK_RECEIVED;
+        let includes = vec![BlockStatus::BLOCK_RECEIVED, BlockStatus::BLOCK_STORED];
+        assert_(includes, target);
+    }
+
+    #[test]
+    fn test_block_invalid() {
+        let target = BlockStatus::BLOCK_INVALID;
+        let includes = vec![BlockStatus::BLOCK_INVALID];
+        assert_(includes, target);
+    }
+}

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -3,6 +3,7 @@
 //! Sync module implement ckb sync protocol as specified here:
 //! https://github.com/nervosnetwork/rfcs/tree/master/rfcs/0000-block-sync-protocol
 
+mod block_status;
 mod net_time_checker;
 mod relayer;
 mod synchronizer;

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -162,6 +162,9 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                     return Ok(());
                 }
                 compact_block_verifier.verify(&compact_block)?;
+                self.relayer
+                    .shared()
+                    .insert_block_status(block_hash.to_owned(), BlockStatus::HEADER_VERIFIED);
             }
 
             // Reconstruct block

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -1,3 +1,4 @@
+use crate::block_status::BlockStatus;
 use crate::relayer::compact_block::CompactBlock;
 use crate::relayer::compact_block_verifier::CompactBlockVerifier;
 use crate::relayer::Relayer;
@@ -111,7 +112,10 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                 .get(&block_hash)
                 .map(|(_, peers_set)| peers_set.contains(&self.peer))
                 .unwrap_or(false)
-                || self.relayer.shared.store().get_block(&block_hash).is_some()
+                || self
+                    .relayer
+                    .shared()
+                    .contains_block_status(&block_hash, BlockStatus::BLOCK_STORED)
             {
                 debug_target!(
                     crate::LOG_TARGET_RELAY,

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -22,6 +22,7 @@ use self::get_block_transactions_process::GetBlockTransactionsProcess;
 use self::get_transaction_process::GetTransactionProcess;
 use self::transaction_hash_process::TransactionHashProcess;
 use self::transaction_process::TransactionProcess;
+use crate::block_status::BlockStatus;
 use crate::relayer::compact_block::ShortTransactionID;
 use crate::types::SyncSharedState;
 use crate::BAD_MESSAGE_BAN_TIME;
@@ -216,6 +217,13 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
     }
 
     pub fn accept_block(&self, nc: &CKBProtocolContext, peer: PeerIndex, block: Block) {
+        if self
+            .shared()
+            .contains_block_status(block.header().hash(), BlockStatus::BLOCK_STORED)
+        {
+            return;
+        }
+
         let boxed = Arc::new(block);
         if self
             .shared()

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -160,8 +160,7 @@ where
                 if self
                     .synchronizer
                     .shared()
-                    .get_block_status(to_fetch_hash)
-                    .contains(BlockStatus::BLOCK_RECEIVED)
+                    .contains_block_status(to_fetch_hash, BlockStatus::BLOCK_RECEIVED)
                 {
                     continue;
                 }

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -1,4 +1,5 @@
-use crate::synchronizer::{BlockStatus, Synchronizer};
+use crate::block_status::BlockStatus;
+use crate::synchronizer::Synchronizer;
 use crate::types::HeaderView;
 use crate::{BLOCK_DOWNLOAD_WINDOW, MAX_BLOCKS_IN_TRANSIT_PER_PEER, PER_FETCH_BLOCK_LIMIT};
 use ckb_core::header::Header;
@@ -156,10 +157,11 @@ where
                     .shared
                     .get_ancestor(max_height_header.hash(), index_height)?;
                 let to_fetch_hash = to_fetch.hash();
-
-                let block_status = self.synchronizer.shared().get_block_status(to_fetch_hash);
-                if block_status != BlockStatus::VALID_MASK
-                    || self.synchronizer.shared().contains_orphan_block(&to_fetch)
+                if self
+                    .synchronizer
+                    .shared()
+                    .get_block_status(to_fetch_hash)
+                    .contains(BlockStatus::BLOCK_RECEIVED)
                 {
                     continue;
                 }

--- a/sync/src/synchronizer/block_pool.rs
+++ b/sync/src/synchronizer/block_pool.rs
@@ -1,5 +1,4 @@
 use ckb_core::block::Block;
-use ckb_core::header::Header;
 use ckb_util::RwLock;
 use fnv::FnvHashMap;
 use numext_fixed_hash::H256;
@@ -7,6 +6,8 @@ use std::collections::VecDeque;
 
 pub type ParentHash = H256;
 
+// NOTE: Never use `LruCache` as container. We have to ensure synchronizing between
+// orphan_block_pool and block_status_map, but `LruCache` would prune old items implicitly.
 #[derive(Default)]
 pub struct OrphanBlockPool {
     blocks: RwLock<FnvHashMap<ParentHash, FnvHashMap<H256, Block>>>,
@@ -45,14 +46,6 @@ impl OrphanBlockPool {
             }
         }
         removed
-    }
-
-    pub fn contains(&self, header: &Header) -> bool {
-        self.blocks
-            .read()
-            .get(header.parent_hash())
-            .map(|blocks| blocks.contains_key(header.hash()))
-            .unwrap_or(false)
     }
 }
 

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -56,7 +56,8 @@ where
                 BAD_MESSAGE_BAN_TIME.as_secs()
             );
             self.synchronizer
-                .insert_block_status(block_hash, BlockStatus::FAILED_VALID);
+                .shared()
+                .insert_block_status(block_hash, BlockStatus::BLOCK_INVALID);
             self.nc.ban_peer(self.peer, BAD_MESSAGE_BAN_TIME);
         }
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -396,6 +396,7 @@ where
                 self.header.number()
             );
             self.synchronizer
+                .shared()
                 .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_CHILD);
             return result;
         }
@@ -406,6 +407,7 @@ where
                 self.header.number()
             );
             self.synchronizer
+                .shared()
                 .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_VALID);
             return result;
         }
@@ -413,6 +415,7 @@ where
         if self.version_check(&mut result).is_err() {
             debug!("HeadersProcess accept {:?} version", self.header.number());
             self.synchronizer
+                .shared()
                 .insert_block_status(self.header.hash().to_owned(), BlockStatus::FAILED_VALID);
             return result;
         }
@@ -427,6 +430,7 @@ where
                 .clone(),
         );
         self.synchronizer
+            .shared()
             .insert_block_status(self.header.hash().to_owned(), BlockStatus::VALID_MASK);
         result
     }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -111,10 +111,6 @@ impl<CS: ChainStore> Synchronizer<CS> {
         self.shared().peers()
     }
 
-    pub fn insert_block_status(&self, hash: H256, status: BlockStatus) {
-        self.shared().insert_block_status(hash, status);
-    }
-
     pub fn predict_headers_sync_time(&self, header: &Header) -> u64 {
         let now = unix_time_as_millis();
         let expected_headers = min(

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -146,12 +146,12 @@ impl<CS: ChainStore> Synchronizer<CS> {
     }
 
     //TODO: process block which we don't request
-    pub fn process_new_block(&self, peer: PeerIndex, block: Block) -> Result<(), FailureError> {
+    pub fn process_new_block(&self, peer: PeerIndex, block: Block) -> Result<bool, FailureError> {
         let block_hash = block.header().hash();
         let status = self.shared().get_block_status(block_hash);
         if status.contains(BlockStatus::BLOCK_RECEIVED) {
             debug!("block {:x} already received", block_hash);
-            Ok(())
+            Ok(false)
         } else if status.contains(BlockStatus::HEADER_VERIFIED) {
             self.shared()
                 .insert_new_block(&self.chain, peer, Arc::new(block))
@@ -160,7 +160,8 @@ impl<CS: ChainStore> Synchronizer<CS> {
                 "Synchronizer process_new_block unexpected status {:?} {:#x}",
                 status, block_hash,
             );
-            Ok(())
+            // TODO which error should we return?
+            Ok(false)
         }
     }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -11,7 +11,7 @@ use self::block_process::BlockProcess;
 use self::get_blocks_process::GetBlocksProcess;
 use self::get_headers_process::GetHeadersProcess;
 use self::headers_process::HeadersProcess;
-use crate::types::BlockStatus;
+use crate::block_status::BlockStatus;
 use crate::types::{HeaderView, Peers, SyncSharedState};
 use crate::{
     BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -587,14 +587,6 @@ mod tests {
         Synchronizer::new(chain_controller, shared)
     }
 
-    #[test]
-    fn test_block_status() {
-        let status1 = BlockStatus::FAILED_VALID;
-        let status2 = BlockStatus::FAILED_CHILD;
-        assert!((status1 & BlockStatus::FAILED_MASK) == status1);
-        assert!((status2 & BlockStatus::FAILED_MASK) == status2);
-    }
-
     fn gen_block<CS: ChainStore>(
         shared: &Shared<CS>,
         parent_header: &Header,

--- a/sync/src/tests/sync_shared_state.rs
+++ b/sync/src/tests/sync_shared_state.rs
@@ -123,7 +123,10 @@ fn test_insert_parent_unknown_block() {
         shared.get_block_status(valid_hash),
         BlockStatus::BLOCK_STORED
     );
-    assert_eq!(shared.get_block_status(invalid_hash), BlockStatus::UNKNOWN);
+    assert_eq!(
+        shared.get_block_status(invalid_hash),
+        BlockStatus::BLOCK_INVALID
+    );
     assert_eq!(
         shared.get_block_status(parent_hash),
         BlockStatus::BLOCK_STORED

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1147,14 +1147,14 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     ) -> Result<bool, FailureError> {
         let ret = chain.process_block(Arc::clone(&block), true);
         if ret.is_err() {
-            self.insert_block_status(block.header().hash().to_owned(), BlockStatus::FAILED_MASK);
+            self.insert_block_status(block.header().hash().to_owned(), BlockStatus::BLOCK_INVALID);
             return ret;
         }
 
         self.remove_header_view(block.header().hash());
         self.insert_block_status(
             block.header().hash().to_owned(),
-            BlockStatus::BLOCK_HAVE_MASK,
+            BlockStatus::BLOCK_STORED,
         );
         self.peers()
             .set_last_common_header(peer, block.header().clone());

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -12,7 +12,7 @@ use ckb_core::extras::EpochExt;
 use ckb_core::header::{BlockNumber, Header};
 use ckb_core::transaction::ProposalShortId;
 use ckb_core::Cycle;
-use ckb_logger::{debug, debug_target};
+use ckb_logger::{debug, debug_target, error};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::SyncMessage;
 use ckb_shared::chain_state::ChainState;
@@ -1138,12 +1138,14 @@ impl<CS: ChainStore> SyncSharedState<CS> {
     ) -> Result<bool, FailureError> {
         let ret = chain.process_block(Arc::clone(&block), true);
         if ret.is_err() {
+            error!("accept block {:?} {:?}", block, ret);
             self.insert_block_status(block.header().hash().to_owned(), BlockStatus::BLOCK_INVALID);
             return ret;
+        } else {
+            self.insert_block_status(block_hash, BlockStatus::BLOCK_STORED);
         }
 
         self.remove_header_view(block.header().hash());
-        self.insert_block_status(block.header().hash().to_owned(), BlockStatus::BLOCK_STORED);
         self.peers()
             .set_last_common_header(peer, block.header().clone());
         ret

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1038,6 +1038,14 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         }
     }
 
+    pub fn contains_block_status(&self, block_hash: &H256, status: BlockStatus) -> bool {
+        self.get_block_status(block_hash).contains(status)
+    }
+
+    pub fn unknown_block_status(&self, block_hash: &H256) -> bool {
+        self.get_block_status(block_hash) == BlockStatus::UNKNOWN
+    }
+
     pub fn insert_block_status(&self, block_hash: H256, status: BlockStatus) {
         self.block_status_map.lock().insert(block_hash, status);
     }

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1,10 +1,10 @@
+use crate::block_status::BlockStatus;
 use crate::relayer::compact_block::CompactBlock;
 use crate::synchronizer::OrphanBlockPool;
 use crate::NetworkProtocol;
 use crate::BLOCK_DOWNLOAD_TIMEOUT;
 use crate::MAX_PEERS_PER_BLOCK;
 use crate::{MAX_HEADERS_LEN, MAX_TIP_AGE};
-use bitflags::bitflags;
 use ckb_chain::chain::ChainController;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::block::Block;
@@ -601,26 +601,6 @@ impl EpochIndices {
     }
 }
 
-bitflags! {
-    pub struct BlockStatus: u32 {
-        const UNKNOWN            = 0;
-        const VALID_HEADER       = 1;
-        const VALID_TREE         = 2;
-        const VALID_TRANSACTIONS = 3;
-        const VALID_CHAIN        = 4;
-        const VALID_SCRIPTS      = 5;
-
-        const VALID_MASK         = Self::VALID_HEADER.bits | Self::VALID_TREE.bits | Self::VALID_TRANSACTIONS.bits |
-                                   Self::VALID_CHAIN.bits | Self::VALID_SCRIPTS.bits;
-        const BLOCK_HAVE_DATA    = 8;
-        const BLOCK_HAVE_UNDO    = 16;
-        const BLOCK_HAVE_MASK    = Self::BLOCK_HAVE_DATA.bits | Self::BLOCK_HAVE_UNDO.bits;
-        const FAILED_VALID       = 32;
-        const FAILED_CHILD       = 64;
-        const FAILED_MASK        = Self::FAILED_VALID.bits | Self::FAILED_CHILD.bits;
-    }
-}
-
 pub struct SyncSharedState<CS> {
     shared: Shared<CS>,
 
@@ -1028,16 +1008,19 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         ids.iter().map(|id| locked.remove(id)).collect()
     }
 
-    pub fn contains_orphan_block(&self, header: &Header) -> bool {
-        self.orphan_block_pool.contains(header)
-    }
-
     pub fn insert_orphan_block(&self, block: Block) {
-        self.orphan_block_pool.insert(block)
+        let block_hash = block.header().hash().to_owned();
+        self.orphan_block_pool.insert(block);
+        self.insert_block_status(block_hash, BlockStatus::BLOCK_RECEIVED);
     }
 
     pub fn remove_orphan_by_parent(&self, parent_hash: &H256) -> Vec<Block> {
-        self.orphan_block_pool.remove_blocks_by_parent(parent_hash)
+        let blocks = self.orphan_block_pool.remove_blocks_by_parent(parent_hash);
+        let mut block_status_map = self.block_status_map.lock();
+        blocks.iter().for_each(|b| {
+            block_status_map.remove(b.header().hash());
+        });
+        blocks
     }
 
     pub fn get_block_status(&self, block_hash: &H256) -> BlockStatus {
@@ -1046,8 +1029,8 @@ impl<CS: ChainStore> SyncSharedState<CS> {
             Some(status) => status,
             None => {
                 if self.shared.store().get_block_header(block_hash).is_some() {
-                    locked.insert(block_hash.clone(), BlockStatus::BLOCK_HAVE_MASK);
-                    BlockStatus::BLOCK_HAVE_MASK
+                    locked.insert(block_hash.clone(), BlockStatus::BLOCK_STORED);
+                    BlockStatus::BLOCK_STORED
                 } else {
                     BlockStatus::UNKNOWN
                 }
@@ -1152,10 +1135,7 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         }
 
         self.remove_header_view(block.header().hash());
-        self.insert_block_status(
-            block.header().hash().to_owned(),
-            BlockStatus::BLOCK_STORED,
-        );
+        self.insert_block_status(block.header().hash().to_owned(), BlockStatus::BLOCK_STORED);
         self.peers()
             .set_last_common_header(peer, block.header().clone());
         ret


### PR DESCRIPTION
* refactor: Move `orphan_block_pool` into `SyncSharedState`
* feat: Rewrite `BlockStatus` and `block_status_map`
* perf: Use `BlockStatus` to avoid re-processing the same headers/blocks