### PR TITLE
[HOLD] feat: min transaction fee fitler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,13 +422,13 @@ dependencies = [
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
+ "ckb-tx-cache 0.19.0-pre",
  "ckb-types 0.19.0-pre",
  "ckb-verification 0.19.0-pre",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -849,11 +849,13 @@ dependencies = [
  "ckb-db 0.19.0-pre",
  "ckb-logger 0.19.0-pre",
  "ckb-notify 0.19.0-pre",
+ "ckb-occupied-capacity 0.19.0-pre",
  "ckb-reward-calculator 0.19.0-pre",
  "ckb-script 0.19.0-pre",
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
+ "ckb-tx-cache 0.19.0-pre",
  "ckb-types 0.19.0-pre",
  "ckb-util 0.19.0-pre",
  "ckb-verification 0.19.0-pre",
@@ -912,6 +914,7 @@ dependencies = [
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
+ "ckb-tx-cache 0.19.0-pre",
  "ckb-tx-pool-executor 0.19.0-pre",
  "ckb-types 0.19.0-pre",
  "ckb-util 0.19.0-pre",
@@ -965,17 +968,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-tx-cache"
+version = "0.19.0-pre"
+dependencies = [
+ "ckb-types 0.19.0-pre",
+ "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",
+]
+
+[[package]]
 name = "ckb-tx-pool-executor"
 version = "0.19.0-pre"
 dependencies = [
  "ckb-chain 0.19.0-pre",
  "ckb-chain-spec 0.19.0-pre",
+ "ckb-dao 0.19.0-pre",
  "ckb-db 0.19.0-pre",
+ "ckb-logger 0.19.0-pre",
  "ckb-notify 0.19.0-pre",
  "ckb-shared 0.19.0-pre",
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
+ "ckb-tx-cache 0.19.0-pre",
  "ckb-types 0.19.0-pre",
  "ckb-verification 0.19.0-pre",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1027,6 +1041,7 @@ dependencies = [
  "ckb-store 0.19.0-pre",
  "ckb-test-chain-utils 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
+ "ckb-tx-cache 0.19.0-pre",
  "ckb-types 0.19.0-pre",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ckb-bin = { path = "ckb-bin" }
 [workspace]
 members = [
     # Members are ordered by dependencies. Crates at top has fewer dependencies.
+    "util/tx-cache",
     "util/build-info",
     "util/logger",
     "util",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -16,10 +16,10 @@ ckb-verification = { path = "../verification" }
 faketime = "0.2.0"
 crossbeam-channel = "0.3"
 ckb-stop-handler = { path = "../util/stop-handler" }
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
 ckb-traits = { path = "../traits" }
 failure = "0.1.5"
 ckb-dao = { path = "../util/dao" }
+ckb-tx-cache = { path = "../util/tx-cache" }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -7,11 +7,12 @@ use ckb_shared::shared::Shared;
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_store::{ChainStore, StoreTransaction};
 use ckb_traits::ChainProvider;
+use ckb_tx_cache::TxCache;
 use ckb_types::{
     core::{
         cell::{resolve_transaction, BlockCellProvider, OverlayCellProvider, ResolvedTransaction},
         service::{Request, DEFAULT_CHANNEL_SIZE, SIGNAL_CHANNEL_SIZE},
-        BlockExt, BlockNumber, BlockView, Cycle,
+        BlockExt, BlockNumber, BlockView,
     },
     packed::{Byte32, OutPoint, ProposalShortId},
     prelude::*,
@@ -21,7 +22,6 @@ use ckb_verification::{BlockVerifier, ContextualBlockVerifier, Verifier, VerifyC
 use crossbeam_channel::{self, select, Receiver, Sender};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
-use lru_cache::LruCache;
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::{cmp, thread};
@@ -505,7 +505,7 @@ impl ChainService {
         txn: &StoreTransaction,
         fork: &mut ForkChanges,
         chain_state: &mut ChainState,
-        txs_verify_cache: &mut LruCache<Byte32, Cycle>,
+        txs_verify_cache: &mut TxCache,
         need_verify: bool,
     ) -> Result<CellSetDiff, FailureError> {
         let verified_len = fork.verified_len();

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -93,6 +93,7 @@ max_cycles = 200_000_000_000
 max_verify_cache_size = 100_000
 max_conflict_cache_size = 1_000
 max_committed_txs_hash_cache_size = 100_000
+min_fee_rate = 1_000 # shannons per kilobyte
 
 [script]
 runner = "Rust" # {{

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -1,6 +1,6 @@
 use crate::error::RPCError;
 use ckb_chain::chain::ChainController;
-use ckb_jsonrpc_types::{Block, Transaction};
+use ckb_jsonrpc_types::{Block, Cycle, Transaction};
 use ckb_logger::error;
 use ckb_network::NetworkController;
 use ckb_shared::shared::Shared;
@@ -24,7 +24,7 @@ pub trait IntegrationTestRpc {
     fn process_block_without_verify(&self, data: Block) -> Result<Option<H256>>;
 
     #[rpc(name = "broadcast_transaction")]
-    fn broadcast_transaction(&self, transaction: Transaction) -> Result<H256>;
+    fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256>;
 }
 
 pub(crate) struct IntegrationTestRpcImpl {
@@ -60,11 +60,11 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
         }
     }
 
-    fn broadcast_transaction(&self, transaction: Transaction) -> Result<H256> {
+    fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256> {
         let tx: packed::Transaction = transaction.into();
         let hash = tx.calc_tx_hash();
         let relay_tx = packed::RelayTransaction::new_builder()
-            .cycles(10000u64.pack())
+            .cycles(cycles.0.pack())
             .transaction(tx)
             .build();
         let relay_txs = packed::RelayTransactions::new_builder()

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -22,6 +22,8 @@ ckb-verification = { path = "../verification" }
 ckb-script = { path = "../script" }
 ckb-dao = { path = "../util/dao" }
 ckb-reward-calculator = { path = "../util/reward-calculator" }
+ckb-occupied-capacity = { path = "../util/occupied-capacity"}
+ckb-tx-cache = { path = "../util/tx-cache"}
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/shared/src/fee_rate.rs
+++ b/shared/src/fee_rate.rs
@@ -1,0 +1,27 @@
+use ckb_occupied_capacity::Capacity;
+use serde_derive::{Deserialize, Serialize};
+
+/// shannons per kilobytes
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FeeRate(u64);
+
+impl FeeRate {
+    pub const fn new(fee_per_kilobyte: Capacity) -> Self {
+        FeeRate(fee_per_kilobyte.as_u64())
+    }
+
+    pub const fn zero() -> Self {
+        Self::new(Capacity::zero())
+    }
+
+    pub fn fee(self, size: usize) -> Capacity {
+        let fee = self.0.saturating_mul(size as u64) / 1000;
+        Capacity::shannons(fee)
+    }
+}
+
+impl ::std::fmt::Display for FeeRate {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod cell_set;
 pub mod chain_state;
 pub mod error;
+pub mod fee_rate;
 pub mod shared;
 pub mod tx_pool;
 mod tx_proposal_table;

--- a/shared/src/tx_pool/orphan.rs
+++ b/shared/src/tx_pool/orphan.rs
@@ -1,6 +1,7 @@
 use crate::tx_pool::types::DefectEntry;
+use ckb_tx_cache::TxCacheItem;
 use ckb_types::{
-    core::{Cycle, TransactionView},
+    core::TransactionView,
     packed::{OutPoint, ProposalShortId},
 };
 use ckb_util::FnvHashMap;
@@ -40,13 +41,13 @@ impl OrphanPool {
     /// add orphan transaction
     pub(crate) fn add_tx(
         &mut self,
-        cycles: Option<Cycle>,
+        tx_cache: Option<TxCacheItem>,
         size: usize,
         tx: TransactionView,
         unknown: impl ExactSizeIterator<Item = OutPoint>,
     ) -> Option<DefectEntry> {
         let short_id = tx.proposal_short_id();
-        let entry = DefectEntry::new(tx, unknown.len(), cycles, size);
+        let entry = DefectEntry::new(tx, unknown.len(), tx_cache, size);
         for out_point in unknown {
             let edge = self.edges.entry(out_point).or_insert_with(Vec::new);
             edge.push(short_id.clone());

--- a/shared/tx-pool-executor/Cargo.toml
+++ b/shared/tx-pool-executor/Cargo.toml
@@ -11,6 +11,9 @@ ckb-types = { path = "../../util/types" }
 ckb-store = { path = "../../store" }
 ckb-traits = { path = "../../traits" }
 ckb-verification = { path = "../../verification" }
+ckb-dao = { path = "../../util/dao" }
+ckb-logger = { path = "../../util/logger" }
+ckb-tx-cache = { path = "../../util/tx-cache" }
 
 [dev-dependencies]
 ckb-chain = { path = "../../chain" }

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -13,6 +13,7 @@ ckb-types = {path = "../util/types"}
 ckb-tx-pool-executor = { path = "../shared/tx-pool-executor" }
 ckb-network = { path = "../network" }
 ckb-logger = {path = "../util/logger"}
+ckb-tx-cache = {path = "../util/tx-cache"}
 fnv = "1.0"
 ckb-util = { path = "../util" }
 faketime = "0.2.0"

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -66,7 +66,7 @@ impl<'a> BlockProposalProcess<'a> {
             {
                 let tx_pool_executor = Arc::clone(&self.relayer.tx_pool_executor);
                 Box::new(lazy(move || -> FutureResult<(), ()> {
-                    let ret = tx_pool_executor.verify_and_add_txs_to_pool(asked_txs);
+                    let ret = tx_pool_executor.verify_and_add_txs_to_pool(asked_txs, None);
                     if ret.is_err() {
                         warn_target!(
                             crate::LOG_TARGET_RELAY,

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -254,7 +254,9 @@ fn test_collision_and_send_missing_indexes() {
 
     {
         let chain_state = relayer.shared.lock_chain_state();
-        chain_state.add_tx_to_pool(tx3, 10000u16.into()).unwrap();
+        chain_state
+            .add_tx_to_pool(tx3, 10000u16.into(), Capacity::shannons(1000u64))
+            .unwrap();
     }
 
     {

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -599,7 +599,7 @@ fn test_collision() {
     let parent = {
         let chain_state = relayer.shared.lock_chain_state();
         chain_state
-            .add_tx_to_pool(missing_tx.clone(), 100u16.into())
+            .add_tx_to_pool(missing_tx.clone(), 100u16.into(), Capacity::shannons(1000))
             .unwrap();
         chain_state.tip_header().clone()
     };

--- a/sync/src/relayer/transactions_process.rs
+++ b/sync/src/relayer/transactions_process.rs
@@ -95,18 +95,31 @@ impl<'a> TransactionsProcess<'a> {
                         let tx_result = tx_pool_executor.verify_and_add_tx_to_pool(tx.clone());
                         // disconnect peer if cycles mismatch
                         match tx_result {
-                            Ok(cycles) if cycles == relay_cycles => {
+                            Ok(tx_cache) if tx_cache.cycles == relay_cycles => {
+                                let min_fee_rate = shared.shared().min_fee_rate();
+                                if tx_cache.fee < min_fee_rate.fee(tx.serialized_size()) {
+                                    debug_target!(
+                                        crate::LOG_TARGET_RELAY,
+                                        "peer {} relay tx lower than our min fee rate {} shannons per bytes. tx: {:?}  size {} fee {}",
+                                        peer_index,
+                                        min_fee_rate,
+                                        tx,
+                                        tx.serialized_size(),
+                                        tx_cache.fee,
+                                    );
+                                    break;
+                                }
                                 let mut cache = shared.tx_hashes();
                                 let entry = cache.entry(peer_index).or_insert_with(FnvHashSet::default);
                                 entry.insert(tx_hash);
                             }
-                            Ok(cycles) => {
+                            Ok(tx_cache) => {
                                 debug_target!(
                                     crate::LOG_TARGET_RELAY,
                                     "peer {} relay wrong cycles tx: {:?} real cycles {} wrong cycles {}",
                                     peer_index,
                                     tx,
-                                    cycles,
+                                    tx_cache.cycles,
                                     relay_cycles,
                                 );
 

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -12,8 +12,9 @@ use ckb_shared::chain_state::ChainState;
 use ckb_shared::shared::Shared;
 use ckb_store::{ChainDB, ChainStore};
 use ckb_traits::ChainProvider;
+use ckb_tx_cache::TxCache;
 use ckb_types::{
-    core::{self, BlockNumber, Cycle, EpochExt},
+    core::{self, BlockNumber, EpochExt},
     packed::{self, Byte32},
     prelude::*,
     H256, U256,
@@ -719,7 +720,7 @@ impl SyncSharedState {
     pub fn lock_chain_state(&self) -> MutexGuard<ChainState> {
         self.shared.lock_chain_state()
     }
-    pub fn lock_txs_verify_cache(&self) -> MutexGuard<LruCache<Byte32, Cycle>> {
+    pub fn lock_txs_verify_cache(&self) -> MutexGuard<TxCache> {
         self.shared.lock_txs_verify_cache()
     }
     pub fn tx_hashes(&self) -> MutexGuard<FnvHashMap<PeerIndex, FnvHashSet<Byte32>>> {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "2" }
 toml = "0.5.0"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 ckb-app-config = { path = "../util/app-config" }
+ckb-shared = { path = "../shared" }
 ckb-network = { path = "../network" }
 ckb-sync = { path = "../sync" }
 ckb-miner = { path = "../miner" }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -201,6 +201,7 @@ fn all_specs() -> SpecMap {
         Box::new(PoolReconcile),
         Box::new(PoolResurrect),
         Box::new(TransactionRelayBasic),
+        Box::new(TransactionRelayLowFeeRate),
         // FIXME: There is a probability of failure on low resouce CI server
         // Box::new(TransactionRelayMultiple),
         Box::new(Discovery),
@@ -211,6 +212,7 @@ fn all_specs() -> SpecMap {
         // TODO enable these after proposed/pending pool tip verfiry logic changing
         // Box::new(CellbaseMaturity),
         Box::new(ValidSince),
+        Box::new(SendLowFeeRateTx),
         Box::new(DifferentTxsWithSameInput),
         Box::new(CompactBlockEmpty),
         Box::new(CompactBlockEmptyParentUnknown),

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,8 +1,8 @@
 use ckb_jsonrpc_types::{
     Alert, BannedAddress, Block, BlockNumber, BlockTemplate, BlockView, Capacity,
-    CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, DryRunResult, EpochNumber,
-    EpochView, HeaderView, LiveCell, LockHashIndexState, Node, OutPoint, PeerState, Timestamp,
-    Transaction, TransactionWithStatus, TxPoolInfo, Unsigned, Version,
+    CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle, DryRunResult,
+    EpochNumber, EpochView, HeaderView, LiveCell, LockHashIndexState, Node, OutPoint, PeerState,
+    Timestamp, Transaction, TransactionWithStatus, TxPoolInfo, Unsigned, Version,
 };
 use ckb_types::core::{
     BlockNumber as CoreBlockNumber, Capacity as CoreCapacity, EpochNumber as CoreEpochNumber,
@@ -217,6 +217,14 @@ impl RpcClient {
         self.inner.lock().send_transaction(tx).call()
     }
 
+    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> JsonRpcResult<H256> {
+        self.inner.lock().broadcast_transaction(tx, cycles).call()
+    }
+
+    pub fn dry_run_transaction(&self, tx: Transaction) -> JsonRpcResult<DryRunResult> {
+        self.inner.lock().dry_run_transaction(tx).call()
+    }
+
     pub fn send_alert(&self, alert: Alert) {
         self.inner
             .lock()
@@ -390,4 +398,6 @@ jsonrpc_client!(pub struct Inner {
     pub fn deindex_lock_hash(&mut self, lock_hash: H256) -> RpcRequest<()>;
     pub fn get_lock_hash_index_states(&mut self) -> RpcRequest<Vec<LockHashIndexState>>;
     pub fn calculate_dao_maximum_withdraw(&mut self, _out_point: OutPoint, _hash: H256) -> RpcRequest<Capacity>;
+
+    pub fn broadcast_transaction(&mut self, tx: Transaction, cycles: Cycle) -> RpcRequest<H256>;
 });

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -18,7 +18,9 @@ use crate::Net;
 use ckb_app_config::CKBAppConfig;
 use ckb_chain_spec::ChainSpec;
 use ckb_network::{ProtocolId, ProtocolVersion};
+use ckb_shared::fee_rate::FeeRate;
 use ckb_sync::NetworkProtocol;
+use ckb_types::core::Capacity;
 
 #[macro_export]
 macro_rules! name {
@@ -81,6 +83,7 @@ pub trait Spec {
         Box::new(|config| {
             config.network.connect_outbound_interval_secs = 0;
             config.network.discovery_local_address = true;
+            config.tx_pool.min_fee_rate = FeeRate::new(Capacity::zero());
         })
     }
 

--- a/test/src/specs/relay/mod.rs
+++ b/test/src/specs/relay/mod.rs
@@ -1,7 +1,9 @@
 mod block_relay;
 mod compact_block;
 mod transaction_relay;
+mod transaction_relay_low_fee_rate;
 
 pub use block_relay::BlockRelayBasic;
 pub use compact_block::*;
 pub use transaction_relay::{TransactionRelayBasic, TransactionRelayMultiple};
+pub use transaction_relay_low_fee_rate::TransactionRelayLowFeeRate;

--- a/test/src/specs/relay/transaction_relay_low_fee_rate.rs
+++ b/test/src/specs/relay/transaction_relay_low_fee_rate.rs
@@ -1,0 +1,89 @@
+use crate::utils::wait_until;
+use crate::{Net, Spec};
+use ckb_app_config::CKBAppConfig;
+use ckb_shared::fee_rate::FeeRate;
+use ckb_types::{
+    core::{Capacity, TransactionView},
+    packed,
+    prelude::*,
+};
+use log::info;
+
+pub struct TransactionRelayLowFeeRate;
+
+impl Spec for TransactionRelayLowFeeRate {
+    crate::name!("transaction_relay_low_fee_rate");
+
+    crate::setup!(num_nodes: 3);
+
+    fn run(&self, net: Net) {
+        net.exit_ibd_mode();
+
+        let node0 = &net.nodes[0];
+        let node1 = &net.nodes[1];
+        let node2 = &net.nodes[2];
+
+        info!("Generate new transaction on node1");
+        node1.generate_block();
+        let hash = node1.generate_transaction();
+        let ret = wait_until(10, || {
+            node1.rpc_client().get_transaction(hash.clone()).is_some()
+        });
+        assert!(ret, "send tx should success");
+        let tx: TransactionView = packed::Transaction::from(
+            node1
+                .rpc_client()
+                .get_transaction(hash.clone())
+                .unwrap()
+                .transaction
+                .inner,
+        )
+        .into_view();
+        let capacity = tx.outputs_capacity().unwrap();
+
+        info!("Generate zero fee rate tx");
+        let tx_low_fee = node1.new_transaction(hash.clone());
+        // Set to zero fee
+        let output = tx_low_fee
+            .outputs()
+            .get(0)
+            .unwrap()
+            .as_builder()
+            .capacity(capacity.pack())
+            .build();
+        let tx_low_fee = tx_low_fee
+            .data()
+            .as_advanced_builder()
+            .set_outputs(vec![])
+            .output(output)
+            .build();
+
+        info!("Get tx cycles");
+        let cycles = node1
+            .rpc_client()
+            .dry_run_transaction(tx_low_fee.data().into())
+            .unwrap()
+            .cycles;
+
+        info!("Broadcast zero fee tx");
+        let hash = node1
+            .rpc_client()
+            .broadcast_transaction(tx_low_fee.data().into(), cycles)
+            .unwrap();
+
+        info!("Waiting for relay");
+        let rpc_client = node0.rpc_client();
+        let ret = wait_until(1, || rpc_client.get_transaction(hash.clone()).is_some());
+        assert!(!ret, "Transaction should not be relayed to node0");
+
+        let rpc_client = node2.rpc_client();
+        let ret = wait_until(1, || rpc_client.get_transaction(hash.clone()).is_some());
+        assert!(!ret, "Transaction should not be relayed to node2");
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        Box::new(|config| {
+            config.tx_pool.min_fee_rate = FeeRate::new(Capacity::shannons(1000));
+        })
+    }
+}

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -1,5 +1,7 @@
 use crate::{assert_regex_match, Net, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
 use ckb_app_config::CKBAppConfig;
+use ckb_shared::fee_rate::FeeRate;
+use ckb_types::core::Capacity;
 use log::info;
 
 pub struct SizeLimit;
@@ -48,6 +50,7 @@ impl Spec for SizeLimit {
         Box::new(|config| {
             config.tx_pool.max_mem_size = 1710;
             config.tx_pool.max_cycles = 200_000_000_000;
+            config.tx_pool.min_fee_rate = FeeRate::new(Capacity::zero());
         })
     }
 }
@@ -98,6 +101,7 @@ impl Spec for CyclesLimit {
         Box::new(|config| {
             config.tx_pool.max_mem_size = 20_000_000;
             config.tx_pool.max_cycles = 60;
+            config.tx_pool.min_fee_rate = FeeRate::new(Capacity::zero());
         })
     }
 }

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -5,6 +5,7 @@ mod different_txs_with_same_input;
 mod limit;
 mod pool_reconcile;
 mod pool_resurrect;
+mod send_low_fee_rate_tx;
 mod send_secp_tx;
 mod valid_since;
 
@@ -18,5 +19,6 @@ pub use different_txs_with_same_input::DifferentTxsWithSameInput;
 pub use limit::{CyclesLimit, SizeLimit};
 pub use pool_reconcile::PoolReconcile;
 pub use pool_resurrect::PoolResurrect;
+pub use send_low_fee_rate_tx::SendLowFeeRateTx;
 pub use send_secp_tx::SendSecpTxUseDepGroup;
 pub use valid_since::ValidSince;

--- a/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
+++ b/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
@@ -1,0 +1,87 @@
+use crate::utils::wait_until;
+use crate::{assert_regex_match, Net, Spec};
+use ckb_app_config::CKBAppConfig;
+use ckb_shared::fee_rate::FeeRate;
+use ckb_types::{
+    core::{Capacity, TransactionView},
+    packed,
+    prelude::*,
+};
+use log::info;
+
+pub struct SendLowFeeRateTx;
+
+impl Spec for SendLowFeeRateTx {
+    crate::name!("send_low_fee_rate_tx");
+
+    fn run(&self, net: Net) {
+        let node0 = &net.nodes[0];
+
+        node0.generate_block();
+        let tx_hash_0 = node0.generate_transaction();
+        let ret = wait_until(10, || {
+            node0
+                .rpc_client()
+                .get_transaction(tx_hash_0.clone())
+                .is_some()
+        });
+        assert!(ret, "send tx should success");
+        let tx: TransactionView = packed::Transaction::from(
+            node0
+                .rpc_client()
+                .get_transaction(tx_hash_0.clone())
+                .unwrap()
+                .transaction
+                .inner,
+        )
+        .into_view();
+        let capacity = tx.outputs_capacity().unwrap();
+
+        info!("Generate zero fee rate tx");
+        let tx_low_fee = node0.new_transaction(tx_hash_0.clone());
+        // Set to zero fee
+        let output = tx_low_fee
+            .outputs()
+            .get(0)
+            .unwrap()
+            .as_builder()
+            .capacity(capacity.pack())
+            .build();
+        let tx_low_fee = tx_low_fee
+            .data()
+            .as_advanced_builder()
+            .set_outputs(vec![])
+            .output(output)
+            .build();
+        let error = node0
+            .rpc_client()
+            .send_transaction_result(tx_low_fee.data().into())
+            .unwrap_err();
+        assert_regex_match(&error.to_string(), r"TxFeeToLow");
+
+        info!("Generate normal fee rate tx");
+        let tx_high_fee = node0.new_transaction(tx_hash_0.clone());
+        let output = tx_high_fee
+            .outputs()
+            .get(0)
+            .unwrap()
+            .as_builder()
+            .capacity(capacity.safe_sub(1000u32).unwrap().pack())
+            .build();
+        let tx_high_fee = tx_high_fee
+            .data()
+            .as_advanced_builder()
+            .set_outputs(vec![])
+            .output(output)
+            .build();
+        node0
+            .rpc_client()
+            .send_transaction(tx_high_fee.data().into());
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        Box::new(|config| {
+            config.tx_pool.min_fee_rate = FeeRate::new(Capacity::shannons(1000));
+        })
+    }
+}

--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -91,7 +91,7 @@ impl Capacity {
             .ok_or(Error::Overflow)
     }
 
-    pub fn as_u64(self) -> u64 {
+    pub const fn as_u64(self) -> u64 {
         self.0
     }
 

--- a/util/tx-cache/Cargo.toml
+++ b/util/tx-cache/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ckb-tx-cache"
+version = "0.19.0-pre"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ckb-types = { path = "../types" }
+lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }

--- a/util/tx-cache/src/lib.rs
+++ b/util/tx-cache/src/lib.rs
@@ -1,0 +1,18 @@
+use ckb_types::{
+    core::{Capacity, Cycle},
+    packed::Byte32,
+};
+
+pub type TxCache = lru_cache::LruCache<Byte32, TxCacheItem>;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TxCacheItem {
+    pub cycles: Cycle,
+    pub fee: Capacity,
+}
+
+impl TxCacheItem {
+    pub fn new(cycles: Cycle, fee: Capacity) -> Self {
+        TxCacheItem { cycles, fee }
+    }
+}

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -19,7 +19,8 @@ ckb-chain-spec = { path = "../spec" }
 ckb-dao = { path = "../util/dao" }
 ckb-logger = {path = "../util/logger"}
 ckb-resource = { path = "../resource" }
-ckb-reward-calculator= { path = "../util/reward-calculator" }
+ckb-reward-calculator = { path = "../util/reward-calculator" }
+ckb-tx-cache = { path = "../util/tx-cache" }
 
 [dev-dependencies]
 ckb-db = { path = "../db" }


### PR DESCRIPTION
This PR enable min fee rate feature to ckb.

This PR adds a `tx_pool.min_fee_rate` option in `ckb.toml`, the default value is `1_000` shannons for per kilobytes, txs that with a fee rate lower than this value will be ignored by the node.

The intention is two:
1. allow miners control which txs be mined by set tx's fee rate
2. to prevent zero-fee or extremely low fee spam txs occupy the network

However it's not a part of the consensus, a node can set the `tx_pool.min_fee_rate` to a lower value or `0`.

Changes:

* Cache tx fee in tx_verify_cache
* Add a new option to `ckb.toml`: tx_pool.min_fee_rate = 1_000 # shannons per kilobyte
* Return an error in RPC `send_transaction` when tx fee rate is lower than `min_fee_rate`
* txs propose && commit will ignores txs that fee rate lower than `min_fee_rate`
* txs will not relay by node if it's fee rate is lower than `min_fee_rate`