### PR TITLE
chore: Remove useless known_blocks filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,11 +1023,15 @@ dependencies = [
 name = "ckb-test-chain-utils"
 version = "0.17.0-pre"
 dependencies = [
+ "ckb-chain-spec 0.17.0-pre",
  "ckb-core 0.17.0-pre",
+ "ckb-dao-utils 0.17.0-pre",
  "ckb-db 0.17.0-pre",
  "ckb-hash 0.17.0-pre",
  "ckb-store 0.17.0-pre",
+ "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -12,7 +12,7 @@ use ckb_core::transaction::{
 use ckb_core::uncle::UncleBlock;
 use ckb_core::{capacity_bytes, Bytes, Capacity};
 use ckb_dao_utils::genesis_dao_data;
-use ckb_test_chain_utils::create_always_success_cell;
+use ckb_test_chain_utils::always_success_cell;
 use ckb_traits::ChainProvider;
 use std::sync::Arc;
 
@@ -86,7 +86,7 @@ pub(crate) fn gen_block(
 }
 
 pub(crate) fn create_transaction(parent: &Transaction, index: u32) -> Transaction {
-    let (_, always_success_script) = create_always_success_cell();
+    let (_, always_success_script) = always_success_cell();
     let always_success_out_point = create_always_success_out_point();
 
     TransactionBuilder::default()
@@ -106,7 +106,7 @@ pub(crate) fn create_transaction(parent: &Transaction, index: u32) -> Transactio
 
 #[test]
 fn finalize_reward() {
-    let (_, always_success_script) = create_always_success_cell();
+    let (_, always_success_script) = always_success_cell();
     let tx = TransactionBuilder::default()
         .input(CellInput::new(OutPoint::null(), 0))
         .output(CellOutput::new(

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -13,7 +13,7 @@ use ckb_notify::NotifyService;
 use ckb_shared::shared::Shared;
 use ckb_shared::shared::SharedBuilder;
 use ckb_store::{ChainKVStore, ChainStore};
-use ckb_test_chain_utils::{build_block, create_always_success_cell};
+use ckb_test_chain_utils::{always_success_cell, build_block};
 use ckb_traits::chain_provider::ChainProvider;
 use fnv::FnvHashSet;
 use numext_fixed_hash::H256;
@@ -25,7 +25,7 @@ pub use ckb_test_chain_utils::MockStore;
 const MIN_CAP: Capacity = capacity_bytes!(60);
 
 pub(crate) fn create_always_success_tx() -> Transaction {
-    let (ref always_success_cell, ref script) = create_always_success_cell();
+    let (ref always_success_cell, ref script) = always_success_cell();
     TransactionBuilder::default()
         .witness(script.clone().into_witness())
         .input(CellInput::new(OutPoint::null(), 0))
@@ -93,7 +93,7 @@ pub(crate) fn create_cellbase(
     consensus: &Consensus,
     parent: &Header,
 ) -> Transaction {
-    let (_, always_success_script) = create_always_success_cell();
+    let (_, always_success_script) = always_success_cell();
     let capacity = calculate_reward(store, consensus, parent);
     TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(parent.number() + 1))
@@ -114,7 +114,7 @@ pub(crate) fn create_multi_outputs_transaction(
     output_len: usize,
     data: Vec<u8>,
 ) -> Transaction {
-    let (_, always_success_script) = create_always_success_cell();
+    let (_, always_success_script) = always_success_cell();
     let always_success_out_point = create_always_success_out_point();
 
     let parent_outputs = parent.outputs();
@@ -159,7 +159,7 @@ pub(crate) fn create_transaction_with_out_point(
     out_point: OutPoint,
     unique_data: u8,
 ) -> Transaction {
-    let (_, always_success_script) = create_always_success_cell();
+    let (_, always_success_script) = always_success_cell();
     let always_success_out_point = create_always_success_out_point();
 
     TransactionBuilder::default()

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -20,7 +20,7 @@ use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
 use ckb_sync::{SyncSharedState, Synchronizer};
-use ckb_test_chain_utils::create_always_success_cell;
+use ckb_test_chain_utils::always_success_cell;
 use ckb_traits::chain_provider::ChainProvider;
 use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::ServerBuilder;
@@ -70,7 +70,7 @@ fn setup_node(
     ChainController,
     RpcServer,
 ) {
-    let (always_success_cell, always_success_script) = create_always_success_cell();
+    let (always_success_cell, always_success_script) = always_success_cell();
     let always_success_tx = TransactionBuilder::default()
         .witness(always_success_script.clone().into_witness())
         .input(CellInput::new(OutPoint::null(), 0))

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -441,7 +441,7 @@ mod tests {
     use ckb_store::{data_loader_wrapper::DataLoaderWrapper, ChainKVStore, COLUMNS};
     use faster_hex::hex_encode;
 
-    use ckb_test_chain_utils::create_always_success_cell;
+    use ckb_test_chain_utils::always_success_cell;
     use ckb_vm::Error as VMInternalError;
     use numext_fixed_hash::{h256, H256};
     use std::fs::File;
@@ -492,7 +492,7 @@ mod tests {
 
     #[test]
     fn check_always_success_hash() {
-        let (always_success_cell, always_success_script) = create_always_success_cell();
+        let (always_success_cell, always_success_script) = always_success_cell();
         let output = CellOutput::new(
             capacity_bytes!(100),
             Bytes::default(),
@@ -941,7 +941,7 @@ mod tests {
         args.push(Bytes::from(to_hex_signature(&signature)));
 
         let input = CellInput::new(OutPoint::null(), 0);
-        let (always_success_cell, always_success_script) = create_always_success_cell();
+        let (always_success_cell, always_success_script) = always_success_cell();
         let output = CellOutput::new(
             capacity_bytes!(100),
             Bytes::default(),
@@ -1021,7 +1021,7 @@ mod tests {
         args.push(Bytes::from(to_hex_signature(&signature)));
 
         let input = CellInput::new(OutPoint::null(), 0);
-        let (always_success_cell, always_success_script) = create_always_success_cell();
+        let (always_success_cell, always_success_script) = always_success_cell();
         let output = CellOutput::new(
             capacity_bytes!(100),
             Bytes::default(),

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -192,14 +192,14 @@ mod tests {
     use ckb_notify::NotifyService;
     use ckb_shared::shared::{Shared, SharedBuilder};
     use ckb_store::ChainKVStore;
-    use ckb_test_chain_utils::create_always_success_cell;
+    use ckb_test_chain_utils::always_success_cell;
     use ckb_traits::ChainProvider;
     use ckb_verification::TransactionError;
     use faketime::{self, unix_time_as_millis};
     use numext_fixed_uint::U256;
 
     fn setup(height: u64) -> (Shared<ChainKVStore<MemoryKeyValueDB>>, OutPoint) {
-        let (always_success_cell, always_success_script) = create_always_success_cell();
+        let (always_success_cell, always_success_script) = always_success_cell();
         let always_success_tx = TransactionBuilder::default()
             .witness(always_success_script.clone().into_witness())
             .input(CellInput::new(OutPoint::null(), 0))

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -235,13 +235,10 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             fbb.finish(message, None);
             let data = fbb.finished_data().into();
 
-            let mut known_blocks = self.shared().known_blocks();
             let selected_peers: Vec<PeerIndex> = nc
                 .connected_peers()
                 .into_iter()
-                .filter(|target_peer| {
-                    known_blocks.insert(*target_peer, block_hash.clone()) && (peer != *target_peer)
-                })
+                .filter(|target_peer| peer != *target_peer)
                 .take(MAX_RELAY_PEERS)
                 .collect();
             if let Err(err) = nc.quick_filter_broadcast(TargetSession::Multi(selected_peers), data)

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -14,7 +14,7 @@ use ckb_notify::NotifyService;
 use ckb_protocol::{short_transaction_id, short_transaction_id_keys};
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::{ChainKVStore, ChainStore};
-use ckb_test_chain_utils::create_always_success_cell;
+use ckb_test_chain_utils::always_success_cell;
 use ckb_traits::ChainProvider;
 use faketime::{self, unix_time_as_millis};
 use numext_fixed_uint::U256;
@@ -71,7 +71,7 @@ fn new_transaction(
 }
 
 fn build_chain(tip: BlockNumber) -> (Relayer<ChainKVStore<MemoryKeyValueDB>>, OutPoint) {
-    let (always_success_cell, always_success_script) = create_always_success_cell();
+    let (always_success_cell, always_success_script) = always_success_cell();
     let always_success_tx = TransactionBuilder::default()
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -11,8 +11,10 @@ use std::thread;
 use std::time::Duration;
 
 mod inflight_blocks;
+mod sync_shared_state;
 #[cfg(not(disable_faketime))]
 mod synchronizer;
+mod util;
 
 const DEFAULT_CHANNEL: usize = 128;
 

--- a/sync/src/tests/sync_shared_state.rs
+++ b/sync/src/tests/sync_shared_state.rs
@@ -1,0 +1,125 @@
+use crate::tests::util::{build_chain, inherit_block};
+use crate::types::BlockStatus;
+use crate::SyncSharedState;
+use ckb_chain::chain::ChainService;
+use ckb_core::block::BlockBuilder;
+use ckb_core::header::HeaderBuilder;
+use ckb_core::Capacity;
+use ckb_db::MemoryKeyValueDB;
+use ckb_network::PeerIndex;
+use ckb_notify::NotifyService;
+use ckb_shared::shared::SharedBuilder;
+use ckb_store::ChainStore;
+use ckb_test_chain_utils::always_success_cellbase;
+use std::sync::Arc;
+
+#[test]
+fn test_insert_new_block() {
+    let (shared, chain) = build_chain(2);
+    let new_block = {
+        let tip_number = shared.tip_header().number();
+        let next_block = inherit_block(shared.shared(), tip_number).build();
+        Arc::new(next_block)
+    };
+
+    assert_eq!(
+        shared
+            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
+            .expect("insert valid block"),
+        true,
+    );
+    assert_eq!(
+        shared
+            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
+            .expect("insert duplicated valid block"),
+        false,
+    );
+}
+
+#[test]
+fn test_insert_invalid_block() {
+    let (shared, chain) = build_chain(2);
+    let invalid_block = {
+        let tip_number = shared.tip_header().number();
+        let invalid_cellbase = always_success_cellbase(tip_number, Capacity::zero());
+        let next_block = inherit_block(shared.shared(), tip_number)
+            .transaction(invalid_cellbase)
+            .build();
+        Arc::new(next_block)
+    };
+
+    assert!(shared
+        .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_block))
+        .is_err(),);
+}
+
+#[test]
+fn test_insert_parent_unknown_block() {
+    let (shared1, _) = build_chain(2);
+    let (shared, chain) = {
+        let shared = SharedBuilder::<MemoryKeyValueDB>::new()
+            .consensus(shared1.consensus().clone())
+            .build()
+            .unwrap();
+        let chain_controller = {
+            let notify_controller = NotifyService::default().start::<&str>(None);
+            let chain_service = ChainService::new(shared.clone(), notify_controller);
+            chain_service.start::<&str>(None)
+        };
+        (SyncSharedState::new(shared), chain_controller)
+    };
+
+    let block = shared1
+        .store()
+        .get_block(shared1.tip_header().hash())
+        .unwrap();
+    let parent = {
+        let parent = shared1
+            .store()
+            .get_block(block.header().parent_hash())
+            .unwrap();
+        Arc::new(parent)
+    };
+    let invalid_orphan = {
+        let invalid_orphan = BlockBuilder::from_block(block.clone())
+            .header_builder(HeaderBuilder::from_header(block.header().clone()).number(1000))
+            .build();
+        Arc::new(invalid_orphan)
+    };
+    let valid_orphan = Arc::new(block);
+
+    assert_eq!(
+        shared
+            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&valid_orphan))
+            .expect("insert orphan block"),
+        false,
+    );
+    assert_eq!(
+        shared
+            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_orphan))
+            .expect("insert orphan block"),
+        false,
+    );
+    assert!(shared.contains_orphan_block(valid_orphan.header()));
+    assert!(shared.contains_orphan_block(invalid_orphan.header()));
+
+    // After inserting parent of an orphan block
+    assert_eq!(
+        shared
+            .insert_new_block(&chain, PeerIndex::new(2), Arc::clone(&parent))
+            .expect("insert parent of orphan block"),
+        true,
+    );
+    assert!(!shared.contains_orphan_block(valid_orphan.header()));
+    assert!(!shared.contains_orphan_block(invalid_orphan.header()));
+    assert!(!shared.contains_orphan_block(parent.header()));
+
+    assert_eq!(
+        shared.get_block_status(valid_orphan.header().hash()),
+        BlockStatus::BLOCK_HAVE_MASK,
+    );
+    assert_eq!(
+        shared.get_block_status(invalid_orphan.header().hash()),
+        BlockStatus::FAILED_MASK,
+    );
+}

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -18,7 +18,7 @@ use ckb_notify::NotifyService;
 use ckb_protocol::SyncMessage;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
-use ckb_test_chain_utils::create_always_success_cell;
+use ckb_test_chain_utils::always_success_cell;
 use ckb_traits::ChainProvider;
 use ckb_util::RwLock;
 use faketime::{self, unix_time_as_millis};
@@ -77,7 +77,7 @@ fn setup_node(
     thread_name: &str,
     height: u64,
 ) -> (TestNode, Shared<ChainKVStore<MemoryKeyValueDB>>) {
-    let (always_success_cell, always_success_script) = create_always_success_cell();
+    let (always_success_cell, always_success_script) = always_success_cell();
     let always_success_tx = TransactionBuilder::default()
         .witness(always_success_script.clone().into_witness())
         .input(CellInput::new(OutPoint::null(), 0))

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -1,0 +1,111 @@
+use crate::SyncSharedState;
+use ckb_chain::chain::{ChainController, ChainService};
+use ckb_core::block::BlockBuilder;
+use ckb_core::cell::resolve_transaction;
+use ckb_core::header::HeaderBuilder;
+use ckb_core::transaction::Transaction;
+use ckb_core::BlockNumber;
+use ckb_dao::DaoCalculator;
+use ckb_db::MemoryKeyValueDB;
+use ckb_notify::NotifyService;
+use ckb_shared::shared::{Shared, SharedBuilder};
+use ckb_store::{ChainKVStore, ChainStore};
+use ckb_test_chain_utils::{always_success_cellbase, always_success_consensus};
+use ckb_traits::ChainProvider;
+use std::sync::Arc;
+
+pub fn build_chain(
+    tip: BlockNumber,
+) -> (
+    SyncSharedState<ChainKVStore<MemoryKeyValueDB>>,
+    ChainController,
+) {
+    let shared = SharedBuilder::<MemoryKeyValueDB>::new()
+        .consensus(always_success_consensus())
+        .build()
+        .unwrap();
+    let chain_controller = {
+        let notify_controller = NotifyService::default().start::<&str>(None);
+        let chain_service = ChainService::new(shared.clone(), notify_controller);
+        chain_service.start::<&str>(None)
+    };
+    generate_blocks(&shared, &chain_controller, tip);
+    let sync_shared_state = SyncSharedState::new(shared);
+    (sync_shared_state, chain_controller)
+}
+
+pub fn generate_blocks(
+    shared: &Shared<ChainKVStore<MemoryKeyValueDB>>,
+    chain_controller: &ChainController,
+    count: u64,
+) {
+    for parent_number in 0..count {
+        let block = inherit_block(shared, parent_number).build();
+        chain_controller
+            .process_block(Arc::new(block), false)
+            .expect("processing block should be ok");
+    }
+}
+
+pub fn inherit_block(
+    shared: &Shared<ChainKVStore<MemoryKeyValueDB>>,
+    parent_number: BlockNumber,
+) -> BlockBuilder {
+    let parent = shared
+        .store()
+        .get_block_hash(parent_number)
+        .and_then(|block_hash| shared.store().get_block(&block_hash))
+        .unwrap();
+    let parent_hash = parent.header().hash();
+    let parent_epoch = shared.get_block_epoch(&parent_hash).unwrap();
+    let epoch = shared
+        .next_epoch_ext(&parent_epoch, parent.header())
+        .unwrap_or(parent_epoch);
+    let cellbase = {
+        let (_, reward) = shared.finalize_block_reward(parent.header()).unwrap();
+        always_success_cellbase(parent_number + 1, reward)
+    };
+    let dao = {
+        let chain_state = shared.lock_chain_state();
+        let resolved_cellbase = resolve_transaction(
+            &cellbase,
+            &mut Default::default(),
+            &*chain_state,
+            &*chain_state,
+        )
+        .unwrap();
+        DaoCalculator::new(shared.consensus(), Arc::clone(shared.store()))
+            .dao_field(&[resolved_cellbase], parent.header())
+            .unwrap()
+    };
+
+    BlockBuilder::from_header_builder(
+        HeaderBuilder::default()
+            .parent_hash(parent_hash.to_owned())
+            .number(parent.header().number() + 1)
+            .timestamp(parent.header().timestamp() + 1)
+            .epoch(epoch.number())
+            .difficulty(epoch.difficulty().to_owned())
+            .dao(dao),
+    )
+    .transaction(inherit_cellbase(shared, parent_number))
+}
+
+pub fn inherit_cellbase(
+    shared: &Shared<ChainKVStore<MemoryKeyValueDB>>,
+    parent_number: BlockNumber,
+) -> Transaction {
+    let parent_header = {
+        let chain = shared.lock_chain_state();
+        let parent_hash = chain
+            .store()
+            .get_block_hash(parent_number)
+            .expect("parent exist");
+        chain
+            .store()
+            .get_block_header(&parent_hash)
+            .expect("parent exist")
+    };
+    let (_, reward) = shared.finalize_block_reward(&parent_header).unwrap();
+    always_success_cellbase(parent_number + 1, reward)
+}

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -638,7 +638,6 @@ pub struct SyncSharedState<CS> {
     /* Status relevant to peers */
     peers: Peers,
     misbehavior: RwLock<FnvHashMap<PeerIndex, u32>>,
-    known_blocks: Mutex<KnownFilter>,
     known_txs: Mutex<KnownFilter>,
 
     /* Cached items which we had received but not completely process */
@@ -685,7 +684,6 @@ impl<CS: ChainStore> SyncSharedState<CS> {
             tx_filter: Mutex::new(Filter::new(TX_FILTER_SIZE)),
             peers: Peers::default(),
             misbehavior: RwLock::new(FnvHashMap::default()),
-            known_blocks: Mutex::new(KnownFilter::default()),
             known_txs: Mutex::new(KnownFilter::default()),
             pending_get_block_proposals: Mutex::new(FnvHashMap::default()),
             pending_compact_blocks: Mutex::new(FnvHashMap::default()),
@@ -717,9 +715,6 @@ impl<CS: ChainStore> SyncSharedState<CS> {
                 .and_modify(|s| *s += score)
                 .or_insert_with(|| score);
         }
-    }
-    pub fn known_blocks(&self) -> MutexGuard<KnownFilter> {
-        self.known_blocks.lock()
     }
     pub fn known_txs(&self) -> MutexGuard<KnownFilter> {
         self.known_txs.lock()
@@ -1081,7 +1076,6 @@ impl<CS: ChainStore> SyncSharedState<CS> {
 
     pub fn disconnected(&self, pi: PeerIndex) -> Option<PeerState> {
         self.known_txs.lock().inner.remove(&pi);
-        self.known_blocks.lock().inner.remove(&pi);
         self.inflight_blocks.write().remove_by_peer(pi);
         self.peers().disconnected(pi)
     }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -81,6 +81,10 @@ fn main() {
         "compact_block_relay_parent_of_orphan_block",
         Box::new(CompactBlockRelayParentOfOrphanBlock),
     );
+    specs.insert(
+        "compact_block_relay_less_then_shared_best_known",
+        Box::new(CompactBlockRelayLessThenSharedBestKnown),
+    );
     specs.insert("invalid_locator_size", Box::new(InvalidLocatorSize));
     specs.insert("tx_pool_size_limit", Box::new(SizeLimit));
     specs.insert("tx_pool_cycles_limit", Box::new(CyclesLimit));

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -47,6 +47,22 @@ impl RpcClient {
             .expect("rpc call get_block_by_number")
     }
 
+    pub fn get_header(&self, hash: H256) -> Option<HeaderView> {
+        self.inner
+            .lock()
+            .get_header(hash)
+            .call()
+            .expect("rpc call get_header")
+    }
+
+    pub fn get_header_by_number(&self, number: CoreBlockNumber) -> Option<HeaderView> {
+        self.inner
+            .lock()
+            .get_header_by_number(BlockNumber(number))
+            .call()
+            .expect("rpc call get_header_by_number")
+    }
+
     pub fn get_transaction(&self, hash: H256) -> Option<TransactionWithStatus> {
         self.inner
             .lock()
@@ -287,6 +303,8 @@ impl RpcClient {
 jsonrpc_client!(pub struct Inner {
     pub fn get_block(&mut self, _hash: H256) -> RpcRequest<Option<BlockView>>;
     pub fn get_block_by_number(&mut self, _number: BlockNumber) -> RpcRequest<Option<BlockView>>;
+    pub fn get_header(&mut self, _hash: H256) -> RpcRequest<Option<HeaderView>>;
+    pub fn get_header_by_number(&mut self, _number: BlockNumber) -> RpcRequest<Option<HeaderView>>;
     pub fn get_transaction(&mut self, _hash: H256) -> RpcRequest<Option<TransactionWithStatus>>;
     pub fn get_block_hash(&mut self, _number: BlockNumber) -> RpcRequest<Option<H256>>;
     pub fn get_tip_header(&mut self) -> RpcRequest<HeaderView>;

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -47,8 +47,12 @@ pub fn build_block_transactions(block: &Block) -> Bytes {
 }
 
 pub fn build_header(header: &Header) -> Bytes {
+    build_headers(&[header.clone()])
+}
+
+pub fn build_headers(headers: &[Header]) -> Bytes {
     let fbb = &mut FlatBufferBuilder::new();
-    let message = SyncMessage::build_headers(fbb, &[header.clone()]);
+    let message = SyncMessage::build_headers(fbb, headers);
     fbb.finish(message, None);
     fbb.finished_data().into()
 }

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -10,4 +10,8 @@ ckb-core = { path = "../../core" }
 ckb-db = { path = "../../db" }
 ckb-hash = { path = "../hash" }
 ckb-store = { path = "../../store" }
+ckb-chain-spec = { path = "../../spec" }
+ckb-dao-utils = { path = "../dao/utils" }
 lazy_static = "1.3.0"
+faketime = "0.2.0"
+numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }

--- a/util/test-chain-utils/src/chain.rs
+++ b/util/test-chain-utils/src/chain.rs
@@ -1,0 +1,76 @@
+use ckb_chain_spec::consensus::Consensus;
+use ckb_core::block::BlockBuilder;
+use ckb_core::header::HeaderBuilder;
+use ckb_core::script::{Script, ScriptHashType};
+use ckb_core::transaction::{CellInput, CellOutput, OutPoint, Transaction, TransactionBuilder};
+use ckb_core::Capacity;
+use ckb_core::{BlockNumber, Bytes};
+use ckb_dao_utils::genesis_dao_data;
+use ckb_hash::blake2b_256;
+use faketime::unix_time_as_millis;
+use lazy_static::lazy_static;
+use numext_fixed_uint::U256;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+lazy_static! {
+    static ref SUCCESS_CELL: (CellOutput, Script) = {
+        let mut file = File::open(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../script/testdata/always_success"),
+        )
+        .unwrap();
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).unwrap();
+
+        let cell = CellOutput::new(
+            Capacity::bytes(buffer.len()).unwrap(),
+            buffer.into(),
+            Script::default(),
+            None,
+        );
+
+        let script = Script::new(vec![], blake2b_256(&cell.data).into(), ScriptHashType::Data);
+
+        (cell, script)
+    };
+}
+
+pub fn always_success_cell() -> &'static (CellOutput, Script) {
+    &SUCCESS_CELL
+}
+
+pub fn always_success_consensus() -> Consensus {
+    let (always_success_cell, always_success_script) = always_success_cell();
+    let always_success_tx = TransactionBuilder::default()
+        .input(CellInput::new(OutPoint::null(), 0))
+        .output(always_success_cell.clone())
+        .witness(always_success_script.clone().into_witness())
+        .build();
+    let dao = genesis_dao_data(&always_success_tx).unwrap();
+    let genesis = BlockBuilder::from_header_builder(
+        HeaderBuilder::default()
+            .timestamp(unix_time_as_millis())
+            .difficulty(U256::from(1000u64))
+            .dao(dao),
+    )
+    .transaction(always_success_tx)
+    .build();
+    Consensus::default()
+        .set_genesis_block(genesis)
+        .set_cellbase_maturity(0)
+}
+
+pub fn always_success_cellbase(block_number: BlockNumber, reward: Capacity) -> Transaction {
+    let (_, always_success_script) = always_success_cell();
+    TransactionBuilder::default()
+        .input(CellInput::new_cellbase_input(block_number))
+        .output(CellOutput::new(
+            reward,
+            Bytes::default(),
+            always_success_script.to_owned(),
+            None,
+        ))
+        .witness(always_success_script.to_owned().into_witness())
+        .build()
+}

--- a/util/test-chain-utils/src/lib.rs
+++ b/util/test-chain-utils/src/lib.rs
@@ -1,40 +1,7 @@
 #[macro_use]
 mod macros;
+mod chain;
 mod mock_store;
 
-use ckb_core::script::{Script, ScriptHashType};
-use ckb_core::transaction::CellOutput;
-use ckb_core::Capacity;
-use ckb_hash::blake2b_256;
-use lazy_static::lazy_static;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
-
+pub use chain::{always_success_cell, always_success_cellbase, always_success_consensus};
 pub use mock_store::MockStore;
-
-lazy_static! {
-    static ref SUCCESS_CELL: (CellOutput, Script) = {
-        let mut file = File::open(
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../script/testdata/always_success"),
-        )
-        .unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let cell = CellOutput::new(
-            Capacity::bytes(buffer.len()).unwrap(),
-            buffer.into(),
-            Script::default(),
-            None,
-        );
-
-        let script = Script::new(vec![], blake2b_256(&cell.data).into(), ScriptHashType::Data);
-
-        (cell, script)
-    };
-}
-
-pub fn create_always_success_cell() -> &'static (CellOutput, Script) {
-    &SUCCESS_CELL
-}

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -15,7 +15,7 @@ use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainKVStore;
 use ckb_store::ChainStore;
-use ckb_test_chain_utils::create_always_success_cell;
+use ckb_test_chain_utils::always_success_cell;
 use ckb_traits::ChainProvider;
 use numext_fixed_hash::H256;
 use numext_fixed_uint::U256;
@@ -105,7 +105,7 @@ fn setup_env() -> (
     Script,
     OutPoint,
 ) {
-    let (always_success_cell, always_success_script) = create_always_success_cell();
+    let (always_success_cell, always_success_script) = always_success_cell();
     let tx = TransactionBuilder::default()
         .witness(always_success_script.clone().into_witness())
         .input(CellInput::new(OutPoint::null(), 0))


### PR DESCRIPTION
Originally we use `known_blocks` to avoid re-relay the same blocks to the same peers.
But now our code ensures that, as for the same blocks, we accept and relay only once. So this block-filter is useless.