### PR TITLE
chore: Disable whitelist-only mode by default

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NetworkConfig {
+    #[serde(default)]
     pub whitelist_only: bool,
     pub max_peers: u32,
     pub max_outbound_peers: u32,
@@ -29,8 +30,10 @@ pub struct NetworkConfig {
     pub ping_timeout_secs: u64,
     pub connect_outbound_interval_secs: u64,
     pub listen_addresses: Vec<Multiaddr>,
+    #[serde(default)]
     pub public_addresses: Vec<Multiaddr>,
     pub bootnodes: Vec<Multiaddr>,
+    #[serde(default)]
     pub whitelist_peers: Vec<Multiaddr>,
     #[serde(default)]
     pub upnp: bool,

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -39,7 +39,8 @@ dsn = "" # {{
 listen_addresses = ["/ip4/0.0.0.0/tcp/8115"] # {{
 # _ => listen_addresses = ["/ip4/0.0.0.0/tcp/{p2p_port}"]
 # }}
-public_addresses = []
+### Specify the public and routable network addresses
+# public_addresses = []
 
 # Node connects to nodes listed here to discovery other peers when there's no local stored peers.
 # When chain.spec is changed, this usually should also be changed to the bootnodes in the new chain.
@@ -47,8 +48,11 @@ bootnodes = [] # {{
 # testnet => bootnodes = [\n  # Hangzhou (China)\n  "/ip4/47.111.169.36/tcp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W",\n  # Ohio (USA)\n  "/ip4/18.217.146.65/tcp/8111/p2p/QmT6DFfm18wtbJz3y4aPNn3ac86N4d4p4xtfQRRPf73frC",\n  # Singapore\n  "/ip4/18.136.60.221/tcp/8111/p2p/QmTt6HeNakL8Fpmevrhdna7J4NzEMf9pLchf1CXtmtSrwb",\n  # London\n  "/ip4/35.176.207.239/tcp/8111/p2p/QmSJTsMsMGBjzv1oBNwQU36VhQRxc2WQpFoRu1ZifYKrjZ",\n]
 # }}
 
-whitelist_peers = []
-whitelist_only = false
+### Whitelist-only mode
+# whitelist_only = false
+### Whitelist peers connecting from the given IP addresses
+# whitelist_peers = []
+
 max_peers = 125
 max_outbound_peers = 8
 # 2 minutes


### PR DESCRIPTION
* Most people don't care `whitelist_peers/whitelist_only` and `public_addresses`. So I think it may be better to hide them.