### PR TITLE
feat: Remove block_number from BMT

### DIFF
--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -33,8 +33,7 @@ impl<CS: ChainStore + 'static> StatsRpc for StatsRpcImpl<CS> {
         let (tip_header, median_time) = {
             let chain_state = self.shared.lock_chain_state();
             let tip_header = chain_state.tip_header().clone();
-            let median_time =
-                (&*chain_state).block_median_time(tip_header.number(), tip_header.hash());
+            let median_time = (&*chain_state).block_median_time(tip_header.hash());
             (tip_header, median_time)
         };
         let epoch = tip_header.epoch();

--- a/shared/src/chain_state.rs
+++ b/shared/src/chain_state.rs
@@ -833,11 +833,15 @@ impl<CS: ChainStore> BlockMedianTimeContext for &ChainState<CS> {
         self.consensus.median_time_block_count() as u64
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         let header = self
             .store
             .get_block_header(&block_hash)
             .expect("[ChainState] blocks used for median time exist");
-        (header.timestamp(), header.parent_hash().to_owned())
+        (
+            header.timestamp(),
+            header.number(),
+            header.parent_hash().to_owned(),
+        )
     }
 }

--- a/shared/src/tests/shared.rs
+++ b/shared/src/tests/shared.rs
@@ -39,14 +39,14 @@ fn test_block_median_time() {
     let shared = new_shared();
     let chain_state = shared.lock_chain_state();
     let hash = shared.store().get_block_hash(0).unwrap();
-    assert_eq!((&*chain_state).block_median_time(0, &hash), 0);
+    assert_eq!((&*chain_state).block_median_time(&hash), 0);
     let now = faketime::unix_time_as_millis();
     insert_block_timestamps(shared.store(), &[now]);
     let hash = shared.store().get_block_hash(1).unwrap();
-    assert_eq!((&*chain_state).block_median_time(1, &hash), now);
+    assert_eq!((&*chain_state).block_median_time(&hash), now);
     let timestamps = (1..=22).collect::<Vec<_>>();
     insert_block_timestamps(shared.store(), &timestamps);
     let block_number = *timestamps.last().expect("last");
     let hash = shared.store().get_block_hash(block_number).unwrap();
-    assert_eq!((&*chain_state).block_median_time(block_number, &hash), 17);
+    assert_eq!((&*chain_state).block_median_time(&hash), 17);
 }

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -1,4 +1,4 @@
-use ckb_core::{transaction::Transaction, Cycle};
+use ckb_core::{transaction::Transaction, BlockNumber, Cycle};
 use ckb_shared::shared::Shared;
 use ckb_shared::tx_pool::PoolError;
 use ckb_store::ChainStore;
@@ -19,12 +19,16 @@ impl<CS: ChainStore> BlockMedianTimeContext for StoreBlockMedianTimeContext<CS> 
         self.median_time_block_count
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         let header = self
             .store
             .get_block_header(block_hash)
             .expect("[StoreBlockMedianTimeContext] blocks used for median time exist");
-        (header.timestamp(), header.parent_hash().to_owned())
+        (
+            header.timestamp(),
+            header.number(),
+            header.parent_hash().to_owned(),
+        )
     }
 }
 

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -2,6 +2,7 @@ use crate::relayer::compact_block::CompactBlock;
 use crate::relayer::compact_block_verifier::CompactBlockVerifier;
 use crate::relayer::Relayer;
 use ckb_core::header::Header;
+use ckb_core::BlockNumber;
 use ckb_logger::debug_target;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{CompactBlock as FbsCompactBlock, RelayMessage};
@@ -242,10 +243,14 @@ where
         self.shared.consensus().median_time_block_count() as u64
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         let header = self
             .get_header(&block_hash)
             .expect("[CompactBlockMedianTimeView] blocks used for median time exist");
-        (header.timestamp(), header.parent_hash().to_owned())
+        (
+            header.timestamp(),
+            header.number(),
+            header.parent_hash().to_owned(),
+        )
     }
 }

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -2,6 +2,7 @@ use crate::synchronizer::{BlockStatus, Synchronizer};
 use crate::MAX_HEADERS_LEN;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
+use ckb_core::BlockNumber;
 use ckb_logger::{debug, log_enabled, warn, Level};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::{cast, FlatbuffersVectorIterator, Headers};
@@ -75,13 +76,17 @@ impl<'a, CS: ChainStore + 'a> BlockMedianTimeContext for VerifierResolver<'a, CS
             .median_time_block_count() as u64
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         let header = self
             .synchronizer
             .shared
             .get_header(&block_hash)
             .expect("[VerifierResolver] blocks used for median time exist");
-        (header.timestamp(), header.parent_hash().to_owned())
+        (
+            header.timestamp(),
+            header.number(),
+            header.parent_hash().to_owned(),
+        )
     }
 }
 

--- a/traits/src/block_median_time_context.rs
+++ b/traits/src/block_median_time_context.rs
@@ -1,33 +1,34 @@
 use ckb_core::BlockNumber;
 use numext_fixed_hash::H256;
-use std::cmp::min;
 
 /// The invoker should only rely on `block_median_time` function
 /// the other functions only use to help the default `block_median_time`, and maybe unimplemented.
 pub trait BlockMedianTimeContext {
     fn median_block_count(&self) -> u64;
 
-    /// Return timestamp of the corresponding bloch_hash, and hash of parent block
+    /// Return timestamp and block_number of the corresponding bloch_hash, and hash of parent block
     ///
     /// Fake implementation:
     /// ```ignore
     /// let current_header = get_block_header(block_hash);
     /// let parent_header = current_header.timestamp_and_parent().header();
-    /// return (parent_header.timestamp(), parent_header.hash());
+    /// return (parent_header.timestamp(), current_header.number(), parent_header.hash());
     /// ```
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256);
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256);
 
     /// Return past block median time, **including the timestamp of the given one**
-    ///
-    /// It's duty for outside caller to ensure that the block_number and block_hash are matched
-    fn block_median_time(&self, block_number: BlockNumber, block_hash: &H256) -> u64 {
-        let median_time_span = min(block_number + 1, self.median_block_count());
+    fn block_median_time(&self, block_hash: &H256) -> u64 {
+        let median_time_span = self.median_block_count();
         let mut timestamps: Vec<u64> = Vec::with_capacity(median_time_span as usize);
         let mut block_hash = block_hash.to_owned();
         for _ in 0..median_time_span {
-            let (timestamp, parent_hash) = self.timestamp_and_parent(&block_hash);
+            let (timestamp, block_number, parent_hash) = self.timestamp_and_parent(&block_hash);
             timestamps.push(timestamp);
             block_hash = parent_hash;
+
+            if block_number == 0 {
+                break;
+            }
         }
 
         // return greater one if count is even.

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -41,11 +41,15 @@ impl<'a, P: ChainProvider> BlockMedianTimeContext for ForkContext<'a, P> {
         self.provider.consensus().median_time_block_count() as u64
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         let header = self
             .get_block_header(block_hash)
             .expect("[ForkContext] blocks used for median time exist");
-        (header.timestamp(), header.parent_hash().to_owned())
+        (
+            header.timestamp(),
+            header.number(),
+            header.parent_hash().to_owned(),
+        )
     }
 }
 

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -88,10 +88,9 @@ impl<'a, M: BlockMedianTimeContext> TimestampVerifier<'a, M> {
             return Ok(());
         }
 
-        let parent_number = self.header.number() - 1;
         let min = self
             .block_median_time_context
-            .block_median_time(parent_number, self.header.parent_hash());
+            .block_median_time(self.header.parent_hash());
         if self.header.timestamp() <= min {
             return Err(Error::Timestamp(TimestampError::BlockTimeTooOld {
                 min,

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -248,13 +248,13 @@ impl BlockMedianTimeContext for FakeMedianTime {
         11
     }
 
-    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, H256) {
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
         for i in 0..self.timestamps.len() {
             if &get_block_hash(i as u64) == block_hash {
                 if i == 0 {
-                    return (self.timestamps[i], H256::zero());
+                    return (self.timestamps[i], i as u64, H256::zero());
                 } else {
-                    return (self.timestamps[i], get_block_hash(i as u64 - 1));
+                    return (self.timestamps[i], i as u64, get_block_hash(i as u64 - 1));
                 }
             }
         }


### PR DESCRIPTION
* Remove `block_number` from API `BlockMedianTimeContext::block_median_time`. 

  Originally we pass `block_number` as a parameter to help calculate the span

  ```
  span_start = min(0, block_number-customed_span)
  span = [span_start, block_number]
  ```

  In fact, it is unnecessary to calculate the span if we can know whether we reach the genesis during traveling the blocks. We can get it with the help of `timestamp_and_parent`!
  So I reduce the `block_number` from `block_median_time`, to make the API more simplified.