### PR TITLE
fix: ibd only with protect/whitelist peers

### DIFF
--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -271,17 +271,17 @@ where
 
         // If we're in IBD, we want outbound peers that will serve us a useful
         // chain. Disconnect peers that are on chains with insufficient work.
-        let (is_outbound, is_protected) = self
+        let peer_flags = self
             .synchronizer
             .peers()
             .state
             .read()
             .get(&self.peer)
-            .map(|state| (state.peer_flags.is_outbound, state.peer_flags.is_protect))
-            .unwrap_or((false, false));
+            .map(|state| state.peer_flags)
+            .unwrap_or_default();
         if self.synchronizer.shared.is_initial_block_download()
             && headers.len() != MAX_HEADERS_LEN
-            && (is_outbound && !is_protected)
+            && (!peer_flags.is_protect && !peer_flags.is_whitelist && peer_flags.is_outbound)
         {
             debug!("Disconnect peer({}) is unprotected outbound", self.peer);
             if let Err(err) = self

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -124,8 +124,8 @@ impl PeerState {
     }
 
     pub fn can_sync(&self, now: u64, ibd: bool) -> bool {
-        // only sync with outbound/whitelist peer in IBD
-        ((self.peer_flags.is_outbound || self.peer_flags.is_whitelist) || !ibd)
+        // only sync with protect/whitelist peer in IBD
+        ((self.peer_flags.is_protect || self.peer_flags.is_whitelist) || !ibd)
             && !self.sync_started
             && self
                 .chain_sync

--- a/test/src/specs/sync/ibd_process.rs
+++ b/test/src/specs/sync/ibd_process.rs
@@ -24,6 +24,7 @@ impl Spec for IBDProcess {
         // will never connect
         node0.connect_uncheck(node5);
         node0.connect_uncheck(node6);
+        node0.generate_blocks(1);
 
         sleep(Duration::from_secs(5));
 


### PR DESCRIPTION
The ibd with non-protect/whitelist node has no sense, because after the headers are synchronized,
the node must be disconnected.

Furthermore, if ibd with the non-protected node, there may be a state that cannot be synchronized for a long time：

1. Assume that it has been impossible(long time) to randomize to the protected node
2. Random to the protected node, if the `shared_best_header` is the same as the protected node, [unable to start syncing](https://github.com/nervosnetwork/ckb/blob/develop/sync/src/synchronizer/headers_process.rs#L170), may stop sync with this node and then randomize to another node, go back to 1, else sync with protected node