### PR TITLE
chore: Correct typo block_assember to block_assembler

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,7 @@ curl -d '{"id": 1, "jsonrpc": "2.0", "method":"get_tip_header","params": []}' \
 ## Run Miner
 
 Miner is disabled by default, unless you have setup the miner lock
-to keep your mined CKB safe. See the comment of the section `[block_assember]`
+to keep your mined CKB safe. See the comment of the section `[block_assembler]`
 in `ckb.toml` how to configure it.
 
 After setting up the config file, restart the process `ckb run`, and start the

--- a/docs/run-ckb-with-docker.md
+++ b/docs/run-ckb-with-docker.md
@@ -50,7 +50,7 @@ docker cp ckb-testnet-node:/var/lib/ckb/ckb-miner.toml .
 ```
 
 Edit the config files as you like. If you want to run a miner, remember to
-replace `[block_assember]` section in `ckb.toml`.
+replace `[block_assembler]` section in `ckb.toml`.
 
 Copy back the edited config files back to container:
 


### PR DESCRIPTION
* chore: Correct typo block_assember to block_assembler.

  https://gist.github.com/apiraino/76d878104d3b6f649e6a3db8f6510914