### PR TITLE
feat: only allow default secp256k1 block assembler

### DIFF
--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -35,7 +35,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
     let _guard = setup.setup_app(&version);
 
     match app_matches.subcommand() {
-        (cli::CMD_RUN, _) => subcommand::run(setup.run()?, version),
+        (cli::CMD_RUN, Some(matches)) => subcommand::run(setup.run(&matches)?, version),
         (cli::CMD_MINER, _) => subcommand::miner(setup.miner()?),
         (cli::CMD_PROF, Some(matches)) => subcommand::profile(setup.prof(&matches)?),
         (cli::CMD_EXPORT, Some(matches)) => subcommand::export(setup.export(&matches)?),

--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -6,6 +6,8 @@ use ckb_resource::{
 };
 use ckb_script::Runner;
 
+const SECP256K1_BLAKE160_SIGHASH_ALL_ARG_LEN: usize = 20 * 2 + 2; // 42 = 20 x 2 + prefix 0x
+
 pub fn init(args: InitArgs) -> Result<(), ExitCode> {
     if args.list_chains {
         for spec in AVAILABLE_SPECS {
@@ -28,8 +30,16 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         Some(hash) => {
             if default_hash != *hash {
                 eprintln!(
-                    "WARN: the default secp256k1 code hash is `{}`, you are using `{}`",
+                    "WARN: the default secp256k1 code hash is `{}`, you are using `{}`.\n\
+                     It will require `ckb run --ba-advanced` to enable this block assembler",
                     default_hash, hash
+                );
+            } else if args.block_assembler_args.len() != 1
+                || args.block_assembler_args[0].len() != SECP256K1_BLAKE160_SIGHASH_ALL_ARG_LEN
+            {
+                eprintln!(
+                    "WARN: the block assembler arg is not a valid secp256k1 pubkey hash.\n\
+                     It will require `ckb run --ba-advanced` to enable this block assembler"
                 );
             }
             format!(

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -23,6 +23,7 @@ pub struct ImportArgs {
 pub struct RunArgs {
     pub config: Box<CKBAppConfig>,
     pub consensus: Consensus,
+    pub block_assembler_advanced: bool,
 }
 
 pub struct ProfArgs {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -30,6 +30,7 @@ pub const ARG_BUNDLED: &str = "bundled";
 pub const ARG_BA_CODE_HASH: &str = "ba-code-hash";
 pub const ARG_BA_ARG: &str = "ba-arg";
 pub const ARG_BA_DATA: &str = "ba-data";
+pub const ARG_BA_ADVANCED: &str = "ba-advanced";
 pub const ARG_FROM: &str = "from";
 pub const ARG_TO: &str = "to";
 
@@ -68,7 +69,11 @@ pub fn get_matches(version: &Version) -> ArgMatches<'static> {
 }
 
 fn run() -> App<'static, 'static> {
-    SubCommand::with_name(CMD_RUN).about("Runs ckb node")
+    SubCommand::with_name(CMD_RUN).about("Runs ckb node").arg(
+        Arg::with_name(ARG_BA_ADVANCED)
+            .long(ARG_BA_ADVANCED)
+            .help("Allows any block assembler code hash and args"),
+    )
 }
 
 fn miner() -> App<'static, 'static> {
@@ -399,5 +404,15 @@ mod tests {
             "--ba-code-hash is OK with --ba-arg, but gets error: {:?}",
             ok_matches.err()
         );
+    }
+
+    #[test]
+    fn ba_advanced() {
+        let matches = basic_app()
+            .get_matches_from_safe(&["ckb", "run", "--ba-advanced"])
+            .unwrap();
+        let sub_matches = matches.subcommand().1.unwrap();
+
+        assert_eq!(1, sub_matches.occurrences_of(ARG_BA_ADVANCED));
     }
 }

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -88,11 +88,15 @@ impl Setup {
         })
     }
 
-    pub fn run(self) -> Result<RunArgs, ExitCode> {
+    pub fn run<'m>(self, matches: &ArgMatches<'m>) -> Result<RunArgs, ExitCode> {
         let consensus = self.consensus()?;
         let config = self.config.into_ckb()?;
 
-        Ok(RunArgs { config, consensus })
+        Ok(RunArgs {
+            config,
+            consensus,
+            block_assembler_advanced: matches.is_present(cli::ARG_BA_ADVANCED),
+        })
     }
 
     pub fn miner(self) -> Result<MinerArgs, ExitCode> {


### PR DESCRIPTION
Unless start the node with `ckb run --ba-advanced`