### PR TITLE
fix: compact block short_id collides

### DIFF
--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -1,11 +1,23 @@
 use crate::relayer::block_transactions_verifier::BlockTransactionsVerifier;
-use crate::relayer::Relayer;
+use crate::relayer::error::{Error, Misbehavior};
+use crate::relayer::{ReconstructionError, Relayer};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{core, packed, prelude::*};
 use failure::Error as FailureError;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
+// Keeping in mind that short_ids are expected to occasionally collide.
+// On receiving block-transactions message,
+// while the reconstructed the block has a different transactions_root,
+// 1. If the BlockTransactions includes all the transactions matched short_ids in the compact block,
+// In this situation, the peer sends all the transactions by either prefilled or block-transactions,
+// no one transaction from the tx-pool or store,
+// the node should ban the peer but not mark the block invalid
+// because of the block hash may be wrong.
+// 2. If not all the transactions comes from the peer,
+// there may be short_id collision in transaction pool.
+// the node retreat to request all the short_ids from the peer.
 pub struct BlockTransactionsProcess<'a> {
     message: packed::BlockTransactionsReader<'a>,
     relayer: &'a Relayer,
@@ -13,6 +25,7 @@ pub struct BlockTransactionsProcess<'a> {
     peer: PeerIndex,
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub enum Status {
     // BlockTransactionsVerifier has checked it,
     // so shoud not reach here unless the peer loses the transactions in tx_pool
@@ -23,6 +36,8 @@ pub enum Status {
     // The peer may lose it's cache
     // or other peer makes some mistakes
     UnkownRequest,
+    // Maybe short_id collides, re-send get_block_transactions message
+    CollisionAndSendMissingIndexes,
 }
 
 impl<'a> BlockTransactionsProcess<'a> {
@@ -41,7 +56,17 @@ impl<'a> BlockTransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Result<Status, FailureError> {
-        let block_hash = self.message.block_hash().to_entity();
+        let block_transactions = self.message.to_entity();
+        let block_hash = block_transactions.block_hash();
+        let transactions: Vec<core::TransactionView> = block_transactions
+            .transactions()
+            .into_iter()
+            .map(|tx| tx.into_view())
+            .collect();
+
+        let missing_indexes: Vec<u32>;
+        let mut collision = false;
+
         if let Entry::Occupied(mut pending) = self
             .relayer
             .shared()
@@ -56,27 +81,50 @@ impl<'a> BlockTransactionsProcess<'a> {
                     self.peer
                 );
 
-                let transactions: Vec<core::TransactionView> = self
-                    .message
-                    .transactions()
-                    .to_entity()
-                    .into_iter()
-                    .map(|tx| tx.into_view())
-                    .collect();
-
                 BlockTransactionsVerifier::verify(&compact_block, &indexes, &transactions)?;
 
                 let ret = self.relayer.reconstruct_block(compact_block, transactions);
 
-                // TODO Add this (compact_block, peer) into RecentRejects if reconstruct_block failed?
-                // TODO Add this block into RecentRejects if accept_block failed?
-                if let Ok(block) = ret {
-                    pending.remove();
-                    self.relayer
-                        .accept_block(self.nc.as_ref(), self.peer, block);
-                    return Ok(Status::Accept);
+                match ret {
+                    Ok(block) => {
+                        pending.remove();
+                        self.relayer
+                            .accept_block(self.nc.as_ref(), self.peer, block);
+                        return Ok(Status::Accept);
+                    }
+                    Err(ReconstructionError::InvalidTransactionRoot) => {
+                        return Err(Error::Misbehavior(Misbehavior::InvalidTransactionRoot).into());
+                    }
+                    Err(ReconstructionError::MissingIndexes(missing)) => {
+                        missing_indexes = missing.into_iter().map(|i| i as u32).collect();
+                    }
+                    Err(ReconstructionError::Collision) => {
+                        missing_indexes = compact_block
+                            .short_id_indexes()
+                            .into_iter()
+                            .map(|i| i as u32)
+                            .collect();
+                        collision = true;
+                    }
                 }
-                return Ok(Status::Missing);
+
+                assert!(!missing_indexes.is_empty());
+
+                let content = packed::GetBlockTransactions::new_builder()
+                    .block_hash(block_hash)
+                    .indexes(missing_indexes.pack())
+                    .build();
+                let message = packed::RelayMessage::new_builder().set(content).build();
+                let data = message.as_slice().into();
+                if let Err(err) = self.nc.send_message_to(self.peer, data) {
+                    ckb_logger::debug!("relayer send get_block_transactions error: {:?}", err);
+                }
+
+                if collision {
+                    return Ok(Status::CollisionAndSendMissingIndexes);
+                } else {
+                    return Ok(Status::Missing);
+                }
             }
         }
 

--- a/sync/src/relayer/compact_block_verifier.rs
+++ b/sync/src/relayer/compact_block_verifier.rs
@@ -2,6 +2,9 @@ use crate::relayer::error::{Error, Misbehavior};
 use ckb_types::{packed, prelude::*};
 use std::collections::HashSet;
 
+// we assume that all the short_ids and prefilled transactions
+// should NOT collide with each other,
+// because in the tx-pool, the node should use short_id as the key.
 pub struct CompactBlockVerifier {}
 
 impl CompactBlockVerifier {

--- a/sync/src/relayer/error.rs
+++ b/sync/src/relayer/error.rs
@@ -29,6 +29,8 @@ pub enum Misbehavior {
     OverflowPrefilledTransactions,
     #[fail(display = "CompactBlockError::IntersectedPrefilledTransactions")]
     IntersectedPrefilledTransactions,
+    #[fail(display = "CompactBlockError::InvalidTransactionRoot")]
+    InvalidTransactionRoot,
     #[fail(
         display = "block transactions' length is invalid, expect {}, but got {}",
         expect, got

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -2,11 +2,15 @@ use crate::relayer::block_transactions_process::{BlockTransactionsProcess, Statu
 use crate::relayer::error::{Error, Misbehavior};
 use crate::relayer::tests::helper::{build_chain, MockProtocalContext};
 use ckb_network::PeerIndex;
+use ckb_store::ChainStore;
 use ckb_types::prelude::*;
 use ckb_types::{
     bytes::Bytes,
     core::{BlockBuilder, Capacity, TransactionBuilder},
-    packed::{self, BlockTransactions, CellOutputBuilder, CompactBlock, Header, IndexTransaction},
+    packed::{
+        self, BlockTransactions, CellInput, CellOutputBuilder, CompactBlock, Header,
+        IndexTransaction, OutPoint,
+    },
     H256,
 };
 use std::collections::HashMap;
@@ -190,29 +194,33 @@ fn test_invalid_transaction_root() {
     );
 }
 
-// Generate a transaction T, and add that transaction
-// to the proposed pool, as usual.
-// Generate a block, which includes the transaction.
-// Change the merkle root to other value.
-// Send the block as compact block, which does not prefill T.
-// The test should work because from the peer's perspective,
-// it cannot tell the differences between a collision and
-// a real unmatched merkle root.
 #[test]
 fn test_collision_and_send_missing_indexes() {
     let (relayer, _) = build_chain(5);
+
+    let last_block = relayer
+        .shared
+        .store()
+        .get_block(&relayer.shared.lock_chain_state().tip_hash())
+        .unwrap();
+    let last_cellbase = last_block.transactions().first().cloned().unwrap();
+
     let peer_index: PeerIndex = 100.into();
 
     let tx1 = TransactionBuilder::default().build();
     let tx2 = TransactionBuilder::default()
         .output(
             CellOutputBuilder::default()
-                .capacity(Capacity::bytes(1).unwrap().pack())
+                .capacity(Capacity::bytes(1000).unwrap().pack())
                 .build(),
         )
         .output_data(Bytes::new().pack())
         .build();
     let tx3 = TransactionBuilder::default()
+        .input(CellInput::new(
+            OutPoint::new(last_cellbase.hash().unpack(), 0),
+            0,
+        ))
         .output(
             CellOutputBuilder::default()
                 .capacity(Capacity::bytes(2).unwrap().pack())
@@ -221,8 +229,23 @@ fn test_collision_and_send_missing_indexes() {
         .output_data(Bytes::new().pack())
         .build();
 
+    let fake_hash = tx3
+        .hash()
+        .clone()
+        .as_builder()
+        .nth31(0u8)
+        .nth30(0u8)
+        .nth29(0u8)
+        .nth28(0u8)
+        .build();
+    // Fake tx with the same ProposalShortId but different hash with tx3
+    let fake_tx = tx3.clone().fake_hash(fake_hash);
+
+    assert_eq!(tx3.proposal_short_id(), fake_tx.proposal_short_id());
+    assert_ne!(tx3.hash(), fake_tx.hash());
+
     let block = BlockBuilder::default()
-        .transactions(vec![tx1.clone(), tx2.clone(), tx3.clone()])
+        .transactions(vec![tx1.clone(), tx2.clone(), fake_tx])
         .build_unchecked();
 
     let prefilled = HashSet::from_iter(vec![0usize].into_iter());
@@ -231,7 +254,7 @@ fn test_collision_and_send_missing_indexes() {
 
     {
         let chain_state = relayer.shared.lock_chain_state();
-        chain_state.add_tx_to_pool(tx3, 100u16.into()).unwrap();
+        chain_state.add_tx_to_pool(tx3, 10000u16.into()).unwrap();
     }
 
     {

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -1,0 +1,356 @@
+use crate::relayer::block_transactions_process::{BlockTransactionsProcess, Status};
+use crate::relayer::error::{Error, Misbehavior};
+use crate::relayer::tests::helper::{build_chain, MockProtocalContext};
+use ckb_network::PeerIndex;
+use ckb_types::prelude::*;
+use ckb_types::{
+    bytes::Bytes,
+    core::{BlockBuilder, Capacity, TransactionBuilder},
+    packed::{self, BlockTransactions, CellOutputBuilder, CompactBlock, Header, IndexTransaction},
+    H256,
+};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::iter::FromIterator;
+use std::sync::Arc;
+
+#[test]
+fn test_accept_block() {
+    let (relayer, _) = build_chain(5);
+    let peer_index: PeerIndex = 100.into();
+
+    let tx1 = TransactionBuilder::default().build();
+    let tx2 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(1).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .transactions(vec![tx1.clone(), tx2.clone()])
+        .build();
+    let prefilled = HashSet::from_iter(vec![0usize].into_iter());
+
+    let compact_block = CompactBlock::build_from_block(&block, &prefilled);
+
+    {
+        let mut pending_compact_blocks = relayer.shared.pending_compact_blocks();
+        pending_compact_blocks.insert(
+            compact_block.header().calc_header_hash().pack(),
+            (
+                compact_block,
+                HashMap::from_iter(vec![(peer_index, vec![1])]),
+            ),
+        );
+    }
+
+    let block_transactions: BlockTransactions = packed::BlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .transactions(vec![tx2.data()].pack())
+        .build();
+
+    let mock_protocal_context = MockProtocalContext::default();
+    let nc = Arc::new(mock_protocal_context);
+
+    let process = BlockTransactionsProcess::new(
+        block_transactions.as_reader(),
+        &relayer,
+        Arc::<MockProtocalContext>::clone(&nc),
+        peer_index,
+    );
+
+    let r = process.execute();
+
+    assert_eq!(r.ok(), Some(Status::Accept));
+}
+
+#[test]
+fn test_unknown_request() {
+    let (relayer, _) = build_chain(5);
+    let peer_index: PeerIndex = 100.into();
+
+    let tx1 = TransactionBuilder::default().build();
+    let tx2 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(1).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .transactions(vec![tx1.clone(), tx2.clone()])
+        .build();
+
+    let prefilled = HashSet::from_iter(vec![0usize].into_iter());
+
+    let compact_block = CompactBlock::build_from_block(&block, &prefilled);
+
+    let foo_peer_index: PeerIndex = 998.into();
+    {
+        let mut pending_compact_blocks = relayer.shared.pending_compact_blocks();
+        pending_compact_blocks.insert(
+            compact_block.header().calc_header_hash().pack(),
+            (
+                compact_block,
+                HashMap::from_iter(vec![(foo_peer_index, vec![1])]),
+            ),
+        );
+    }
+
+    let block_transactions: BlockTransactions = packed::BlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .transactions(vec![tx2.data()].pack())
+        .build();
+
+    let mock_protocal_context = MockProtocalContext::default();
+    let nc = Arc::new(mock_protocal_context);
+
+    let process = BlockTransactionsProcess::new(
+        block_transactions.as_reader(),
+        &relayer,
+        Arc::<MockProtocalContext>::clone(&nc),
+        peer_index,
+    );
+
+    let r = process.execute();
+    assert_eq!(r.ok(), Some(Status::UnkownRequest));
+}
+
+#[test]
+fn test_invalid_transaction_root() {
+    let (relayer, _) = build_chain(5);
+    let peer_index: PeerIndex = 100.into();
+
+    let tx1 = TransactionBuilder::default().build();
+    let tx2 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(1).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+
+    let prefilled = IndexTransaction::new_builder()
+        .index(0u32.pack())
+        .transaction(tx1.data())
+        .build();
+
+    let header_with_invalid_tx_root = Header::new_builder()
+        .raw(
+            packed::RawHeader::new_builder()
+                .transactions_root(H256::zero().pack())
+                .build(),
+        )
+        .build();
+
+    let compact_block = packed::CompactBlock::new_builder()
+        .header(header_with_invalid_tx_root)
+        .short_ids(vec![tx2.proposal_short_id()].pack())
+        .prefilled_transactions(vec![prefilled].pack())
+        .build();
+
+    let block_hash = compact_block.header().calc_header_hash();
+
+    {
+        let mut pending_compact_blocks = relayer.shared.pending_compact_blocks();
+        pending_compact_blocks.insert(
+            block_hash.clone().pack(),
+            (
+                compact_block,
+                HashMap::from_iter(vec![(peer_index, vec![1])]),
+            ),
+        );
+    }
+
+    let block_transactions: BlockTransactions = packed::BlockTransactions::new_builder()
+        .block_hash(block_hash.pack())
+        .transactions(vec![tx2.data()].pack())
+        .build();
+
+    let mock_protocal_context = MockProtocalContext::default();
+    let nc = Arc::new(mock_protocal_context);
+
+    let process = BlockTransactionsProcess::new(
+        block_transactions.as_reader(),
+        &relayer,
+        Arc::<MockProtocalContext>::clone(&nc),
+        peer_index,
+    );
+
+    let r = process.execute();
+    assert_eq!(
+        r.unwrap_err().downcast::<Error>().unwrap(),
+        Error::Misbehavior(Misbehavior::InvalidTransactionRoot)
+    );
+}
+
+// Generate a transaction T, and add that transaction
+// to the proposed pool, as usual.
+// Generate a block, which includes the transaction.
+// Change the merkle root to other value.
+// Send the block as compact block, which does not prefill T.
+// The test should work because from the peer's perspective,
+// it cannot tell the differences between a collision and
+// a real unmatched merkle root.
+#[test]
+fn test_collision_and_send_missing_indexes() {
+    let (relayer, _) = build_chain(5);
+    let peer_index: PeerIndex = 100.into();
+
+    let tx1 = TransactionBuilder::default().build();
+    let tx2 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(1).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+    let tx3 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(2).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .transactions(vec![tx1.clone(), tx2.clone(), tx3.clone()])
+        .build_unchecked();
+
+    let prefilled = HashSet::from_iter(vec![0usize].into_iter());
+
+    let compact_block = CompactBlock::build_from_block(&block, &prefilled);
+
+    {
+        let chain_state = relayer.shared.lock_chain_state();
+        chain_state.add_tx_to_pool(tx3, 100u16.into()).unwrap();
+    }
+
+    {
+        let mut pending_compact_blocks = relayer.shared.pending_compact_blocks();
+        pending_compact_blocks.insert(
+            compact_block.header().calc_header_hash().pack(),
+            (
+                compact_block,
+                HashMap::from_iter(vec![(peer_index, vec![1])]),
+            ),
+        );
+    }
+
+    let block_transactions = packed::BlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .transactions(vec![tx2.data()].pack())
+        .build();
+
+    let mock_protocal_context = MockProtocalContext::default();
+    let nc = Arc::new(mock_protocal_context);
+
+    let process = BlockTransactionsProcess::new(
+        block_transactions.as_reader(),
+        &relayer,
+        Arc::<MockProtocalContext>::clone(&nc),
+        peer_index,
+    );
+
+    let r = process.execute();
+    assert_eq!(r.ok(), Some(Status::CollisionAndSendMissingIndexes));
+
+    let content = packed::GetBlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .indexes(vec![1u32, 2u32].pack())
+        .build();
+    let message = packed::RelayMessage::new_builder().set(content).build();
+    let data = message.as_slice().into();
+
+    // send missing indexes messages
+    assert!(nc
+        .as_ref()
+        .sent_messages_to
+        .borrow()
+        .contains(&(peer_index, data)));
+}
+
+#[test]
+fn test_missing() {
+    let (relayer, _) = build_chain(5);
+    let peer_index: PeerIndex = 100.into();
+
+    let tx1 = TransactionBuilder::default().build();
+    let tx2 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(1).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+    let tx3 = TransactionBuilder::default()
+        .output(
+            CellOutputBuilder::default()
+                .capacity(Capacity::bytes(2).unwrap().pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .transactions(vec![tx1.clone(), tx2.clone(), tx3.clone()])
+        .build();
+
+    let prefilled = HashSet::from_iter(vec![0usize].into_iter());
+
+    let compact_block = CompactBlock::build_from_block(&block, &prefilled);
+
+    // tx3 should be in tx_pool already, but it's not.
+    // so the reconstruct block will fail
+    {
+        let mut pending_compact_blocks = relayer.shared.pending_compact_blocks();
+        pending_compact_blocks.insert(
+            compact_block.header().calc_header_hash().pack(),
+            (
+                compact_block,
+                HashMap::from_iter(vec![(peer_index, vec![1])]),
+            ),
+        );
+    }
+
+    let block_transactions = packed::BlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .transactions(vec![tx2.data()].pack())
+        .build();
+
+    let mock_protocal_context = MockProtocalContext::default();
+    let nc = Arc::new(mock_protocal_context);
+
+    let process = BlockTransactionsProcess::new(
+        block_transactions.as_reader(),
+        &relayer,
+        Arc::<MockProtocalContext>::clone(&nc),
+        peer_index,
+    );
+
+    let r = process.execute();
+    assert_eq!(r.ok(), Some(Status::Missing));
+
+    let content = packed::GetBlockTransactions::new_builder()
+        .block_hash(block.header().hash())
+        .indexes(vec![2u32].pack())
+        .build();
+    let message = packed::RelayMessage::new_builder().set(content).build();
+    let data = message.as_slice().into();
+
+    // send missing indexes messages
+    assert!(nc
+        .as_ref()
+        .sent_messages_to
+        .borrow()
+        .contains(&(peer_index, data)));
+}

--- a/sync/src/relayer/tests/mod.rs
+++ b/sync/src/relayer/tests/mod.rs
@@ -1,4 +1,5 @@
 mod block_proposal_process;
+mod block_transactions_process;
 mod block_transactions_verifier;
 mod compact_block;
 mod compact_block_process;

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -8,6 +8,7 @@ use ckb_types::{
 };
 use std::collections::HashSet;
 
+// There are more test cases in block_transactions_process and compact_block_process.rs
 #[test]
 fn test_reconstruct_block() {
     let (relayer, always_success_out_point) = build_chain(5);

--- a/util/types/src/extension/shortcuts.rs
+++ b/util/types/src/extension/shortcuts.rs
@@ -204,7 +204,7 @@ impl packed::CompactBlock {
     }
 
     pub fn block_short_ids(&self) -> Vec<Option<packed::ProposalShortId>> {
-        let txs_len = self.prefilled_transactions().len() + self.short_ids().len();
+        let txs_len = self.txs_len();
         let mut block_short_ids: Vec<Option<packed::ProposalShortId>> = Vec::with_capacity(txs_len);
         let prefilled_indexes = self
             .prefilled_transactions()
@@ -222,5 +222,23 @@ impl packed::CompactBlock {
             }
         }
         block_short_ids
+    }
+
+    pub fn txs_len(&self) -> usize {
+        self.prefilled_transactions().len() + self.short_ids().len()
+    }
+
+    pub fn prefilled_indexes_iter(&self) -> impl Iterator<Item = usize> {
+        self.prefilled_transactions()
+            .into_iter()
+            .map(|i| i.index().unpack())
+    }
+
+    pub fn short_id_indexes(&self) -> Vec<usize> {
+        let prefilled_indexes: HashSet<usize> = self.prefilled_indexes_iter().collect();
+
+        (0..self.txs_len())
+            .filter(|index| !prefilled_indexes.contains(&index))
+            .collect()
     }
 }


### PR DESCRIPTION
   nodes should attempt to reconstruct the full block by taking the prefilledtxn transactions
    from the original CompactBlock message and placing them in the marked positions,
    then for each short transaction ID from the original compact_block message, in order,
    find the corresponding transaction either from the BlockTransactions message or
    from other sources and place it in the first available position in the block
    then once the block has been reconstructed, it shall be processed as normal,
    keeping in mind that short_ids are expected to occasionally collide,
    and that nodes must not be penalized for such collisions, wherever they appear.