### PR TITLE
fix: tx pool config typo and new config param

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -86,7 +86,8 @@ modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Experiment"] # {{
 [tx_pool]
 max_mem_size = 20_000_000 # 20mb
 max_cycles = 200_000_000_000
-max_verfify_cache_size = 100_000
+max_verify_cache_size = 100_000
+max_conflict_cache_size = 1_000
 
 [script]
 runner = "Rust" # {{

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -18,8 +18,6 @@ use lru_cache::LruCache;
 use numext_fixed_hash::H256;
 use std::sync::Arc;
 
-const TXS_VERIFY_CACHE_SIZE: usize = 10_000;
-
 #[derive(Debug)]
 pub struct Shared<CS> {
     store: Arc<CS>,
@@ -51,7 +49,9 @@ impl<CS: ChainStore> Shared<CS> {
     ) -> Result<Self, SharedError> {
         let store = Arc::new(store);
         let consensus = Arc::new(consensus);
-        let txs_verify_cache = Arc::new(Mutex::new(LruCache::new(TXS_VERIFY_CACHE_SIZE)));
+        let txs_verify_cache = Arc::new(Mutex::new(LruCache::new(
+            tx_pool_config.max_verify_cache_size,
+        )));
         let chain_state = Arc::new(Mutex::new(ChainState::init(
             &store,
             Arc::clone(&consensus),
@@ -165,8 +165,6 @@ impl SharedBuilder<RocksDB> {
         self
     }
 }
-
-pub const MIN_TXS_VERIFY_CACHE_SIZE: Option<usize> = Some(100);
 
 impl<DB: KeyValueDB> SharedBuilder<DB> {
     pub fn consensus(mut self, value: Consensus) -> Self {

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -32,7 +32,7 @@ pub struct TxPool {
 
 impl TxPool {
     pub fn new(config: TxPoolConfig) -> TxPool {
-        let cache_size = config.max_verfify_cache_size;
+        let cache_size = config.max_conflict_cache_size;
         let last_txs_updated_at = 0u64;
 
         TxPool {

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -18,8 +18,10 @@ pub struct TxPoolConfig {
     pub max_mem_size: usize,
     // Keep the transaction pool below <max_cycles> cycles
     pub max_cycles: Cycle,
-    // tx verfify cache capacity
-    pub max_verfify_cache_size: usize,
+    // tx verify cache capacity
+    pub max_verify_cache_size: usize,
+    // conflict tx cache capacity
+    pub max_conflict_cache_size: usize,
 }
 
 impl Default for TxPoolConfig {
@@ -27,7 +29,8 @@ impl Default for TxPoolConfig {
         TxPoolConfig {
             max_mem_size: 20_000_000, // 20mb
             max_cycles: 200_000_000_000,
-            max_verfify_cache_size: 100_000,
+            max_verify_cache_size: 100_000,
+            max_conflict_cache_size: 1_000,
         }
     }
 }


### PR DESCRIPTION
fix typo `max_verfify_cache_size` => `max_verify_cache_size`, txs verify cache should use this config value instead of a hardcoded value.

added a new config param for conflict txs cache capacity