### PR TITLE
test: Create a mock block_median_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,8 +1029,10 @@ dependencies = [
  "ckb-db 0.17.0-pre",
  "ckb-hash 0.17.0-pre",
  "ckb-store 0.17.0-pre",
+ "ckb-traits 0.17.0-pre",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -12,6 +12,8 @@ ckb-hash = { path = "../hash" }
 ckb-store = { path = "../../store" }
 ckb-chain-spec = { path = "../../spec" }
 ckb-dao-utils = { path = "../dao/utils" }
+ckb-traits = { path = "../../traits" }
 lazy_static = "1.3.0"
 faketime = "0.2.0"
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
+numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }

--- a/util/test-chain-utils/src/lib.rs
+++ b/util/test-chain-utils/src/lib.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 mod macros;
 mod chain;
+mod median_time;
 mod mock_store;
 
 pub use chain::{always_success_cell, always_success_cellbase, always_success_consensus};
+pub use median_time::MockMedianTime;
 pub use mock_store::MockStore;

--- a/util/test-chain-utils/src/median_time.rs
+++ b/util/test-chain-utils/src/median_time.rs
@@ -1,0 +1,47 @@
+use ckb_core::cell::BlockInfo;
+use ckb_core::{BlockNumber, EpochNumber};
+use ckb_traits::BlockMedianTimeContext;
+use numext_fixed_hash::H256;
+
+pub struct MockMedianTime {
+    timestamps: Vec<u64>,
+}
+
+impl BlockMedianTimeContext for MockMedianTime {
+    fn median_block_count(&self) -> u64 {
+        11
+    }
+
+    fn timestamp_and_parent(&self, block_hash: &H256) -> (u64, BlockNumber, H256) {
+        for i in 0..self.timestamps.len() {
+            if &Self::get_block_hash(i as u64) == block_hash {
+                if i == 0 {
+                    return (self.timestamps[i], i as u64, H256::zero());
+                } else {
+                    return (
+                        self.timestamps[i],
+                        i as u64,
+                        Self::get_block_hash(i as u64 - 1),
+                    );
+                }
+            }
+        }
+        unreachable!()
+    }
+}
+
+impl MockMedianTime {
+    pub fn new(timestamps: Vec<u64>) -> Self {
+        Self { timestamps }
+    }
+
+    pub fn get_block_hash(block_number: BlockNumber) -> H256 {
+        let vec: Vec<u8> = (0..32).map(|_| block_number as u8).collect();
+        H256::from_slice(vec.as_slice()).unwrap()
+    }
+
+    pub fn get_block_info(block_number: BlockNumber, epoch_number: EpochNumber) -> BlockInfo {
+        let block_hash = Self::get_block_hash(block_number);
+        BlockInfo::new(block_number, epoch_number, block_hash)
+    }
+}


### PR DESCRIPTION
Create `MockMedianTime`, a testing util type, so that tests can share the same mocked implementation of `BlockMedianTimeContext`