### PR TITLE
fix: should check tx from pool when the short_id set is not empty

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -284,7 +284,7 @@ impl<CS: ChainStore + 'static> Relayer<CS> {
             })
             .collect();
 
-        if short_ids_set.is_empty() {
+        if !short_ids_set.is_empty() {
             let chain_state = self.shared().lock_chain_state();
             for entry in chain_state.tx_pool().proposed_txs_iter() {
                 let short_id = short_transaction_id(key0, key1, &entry.transaction.witness_hash());


### PR DESCRIPTION
I believe it's a typo.