### PR TITLE
perf: refactoring block body store

### DIFF
--- a/core/src/extras.rs
+++ b/core/src/extras.rs
@@ -25,6 +25,15 @@ pub struct TransactionInfo {
     pub index: usize,
 }
 
+impl TransactionInfo {
+    pub fn store_key(&self) -> Vec<u8> {
+        let mut key = Vec::with_capacity(36);
+        key.extend_from_slice(self.block_hash.as_bytes());
+        key.extend_from_slice(&(self.index as u32).to_be_bytes());
+        key
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug, Default)]
 pub struct EpochExt {
     pub(crate) number: EpochNumber,

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 //      - If the data can be migrated manually: update "x.y1.z" to "x.y2.0".
 //      - If the data can not be migrated: update "x1.y.z" to "x2.0.0".
 pub(crate) const VERSION_KEY: &str = "db-version";
-pub(crate) const VERSION_VALUE: &str = "0.1600.0";
+pub(crate) const VERSION_VALUE: &str = "0.1700.0";
 
 pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 //      - If the data can be migrated manually: update "x.y1.z" to "x.y2.0".
 //      - If the data can not be migrated: update "x1.y.z" to "x2.0.0".
 pub(crate) const VERSION_KEY: &str = "db-version";
-pub(crate) const VERSION_VALUE: &str = "0.1700.0";
+pub(crate) const VERSION_VALUE: &str = "0.1900.0";
 
 pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,

--- a/db/src/transaction.rs
+++ b/db/src/transaction.rs
@@ -1,10 +1,12 @@
 use crate::db::cf_handle;
+use crate::iter::{DBIterator, DBIteratorItem, Direction};
 use crate::{Col, Result};
 use rocksdb::ops::{DeleteCF, GetCF, PutCF};
-pub use rocksdb::{DBPinnableSlice, DBVector};
 use rocksdb::{
-    OptimisticTransaction, OptimisticTransactionDB, OptimisticTransactionSnapshot, ReadOptions,
+    ops::IterateCF, Direction as RdbDirection, IteratorMode, OptimisticTransaction,
+    OptimisticTransactionDB, OptimisticTransactionSnapshot, ReadOptions,
 };
+pub use rocksdb::{DBPinnableSlice, DBVector};
 use std::sync::Arc;
 
 pub struct RocksDBTransaction {
@@ -66,6 +68,26 @@ impl RocksDBTransaction {
     }
 }
 
+impl DBIterator for RocksDBTransaction {
+    fn iter<'a>(
+        &'a self,
+        col: Col,
+        from_key: &'a [u8],
+        direction: Direction,
+    ) -> Result<Box<Iterator<Item = DBIteratorItem> + 'a>> {
+        let cf = cf_handle(&self.db, col)?;
+        let iter_direction = match direction {
+            Direction::Forward => RdbDirection::Forward,
+            Direction::Reverse => RdbDirection::Reverse,
+        };
+        let mode = IteratorMode::From(from_key, iter_direction);
+        self.inner
+            .iterator_cf(cf, mode)
+            .map(|iter| Box::new(iter) as Box<_>)
+            .map_err(Into::into)
+    }
+}
+
 pub struct RocksDBTransactionSnapshot<'a> {
     pub(crate) db: Arc<OptimisticTransactionDB>,
     pub(crate) inner: OptimisticTransactionSnapshot<'a>,
@@ -75,5 +97,25 @@ impl<'a> RocksDBTransactionSnapshot<'a> {
     pub fn get(&self, col: Col, key: &[u8]) -> Result<Option<DBVector>> {
         let cf = cf_handle(&self.db, col)?;
         self.inner.get_cf(cf, key).map_err(Into::into)
+    }
+}
+
+impl<'a> DBIterator for RocksDBTransactionSnapshot<'a> {
+    fn iter<'b>(
+        &'b self,
+        col: Col,
+        from_key: &'b [u8],
+        direction: Direction,
+    ) -> Result<Box<Iterator<Item = DBIteratorItem> + 'b>> {
+        let cf = cf_handle(&self.db, col)?;
+        let iter_direction = match direction {
+            Direction::Forward => RdbDirection::Forward,
+            Direction::Reverse => RdbDirection::Reverse,
+        };
+        let mode = IteratorMode::From(from_key, iter_direction);
+        self.inner
+            .iterator_cf(cf, mode)
+            .map(|iter| Box::new(iter) as Box<_>)
+            .map_err(Into::into)
     }
 }

--- a/protos/schemas/storage.fbs
+++ b/protos/schemas/storage.fbs
@@ -12,16 +12,6 @@ table StoredBlockCache {
     tx_witness_hashes: [Bytes32];
 }
 
-table StoredBlockBody {
-    data: BlockBody;
-    cache: StoredBlockBodyCache;
-}
-
-table StoredBlockBodyCache {
-    tx_hashes: [Bytes32];
-    tx_witness_hashes: [Bytes32];
-}
-
 table StoredTransactionInfo {
     data: TransactionInfo;
 }
@@ -33,6 +23,16 @@ table StoredHeader {
 
 table StoredHeaderCache {
     hash: Bytes32;
+}
+
+table StoredTransaction {
+    data: Transaction;
+    cache: StoredTransactionCache;
+}
+
+table StoredTransactionCache {
+    hash: Bytes32;
+    witness_hash: Bytes32;
 }
 
 table StoredUncleBlocks {

--- a/protos/src/convert/to_storage.rs
+++ b/protos/src/convert/to_storage.rs
@@ -57,44 +57,6 @@ impl<'a> CanBuild<'a> for protos::StoredBlock<'a> {
     }
 }
 
-impl<'a> CanBuild<'a> for protos::StoredBlockBodyCache<'a> {
-    type Input = [Transaction];
-    fn build<'b: 'a>(
-        fbb: &mut FlatBufferBuilder<'b>,
-        transactions: &Self::Input,
-    ) -> WIPOffset<protos::StoredBlockBodyCache<'b>> {
-        let mut tx_hashes: Vec<protos::Bytes32> = Vec::with_capacity(transactions.len());
-        let mut tx_witness_hashes: Vec<protos::Bytes32> = Vec::with_capacity(transactions.len());
-        for tx in transactions {
-            tx_hashes.push(tx.hash().into());
-            tx_witness_hashes.push(tx.witness_hash().into());
-        }
-
-        let tx_hashes = fbb.create_vector(&tx_hashes);
-        let tx_witness_hashes = fbb.create_vector(&tx_witness_hashes);
-
-        let mut builder = protos::StoredBlockBodyCacheBuilder::new(fbb);
-        builder.add_tx_hashes(tx_hashes);
-        builder.add_tx_witness_hashes(tx_witness_hashes);
-        builder.finish()
-    }
-}
-
-impl<'a> CanBuild<'a> for protos::StoredBlockBody<'a> {
-    type Input = [Transaction];
-    fn build<'b: 'a>(
-        fbb: &mut FlatBufferBuilder<'b>,
-        transactions: &Self::Input,
-    ) -> WIPOffset<protos::StoredBlockBody<'b>> {
-        let data = protos::BlockBody::build(fbb, transactions);
-        let cache = protos::StoredBlockBodyCache::build(fbb, transactions);
-        let mut builder = protos::StoredBlockBodyBuilder::new(fbb);
-        builder.add_data(data);
-        builder.add_cache(cache);
-        builder.finish()
-    }
-}
-
 impl<'a> CanBuild<'a> for protos::StoredHeaderCache<'a> {
     type Input = Header;
     fn build<'b: 'a>(
@@ -149,6 +111,36 @@ impl<'a> CanBuild<'a> for protos::StoredUncleBlocksCache<'a> {
         let hashes = fbb.create_vector(&hashes_vec);
         let mut builder = protos::StoredUncleBlocksCacheBuilder::new(fbb);
         builder.add_hashes(hashes);
+        builder.finish()
+    }
+}
+
+impl<'a> CanBuild<'a> for protos::StoredTransaction<'a> {
+    type Input = Transaction;
+    fn build<'b: 'a>(
+        fbb: &mut FlatBufferBuilder<'b>,
+        transaction: &Self::Input,
+    ) -> WIPOffset<protos::StoredTransaction<'b>> {
+        let data = protos::Transaction::build(fbb, transaction);
+        let cache = protos::StoredTransactionCache::build(fbb, transaction);
+        let mut builder = protos::StoredTransactionBuilder::new(fbb);
+        builder.add_data(data);
+        builder.add_cache(cache);
+        builder.finish()
+    }
+}
+
+impl<'a> CanBuild<'a> for protos::StoredTransactionCache<'a> {
+    type Input = Transaction;
+    fn build<'b: 'a>(
+        fbb: &mut FlatBufferBuilder<'b>,
+        transaction: &Self::Input,
+    ) -> WIPOffset<protos::StoredTransactionCache<'b>> {
+        let hash = transaction.hash().into();
+        let witness_hash = transaction.witness_hash().into();
+        let mut builder = protos::StoredTransactionCacheBuilder::new(fbb);
+        builder.add_hash(&hash);
+        builder.add_witness_hash(&witness_hash);
         builder.finish()
     }
 }

--- a/protos/src/generated/extra_methods.rs
+++ b/protos/src/generated/extra_methods.rs
@@ -88,18 +88,6 @@ impl<'a> super::StoredBlockCache<'a> {
     }
 }
 
-impl<'a> super::StoredBlockBody<'a> {
-    pub fn from_slice(slice: &'a [u8]) -> Self {
-        flatbuffers::get_root::<Self>(&slice)
-    }
-}
-
-impl<'a> super::StoredBlockBodyCache<'a> {
-    pub fn from_slice(slice: &'a [u8]) -> Self {
-        flatbuffers::get_root::<Self>(&slice)
-    }
-}
-
 impl<'a> super::StoredTransactionInfo<'a> {
     pub fn from_slice(slice: &'a [u8]) -> Self {
         flatbuffers::get_root::<Self>(&slice)
@@ -113,6 +101,18 @@ impl<'a> super::StoredHeader<'a> {
 }
 
 impl<'a> super::StoredHeaderCache<'a> {
+    pub fn from_slice(slice: &'a [u8]) -> Self {
+        flatbuffers::get_root::<Self>(&slice)
+    }
+}
+
+impl<'a> super::StoredTransaction<'a> {
+    pub fn from_slice(slice: &'a [u8]) -> Self {
+        flatbuffers::get_root::<Self>(&slice)
+    }
+}
+
+impl<'a> super::StoredTransactionCache<'a> {
     pub fn from_slice(slice: &'a [u8]) -> Self {
         flatbuffers::get_root::<Self>(&slice)
     }

--- a/protos/src/generated/storage.rs
+++ b/protos/src/generated/storage.rs
@@ -262,222 +262,6 @@ impl<'a: 'b, 'b> StoredBlockCacheBuilder<'a, 'b> {
     }
 }
 
-pub enum StoredBlockBodyOffset {}
-#[derive(Copy, Clone, Debug, PartialEq)]
-
-pub struct StoredBlockBody<'a> {
-    pub _tab: flatbuffers::Table<'a>,
-}
-
-impl<'a> flatbuffers::Follow<'a> for StoredBlockBody<'a> {
-    type Inner = StoredBlockBody<'a>;
-    #[inline]
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
-    }
-}
-
-impl<'a> StoredBlockBody<'a> {
-    #[inline]
-    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        StoredBlockBody { _tab: table }
-    }
-    #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args StoredBlockBodyArgs<'args>,
-    ) -> flatbuffers::WIPOffset<StoredBlockBody<'bldr>> {
-        let mut builder = StoredBlockBodyBuilder::new(_fbb);
-        if let Some(x) = args.cache {
-            builder.add_cache(x);
-        }
-        if let Some(x) = args.data {
-            builder.add_data(x);
-        }
-        builder.finish()
-    }
-
-    pub const VT_DATA: flatbuffers::VOffsetT = 4;
-    pub const VT_CACHE: flatbuffers::VOffsetT = 6;
-
-    #[inline]
-    pub fn data(&self) -> Option<BlockBody<'a>> {
-        self._tab
-            .get::<flatbuffers::ForwardsUOffset<BlockBody<'a>>>(StoredBlockBody::VT_DATA, None)
-    }
-    #[inline]
-    pub fn cache(&self) -> Option<StoredBlockBodyCache<'a>> {
-        self._tab
-            .get::<flatbuffers::ForwardsUOffset<StoredBlockBodyCache<'a>>>(
-                StoredBlockBody::VT_CACHE,
-                None,
-            )
-    }
-}
-
-pub struct StoredBlockBodyArgs<'a> {
-    pub data: Option<flatbuffers::WIPOffset<BlockBody<'a>>>,
-    pub cache: Option<flatbuffers::WIPOffset<StoredBlockBodyCache<'a>>>,
-}
-impl<'a> Default for StoredBlockBodyArgs<'a> {
-    #[inline]
-    fn default() -> Self {
-        StoredBlockBodyArgs {
-            data: None,
-            cache: None,
-        }
-    }
-}
-pub struct StoredBlockBodyBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b> StoredBlockBodyBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_data(&mut self, data: flatbuffers::WIPOffset<BlockBody<'b>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<BlockBody>>(StoredBlockBody::VT_DATA, data);
-    }
-    #[inline]
-    pub fn add_cache(&mut self, cache: flatbuffers::WIPOffset<StoredBlockBodyCache<'b>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<StoredBlockBodyCache>>(
-                StoredBlockBody::VT_CACHE,
-                cache,
-            );
-    }
-    #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> StoredBlockBodyBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        StoredBlockBodyBuilder {
-            fbb_: _fbb,
-            start_: start,
-        }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<StoredBlockBody<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
-}
-
-pub enum StoredBlockBodyCacheOffset {}
-#[derive(Copy, Clone, Debug, PartialEq)]
-
-pub struct StoredBlockBodyCache<'a> {
-    pub _tab: flatbuffers::Table<'a>,
-}
-
-impl<'a> flatbuffers::Follow<'a> for StoredBlockBodyCache<'a> {
-    type Inner = StoredBlockBodyCache<'a>;
-    #[inline]
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
-    }
-}
-
-impl<'a> StoredBlockBodyCache<'a> {
-    #[inline]
-    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        StoredBlockBodyCache { _tab: table }
-    }
-    #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args StoredBlockBodyCacheArgs<'args>,
-    ) -> flatbuffers::WIPOffset<StoredBlockBodyCache<'bldr>> {
-        let mut builder = StoredBlockBodyCacheBuilder::new(_fbb);
-        if let Some(x) = args.tx_witness_hashes {
-            builder.add_tx_witness_hashes(x);
-        }
-        if let Some(x) = args.tx_hashes {
-            builder.add_tx_hashes(x);
-        }
-        builder.finish()
-    }
-
-    pub const VT_TX_HASHES: flatbuffers::VOffsetT = 4;
-    pub const VT_TX_WITNESS_HASHES: flatbuffers::VOffsetT = 6;
-
-    #[inline]
-    pub fn tx_hashes(&self) -> Option<&'a [Bytes32]> {
-        self._tab
-            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<Bytes32>>>(
-                StoredBlockBodyCache::VT_TX_HASHES,
-                None,
-            )
-            .map(|v| v.safe_slice())
-    }
-    #[inline]
-    pub fn tx_witness_hashes(&self) -> Option<&'a [Bytes32]> {
-        self._tab
-            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<Bytes32>>>(
-                StoredBlockBodyCache::VT_TX_WITNESS_HASHES,
-                None,
-            )
-            .map(|v| v.safe_slice())
-    }
-}
-
-pub struct StoredBlockBodyCacheArgs<'a> {
-    pub tx_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Bytes32>>>,
-    pub tx_witness_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Bytes32>>>,
-}
-impl<'a> Default for StoredBlockBodyCacheArgs<'a> {
-    #[inline]
-    fn default() -> Self {
-        StoredBlockBodyCacheArgs {
-            tx_hashes: None,
-            tx_witness_hashes: None,
-        }
-    }
-}
-pub struct StoredBlockBodyCacheBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b> StoredBlockBodyCacheBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_tx_hashes(
-        &mut self,
-        tx_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b, Bytes32>>,
-    ) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            StoredBlockBodyCache::VT_TX_HASHES,
-            tx_hashes,
-        );
-    }
-    #[inline]
-    pub fn add_tx_witness_hashes(
-        &mut self,
-        tx_witness_hashes: flatbuffers::WIPOffset<flatbuffers::Vector<'b, Bytes32>>,
-    ) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            StoredBlockBodyCache::VT_TX_WITNESS_HASHES,
-            tx_witness_hashes,
-        );
-    }
-    #[inline]
-    pub fn new(
-        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    ) -> StoredBlockBodyCacheBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        StoredBlockBodyCacheBuilder {
-            fbb_: _fbb,
-            start_: start,
-        }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<StoredBlockBodyCache<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
-}
-
 pub enum StoredTransactionInfoOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -731,6 +515,209 @@ impl<'a: 'b, 'b> StoredHeaderCacheBuilder<'a, 'b> {
     }
     #[inline]
     pub fn finish(self) -> flatbuffers::WIPOffset<StoredHeaderCache<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+pub enum StoredTransactionOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct StoredTransaction<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for StoredTransaction<'a> {
+    type Inner = StoredTransaction<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> StoredTransaction<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        StoredTransaction { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args StoredTransactionArgs<'args>,
+    ) -> flatbuffers::WIPOffset<StoredTransaction<'bldr>> {
+        let mut builder = StoredTransactionBuilder::new(_fbb);
+        if let Some(x) = args.cache {
+            builder.add_cache(x);
+        }
+        if let Some(x) = args.data {
+            builder.add_data(x);
+        }
+        builder.finish()
+    }
+
+    pub const VT_DATA: flatbuffers::VOffsetT = 4;
+    pub const VT_CACHE: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub fn data(&self) -> Option<Transaction<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<Transaction<'a>>>(StoredTransaction::VT_DATA, None)
+    }
+    #[inline]
+    pub fn cache(&self) -> Option<StoredTransactionCache<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<StoredTransactionCache<'a>>>(
+                StoredTransaction::VT_CACHE,
+                None,
+            )
+    }
+}
+
+pub struct StoredTransactionArgs<'a> {
+    pub data: Option<flatbuffers::WIPOffset<Transaction<'a>>>,
+    pub cache: Option<flatbuffers::WIPOffset<StoredTransactionCache<'a>>>,
+}
+impl<'a> Default for StoredTransactionArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        StoredTransactionArgs {
+            data: None,
+            cache: None,
+        }
+    }
+}
+pub struct StoredTransactionBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> StoredTransactionBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_data(&mut self, data: flatbuffers::WIPOffset<Transaction<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Transaction>>(
+                StoredTransaction::VT_DATA,
+                data,
+            );
+    }
+    #[inline]
+    pub fn add_cache(&mut self, cache: flatbuffers::WIPOffset<StoredTransactionCache<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<StoredTransactionCache>>(
+                StoredTransaction::VT_CACHE,
+                cache,
+            );
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> StoredTransactionBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        StoredTransactionBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<StoredTransaction<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+pub enum StoredTransactionCacheOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct StoredTransactionCache<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for StoredTransactionCache<'a> {
+    type Inner = StoredTransactionCache<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> StoredTransactionCache<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        StoredTransactionCache { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args StoredTransactionCacheArgs<'args>,
+    ) -> flatbuffers::WIPOffset<StoredTransactionCache<'bldr>> {
+        let mut builder = StoredTransactionCacheBuilder::new(_fbb);
+        if let Some(x) = args.witness_hash {
+            builder.add_witness_hash(x);
+        }
+        if let Some(x) = args.hash {
+            builder.add_hash(x);
+        }
+        builder.finish()
+    }
+
+    pub const VT_HASH: flatbuffers::VOffsetT = 4;
+    pub const VT_WITNESS_HASH: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub fn hash(&self) -> Option<&'a Bytes32> {
+        self._tab
+            .get::<Bytes32>(StoredTransactionCache::VT_HASH, None)
+    }
+    #[inline]
+    pub fn witness_hash(&self) -> Option<&'a Bytes32> {
+        self._tab
+            .get::<Bytes32>(StoredTransactionCache::VT_WITNESS_HASH, None)
+    }
+}
+
+pub struct StoredTransactionCacheArgs<'a> {
+    pub hash: Option<&'a Bytes32>,
+    pub witness_hash: Option<&'a Bytes32>,
+}
+impl<'a> Default for StoredTransactionCacheArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        StoredTransactionCacheArgs {
+            hash: None,
+            witness_hash: None,
+        }
+    }
+}
+pub struct StoredTransactionCacheBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> StoredTransactionCacheBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_hash(&mut self, hash: &'b Bytes32) {
+        self.fbb_
+            .push_slot_always::<&Bytes32>(StoredTransactionCache::VT_HASH, hash);
+    }
+    #[inline]
+    pub fn add_witness_hash(&mut self, witness_hash: &'b Bytes32) {
+        self.fbb_
+            .push_slot_always::<&Bytes32>(StoredTransactionCache::VT_WITNESS_HASH, witness_hash);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> StoredTransactionCacheBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        StoredTransactionCacheBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<StoredTransactionCache<'a>> {
         let o = self.fbb_.end_table(self.start_);
         flatbuffers::WIPOffset::new(o.value())
     }

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -4,7 +4,10 @@ use crate::COLUMN_CELL_SET;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_core::extras::BlockExt;
 use ckb_core::transaction_meta::TransactionMeta;
-use ckb_db::{Col, DBPinnableSlice, Error, RocksDB};
+use ckb_db::{
+    iter::{DBIterator, DBIteratorItem},
+    Col, DBPinnableSlice, Direction, Error, RocksDB,
+};
 use ckb_protos as protos;
 use numext_fixed_hash::H256;
 use std::convert::TryInto;
@@ -19,6 +22,17 @@ impl<'a> ChainStore<'a> for ChainDB {
     fn get(&'a self, col: Col, key: &[u8]) -> Option<Self::Vector> {
         self.db
             .get_pinned(col, key)
+            .expect("db operation should be ok")
+    }
+
+    fn get_iter<'i>(
+        &'i self,
+        col: Col,
+        from_key: &'i [u8],
+        direction: Direction,
+    ) -> Box<Iterator<Item = DBIteratorItem> + 'i> {
+        self.db
+            .iter(col, from_key, direction)
             .expect("db operation should be ok")
     }
 }

--- a/util/reward-calculator/src/lib.rs
+++ b/util/reward-calculator/src/lib.rs
@@ -150,7 +150,6 @@ impl<'a, CS: ChainStore<'a>> RewardCalculator<'a, CS> {
         let committed_idx_proc = |hash: &H256| -> HashSet<ProposalShortId> {
             store
                 .get_block_txs_hashes(hash)
-                .expect("block body stored")
                 .iter()
                 .skip(1)
                 .map(ProposalShortId::from_tx_hash)


### PR DESCRIPTION
This PR splits block body (transactions) into small value store and use rocksdb prefix seek API to improve the DB fetch performance.