### PR TITLE
chore: remove unnecessary lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,6 @@ dependencies = [
  "ckb-store 0.19.0-pre",
  "ckb-traits 0.19.0-pre",
  "ckb-types 0.19.0-pre",
- "ckb-util 0.19.0-pre",
  "ckb-verification 0.19.0-pre",
  "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -11,7 +11,6 @@ ckb-types = { path = "../util/types" }
 ckb-shared = { path = "../shared" }
 ckb-store = { path = "../store" }
 ckb-pow = { path = "../pow" }
-ckb-util = { path = "../util" }
 ckb-notify = { path = "../notify" }
 faketime = "0.2.0"
 rand = "0.6"

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -17,6 +17,7 @@ use ckb_jsonrpc_types::BlockTemplate;
 use ckb_types::packed::Block;
 use std::convert::From;
 
+#[derive(Clone)]
 pub struct Work {
     work_id: u64,
     block: Block,

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -272,7 +272,7 @@ fn wait_connect_state(node: &Node, expect_num: usize) {
 
 #[allow(clippy::block_in_if_condition_stmt)]
 fn wait_discovery(node: &Node) {
-    if !wait_until(10, || {
+    if !wait_until(100, || {
         node.network_state
             .peer_store
             .lock()


### PR DESCRIPTION
1. Remove unnecessary lock
2. The discovery test of the occasional fails due to the timeout caused by resource competition, the test that can be passed on a more long time or run it on single