### PR TITLE
fix: Reject hash type referencing via type with multiple matches

### DIFF
--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -71,4 +71,5 @@ pub enum ScriptError {
     Secp,
     ArgumentNumber,
     NoWitness,
+    MultipleMatches,
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -845,7 +845,10 @@ mod tests {
         };
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
 
-        assert!(verifier.verify(100_000_000).is_err());
+        assert_eq!(
+            verifier.verify(100_000_000),
+            Err(ScriptError::MultipleMatches)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Note this only applies to `Type` as a HashType, since if multiple
cells have the same data hash, the content must be the same.