### PR TITLE
feat: log found block as info when stderr is not tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "ckb-traits 0.17.0-pre",
  "ckb-util 0.17.0-pre",
  "ckb-verification 0.17.0-pre",
+ "console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -31,6 +31,7 @@ ckb-traits = { path = "../traits" }
 failure = "0.1.5"
 ckb-verification = { path = "../verification" }
 indicatif = "0.11"
+console = "0.7.5"
 ckb-dao = { path = "../util/dao" }
 
 [dev-dependencies]


### PR DESCRIPTION
The default systemd init script redirects stderr to /dev/null. This change
ensure the daemon will log the found blocks as info level log.