### PR TITLE
[ᚬrc/v0.18] fix: failed to sync for long forks

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -26,7 +26,6 @@ pub const MAX_UNCONNECTING_HEADERS: usize = 10;
 pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
 pub const MAX_TIP_AGE: u64 = 24 * 60 * 60 * 1000;
 pub const STALE_RELAY_AGE_LIMIT: u64 = 30 * 24 * 60 * 60 * 1000;
-pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024;
 pub const PER_FETCH_BLOCK_LIMIT: usize = 128;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -196,6 +196,7 @@ fn build_specs() -> SpecMap {
     specs.insert("chain_fork_5", Box::new(ChainFork5));
     specs.insert("chain_fork_6", Box::new(ChainFork6));
     specs.insert("chain_fork_7", Box::new(ChainFork7));
+    specs.insert("long_forks", Box::new(LongForks));
     specs.insert("mining_basic", Box::new(MiningBasic));
     specs.insert("mining_bootstrap_cellbase", Box::new(BootstrapCellbase));
     specs.insert("mining_template_size_limit", Box::new(TemplateSizeLimit));

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -431,6 +431,44 @@ impl Spec for ChainFork7 {
     }
 }
 
+pub struct LongForks;
+
+impl Spec for LongForks {
+    fn run(&self, net: Net) {
+        const PER_FETCH_BLOCK_LIMIT: usize = 128;
+
+        net.exit_ibd_mode();
+        let test_node = &net.nodes[0];
+        let node1 = &net.nodes[1];
+        let node2 = &net.nodes[2];
+
+        // test_node == node1 == chain1, height = 139 = PER_FETCH_BLOCK_LIMIT + 10 + 1
+        node1.generate_blocks(PER_FETCH_BLOCK_LIMIT + 10);
+        test_node.connect(node1);
+        test_node.waiting_for_sync(node1, PER_FETCH_BLOCK_LIMIT as u64 + 10 + 1);
+        test_node.disconnect(node1);
+
+        // test_node == node2 == chain2, height = 149 = PER_FETCH_BLOCK_LIMIT + 20 + 1
+        node2.generate_blocks(PER_FETCH_BLOCK_LIMIT + 20);
+        test_node.connect(node2);
+        test_node.waiting_for_sync(node2, PER_FETCH_BLOCK_LIMIT as u64 + 20 + 1);
+        test_node.disconnect(node2);
+
+        // test_node == node1 == chain1, height = 169 = PER_FETCH_BLOCK_LIMIT + 10 + 30 + 1
+        node1.generate_blocks(30);
+        test_node.connect(node1);
+        test_node.waiting_for_sync(node1, PER_FETCH_BLOCK_LIMIT as u64 + 10 + 30 + 1);
+    }
+
+    fn num_nodes(&self) -> usize {
+        3
+    }
+
+    fn connect_all(&self) -> bool {
+        false
+    }
+}
+
 fn modify_block_transaction<F>(
     block: Block,
     transaction_index: usize,


### PR DESCRIPTION
* fix: Two long forks(> 128) cannot synchronize with each other