### PR TITLE
chore: Run niche checks posteriorly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ bench-test:
 ##@ Continuous Integration
 
 ci: ## Run recipes for CI.
-ci: check-cargotoml fmt check-dirty-rpc-doc clippy security-audit test bench-test
+ci: fmt clippy test bench-test check-cargotoml check-dirty-rpc-doc security-audit
 	git diff --exit-code Cargo.lock
 
 check-cargotoml:

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -85,6 +85,8 @@ fn main() {
         }
     }
 
+    info!("Total elapsed time: {:?}", start_time.elapsed());
+
     rerun_specs.extend(specs_iter.map(|t| (t.1).0));
     if rerun_specs.is_empty() {
         return;


### PR DESCRIPTION
* `make ci` runs prior checks `fmt/clippy/test` first.