### PR TITLE
fix: use remote peer observed address

### DIFF
--- a/network/src/errors.rs
+++ b/network/src/errors.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Io(IoError),
     P2P(P2PError),
     DB(DBError),
+    Addr(String),
+    Dial(String),
     Shutdown,
 }
 

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -76,11 +76,12 @@ pub struct SessionInfo {
 pub struct NetworkState {
     pub(crate) peer_registry: RwLock<PeerRegistry>,
     pub(crate) peer_store: Mutex<Box<dyn PeerStore>>,
-    pub(crate) original_listened_addresses: RwLock<Vec<Multiaddr>>,
+    pub(crate) original_listened_addrs: RwLock<Vec<Multiaddr>>,
     dialing_addrs: RwLock<HashMap<PeerId, Instant>>,
 
     pub(crate) protocol_ids: RwLock<HashSet<ProtocolId>>,
-    listened_addresses: RwLock<HashMap<Multiaddr, u8>>,
+    listened_addrs: RwLock<HashMap<Multiaddr, u8>>,
+    pending_observed_addrs: RwLock<HashSet<Multiaddr>>,
     // Send disconnect message but not disconnected yet
     disconnecting_sessions: RwLock<HashSet<SessionId>>,
     local_private_key: secio::SecioKeyPair,
@@ -93,7 +94,7 @@ impl NetworkState {
         config.create_dir_if_not_exists()?;
         let local_private_key = config.fetch_private_key()?;
         // set max score to public addresses
-        let listened_addresses: HashMap<Multiaddr, u8> = config
+        let listened_addrs: HashMap<Multiaddr, u8> = config
             .listen_addresses
             .iter()
             .chain(config.public_addresses.iter())
@@ -126,8 +127,9 @@ impl NetworkState {
             config,
             peer_registry: RwLock::new(peer_registry),
             dialing_addrs: RwLock::new(HashMap::default()),
-            listened_addresses: RwLock::new(listened_addresses),
-            original_listened_addresses: RwLock::new(Vec::new()),
+            listened_addrs: RwLock::new(listened_addrs),
+            original_listened_addrs: RwLock::new(Vec::new()),
+            pending_observed_addrs: RwLock::new(HashSet::default()),
             disconnecting_sessions: RwLock::new(HashSet::default()),
             local_private_key: local_private_key.clone(),
             local_peer_id: local_private_key.to_public_key().peer_id(),
@@ -282,8 +284,8 @@ impl NetworkState {
         self.local_private_key().to_peer_id().to_base58()
     }
 
-    pub(crate) fn listened_addresses(&self, count: usize) -> Vec<(Multiaddr, u8)> {
-        self.listened_addresses
+    pub(crate) fn listened_addrs(&self, count: usize) -> Vec<(Multiaddr, u8)> {
+        self.listened_addrs
             .read()
             .iter()
             .take(count)
@@ -291,17 +293,23 @@ impl NetworkState {
             .collect()
     }
 
+    pub(crate) fn vote_listened_addr(&self, addr: Multiaddr, votes: u8) {
+        let mut listened_addrs = self.listened_addrs.write();
+        let score = listened_addrs.entry(addr).or_default();
+        *score = score.saturating_add(votes);
+    }
+
     pub(crate) fn connection_status(&self) -> ConnectionStatus {
         self.peer_registry.read().connection_status()
     }
 
     pub fn external_urls(&self, max_urls: usize) -> Vec<(String, u8)> {
-        let original_listened_addresses = self.original_listened_addresses.read();
-        self.listened_addresses(max_urls.saturating_sub(original_listened_addresses.len()))
+        let original_listened_addrs = self.original_listened_addrs.read();
+        self.listened_addrs(max_urls.saturating_sub(original_listened_addrs.len()))
             .into_iter()
-            .filter(|(addr, _)| !original_listened_addresses.contains(addr))
+            .filter(|(addr, _)| !original_listened_addrs.contains(addr))
             .chain(
-                original_listened_addresses
+                original_listened_addrs
                     .iter()
                     .map(|addr| (addr.to_owned(), 1)),
             )
@@ -331,12 +339,17 @@ impl NetworkState {
             .collect::<Vec<_>>()
     }
 
-    pub(crate) fn can_dial(&self, peer_id: &PeerId, addr: &Multiaddr) -> bool {
-        if self.local_peer_id() == peer_id {
+    pub(crate) fn can_dial(
+        &self,
+        peer_id: &PeerId,
+        addr: &Multiaddr,
+        allow_dial_to_self: bool,
+    ) -> bool {
+        if !allow_dial_to_self && self.local_peer_id() == peer_id {
             trace!("Do not dial self: {:?}, {}", peer_id, addr);
             return false;
         }
-        if self.listened_addresses.read().contains_key(&addr) {
+        if self.listened_addrs.read().contains_key(&addr) {
             trace!(
                 "Do not dial listened address(self): {:?}, {}",
                 peer_id,
@@ -396,56 +409,94 @@ impl NetworkState {
 
     /// Dial
     /// return value indicates the dialing is actually sent or denied.
-    pub fn dial(
+    fn dial_inner(
         &self,
         p2p_control: &ServiceControl,
         peer_id: &PeerId,
         mut addr: Multiaddr,
         target: DialProtocol,
-    ) -> bool {
-        if self.can_dial(peer_id, &addr) {
-            match Multihash::from_bytes(peer_id.as_bytes().to_vec()) {
-                Ok(peer_id_hash) => {
-                    addr.push(multiaddr::Protocol::P2p(peer_id_hash));
-                    debug!("dialing {} with {:?}", addr, target);
-                    if let Err(err) = p2p_control.dial(addr.clone(), target) {
-                        debug!("dial failed: {:?}", err);
-                    } else {
-                        self.dialing_addrs
-                            .write()
-                            .insert(peer_id.to_owned(), Instant::now());
-                        return true;
-                    }
-                }
-                Err(err) => {
-                    error!("failed to convert peer_id to addr: {}", err);
-                }
-            }
+        allow_dial_to_self: bool,
+    ) -> Result<(), Error> {
+        if !self.can_dial(peer_id, &addr, allow_dial_to_self) {
+            return Err(Error::Dial(format!(
+                "ignore dialing peer_id {:?}, addr {}",
+                peer_id, addr
+            )));
         }
-        false
+
+        let peer_id_hash = Multihash::from_bytes(peer_id.as_bytes().to_vec())
+            .map_err(|err| Error::Addr(format!("peer_id is not valid: {}", err)))?;
+        addr.push(multiaddr::Protocol::P2p(peer_id_hash));
+        debug!("dialing {} with {:?}", addr, target);
+        p2p_control.dial(addr.clone(), target)?;
+        self.dialing_addrs
+            .write()
+            .insert(peer_id.to_owned(), Instant::now());
+        Ok(())
     }
 
     /// Dial just identify protocol
     pub fn dial_identify(&self, p2p_control: &ServiceControl, peer_id: &PeerId, addr: Multiaddr) {
-        self.dial(
+        if let Err(err) = self.dial_inner(
             p2p_control,
             peer_id,
             addr,
             DialProtocol::Single(IDENTIFY_PROTOCOL_ID.into()),
-        );
+            false,
+        ) {
+            debug!("dial_identify error: {}", err);
+        }
     }
 
     /// Dial just feeler protocol
     pub fn dial_feeler(&self, p2p_control: &ServiceControl, peer_id: &PeerId, addr: Multiaddr) {
-        if self.dial(
+        if let Err(err) = self.dial_inner(
             p2p_control,
             peer_id,
             addr,
             DialProtocol::Single(FEELER_PROTOCOL_ID.into()),
+            false,
         ) {
+            debug!("dial_feeler error {}", err);
+        } else {
             self.with_peer_registry_mut(|reg| {
                 reg.add_feeler(peer_id.clone());
             });
+        }
+    }
+
+    /// this method is intent to check observed addr by dial to self
+    pub(crate) fn try_dial_observed_addrs(&self, p2p_control: &ServiceControl) {
+        let mut pending_observed_addrs = self.pending_observed_addrs.write();
+        for addr in pending_observed_addrs.drain() {
+            trace!("try dial observed addr: {:?}", addr);
+            if let Err(err) = self.dial_inner(
+                p2p_control,
+                self.local_peer_id(),
+                addr,
+                DialProtocol::Single(IDENTIFY_PROTOCOL_ID.into()),
+                true,
+            ) {
+                debug!("try_dial_observed_addrs error {}", err);
+            }
+        }
+    }
+
+    pub fn add_observed_addrs(&self, iter: impl Iterator<Item = Multiaddr>) {
+        let mut listened_addrs = self.listened_addrs.write();
+        let mut pending_observed_addrs = self.pending_observed_addrs.write();
+        for addr in iter {
+            if let Some(score) = listened_addrs.get_mut(&addr) {
+                *score = score.saturating_add(1);
+                trace!(
+                    "increase score for exists observed addr: {:?} {}",
+                    addr,
+                    score
+                );
+            } else {
+                trace!("pending observed addr: {:?}", addr,);
+                pending_observed_addrs.insert(addr);
+            }
         }
     }
 }
@@ -498,7 +549,7 @@ impl ServiceHandle for EventHandler {
             } => {
                 debug!("DialerError({}) {}", address, error);
                 if error == &P2pError::ConnectSelf {
-                    debug!("add self address: {:?}", address);
+                    debug!("dial observed address success: {:?}", address);
                     let addr = address
                         .iter()
                         .filter(|proto| match proto {
@@ -506,10 +557,7 @@ impl ServiceHandle for EventHandler {
                             _ => true,
                         })
                         .collect();
-                    self.network_state
-                        .listened_addresses
-                        .write()
-                        .insert(addr, std::u8::MAX);
+                    self.network_state.vote_listened_addr(addr, 1);
                 }
                 let peer_id = extract_peer_id(address).expect("Secio must enabled");
                 self.network_state.dial_failed(peer_id);
@@ -892,7 +940,7 @@ impl NetworkService {
                         self.network_state.to_external_url(&listen_address)
                     );
                     self.network_state
-                        .original_listened_addresses
+                        .original_listened_addrs
                         .write()
                         .push(listen_address.clone())
                 }

--- a/network/src/protocols/identify.rs
+++ b/network/src/protocols/identify.rs
@@ -35,9 +35,7 @@ impl IdentifyCallback {
     }
 
     fn listen_addrs(&self) -> Vec<Multiaddr> {
-        let mut addrs = self
-            .network_state
-            .listened_addrs(MAX_RETURN_LISTEN_ADDRS * 2);
+        let mut addrs = self.network_state.public_addrs(MAX_RETURN_LISTEN_ADDRS * 2);
         addrs.sort_by(|a, b| a.1.cmp(&b.1));
         addrs
             .into_iter()

--- a/network/src/protocols/identify.rs
+++ b/network/src/protocols/identify.rs
@@ -10,7 +10,6 @@ use p2p::{
     utils::{is_reachable, multiaddr_to_socketaddr},
 };
 use p2p_identify::{Callback, MisbehaveResult, Misbehavior};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 const MAX_RETURN_LISTEN_ADDRS: usize = 10;
@@ -19,8 +18,6 @@ const MAX_RETURN_LISTEN_ADDRS: usize = 10;
 pub(crate) struct IdentifyCallback {
     network_state: Arc<NetworkState>,
     identify: Identify,
-    // local listen addresses for scoring and for rpc output
-    remote_listen_addrs: HashMap<PeerId, Vec<Multiaddr>>,
 }
 
 impl IdentifyCallback {
@@ -34,14 +31,13 @@ impl IdentifyCallback {
         IdentifyCallback {
             network_state,
             identify: Identify::new(name, flags, client_version),
-            remote_listen_addrs: HashMap::default(),
         }
     }
 
     fn listen_addrs(&self) -> Vec<Multiaddr> {
         let mut addrs = self
             .network_state
-            .listened_addresses(MAX_RETURN_LISTEN_ADDRS * 2);
+            .listened_addrs(MAX_RETURN_LISTEN_ADDRS * 2);
         addrs.sort_by(|a, b| a.1.cmp(&b.1));
         addrs
             .into_iter()
@@ -108,8 +104,6 @@ impl Callback for IdentifyCallback {
             peer_id,
             addrs,
         );
-        self.remote_listen_addrs
-            .insert(peer_id.clone(), addrs.clone());
         self.network_state.with_peer_store_mut(|peer_store| {
             for addr in addrs {
                 peer_store.add_discovered_addr(&peer_id, addr);
@@ -133,29 +127,28 @@ impl Callback for IdentifyCallback {
             return MisbehaveResult::Continue;
         }
 
-        for transformed_addr in self
+        // observed addr is not a reachable ip
+        if !multiaddr_to_socketaddr(&addr)
+            .map(|socket_addr| is_reachable(socket_addr.ip()))
+            .unwrap_or(false)
+        {
+            return MisbehaveResult::Continue;
+        }
+
+        let observed_addrs_iter = self
             .listen_addrs()
             .into_iter()
             .filter_map(|listen_addr| multiaddr_to_socketaddr(&listen_addr))
-            .filter(|socket_addr| is_reachable(socket_addr.ip()))
-            .map(|socket_addr| socket_addr.port())
-            .map(|listen_port| {
+            .map(|socket_addr| {
                 addr.iter()
                     .filter_map(|proto| match proto {
-                        // Replace only it's an outbound connnection
                         Protocol::P2p(_) => None,
-                        Protocol::Tcp(_) => Some(Protocol::Tcp(listen_port)),
+                        Protocol::Tcp(_) => Some(Protocol::Tcp(socket_addr.port())),
                         value => Some(value),
                     })
                     .collect::<Multiaddr>()
-            })
-        {
-            debug!("identify add transformed addr: {:?}", transformed_addr);
-            let local_peer_id = self.network_state.local_peer_id();
-            self.network_state.with_peer_store_mut(|peer_store| {
-                peer_store.add_discovered_addr(local_peer_id, transformed_addr);
             });
-        }
+        self.network_state.add_observed_addrs(observed_addrs_iter);
         // NOTE: for future usage
         MisbehaveResult::Continue
     }

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -46,7 +46,7 @@ impl NetworkRpc for NetworkRpcImpl {
             node_id: self.network_controller.node_id(),
             addresses: self
                 .network_controller
-                .external_urls(MAX_ADDRS)
+                .public_urls(MAX_ADDRS)
                 .into_iter()
                 .map(|(address, score)| NodeAddress {
                     address,


### PR DESCRIPTION
Fix broken observe address feature.

Observe address is a feature to leverage remote peers to report external IPs for a node.

In p2p network, when a node establishes outbound connections, the remote peers can observe the external IP of the node, remote peers should report the external IP through identify protocol, to help the node find out it's IP, it's kinda like the DDNS.

We have this feature built-in the original design, see the [identity protocol](https://github.com/nervosnetwork/p2p/blob/master/protocols/identify/src/protocol.fbs#L11) for details.

However, after a few development cycles, the observe address feature is broken.

In the current version, a node will not discovery external IPs through identify protocol. call `local_node_info` [rpc](https://github.com/nervosnetwork/ckb/tree/develop/rpc#local_node_info) will only show listened `addresses` that from config file.

After apply this fix, the `local_node_info` will show additional new discovered external IPs.

Changes:

* Fix identify, skip an observed address if it's an unreachable IP.
* Save observed address in a queue `pending_observed_addrs`.
* Dial observed address(dial to self node) repeatedly in `outbound_service`.
* If dialing to self is succeeded, the node saves the address as listened addr or increases its score if already exists, the address will show in `local_node_info` RPC.

Additional: because of p2p library hard coded to filtered out local addresses for us, we can't write an integration test for now, I'd happy to add test after change the p2p library behavior.