### PR TITLE
fix: network continuely retry dialing on failed address

### DIFF
--- a/network/src/peer_store/sqlite/peer_store.rs
+++ b/network/src/peer_store/sqlite/peer_store.rs
@@ -335,9 +335,11 @@ impl PeerStore for SqlitePeerStore {
                 let mut rng = thread_rng();
                 // randomly find a address to attempt
                 paddrs.shuffle(&mut rng);
-                paddrs
-                    .into_iter()
-                    .find(|paddr| !self.is_addr_banned(&paddr.addr) && !paddr.is_terrible(now_ms))
+                paddrs.into_iter().find(|paddr| {
+                    !(self.is_addr_banned(&paddr.addr)
+                        || paddr.tried_in_last_minute(now_ms)
+                        || paddr.is_terrible(now_ms))
+                })
             })
             .collect()
     }
@@ -360,7 +362,7 @@ impl PeerStore for SqlitePeerStore {
                             .expect("delete peer addr");
                         false
                     } else {
-                        !self.is_addr_banned(&paddr.addr) && !paddr.tried_in_last_minute(now_ms)
+                        !(self.is_addr_banned(&paddr.addr) || paddr.tried_in_last_minute(now_ms))
                     }
                 })
             })

--- a/network/src/tests/sqlite_peer_store.rs
+++ b/network/src/tests/sqlite_peer_store.rs
@@ -102,6 +102,23 @@ fn test_peers_to_attempt() {
 }
 
 #[test]
+fn test_peers_to_attempt_in_last_minutes() {
+    let mut peer_store: Box<dyn PeerStore> = Box::new(new_peer_store());
+    let peer_id = PeerId::random();
+    let addr = "/ip4/127.0.0.1".parse::<Multiaddr>().unwrap();
+    peer_store.add_discovered_addr(&peer_id, addr.clone());
+    let mut peer = peer_store.peers_to_attempt(1).remove(0);
+    let now = faketime::unix_time_as_millis();
+    peer.mark_tried(now);
+    peer_store.update_peer_addr(&peer);
+    assert!(peer_store.peers_to_attempt(1).is_empty());
+    // after 60 seconds
+    peer.mark_tried(now - 60_001);
+    peer_store.update_peer_addr(&peer);
+    assert_eq!(peer_store.peers_to_attempt(1).len(), 1);
+}
+
+#[test]
 fn test_peers_to_feeler() {
     let mut peer_store: Box<dyn PeerStore> = Box::new(new_peer_store());
     assert!(peer_store.peers_to_feeler(1).is_empty());


### PR DESCRIPTION
Fix network continually retry failed dialing.

* node will not retry to dial a failed address within 1 minute
* node will stop trying to dial a *terrible* address after 3 failed retries
* node will try to dial a terrible address after 7 days since the last try.