### PR TITLE
[HOLD] fix: conduct GCD before rational ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "ckb-traits 0.20.0-pre",
  "ckb-types 0.20.0-pre",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -29,6 +29,7 @@ ckb-dao = { path = "../util/dao" }
 ckb-system-scripts = { version = "= 0.3.1" }
 lazy_static = "1.3.0"
 ckb-crypto = { path = "../util/crypto" }
+faketime = "0.2.0"
 
 [[bench]]
 name = "bench_main"

--- a/benches/benches/bench_main.rs
+++ b/benches/benches/bench_main.rs
@@ -5,4 +5,5 @@ use criterion::criterion_main;
 criterion_main! {
     benchmarks::always_success::process_block,
     benchmarks::secp_2in2out::process_block,
+    benchmarks::next_epoch_ext::next_epoch_ext,
 }

--- a/benches/benches/benchmarks/mod.rs
+++ b/benches/benches/benchmarks/mod.rs
@@ -1,3 +1,4 @@
 pub mod always_success;
+pub mod next_epoch_ext;
 pub mod secp_2in2out;
 pub mod util;

--- a/benches/benches/benchmarks/next_epoch_ext.rs
+++ b/benches/benches/benchmarks/next_epoch_ext.rs
@@ -1,0 +1,126 @@
+use ckb_chain_spec::consensus::Consensus;
+use ckb_dao_utils::genesis_dao_data;
+use ckb_types::{
+    core::{capacity_bytes, BlockBuilder, Capacity, HeaderBuilder, HeaderView, TransactionBuilder},
+    h256,
+    packed::{Byte32, CellInput, Script},
+    prelude::*,
+    H256, U256,
+};
+use criterion::{criterion_group, Criterion};
+use faketime::unix_time_as_millis;
+use rand::{thread_rng, Rng};
+use std::collections::HashMap;
+
+const GENESIS_DIFFICULTY: H256 = h256!("0x1000000");
+const DEFAULT_EPOCH_REWARD: Capacity = capacity_bytes!(1_250_000);
+const MIN_BLOCK_INTERVAL: u64 = 8;
+
+#[cfg(not(feature = "ci"))]
+const SAMPLES: &[usize] = &[100usize, 500];
+
+#[cfg(feature = "ci")]
+const SAMPLES: &[usize] = &[1usize];
+
+#[derive(Default, Clone)]
+pub struct FakeStore {
+    headers: HashMap<Byte32, HeaderView>,
+    total_uncles_count: HashMap<Byte32, u64>,
+}
+
+impl FakeStore {
+    fn insert(&mut self, header: HeaderView) {
+        let before_total_uncles_count = self
+            .total_uncles_count
+            .get(&header.parent_hash())
+            .cloned()
+            .unwrap_or(0u64);
+        self.total_uncles_count.insert(
+            header.hash(),
+            before_total_uncles_count + u64::from(header.uncles_count()),
+        );
+        self.headers.insert(header.hash(), header);
+    }
+
+    pub(crate) fn get_block_header(&self, hash: &Byte32) -> Option<HeaderView> {
+        self.headers.get(hash).cloned()
+    }
+
+    pub(crate) fn total_uncles_count(&self, hash: &Byte32) -> Option<u64> {
+        self.total_uncles_count.get(hash).cloned()
+    }
+}
+
+fn gen_empty_header(parent: &HeaderView) -> HeaderView {
+    let mut rng = thread_rng();
+    let uncles_count: u32 = rng.gen_range(0, 2);
+    HeaderBuilder::default()
+        .parent_hash(parent.hash().to_owned())
+        .number((parent.number() + 1).pack())
+        .difficulty(parent.difficulty().pack())
+        .uncles_count(uncles_count.pack())
+        .timestamp((parent.timestamp() + MIN_BLOCK_INTERVAL * 1000).pack())
+        .build()
+}
+
+fn bench(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "next_epoch_ext",
+        |b, samples| {
+            b.iter_with_setup(
+                || {
+                    let now = unix_time_as_millis();
+                    let header = HeaderBuilder::default()
+                        .difficulty(GENESIS_DIFFICULTY.pack())
+                        .timestamp(now.pack())
+                        .build();
+
+                    let input = CellInput::new_cellbase_input(0);
+                    let witness = Script::default().into_witness();
+                    let cellbase = TransactionBuilder::default()
+                        .input(input)
+                        .witness(witness)
+                        .build();
+                    let dao = genesis_dao_data(&cellbase).unwrap();
+                    let genesis_block = BlockBuilder::default()
+                        .difficulty(U256::one().pack())
+                        .dao(dao)
+                        .transaction(cellbase)
+                        .header(header)
+                        .build();
+
+                    let mut parent = genesis_block.header().clone();
+                    let consensus = Consensus::new(genesis_block, DEFAULT_EPOCH_REWARD);
+                    let genesis_epoch_ext = consensus.genesis_epoch_ext().clone();
+
+                    let mut store = FakeStore::default();
+
+                    store.insert(parent.clone());
+                    for _ in 1..genesis_epoch_ext.length() {
+                        parent = gen_empty_header(&parent);
+                        store.insert(parent.clone());
+                    }
+
+                    (consensus, genesis_epoch_ext, parent, store)
+                },
+                |(consensus, genesis_epoch_ext, parent, store)| {
+                    let get_block_header = |hash: &Byte32| store.get_block_header(hash);
+
+                    let total_uncles_count = |hash: &Byte32| store.total_uncles_count(hash);
+
+                    for _ in 0..=**samples {
+                        consensus.next_epoch_ext(
+                            &genesis_epoch_ext,
+                            &parent,
+                            get_block_header,
+                            total_uncles_count,
+                        );
+                    }
+                },
+            )
+        },
+        SAMPLES,
+    );
+}
+
+criterion_group!(next_epoch_ext, bench);


### PR DESCRIPTION
updated:

1. https://github.com/rust-num/num-rational/pull/42
2. For mul/div Rational or U256, we use new_raw is well, the same as add/sub U256, we assume that the Rational is already reduced when initialized.
3. for add/sub Rational, we compare the denom firstly.