### PR TITLE
chore: optional start some network service

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -141,4 +141,12 @@ impl NetworkConfig {
         }
         Ok(peers)
     }
+
+    pub fn outbound_peer_service_enabled(&self) -> bool {
+        self.connect_outbound_interval_secs > 0
+    }
+
+    pub fn dns_seeding_service_enabled(&self) -> bool {
+        !self.dns_seeds.is_empty()
+    }
 }

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -815,21 +815,24 @@ impl NetworkService {
             p2p_service.control().to_owned(),
             ping_receiver,
         );
-        let outbound_peer_service = OutboundPeerService::new(
-            Arc::clone(&network_state),
-            p2p_service.control().to_owned(),
-            Duration::from_secs(config.connect_outbound_interval_secs),
-        );
-        let dns_seeding_service = DnsSeedingService::new(
-            Arc::clone(&network_state),
-            network_state.config.dns_seeds.clone(),
-        );
-        let bg_services = vec![
+        let mut bg_services = vec![
             Box::new(ping_service.for_each(|_| Ok(()))) as Box<_>,
             Box::new(disc_service) as Box<_>,
-            Box::new(outbound_peer_service) as Box<_>,
-            Box::new(dns_seeding_service) as Box<_>,
         ];
+        if config.outbound_peer_service_enabled() {
+            let outbound_peer_service = OutboundPeerService::new(
+                Arc::clone(&network_state),
+                p2p_service.control().to_owned(),
+                Duration::from_secs(config.connect_outbound_interval_secs),
+            );
+            bg_services.push(Box::new(outbound_peer_service) as Box<_>);
+        };
+
+        if config.dns_seeding_service_enabled() {
+            let dns_seeding_service =
+                DnsSeedingService::new(Arc::clone(&network_state), config.dns_seeds.clone());
+            bg_services.push(Box::new(dns_seeding_service) as Box<_>);
+        };
 
         NetworkService {
             p2p_service,

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -78,7 +78,7 @@ impl Net {
                         .to_path_buf(),
                     ping_interval_secs: 15,
                     ping_timeout_secs: 20,
-                    connect_outbound_interval_secs: 1,
+                    connect_outbound_interval_secs: 0,
                     discovery_local_address: true,
                     upnp: false,
                     bootnode_mode: false,

--- a/test/src/specs/alert/alert_propagation.rs
+++ b/test/src/specs/alert/alert_propagation.rs
@@ -114,7 +114,6 @@ impl Spec for AlertPropagation {
     fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
         let alert_config = self.alert_config.to_owned();
         Box::new(move |config| {
-            config.network.connect_outbound_interval_secs = 1;
             config.network.discovery_local_address = true;
             // set test alert config
             config.alert_signature = Some(alert_config.clone());

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -40,8 +40,9 @@ pub trait Spec {
     }
 
     fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        // disable outbound peer service
         Box::new(|config| {
-            config.network.connect_outbound_interval_secs = 1;
+            config.network.connect_outbound_interval_secs = 0;
             config.network.discovery_local_address = true;
         })
     }

--- a/test/src/specs/p2p/discovery.rs
+++ b/test/src/specs/p2p/discovery.rs
@@ -1,5 +1,6 @@
 use crate::utils::wait_until;
 use crate::{Net, Spec};
+use ckb_app_config::CKBAppConfig;
 use log::info;
 
 pub struct Discovery;
@@ -25,5 +26,13 @@ impl Spec for Discovery {
 
     fn num_nodes(&self) -> usize {
         3
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        // enable outbound peer service to connect discovered peers
+        Box::new(|config| {
+            config.network.connect_outbound_interval_secs = 1;
+            config.network.discovery_local_address = true;
+        })
     }
 }

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -1,5 +1,4 @@
 use crate::{Net, Spec};
-use ckb_app_config::CKBAppConfig;
 use ckb_core::block::{Block, BlockBuilder};
 use ckb_core::transaction::{Transaction, TransactionBuilder};
 use ckb_core::{capacity_bytes, Capacity};
@@ -96,11 +95,6 @@ impl Spec for ChainFork2 {
     fn connect_all(&self) -> bool {
         false
     }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
-    }
 }
 
 pub struct ChainFork3;
@@ -167,11 +161,6 @@ impl Spec for ChainFork3 {
     fn connect_all(&self) -> bool {
         false
     }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
-    }
 }
 
 pub struct ChainFork4;
@@ -237,11 +226,6 @@ impl Spec for ChainFork4 {
 
     fn connect_all(&self) -> bool {
         false
-    }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
     }
 }
 
@@ -313,11 +297,6 @@ impl Spec for ChainFork5 {
     fn connect_all(&self) -> bool {
         false
     }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
-    }
 }
 
 pub struct ChainFork6;
@@ -379,11 +358,6 @@ impl Spec for ChainFork6 {
 
     fn connect_all(&self) -> bool {
         false
-    }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
     }
 }
 
@@ -454,11 +428,6 @@ impl Spec for ChainFork7 {
 
     fn connect_all(&self) -> bool {
         false
-    }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
     }
 }
 

--- a/test/src/specs/sync/sync_timeout.rs
+++ b/test/src/specs/sync/sync_timeout.rs
@@ -1,5 +1,4 @@
 use crate::{Net, Spec};
-use ckb_app_config::CKBAppConfig;
 use log::info;
 
 pub struct SyncTimeout;
@@ -51,10 +50,5 @@ impl Spec for SyncTimeout {
 
     fn connect_all(&self) -> bool {
         false
-    }
-
-    // workaround to disable node discovery
-    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
-        Box::new(|config| config.network.connect_outbound_interval_secs = 100_000)
     }
 }


### PR DESCRIPTION
optional start `OutboundPeerService` and `DnsSeedingService`, and fix random failure integration test `BlockSyncDuplicatedAndReconnect `