### PR TITLE
fix: build.rs failed without git dir

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ fn main() {
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-changed=.git/HEAD");
 
-        let head = std::fs::read_to_string(".git/HEAD").expect("read .git/HEAD");
+        let head = std::fs::read_to_string(".git/HEAD").unwrap_or_default();
         if head.starts_with("ref: ") {
             println!("cargo:rerun-if-changed=.git/{}", head[5..].trim());
         }


### PR DESCRIPTION
Ignore the error when failed to read .git/HEAD.

Closes https://github.com/nervosnetwork/ckb/issues/1231