### PR TITLE
chore: lock exact ckb-system-scripts version

### DIFF
--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -13,10 +13,10 @@ tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = { version = "0.3.1-alpha.1" }
+ckb-system-scripts = { version = "= 0.3.1-alpha.1" }
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = { version = "0.3.1-alpha.1" }
+ckb-system-scripts = { version = "= 0.3.1-alpha.1" }


### PR DESCRIPTION
When `ckb-releases` is used external, it may uses a newer version of
ckb-system-scripts if the caret requirement is used in Cargo.toml, since the
version is only locked in the Cargo.lock in this repository.

This change ensures that when this is used as a crate externally, it always
use the exact version of ckb-system-scripts.