### PR TITLE
feat: Network flood control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tentacle-discovery 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tentacle-identify 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tentacle-ping 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3288,7 +3288,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-secio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-secio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-yamux 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3308,7 +3308,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3321,7 +3321,7 @@ dependencies = [
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers-verifier 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3336,12 +3336,12 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-secio"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3358,6 +3358,7 @@ dependencies = [
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4189,11 +4190,11 @@ dependencies = [
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum tentacle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8dcddd2761682b538db6c0d20723a031d6beeac74d73656e5e9b54ff6cd25bed"
+"checksum tentacle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ea86eecc50e36fdcdc6988df3eda74f4c8db0e8c3662967727f22b9dc9f04828"
 "checksum tentacle-discovery 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66079c177dba4f89cc882d74a16b037774059cf5be4fe9179b12937d7b4ffe40"
 "checksum tentacle-identify 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0f13bf5f9f87cb2fa5d1a8096e5bcb6d44d2129cf4267589253218999e1c0595"
 "checksum tentacle-ping 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad0c0e23ab0c103ce91f6d5c19554fce95f82abc542739360b273e1bc46edbe"
-"checksum tentacle-secio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1f7e6cfc62a132bec2b68c0827dcbfbe7b54744783aeaf15219acaeb8e07e8cd"
+"checksum tentacle-secio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68e251e2ba61b9eee447df6a7e1d8eeda96b480f007206eb50e18f757f89fb30"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,7 +21,7 @@ tokio = "0.1.18"
 tokio-threadpool = "0.1"
 futures = "0.1"
 crossbeam-channel = "0.3"
-p2p = { version="0.2.1", package="tentacle" }
+p2p = { version="0.2.3", package="tentacle" }
 p2p-ping = { version="0.3.5", package="tentacle-ping" }
 p2p-discovery = { version="0.2.5", package="tentacle-discovery" }
 p2p-identify = { version="0.2.6", package="tentacle-identify" }

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -1,5 +1,7 @@
-use crate::errors::{ConfigError, Error};
-use crate::PeerId;
+use crate::{
+    errors::{ConfigError, Error},
+    PeerId, DEFAULT_SEND_BUFFER,
+};
 use ckb_logger::info;
 use p2p::{
     multiaddr::{Multiaddr, Protocol},
@@ -36,6 +38,9 @@ pub struct NetworkConfig {
     pub upnp: bool,
     #[serde(default)]
     pub bootnode_mode: bool,
+    // Max send buffer size
+    #[serde(default)]
+    pub max_send_buffer: Option<usize>,
 }
 
 fn generate_random_key() -> [u8; 32] {
@@ -74,6 +79,10 @@ impl NetworkConfig {
 
     pub fn max_outbound_peers(&self) -> u32 {
         self.max_outbound_peers
+    }
+
+    pub fn max_send_buffer(&self) -> usize {
+        self.max_send_buffer.unwrap_or(DEFAULT_SEND_BUFFER)
     }
 
     fn read_secret_key(&self) -> Result<Option<secio::SecioKeyPair>, Error> {

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -39,7 +39,6 @@ pub struct NetworkConfig {
     #[serde(default)]
     pub bootnode_mode: bool,
     // Max send buffer size
-    #[serde(default)]
     pub max_send_buffer: Option<usize>,
 }
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -33,4 +33,7 @@ pub use p2p::{
 
 // Max message frame length: 20MB
 pub const MAX_FRAME_LENGTH: usize = 20 * 1024 * 1024;
+// Max data size in send buffer: 24MB (a little larger than max frame length)
+pub const DEFAULT_SEND_BUFFER: usize = 24 * 1024 * 1024;
+
 pub type ProtocolVersion = String;

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -56,6 +56,7 @@ pub trait CKBProtocolContext: Send {
     fn connected_peers(&self) -> Vec<PeerIndex>;
     fn report_peer(&self, peer_index: PeerIndex, behaviour: Behaviour);
     fn ban_peer(&self, peer_index: PeerIndex, duration: Duration);
+    fn pause_send(&self) -> bool;
     // Other methods
     fn protocol_id(&self) -> ProtocolId;
 }
@@ -173,6 +174,7 @@ impl ServiceProtocol for CKBHandler {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
+            pause_send: false,
         };
         nc.set_notify(Duration::from_secs(6), std::u64::MAX)
             .expect("set_notify at init should be ok");
@@ -180,20 +182,26 @@ impl ServiceProtocol for CKBHandler {
     }
 
     fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+        let pending_data_size = context.session.pending_data_size();
+        let pause_send = pending_data_size >= self.network_state.config.max_send_buffer();
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
+            pause_send,
         };
         let peer_index = context.session.id;
         self.handler.connected(Arc::new(nc), peer_index, version);
     }
 
     fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        let pending_data_size = context.session.pending_data_size();
+        let pause_send = pending_data_size >= self.network_state.config.max_send_buffer();
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
+            pause_send,
         };
         let peer_index = context.session.id;
         self.handler.disconnected(Arc::new(nc), peer_index);
@@ -206,10 +214,13 @@ impl ServiceProtocol for CKBHandler {
             context.session.id,
             data.len()
         );
+        let pending_data_size = context.session.pending_data_size();
+        let pause_send = pending_data_size >= self.network_state.config.max_send_buffer();
         let nc = DefaultCKBProtocolContext {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
+            pause_send,
         };
         let peer_index = context.session.id;
         self.handler.received(Arc::new(nc), peer_index, data);
@@ -223,6 +234,7 @@ impl ServiceProtocol for CKBHandler {
                 proto_id: self.proto_id,
                 network_state: Arc::clone(&self.network_state),
                 p2p_control: context.control().to_owned(),
+                pause_send: false,
             };
             self.handler.notify(Arc::new(nc), token);
         }
@@ -233,6 +245,7 @@ impl ServiceProtocol for CKBHandler {
             proto_id: self.proto_id,
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
+            pause_send: false,
         };
         self.handler.poll(Arc::new(nc));
     }
@@ -242,6 +255,7 @@ struct DefaultCKBProtocolContext {
     proto_id: ProtocolId,
     network_state: Arc<NetworkState>,
     p2p_control: ServiceControl,
+    pause_send: bool,
 }
 
 impl CKBProtocolContext for DefaultCKBProtocolContext {
@@ -347,6 +361,10 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
 
     fn protocol_id(&self) -> ProtocolId {
         self.proto_id
+    }
+
+    fn pause_send(&self) -> bool {
+        self.pause_send
     }
 }
 

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -105,6 +105,7 @@ fn net_service_start(name: String) -> Node {
         discovery_local_address: true,
         upnp: false,
         bootnode_mode: true,
+        max_send_buffer: None,
     };
 
     let network_state =

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -55,6 +55,14 @@ where
                 continue;
             }
 
+            if self.nc.pause_send() {
+                debug!(
+                    "Session send buffer is full, stop send blocks to peer {:?}",
+                    self.peer
+                );
+                break;
+            }
+
             if let Some(block) = store.get_block(&block_hash) {
                 debug!(
                     "respond_block {} {:x} to peer {:?}",

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -55,7 +55,7 @@ where
                 continue;
             }
 
-            if self.nc.pause_send() {
+            if self.nc.send_paused() {
                 debug!(
                     "Session send buffer is full, stop send blocks to peer {:?}",
                     self.peer

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -977,7 +977,7 @@ mod tests {
         fn protocol_id(&self) -> ProtocolId {
             unimplemented!();
         }
-        fn pause_send(&self) -> bool {
+        fn send_paused(&self) -> bool {
             false
         }
     }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -977,6 +977,9 @@ mod tests {
         fn protocol_id(&self) -> ProtocolId {
             unimplemented!();
         }
+        fn pause_send(&self) -> bool {
+            false
+        }
     }
 
     fn mock_network_context(peer_num: usize) -> DummyNetworkContext {

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -242,4 +242,7 @@ impl CKBProtocolContext for TestNetworkContext {
     fn protocol_id(&self) -> ProtocolId {
         self.protocol
     }
+    fn pause_send(&self) -> bool {
+        false
+    }
 }

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -242,7 +242,7 @@ impl CKBProtocolContext for TestNetworkContext {
     fn protocol_id(&self) -> ProtocolId {
         self.protocol
     }
-    fn pause_send(&self) -> bool {
+    fn send_paused(&self) -> bool {
         false
     }
 }

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -82,6 +82,7 @@ impl Net {
                     discovery_local_address: true,
                     upnp: false,
                     bootnode_mode: false,
+                    max_send_buffer: None,
                 };
 
                 let network_state =


### PR DESCRIPTION
Do not send blocks to peer when session send buffer is full.