### PR TITLE
chore: quick exit on reconcile find an error

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -656,6 +656,7 @@ impl<CS: ChainStore + 'static> ChainService<CS> {
                     }
                 } else {
                     *verified = Some(false);
+                    return Err(found_error.unwrap().into());
                 }
             } else {
                 cell_set_diff.push_new(b);


### PR DESCRIPTION
Once `found_error` has a value, the function `reconcile_main_chain` must return Error, which can be logged out early.

Take a closer look, maybe there is no need for a variable such as `found_error`