### PR TITLE
refactor: using ProposalShortId in CompactBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,17 +782,13 @@ dependencies = [
 name = "ckb-protocol"
 version = "0.19.0-pre"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-core 0.19.0-pre",
- "ckb-hash 0.19.0-pre",
  "ckb-merkle-tree 0.19.0-pre",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers-verifier 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-hash 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "siphasher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3158,11 +3154,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "siphasher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "sized-chunks"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4163,7 +4154,6 @@ dependencies = [
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-"checksum siphasher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9913c75df657d84a03fa689c016b0bb2863ff0b497b26a8d6e9703f8d5df03a8"
 "checksum sized-chunks 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "882678bcc6f62ef6bb83ce1b7dbbec316f24a2be7f3033acc107d3b11735cb50"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -10,10 +10,6 @@ flatbuffers = "0.6.0"
 flatbuffers-verifier = "0.2.0"
 numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
-byteorder = "1.3.1"
 ckb-core = { path = "../core" }
-ckb-hash = { path = "../util/hash"}
-siphasher = "0.3.0"
-rand = "0.6"
 ckb-merkle-tree = { path = "../util/merkle-tree"}
 failure = "0.1.5"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -9,12 +9,7 @@ mod protocol_generated;
 mod protocol_generated_verifier;
 
 pub use crate::protocol_generated::ckb::protocol::*;
-use byteorder::{LittleEndian, ReadBytesExt};
-use ckb_hash::new_blake2b;
 pub use flatbuffers;
-use numext_fixed_hash::H256;
-use siphasher::sip::SipHasher;
-use std::hash::Hasher;
 
 pub fn get_root<'a, T>(data: &'a [u8]) -> Result<T::Inner, error::Error>
 where
@@ -47,40 +42,6 @@ impl<'a, T: flatbuffers::Follow<'a> + 'a> Iterator for FlatbuffersVectorIterator
             None
         }
     }
-}
-
-pub type ShortTransactionID = [u8; 6];
-
-pub fn short_transaction_id_keys(header_nonce: u64, random_nonce: u64) -> (u64, u64) {
-    // blake2b-256(header nonce + random nonce) in little-endian
-    let mut block_header_with_nonce_hash = [0; 32];
-    let mut blake2b = new_blake2b();
-    blake2b.update(&header_nonce.to_le_bytes());
-    blake2b.update(&random_nonce.to_le_bytes());
-    blake2b.finalize(&mut block_header_with_nonce_hash);
-
-    let key0 = (&block_header_with_nonce_hash[0..8])
-        .read_u64::<LittleEndian>()
-        .expect("read bound checked, should not fail");
-    let key1 = (&block_header_with_nonce_hash[8..16])
-        .read_u64::<LittleEndian>()
-        .expect("read bound checked, should not fail");
-
-    (key0, key1)
-}
-
-pub fn short_transaction_id(key0: u64, key1: u64, witness_hash: &H256) -> ShortTransactionID {
-    let mut hasher = SipHasher::new_with_keys(key0, key1);
-    hasher.write(witness_hash.as_bytes());
-    let siphash_transaction_hash = hasher.finish();
-
-    let siphash_transaction_hash_bytes = siphash_transaction_hash.to_le_bytes();
-
-    let mut short_transaction_id = [0u8; 6];
-
-    short_transaction_id.copy_from_slice(&siphash_transaction_hash_bytes[..6]);
-
-    short_transaction_id
 }
 
 #[macro_export]

--- a/protocol/src/protocol.fbs
+++ b/protocol/src/protocol.fbs
@@ -121,8 +121,7 @@ table RelayMessage {
 
 table CompactBlock {
     header:                     Header;
-    nonce:                      uint64;
-    short_ids:                  [Bytes];
+    short_ids:                  [ProposalShortId];
     prefilled_transactions:     [IndexTransaction];
     uncles:                     [UncleBlock];
     proposals:                  [ProposalShortId];

--- a/protocol/src/protocol_generated.rs
+++ b/protocol/src/protocol_generated.rs
@@ -2275,7 +2275,6 @@ impl<'a> CompactBlock<'a> {
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
         args: &'args CompactBlockArgs<'args>) -> flatbuffers::WIPOffset<CompactBlock<'bldr>> {
       let mut builder = CompactBlockBuilder::new(_fbb);
-      builder.add_nonce(args.nonce);
       if let Some(x) = args.proposals { builder.add_proposals(x); }
       if let Some(x) = args.uncles { builder.add_uncles(x); }
       if let Some(x) = args.prefilled_transactions { builder.add_prefilled_transactions(x); }
@@ -2285,23 +2284,18 @@ impl<'a> CompactBlock<'a> {
     }
 
     pub const VT_HEADER: flatbuffers::VOffsetT = 4;
-    pub const VT_NONCE: flatbuffers::VOffsetT = 6;
-    pub const VT_SHORT_IDS: flatbuffers::VOffsetT = 8;
-    pub const VT_PREFILLED_TRANSACTIONS: flatbuffers::VOffsetT = 10;
-    pub const VT_UNCLES: flatbuffers::VOffsetT = 12;
-    pub const VT_PROPOSALS: flatbuffers::VOffsetT = 14;
+    pub const VT_SHORT_IDS: flatbuffers::VOffsetT = 6;
+    pub const VT_PREFILLED_TRANSACTIONS: flatbuffers::VOffsetT = 8;
+    pub const VT_UNCLES: flatbuffers::VOffsetT = 10;
+    pub const VT_PROPOSALS: flatbuffers::VOffsetT = 12;
 
   #[inline]
   pub fn header(&self) -> Option<Header<'a>> {
     self._tab.get::<flatbuffers::ForwardsUOffset<Header<'a>>>(CompactBlock::VT_HEADER, None)
   }
   #[inline]
-  pub fn nonce(&self) -> u64 {
-    self._tab.get::<u64>(CompactBlock::VT_NONCE, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn short_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Bytes<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Bytes<'a>>>>>(CompactBlock::VT_SHORT_IDS, None)
+  pub fn short_ids(&self) -> Option<&'a [ProposalShortId]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<ProposalShortId>>>(CompactBlock::VT_SHORT_IDS, None).map(|v| v.safe_slice() )
   }
   #[inline]
   pub fn prefilled_transactions(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IndexTransaction<'a>>>> {
@@ -2319,8 +2313,7 @@ impl<'a> CompactBlock<'a> {
 
 pub struct CompactBlockArgs<'a> {
     pub header: Option<flatbuffers::WIPOffset<Header<'a >>>,
-    pub nonce: u64,
-    pub short_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Bytes<'a >>>>>,
+    pub short_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
     pub prefilled_transactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<IndexTransaction<'a >>>>>,
     pub uncles: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<UncleBlock<'a >>>>>,
     pub proposals: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , ProposalShortId>>>,
@@ -2330,7 +2323,6 @@ impl<'a> Default for CompactBlockArgs<'a> {
     fn default() -> Self {
         CompactBlockArgs {
             header: None,
-            nonce: 0,
             short_ids: None,
             prefilled_transactions: None,
             uncles: None,
@@ -2348,11 +2340,7 @@ impl<'a: 'b, 'b> CompactBlockBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Header>>(CompactBlock::VT_HEADER, header);
   }
   #[inline]
-  pub fn add_nonce(&mut self, nonce: u64) {
-    self.fbb_.push_slot::<u64>(CompactBlock::VT_NONCE, nonce, 0);
-  }
-  #[inline]
-  pub fn add_short_ids(&mut self, short_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Bytes<'b >>>>) {
+  pub fn add_short_ids(&mut self, short_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , ProposalShortId>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CompactBlock::VT_SHORT_IDS, short_ids);
   }
   #[inline]

--- a/protocol/src/protocol_generated_verifier.rs
+++ b/protocol/src/protocol_generated_verifier.rs
@@ -1113,15 +1113,6 @@ pub mod ckb {
                     }
                 }
 
-                if Self::VT_NONCE as usize + flatbuffers::SIZE_VOFFSET
-                    <= vtab_num_bytes
-                {
-                    let voffset = vtab.get(Self::VT_NONCE) as usize;
-                    if voffset > 0 && object_inline_num_bytes - voffset < 8 {
-                        return Err(Error::OutOfBounds);
-                    }
-                }
-
                 if Self::VT_SHORT_IDS as usize + flatbuffers::SIZE_VOFFSET
                     <= vtab_num_bytes
                 {
@@ -1135,8 +1126,7 @@ pub mod ckb {
                             buf,
                             try_follow_uoffset(buf, tab.loc + voffset)?,
                         );
-                        short_ids_verifier
-                            .verify_reference_elements::<reader::Bytes>()?;
+                        short_ids_verifier.verify_scalar_elements(10)?;
                     }
                 }
 

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -212,6 +212,16 @@ impl TxPool {
         self.proposed.get_tx(id).cloned()
     }
 
+    pub fn get_tx_from_proposed_and_others(&self, id: &ProposalShortId) -> Option<Transaction> {
+        self.proposed
+            .get_tx(id)
+            .or_else(|| self.gap.get_tx(id))
+            .or_else(|| self.pending.get_tx(id))
+            .or_else(|| self.orphan.get_tx(id))
+            .or_else(|| self.conflict.get(id).map(|e| &e.transaction))
+            .cloned()
+    }
+
     pub(crate) fn remove_committed_txs_from_proposed<'a>(
         &mut self,
         txs: impl Iterator<Item = &'a Transaction>,

--- a/sync/src/relayer/block_transactions_verifier.rs
+++ b/sync/src/relayer/block_transactions_verifier.rs
@@ -1,7 +1,6 @@
 use crate::relayer::compact_block::CompactBlock;
 use crate::relayer::error::{Error, Misbehavior};
-use ckb_core::transaction::Transaction;
-use ckb_protocol::{short_transaction_id, short_transaction_id_keys, ShortTransactionID};
+use ckb_core::transaction::{ProposalShortId, Transaction};
 
 pub struct BlockTransactionsVerifier {}
 
@@ -12,7 +11,7 @@ impl BlockTransactionsVerifier {
         transactions: &[Transaction],
     ) -> Result<(), Error> {
         let block_short_ids = block.block_short_ids();
-        let missing_short_ids: Vec<&ShortTransactionID> = indexes
+        let missing_short_ids: Vec<&ProposalShortId> = indexes
             .iter()
             .filter_map(|index| {
                 block_short_ids
@@ -31,10 +30,8 @@ impl BlockTransactionsVerifier {
             ));
         }
 
-        let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
-
         for (expected_short_id, tx) in missing_short_ids.iter().zip(transactions) {
-            let short_id = short_transaction_id(key0, key1, &tx.witness_hash());
+            let short_id = tx.proposal_short_id();
             if *expected_short_id != &short_id {
                 return Err(Error::Misbehavior(Misbehavior::InvalidBlockTransactions {
                     expect: **expected_short_id,

--- a/sync/src/relayer/error.rs
+++ b/sync/src/relayer/error.rs
@@ -1,4 +1,4 @@
-use ckb_protocol::ShortTransactionID;
+use ckb_core::transaction::ProposalShortId;
 use failure::Fail;
 
 #[derive(Debug, Fail, Eq, PartialEq)]
@@ -39,8 +39,8 @@ pub enum Misbehavior {
         expect, got
     )]
     InvalidBlockTransactions {
-        expect: ShortTransactionID,
-        got: ShortTransactionID,
+        expect: ProposalShortId,
+        got: ProposalShortId,
     },
     #[fail(display = "BlockInvalid")]
     BlockInvalid,

--- a/sync/src/relayer/tests/compact_block.rs
+++ b/sync/src/relayer/tests/compact_block.rs
@@ -1,10 +1,13 @@
 use crate::relayer::compact_block::CompactBlock;
-use ckb_core::transaction::{IndexTransaction, TransactionBuilder};
+use ckb_core::transaction::{IndexTransaction, ProposalShortId, TransactionBuilder};
 
 #[test]
 fn test_block_short_ids() {
     let mut compact_block = CompactBlock::default();
-    let short_ids = vec![[1u8; 6], [2u8; 6]];
+    let short_ids = vec![
+        ProposalShortId::new([1u8; 10]),
+        ProposalShortId::new([2u8; 10]),
+    ];
     let prefilled_transactions = vec![
         IndexTransaction {
             index: 0,
@@ -21,6 +24,11 @@ fn test_block_short_ids() {
 
     assert_eq!(
         compact_block.block_short_ids(),
-        vec![None, Some([1u8; 6]), None, Some([2u8; 6])]
+        vec![
+            None,
+            Some(ProposalShortId::new([1u8; 10])),
+            None,
+            Some(ProposalShortId::new([2u8; 10]))
+        ]
     );
 }

--- a/sync/src/relayer/tests/compact_block_verifier.rs
+++ b/sync/src/relayer/tests/compact_block_verifier.rs
@@ -1,9 +1,8 @@
 use super::helper::new_index_transaction;
-use crate::relayer::compact_block::{CompactBlock, ShortTransactionID};
+use crate::relayer::compact_block::CompactBlock;
 use crate::relayer::compact_block_verifier::{PrefilledVerifier, ShortIdsVerifier};
 use crate::relayer::error::{Error, Misbehavior};
-use ckb_core::transaction::IndexTransaction;
-use ckb_protocol::{short_transaction_id, short_transaction_id_keys};
+use ckb_core::transaction::{IndexTransaction, ProposalShortId};
 
 #[test]
 fn test_unordered_prefilled() {
@@ -65,10 +64,8 @@ fn test_cellbase_not_prefilled() {
 #[test]
 fn test_duplicated_short_ids() {
     let mut block = CompactBlock::default();
-    let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
-    let mut short_ids: Vec<ShortTransactionID> = (1..5)
-        .map(new_index_transaction)
-        .map(|tx| short_transaction_id(key0, key1, &tx.transaction.witness_hash()))
+    let mut short_ids: Vec<ProposalShortId> = (1..5)
+        .map(|i| new_index_transaction(i).transaction.proposal_short_id())
         .collect();
     short_ids.push(short_ids[0]);
     block.short_ids = short_ids;
@@ -81,11 +78,9 @@ fn test_duplicated_short_ids() {
 #[test]
 fn test_intersected_short_ids() {
     let mut block = CompactBlock::default();
-    let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
     let prefilled: Vec<IndexTransaction> = (0..=5).map(new_index_transaction).collect();
-    let short_ids: Vec<ShortTransactionID> = (5..9)
-        .map(new_index_transaction)
-        .map(|tx| short_transaction_id(key0, key1, &tx.transaction.witness_hash()))
+    let short_ids: Vec<ProposalShortId> = (5..9)
+        .map(|i| new_index_transaction(i).transaction.proposal_short_id())
         .collect();
     block.prefilled_transactions = prefilled;
     block.short_ids = short_ids;
@@ -100,15 +95,13 @@ fn test_intersected_short_ids() {
 #[test]
 fn test_normal() {
     let mut block = CompactBlock::default();
-    let (key0, key1) = short_transaction_id_keys(block.header.nonce(), block.nonce);
     let prefilled: Vec<IndexTransaction> = vec![1, 2, 5]
         .into_iter()
         .map(new_index_transaction)
         .collect();
-    let short_ids: Vec<ShortTransactionID> = vec![0, 3, 4]
+    let short_ids: Vec<ProposalShortId> = vec![0, 3, 4]
         .into_iter()
-        .map(new_index_transaction)
-        .map(|tx| short_transaction_id(key0, key1, &tx.transaction.witness_hash()))
+        .map(|i| new_index_transaction(i).transaction.proposal_short_id())
         .collect();
     block.prefilled_transactions = prefilled;
     block.short_ids = short_ids;


### PR DESCRIPTION
This PR changes `CompactBlock#short_id` to `ProposalShortId`, and `reconstruct_block` will try to get tx from the entire tx pool instead of proposal tx pool only.