### PR TITLE
[ᚬrc/v0.16] [rc/v0.16] fix: random failure caused by dirty exit in RPC test

### DIFF
--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -333,4 +333,6 @@ fn test_rpc() {
     if print_mode {
         println!("{}", to_string_pretty(&Value::Array(outputs)).unwrap());
     }
+
+    server.close();
 }


### PR DESCRIPTION
Backports the following commits to rc/v0.16:
 - fix: random failure caused by dirty exit in RPC test (#1092)