### PR TITLE
feat: tx_pool support sort by fee rate

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -22,8 +22,7 @@ use crossbeam_channel::{self, select, Receiver, Sender};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use lru_cache::LruCache;
-use std::collections::HashSet;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::{cmp, thread};
 

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -9,7 +9,11 @@ use ckb_jsonrpc_types::{
 };
 use ckb_logger::{error, info};
 use ckb_notify::NotifyController;
-use ckb_shared::{shared::Shared, tx_pool::ProposedEntry};
+use ckb_shared::{
+    chain_state::ChainState,
+    shared::Shared,
+    tx_pool::{commit_txs_scanner::CommitTxsScanner, TxEntry},
+};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_store::ChainStore;
 use ckb_traits::ChainProvider;
@@ -220,7 +224,7 @@ impl BlockAssembler {
     }
 
     fn transform_tx(
-        tx: &ProposedEntry,
+        tx: &TxEntry,
         required: bool,
         depends: Option<Vec<u32>>,
     ) -> TransactionTemplate {
@@ -351,8 +355,7 @@ impl BlockAssembler {
         let proposals = chain_state.get_proposals(proposals_limit as usize);
         let txs_size_limit =
             self.calculate_txs_size_limit(bytes_limit, cellbase.data(), &uncles, &proposals)?;
-
-        let (entries, size, cycles) = chain_state.get_proposed_txs(txs_size_limit, cycles_limit);
+        let (entries, size, cycles) = self.package_txs(&chain_state, txs_size_limit, cycles_limit);
         if !entries.is_empty() {
             info!(
                 "[get_block_template] candidate txs count: {}, size: {}/{}, cycles:{}/{}",
@@ -430,6 +433,16 @@ impl BlockAssembler {
         );
 
         Ok(template)
+    }
+
+    fn package_txs(
+        &self,
+        chain_state: &ChainState,
+        size_limit: usize,
+        cycles_limit: Cycle,
+    ) -> (Vec<TxEntry>, usize, Cycle) {
+        let tx_pool = chain_state.tx_pool();
+        CommitTxsScanner::new(tx_pool.proposed()).txs_to_commit(size_limit, cycles_limit)
     }
 
     /// Miner mined block H(c), the block reward will be finalized at H(c + w_far + 1).
@@ -563,11 +576,13 @@ mod tests {
             BlockBuilder, BlockNumber, BlockView, EpochExt, HeaderBuilder, HeaderView,
             TransactionBuilder, TransactionView,
         },
-        packed::{Block, CellInput, CellOutput},
+        packed::{Block, CellInput, CellOutput, CellOutputBuilder},
         H256,
     };
     use ckb_verification::{BlockVerifier, HeaderResolverWrapper, HeaderVerifier, Verifier};
     use std::sync::Arc;
+
+    const BASIC_BLOCK_SIZE: u64 = 706;
 
     fn start_chain(
         consensus: Option<Consensus>,
@@ -744,5 +759,376 @@ mod tests {
             .unwrap();
         // block number 5, epoch 1, block_template should not include last epoch uncles
         assert!(block_template.uncles.is_empty());
+    }
+
+    fn build_tx(
+        parent_tx: &TransactionView,
+        inputs: &[u32],
+        outputs_len: usize,
+    ) -> TransactionView {
+        let per_output_capacity =
+            Capacity::shannons(parent_tx.outputs_capacity().unwrap().as_u64() / outputs_len as u64);
+        TransactionBuilder::default()
+            .inputs(inputs.iter().map(|index| {
+                CellInput::new(
+                    OutPoint::new(parent_tx.hash().to_owned().unpack(), *index),
+                    0,
+                )
+            }))
+            .outputs(
+                (0..outputs_len)
+                    .map(|_| {
+                        CellOutputBuilder::default()
+                            .capacity(per_output_capacity.pack())
+                            .build()
+                    })
+                    .collect::<Vec<CellOutput>>(),
+            )
+            .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
+            .build()
+    }
+
+    #[test]
+    fn test_package_basic() {
+        let mut consensus = Consensus::default();
+        consensus.genesis_epoch_ext.set_length(5);
+        let epoch = consensus.genesis_epoch_ext().clone();
+
+        let (chain_controller, shared, notify) = start_chain(Some(consensus), None);
+        let config = BlockAssemblerConfig {
+            code_hash: H256::zero(),
+            args: vec![],
+            data: JsonBytes::default(),
+            hash_type: ScriptHashType::Data,
+        };
+        let block_assembler = setup_block_assembler(shared.clone(), config);
+        let block_assembler_controller = block_assembler.start(Some("test"), &notify.clone());
+
+        let genesis = shared
+            .store()
+            .get_block_header(&shared.store().get_block_hash(0).unwrap())
+            .unwrap();
+        let mut parent_header = genesis.to_owned();
+        let mut blocks = vec![];
+        for _i in 0..4 {
+            let block = gen_block(&parent_header, 11, &epoch);
+            chain_controller
+                .process_block(Arc::new(block.clone()), false)
+                .expect("process block");
+            parent_header = block.header().to_owned();
+            blocks.push(block);
+        }
+
+        let tx0 = &blocks[0].transactions()[0];
+        let tx1 = build_tx(tx0, &[0], 2);
+        let tx2 = build_tx(&tx1, &[0], 2);
+        let tx3 = build_tx(&tx2, &[0], 2);
+        let tx4 = build_tx(&tx3, &[0], 2);
+
+        let tx2_0 = &blocks[1].transactions()[0];
+        let tx2_1 = build_tx(tx2_0, &[0], 2);
+        let tx2_2 = build_tx(&tx2_1, &[0], 2);
+        let tx2_3 = build_tx(&tx2_2, &[0], 2);
+
+        {
+            let mut chain_state = shared.lock_chain_state();
+            let tx_pool = chain_state.mut_tx_pool();
+            for (tx, fee, cycles, size) in &[
+                (&tx1, 100, 0, 100),
+                (&tx2, 100, 0, 100),
+                (&tx3, 100, 0, 100),
+                (&tx4, 1500, 0, 500),
+                (&tx2_1, 150, 0, 100),
+                (&tx2_2, 150, 0, 100),
+                (&tx2_3, 150, 0, 100),
+            ] {
+                tx_pool.add_proposed(
+                    *cycles,
+                    Capacity::shannons(*fee),
+                    *size,
+                    (*tx).to_owned(),
+                    vec![],
+                );
+            }
+        }
+
+        let check_txs = |block_template: &BlockTemplate, expect_txs: Vec<&TransactionView>| {
+            assert_eq!(
+                block_template
+                    .transactions
+                    .iter()
+                    .map(|tx| format!("{}", tx.hash))
+                    .collect::<Vec<_>>(),
+                expect_txs
+                    .iter()
+                    .map(|tx| format!("{}", Unpack::<H256>::unpack(&tx.hash())))
+                    .collect::<Vec<_>>()
+            );
+        };
+
+        // 300 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(300 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx2_1, &tx2_2, &tx2_3]);
+
+        // 400 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(400 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx2_1, &tx2_2, &tx2_3, &tx1]);
+
+        // 500 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(500 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx2_1, &tx2_2, &tx2_3, &tx1, &tx2]);
+
+        // 600 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(600 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(
+            &block_template,
+            vec![&tx2_1, &tx2_2, &tx2_3, &tx1, &tx2, &tx3],
+        );
+
+        // 700 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(700 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(
+            &block_template,
+            vec![&tx2_1, &tx2_2, &tx2_3, &tx1, &tx2, &tx3],
+        );
+
+        // 800 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(800 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx3, &tx4]);
+
+        // none package txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(30 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![]);
+
+        // best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(None, None, None)
+            .unwrap();
+        check_txs(
+            &block_template,
+            vec![&tx1, &tx2, &tx3, &tx4, &tx2_1, &tx2_2, &tx2_3],
+        );
+    }
+
+    #[test]
+    fn test_package_multi_best_scores() {
+        let mut consensus = Consensus::default();
+        consensus.genesis_epoch_ext.set_length(5);
+        let epoch = consensus.genesis_epoch_ext().clone();
+
+        let (chain_controller, shared, notify) = start_chain(Some(consensus), None);
+        let config = BlockAssemblerConfig {
+            code_hash: H256::zero(),
+            args: vec![],
+            data: JsonBytes::default(),
+            hash_type: ScriptHashType::Data,
+        };
+        let block_assembler = setup_block_assembler(shared.clone(), config);
+        let block_assembler_controller = block_assembler.start(Some("test"), &notify.clone());
+
+        let genesis = shared
+            .store()
+            .get_block_header(&shared.store().get_block_hash(0).unwrap())
+            .unwrap();
+        let mut parent_header = genesis.to_owned();
+        let mut blocks = vec![];
+        for _i in 0..4 {
+            let block = gen_block(&parent_header, 11, &epoch);
+            chain_controller
+                .process_block(Arc::new(block.clone()), false)
+                .expect("process block");
+            parent_header = block.header().to_owned();
+            blocks.push(block);
+        }
+
+        let tx0 = &blocks[0].transactions()[0];
+        let tx1 = build_tx(tx0, &[0], 2);
+        let tx2 = build_tx(&tx1, &[0], 2);
+        let tx3 = build_tx(&tx2, &[0], 2);
+        let tx4 = build_tx(&tx3, &[0], 2);
+
+        let tx2_0 = &blocks[1].transactions()[0];
+        let tx2_1 = build_tx(tx2_0, &[0], 2);
+        let tx2_2 = build_tx(&tx2_1, &[0], 2);
+        let tx2_3 = build_tx(&tx2_2, &[0], 2);
+        let tx2_4 = build_tx(&tx2_3, &[0], 2);
+
+        let tx3_0 = &blocks[2].transactions()[0];
+        let tx3_1 = build_tx(tx3_0, &[0], 1);
+
+        let tx4_0 = &blocks[3].transactions()[0];
+        let tx4_1 = build_tx(tx4_0, &[0], 1);
+
+        {
+            let mut chain_state = shared.lock_chain_state();
+            let tx_pool = chain_state.mut_tx_pool();
+            for (tx, fee, cycles, size) in &[
+                (&tx1, 200, 0, 100),
+                (&tx2, 200, 0, 100),
+                (&tx3, 50, 0, 50),
+                (&tx4, 1500, 0, 500),
+                (&tx2_1, 150, 0, 100),
+                (&tx2_2, 150, 0, 100),
+                (&tx2_3, 150, 0, 100),
+                (&tx2_4, 150, 0, 100),
+                (&tx3_1, 1000, 0, 1000),
+                (&tx4_1, 300, 0, 250),
+            ] {
+                tx_pool.add_proposed(
+                    *cycles,
+                    Capacity::shannons(*fee),
+                    *size,
+                    (*tx).to_owned(),
+                    vec![],
+                );
+            }
+        }
+
+        let check_txs = |block_template: &BlockTemplate, expect_txs: Vec<&TransactionView>| {
+            assert_eq!(
+                block_template
+                    .transactions
+                    .iter()
+                    .map(|tx| format!("{}", tx.hash))
+                    .collect::<Vec<_>>(),
+                expect_txs
+                    .iter()
+                    .map(|tx| format!("{}", Unpack::<H256>::unpack(&tx.hash())))
+                    .collect::<Vec<_>>()
+            );
+        };
+
+        // 250 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(250 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx3]);
+
+        // 400 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(400 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx2_1, &tx2_2]);
+
+        // 500 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(500 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx2_1, &tx2_2, &tx2_3]);
+
+        // 900 size best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(900 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx3, &tx4, &tx2_1]);
+
+        // none package txs
+        let block_template = block_assembler_controller
+            .get_block_template(Some(30 + BASIC_BLOCK_SIZE), None, None)
+            .unwrap();
+        check_txs(&block_template, vec![]);
+
+        // best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(None, None, None)
+            .unwrap();
+        check_txs(
+            &block_template,
+            vec![
+                &tx1, &tx2, &tx3, &tx4, &tx2_1, &tx2_2, &tx2_3, &tx2_4, &tx4_1, &tx3_1,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_package_zero_fee_txs() {
+        let mut consensus = Consensus::default();
+        consensus.genesis_epoch_ext.set_length(5);
+        let epoch = consensus.genesis_epoch_ext().clone();
+
+        let (chain_controller, shared, notify) = start_chain(Some(consensus), None);
+        let config = BlockAssemblerConfig {
+            code_hash: H256::zero(),
+            args: vec![],
+            data: JsonBytes::default(),
+            hash_type: ScriptHashType::Data,
+        };
+        let block_assembler = setup_block_assembler(shared.clone(), config);
+        let block_assembler_controller = block_assembler.start(Some("test"), &notify.clone());
+
+        let genesis = shared
+            .store()
+            .get_block_header(&shared.store().get_block_hash(0).unwrap())
+            .unwrap();
+        let mut parent_header = genesis.to_owned();
+        let mut blocks = vec![];
+        for _i in 0..4 {
+            let block = gen_block(&parent_header, 11, &epoch);
+            chain_controller
+                .process_block(Arc::new(block.clone()), false)
+                .expect("process block");
+            parent_header = block.header().to_owned();
+            blocks.push(block);
+        }
+
+        let tx0 = &blocks[0].transactions()[0];
+        let tx1 = build_tx(tx0, &[0], 2);
+        let tx2 = build_tx(&tx1, &[0], 2);
+        let tx3 = build_tx(&tx2, &[0], 2);
+        let tx4 = build_tx(&tx3, &[0], 2);
+        let tx5 = build_tx(&tx4, &[0], 2);
+
+        {
+            let mut chain_state = shared.lock_chain_state();
+            let tx_pool = chain_state.mut_tx_pool();
+            for (tx, fee, cycles, size) in &[
+                (&tx1, 1000, 0, 100),
+                (&tx2, 0, 0, 100),
+                (&tx3, 0, 0, 100),
+                (&tx4, 0, 0, 100),
+                (&tx5, 0, 0, 100),
+            ] {
+                tx_pool.add_proposed(
+                    *cycles,
+                    Capacity::shannons(*fee),
+                    *size,
+                    (*tx).to_owned(),
+                    vec![],
+                );
+            }
+        }
+
+        let check_txs = |block_template: &BlockTemplate, expect_txs: Vec<&TransactionView>| {
+            assert_eq!(
+                block_template
+                    .transactions
+                    .iter()
+                    .map(|tx| format!("{}", tx.hash))
+                    .collect::<Vec<_>>(),
+                expect_txs
+                    .iter()
+                    .map(|&tx| format!("{}", Unpack::<H256>::unpack(&tx.hash())))
+                    .collect::<Vec<_>>()
+            );
+        };
+        // best scored txs
+        let block_template = block_assembler_controller
+            .get_block_template(None, None, None)
+            .unwrap();
+        check_txs(&block_template, vec![&tx1, &tx2, &tx3, &tx4, &tx5]);
     }
 }

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -100,8 +100,9 @@ impl ChainRpc for ChainRpcImpl {
 
             let tx_pool = chan_state.tx_pool();
             tx_pool
-                .get_tx_from_proposed(&id)
-                .map(TransactionWithStatus::with_proposed)
+                .proposed()
+                .get(&id)
+                .map(|entry| TransactionWithStatus::with_proposed(entry.transaction.to_owned()))
                 .or_else(|| {
                     tx_pool
                         .get_tx_without_conflict(&id)

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -582,6 +582,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![always_success_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -647,6 +648,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
@@ -730,6 +732,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
@@ -806,6 +809,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
@@ -902,6 +906,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell, dep_cell2],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
@@ -984,6 +989,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1051,6 +1057,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1108,6 +1115,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1194,6 +1202,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell, always_success_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1273,6 +1282,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell, always_success_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1343,6 +1353,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![dep_cell],
             resolved_inputs: vec![dummy_cell],
+            resolved_dep_groups: vec![],
         };
         let config = ScriptConfig {
             runner: Runner::default(),
@@ -1404,6 +1415,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1466,6 +1478,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1544,6 +1557,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1605,6 +1619,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1681,6 +1696,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1763,6 +1779,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();
@@ -1834,6 +1851,7 @@ mod tests {
             transaction: &transaction,
             resolved_cell_deps: vec![resolved_always_success_cell],
             resolved_inputs: vec![resolved_input_cell],
+            resolved_dep_groups: vec![],
         };
 
         let store = new_store();

--- a/shared/src/tx_pool.rs
+++ b/shared/src/tx_pool.rs
@@ -1,3 +1,4 @@
+pub mod commit_txs_scanner;
 pub mod pool;
 pub mod types;
 
@@ -6,4 +7,15 @@ mod pending;
 mod proposed;
 
 pub use self::pool::TxPool;
-pub use self::types::{DefectEntry, PendingEntry, PoolError, ProposedEntry, TxPoolConfig};
+pub use self::types::{DefectEntry, PoolError, TxEntry, TxPoolConfig};
+
+const DEFAULT_BYTES_PER_CYCLES: f64 = 0.00042f64;
+
+/// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
+/// tx_pool use vbytes to estimate transaction fee rate.
+pub(crate) fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
+    std::cmp::max(
+        tx_size as u64,
+        (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,
+    )
+}

--- a/shared/src/tx_pool/commit_txs_scanner.rs
+++ b/shared/src/tx_pool/commit_txs_scanner.rs
@@ -1,0 +1,209 @@
+use crate::tx_pool::{
+    proposed::ProposedPool,
+    types::{TxEntry, TxModifiedEntries},
+};
+use ckb_types::{core::Cycle, packed::ProposalShortId};
+use std::cmp::max;
+use std::collections::HashSet;
+
+/// node will give up to package more txs after MAX_CONSECUTIVE_FAILED
+const MAX_CONSECUTIVE_FAILED: usize = 500;
+
+/// find txs to package into commitment
+pub struct CommitTxsScanner<'a> {
+    proposed_pool: &'a ProposedPool,
+    entries: Vec<TxEntry>,
+    // modified entries, after put a tx into block,
+    // the scores of descendants txs should be updated,
+    // these modified entries is stored in modified_entries.
+    // in each loop,
+    // we pick tx from modified_entries and pool to find the best tx to package
+    modified_entries: TxModifiedEntries,
+    // txs that packaged in block
+    fetched_txs: HashSet<ProposalShortId>,
+}
+
+impl<'a> CommitTxsScanner<'a> {
+    pub fn new(proposed_pool: &'a ProposedPool) -> CommitTxsScanner<'a> {
+        CommitTxsScanner {
+            proposed_pool,
+            entries: Vec::new(),
+            modified_entries: TxModifiedEntries::default(),
+            fetched_txs: HashSet::default(),
+        }
+    }
+    /// find txs to commit, return TxEntry vector, total_size and total_cycles.
+    pub fn txs_to_commit(
+        mut self,
+        size_limit: usize,
+        cycles_limit: Cycle,
+    ) -> (Vec<TxEntry>, usize, Cycle) {
+        let mut size: usize = 0;
+        let mut cycles: Cycle = 0;
+        self.proposed_pool.with_sorted_by_score_iter(|iter| {
+            let mut candidate_pool_tx = None;
+            let mut candidate_modified_tx = None;
+            loop {
+                // 1. choose best tx from pool and modified entries
+                // 2. compare the two txs, package the better one
+                // 3. update modified entries
+                Self::next_candidate_tx(
+                    &mut candidate_pool_tx,
+                    iter,
+                    size_limit,
+                    cycles_limit,
+                    size,
+                    cycles,
+                    |tx| {
+                        let tx_id = tx.transaction.proposal_short_id();
+                        !self.fetched_txs.contains(&tx_id)
+                            && !self.modified_entries.contains_key(&tx_id)
+                    },
+                );
+                self.modified_entries.with_sorted_by_score_iter(|iter| {
+                    Self::next_candidate_tx(
+                        &mut candidate_modified_tx,
+                        iter,
+                        size_limit,
+                        cycles_limit,
+                        size,
+                        cycles,
+                        |_| true,
+                    );
+                });
+                // take tx with higher scores
+                let tx_entry = match max(&mut candidate_pool_tx, &mut candidate_modified_tx).take()
+                {
+                    Some(entry) => entry,
+                    None => {
+                        // can't find any satisfied tx
+                        break;
+                    }
+                };
+                debug_assert!(!self
+                    .fetched_txs
+                    .contains(&tx_entry.transaction.proposal_short_id()));
+                // prepare to package tx with ancestors
+                let mut ancestors = self
+                    .proposed_pool
+                    .get_ancestors(&tx_entry.transaction.proposal_short_id())
+                    .into_iter()
+                    .filter_map(|short_id| {
+                        if self.fetched_txs.contains(&short_id) {
+                            None
+                        } else {
+                            self.modified_entries.get(&short_id).or_else(|| {
+                                let entry = self
+                                    .proposed_pool
+                                    .get(&short_id)
+                                    .expect("pool should be consistent");
+                                Some(entry)
+                            })
+                        }
+                    })
+                    .cloned()
+                    .collect::<HashSet<TxEntry>>();
+                ancestors.insert(tx_entry.to_owned());
+                debug_assert_eq!(
+                    tx_entry.ancestors_cycles,
+                    ancestors.iter().map(|entry| entry.cycles).sum::<u64>(),
+                    "proposed tx pool ancestors cycles inconsistent"
+                );
+                debug_assert_eq!(
+                    tx_entry.ancestors_size,
+                    ancestors.iter().map(|entry| entry.size).sum::<usize>(),
+                    "proposed tx pool ancestors size inconsistent"
+                );
+                debug_assert_eq!(
+                    tx_entry.ancestors_count,
+                    ancestors.len(),
+                    "proposed tx pool ancestors count inconsistent"
+                );
+                // update all decendents and insert into modified
+                self.update_modified_entries(&ancestors);
+                // sort acestors by ancestors_count,
+                // if A is an ancestor of B, B.ancestors_count must large than A
+                let mut ancestors = ancestors.into_iter().collect::<Vec<_>>();
+                ancestors.sort_unstable_by_key(|entry| entry.ancestors_count);
+                // insert ancestors
+                for entry in ancestors {
+                    let short_id = entry.transaction.proposal_short_id();
+                    // try remove from modified
+                    self.modified_entries.remove(&short_id);
+                    let is_inserted = self.fetched_txs.insert(short_id);
+                    debug_assert!(is_inserted, "package duplicate txs");
+                    cycles = cycles.saturating_add(entry.cycles);
+                    size = size.saturating_add(entry.size);
+                    self.entries.push(entry);
+                }
+            }
+        });
+        (self.entries, size, cycles)
+    }
+
+    /// update weight for all descendants of packaged txs
+    fn update_modified_entries(&mut self, new_fetched_txs: &HashSet<TxEntry>) {
+        for ptx in new_fetched_txs {
+            let ptx_id = ptx.transaction.proposal_short_id();
+            if self.fetched_txs.contains(&ptx_id) {
+                continue;
+            }
+            let descendants = self.proposed_pool.get_descendants(&ptx_id);
+            for id in descendants {
+                let mut tx = self.modified_entries.remove(&id).unwrap_or_else(|| {
+                    self.proposed_pool
+                        .get(&id)
+                        .map(ToOwned::to_owned)
+                        .expect("pool consistent")
+                });
+                tx.sub_entry_weight(&ptx);
+                self.modified_entries.insert(tx);
+            }
+        }
+    }
+
+    /// find next fetchable candidate tx from iterator then place it into entry
+    /// the tx should satisfy the size and cycles limits and pass the is_satisfied
+    fn next_candidate_tx<F: Fn(&TxEntry) -> bool>(
+        entry: &mut Option<TxEntry>,
+        iter: &mut dyn Iterator<Item = &TxEntry>,
+        size_limit: usize,
+        cycles_limit: Cycle,
+        size: usize,
+        cycles: Cycle,
+        is_satisfied: F,
+    ) {
+        let is_satisfy_limit = |entry: &TxEntry| -> bool {
+            let next_cycles = cycles.saturating_add(entry.ancestors_cycles);
+            let next_size = size.saturating_add(entry.ancestors_size);
+            next_cycles <= cycles_limit && next_size <= size_limit
+        };
+        // return entry if it's exists and satisfy the requirements
+        if let Some(tx_entry) = entry {
+            if is_satisfied(&tx_entry) && is_satisfy_limit(&tx_entry) {
+                return;
+            }
+        }
+        let mut consecutive_failed = 0;
+        for tx_entry in iter {
+            if !is_satisfied(&tx_entry) {
+                continue;
+            }
+
+            if !is_satisfy_limit(&tx_entry) {
+                consecutive_failed += 1;
+                // give up if failed too many times
+                if consecutive_failed > MAX_CONSECUTIVE_FAILED {
+                    break;
+                }
+                continue;
+            }
+
+            // find new tx entry
+            entry.replace(tx_entry.to_owned());
+            return;
+        }
+        // set entry to None if iter is end or consecutive failed
+        entry.take();
+    }
+}

--- a/shared/src/tx_pool/pending.rs
+++ b/shared/src/tx_pool/pending.rs
@@ -1,64 +1,78 @@
-use crate::tx_pool::types::PendingEntry;
+use crate::tx_pool::types::{TxEntriesPool, TxEntry};
 use ckb_types::{
     core::{
         cell::{CellMetaBuilder, CellProvider, CellStatus},
-        Cycle, TransactionView,
+        TransactionView,
     },
     packed::{OutPoint, ProposalShortId},
     prelude::*,
     H256,
 };
-use ckb_util::{LinkedFnvHashMap, LinkedFnvHashMapEntries};
+use std::collections::HashSet;
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct PendingQueue {
-    pub(crate) inner: LinkedFnvHashMap<ProposalShortId, PendingEntry>,
+    inner: TxEntriesPool,
 }
 
 impl PendingQueue {
     pub(crate) fn new() -> Self {
         PendingQueue {
-            inner: LinkedFnvHashMap::default(),
+            inner: Default::default(),
         }
     }
 
     pub(crate) fn size(&self) -> usize {
-        self.inner.len()
+        self.inner.size()
     }
 
-    pub(crate) fn add_tx(
-        &mut self,
-        cycles: Option<Cycle>,
-        size: usize,
-        tx: TransactionView,
-    ) -> Option<PendingEntry> {
-        let short_id = tx.proposal_short_id();
-        self.inner
-            .insert(short_id, PendingEntry::new(tx, cycles, size))
+    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Option<TxEntry> {
+        self.inner.add_entry(entry)
     }
 
     pub(crate) fn contains_key(&self, id: &ProposalShortId) -> bool {
         self.inner.contains_key(id)
     }
 
-    pub(crate) fn get(&self, id: &ProposalShortId) -> Option<&PendingEntry> {
+    pub(crate) fn get(&self, id: &ProposalShortId) -> Option<&TxEntry> {
         self.inner.get(id)
     }
 
     pub(crate) fn get_tx(&self, id: &ProposalShortId) -> Option<&TransactionView> {
-        self.get(id).map(|x| &x.transaction)
+        self.inner.get(id).map(|x| &x.transaction)
     }
 
-    pub(crate) fn remove(&mut self, id: &ProposalShortId) -> Option<PendingEntry> {
-        self.inner.remove(id)
+    pub(crate) fn remove_entry_and_descendants(&mut self, id: &ProposalShortId) -> Vec<TxEntry> {
+        self.inner.remove_entry_and_descendants(id)
     }
 
-    pub(crate) fn keys(&self) -> impl Iterator<Item = &ProposalShortId> {
-        self.inner.keys()
+    /// find all ancestors from pool
+    pub(crate) fn get_ancestors(&self, tx_short_id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        self.inner.get_ancestors(tx_short_id)
     }
 
-    pub(crate) fn entries(&mut self) -> LinkedFnvHashMapEntries<ProposalShortId, PendingEntry> {
-        self.inner.entries()
+    pub(crate) fn sorted_keys(&self) -> impl Iterator<Item = &ProposalShortId> {
+        self.inner.sorted_keys().map(|key| &key.id)
+    }
+
+    // fill proposal txs
+    pub fn fill_proposals(&self, limit: usize, proposals: &mut HashSet<ProposalShortId>) {
+        for id in self.sorted_keys() {
+            if proposals.len() == limit {
+                break;
+            } else if proposals.contains(&id) {
+                // implies that ancestors are already in proposals
+                continue;
+            }
+            let mut ancestors = self.get_ancestors(&id).into_iter().collect::<Vec<_>>();
+            ancestors.sort_unstable_by_key(|id| {
+                self.get(&id)
+                    .map(|entry| entry.ancestors_count)
+                    .expect("exists")
+            });
+            ancestors.push(id.clone());
+            proposals.extend(ancestors.into_iter().take(limit - proposals.len()));
+        }
     }
 }
 
@@ -77,5 +91,157 @@ impl CellProvider for PendingQueue {
         } else {
             CellStatus::Unknown
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ckb_types::{
+        bytes::Bytes,
+        core::{Capacity, Cycle, TransactionBuilder},
+        packed::{CellInput, CellOutputBuilder},
+    };
+
+    fn build_tx(inputs: Vec<(&H256, u32)>, outputs_len: usize) -> TransactionView {
+        TransactionBuilder::default()
+            .inputs(
+                inputs
+                    .into_iter()
+                    .map(|(txid, index)| CellInput::new(OutPoint::new(txid.to_owned(), index), 0)),
+            )
+            .outputs((0..outputs_len).map(|i| {
+                CellOutputBuilder::default()
+                    .capacity(Capacity::bytes(i + 1).unwrap().pack())
+                    .build()
+            }))
+            .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
+            .build()
+    }
+
+    const MOCK_CYCLES: Cycle = 5_000_000;
+    const MOCK_SIZE: usize = 200;
+
+    #[test]
+    fn test_sorted_by_tx_fee_rate() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 1);
+        let tx2 = build_tx(vec![(&H256::zero(), 2)], 1);
+        let tx3 = build_tx(vec![(&H256::zero(), 3)], 1);
+
+        let mut pool = PendingQueue::new();
+
+        pool.add_entry(TxEntry::new(
+            tx1.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(100),
+            MOCK_SIZE,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx2.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(300),
+            MOCK_SIZE,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx3.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(200),
+            MOCK_SIZE,
+            vec![],
+        ));
+
+        let txs_sorted_by_fee_rate = pool.sorted_keys().cloned().collect::<Vec<_>>();
+        let expect_result = vec![
+            tx2.proposal_short_id(),
+            tx3.proposal_short_id(),
+            tx1.proposal_short_id(),
+        ];
+        assert_eq!(txs_sorted_by_fee_rate, expect_result);
+    }
+
+    #[test]
+    fn test_sorted_by_ancestors_score() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 2);
+        let tx1_hash = tx1.hash();
+        let tx2 = build_tx(vec![(&tx1_hash.unpack(), 1)], 1);
+        let tx2_hash = tx2.hash();
+        let tx3 = build_tx(vec![(&tx1_hash.unpack(), 2)], 1);
+        let tx4 = build_tx(vec![(&tx2_hash.unpack(), 1)], 1);
+
+        let mut pool = PendingQueue::new();
+
+        pool.add_entry(TxEntry::new(
+            tx1.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(100),
+            MOCK_SIZE,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx2.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(300),
+            MOCK_SIZE,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx3.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(200),
+            MOCK_SIZE,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx4.clone(),
+            MOCK_CYCLES,
+            Capacity::shannons(400),
+            MOCK_SIZE,
+            vec![],
+        ));
+
+        let txs_sorted_by_fee_rate = pool.sorted_keys().cloned().collect::<Vec<_>>();
+        let expect_result = vec![
+            tx4.proposal_short_id(),
+            tx2.proposal_short_id(),
+            tx3.proposal_short_id(),
+            tx1.proposal_short_id(),
+        ];
+        assert_eq!(txs_sorted_by_fee_rate, expect_result);
+    }
+
+    #[test]
+    fn test_sorted_by_ancestors_score_competitive() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 2);
+        let tx1_hash = tx1.hash();
+        let tx2 = build_tx(vec![(&tx1_hash.unpack(), 0)], 1);
+        let tx2_hash = tx2.hash();
+        let tx3 = build_tx(vec![(&tx2_hash.unpack(), 0)], 1);
+
+        let tx2_1 = build_tx(vec![(&H256::zero(), 2)], 2);
+        let tx2_1_hash = tx2_1.hash();
+        let tx2_2 = build_tx(vec![(&tx2_1_hash.unpack(), 0)], 1);
+        let tx2_2_hash = tx2_2.hash();
+        let tx2_3 = build_tx(vec![(&tx2_2_hash.unpack(), 0)], 1);
+        let tx2_3_hash = tx2_3.hash();
+        let tx2_4 = build_tx(vec![(&tx2_3_hash.unpack(), 0)], 1);
+
+        let mut pool = PendingQueue::new();
+
+        for &tx in &[&tx1, &tx2, &tx3, &tx2_1, &tx2_2, &tx2_3, &tx2_4] {
+            pool.add_entry(TxEntry::new(
+                tx.clone(),
+                MOCK_CYCLES,
+                Capacity::shannons(200),
+                MOCK_SIZE,
+                vec![],
+            ));
+        }
+
+        let txs_sorted_by_fee_rate = pool.sorted_keys().cloned().collect::<Vec<_>>();
+        // the entry with most ancestors score will win
+        let expect_result = tx2_4.proposal_short_id();
+        assert_eq!(txs_sorted_by_fee_rate[0], expect_result);
     }
 }

--- a/shared/src/tx_pool/proposed.rs
+++ b/shared/src/tx_pool/proposed.rs
@@ -1,22 +1,21 @@
-use crate::tx_pool::types::ProposedEntry;
+use crate::tx_pool::types::{TxEntriesPool, TxEntry};
 use ckb_types::{
     bytes::Bytes,
     core::{
         cell::{CellMetaBuilder, CellProvider, CellStatus},
-        Capacity, Cycle, TransactionView,
+        TransactionView,
     },
     packed::{CellOutput, OutPoint, ProposalShortId},
     prelude::*,
 };
-use ckb_util::{FnvHashMap, FnvHashSet, LinkedFnvHashMap};
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Edges<K: Hash + Eq, V: Eq + Hash> {
-    pub(crate) inner: FnvHashMap<K, Option<V>>,
-    pub(crate) outer: FnvHashMap<K, Option<V>>,
-    pub(crate) deps: FnvHashMap<K, FnvHashSet<V>>,
+    pub(crate) inner: HashMap<K, Option<V>>,
+    pub(crate) outer: HashMap<K, Option<V>>,
+    pub(crate) deps: HashMap<K, HashSet<V>>,
 }
 
 impl<K: Hash + Eq, V: Eq + Hash> Edges<K, V> {
@@ -58,21 +57,12 @@ impl<K: Hash + Eq, V: Eq + Hash> Edges<K, V> {
         self.inner.get_mut(key)
     }
 
-    pub(crate) fn get_deps(&self, key: &K) -> Option<&FnvHashSet<V>> {
-        self.deps.get(key)
-    }
-
-    pub(crate) fn remove_deps(&mut self, key: &K) -> Option<FnvHashSet<V>> {
+    pub(crate) fn remove_deps(&mut self, key: &K) -> Option<HashSet<V>> {
         self.deps.remove(key)
     }
 
-    pub(crate) fn contains_key(&self, key: &K) -> bool {
-        self.inner.contains_key(&key)
-    }
-
     pub(crate) fn insert_deps(&mut self, key: K, value: V) {
-        let e = self.deps.entry(key).or_insert_with(FnvHashSet::default);
-        e.insert(value);
+        self.deps.entry(key).or_default().insert(value);
     }
 
     pub(crate) fn delete_value_in_deps(&mut self, key: &K, value: &V) {
@@ -90,9 +80,9 @@ impl<K: Hash + Eq, V: Eq + Hash> Edges<K, V> {
 }
 
 #[derive(Default, Debug, Clone)]
-pub(crate) struct ProposedPool {
-    pub(crate) vertices: LinkedFnvHashMap<ProposalShortId, ProposedEntry>,
+pub struct ProposedPool {
     pub(crate) edges: Edges<OutPoint, ProposalShortId>,
+    inner: TxEntriesPool,
 }
 
 impl CellProvider for ProposedPool {
@@ -122,122 +112,59 @@ impl ProposedPool {
     }
 
     pub(crate) fn contains_key(&self, id: &ProposalShortId) -> bool {
-        self.vertices.contains_key(id)
+        self.inner.contains_key(id)
     }
 
-    pub(crate) fn get(&self, id: &ProposalShortId) -> Option<&ProposedEntry> {
-        self.vertices.get(id)
+    pub fn get(&self, id: &ProposalShortId) -> Option<&TxEntry> {
+        self.inner.get(id)
     }
 
     pub(crate) fn get_tx(&self, id: &ProposalShortId) -> Option<&TransactionView> {
         self.get(id).map(|x| &x.transaction)
     }
 
+    pub fn size(&self) -> usize {
+        self.inner.size()
+    }
+
     pub(crate) fn get_output_with_data(&self, out_point: &OutPoint) -> Option<(CellOutput, Bytes)> {
-        self.vertices
+        self.inner
             .get(&ProposalShortId::from_tx_hash(
                 &out_point.tx_hash().unpack(),
             ))
             .and_then(|x| x.transaction.output_with_data(out_point.index().unpack()))
     }
 
-    pub(crate) fn remove_vertex(&mut self, id: &ProposalShortId) -> Vec<ProposedEntry> {
-        let mut entries = Vec::new();
-        let mut queue = VecDeque::new();
-
-        queue.push_back(id.to_owned());
-
-        while let Some(id) = queue.pop_front() {
-            if let Some(entry) = self.vertices.remove(&id) {
-                {
-                    let tx = &entry.transaction;
-                    let inputs = tx.input_pts_iter();
-                    let outputs = tx.output_pts();
-                    // TODO: handle header deps
-
-                    for i in inputs {
-                        if self.edges.inner.remove(&i).is_none() {
-                            self.edges.outer.remove(&i);
-                        }
-                    }
-
-                    for d in &entry.related_out_points {
-                        self.edges.delete_value_in_deps(&d, &id);
-                    }
-
-                    for o in outputs {
-                        if let Some(cid) = self.edges.remove_inner(&o) {
-                            queue.push_back(cid);
-                        }
-
-                        if let Some(ids) = self.edges.remove_deps(&o) {
-                            for cid in ids {
-                                queue.push_back(cid);
-                            }
-                        }
-                    }
+    // remove entry and all it's descendants
+    pub(crate) fn remove_entry_and_descendants(&mut self, id: &ProposalShortId) -> Vec<TxEntry> {
+        let removed_entries = self.inner.remove_entry_and_descendants(id);
+        for entry in &removed_entries {
+            let tx = &entry.transaction;
+            let inputs = tx.input_pts_iter();
+            let outputs = tx.output_pts();
+            for i in inputs {
+                if self.edges.inner.remove(&i).is_none() {
+                    self.edges.outer.remove(&i);
                 }
-                entries.push(entry);
-            }
-        }
-        entries
-    }
-
-    pub(crate) fn remove(&mut self, id: &ProposalShortId) -> Vec<ProposedEntry> {
-        self.remove_vertex(id)
-    }
-
-    pub(crate) fn add_tx(
-        &mut self,
-        cycles: Cycle,
-        fee: Capacity,
-        size: usize,
-        tx: TransactionView,
-        related_out_points: Vec<OutPoint>,
-    ) {
-        let inputs = tx.input_pts_iter();
-        let outputs = tx.output_pts();
-        // TODO: handle header deps
-
-        let id = tx.proposal_short_id();
-
-        let mut count: usize = 0;
-
-        for i in inputs {
-            let mut flag = true;
-            if let Some(x) = self.edges.get_inner_mut(&i) {
-                *x = Some(id.clone());
-                count += 1;
-                flag = false;
             }
 
-            if flag {
-                self.edges.insert_outer(i.to_owned(), id.clone());
+            for d in &entry.related_out_points {
+                self.edges.delete_value_in_deps(&d, &id);
+            }
+
+            for o in outputs {
+                self.edges.remove_inner(&o);
+                self.edges.remove_deps(&o);
             }
         }
-
-        for d in &related_out_points {
-            if self.edges.contains_key(&d) {
-                count += 1;
-            }
-            self.edges.insert_deps(d.to_owned(), id.clone());
-        }
-
-        for o in outputs {
-            self.edges.mark_inpool(o);
-        }
-
-        self.vertices.insert(
-            id,
-            ProposedEntry::new(tx, related_out_points, count, cycles, fee, size),
-        );
+        removed_entries
     }
 
     pub(crate) fn remove_committed_tx(
         &mut self,
         tx: &TransactionView,
         related_out_points: &[OutPoint],
-    ) -> Vec<ProposedEntry> {
+    ) -> Vec<TxEntry> {
         let outputs = tx.output_pts();
         let inputs = tx.input_pts_iter();
         // TODO: handle header deps
@@ -245,18 +172,11 @@ impl ProposedPool {
 
         let mut removed = Vec::new();
 
-        if let Some(entry) = self.vertices.remove(&id) {
+        if let Some(entry) = self.inner.remove_entry(&id) {
             removed.push(entry);
             for o in outputs {
                 if let Some(cid) = self.edges.remove_inner(&o) {
-                    self.dec_ref(&cid);
                     self.edges.insert_outer(o.clone(), cid);
-                }
-
-                if let Some(x) = { self.edges.get_deps(&o).cloned() } {
-                    for cid in x {
-                        self.dec_ref(&cid);
-                    }
                 }
             }
 
@@ -273,42 +193,71 @@ impl ProposedPool {
         removed
     }
 
-    pub(crate) fn resolve_conflict(&mut self, tx: &TransactionView) -> Vec<ProposedEntry> {
+    pub(crate) fn add_entry(&mut self, entry: TxEntry) {
+        let inputs = entry.transaction.input_pts_iter();
+        let outputs = entry.transaction.output_pts();
+
+        let tx_short_id = entry.transaction.proposal_short_id();
+
+        for i in inputs {
+            if let Some(id) = self.edges.get_inner_mut(&i) {
+                *id = Some(tx_short_id.clone());
+            } else {
+                self.edges.insert_outer(i.to_owned(), tx_short_id.clone());
+            }
+        }
+
+        for d in &entry.related_out_points {
+            self.edges.insert_deps(d.to_owned(), tx_short_id.clone());
+        }
+
+        for o in outputs {
+            self.edges.mark_inpool(o);
+        }
+        self.inner.add_entry(entry);
+    }
+
+    fn resolve_conflict(&mut self, tx: &TransactionView) -> Vec<TxEntry> {
         let inputs = tx.input_pts_iter();
         let mut removed = Vec::new();
 
         for i in inputs {
             if let Some(id) = self.edges.remove_outer(&i) {
-                removed.append(&mut self.remove(&id));
+                removed.append(&mut self.remove_entry_and_descendants(&id));
             }
 
             if let Some(x) = self.edges.remove_deps(&i) {
                 for id in x {
-                    removed.append(&mut self.remove(&id));
+                    removed.append(&mut self.remove_entry_and_descendants(&id));
                 }
             }
         }
         removed
     }
 
-    /// Get n transactions in topology
-    #[cfg(test)]
-    pub(crate) fn get_txs(&self, n: usize) -> Vec<ProposedEntry> {
-        self.vertices
-            .front_n(n)
-            .iter()
-            .map(|x| x.1.clone())
-            .collect()
+    /// Iterate sorted transactions
+    /// transaction is sorted by ancestor score from higher to lower,
+    /// this method is used for package txs into block
+    pub(crate) fn with_sorted_by_score_iter<F, Ret>(&self, func: F) -> Ret
+    where
+        F: FnOnce(&mut dyn Iterator<Item = &TxEntry>) -> Ret,
+    {
+        let mut iter = self.inner.sorted_keys().map(|key| {
+            self.inner
+                .get(&key.id)
+                .expect("proposed pool must be consistent")
+        });
+        func(&mut iter)
     }
 
-    pub(crate) fn txs_iter(&self) -> impl Iterator<Item = &ProposedEntry> {
-        self.vertices.values()
+    /// find all ancestors from pool
+    pub fn get_ancestors(&self, tx_short_id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        self.inner.get_ancestors(&tx_short_id)
     }
 
-    pub(crate) fn dec_ref(&mut self, id: &ProposalShortId) {
-        if let Some(x) = self.vertices.get_mut(&id) {
-            x.refs_count -= 1;
-        }
+    /// find all descendants from pool
+    pub fn get_descendants(&self, tx_short_id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        self.inner.get_descendants(&tx_short_id)
     }
 }
 
@@ -317,7 +266,9 @@ mod tests {
     use super::*;
     use ckb_types::{
         bytes::Bytes,
-        core::{cell::get_related_dep_out_points, Capacity, TransactionBuilder, TransactionView},
+        core::{
+            cell::get_related_dep_out_points, Capacity, Cycle, TransactionBuilder, TransactionView,
+        },
         h256,
         packed::{CellDep, CellInput, CellOutput},
         H256,
@@ -350,36 +301,29 @@ mod tests {
         let tx2 = build_tx(vec![(&tx1_hash, 0)], 1);
 
         let mut pool = ProposedPool::new();
-        let id1 = tx1.proposal_short_id();
-        let id2 = tx2.proposal_short_id();
 
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        pool.add_entry(TxEntry::new(
             tx1.clone(),
-            get_related_dep_out_points(&tx1, |_| None).unwrap(),
-        );
-        pool.add_tx(
             MOCK_CYCLES,
             MOCK_FEE,
             MOCK_SIZE,
+            get_related_dep_out_points(&tx1, |_| None).unwrap(),
+        ));
+        pool.add_entry(TxEntry::new(
             tx2.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx2, |_| None).unwrap(),
-        );
+        ));
 
-        assert_eq!(pool.vertices.len(), 2);
+        assert_eq!(pool.size(), 2);
         assert_eq!(pool.edges.inner_len(), 2);
         assert_eq!(pool.edges.outer_len(), 2);
-
-        assert_eq!(pool.get(&id1).unwrap().refs_count, 0);
-        assert_eq!(pool.get(&id2).unwrap().refs_count, 1);
 
         pool.remove_committed_tx(&tx1, &get_related_dep_out_points(&tx1, |_| None).unwrap());
         assert_eq!(pool.edges.inner_len(), 1);
         assert_eq!(pool.edges.outer_len(), 1);
-
-        assert_eq!(pool.get(&id2).unwrap().refs_count, 0);
     }
 
     #[test]
@@ -389,43 +333,23 @@ mod tests {
 
         let mut pool = ProposedPool::new();
 
-        let id1 = tx1.proposal_short_id();
-        let id2 = tx2.proposal_short_id();
-
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        pool.add_entry(TxEntry::new(
             tx1.clone(),
-            get_related_dep_out_points(&tx1, |_| None).unwrap(),
-        );
-        pool.add_tx(
             MOCK_CYCLES,
             MOCK_FEE,
             MOCK_SIZE,
+            get_related_dep_out_points(&tx1, |_| None).unwrap(),
+        ));
+        pool.add_entry(TxEntry::new(
             tx2.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx2, |_| None).unwrap(),
-        );
+        ));
 
-        assert_eq!(pool.get(&id1).unwrap().refs_count, 0);
-        assert_eq!(pool.get(&id2).unwrap().refs_count, 0);
         assert_eq!(pool.edges.inner_len(), 4);
         assert_eq!(pool.edges.outer_len(), 4);
-
-        let mut mineable: Vec<_> = pool.get_txs(0).into_iter().map(|e| e.transaction).collect();
-        assert_eq!(0, mineable.len());
-
-        mineable = pool.get_txs(1).into_iter().map(|e| e.transaction).collect();
-        assert_eq!(1, mineable.len());
-        assert!(mineable.contains(&tx1));
-
-        mineable = pool.get_txs(2).into_iter().map(|e| e.transaction).collect();
-        assert_eq!(2, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
-
-        mineable = pool.get_txs(3).into_iter().map(|e| e.transaction).collect();
-        assert_eq!(2, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
 
         pool.remove_committed_tx(&tx1, &get_related_dep_out_points(&tx1, |_| None).unwrap());
 
@@ -447,114 +371,289 @@ mod tests {
         let tx3_hash: H256 = tx3.hash().unpack();
         let tx5 = build_tx(vec![(&tx1_hash, 2), (&tx3_hash, 0)], 2);
 
-        let id1 = tx1.proposal_short_id();
-        let id3 = tx3.proposal_short_id();
-        let id5 = tx5.proposal_short_id();
-
         let mut pool = ProposedPool::new();
 
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        pool.add_entry(TxEntry::new(
             tx1.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx1, |_| None).unwrap(),
-        );
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        ));
+        pool.add_entry(TxEntry::new(
             tx2.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx2, |_| None).unwrap(),
-        );
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        ));
+        pool.add_entry(TxEntry::new(
             tx3.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx3, |_| None).unwrap(),
-        );
-        pool.add_tx(
-            MOCK_CYCLES,
-            MOCK_FEE,
-            MOCK_SIZE,
+        ));
+        pool.add_entry(TxEntry::new(
             tx4.clone(),
-            get_related_dep_out_points(&tx4, |_| None).unwrap(),
-        );
-        pool.add_tx(
             MOCK_CYCLES,
             MOCK_FEE,
             MOCK_SIZE,
+            get_related_dep_out_points(&tx4, |_| None).unwrap(),
+        ));
+        pool.add_entry(TxEntry::new(
             tx5.clone(),
+            MOCK_CYCLES,
+            MOCK_FEE,
+            MOCK_SIZE,
             get_related_dep_out_points(&tx5, |_| None).unwrap(),
-        );
+        ));
 
-        assert_eq!(pool.get(&id1).unwrap().refs_count, 0);
-        assert_eq!(pool.get(&id3).unwrap().refs_count, 1);
-        assert_eq!(pool.get(&id5).unwrap().refs_count, 2);
         assert_eq!(pool.edges.inner_len(), 13);
         assert_eq!(pool.edges.outer_len(), 2);
 
-        let mut mineable: Vec<_> = pool.get_txs(0).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(0, mineable.len());
-
-        mineable = pool.get_txs(1).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(1, mineable.len());
-        assert!(mineable.contains(&tx1));
-
-        mineable = pool.get_txs(2).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(2, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
-
-        mineable = pool.get_txs(3).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(3, mineable.len());
-
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2) && mineable.contains(&tx3));
-
-        mineable = pool.get_txs(4).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(4, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
-        assert!(mineable.contains(&tx3) && mineable.contains(&tx4));
-
-        mineable = pool.get_txs(5).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(5, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
-        assert!(mineable.contains(&tx3) && mineable.contains(&tx4));
-        assert!(mineable.contains(&tx5));
-
-        mineable = pool.get_txs(6).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(5, mineable.len());
-        assert!(mineable.contains(&tx1) && mineable.contains(&tx2));
-        assert!(mineable.contains(&tx3) && mineable.contains(&tx4));
-        assert!(mineable.contains(&tx5));
-
         pool.remove_committed_tx(&tx1, &get_related_dep_out_points(&tx1, |_| None).unwrap());
 
-        assert_eq!(pool.get(&id3).unwrap().refs_count, 0);
-        assert_eq!(pool.get(&id5).unwrap().refs_count, 1);
         assert_eq!(pool.edges.inner_len(), 10);
         assert_eq!(pool.edges.outer_len(), 4);
+    }
 
-        mineable = pool.get_txs(1).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(1, mineable.len());
-        assert!(mineable.contains(&tx2));
+    #[test]
+    fn test_sorted_by_tx_fee_rate() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 1);
+        let tx2 = build_tx(vec![(&H256::zero(), 2)], 1);
+        let tx3 = build_tx(vec![(&H256::zero(), 3)], 1);
 
-        mineable = pool.get_txs(2).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(2, mineable.len());
-        assert!(mineable.contains(&tx2) && mineable.contains(&tx3));
+        let mut pool = ProposedPool::new();
 
-        mineable = pool.get_txs(3).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(3, mineable.len());
-        assert!(mineable.contains(&tx2) && mineable.contains(&tx3));
-        assert!(mineable.contains(&tx4));
+        let cycles = 5_000_000;
+        let size = 200;
 
-        mineable = pool.get_txs(4).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(4, mineable.len());
-        assert!(mineable.contains(&tx2) && mineable.contains(&tx3));
-        assert!(mineable.contains(&tx4) && mineable.contains(&tx5));
+        pool.add_entry(TxEntry::new(
+            tx1.clone(),
+            cycles,
+            Capacity::shannons(100),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx2.clone(),
+            cycles,
+            Capacity::shannons(300),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx3.clone(),
+            cycles,
+            Capacity::shannons(200),
+            size,
+            vec![],
+        ));
 
-        mineable = pool.get_txs(5).into_iter().map(|x| x.transaction).collect();
-        assert_eq!(4, mineable.len());
+        let txs_sorted_by_fee_rate = pool.with_sorted_by_score_iter(|iter| {
+            iter.map(|entry| entry.transaction.hash().to_owned())
+                .collect::<Vec<_>>()
+        });
+        let expect_result = vec![
+            tx2.hash().to_owned(),
+            tx3.hash().to_owned(),
+            tx1.hash().to_owned(),
+        ];
+        assert_eq!(txs_sorted_by_fee_rate, expect_result);
+    }
+
+    #[test]
+    fn test_sorted_by_ancestors_score() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 2);
+        let tx1_hash = tx1.hash();
+        let tx2 = build_tx(vec![(&tx1_hash.unpack(), 1)], 1);
+        let tx2_hash = tx2.hash();
+        let tx3 = build_tx(vec![(&tx1_hash.unpack(), 2)], 1);
+        let tx4 = build_tx(vec![(&tx2_hash.unpack(), 1)], 1);
+
+        let mut pool = ProposedPool::new();
+
+        let cycles = 5_000_000;
+        let size = 200;
+
+        pool.add_entry(TxEntry::new(
+            tx1.clone(),
+            cycles,
+            Capacity::shannons(100),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx2.clone(),
+            cycles,
+            Capacity::shannons(300),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx3.clone(),
+            cycles,
+            Capacity::shannons(200),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx4.clone(),
+            cycles,
+            Capacity::shannons(400),
+            size,
+            vec![],
+        ));
+
+        let txs_sorted_by_fee_rate = pool.with_sorted_by_score_iter(|iter| {
+            iter.map(|entry| entry.transaction.hash().to_owned())
+                .collect::<Vec<_>>()
+        });
+        let expect_result = vec![
+            tx4.hash().to_owned(),
+            tx2.hash().to_owned(),
+            tx3.hash().to_owned(),
+            tx1.hash().to_owned(),
+        ];
+        assert_eq!(txs_sorted_by_fee_rate, expect_result);
+    }
+
+    #[test]
+    fn test_sorted_by_ancestors_score_competitive() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 2);
+        let tx1_hash = tx1.hash();
+        let tx2 = build_tx(vec![(&tx1_hash.unpack(), 0)], 1);
+        let tx2_hash = tx2.hash();
+        let tx3 = build_tx(vec![(&tx2_hash.unpack(), 0)], 1);
+
+        let tx2_1 = build_tx(vec![(&H256::zero(), 2)], 2);
+        let tx2_1_hash = tx2_1.hash();
+        let tx2_2 = build_tx(vec![(&tx2_1_hash.unpack(), 0)], 1);
+        let tx2_2_hash = tx2_2.hash();
+        let tx2_3 = build_tx(vec![(&tx2_2_hash.unpack(), 0)], 1);
+        let tx2_3_hash = tx2_3.hash();
+        let tx2_4 = build_tx(vec![(&tx2_3_hash.unpack(), 0)], 1);
+
+        let mut pool = ProposedPool::new();
+
+        let cycles = 5_000_000;
+        let size = 200;
+
+        for &tx in &[&tx1, &tx2, &tx3, &tx2_1, &tx2_2, &tx2_3, &tx2_4] {
+            pool.add_entry(TxEntry::new(
+                tx.clone(),
+                cycles,
+                Capacity::shannons(200),
+                size,
+                vec![],
+            ));
+        }
+
+        let txs_sorted_by_fee_rate = pool.with_sorted_by_score_iter(|iter| {
+            iter.map(|entry| format!("{}", entry.transaction.hash()))
+                .collect::<Vec<_>>()
+        });
+        // the entry with most ancestors score will win
+        let expect_result = format!("{}", tx2_4.hash());
+        assert_eq!(txs_sorted_by_fee_rate[0], expect_result);
+    }
+
+    #[test]
+    fn test_get_ancestors() {
+        let tx1 = build_tx(vec![(&H256::zero(), 1)], 2);
+        let tx1_hash = tx1.hash();
+        let tx2 = build_tx(vec![(&tx1_hash.unpack(), 0)], 1);
+        let tx2_hash = tx2.hash();
+        let tx3 = build_tx(vec![(&tx1_hash.unpack(), 1)], 1);
+        let tx4 = build_tx(vec![(&tx2_hash.unpack(), 0)], 1);
+
+        let mut pool = ProposedPool::new();
+
+        let cycles = 5_000_000;
+        let size = 200;
+
+        pool.add_entry(TxEntry::new(
+            tx1.clone(),
+            cycles,
+            Capacity::shannons(100),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx2.clone(),
+            cycles,
+            Capacity::shannons(300),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx3.clone(),
+            cycles,
+            Capacity::shannons(200),
+            size,
+            vec![],
+        ));
+        pool.add_entry(TxEntry::new(
+            tx4.clone(),
+            cycles,
+            Capacity::shannons(400),
+            size,
+            vec![],
+        ));
+
+        let ancestors = pool.get_ancestors(&tx4.proposal_short_id());
+        let expect_result = vec![tx1.proposal_short_id(), tx2.proposal_short_id()]
+            .into_iter()
+            .collect();
+        assert_eq!(ancestors, expect_result);
+        let entry = pool.get(&tx4.proposal_short_id()).expect("exists");
+        assert_eq!(
+            entry.ancestors_cycles,
+            ancestors
+                .iter()
+                .map(|id| pool.get(id).unwrap().cycles)
+                .sum::<u64>()
+                + cycles
+        );
+        assert_eq!(
+            entry.ancestors_size,
+            ancestors
+                .iter()
+                .map(|id| pool.get(id).unwrap().size)
+                .sum::<usize>()
+                + size
+        );
+        assert_eq!(entry.ancestors_count, ancestors.len() + 1);
+
+        let ancestors = pool.get_ancestors(&tx3.proposal_short_id());
+        let expect_result = vec![tx1.proposal_short_id()].into_iter().collect();
+        assert_eq!(ancestors, expect_result);
+        let entry = pool.get(&tx3.proposal_short_id()).expect("exists");
+        assert_eq!(
+            entry.ancestors_cycles,
+            ancestors
+                .iter()
+                .map(|id| pool.get(id).unwrap().cycles)
+                .sum::<u64>()
+                + cycles
+        );
+        assert_eq!(
+            entry.ancestors_size,
+            ancestors
+                .iter()
+                .map(|id| pool.get(id).unwrap().size)
+                .sum::<usize>()
+                + size
+        );
+        assert_eq!(entry.ancestors_count, ancestors.len() + 1);
+
+        let ancestors = pool.get_ancestors(&tx1.proposal_short_id());
+        assert_eq!(ancestors, Default::default());
+        let entry = pool.get(&tx1.proposal_short_id()).expect("exists");
+        assert_eq!(entry.ancestors_cycles, cycles);
+        assert_eq!(entry.ancestors_size, size);
+        assert_eq!(entry.ancestors_count, 1);
     }
 
     #[test]
@@ -600,18 +699,19 @@ mod tests {
 
         let mut pool = ProposedPool::new();
         for tx in &[&tx1, &tx2, &tx3] {
-            pool.add_tx(
+            pool.add_entry(TxEntry::new(
+                (*tx).clone(),
                 MOCK_CYCLES,
                 MOCK_FEE,
                 MOCK_SIZE,
-                (*tx).clone(),
                 get_related_dep_out_points(*tx, &get_cell_data).unwrap(),
-            );
+            ));
         }
 
         let get_deps_len = |pool: &ProposedPool, out_point: &OutPoint| -> usize {
             pool.edges
-                .get_deps(out_point)
+                .deps
+                .get(out_point)
                 .map(|deps| deps.len())
                 .unwrap_or_default()
         };

--- a/shared/src/tx_pool/types.rs
+++ b/shared/src/tx_pool/types.rs
@@ -1,13 +1,17 @@
 //! The primary module containing the implementations of the transaction pool
 //! and its top-level members.
 
+use crate::tx_pool::get_transaction_virtual_bytes;
 use ckb_types::{
     core::{cell::UnresolvableError, Capacity, Cycle, TransactionView},
-    packed::OutPoint,
+    packed::{OutPoint, ProposalShortId},
+    prelude::Unpack,
 };
 use ckb_verification::TransactionError;
 use failure::Fail;
 use serde_derive::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -106,73 +110,457 @@ impl DefectEntry {
 }
 
 /// An entry in the transaction pool.
-#[derive(Debug, Clone)]
-pub struct PendingEntry {
+#[derive(Debug, Clone, Eq)]
+pub struct TxEntry {
     /// Transaction
     pub transaction: TransactionView,
-    /// Cycles
-    pub cycles: Option<Cycle>,
-    /// tx size
-    pub size: usize,
-}
-
-impl PendingEntry {
-    /// Create new transaction pool entry
-    pub fn new(tx: TransactionView, cycles: Option<Cycle>, size: usize) -> PendingEntry {
-        PendingEntry {
-            transaction: tx,
-            cycles,
-            size,
-        }
-    }
-}
-
-/// An entry in the transaction pool.
-#[derive(Debug, Clone)]
-pub struct ProposedEntry {
-    /// Transaction
-    pub transaction: TransactionView,
-    /// Related out points (cell dep)
-    pub related_out_points: Vec<OutPoint>,
-    /// refs count
-    pub refs_count: usize,
     /// Cycles
     pub cycles: Cycle,
-    /// fee
-    pub fee: Capacity,
     /// tx size
     pub size: usize,
+    /// fee
+    pub fee: Capacity,
+    /// ancestors txs size
+    pub ancestors_size: usize,
+    /// ancestors txs fee
+    pub ancestors_fee: Capacity,
+    /// ancestors txs cycles
+    pub ancestors_cycles: Cycle,
+    /// ancestors txs count
+    pub ancestors_count: usize,
+    /// related out points (cell deps includs cell group itself)
+    pub related_out_points: Vec<OutPoint>,
 }
 
-impl ProposedEntry {
+impl TxEntry {
     /// Create new transaction pool entry
     pub fn new(
         tx: TransactionView,
-        related_out_points: Vec<OutPoint>,
-        refs_count: usize,
         cycles: Cycle,
         fee: Capacity,
         size: usize,
-    ) -> ProposedEntry {
-        ProposedEntry {
+        related_out_points: Vec<OutPoint>,
+    ) -> Self {
+        TxEntry {
             transaction: tx,
-            related_out_points,
-            refs_count,
             cycles,
-            fee,
             size,
+            fee,
+            ancestors_size: size,
+            ancestors_fee: fee,
+            ancestors_cycles: cycles,
+            ancestors_count: 1,
+            related_out_points,
+        }
+    }
+
+    pub fn as_sorted_key(&self) -> AncestorsScoreSortKey {
+        AncestorsScoreSortKey::from(self)
+    }
+
+    pub fn add_entry_weight(&mut self, entry: &TxEntry) {
+        self.ancestors_count = self.ancestors_count.saturating_add(1);
+        self.ancestors_size = self.ancestors_size.saturating_add(entry.size);
+        self.ancestors_cycles = self.ancestors_cycles.saturating_add(entry.cycles);
+        self.ancestors_fee = Capacity::shannons(
+            self.ancestors_fee
+                .as_u64()
+                .saturating_add(entry.fee.as_u64()),
+        );
+    }
+    pub fn sub_entry_weight(&mut self, entry: &TxEntry) {
+        self.ancestors_count = self.ancestors_count.saturating_sub(1);
+        self.ancestors_size = self.ancestors_size.saturating_sub(entry.size);
+        self.ancestors_cycles = self.ancestors_cycles.saturating_sub(entry.cycles);
+        self.ancestors_fee = Capacity::shannons(
+            self.ancestors_fee
+                .as_u64()
+                .saturating_sub(entry.fee.as_u64()),
+        );
+    }
+
+    pub fn add_ancestors_weight(&mut self, entry: &TxEntry) {
+        self.ancestors_count = self.ancestors_count.saturating_add(entry.ancestors_count);
+        self.ancestors_size = self.ancestors_size.saturating_add(entry.ancestors_size);
+        self.ancestors_cycles = self.ancestors_cycles.saturating_add(entry.ancestors_cycles);
+        self.ancestors_fee = Capacity::shannons(
+            self.ancestors_fee
+                .as_u64()
+                .saturating_add(entry.ancestors_fee.as_u64()),
+        );
+    }
+    pub fn sub_ancestors_weight(&mut self, entry: &TxEntry) {
+        self.ancestors_count = self.ancestors_count.saturating_sub(entry.ancestors_count);
+        self.ancestors_size = self.ancestors_size.saturating_sub(entry.ancestors_size);
+        self.ancestors_cycles = self.ancestors_cycles.saturating_sub(entry.ancestors_cycles);
+        self.ancestors_fee = Capacity::shannons(
+            self.ancestors_fee
+                .as_u64()
+                .saturating_sub(entry.ancestors_fee.as_u64()),
+        );
+    }
+}
+
+impl From<&TxEntry> for AncestorsScoreSortKey {
+    fn from(entry: &TxEntry) -> Self {
+        let vbytes = get_transaction_virtual_bytes(entry.size, entry.cycles);
+        let ancestors_vbytes =
+            get_transaction_virtual_bytes(entry.ancestors_size, entry.ancestors_cycles);
+        AncestorsScoreSortKey {
+            fee: entry.fee,
+            vbytes,
+            id: entry.transaction.proposal_short_id(),
+            ancestors_fee: entry.ancestors_fee,
+            ancestors_vbytes,
         }
     }
 }
 
-impl Hash for ProposedEntry {
+impl Hash for TxEntry {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&self.transaction, state);
     }
 }
 
-impl PartialEq for ProposedEntry {
-    fn eq(&self, other: &ProposedEntry) -> bool {
+impl PartialEq for TxEntry {
+    fn eq(&self, other: &TxEntry) -> bool {
         self.transaction == other.transaction
+    }
+}
+
+impl PartialOrd for TxEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TxEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_sorted_key().cmp(&other.as_sorted_key())
+    }
+}
+
+/// A struct to use as a sorted key
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub struct AncestorsScoreSortKey {
+    pub fee: Capacity,
+    pub vbytes: u64,
+    pub id: ProposalShortId,
+    pub ancestors_fee: Capacity,
+    pub ancestors_vbytes: u64,
+}
+
+impl AncestorsScoreSortKey {
+    /// compare tx fee rate with ancestors fee rate and return the min one
+    fn min_fee_and_vbytes(&self) -> (Capacity, u64) {
+        // avoid division a_fee/a_vbytes > b_fee/b_vbytes
+        let tx_weight = self.fee.as_u64() * self.ancestors_vbytes;
+        let ancestors_weight = self.ancestors_fee.as_u64() * self.vbytes;
+
+        if tx_weight < ancestors_weight {
+            (self.fee, self.vbytes)
+        } else {
+            (self.ancestors_fee, self.ancestors_vbytes)
+        }
+    }
+}
+
+impl PartialOrd for AncestorsScoreSortKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AncestorsScoreSortKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // avoid division a_fee/a_vbytes > b_fee/b_vbytes
+        let (fee, vbytes) = self.min_fee_and_vbytes();
+        let (other_fee, other_vbytes) = other.min_fee_and_vbytes();
+        let self_weight = fee.as_u64() * other_vbytes;
+        let other_weight = other_fee.as_u64() * vbytes;
+        if self_weight == other_weight {
+            // if fee rate weight is same, then compare with ancestor vbytes
+            if self.ancestors_vbytes == other.ancestors_vbytes {
+                self.id.raw_data().cmp(&other.id.raw_data())
+            } else {
+                self.ancestors_vbytes.cmp(&other.ancestors_vbytes)
+            }
+        } else {
+            self_weight.cmp(&other_weight)
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct TxLink {
+    pub parents: HashSet<ProposalShortId>,
+    pub children: HashSet<ProposalShortId>,
+}
+
+#[derive(Clone, Copy)]
+enum Relation {
+    Parents,
+    Children,
+}
+
+impl TxLink {
+    fn get_direct_ids(&self, r: Relation) -> &HashSet<ProposalShortId> {
+        match r {
+            Relation::Parents => &self.parents,
+            Relation::Children => &self.children,
+        }
+    }
+
+    fn get_relative_ids(
+        links: &HashMap<ProposalShortId, TxLink>,
+        tx_short_id: &ProposalShortId,
+        relation: Relation,
+    ) -> HashSet<ProposalShortId> {
+        let mut family_txs = links
+            .get(tx_short_id)
+            .map(|link| link.get_direct_ids(relation).clone())
+            .unwrap_or_default();
+        let mut relative_txs = HashSet::with_capacity(family_txs.len());
+        while !family_txs.is_empty() {
+            let id = family_txs
+                .iter()
+                .next()
+                .map(ToOwned::to_owned)
+                .expect("exists");
+            relative_txs.insert(id.clone());
+            family_txs.remove(&id);
+
+            // check parents recursively
+            for id in links
+                .get(&id)
+                .map(|link| link.get_direct_ids(relation).clone())
+                .unwrap_or_default()
+            {
+                if !relative_txs.contains(&id) {
+                    family_txs.insert(id);
+                }
+            }
+        }
+        relative_txs
+    }
+
+    pub fn get_ancestors(
+        links: &HashMap<ProposalShortId, TxLink>,
+        tx_short_id: &ProposalShortId,
+    ) -> HashSet<ProposalShortId> {
+        TxLink::get_relative_ids(links, tx_short_id, Relation::Parents)
+    }
+
+    pub fn get_descendants(
+        links: &HashMap<ProposalShortId, TxLink>,
+        tx_short_id: &ProposalShortId,
+    ) -> HashSet<ProposalShortId> {
+        TxLink::get_relative_ids(links, tx_short_id, Relation::Children)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub(crate) struct TxEntriesPool {
+    entries: HashMap<ProposalShortId, TxEntry>,
+    sorted_index: BTreeSet<AncestorsScoreSortKey>,
+    /// A map track transaction ancestors and descendants
+    links: HashMap<ProposalShortId, TxLink>,
+}
+
+impl TxEntriesPool {
+    pub fn size(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// update entry ancestor prefix fields
+    fn update_ancestors_stat_for_entry(
+        &self,
+        entry: &mut TxEntry,
+        parents: &HashSet<ProposalShortId>,
+    ) {
+        for id in parents {
+            let parent_entry = self.entries.get(&id).expect("pool consistent");
+            entry.add_ancestors_weight(&parent_entry);
+        }
+    }
+
+    pub fn add_entry(&mut self, mut entry: TxEntry) -> Option<TxEntry> {
+        let short_id = entry.transaction.proposal_short_id();
+
+        // find in pool parents
+        let mut parents: HashSet<ProposalShortId> = HashSet::with_capacity(
+            entry.transaction.inputs().len() + entry.transaction.cell_deps().len(),
+        );
+        for input in entry.transaction.inputs() {
+            let parent_hash = &input.previous_output().tx_hash();
+            let id = ProposalShortId::from_tx_hash(&(parent_hash.unpack()));
+            if self.links.contains_key(&id) {
+                parents.insert(id);
+            }
+        }
+        for cell_dep in entry.transaction.cell_deps() {
+            let id = ProposalShortId::from_tx_hash(&(cell_dep.out_point().tx_hash().unpack()));
+            if self.links.contains_key(&id) {
+                parents.insert(id);
+            }
+        }
+        // update ancestor_fields
+        self.update_ancestors_stat_for_entry(&mut entry, &parents);
+        // update parents references
+        for parent_id in &parents {
+            self.links
+                .get_mut(parent_id)
+                .expect("exists")
+                .children
+                .insert(short_id.clone());
+        }
+        // insert links
+        self.links.insert(
+            short_id.clone(),
+            TxLink {
+                parents,
+                children: Default::default(),
+            },
+        );
+        self.sorted_index
+            .insert(AncestorsScoreSortKey::from(&entry));
+        self.entries.insert(short_id, entry)
+    }
+
+    pub fn contains_key(&self, id: &ProposalShortId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn get(&self, id: &ProposalShortId) -> Option<&TxEntry> {
+        self.entries.get(id)
+    }
+
+    pub fn remove_entry_and_descendants(&mut self, id: &ProposalShortId) -> Vec<TxEntry> {
+        let mut queue = VecDeque::new();
+        let mut removed = Vec::new();
+        queue.push_back(id.clone());
+        while let Some(id) = queue.pop_front() {
+            if let Some(entry) = self.entries.remove(&id) {
+                let deleted = self
+                    .sorted_index
+                    .remove(&AncestorsScoreSortKey::from(&entry));
+                debug_assert!(deleted, "pending pool inconsistent");
+                if let Some(link) = self.links.remove(&id) {
+                    queue.extend(link.children);
+                }
+                removed.push(entry);
+            }
+        }
+        removed
+    }
+
+    pub fn remove_entry(&mut self, id: &ProposalShortId) -> Option<TxEntry> {
+        self.entries.remove(&id).map(|entry| {
+            let deleted = self
+                .sorted_index
+                .remove(&AncestorsScoreSortKey::from(&entry));
+            debug_assert!(deleted, "pending pool inconsistent");
+            // update descendants entries
+            for desc_id in self.get_descendants(&id) {
+                if let Some(key) = self
+                    .entries
+                    .get(&desc_id)
+                    .map(|entry| entry.as_sorted_key())
+                {
+                    self.sorted_index.remove(&key);
+                }
+                if let Some(desc_entry) = self.entries.get_mut(&desc_id) {
+                    // remove entry
+                    desc_entry.sub_entry_weight(&entry);
+                }
+                if let Some(key) = self
+                    .entries
+                    .get(&desc_id)
+                    .map(|entry| entry.as_sorted_key())
+                {
+                    self.sorted_index.insert(key);
+                }
+            }
+            // update links
+            if let Some(link) = self.links.remove(&id) {
+                for p_id in link.parents {
+                    self.links
+                        .get_mut(&p_id)
+                        .map(|link| link.children.remove(&id));
+                }
+                for c_id in link.children {
+                    self.links
+                        .get_mut(&c_id)
+                        .map(|link| link.parents.remove(&id));
+                }
+            }
+            entry
+        })
+    }
+
+    /// find all ancestors from pool
+    pub fn get_ancestors(&self, tx_short_id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        TxLink::get_ancestors(&self.links, tx_short_id)
+    }
+
+    /// find all descendants from pool
+    pub fn get_descendants(&self, tx_short_id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        TxLink::get_descendants(&self.links, tx_short_id)
+    }
+
+    /// return sorted keys
+    pub fn sorted_keys(&self) -> impl Iterator<Item = &AncestorsScoreSortKey> {
+        self.sorted_index.iter().rev()
+    }
+}
+
+// A template data struct used to store modified entries when package txs
+pub struct TxModifiedEntries {
+    entries: HashMap<ProposalShortId, TxEntry>,
+    sort_index: BTreeSet<AncestorsScoreSortKey>,
+}
+
+impl Default for TxModifiedEntries {
+    fn default() -> Self {
+        TxModifiedEntries {
+            entries: HashMap::default(),
+            sort_index: BTreeSet::default(),
+        }
+    }
+}
+
+impl TxModifiedEntries {
+    pub fn with_sorted_by_score_iter<F, Ret>(&self, func: F) -> Ret
+    where
+        F: FnOnce(&mut dyn Iterator<Item = &TxEntry>) -> Ret,
+    {
+        let mut iter = self
+            .sort_index
+            .iter()
+            .rev()
+            .map(|key| self.entries.get(&key.id).expect("must be consistent"));
+        func(&mut iter)
+    }
+
+    pub fn get(&self, id: &ProposalShortId) -> Option<&TxEntry> {
+        self.entries.get(id)
+    }
+
+    pub fn contains_key(&self, id: &ProposalShortId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn insert(&mut self, entry: TxEntry) {
+        let key = AncestorsScoreSortKey::from(&entry);
+        let short_id = entry.transaction.proposal_short_id();
+        self.entries.insert(short_id, entry);
+        self.sort_index.insert(key);
+    }
+
+    pub fn remove(&mut self, id: &ProposalShortId) -> Option<TxEntry> {
+        self.entries.remove(id).map(|entry| {
+            self.sort_index.remove(&(&entry).into());
+            entry
+        })
     }
 }

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -80,7 +80,8 @@ impl TxPoolExecutor {
                 if let Some(cycles) = txs_verify_cache.get(&tx.hash()) {
                     cached_txs.push((tx.hash(), Ok(*cycles)));
                 } else {
-                    match chain_state.resolve_tx_from_pending_and_proposed(tx) {
+                    let tx_pool = chain_state.tx_pool();
+                    match chain_state.resolve_tx_from_pending_and_proposed(tx, &tx_pool) {
                         Ok(resolved_tx) => resolved_txs.push((tx.hash(), resolved_tx)),
                         Err(err) => unresolvable_txs
                             .push((tx.hash(), PoolError::UnresolvableTransaction(err))),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -304,6 +304,15 @@ impl Node {
     }
 
     pub fn new_transaction_with_since(&self, hash: H256, since: u64) -> TransactionView {
+        self.new_transaction_with_since_capacity(hash, since, capacity_bytes!(100))
+    }
+
+    pub fn new_transaction_with_since_capacity(
+        &self,
+        hash: H256,
+        since: u64,
+        capacity: Capacity,
+    ) -> TransactionView {
         let always_success_out_point = OutPoint::new(self.genesis_cellbase_hash.clone(), 1);
         let always_success_script = Script::new_builder()
             .code_hash(self.always_success_code_hash.clone().pack())
@@ -314,7 +323,7 @@ impl Node {
             .cell_dep(CellDep::new(always_success_out_point, false))
             .output(
                 CellOutputBuilder::default()
-                    .capacity(capacity_bytes!(100).pack())
+                    .capacity(capacity.pack())
                     .lock(always_success_script)
                     .build(),
             )

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -576,6 +576,7 @@ mod tests {
             resolved_inputs: vec![
                 CellMetaBuilder::from_cell_output(input_cell, input_cell_data).build(),
             ],
+            resolved_dep_groups: vec![],
         };
 
         let result = DaoCalculator::new(&consensus, &store)

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -84,6 +84,7 @@ pub fn test_capacity_outofbound() {
             Bytes::new(),
         )
         .build()],
+        resolved_dep_groups: vec![],
     };
     let verifier = CapacityVerifier::new(&rtx);
 
@@ -119,6 +120,7 @@ pub fn test_skip_dao_capacity_check() {
         transaction: &transaction,
         resolved_cell_deps: Vec::new(),
         resolved_inputs: vec![],
+        resolved_dep_groups: vec![],
     };
     let verifier = CapacityVerifier::new(&rtx);
 
@@ -141,6 +143,7 @@ pub fn test_inputs_cellbase_maturity() {
                 .transaction_info(MockMedianTime::get_transaction_info(30, 0, 0))
                 .build(),
         ],
+        resolved_dep_groups: vec![],
     };
 
     let tip_number = 70;
@@ -177,6 +180,7 @@ pub fn test_deps_cellbase_maturity() {
                 .build(),
         ],
         resolved_inputs: Vec::new(),
+        resolved_dep_groups: vec![],
     };
 
     let tip_number = 70;
@@ -229,6 +233,7 @@ pub fn test_capacity_invalid() {
             )
             .build(),
         ],
+        resolved_dep_groups: vec![],
     };
     let verifier = CapacityVerifier::new(&rtx);
 
@@ -323,6 +328,7 @@ fn create_resolve_tx_with_transaction_info(
         )
         .transaction_info(transaction_info)
         .build()],
+        resolved_dep_groups: vec![],
     }
 }
 


### PR DESCRIPTION
Changes:

1. proposed pool and pending pool track txs in-pool ancestors and record the `ancestors_fee`, `ancestors_size`, `ancestors_cycles` for each tx.
2. proposed pool and pending pool are sort txs by tx's in-pool ancestors fee rate(aka ancestors score).
3. block_assembler package txs by the sort that tx_pool provides.