### PR TITLE
feat: Upgrade CKB VM to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
  "ckb-script-data-loader 0.19.0-pre",
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
- "ckb-vm 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1111,20 +1111,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2086,6 +2087,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3925,8 +3935,8 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum ckb-system-scripts 0.2.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bacc4120faaa43c0eaf20999d597dbeaedc7350f0d1fb35970f3e61789a1cd13"
-"checksum ckb-vm 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18b51030e40fcedaf36738d9b874565e51265facd279e2024d1d1798b52a17b2"
-"checksum ckb-vm-definitions 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb652578c56840b6db86364105df9af6cb3413076d06cf55a5b335724da16dea"
+"checksum ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f089b008f8fa02e44b409b2c24ee9a9f65216f24cebeccc598162d3a44a675ad"
+"checksum ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd297669e4783ddca472fa00e7d2117b2d1dcb67cca814d5dd222852b8dba088"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
@@ -4035,6 +4045,7 @@ dependencies = [
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d589b5a7ca642540e7ccfbca3bcd0aa18693eb9287e2a6b17c79b1d062d52863"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -11,7 +11,7 @@ numext-fixed-hash = { version = "0.1", features = ["support_rand", "support_heap
 byteorder = "1.3.1"
 ckb-core = { path = "../core" }
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.13.0", features = ["asm"] }
+ckb-vm = { version = "0.15.1", features = ["asm"] }
 faster-hex = "0.3"
 fnv = "1.0.3"
 flatbuffers = "0.6.0"

--- a/script/src/syscalls/debugger.rs
+++ b/script/src/syscalls/debugger.rs
@@ -25,13 +25,13 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for Debugger<'a> {
             return Ok(false);
         }
 
-        let mut addr = machine.registers()[A0].to_usize();
+        let mut addr = machine.registers()[A0].to_u64();
         let mut buffer = Vec::new();
 
         loop {
             let byte = machine
                 .memory_mut()
-                .load8(&Mac::REG::from_usize(addr))?
+                .load8(&Mac::REG::from_u64(addr))?
                 .to_u8();
             if byte == 0 {
                 break;

--- a/script/src/syscalls/load_cell.rs
+++ b/script/src/syscalls/load_cell.rs
@@ -184,10 +184,10 @@ impl<'a, Mac: SupportMachine, CS: DataLoader> Syscalls<Mac> for LoadCell<'a, CS>
             _ => return Ok(false),
         };
 
-        let index = machine.registers()[A3].to_usize();
+        let index = machine.registers()[A3].to_u64();
         let source = Source::parse_from_u64(machine.registers()[A4].to_u64())?;
 
-        let cell = self.fetch_cell(source, index);
+        let cell = self.fetch_cell(source, index as usize);
         if cell.is_err() {
             machine.set_register(A0, Mac::REG::from_u8(cell.unwrap_err()));
             return Ok(true);

--- a/script/src/syscalls/load_header.rs
+++ b/script/src/syscalls/load_header.rs
@@ -70,10 +70,10 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for LoadHeader<'a> {
             return Ok(false);
         }
 
-        let index = machine.registers()[A3].to_usize();
+        let index = machine.registers()[A3].to_u64();
         let source = Source::parse_from_u64(machine.registers()[A4].to_u64())?;
 
-        let header = self.fetch_header(source, index);
+        let header = self.fetch_header(source, index as usize);
         if header.is_err() {
             machine.set_register(A0, Mac::REG::from_u8(header.unwrap_err()));
             return Ok(true);

--- a/script/src/syscalls/load_input.rs
+++ b/script/src/syscalls/load_input.rs
@@ -100,10 +100,10 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for LoadInput<'a> {
             _ => return Ok(false),
         };
 
-        let index = machine.registers()[A3].to_usize();
+        let index = machine.registers()[A3].to_u64();
         let source = Source::parse_from_u64(machine.registers()[A4].to_u64())?;
 
-        let input = self.fetch_input(source, index);
+        let input = self.fetch_input(source, index as usize);
         if input.is_err() {
             machine.set_register(A0, Mac::REG::from_u8(input.unwrap_err()));
             return Ok(true);

--- a/script/src/syscalls/load_witness.rs
+++ b/script/src/syscalls/load_witness.rs
@@ -46,10 +46,10 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for LoadWitness<'a> {
             return Ok(false);
         }
 
-        let index = machine.registers()[A3].to_usize();
+        let index = machine.registers()[A3].to_u64();
         let source = Source::parse_from_u64(machine.registers()[A4].to_u64())?;
 
-        let witness = self.fetch_witness(source, index);
+        let witness = self.fetch_witness(source, index as usize);
         if witness.is_none() {
             machine.set_register(A0, Mac::REG::from_u8(INDEX_OUT_OF_BOUND));
             return Ok(true);

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -1087,10 +1087,7 @@ mod tests {
             &group_outputs,
         );
 
-        prop_assert!(machine
-            .memory_mut()
-            .store_byte(addr as usize, addr_size as usize, 1)
-            .is_ok());
+        prop_assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
 
         prop_assert!(load_code.ecall(&mut machine).is_ok());
         prop_assert_eq!(machine.registers()[A0], u64::from(SUCCESS));
@@ -1098,7 +1095,7 @@ mod tests {
         prop_assert_eq!(
             machine
                 .memory_mut()
-                .fetch_flag(addr as usize / RISCV_PAGESIZE),
+                .fetch_flag(addr / RISCV_PAGESIZE as u64),
             Ok(FLAG_EXECUTABLE | FLAG_FREEZED)
         );
         for (i, addr) in (addr..addr + data.len() as u64).enumerate() {
@@ -1126,13 +1123,7 @@ mod tests {
 
         prop_assert!(machine
             .memory_mut()
-            .init_pages(
-                addr as usize,
-                addr_size as usize,
-                FLAG_EXECUTABLE | FLAG_FREEZED,
-                None,
-                0
-            )
+            .init_pages(addr, addr_size, FLAG_EXECUTABLE | FLAG_FREEZED, None, 0)
             .is_ok());
 
         machine.set_register(A0, addr); // addr
@@ -1219,10 +1210,7 @@ mod tests {
             &group_outputs,
         );
 
-        assert!(machine
-            .memory_mut()
-            .store_byte(addr as usize, addr_size as usize, 1)
-            .is_ok());
+        assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
 
         assert!(load_code.ecall(&mut machine).is_err());
 
@@ -1269,10 +1257,7 @@ mod tests {
             &group_outputs,
         );
 
-        assert!(machine
-            .memory_mut()
-            .store_byte(addr as usize, addr_size as usize, 1)
-            .is_ok());
+        assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
 
         assert!(load_code.ecall(&mut machine).is_ok());
         assert_eq!(machine.registers()[A0], u64::from(SLICE_OUT_OF_BOUND));
@@ -1322,10 +1307,7 @@ mod tests {
             &group_outputs,
         );
 
-        assert!(machine
-            .memory_mut()
-            .store_byte(addr as usize, addr_size as usize, 1)
-            .is_ok());
+        assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
 
         assert!(load_code.ecall(&mut machine).is_ok());
         assert_eq!(machine.registers()[A0], u64::from(SLICE_OUT_OF_BOUND));

--- a/script/src/syscalls/utils.rs
+++ b/script/src/syscalls/utils.rs
@@ -5,18 +5,18 @@ use ckb_vm::{
 use std::cmp;
 
 pub fn store_data<Mac: SupportMachine>(machine: &mut Mac, data: &[u8]) -> Result<(), VMError> {
-    let addr = machine.registers()[A0].to_usize();
+    let addr = machine.registers()[A0].to_u64();
     let size_addr = machine.registers()[A1].clone();
-    let offset = machine.registers()[A2].to_usize();
+    let offset = machine.registers()[A2].to_u64();
 
-    let size = machine.memory_mut().load64(&size_addr)?.to_usize();
-    let full_size = data.len() - offset;
+    let size = machine.memory_mut().load64(&size_addr)?.to_u64();
+    let full_size = data.len() as u64 - offset;
     let real_size = cmp::min(size, full_size);
     machine
         .memory_mut()
-        .store64(&size_addr, &Mac::REG::from_usize(full_size))?;
+        .store64(&size_addr, &Mac::REG::from_u64(full_size))?;
     machine
         .memory_mut()
-        .store_bytes(addr, &data[offset..offset + real_size])?;
+        .store_bytes(addr, &data[offset as usize..(offset + real_size) as usize])?;
     Ok(())
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -315,7 +315,7 @@ impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
                     )))
                     .syscall(Box::new(Debugger::new(&debug_printer)))
                     .build();
-                let mut machine = AsmMachine::new(machine);
+                let mut machine = AsmMachine::new(machine, None);
                 machine
                     .load_program(&program, &args)
                     .map_err(ScriptError::VMError)?;


### PR DESCRIPTION
Please refer to the following URLs for changes from 0.13.0 to 0.15.1 in CKB VM.

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.14.0
https://github.com/nervosnetwork/ckb-vm/releases/tag/0.15.0
https://github.com/nervosnetwork/ckb-vm/releases/tag/0.15.1

One important note is that even though CKB VM supports the all new AOT mode right now, we are still only using the ASM interpreter in CKB since the performance is already good enough.