### PR TITLE
test: sync fork contains invalid blocks

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -30,6 +30,14 @@ fn main() {
     );
     specs.insert("block_sync_orphan_blocks", Box::new(BlockSyncOrphanBlocks));
     specs.insert("sync_timeout", Box::new(SyncTimeout));
+    specs.insert(
+        "chain_contains_invalid_block",
+        Box::new(ChainContainsInvalidBlock),
+    );
+    specs.insert(
+        "fork_contains_invalid_block",
+        Box::new(ForkContainsInvalidBlock),
+    );
     specs.insert("chain_fork_1", Box::new(ChainFork1));
     specs.insert("chain_fork_2", Box::new(ChainFork2));
     // FIXME these 4 tests will fail, because of https://github.com/nervosnetwork/ckb/pull/1164

--- a/test/src/specs/sync/invalid_block.rs
+++ b/test/src/specs/sync/invalid_block.rs
@@ -1,0 +1,204 @@
+use crate::utils::{build_block, build_get_blocks, build_headers, wait_until};
+use crate::{Net, Spec, TestProtocol};
+use ckb_core::block::Block;
+use ckb_core::transaction::TransactionBuilder;
+use ckb_protocol::{get_root, SyncMessage, SyncPayload};
+use ckb_sync::NetworkProtocol;
+use std::time::Duration;
+
+pub struct ChainContainsInvalidBlock;
+
+impl Spec for ChainContainsInvalidBlock {
+    // Case:
+    //   1. `bad_node` generate a long chain `CN` contains a invalid block
+    //      B[i] is an invalid block.
+    //   2. `good_node` synchronizes from `bad_node`. We expect that `good_node`
+    //      end synchronizing at B[i-1].
+    //   3. `good_node` mines a new block B[i]', i < `CN.length`.
+    //   4. `fresh_node` synchronizes from `bad_node` and `good_node`. We expect
+    //      that `fresh_node` synchronizes the valid chain.
+    fn run(&self, net: Net) {
+        let mut net = net;
+        let bad_node = net.nodes.pop().unwrap();
+        let good_node = net.nodes.pop().unwrap();
+        let fresh_node = net.nodes.pop().unwrap();
+
+        // Build invalid chain on bad_node
+        bad_node.generate_blocks(3);
+        let invalid_block = bad_node
+            .new_block_builder(None, None, None)
+            .transaction(TransactionBuilder::default().build())
+            .build();
+        let invalid_number = invalid_block.header().number();
+        let invalid_hash = bad_node.process_block_without_verify(&invalid_block);
+        bad_node.generate_blocks(3);
+
+        // Start good_node and let it synchronize from bad_node
+        good_node.generate_block();
+        fresh_node.connect(&good_node);
+        good_node.connect(&bad_node);
+        fresh_node.connect(&bad_node);
+        assert!(
+            wait_until(5, || good_node.get_tip_block_number() >= invalid_number - 1),
+            "good_node should synchronize from bad_node 1~{}",
+            invalid_number - 1,
+        );
+        assert!(
+            !wait_until(5, || good_node
+                .rpc_client()
+                .get_block(invalid_hash.clone())
+                .is_some()),
+            "good_node should not synchronize invalid block {} from bad_node",
+            invalid_number,
+        );
+
+        // good_node mine the next block
+        good_node.generate_block();
+        let valid_hash = good_node.get_tip_block().header().hash().clone();
+        let valid_number = invalid_number + 1;
+
+        assert!(
+            !wait_until(5, || fresh_node.get_tip_block_number() > valid_number),
+            "fresh_node should synchronize the valid blocks only",
+        );
+        assert!(
+            wait_until(5, || fresh_node.get_tip_block().header().hash()
+                == &valid_hash),
+            "fresh_node should synchronize the valid blocks only",
+        );
+    }
+
+    fn connect_all(&self) -> bool {
+        false
+    }
+
+    fn num_nodes(&self) -> usize {
+        3
+    }
+
+    fn test_protocols(&self) -> Vec<TestProtocol> {
+        vec![TestProtocol::sync()]
+    }
+}
+
+pub struct ForkContainsInvalidBlock;
+
+impl Spec for ForkContainsInvalidBlock {
+    fn run(&self, net: Net) {
+        let mut net = net;
+
+        // Build bad forks
+        let invalid_number = 4;
+        let bad_chain: Vec<Block> = {
+            let tip_number = invalid_number * 2;
+            let bad_node = net.nodes.pop().unwrap();
+            bad_node.generate_blocks(invalid_number - 1);
+            let invalid_block = bad_node
+                .new_block_builder(None, None, None)
+                .transaction(TransactionBuilder::default().build())
+                .build();
+            bad_node.process_block_without_verify(&invalid_block);
+            bad_node.generate_blocks(tip_number - invalid_number);
+            (1..=bad_node.get_tip_block_number())
+                .map(|i| bad_node.get_block_by_number(i))
+                .collect()
+        };
+        let bad_hashes: Vec<_> = bad_chain
+            .iter()
+            .skip(invalid_number - 1)
+            .map(|b| b.header().hash().to_owned())
+            .collect();
+
+        // Sync headers of bad forks
+        let good_node = net.nodes.pop().unwrap();
+        good_node.generate_block();
+        net.connect(&good_node);
+        let (pi, _, _) = net.receive();
+        let headers: Vec<_> = bad_chain.iter().map(|b| b.header().clone()).collect();
+        net.send(NetworkProtocol::SYNC.into(), pi, build_headers(&headers));
+        assert!(wait_get_blocks(&net), "timeout to wait GetBlocks",);
+
+        // Build good chain (good_chain.len < bad_chain.len)
+        good_node.generate_blocks(invalid_number + 2);
+        let tip_block = good_node.get_tip_block();
+
+        // Sync first part of bad fork which contains an invalid block
+        // Good_node cannot detect the invalid block since "block delay verification".
+        let (bad_chain1, bad_chain2) = bad_chain.split_at(invalid_number + 1);
+        bad_chain1
+            .iter()
+            .for_each(|block| net.send(NetworkProtocol::SYNC.into(), pi, build_block(block)));
+        let last_hash = bad_chain1
+            .last()
+            .map(|b| b.header().hash().to_owned())
+            .unwrap();
+        assert!(
+            wait_until(10, || good_node
+                .rpc_client()
+                .get_block(last_hash.clone())
+                .is_some()),
+            "good_node should store the fork blocks even it contains invalid blocks",
+        );
+        assert_eq!(good_node.get_tip_block(), tip_block);
+
+        // Sync second part of bad fork.
+        // Good_node detect the invalid block when fork.total_difficulty > tip.difficulty
+        bad_chain2
+            .iter()
+            .for_each(|block| net.send(NetworkProtocol::SYNC.into(), pi, build_block(block)));
+        let last_hash = bad_chain2
+            .last()
+            .map(|b| b.header().hash().to_owned())
+            .unwrap();
+        assert!(
+            !wait_until(10, || good_node
+                .rpc_client()
+                .get_block(last_hash.clone())
+                .is_some()),
+            "good_node should keep the good chain",
+        );
+        assert_eq!(good_node.get_tip_block(), tip_block);
+
+        // Additional testing: request an invalid fork via `GetBlock` should be failed
+        net.send(
+            NetworkProtocol::SYNC.into(),
+            pi,
+            build_get_blocks(&bad_hashes),
+        );
+        let ret = wait_until(10, || {
+            if let Ok((_, _, data)) = net.receive_timeout(Duration::from_secs(10)) {
+                if let Ok(message) = get_root::<SyncMessage>(&data) {
+                    return message.payload_type() == SyncPayload::Block;
+                }
+            }
+            false
+        });
+        assert!(
+            !ret,
+            "request an invalid fork via GetBlock should be failed"
+        );
+    }
+
+    fn connect_all(&self) -> bool {
+        false
+    }
+
+    fn num_nodes(&self) -> usize {
+        2
+    }
+
+    fn test_protocols(&self) -> Vec<TestProtocol> {
+        vec![TestProtocol::sync()]
+    }
+}
+
+fn wait_get_blocks(net: &Net) -> bool {
+    wait_until(10, || {
+        if let Ok((_, _, data)) = net.receive_timeout(Duration::from_secs(10)) {
+            if let Ok(message) = get_root::<SyncMessage>(&data) {
+                return message.payload_type() == SyncPayload::GetBlocks;
+            }
+        }
+        false
+    })
+}

--- a/test/src/specs/sync/mod.rs
+++ b/test/src/specs/sync/mod.rs
@@ -1,9 +1,11 @@
 mod block_sync;
 mod chain_forks;
+mod invalid_block;
 mod invalid_locator_size;
 mod sync_timeout;
 
 pub use block_sync::*;
 pub use chain_forks::*;
+pub use invalid_block::{ChainContainsInvalidBlock, ForkContainsInvalidBlock};
 pub use invalid_locator_size::InvalidLocatorSize;
 pub use sync_timeout::SyncTimeout;

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -6,6 +6,7 @@ use ckb_core::BlockNumber;
 use ckb_jsonrpc_types::BlockTemplate;
 use ckb_protocol::{RelayMessage, SyncMessage};
 use flatbuffers::FlatBufferBuilder;
+use numext_fixed_hash::H256;
 use std::collections::HashSet;
 use std::convert::Into;
 use std::thread::sleep;
@@ -60,6 +61,13 @@ pub fn build_headers(headers: &[Header]) -> Bytes {
 pub fn build_block(block: &Block) -> Bytes {
     let fbb = &mut FlatBufferBuilder::new();
     let message = SyncMessage::build_block(fbb, block);
+    fbb.finish(message, None);
+    fbb.finished_data().into()
+}
+
+pub fn build_get_blocks(hashes: &[H256]) -> Bytes {
+    let fbb = &mut FlatBufferBuilder::new();
+    let message = SyncMessage::build_get_blocks(fbb, hashes);
     fbb.finish(message, None);
     fbb.finished_data().into()
 }


### PR DESCRIPTION
A bug we meet during the last testnet: A fork contains an invalid block. When we try to switch the fork as the main chain, it should be failed as expected.