### PR TITLE
chore: Expand macros in calc_hash

### DIFF
--- a/util/types/src/extension/calc_hash.rs
+++ b/util/types/src/extension/calc_hash.rs
@@ -21,20 +21,6 @@ where
     }
 }
 
-/*
- * Calculate special hash for packed bytes wrappers.
- */
-
-macro_rules! impl_calc_special_hash_for_entity {
-    ($entity:ident, $func_name:ident) => {
-        impl packed::$entity {
-            pub fn $func_name(&self) -> H256 {
-                self.as_reader().$func_name()
-            }
-        }
-    };
-}
-
 impl packed::CellOutput {
     pub fn calc_data_hash(data: &[u8]) -> H256 {
         if data.is_empty() {
@@ -50,14 +36,24 @@ impl<'r> packed::ScriptReader<'r> {
         self.calc_hash()
     }
 }
-impl_calc_special_hash_for_entity!(Script, calc_script_hash);
+
+impl packed::Script {
+    pub fn calc_script_hash(&self) -> H256 {
+        self.as_reader().calc_script_hash()
+    }
+}
 
 impl<'r> packed::CellOutputReader<'r> {
     pub fn calc_lock_hash(&self) -> H256 {
         self.lock().calc_script_hash()
     }
 }
-impl_calc_special_hash_for_entity!(CellOutput, calc_lock_hash);
+
+impl packed::CellOutput {
+    pub fn calc_lock_hash(&self) -> H256 {
+        self.as_reader().calc_lock_hash()
+    }
+}
 
 impl<'r> packed::ProposalShortIdVecReader<'r> {
     pub fn calc_proposals_hash(&self) -> H256 {
@@ -74,7 +70,12 @@ impl<'r> packed::ProposalShortIdVecReader<'r> {
         }
     }
 }
-impl_calc_special_hash_for_entity!(ProposalShortIdVec, calc_proposals_hash);
+
+impl packed::ProposalShortIdVec {
+    pub fn calc_proposals_hash(&self) -> H256 {
+        self.as_reader().calc_proposals_hash()
+    }
+}
 
 impl<'r> packed::TransactionReader<'r> {
     pub fn calc_tx_hash(&self) -> H256 {
@@ -85,15 +86,28 @@ impl<'r> packed::TransactionReader<'r> {
         self.slim().calc_hash()
     }
 }
-impl_calc_special_hash_for_entity!(Transaction, calc_tx_hash);
-impl_calc_special_hash_for_entity!(Transaction, calc_witness_hash);
+
+impl packed::Transaction {
+    pub fn calc_tx_hash(&self) -> H256 {
+        self.as_reader().calc_tx_hash()
+    }
+
+    pub fn calc_witness_hash(&self) -> H256 {
+        self.as_reader().calc_witness_hash()
+    }
+}
 
 impl<'r> packed::RawHeaderReader<'r> {
     pub fn calc_pow_hash(&self) -> H256 {
         self.calc_hash()
     }
 }
-impl_calc_special_hash_for_entity!(RawHeader, calc_pow_hash);
+
+impl packed::RawHeader {
+    pub fn calc_pow_hash(&self) -> H256 {
+        self.as_reader().calc_pow_hash()
+    }
+}
 
 impl<'r> packed::HeaderReader<'r> {
     pub fn calc_pow_hash(&self) -> H256 {
@@ -104,8 +118,16 @@ impl<'r> packed::HeaderReader<'r> {
         self.calc_hash()
     }
 }
-impl_calc_special_hash_for_entity!(Header, calc_pow_hash);
-impl_calc_special_hash_for_entity!(Header, calc_header_hash);
+
+impl packed::Header {
+    pub fn calc_pow_hash(&self) -> H256 {
+        self.as_reader().calc_pow_hash()
+    }
+
+    pub fn calc_header_hash(&self) -> H256 {
+        self.as_reader().calc_header_hash()
+    }
+}
 
 impl<'r> packed::UncleBlockReader<'r> {
     pub fn calc_header_hash(&self) -> H256 {
@@ -116,8 +138,16 @@ impl<'r> packed::UncleBlockReader<'r> {
         self.proposals().calc_proposals_hash()
     }
 }
-impl_calc_special_hash_for_entity!(UncleBlock, calc_header_hash);
-impl_calc_special_hash_for_entity!(UncleBlock, calc_proposals_hash);
+
+impl packed::UncleBlock {
+    pub fn calc_header_hash(&self) -> H256 {
+        self.as_reader().calc_header_hash()
+    }
+
+    pub fn calc_proposals_hash(&self) -> H256 {
+        self.as_reader().calc_proposals_hash()
+    }
+}
 
 impl<'r> packed::UncleBlockVecReader<'r> {
     pub fn calc_uncles_hash(&self) -> H256 {
@@ -128,7 +158,12 @@ impl<'r> packed::UncleBlockVecReader<'r> {
         }
     }
 }
-impl_calc_special_hash_for_entity!(UncleBlockVec, calc_uncles_hash);
+
+impl packed::UncleBlockVec {
+    pub fn calc_uncles_hash(&self) -> H256 {
+        self.as_reader().calc_uncles_hash()
+    }
+}
 
 impl<'r> packed::BlockReader<'r> {
     pub fn calc_header_hash(&self) -> H256 {
@@ -158,9 +193,19 @@ impl<'r> packed::BlockReader<'r> {
     }
 }
 
-impl_calc_special_hash_for_entity!(Block, calc_header_hash);
-impl_calc_special_hash_for_entity!(Block, calc_proposals_hash);
-impl_calc_special_hash_for_entity!(Block, calc_uncles_hash);
+impl packed::Block {
+    pub fn calc_header_hash(&self) -> H256 {
+        self.as_reader().calc_header_hash()
+    }
+
+    pub fn calc_proposals_hash(&self) -> H256 {
+        self.as_reader().calc_proposals_hash()
+    }
+
+    pub fn calc_uncles_hash(&self) -> H256 {
+        self.as_reader().calc_uncles_hash()
+    }
+}
 
 impl packed::Block {
     pub fn calc_tx_hashes(&self) -> Vec<H256> {
@@ -177,18 +222,33 @@ impl<'r> packed::CompactBlockReader<'r> {
         self.header().calc_header_hash()
     }
 }
-impl_calc_special_hash_for_entity!(CompactBlock, calc_header_hash);
+
+impl packed::CompactBlock {
+    pub fn calc_header_hash(&self) -> H256 {
+        self.as_reader().calc_header_hash()
+    }
+}
 
 impl<'r> packed::RawAlertReader<'r> {
     pub fn calc_alert_hash(&self) -> H256 {
         self.calc_hash()
     }
 }
-impl_calc_special_hash_for_entity!(RawAlert, calc_alert_hash);
+
+impl packed::RawAlert {
+    pub fn calc_alert_hash(&self) -> H256 {
+        self.as_reader().calc_alert_hash()
+    }
+}
 
 impl<'r> packed::AlertReader<'r> {
     pub fn calc_alert_hash(&self) -> H256 {
         self.raw().calc_alert_hash()
     }
 }
-impl_calc_special_hash_for_entity!(Alert, calc_alert_hash);
+
+impl packed::Alert {
+    pub fn calc_alert_hash(&self) -> H256 {
+        self.as_reader().calc_alert_hash()
+    }
+}


### PR DESCRIPTION
I would like the frequently used APIs can be auto-completed by IDE. So I expand the macro `impl_calc_special_hash_for_entity` in `calc_hash.rs`