### PR TITLE
fix: there is an incorrect deserialization in indexer

### DIFF
--- a/indexer/src/store.rs
+++ b/indexer/src/store.rs
@@ -516,10 +516,10 @@ impl IndexerStoreBatch {
                 db.read(COLUMN_LOCK_HASH_LIVE_CELL, &lock_hash_index.to_vec())
                     .expect("indexer db read should be ok")
                     .map(|value| deserialize(&value).expect("deserialize CellOutput should be ok"))
-                    .map(|cell_output| LockHashCellOutput {
+                    .map(|cell_output: CellOutput| LockHashCellOutput {
                         lock_hash: lock_hash_index.lock_hash.clone(),
                         block_number: lock_hash_index.block_number,
-                        cell_output,
+                        cell_output: Some(cell_output),
                     })
             })
         {


### PR DESCRIPTION
### Bug

- Insert a `CellOutput`
  https://github.com/nervosnetwork/ckb/blob/bd7865a76e5b53608f698a5fbeafc1f797ceb69d/indexer/src/store.rs#L548-L555

- Select as `Option<CellOutput>`
  https://github.com/nervosnetwork/ckb/blob/bd7865a76e5b53608f698a5fbeafc1f797ceb69d/indexer/src/store.rs#L516-L522
  https://github.com/nervosnetwork/ckb/blob/bd7865a76e5b53608f698a5fbeafc1f797ceb69d/indexer/src/types.rs#L36-L41