### PR TITLE
chore: Set long poll interval for dummy miner

### DIFF
--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -40,7 +40,9 @@ rpc_url = "http://127.0.0.1:8114/" # {{
 block_on_submit = true
 
 # block template polling interval in milliseconds
-poll_interval = 1000
+poll_interval = 1000 # {{
+# dev => poll_interval = 1_000_000_000_000
+# }}
 
 [[miner.workers]]
 worker_type = "CuckooSimple" # {{


### PR DESCRIPTION
Long `poll_interval` can prevent dummy miner re-poll frequently, so that avoid generating uncle blocks.