### PR TITLE
feat: uncle descendant limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,6 @@ dependencies = [
  "ckb-test-chain-utils 0.17.0-pre",
  "ckb-traits 0.17.0-pre",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -365,7 +365,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
             );
             for detached_block in fork.detached_blocks() {
                 self.notify
-                    .notify_new_uncle(Arc::new(detached_block.clone()));
+                    .notify_new_uncle(Arc::new(detached_block.into()));
             }
             if log_enabled!(ckb_logger::Level::Debug) {
                 self.print_chain(&chain_state, 10);
@@ -378,7 +378,8 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                 cannon_total_difficulty,
                 block.transactions().len()
             );
-            self.notify.notify_new_uncle(block);
+            let block_ref: &Block = &block;
+            self.notify.notify_new_uncle(Arc::new(block_ref.into()));
         }
 
         Ok(true)
@@ -618,8 +619,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                                     if log_enabled!(ckb_logger::Level::Trace) {
                                         trace!("block {}", serde_json::to_string(b).unwrap());
                                     }
-                                    found_error =
-                                        Some(SharedError::InvalidTransaction(err.to_string()));
+                                    found_error = Some(SharedError::InvalidBlock(err.to_string()));
                                     *verified = Some(false);
                                 }
                             }

--- a/core/src/uncle.rs
+++ b/core/src/uncle.rs
@@ -22,6 +22,15 @@ impl From<Block> for UncleBlock {
     }
 }
 
+impl<'a> From<&'a Block> for UncleBlock {
+    fn from(block: &'a Block) -> Self {
+        UncleBlock {
+            header: block.header().to_owned(),
+            proposals: block.proposals().to_vec(),
+        }
+    }
+}
+
 impl UncleBlock {
     pub fn new(header: Header, proposals: Vec<ProposalShortId>) -> UncleBlock {
         UncleBlock { header, proposals }

--- a/miner/src/candidate_uncles.rs
+++ b/miner/src/candidate_uncles.rs
@@ -1,0 +1,156 @@
+use ckb_core::uncle::UncleBlock;
+use ckb_core::BlockNumber;
+use std::collections::{btree_map::Entry, BTreeMap, HashSet};
+use std::sync::Arc;
+
+#[cfg(not(test))]
+const MAX_CANDIDATE_UNCLES: usize = 128;
+#[cfg(test)]
+const MAX_CANDIDATE_UNCLES: usize = 4;
+
+#[cfg(not(test))]
+const MAX_PER_HEIGHT: usize = 10;
+#[cfg(test)]
+const MAX_PER_HEIGHT: usize = 2;
+
+pub struct CandidateUncles {
+    pub(in crate::candidate_uncles) map: BTreeMap<BlockNumber, HashSet<Arc<UncleBlock>>>,
+    count: usize,
+}
+
+impl CandidateUncles {
+    pub fn new() -> CandidateUncles {
+        CandidateUncles {
+            map: BTreeMap::new(),
+            count: 0,
+        }
+    }
+
+    pub fn insert(&mut self, uncle: Arc<UncleBlock>) -> bool {
+        let number = uncle.header().number();
+        if self.count >= MAX_CANDIDATE_UNCLES {
+            let first_key = *self.map.keys().next().expect("length checked");
+            if number > first_key {
+                if let Some(set) = self.map.remove(&first_key) {
+                    self.count -= set.len();
+                }
+            } else {
+                return false;
+            }
+        }
+
+        let set = self.map.entry(number).or_insert_with(HashSet::new);
+        if set.len() < MAX_PER_HEIGHT {
+            let ret = set.insert(uncle);
+            if ret {
+                self.count += 1;
+            }
+            ret
+        } else {
+            false
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &Arc<UncleBlock>> {
+        self.map.values().flat_map(HashSet::iter)
+    }
+
+    pub fn remove(&mut self, uncle: &Arc<UncleBlock>) -> bool {
+        let number = uncle.header().number();
+
+        if let Entry::Occupied(mut entry) = self.map.entry(number) {
+            let set = entry.get_mut();
+            if set.remove(uncle) {
+                self.count -= 1;
+                if set.is_empty() {
+                    entry.remove();
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ckb_core::block::BlockBuilder;
+    use ckb_core::header::HeaderBuilder;
+
+    #[test]
+    fn test_candidate_uncles_basic() {
+        let mut candidate_uncles = CandidateUncles::new();
+        let block = &BlockBuilder::default().build();
+        assert!(candidate_uncles.insert(Arc::new(block.into())));
+        assert_eq!(candidate_uncles.len(), 1);
+        // insert duplicate
+        assert!(!candidate_uncles.insert(Arc::new(block.into())));
+        assert_eq!(candidate_uncles.len(), 1);
+
+        assert!(candidate_uncles.remove(&Arc::new(block.into())));
+        assert_eq!(candidate_uncles.len(), 0);
+        assert_eq!(candidate_uncles.map.len(), 0);
+    }
+
+    #[test]
+    fn test_candidate_uncles_max_size() {
+        let mut candidate_uncles = CandidateUncles::new();
+
+        let mut blocks = Vec::new();
+        for i in 0..(MAX_CANDIDATE_UNCLES + 3) {
+            let block = BlockBuilder::from_header_builder(
+                HeaderBuilder::default().number(i as BlockNumber),
+            )
+            .build();
+            blocks.push(block);
+        }
+
+        for block in &blocks {
+            candidate_uncles.insert(Arc::new(block.into()));
+        }
+        let first_key = *candidate_uncles.map.keys().next().unwrap();
+        assert_eq!(candidate_uncles.len(), MAX_CANDIDATE_UNCLES);
+        assert_eq!(first_key, 3);
+
+        candidate_uncles.clear();
+        for block in blocks.iter().rev() {
+            candidate_uncles.insert(Arc::new(block.into()));
+        }
+        let first_key = *candidate_uncles.map.keys().next().unwrap();
+        assert_eq!(candidate_uncles.len(), MAX_CANDIDATE_UNCLES);
+        assert_eq!(first_key, 3);
+    }
+
+    #[test]
+    fn test_candidate_uncles_max_per_height() {
+        let mut candidate_uncles = CandidateUncles::new();
+
+        let mut blocks = Vec::new();
+        for i in 0..(MAX_PER_HEIGHT + 3) {
+            let block =
+                BlockBuilder::from_header_builder(HeaderBuilder::default().timestamp(i as u64))
+                    .build();
+            blocks.push(block);
+        }
+
+        for block in &blocks {
+            candidate_uncles.insert(Arc::new(block.into()));
+        }
+        assert_eq!(candidate_uncles.map.len(), 1);
+        assert_eq!(candidate_uncles.len(), MAX_PER_HEIGHT);
+    }
+}

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -1,4 +1,6 @@
 mod block_assembler;
+#[allow(dead_code)]
+mod candidate_uncles;
 mod client;
 mod config;
 mod error;

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_pass_by_value)]
 
-use ckb_core::block::Block;
 use ckb_core::service::Request;
+use ckb_core::uncle::UncleBlock;
 use ckb_logger::{debug, trace, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use crossbeam_channel::{select, Receiver, Sender};
@@ -15,7 +15,7 @@ pub const NOTIFY_CHANNEL_SIZE: usize = 128;
 
 pub type MsgNewTransaction = ();
 // pub type MsgNewTip = Arc<Block>;
-pub type MsgNewUncle = Arc<Block>;
+pub type MsgNewUncle = Arc<UncleBlock>;
 // pub type MsgSwitchFork = Arc<ForkBlocks>;
 pub type NotifyRegister<M> = Sender<Request<(String, usize), Receiver<M>>>;
 

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -6,12 +6,12 @@ use failure::Fail;
 pub enum SharedError {
     #[fail(display = "UnresolvableTransaction: {:?}", _0)]
     UnresolvableTransaction(UnresolvableError),
-    #[fail(display = "InvalidTransaction: {}", _0)]
-    InvalidTransaction(String),
     #[fail(display = "InvalidParentBlock")]
     InvalidParentBlock,
     #[fail(display = "InvalidData error: {}", _0)]
     InvalidData(String),
+    #[fail(display = "InvalidBlock error: {}", _0)]
+    InvalidBlock(String),
     #[fail(display = "DB error: {}", _0)]
     DB(DBError),
 }

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -14,7 +14,6 @@ faketime = "0.2.0"
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 rayon = "1.0"
-fnv = "1.0.3"
 ckb-occupied-capacity = { path = "../util/occupied-capacity" }
 lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
 ckb-traits = { path = "../traits" }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -126,6 +126,7 @@ pub enum UnclesError {
     Duplicate(H256),
     DoubleInclusion(H256),
     InvalidCellbase,
+    DescendantLimit,
     ExceededMaximumProposalsLimit,
 }
 


### PR DESCRIPTION
# break changes
Append uncle verification rule:  A block B1 is considered to be the uncle of another block B2, B1's parent is either B2's ancestor or embedded in B2 or its ancestors as an uncle