### PR TITLE
fix: check sync_started before handle InIBD

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -56,7 +56,7 @@ pub const MAX_PEERS_PER_BLOCK: usize = 2;
 // behind headers chain.
 pub const MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT: usize = 4;
 pub const CHAIN_SYNC_TIMEOUT: u64 = 12 * 60 * 1000; // 12 minutes
-pub const PROTECT_STOP_SYNC_TIME: u64 = 5 * 60 * 1000; // 5 minutes
+pub const SUSPEND_SYNC_TIME: u64 = 5 * 60 * 1000; // 5 minutes
 pub const EVICTION_HEADERS_RESPONSE_TIME: u64 = 120 * 1000; // 2 minutes
 
 //The maximum number of entries in a locator

--- a/sync/src/synchronizer/in_ibd_process.rs
+++ b/sync/src/synchronizer/in_ibd_process.rs
@@ -1,11 +1,8 @@
 use crate::synchronizer::Synchronizer;
-use crate::PROTECT_STOP_SYNC_TIME;
 use ckb_logger::{debug, info};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_protocol::InIBD;
 use failure::Error as FailureError;
-use faketime::unix_time_as_millis;
-use std::sync::atomic::Ordering;
 
 pub struct InIBDProcess<'a> {
     _message: &'a InIBD<'a>,
@@ -47,27 +44,18 @@ impl<'a> InIBDProcess<'a> {
                 return Ok(());
             }
 
-            let now = unix_time_as_millis();
             // The node itself needs to ensure the validity of the outbound connection.
             //
             // If outbound is a ibd node(non-whitelist, non-protect), it should be disconnected automatically.
             // If inbound is a ibd node, just mark the node does not pass header sync authentication.
             if state.peer_flags.is_outbound {
                 if state.peer_flags.is_whitelist || state.peer_flags.is_protect {
-                    state.stop_sync(now + PROTECT_STOP_SYNC_TIME);
-                    self.synchronizer
-                        .shared()
-                        .n_sync_started()
-                        .fetch_sub(1, Ordering::Release);
+                    self.synchronizer.shared().suspend_sync(state);
                 } else if let Err(err) = self.nc.disconnect(self.peer, "outbound in ibd") {
                     debug!("synchronizer disconnect error: {:?}", err);
                 }
             } else {
-                state.stop_sync(now + PROTECT_STOP_SYNC_TIME);
-                self.synchronizer
-                    .shared()
-                    .n_sync_started()
-                    .fetch_sub(1, Ordering::Release);
+                self.synchronizer.shared().suspend_sync(state);
             }
         }
         Ok(())

--- a/sync/src/synchronizer/in_ibd_process.rs
+++ b/sync/src/synchronizer/in_ibd_process.rs
@@ -39,6 +39,14 @@ impl<'a> InIBDProcess<'a> {
             .write()
             .get_mut(&self.peer)
         {
+            // Don't assume that the peer is sync_started.
+            // It is possible that a not-sync-started peer sends us `InIBD` messages:
+            //   - Malicious behavior
+            //   - Peer sends multiple `InIBD` messages
+            if !state.sync_started {
+                return Ok(());
+            }
+
             let now = unix_time_as_millis();
             // The node itself needs to ensure the validity of the outbound connection.
             //

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -18,7 +18,7 @@ use crate::types::{HeaderView, PeerFlags, Peers, SyncSharedState};
 use crate::{
     BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
     HEADERS_DOWNLOAD_TIMEOUT_BASE, HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER, MAX_HEADERS_LEN,
-    MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, POW_SPACE, PROTECT_STOP_SYNC_TIME,
+    MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, POW_SPACE,
 };
 use ckb_chain::chain::ChainController;
 use ckb_core::block::Block;
@@ -234,10 +234,7 @@ impl Synchronizer {
                     if state.chain_sync.sent_getheaders {
                         if state.peer_flags.is_protect || state.peer_flags.is_whitelist {
                             if state.sync_started {
-                                state.stop_sync(now + PROTECT_STOP_SYNC_TIME);
-                                self.shared()
-                                    .n_sync_started()
-                                    .fetch_sub(1, Ordering::Release);
+                                self.shared().suspend_sync(state);
                             }
                         } else {
                             eviction.push(*peer);
@@ -415,26 +412,31 @@ impl CKBProtocolHandler for Synchronizer {
     }
 
     fn disconnected(&mut self, _nc: Arc<CKBProtocolContext + Sync>, peer_index: PeerIndex) {
-        info!("SyncProtocol.disconnected peer={}", peer_index);
         if let Some(peer_state) = self.shared().disconnected(peer_index) {
-            // It shouldn't happen
-            // fetch_sub wraps around on overflow, we still check manually
-            // panic here to prevent some bug be hidden silently.
-            if peer_state.sync_started
-                && self
-                    .shared()
-                    .n_sync_started()
-                    .fetch_sub(1, Ordering::Release)
-                    == 0
-            {
-                panic!("Synchronizer n_sync overflow");
+            info!("SyncProtocol.disconnected peer={}", peer_index);
+
+            if peer_state.sync_started {
+                // It shouldn't happen
+                // fetch_sub wraps around on overflow, we still check manually
+                // panic here to prevent some bug be hidden silently.
+                assert_ne!(
+                    self.shared()
+                        .n_sync_started()
+                        .fetch_sub(1, Ordering::Release),
+                    0,
+                    "n_sync_started overflow when disconnects"
+                );
             }
 
             // Protection node disconnected
             if peer_state.peer_flags.is_protect {
-                self.shared()
-                    .n_protected_outbound_peers()
-                    .fetch_sub(1, Ordering::Release);
+                assert_ne!(
+                    self.shared()
+                        .n_protected_outbound_peers()
+                        .fetch_sub(1, Ordering::Release),
+                    0,
+                    "n_protected_outbound_peers overflow when disconnects"
+                );
             }
         }
     }

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1,9 +1,9 @@
 use crate::block_status::BlockStatus;
 use crate::relayer::compact_block::CompactBlock;
 use crate::synchronizer::OrphanBlockPool;
-use crate::NetworkProtocol;
 use crate::BLOCK_DOWNLOAD_TIMEOUT;
 use crate::MAX_PEERS_PER_BLOCK;
+use crate::{NetworkProtocol, SUSPEND_SYNC_TIME};
 use crate::{MAX_HEADERS_LEN, MAX_TIP_AGE};
 use ckb_chain::chain::ChainController;
 use ckb_chain_spec::consensus::Consensus;
@@ -140,9 +140,10 @@ impl PeerState {
         self.headers_sync_timeout = Some(headers_sync_timeout);
     }
 
-    pub fn stop_sync(&mut self, not_sync_until: u64) {
+    pub fn suspend_sync(&mut self, suspend_time: u64) {
+        let now = unix_time_as_millis();
         self.sync_started = false;
-        self.chain_sync.not_sync_until = Some(not_sync_until);
+        self.chain_sync.not_sync_until = Some(now + suspend_time);
         self.headers_sync_timeout = None;
     }
 
@@ -1239,6 +1240,15 @@ impl SyncSharedState {
             });
 
         HeaderResolverWrapper::build(header, Some(parent), epoch)
+    }
+
+    pub(crate) fn suspend_sync(&self, peer_state: &mut PeerState) {
+        peer_state.suspend_sync(SUSPEND_SYNC_TIME);
+        assert_ne!(
+            self.n_sync_started().fetch_sub(1, Ordering::Release),
+            0,
+            "n_sync_started overflow when suspend_sync"
+        );
     }
 }
 


### PR DESCRIPTION
* fix: `ibd_process` will improperly substrate `n_sync_started` without checking whether the peer is `sync_started == true`, and then cause panic when disconnects peers.
* feat: Add `suspend_sync` function to help suspend the synchronization to the specified peers.
* feat: Assert `sync_started/n_protected_outbound_peers` overflow.