### PR TITLE
fix: header verifier with wrong header resolver

### DIFF
--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -584,7 +584,7 @@ mod tests {
         let block: BlockBuilder = block_template.into();
         let block = block.build();
 
-        let resolver = HeaderResolverWrapper::new(block.header(), shared.clone());
+        let resolver = HeaderResolverWrapper::new(block.header(), &shared);
         let header_verify_result = {
             let chain_state = shared.lock_chain_state();
             let header_verifier = HeaderVerifier::new(&*chain_state, Pow::Dummy.engine());

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -75,7 +75,7 @@ impl<CS: ChainStore + 'static> MinerRpc for MinerRpcImpl<CS> {
 
         debug!("[{}] submit block", work_id);
         let block: Arc<CoreBlock> = Arc::new(data.into());
-        let resolver = HeaderResolverWrapper::new(block.header(), self.shared.clone());
+        let resolver = HeaderResolverWrapper::new(block.header(), &self.shared);
         let header_verify_ret = {
             let chain_state = self.shared.lock_chain_state();
             let header_verifier = HeaderVerifier::new(

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -11,7 +11,7 @@ use ckb_protocol::{CompactBlock as FbsCompactBlock, RelayMessage};
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_traits::{BlockMedianTimeContext, ChainProvider};
-use ckb_verification::{HeaderResolver, HeaderResolverWrapper, HeaderVerifier, Verifier};
+use ckb_verification::{HeaderResolver, HeaderVerifier, Verifier};
 use failure::Error as FailureError;
 use flatbuffers::FlatBufferBuilder;
 use fnv::FnvHashSet;
@@ -90,8 +90,8 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
             return Ok(Status::UnknownParent);
         }
 
+        let parent = parent.unwrap();
         {
-            let parent = parent.unwrap();
             let tip_header = self.relayer.shared.tip_header();
             let tip_header_view = self
                 .relayer
@@ -155,10 +155,10 @@ impl<'a, CS: ChainStore + 'static> CompactBlockProcess<'a, CS> {
                             .map(|(compact_block, _)| compact_block.header.to_owned())
                     }
                 };
-                let resolver = HeaderResolverWrapper::new(
-                    &compact_block.header,
-                    self.relayer.shared.shared().to_owned(),
-                );
+                let resolver = self
+                    .relayer
+                    .shared
+                    .new_header_resolver(&compact_block.header, parent.into_inner());
                 let header_verifier = HeaderVerifier::new(
                     CompactBlockMedianTimeView {
                         fn_get_pending_header: Box::new(fn_get_pending_header),

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -21,6 +21,7 @@ use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
 use ckb_util::{Mutex, MutexGuard};
 use ckb_util::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use ckb_verification::HeaderResolverWrapper;
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use flatbuffers::FlatBufferBuilder;
@@ -1180,6 +1181,22 @@ impl<CS: ChainStore> SyncSharedState<CS> {
         self.peers()
             .set_last_common_header(peer, block.header().clone());
         ret
+    }
+
+    pub(crate) fn new_header_resolver<'a>(
+        &'a self,
+        header: &'a Header,
+        parent: Header,
+    ) -> HeaderResolverWrapper<'a> {
+        let epoch = self
+            .get_epoch_ext(parent.hash())
+            .map(|ext| ext)
+            .map(|last_epoch| {
+                self.next_epoch_ext(&last_epoch, &parent)
+                    .unwrap_or(last_epoch)
+            });
+
+        HeaderResolverWrapper::build(header, Some(parent), epoch)
     }
 }
 

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -154,7 +154,7 @@ pub struct HeaderResolverWrapper<'a> {
 }
 
 impl<'a> HeaderResolverWrapper<'a> {
-    pub fn new<CP>(header: &'a Header, provider: CP) -> Self
+    pub fn new<CP>(header: &'a Header, provider: &CP) -> Self
     where
         CP: ChainProvider,
     {
@@ -172,6 +172,14 @@ impl<'a> HeaderResolverWrapper<'a> {
                     .unwrap_or(last_epoch)
             });
 
+        HeaderResolverWrapper {
+            parent,
+            header,
+            epoch,
+        }
+    }
+
+    pub fn build(header: &'a Header, parent: Option<Header>, epoch: Option<EpochExt>) -> Self {
         HeaderResolverWrapper {
             parent,
             header,


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb/blob/develop/verification/src/block_verifier.rs#L161-L173
https://github.com/nervosnetwork/ckb/blob/develop/sync/src/types.rs#L786
https://github.com/nervosnetwork/ckb/blob/develop/sync/src/types.rs#L811

Should find parent from header_map firstly, otherwise, it may not find the parent and lead to the UnknownParent.

todo:
- [ ] add test