### PR TITLE
ci: speed up ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,13 @@ matrix:
       os: linux
       script: make CKB_TEST_ARGS="--max-time 1200" integration
     - name: Linters
-      env: CACHE_NAME=linters
+      env: CACHE_NAME=linters-2
       if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, trying) OR repo != nervosnetwork/ckb)'
       os: linux
+      before_install:
+        - echo "Today is $(date)"
+        - if [[ $(date +%u) -eq 1 ]] ; then cargo sweep --version || travis_retry cargo install --git https://github.com/holmgr/cargo-sweep --rev 4770deda37a2203c783e301b8c0c895964e8971e; fi
+        - if [[ $(date +%u) -eq 1 ]] ; then cargo sweep -s; fi
       install:
         - cargo fmt --version || travis_retry rustup component add rustfmt
         - cargo clippy --version || travis_retry rustup component add clippy
@@ -76,6 +80,13 @@ matrix:
         - make fmt
         - make clippy
         - git diff --exit-code Cargo.lock
+      before_cache:
+        - rm -rfv target/debug/incremental/*
+        - rm -rfv target/debug/.fingerprint/ckb-*
+        - rm -rfv target/debug/deps/ckb-*
+        - rm -rfv target/debug/ckb.d
+        - cargo clean -p ckb
+        - if [[ $(date +%u) -eq 1 ]] ; then cargo sweep -f; fi
     - name: Quick Check
       if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, trying) OR repo != nervosnetwork/ckb)'
       os: linux


### PR DESCRIPTION
Most of the time the installing of cargo-sweep is more than 190s, sometimes even more than 240s

https://travis-ci.com/nervosnetwork/ckb/jobs/218871807
https://travis-ci.com/nervosnetwork/ckb/jobs/218871808
https://travis-ci.com/nervosnetwork/ckb/jobs/218871809

cargo-sweep make the ci very slow, it cleans something that we need.

After remove `cargo sweep -f`, only 8 minutes 50 seconds for Clippy,

https://travis-ci.com/nervosnetwork/ckb/jobs/219325780#L249
https://travis-ci.com/nervosnetwork/ckb/jobs/219325476#L252
https://travis-ci.com/nervosnetwork/ckb/jobs/219351657#L250

but the ci cache will quickly bloat.

https://gist.github.com/jkcclemens/000456ca646bd502cac0dbddcb8fa307

solution:

1. ~~use release mode, cut down the cache.~~ 
3. sweep the cache periodically.

~~before: uint test on macOS is 30 min; after: it's 23 min~~
**before: Clippy is 31 min; after: less than 8 min**
~~uint test on Linux is 1 min more than before, so keep as before.~~

~~the cache size is ~~4851.mb~~ 3924.10mb, the other cache size is between 4851MB and 5092.92MB.~~

the clippy cache size is about 1.3g;
the linux unit test cache size is about 2.2g;
the macOS uint test cache size is about 1.3g. 

I have tried other methods also:
1. rm `~/.cargo/registry`, the cache size is small, but the ci speed is not improved.
2. rm verbose, it did not contribute to the ci speed and the cache size at all.

https://travis-ci.com/nervosnetwork/ckb/builds/120998111

Now I only keep the Linter improvement, because of the unit test optimization was not so remarkable and stable. And we need to observe this change for one or two weeks.