### PR TITLE
[HOLD] chore: lto makes a smaller and/or faster executable 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
 [profile.release]
 debug = true
 overflow-checks = true
+lto = true
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { version = "0.3.0" }

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ integration-windows:
 	cd test && cargo run -- --bin target/debug/ckb ${CKB_TEST_ARGS}
 
 integration-release: setup-ckb-test
-	cargo build --release
-	cd test && cargo run --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
+	RUSTFLAGS="-C lto=off" cargo build --release
+	cd test && RUSTFLAGS="-C lto=off" cargo run --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
 
 ##@ Document
 doc: ## Build the documentation for the local package.
@@ -53,13 +53,13 @@ check: setup-ckb-test ## Runs all of the compiler's checks.
 	cd test && cargo check ${VERBOSE} --all --all-targets --all-features
 
 build: ## Build binary with release profile.
-	cargo build ${VERBOSE} --release
+	RUSTFLAGS="-C lto=off" cargo build ${VERBOSE} --release
 
 prod: ## Build binary for production release.
-	RUSTFLAGS="--cfg disable_faketime" cargo build ${VERBOSE} --release
+	RUSTFLAGS="--cfg disable_faketime -C codegen-units=1" cargo build ${VERBOSE} --release
 
 prod-docker:
-	RUSTFLAGS="--cfg disable_faketime --cfg docker" cargo build --verbose --release
+	RUSTFLAGS="--cfg disable_faketime -C codegen-units=1 --cfg docker" cargo build --verbose --release
 
 prod-test:
 	RUSTFLAGS="--cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" cargo test ${VERBOSE} --all -- --nocapture
@@ -89,6 +89,9 @@ security-audit: ## Use cargo-audit to audit Cargo.lock for crates with security 
 
 bench-test:
 	cd benches && cargo bench --features ci -- --test
+
+bench:
+	cd benches && RUSTFLAGS="-C lto=off" cargo bench
 
 ##@ Continuous Integration
 


### PR DESCRIPTION
before the size of ckb is 407m,
after `lto = true` it's 307M, 
after `codegen-units = 1` it's 256M

https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units

> Link-time Optimization (LTO)
> …except that we can. Enter the world of link-time optimization.
> 
> So the story is as follows: We can individually optimize each crate, and in fact all standard libraries ship in the optimized form. Once the compiler produces an optimized binary, it gets assembled to a single executable by a program called “the linker”. But we don’t need the entirety of standard library: a simple “Hello, world” program definitely does not need std::net for example. Yet, the linker is so stupid that it won’t try to remove unused parts of crates; it will just paste them in.
> 
> There is actually a good reason that the traditional linker behaves like this. The linker is commonly used in the C and C++ languages among others, and each file is compiled individually. This is a sharp difference from Rust where the entire crate is compiled altogether. Unless required functions are scattered throughout the files, the linker can fairly easily get rid of unused files all at once. It’s not perfect, but reasonably approximates what we want: removing unused functions. One disadvantage is that the compiler is unable to optimize function calls pointing to other files; it simply lacks the required information.
> 
> C and C++ folks had been fine with that approximation for decades, but in the recent decades they decided they'd had enough and started to provide an option to enable link-time optimization (LTO). In this scheme the compiler produces optimized binaries from each file without looking at others, and then the linker actively looks at them all and tries to optimize the binary. It is much harder than working with (internally simplified) sources, and it hugely increases the compilation time, but it is worth trying if a smaller and/or faster executable is needed.
> 
> So far we have talked about C and C++, but the LTO is much more beneficial for Rust. Cargo.toml has an option to enable LTO:
> 
> [profile.release]
> lto = true
> Did that work? Well, sort of:
> 
> $ ls -al target/release/hello
> -rwxrwxr-x 1 lifthrasiir 615725 May 31 20:17 target/release/hello*
> It had a larger effect than the optimization level, but not much. Maybe it is time to look at the executable itself.

refs: https://lifthrasiir.github.io/rustlog/why-is-a-rust-executable-large.html

Question: after `strip` the size is sharply down to 24M, but the stack info is not human readable, what about adding `sentry_disable` cfg and for this special artificial we could strip it before release. The disadvantage is that the user would always prefer the smaller size one.