### PR TITLE
fix: Multiple type ID cell creation in single transaction

### DIFF
--- a/script/src/type_id.rs
+++ b/script/src/type_id.rs
@@ -72,6 +72,14 @@ impl<'a> TypeIdSystemScript<'a> {
                 LittleEndian::write_u64(&mut buf, input.since);
                 blake2b.update(&buf[..]);
             }
+            // Hash output indices(actually there is only one index) for current
+            // script group as well, so we can generate cells with different types
+            // In one transaction
+            for index in &self.script_group.output_indices {
+                let mut buf = [0; 8];
+                LittleEndian::write_u64(&mut buf, *index as u64);
+                blake2b.update(&buf[..]);
+            }
             let mut ret = [0; 32];
             blake2b.finalize(&mut ret);
             if ret[..] != self.script_group.script.args[0] {

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1423,6 +1423,8 @@ mod tests {
             let mut buf = [0; 8];
             LittleEndian::write_u64(&mut buf, input.since);
             blake2b.update(&buf[..]);
+            LittleEndian::write_u64(&mut buf, 0);
+            blake2b.update(&buf[..]);
             let mut ret = [0; 32];
             blake2b.finalize(&mut ret);
             Bytes::from(&ret[..])
@@ -1565,6 +1567,8 @@ mod tests {
             let mut buf = [0; 8];
             LittleEndian::write_u64(&mut buf, input.since);
             blake2b.update(&buf[..]);
+            LittleEndian::write_u64(&mut buf, 0);
+            blake2b.update(&buf[..]);
             blake2b.update(b"unnecessary data");
             let mut ret = [0; 32];
             blake2b.finalize(&mut ret);
@@ -1649,6 +1653,8 @@ mod tests {
             blake2b.update(b"since");
             let mut buf = [0; 8];
             LittleEndian::write_u64(&mut buf, input.since);
+            blake2b.update(&buf[..]);
+            LittleEndian::write_u64(&mut buf, 0);
             blake2b.update(&buf[..]);
             let mut ret = [0; 32];
             blake2b.finalize(&mut ret);

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1406,7 +1406,6 @@ mod tests {
 
         let input_hash = {
             let mut blake2b = new_blake2b();
-            blake2b.update(b"cell");
             blake2b.update(
                 input
                     .previous_output
@@ -1419,10 +1418,7 @@ mod tests {
             let mut buf = [0; 4];
             LittleEndian::write_u32(&mut buf, input.previous_output.cell.as_ref().unwrap().index);
             blake2b.update(&buf[..]);
-            blake2b.update(b"since");
             let mut buf = [0; 8];
-            LittleEndian::write_u64(&mut buf, input.since);
-            blake2b.update(&buf[..]);
             LittleEndian::write_u64(&mut buf, 0);
             blake2b.update(&buf[..]);
             let mut ret = [0; 32];
@@ -1550,7 +1546,6 @@ mod tests {
 
         let input_hash = {
             let mut blake2b = new_blake2b();
-            blake2b.update(b"cell");
             blake2b.update(
                 input
                     .previous_output
@@ -1563,10 +1558,7 @@ mod tests {
             let mut buf = [0; 4];
             LittleEndian::write_u32(&mut buf, input.previous_output.cell.as_ref().unwrap().index);
             blake2b.update(&buf[..]);
-            blake2b.update(b"since");
             let mut buf = [0; 8];
-            LittleEndian::write_u64(&mut buf, input.since);
-            blake2b.update(&buf[..]);
             LittleEndian::write_u64(&mut buf, 0);
             blake2b.update(&buf[..]);
             blake2b.update(b"unnecessary data");
@@ -1637,7 +1629,6 @@ mod tests {
 
         let input_hash = {
             let mut blake2b = new_blake2b();
-            blake2b.update(b"cell");
             blake2b.update(
                 input
                     .previous_output
@@ -1650,10 +1641,7 @@ mod tests {
             let mut buf = [0; 4];
             LittleEndian::write_u32(&mut buf, input.previous_output.cell.as_ref().unwrap().index);
             blake2b.update(&buf[..]);
-            blake2b.update(b"since");
             let mut buf = [0; 8];
-            LittleEndian::write_u64(&mut buf, input.since);
-            blake2b.update(&buf[..]);
             LittleEndian::write_u64(&mut buf, 0);
             blake2b.update(&buf[..]);
             let mut ret = [0; 32];


### PR DESCRIPTION
While previous implementation allows cells to have different type IDs
when they are created in different transactions. One quirk of the
solution, is that all cells in a single transaction will have the same
type ID, since the type ID script arg only hashs all inputs in the
transaction. This commit fixes the problem by hashing the cell's own
index in outputs as well, this way different cells created together
can also have different type IDs.

Notice while we implement it in Rust, the logic here can also be
implemented via a script running in CKB VM