### PR TITLE
feature: add get_block_finalized_reward_info rpc

### DIFF
--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -212,7 +212,7 @@ fn finalize_reward() {
         .unwrap()
         .safe_add(block_reward)
         .unwrap();
-    assert_eq!(reward, bob_reward,);
+    assert_eq!(reward.total, bob_reward,);
 
     let block = gen_block(
         &parent,
@@ -246,7 +246,7 @@ fn finalize_reward() {
         .unwrap()
         .safe_add(block_reward)
         .unwrap();
-    assert_eq!(reward, alice_reward);
+    assert_eq!(reward.total, alice_reward);
 
     let block = gen_block(
         &parent,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cell;
 pub mod difficulty;
 pub mod extras;
 pub mod header;
+pub mod reward;
 pub mod script;
 pub mod service;
 pub mod transaction;

--- a/core/src/reward.rs
+++ b/core/src/reward.rs
@@ -1,0 +1,9 @@
+use ckb_occupied_capacity::Capacity;
+
+pub struct BlockReward {
+    pub total: Capacity,
+    pub primary: Capacity,
+    pub secondary: Capacity,
+    pub tx_fee: Capacity,
+    pub proposal_reward: Capacity,
+}

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -428,8 +428,9 @@ impl<CS: ChainStore + 'static> BlockAssembler<CS> {
             let (target_lock, block_reward) = self.shared.finalize_block_reward(tip)?;
             let witness = lock.into_witness();
             let input = CellInput::new_cellbase_input(candidate_number);
-            let raw_output = CellOutput::new(block_reward, Bytes::default(), target_lock, None);
-            let output = self.custom_output(block_reward, raw_output)?;
+            let raw_output =
+                CellOutput::new(block_reward.total, Bytes::default(), target_lock, None);
+            let output = self.custom_output(block_reward.total, raw_output)?;
 
             TransactionBuilder::default()
                 .input(input)

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -5,6 +5,7 @@
     *   [`get_block`](#get_block)
     *   [`get_block_by_number`](#get_block_by_number)
     *   [`get_block_hash`](#get_block_hash)
+    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
     *   [`get_cells_by_lock_hash`](#get_cells_by_lock_hash)
     *   [`get_current_epoch`](#get_current_epoch)
     *   [`get_epoch_by_number`](#get_epoch_by_number)
@@ -246,6 +247,44 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086"
+}
+```
+
+### `get_cellbase_output_capacity_details`
+
+Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
+
+#### Parameters
+
+    hash - Block hash
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_cellbase_output_capacity_details",
+    "params": [
+        "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "primary": "100000000000",
+        "proposal_reward": "0",
+        "secondary": "3936000",
+        "total": "100003936000",
+        "tx_fee": "0"
+    }
 }
 ```
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -55,7 +55,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344"
+        "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086"
     ]
 }' \
 | tr -d '\n' \
@@ -72,9 +72,9 @@ http://localhost:8114
             "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
             "difficulty": "0x3e8",
             "epoch": "0",
-            "hash": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344",
+            "hash": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086",
             "number": "2",
-            "parent_hash": "0x2de0ba77b1a3c97be964c43a00d19963d47723af34bcae759dbe44625bb848c5",
+            "parent_hash": "0xef7ac67bbfbbc5df47a5af9d2d4695441d44c3258ae156eda98dc1ed01eae8f5",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "seal": {
                 "nonce": "0",
@@ -85,7 +85,7 @@ http://localhost:8114
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0x7ef131cca955519c025ddd4d3a3a92f52ffef67a967d3d867f5f6d1147fe2937"
+            "witnesses_root": "0x888af6c798c27a8910495651ed75cda9445213a9b5527f4d3f4cafc5dcf93568"
         },
         "proposals": [],
         "transactions": [
@@ -114,7 +114,13 @@ http://localhost:8114
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             }
         ],
         "uncles": []
@@ -155,9 +161,9 @@ http://localhost:8114
             "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
             "difficulty": "0x3e8",
             "epoch": "0",
-            "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "number": "1024",
-            "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+            "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "seal": {
                 "nonce": "0",
@@ -168,7 +174,7 @@ http://localhost:8114
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+            "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
         },
         "proposals": [],
         "transactions": [
@@ -197,7 +203,13 @@ http://localhost:8114
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             }
         ],
         "uncles": []
@@ -233,7 +245,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344"
+    "result": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086"
 }
 ```
 
@@ -278,7 +290,7 @@ http://localhost:8114
                 "hash_type": "Data"
             },
             "out_point": {
-                "block_hash": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344",
+                "block_hash": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086",
                 "cell": {
                     "index": "0",
                     "tx_hash": "0x81766f545198f7cb095d20bdf1ceb1fa7a3d9caf9dae0409370f334233e9c816"
@@ -293,7 +305,7 @@ http://localhost:8114
                 "hash_type": "Data"
             },
             "out_point": {
-                "block_hash": "0xf458a2800aa1da2b05656f966bb8d3a2326a04c38f355beebb48bde31c053ab7",
+                "block_hash": "0xb691cce096dde15f57d9b992e0f6bf3ee573f580ed1b692237846a6d541923ec",
                 "cell": {
                     "index": "0",
                     "tx_hash": "0xe84a3383d724d5a82db3335870e424d3a706ac64d8ceeb4716387ec37c346659"
@@ -308,7 +320,7 @@ http://localhost:8114
                 "hash_type": "Data"
             },
             "out_point": {
-                "block_hash": "0xa191d9800b19475b2541feef25559fe137f4cd86ad52d0eaddc0c4e0ec1257de",
+                "block_hash": "0xe3f126e4d25f227e6c1d137a29fcf70a302f12cb94d508a1f8674c89b9ce364d",
                 "cell": {
                     "index": "0",
                     "tx_hash": "0x1c5f992b8a7c5e13b5ab6aedadb4839cf135627f100cdf44a2ec333a60b44e8c"
@@ -323,7 +335,7 @@ http://localhost:8114
                 "hash_type": "Data"
             },
             "out_point": {
-                "block_hash": "0xd010752a6a30ecb8303b844320d9f577d840f2a050c010e8f33ba46f3a1d13c7",
+                "block_hash": "0x019077b2db0f5c8036a08bac04709c443f61fc3a3f305914c83af0395a3aa26f",
                 "cell": {
                     "index": "0",
                     "tx_hash": "0x01f306cfbd5985f7275d3a91230b84773e698bff195ade13787c2316bd4c8b19"
@@ -418,7 +430,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d"
+        "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672"
     ]
 }' \
 | tr -d '\n' \
@@ -434,9 +446,9 @@ http://localhost:8114
         "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
         "difficulty": "0x3e8",
         "epoch": "0",
-        "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+        "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
         "number": "1024",
-        "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+        "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "seal": {
             "nonce": "0",
@@ -447,7 +459,7 @@ http://localhost:8114
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+        "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
     }
 }
 ```
@@ -481,9 +493,9 @@ http://localhost:8114
         "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
         "difficulty": "0x3e8",
         "epoch": "0",
-        "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+        "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
         "number": "1024",
-        "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+        "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "seal": {
             "nonce": "0",
@@ -494,7 +506,7 @@ http://localhost:8114
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+        "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
     }
 }
 ```
@@ -603,9 +615,9 @@ http://localhost:8114
         "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
         "difficulty": "0x3e8",
         "epoch": "0",
-        "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+        "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
         "number": "1024",
-        "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+        "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "seal": {
             "nonce": "0",
@@ -616,7 +628,7 @@ http://localhost:8114
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+        "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
     }
 }
 ```
@@ -675,10 +687,16 @@ http://localhost:8114
                 }
             ],
             "version": "0",
-            "witnesses": []
+            "witnesses": [
+                {
+                    "data": [
+                        "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                    ]
+                }
+            ]
         },
         "tx_status": {
-            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "status": "committed"
         }
     }
@@ -792,7 +810,7 @@ echo '{
                 {
                     "args": [],
                     "previous_output": {
-                        "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                        "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                         "cell": {
                             "index": "0",
                             "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -814,7 +832,13 @@ echo '{
                 }
             ],
             "version": "0",
-            "witnesses": []
+            "witnesses": [
+                {
+                    "data": [
+                        "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                    ]
+                }
+            ]
         }
     ]
 }' \
@@ -827,7 +851,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x10bffb7b67bfba00efcce595a07f6a5a648b97b299a5be632af15b6d06398246"
+    "result": "0x1e0770955e0abd60f781522054f0ac184cfca3b567a48775c47a60dc56020106"
 }
 ```
 
@@ -861,7 +885,7 @@ echo '{
                 {
                     "args": [],
                     "previous_output": {
-                        "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                        "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                         "cell": {
                             "index": "0",
                             "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -883,7 +907,13 @@ echo '{
                 }
             ],
             "version": "0",
-            "witnesses": []
+            "witnesses": [
+                {
+                    "data": [
+                        "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                    ]
+                }
+            ]
         }
     ]
 }' \
@@ -1033,7 +1063,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "block_number": "1024",
             "lock_hash": "0xa6ed2edad0d48a3d58d0bec407ddf2e40ddd5f533d7059a160149f4021c2a589"
         }
@@ -1126,7 +1156,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+        "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
         "block_number": "1024",
         "lock_hash": "0xa6ed2edad0d48a3d58d0bec407ddf2e40ddd5f533d7059a160149f4021c2a589"
     }
@@ -1343,7 +1373,7 @@ echo '{
                 {
                     "args": [],
                     "previous_output": {
-                        "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                        "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                         "cell": {
                             "index": "0",
                             "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -1365,7 +1395,13 @@ echo '{
                 }
             ],
             "version": "0",
-            "witnesses": []
+            "witnesses": [
+                {
+                    "data": [
+                        "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                    ]
+                }
+            ]
         }
     ]
 }' \
@@ -1378,7 +1414,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0xc00763e95b225031df58c204d65089414482e629fd2f52b19e2c7e21eaa179ba"
+    "result": "0xec272db158689c3e2f0ad04ac995f57289a40baba7ab616dc695e96b2d8c6cc3"
 }
 ```
 
@@ -1411,7 +1447,7 @@ http://localhost:8114
         "pending": "1",
         "proposed": "0",
         "total_tx_cycles": "12",
-        "total_tx_size": "181"
+        "total_tx_size": "213"
     }
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -15,9 +15,9 @@
             "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
             "difficulty": "0x3e8",
             "epoch": "0",
-            "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "number": "1024",
-            "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+            "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "seal": {
                 "nonce": "0",
@@ -28,7 +28,7 @@
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+            "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
         }
     },
     {
@@ -71,7 +71,7 @@
         "params": [
             "2"
         ],
-        "result": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344",
+        "result": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -83,16 +83,16 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344"
+            "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086"
         ],
         "result": {
             "header": {
                 "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
                 "difficulty": "0x3e8",
                 "epoch": "0",
-                "hash": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344",
+                "hash": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086",
                 "number": "2",
-                "parent_hash": "0x2de0ba77b1a3c97be964c43a00d19963d47723af34bcae759dbe44625bb848c5",
+                "parent_hash": "0xef7ac67bbfbbc5df47a5af9d2d4695441d44c3258ae156eda98dc1ed01eae8f5",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "seal": {
                     "nonce": "0",
@@ -103,7 +103,7 @@
                 "uncles_count": "0",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0",
-                "witnesses_root": "0x7ef131cca955519c025ddd4d3a3a92f52ffef67a967d3d867f5f6d1147fe2937"
+                "witnesses_root": "0x888af6c798c27a8910495651ed75cda9445213a9b5527f4d3f4cafc5dcf93568"
             },
             "proposals": [],
             "transactions": [
@@ -132,7 +132,13 @@
                         }
                     ],
                     "version": "0",
-                    "witnesses": []
+                    "witnesses": [
+                        {
+                            "data": [
+                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                            ]
+                        }
+                    ]
                 }
             ],
             "uncles": []
@@ -148,15 +154,15 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d"
+            "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672"
         ],
         "result": {
             "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
             "difficulty": "0x3e8",
             "epoch": "0",
-            "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "number": "1024",
-            "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+            "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "seal": {
                 "nonce": "0",
@@ -167,7 +173,7 @@
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+            "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
         }
     },
     {
@@ -181,9 +187,9 @@
             "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
             "difficulty": "0x3e8",
             "epoch": "0",
-            "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "number": "1024",
-            "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+            "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "seal": {
                 "nonce": "0",
@@ -194,7 +200,7 @@
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+            "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
         }
     },
     {
@@ -215,7 +221,7 @@
                     "hash_type": "Data"
                 },
                 "out_point": {
-                    "block_hash": "0x2d6d06b953787bc8b4ff3d4d812413487022860f09c5026f9ca0c130c583a344",
+                    "block_hash": "0xadb9674a4ba5a03ade0ce8351a9b5d93abcab96f463aca4777f4e9ae5be35086",
                     "cell": {
                         "index": "0",
                         "tx_hash": "0x81766f545198f7cb095d20bdf1ceb1fa7a3d9caf9dae0409370f334233e9c816"
@@ -230,7 +236,7 @@
                     "hash_type": "Data"
                 },
                 "out_point": {
-                    "block_hash": "0xf458a2800aa1da2b05656f966bb8d3a2326a04c38f355beebb48bde31c053ab7",
+                    "block_hash": "0xb691cce096dde15f57d9b992e0f6bf3ee573f580ed1b692237846a6d541923ec",
                     "cell": {
                         "index": "0",
                         "tx_hash": "0xe84a3383d724d5a82db3335870e424d3a706ac64d8ceeb4716387ec37c346659"
@@ -245,7 +251,7 @@
                     "hash_type": "Data"
                 },
                 "out_point": {
-                    "block_hash": "0xa191d9800b19475b2541feef25559fe137f4cd86ad52d0eaddc0c4e0ec1257de",
+                    "block_hash": "0xe3f126e4d25f227e6c1d137a29fcf70a302f12cb94d508a1f8674c89b9ce364d",
                     "cell": {
                         "index": "0",
                         "tx_hash": "0x1c5f992b8a7c5e13b5ab6aedadb4839cf135627f100cdf44a2ec333a60b44e8c"
@@ -260,7 +266,7 @@
                     "hash_type": "Data"
                 },
                 "out_point": {
-                    "block_hash": "0xd010752a6a30ecb8303b844320d9f577d840f2a050c010e8f33ba46f3a1d13c7",
+                    "block_hash": "0x019077b2db0f5c8036a08bac04709c443f61fc3a3f305914c83af0395a3aa26f",
                     "cell": {
                         "index": "0",
                         "tx_hash": "0x01f306cfbd5985f7275d3a91230b84773e698bff195ade13787c2316bd4c8b19"
@@ -468,7 +474,7 @@
                     {
                         "args": [],
                         "previous_output": {
-                            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                             "cell": {
                                 "index": "0",
                                 "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -490,7 +496,13 @@
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             }
         ],
         "result": {
@@ -508,7 +520,7 @@
                     {
                         "args": [],
                         "previous_output": {
-                            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                             "cell": {
                                 "index": "0",
                                 "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -530,10 +542,16 @@
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             }
         ],
-        "result": "0x10bffb7b67bfba00efcce595a07f6a5a648b97b299a5be632af15b6d06398246",
+        "result": "0x1e0770955e0abd60f781522054f0ac184cfca3b567a48775c47a60dc56020106",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -573,7 +591,7 @@
                     {
                         "args": [],
                         "previous_output": {
-                            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                             "cell": {
                                 "index": "0",
                                 "tx_hash": "0x81389ffabda2d1658c75a81e390a82b335d4cb849b2269d134b042fea9cb9513"
@@ -595,10 +613,16 @@
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             }
         ],
-        "result": "0xc00763e95b225031df58c204d65089414482e629fd2f52b19e2c7e21eaa179ba",
+        "result": "0xec272db158689c3e2f0ad04ac995f57289a40baba7ab616dc695e96b2d8c6cc3",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -653,10 +677,16 @@
                     }
                 ],
                 "version": "0",
-                "witnesses": []
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                        ]
+                    }
+                ]
             },
             "tx_status": {
-                "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                 "status": "committed"
             }
         },
@@ -677,7 +707,7 @@
             "pending": "1",
             "proposed": "0",
             "total_tx_cycles": "12",
-            "total_tx_size": "181"
+            "total_tx_size": "213"
         }
     },
     {
@@ -692,9 +722,9 @@
                 "dao": "0x01000000000000000000c16ff286230000203d88792d0000000961f400000000",
                 "difficulty": "0x3e8",
                 "epoch": "0",
-                "hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                "hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                 "number": "1024",
-                "parent_hash": "0xc66ee8f62599c7e17ef6d8f42411fdf08def85ca12d603a0f80052eab6c5abf9",
+                "parent_hash": "0xba36a49ae9dabc516489701388b38e5202e077a7c967390365672163e59cf75d",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "seal": {
                     "nonce": "0",
@@ -705,7 +735,7 @@
                 "uncles_count": "0",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0",
-                "witnesses_root": "0x106005deb92716b3f4497c9971c2c031ff6bfc7c5731c8821926cc0b0cba50cc"
+                "witnesses_root": "0xf0a67fa5947215b48b1eac38530084808ff0ddbaeb1f133c0c3c4c209d417ad5"
             },
             "proposals": [],
             "transactions": [
@@ -734,7 +764,13 @@
                         }
                     ],
                     "version": "0",
-                    "witnesses": []
+                    "witnesses": [
+                        {
+                            "data": [
+                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
+                            ]
+                        }
+                    ]
                 }
             ],
             "uncles": []
@@ -754,7 +790,7 @@
             "1024"
         ],
         "result": {
-            "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+            "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
             "block_number": "1024",
             "lock_hash": "0xa6ed2edad0d48a3d58d0bec407ddf2e40ddd5f533d7059a160149f4021c2a589"
         },
@@ -774,7 +810,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0x272cc0ca35fb927e1f7cdb096355b6c1eefd29f475161e6670a5c5dce58c418d",
+                "block_hash": "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672",
                 "block_number": "1024",
                 "lock_hash": "0xa6ed2edad0d48a3d58d0bec407ddf2e40ddd5f533d7059a160149f4021c2a589"
             }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -697,6 +697,26 @@
         ]
     },
     {
+        "description": "Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.",
+        "method": "get_cellbase_output_capacity_details",
+        "module": "chain",
+        "params": [
+            "0x10cb7b3ffd10306430d914529fc501a429ae0967144773c7c5bdcfd2f1117672"
+        ],
+        "result": {
+            "total": "100003936000",
+            "primary": "100000000000",
+            "secondary": "3936000",
+            "tx_fee": "0",
+            "proposal_reward": "0"
+        },
+        "types": [
+            {
+                "hash": "Block hash"
+            }
+        ]
+    },
+    {
         "description": "Return the transaction pool information",
         "method": "tx_pool_info",
         "module": "pool",

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -62,6 +62,7 @@ fn new_cellbase(number: BlockNumber, always_success_script: &Script) -> Transact
     TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
         .outputs(outputs)
+        .witness(always_success_script.to_owned().into_witness())
         .build()
 }
 

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -4,8 +4,8 @@ use crate::tx_pool::TxPoolConfig;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
+use ckb_core::reward::BlockReward;
 use ckb_core::script::Script;
-use ckb_core::Capacity;
 use ckb_core::Cycle;
 use ckb_db::{DBConfig, KeyValueDB, MemoryKeyValueDB, RocksDB};
 use ckb_reward_calculator::RewardCalculator;
@@ -111,7 +111,10 @@ impl<CS: ChainStore> ChainProvider for Shared<CS> {
         )
     }
 
-    fn finalize_block_reward(&self, parent: &Header) -> Result<(Script, Capacity), FailureError> {
+    fn finalize_block_reward(
+        &self,
+        parent: &Header,
+    ) -> Result<(Script, BlockReward), FailureError> {
         RewardCalculator::new(self).block_reward(parent)
     }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -549,7 +549,7 @@ mod tests {
         TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))
             .output(CellOutput::new(
-                reward,
+                reward.total,
                 Bytes::default(),
                 Script::default(),
                 None,

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -122,7 +122,7 @@ fn setup_node(
         let cellbase = TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))
             .output(CellOutput::new(
-                reward,
+                reward.total,
                 Bytes::default(),
                 always_success_script.to_owned(),
                 None,

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -63,7 +63,7 @@ pub fn inherit_block(
         .unwrap_or(parent_epoch);
     let cellbase = {
         let (_, reward) = shared.finalize_block_reward(parent.header()).unwrap();
-        always_success_cellbase(parent_number + 1, reward)
+        always_success_cellbase(parent_number + 1, reward.total)
     };
     let dao = {
         let chain_state = shared.lock_chain_state();
@@ -107,5 +107,5 @@ pub fn inherit_cellbase(
             .expect("parent exist")
     };
     let (_, reward) = shared.finalize_block_reward(&parent_header).unwrap();
-    always_success_cellbase(parent_number + 1, reward)
+    always_success_cellbase(parent_number + 1, reward.total)
 }

--- a/traits/src/chain_provider.rs
+++ b/traits/src/chain_provider.rs
@@ -1,8 +1,8 @@
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::extras::EpochExt;
 use ckb_core::header::Header;
+use ckb_core::reward::BlockReward;
 use ckb_core::script::Script;
-use ckb_core::Capacity;
 use ckb_script::ScriptConfig;
 use ckb_store::ChainStore;
 use failure::Error as FailureError;
@@ -22,7 +22,8 @@ pub trait ChainProvider: Sync + Send {
 
     fn next_epoch_ext(&self, last_epoch: &EpochExt, header: &Header) -> Option<EpochExt>;
 
-    fn finalize_block_reward(&self, parent: &Header) -> Result<(Script, Capacity), FailureError>;
+    fn finalize_block_reward(&self, parent: &Header)
+        -> Result<(Script, BlockReward), FailureError>;
 
     fn consensus(&self) -> &Consensus;
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -3,6 +3,7 @@ use crate::{BlockNumber, Capacity, EpochNumber, ProposalShortId, Timestamp, Unsi
 use ckb_core::block::{Block as CoreBlock, BlockBuilder};
 use ckb_core::extras::EpochExt as CoreEpochExt;
 use ckb_core::header::{Header as CoreHeader, HeaderBuilder, Seal as CoreSeal};
+use ckb_core::reward::BlockReward as CoreBlockReward;
 use ckb_core::script::{Script as CoreScript, ScriptHashType as CoreScriptHashType};
 use ckb_core::transaction::{
     CellInput as CoreCellInput, CellOutPoint as CoreCellOutPoint, CellOutput as CoreCellOutput,
@@ -610,6 +611,27 @@ impl EpochView {
             length: BlockNumber(ext.length()),
             difficulty: ext.difficulty().clone(),
             epoch_reward: Capacity(epoch_reward),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct BlockRewardView {
+    pub total: Capacity,
+    pub primary: Capacity,
+    pub secondary: Capacity,
+    pub tx_fee: Capacity,
+    pub proposal_reward: Capacity,
+}
+
+impl<'a> From<CoreBlockReward> for BlockRewardView {
+    fn from(core: CoreBlockReward) -> Self {
+        Self {
+            total: Capacity(core.total),
+            primary: Capacity(core.primary),
+            secondary: Capacity(core.secondary),
+            tx_fee: Capacity(core.tx_fee),
+            proposal_reward: Capacity(core.proposal_reward),
         }
     }
 }

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -38,9 +38,9 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, BlockView, CellInput, CellOutPoint, CellOutput, EpochView, Header, HeaderView, OutPoint,
-    Script, Seal, Transaction, TransactionView, TransactionWithStatus, TxStatus, UncleBlock,
-    UncleBlockView, Witness,
+    Block, BlockRewardView, BlockView, CellInput, CellOutPoint, CellOutput, EpochView, Header,
+    HeaderView, OutPoint, Script, Seal, Transaction, TransactionView, TransactionWithStatus,
+    TxStatus, UncleBlock, UncleBlockView, Witness,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -233,7 +233,7 @@ where
             .provider
             .finalize_block_reward(self.parent)
             .map_err(|_| Error::CannotFetchBlockReward)?;
-        if cellbase.transaction.outputs_capacity()? != block_reward {
+        if cellbase.transaction.outputs_capacity()? != block_reward.total {
             return Err(Error::Cellbase(CellbaseError::InvalidRewardAmount));
         }
         if cellbase.transaction.outputs()[0].lock != target_lock {


### PR DESCRIPTION
Firstly fix test:  `cellbase` should have `witness`, otherwise the RPC test will panic.

https://github.com/nervosnetwork/ckb/pull/1297/commits/25445bc4ab1c35e160fefe2bacd89ada32fcda76