### PR TITLE
fix: Use tip header to ignore compact block

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -64,10 +64,15 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
 
         {
             let parent = parent.unwrap();
-            let shared_best_header = self.relayer.shared.shared_best_header();
+            let tip_header = self.relayer.shared.tip_header();
+            let tip_header_view = self
+                .relayer
+                .shared
+                .get_header_view(tip_header.hash())
+                .expect("Get tip header view failed");
             let current_total_difficulty =
                 parent.total_difficulty() + compact_block.header.difficulty();
-            if shared_best_header
+            if tip_header_view
                 .is_better_than(&current_total_difficulty, compact_block.header.hash())
             {
                 debug_target!(
@@ -75,7 +80,7 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                     "Received a compact block({:#x}), total difficulty {:#x} <= {:#x}, ignore it",
                     block_hash,
                     current_total_difficulty,
-                    shared_best_header.total_difficulty(),
+                    tip_header_view.total_difficulty(),
                 );
                 return Ok(());
             }


### PR DESCRIPTION
Backports the following commits to develop:

fix: Use tip header to ignore compact block (#1176)