### PR TITLE
chore: change is_dep_group(bool) to dep_type(enum)

### DIFF
--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -315,8 +315,12 @@ pub fn gen_secp_block(
 ) -> BlockView {
     let tx = create_secp_tx();
     let secp_cell_deps = vec![
-        CellDep::new(OutPoint::new(tx.hash().unpack(), 0), false),
-        CellDep::new(OutPoint::new(tx.hash().unpack(), 1), false),
+        CellDep::new_builder()
+            .out_point(OutPoint::new(tx.hash().unpack(), 0))
+            .build(),
+        CellDep::new_builder()
+            .out_point(OutPoint::new(tx.hash().unpack(), 1))
+            .build(),
     ];
     let (_, _, secp_script) = secp_cell();
     let (number, timestamp, difficulty) = (
@@ -389,7 +393,7 @@ fn create_transaction(parent_hash: &H256, lock: Script, dep: OutPoint) -> Transa
         )
         .output_data(data.pack())
         .input(CellInput::new(OutPoint::new(parent_hash.to_owned(), 0), 0))
-        .cell_dep(CellDep::new(dep, false))
+        .cell_dep(CellDep::new_builder().out_point(dep).build())
         .build()
 }
 

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -111,7 +111,11 @@ pub(crate) fn create_transaction(parent: &TransactionView, index: u32) -> Transa
             OutPoint::new(parent.hash().unpack(), index),
             0,
         ))
-        .cell_dep(CellDep::new(always_success_out_point, false))
+        .cell_dep(
+            CellDep::new_builder()
+                .out_point(always_success_out_point)
+                .build(),
+        )
         .build()
 }
 

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -154,7 +154,11 @@ pub(crate) fn create_multi_outputs_transaction(
         .outputs(outputs)
         .outputs_data(outputs_data)
         .inputs(inputs)
-        .cell_dep(CellDep::new(always_success_out_point, false))
+        .cell_dep(
+            CellDep::new_builder()
+                .out_point(always_success_out_point)
+                .build(),
+        )
         .build()
 }
 
@@ -179,7 +183,11 @@ pub(crate) fn create_transaction_with_out_point(
         )
         .output_data(data.pack())
         .input(CellInput::new(out_point, 0))
-        .cell_dep(CellDep::new(always_success_out_point, false))
+        .cell_dep(
+            CellDep::new_builder()
+                .out_point(always_success_out_point)
+                .build(),
+        )
         .build()
 }
 

--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -14,7 +14,7 @@ message = "ckb_dev"
 [genesis.genesis_cell.lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 # An array list paths to system cell files, which is absolute or relative to
 # the directory containing this config file.
@@ -34,26 +34,26 @@ create_type_id = true
 [genesis.system_cells_lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 [genesis.bootstrap_lock]
 code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 args = ["0xb2e61ff569acf041b3c2c17724e2379c581eeac3"]
-hash_type = "Data"
+hash_type = "data"
 
 # issue 5M cell for random generated private key: d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc
 [[genesis.issued_cells]]
 capacity = 5_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 
 # issue 5M cell for random generated private key: 63d86723e08f0f813a36ce6aa123bb2289d90680ae1e99d4de8cdb334553f24d
 [[genesis.issued_cells]]
 capacity = 5_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x470dcdc5e44064909650113a274b3b36aecb6dc7"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/resource/specs/staging.toml
+++ b/resource/specs/staging.toml
@@ -14,7 +14,7 @@ message = "ckb_staging"
 [genesis.genesis_cell.lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 # An array list paths to system cell files, which is absolute or relative to
 # the directory containing this config file.
@@ -34,30 +34,30 @@ create_type_id = true
 [genesis.system_cells_lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 [genesis.bootstrap_lock]
 code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 # Lock for developers to run tests
 args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-hash_type = "Data"
+hash_type = "data"
 
 # Locks for developers to run tests
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x3f1573b44218d4c12a91919a58a863be415a2bc3"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -16,7 +16,7 @@ message = "rylai-v8"
 [genesis.genesis_cell.lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 # An array list paths to system cell files, which is absolute or relative to
 # the directory containing this config file.
@@ -36,30 +36,30 @@ create_type_id = true
 [genesis.system_cells_lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 [genesis.bootstrap_lock]
 code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 # Lock for developers to run tests
 args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-hash_type = "Data"
+hash_type = "data"
 
 # Locks for developers to run tests
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x3f1573b44218d4c12a91919a58a863be415a2bc3"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
 lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
-lock.hash_type = "Data"
+lock.hash_type = "data"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -654,7 +654,7 @@ http://localhost:8114
         "transaction": {
             "cell_deps": [
                 {
-                    "is_dep_group": false,
+                    "dep_type": "Code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -768,7 +768,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "is_dep_group": false,
+                    "dep_type": "Code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -839,7 +839,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "is_dep_group": false,
+                    "dep_type": "Code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -1322,7 +1322,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "is_dep_group": false,
+                    "dep_type": "Code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -105,7 +105,7 @@ http://localhost:8114
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -194,7 +194,7 @@ http://localhost:8114
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -326,7 +326,7 @@ http://localhost:8114
             "lock": {
                 "args": [],
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                "hash_type": "Data"
+                "hash_type": "data"
             },
             "out_point": {
                 "index": "0",
@@ -339,7 +339,7 @@ http://localhost:8114
             "lock": {
                 "args": [],
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                "hash_type": "Data"
+                "hash_type": "data"
             },
             "out_point": {
                 "index": "0",
@@ -544,7 +544,7 @@ http://localhost:8114
             "lock": {
                 "args": [],
                 "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "Data"
+                "hash_type": "data"
             },
             "type": null
         },
@@ -654,7 +654,7 @@ http://localhost:8114
         "transaction": {
             "cell_deps": [
                 {
-                    "dep_type": "Code",
+                    "dep_type": "code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -680,7 +680,7 @@ http://localhost:8114
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 }
@@ -711,7 +711,7 @@ Returns script hash of given transaction script
 
     args - Hex encoded arguments passed to reference cell
     code_hash - Code hash of referenced cell
-    hash_type - Data: code_hash matches against dep cell data hash; Type: code_hash matches against dep cell type hash.
+    hash_type - data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash.
 
 #### Examples
 
@@ -724,7 +724,7 @@ echo '{
         {
             "args": [],
             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-            "hash_type": "Data"
+            "hash_type": "data"
         }
     ]
 }' \
@@ -768,7 +768,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "dep_type": "Code",
+                    "dep_type": "code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -793,7 +793,7 @@ echo '{
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 }
@@ -839,7 +839,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "dep_type": "Code",
+                    "dep_type": "code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -864,7 +864,7 @@ echo '{
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 }
@@ -966,7 +966,7 @@ http://localhost:8114
                 "lock": {
                     "args": [],
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                    "hash_type": "Data"
+                    "hash_type": "data"
                 },
                 "type": null
             },
@@ -982,7 +982,7 @@ http://localhost:8114
                 "lock": {
                     "args": [],
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                    "hash_type": "Data"
+                    "hash_type": "data"
                 },
                 "type": null
             },
@@ -1322,7 +1322,7 @@ echo '{
         {
             "cell_deps": [
                 {
-                    "dep_type": "Code",
+                    "dep_type": "code",
                     "out_point": {
                         "index": "0",
                         "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -1347,7 +1347,7 @@ echo '{
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -118,7 +118,7 @@
                             "lock": {
                                 "args": [],
                                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                                "hash_type": "Data"
+                                "hash_type": "data"
                             },
                             "type": null
                         }
@@ -208,7 +208,7 @@
                 "lock": {
                     "args": [],
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                    "hash_type": "Data"
+                    "hash_type": "data"
                 },
                 "out_point": {
                     "index": "0",
@@ -221,7 +221,7 @@
                 "lock": {
                     "args": [],
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                    "hash_type": "Data"
+                    "hash_type": "data"
                 },
                 "out_point": {
                     "index": "0",
@@ -257,7 +257,7 @@
                 "lock": {
                     "args": [],
                     "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                    "hash_type": "Data"
+                    "hash_type": "data"
                 },
                 "type": null
             },
@@ -415,7 +415,7 @@
             {
                 "cell_deps": [
                     {
-                        "dep_type": "Code",
+                        "dep_type": "code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -440,7 +440,7 @@
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -464,7 +464,7 @@
             {
                 "cell_deps": [
                     {
-                        "dep_type": "Code",
+                        "dep_type": "code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -489,7 +489,7 @@
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -534,7 +534,7 @@
             {
                 "cell_deps": [
                     {
-                        "dep_type": "Code",
+                        "dep_type": "code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -559,7 +559,7 @@
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -607,7 +607,7 @@
             "transaction": {
                 "cell_deps": [
                     {
-                        "dep_type": "Code",
+                        "dep_type": "code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -633,7 +633,7 @@
                         "lock": {
                             "args": [],
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "Data"
+                            "hash_type": "data"
                         },
                         "type": null
                     }
@@ -734,7 +734,7 @@
                             "lock": {
                                 "args": [],
                                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                                "hash_type": "Data"
+                                "hash_type": "data"
                             },
                             "type": null
                         }
@@ -811,7 +811,7 @@
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 },
@@ -827,7 +827,7 @@
                     "lock": {
                         "args": [],
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "Data"
+                        "hash_type": "data"
                     },
                     "type": null
                 },
@@ -917,7 +917,7 @@
             {
                 "args": [],
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                "hash_type": "Data"
+                "hash_type": "data"
             }
         ],
         "result": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9",
@@ -929,7 +929,7 @@
                 "code_hash": "Code hash of referenced cell"
             },
             {
-                "hash_type": "Data: code_hash matches against dep cell data hash; Type: code_hash matches against dep cell type hash."
+                "hash_type": "data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash."
             }
         ]
     }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -415,7 +415,7 @@
             {
                 "cell_deps": [
                     {
-                        "is_dep_group": false,
+                        "dep_type": "Code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -464,7 +464,7 @@
             {
                 "cell_deps": [
                     {
-                        "is_dep_group": false,
+                        "dep_type": "Code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -534,7 +534,7 @@
             {
                 "cell_deps": [
                     {
-                        "is_dep_group": false,
+                        "dep_type": "Code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
@@ -607,7 +607,7 @@
             "transaction": {
                 "cell_deps": [
                     {
-                        "is_dep_group": false,
+                        "dep_type": "Code",
                         "out_point": {
                             "index": "0",
                             "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -279,10 +279,12 @@ fn construct_transaction() -> TransactionView {
         .capacity(capacity_bytes!(1000).pack())
         .lock(always_success_cell().2.clone())
         .build();
-    let cell_dep = CellDep::new(
-        OutPoint::new(always_success_transaction().hash().unpack(), 0),
-        false,
-    );
+    let cell_dep = CellDep::new_builder()
+        .out_point(OutPoint::new(
+            always_success_transaction().hash().unpack(),
+            0,
+        ))
+        .build();
     TransactionBuilder::default()
         .input(input)
         .output(output)

--- a/shared/src/tx_pool/proposed.rs
+++ b/shared/src/tx_pool/proposed.rs
@@ -267,7 +267,8 @@ mod tests {
     use ckb_types::{
         bytes::Bytes,
         core::{
-            cell::get_related_dep_out_points, Capacity, Cycle, TransactionBuilder, TransactionView,
+            cell::get_related_dep_out_points, Capacity, Cycle, DepType, TransactionBuilder,
+            TransactionView,
         },
         h256,
         packed::{CellDep, CellInput, CellOutput},
@@ -675,7 +676,10 @@ mod tests {
         let tx2_out_point = OutPoint::new(tx2.hash().unpack(), 0);
 
         // Transaction use dep group
-        let dep = CellDep::new(OutPoint::new(tx2.hash().unpack(), 0), true);
+        let dep = CellDep::new_builder()
+            .out_point(tx2_out_point.clone())
+            .dep_type(DepType::DepGroup.pack())
+            .build();
         let tx3 = TransactionBuilder::default()
             .cell_dep(dep)
             .input(CellInput::new(OutPoint::new(h256!("0x3"), 0), 0))

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -192,7 +192,8 @@ mod tests {
     use ckb_types::{
         bytes::Bytes,
         core::{
-            capacity_bytes, cell::UnresolvableError, BlockBuilder, Capacity, TransactionBuilder,
+            capacity_bytes, cell::UnresolvableError, BlockBuilder, Capacity, DepType,
+            TransactionBuilder,
         },
         packed::{CellDep, CellInput, CellOutput, OutPoint},
         prelude::*,
@@ -269,7 +270,12 @@ mod tests {
                             .build(),
                     )
                     .output_data(Default::default())
-                    .cell_dep(CellDep::new(always_success_out_point.to_owned(), false))
+                    .cell_dep(
+                        CellDep::new_builder()
+                            .out_point(always_success_out_point.to_owned())
+                            .dep_type(DepType::Code.pack())
+                            .build(),
+                    )
                     .build()
             });
 
@@ -315,7 +321,12 @@ mod tests {
                             .build(),
                     )
                     .output_data(data.pack())
-                    .cell_dep(CellDep::new(always_success_out_point.to_owned(), false))
+                    .cell_dep(
+                        CellDep::new_builder()
+                            .out_point(always_success_out_point.to_owned())
+                            .dep_type(DepType::Code.pack())
+                            .build(),
+                    )
                     .build()
             })
             .collect::<Vec<_>>();
@@ -380,7 +391,12 @@ mod tests {
                             .build(),
                     )
                     .output_data(Default::default())
-                    .cell_dep(CellDep::new(always_success_out_point.to_owned(), false))
+                    .cell_dep(
+                        CellDep::new_builder()
+                            .out_point(always_success_out_point.to_owned())
+                            .dep_type(DepType::Code.pack())
+                            .build(),
+                    )
                     .build()
             })
             .collect();

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -340,8 +340,12 @@ impl Genesis {
         let input = packed::CellInput::new(input_out_point, 0);
 
         let cell_deps = vec![
-            packed::CellDep::new(secp_data_out_point.clone(), false),
-            packed::CellDep::new(secp_blake160_out_point.clone(), false),
+            packed::CellDep::new_builder()
+                .out_point(secp_data_out_point.clone())
+                .build(),
+            packed::CellDep::new_builder()
+                .out_point(secp_blake160_out_point.clone())
+                .build(),
         ];
         let tx = TransactionBuilder::default()
             .cell_deps(cell_deps.clone())

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -33,6 +33,7 @@ use ckb_types::{
     packed::{self, Byte32, ProposalShortId},
     prelude::*,
 };
+use failure::err_msg;
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::collections::{HashMap, HashSet};
@@ -84,7 +85,11 @@ impl Relayer {
                 CompactBlockProcess::new(reader, self, nc, peer).execute()?;
             }
             packed::RelayMessageUnionReader::RelayTransactions(reader) => {
-                TransactionsProcess::new(reader, self, nc, peer).execute()?;
+                if reader.check_data() {
+                    TransactionsProcess::new(reader, self, nc, peer).execute()?;
+                } else {
+                    Err(err_msg("RelayTransactions: invalid data"))?;
+                }
             }
             packed::RelayMessageUnionReader::RelayTransactionHashes(reader) => {
                 TransactionHashesProcess::new(reader, self, peer).execute()?;
@@ -96,7 +101,11 @@ impl Relayer {
                 GetBlockTransactionsProcess::new(reader, self, nc, peer).execute()?;
             }
             packed::RelayMessageUnionReader::BlockTransactions(reader) => {
-                BlockTransactionsProcess::new(reader, self, nc, peer).execute()?;
+                if reader.check_data() {
+                    BlockTransactionsProcess::new(reader, self, nc, peer).execute()?;
+                } else {
+                    Err(err_msg("BlockTransactions: invalid data"))?;
+                }
             }
             packed::RelayMessageUnionReader::GetBlockProposal(reader) => {
                 GetBlockProposalProcess::new(reader, self, nc, peer).execute()?;

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -84,7 +84,11 @@ pub(crate) fn new_transaction(
             .build(),
         )
         .output_data(Bytes::new().pack())
-        .cell_dep(CellDep::new(always_success_out_point.to_owned(), false))
+        .cell_dep(
+            CellDep::new_builder()
+                .out_point(always_success_out_point.to_owned())
+                .build(),
+        )
         .build()
 }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -74,7 +74,11 @@ impl Synchronizer {
                 GetBlocksProcess::new(reader, self, peer, nc).execute()?;
             }
             packed::SyncMessageUnionReader::SendBlock(reader) => {
-                BlockProcess::new(reader, self, peer, nc).execute()?;
+                if reader.check_data() {
+                    BlockProcess::new(reader, self, peer, nc).execute()?;
+                } else {
+                    Err(err_msg("SendBlock: invalid data"))?;
+                }
             }
             packed::SyncMessageUnionReader::InIBD(_) => {
                 InIBDProcess::new(self, peer, nc).execute()?;

--- a/test/integration.toml
+++ b/test/integration.toml
@@ -15,7 +15,7 @@ message = ""
 [genesis.genesis_cell.lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 # An array list paths to system cell files, which is absolute or relative to
 # the directory containing this config file.
@@ -38,12 +38,12 @@ create_type_id = true
 [genesis.system_cells_lock]
 code_hash = "0xb35557e7e9854206f7bc13e3c3a7fa4cf8892c84a09237fb0aab40aab3771eee"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 [genesis.bootstrap_lock]
 code_hash = "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5"
 args = []
-hash_type = "Data"
+hash_type = "data"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -323,7 +323,11 @@ impl Node {
         let always_success_script = self.always_success_script();
 
         core::TransactionBuilder::default()
-            .cell_dep(CellDep::new(always_success_out_point, false))
+            .cell_dep(
+                CellDep::new_builder()
+                    .out_point(always_success_out_point)
+                    .build(),
+            )
             .output(
                 CellOutputBuilder::default()
                     .capacity(capacity.pack())

--- a/test/src/specs/tx_pool/dao.rs
+++ b/test/src/specs/tx_pool/dao.rs
@@ -313,15 +313,19 @@ fn deposit_dao_deps(node: &Node) -> (Vec<CellDep>, Vec<H256>) {
     let genesis_tx = &genesis_block.transactions()[0];
 
     // Reference to AlwaysSuccess lock_script, to unlock the cellbase
-    let always_dep = CellDep::new(
-        OutPoint::new(genesis_tx.hash().unpack(), SYSTEM_CELL_ALWAYS_SUCCESS_INDEX),
-        false,
-    );
+    let always_dep = CellDep::new_builder()
+        .out_point(OutPoint::new(
+            genesis_tx.hash().unpack(),
+            SYSTEM_CELL_ALWAYS_SUCCESS_INDEX,
+        ))
+        .build();
     // Reference to DAO type_script
-    let dao_dep = CellDep::new(
-        OutPoint::new(genesis_tx.hash().unpack(), SYSTEM_CELL_DAO_INDEX),
-        false,
-    );
+    let dao_dep = CellDep::new_builder()
+        .out_point(OutPoint::new(
+            genesis_tx.hash().unpack(),
+            SYSTEM_CELL_DAO_INDEX,
+        ))
+        .build();
 
     (
         vec![always_dep, dao_dep],

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -9,7 +9,7 @@ use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use ckb_types::{
     bytes::Bytes,
     constants::TYPE_ID_CODE_HASH,
-    core::{capacity_bytes, Capacity, ScriptHashType, TransactionBuilder},
+    core::{capacity_bytes, Capacity, DepType, ScriptHashType, TransactionBuilder},
     packed::{CellDep, CellInput, CellOutput, OutPoint, Script},
     prelude::*,
     H256,
@@ -49,7 +49,10 @@ impl Spec for SendSecpTxUseDepGroup {
         let block = node.get_tip_block();
         let cellbase_hash: H256 = block.transactions()[0].hash().to_owned().unpack();
 
-        let cell_dep = CellDep::new(secp_out_point, true);
+        let cell_dep = CellDep::new_builder()
+            .out_point(secp_out_point)
+            .dep_type(DepType::DepGroup.pack())
+            .build();
         let output = CellOutput::new_builder()
             .capacity(capacity_bytes!(100).pack())
             .lock(node.always_success_script())

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -363,11 +363,11 @@ fn init() -> App<'static, 'static> {
                 .long(ARG_BA_HASH_TYPE)
                 .value_name("hash_type")
                 .takes_value(true)
-                .possible_values(&["Data", "Type"])
-                .default_value("Data")
+                .possible_values(&["data", "type"])
+                .default_value("data")
                 .help(
                     "Sets hash type in [block_assembler] \
-                     [default: Data]",
+                     [default: data]",
                 ),
         )
         .group(

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -4,6 +4,7 @@ use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum ScriptHashType {
     Data,
     Type,
@@ -179,6 +180,7 @@ impl From<Witness> for packed::Witness {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum DepType {
     Code,
     DepGroup,

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -40,9 +40,9 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, BlockReward, BlockView, CellDep, CellInput, CellOutput, EpochView, Header, HeaderView,
-    OutPoint, Script, ScriptHashType, Status, Transaction, TransactionView, TransactionWithStatus,
-    TxStatus, UncleBlock, UncleBlockView, Witness,
+    Block, BlockReward, BlockView, CellDep, CellInput, CellOutput, DepType, EpochView, Header,
+    HeaderView, OutPoint, Script, ScriptHashType, Status, Transaction, TransactionView,
+    TransactionWithStatus, TxStatus, UncleBlock, UncleBlockView, Witness,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -25,6 +25,7 @@ option ScriptOpt (Script);
 
 array ProposalShortId [byte; 10];
 array ScriptHashType [byte; 1];
+array DepType [byte; 1];
 
 vector HeaderVec <Header>;
 vector UncleBlockVec <UncleBlock>;
@@ -60,7 +61,7 @@ table CellOutput {
 
 table CellDep {
     out_point:      OutPoint,
-    is_dep_group:   Bool,
+    dep_type:       DepType,
 }
 
 vector Witness <Bytes>;

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -77,6 +77,22 @@ impl<'r> Unpack<core::ScriptHashType> for packed::ScriptHashTypeReader<'r> {
 
 impl_conversion_for_entity_unpack!(core::ScriptHashType, ScriptHashType);
 
+impl Pack<packed::DepType> for core::DepType {
+    fn pack(&self) -> packed::DepType {
+        let v = *self as u8;
+        packed::DepType::new_unchecked(Bytes::from(vec![v]))
+    }
+}
+
+impl<'r> Unpack<core::DepType> for packed::DepTypeReader<'r> {
+    fn unpack(&self) -> core::DepType {
+        use std::convert::TryFrom;
+        core::DepType::try_from(self.as_slice()[0]).expect("internal error: fail to unpack DepType")
+    }
+}
+
+impl_conversion_for_entity_unpack!(core::DepType, DepType);
+
 impl Pack<packed::Bytes> for Bytes {
     fn pack(&self) -> packed::Bytes {
         let len = (self.len() as u32).to_le_bytes();

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -25,6 +25,13 @@ impl TryFrom<u8> for ScriptHashType {
     }
 }
 
+impl ScriptHashType {
+    #[inline]
+    pub(crate) fn verify_value(v: u8) -> bool {
+        v <= 1
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DepType {
     Code = 0,
@@ -46,5 +53,12 @@ impl TryFrom<u8> for DepType {
             1 => Ok(DepType::DepGroup),
             _ => Err(err_msg(format!("Invalid dep type {}", v))),
         }
+    }
+}
+
+impl DepType {
+    #[inline]
+    pub(crate) fn verify_value(v: u8) -> bool {
+        v <= 1
     }
 }

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -1,11 +1,6 @@
 use failure::{err_msg, Error as FailureError};
 use std::convert::TryFrom;
 
-// NOTE: we could've used enum as well in the wire format, but as of
-// flatbuffer 1.11.0, unused constants will be generated in the Rust
-// code for enum types, resulting in both compiler warnings and clippy
-// errors. So for now we are sticking to a single integer in the wire
-// format, and only use enums in core data structures.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScriptHashType {
     Data = 0,
@@ -25,7 +20,31 @@ impl TryFrom<u8> for ScriptHashType {
         match v {
             0 => Ok(ScriptHashType::Data),
             1 => Ok(ScriptHashType::Type),
-            _ => Err(err_msg(format!("Invalid string hash type {}", v))),
+            _ => Err(err_msg(format!("Invalid script hash type {}", v))),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DepType {
+    Code = 0,
+    DepGroup = 1,
+}
+
+impl Default for DepType {
+    fn default() -> Self {
+        DepType::Code
+    }
+}
+
+impl TryFrom<u8> for DepType {
+    type Error = FailureError;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(DepType::Code),
+            1 => Ok(DepType::DepGroup),
+            _ => Err(err_msg(format!("Invalid dep type {}", v))),
         }
     }
 }

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -12,7 +12,7 @@ mod reward;
 mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
-pub use blockchain::ScriptHashType;
+pub use blockchain::{DepType, ScriptHashType};
 pub use extras::{BlockExt, EpochExt, TransactionInfo};
 pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};

--- a/util/types/src/extension/check_data.rs
+++ b/util/types/src/extension/check_data.rs
@@ -60,15 +60,9 @@ impl<'r> packed::RawTransactionReader<'r> {
     }
 }
 
-impl<'r> packed::SlimTransactionReader<'r> {
-    pub fn check_data(&self) -> bool {
-        self.raw().check_data()
-    }
-}
-
 impl<'r> packed::TransactionReader<'r> {
     pub fn check_data(&self) -> bool {
-        self.slim().check_data()
+        self.raw().check_data()
     }
 }
 
@@ -138,8 +132,7 @@ mod tests {
             .outputs(outputs.into_iter().pack())
             .cell_deps(cell_deps.into_iter().pack())
             .build();
-        let slim = packed::SlimTransaction::new_builder().raw(raw).build();
-        packed::Transaction::new_builder().slim(slim).build()
+        packed::Transaction::new_builder().raw(raw).build()
     }
 
     fn test_check_data_via_transaction(

--- a/util/types/src/extension/check_data.rs
+++ b/util/types/src/extension/check_data.rs
@@ -1,0 +1,228 @@
+use crate::{core, packed, prelude::*};
+
+/*
+ * Blockchain
+ */
+
+impl<'r> packed::ScriptHashTypeReader<'r> {
+    pub fn check_data(&self) -> bool {
+        core::ScriptHashType::verify_value(self.as_slice()[0])
+    }
+}
+
+impl<'r> packed::DepTypeReader<'r> {
+    pub fn check_data(&self) -> bool {
+        core::DepType::verify_value(self.as_slice()[0])
+    }
+}
+
+impl<'r> packed::ScriptReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.hash_type().check_data()
+    }
+}
+
+impl<'r> packed::ScriptOptReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.to_opt()
+            .map(|i| i.hash_type().check_data())
+            .unwrap_or(true)
+    }
+}
+
+impl<'r> packed::CellOutputReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.lock().check_data() && self.type_().check_data()
+    }
+}
+
+impl<'r> packed::CellOutputVecReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.iter().all(|i| i.check_data())
+    }
+}
+
+impl<'r> packed::CellDepReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.dep_type().check_data()
+    }
+}
+
+impl<'r> packed::CellDepVecReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.iter().all(|i| i.check_data())
+    }
+}
+
+impl<'r> packed::RawTransactionReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.cell_deps().check_data() && self.outputs().check_data()
+    }
+}
+
+impl<'r> packed::SlimTransactionReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.raw().check_data()
+    }
+}
+
+impl<'r> packed::TransactionReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.slim().check_data()
+    }
+}
+
+impl<'r> packed::TransactionVecReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.iter().all(|i| i.check_data())
+    }
+}
+
+impl<'r> packed::BlockReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.transactions().check_data()
+    }
+}
+
+/*
+ * Network
+ */
+
+impl<'r> packed::BlockTransactionsReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.transactions().check_data()
+    }
+}
+
+impl<'r> packed::RelayTransactionReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.transaction().check_data()
+    }
+}
+
+impl<'r> packed::RelayTransactionVecReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.iter().all(|i| i.check_data())
+    }
+}
+
+impl<'r> packed::RelayTransactionsReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.transactions().check_data()
+    }
+}
+
+impl<'r> packed::SendBlockReader<'r> {
+    pub fn check_data(&self) -> bool {
+        self.block().check_data()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{packed, prelude::*};
+
+    fn create_transaction(
+        outputs: &[&packed::CellOutput],
+        cell_deps: &[&packed::CellDep],
+    ) -> packed::Transaction {
+        let outputs = outputs
+            .iter()
+            .map(|d| d.to_owned().to_owned())
+            .collect::<Vec<packed::CellOutput>>();
+        let cell_deps = cell_deps
+            .iter()
+            .map(|d| d.to_owned().to_owned())
+            .collect::<Vec<packed::CellDep>>();
+        let raw = packed::RawTransaction::new_builder()
+            .outputs(outputs.into_iter().pack())
+            .cell_deps(cell_deps.into_iter().pack())
+            .build();
+        let slim = packed::SlimTransaction::new_builder().raw(raw).build();
+        packed::Transaction::new_builder().slim(slim).build()
+    }
+
+    fn test_check_data_via_transaction(
+        expected: bool,
+        outputs: &[&packed::CellOutput],
+        cell_deps: &[&packed::CellDep],
+    ) {
+        let tx = create_transaction(outputs, cell_deps);
+        assert_eq!(tx.as_reader().check_data(), expected);
+    }
+
+    #[test]
+    fn check_data() {
+        let ht_right = packed::ScriptHashType::new_builder().set([1]).build();
+        let ht_error = packed::ScriptHashType::new_builder().set([2]).build();
+        let dt_right = packed::DepType::new_builder().set([1]).build();
+        let dt_error = packed::DepType::new_builder().set([2]).build();
+
+        let script_right = packed::Script::new_builder()
+            .hash_type(ht_right.clone())
+            .build();
+        let script_error = packed::Script::new_builder()
+            .hash_type(ht_error.clone())
+            .build();
+
+        let script_opt_right = packed::ScriptOpt::new_builder()
+            .set(Some(script_right.clone()))
+            .build();
+        let script_opt_error = packed::ScriptOpt::new_builder()
+            .set(Some(script_error.clone()))
+            .build();
+
+        let output_right1 = packed::CellOutput::new_builder()
+            .lock(script_right.clone())
+            .build();
+        let output_right2 = packed::CellOutput::new_builder()
+            .type_(script_opt_right.clone())
+            .build();
+        let output_error1 = packed::CellOutput::new_builder()
+            .lock(script_error.clone())
+            .build();
+        let output_error2 = packed::CellOutput::new_builder()
+            .type_(script_opt_error.clone())
+            .build();
+        let output_error3 = packed::CellOutput::new_builder()
+            .lock(script_right.clone())
+            .type_(script_opt_error.clone())
+            .build();
+        let output_error4 = packed::CellOutput::new_builder()
+            .lock(script_error.clone())
+            .type_(script_opt_right.clone())
+            .build();
+
+        let cell_dep_right = packed::CellDep::new_builder()
+            .dep_type(dt_right.clone())
+            .build();
+        let cell_dep_error = packed::CellDep::new_builder()
+            .dep_type(dt_error.clone())
+            .build();
+
+        test_check_data_via_transaction(true, &[], &[]);
+        test_check_data_via_transaction(true, &[&output_right1], &[&cell_dep_right]);
+        test_check_data_via_transaction(
+            true,
+            &[&output_right1, &output_right2],
+            &[&cell_dep_right, &cell_dep_right],
+        );
+        test_check_data_via_transaction(false, &[&output_error1], &[]);
+        test_check_data_via_transaction(false, &[&output_error2], &[]);
+        test_check_data_via_transaction(false, &[&output_error3], &[]);
+        test_check_data_via_transaction(false, &[&output_error4], &[]);
+        test_check_data_via_transaction(false, &[], &[&cell_dep_error]);
+        test_check_data_via_transaction(
+            false,
+            &[
+                &output_right1,
+                &output_right2,
+                &output_error1,
+                &output_error2,
+                &output_error3,
+                &output_error4,
+            ],
+            &[&cell_dep_right, &cell_dep_error],
+        );
+    }
+}

--- a/util/types/src/extension/mod.rs
+++ b/util/types/src/extension/mod.rs
@@ -8,6 +8,7 @@
 
 mod calc_hash;
 mod capacity;
+mod check_data;
 mod serialized_size;
 mod shortcuts;
 mod std_traits;

--- a/util/types/src/extension/shortcuts.rs
+++ b/util/types/src/extension/shortcuts.rs
@@ -46,15 +46,6 @@ impl packed::OutPoint {
     }
 }
 
-impl packed::CellDep {
-    pub fn new(out_point: packed::OutPoint, is_dep_group: bool) -> packed::CellDep {
-        packed::CellDep::new_builder()
-            .out_point(out_point)
-            .is_dep_group(is_dep_group.pack())
-            .build()
-    }
-}
-
 impl packed::CellInput {
     pub fn new(previous_output: packed::OutPoint, block_number: BlockNumber) -> Self {
         packed::CellInput::new_builder()

--- a/util/types/src/generated/types.rs
+++ b/util/types/src/generated/types.rs
@@ -3963,6 +3963,161 @@ impl ScriptHashTypeBuilder {
     }
 }
 #[derive(Clone)]
+pub struct DepType(molecule::bytes::Bytes);
+#[derive(Clone, Copy)]
+pub struct DepTypeReader<'r>(&'r [u8]);
+impl ::std::fmt::Debug for DepType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "{}(0x{})",
+            Self::NAME,
+            hex_string(self.as_slice()).unwrap()
+        )
+    }
+}
+impl<'r> ::std::fmt::Debug for DepTypeReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "{}(0x{})",
+            Self::NAME,
+            hex_string(self.as_slice()).unwrap()
+        )
+    }
+}
+impl ::std::fmt::Display for DepType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "{}(0x{})",
+            Self::NAME,
+            hex_string(&self.raw_data()).unwrap()
+        )
+    }
+}
+impl<'r> ::std::fmt::Display for DepTypeReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "{}(0x{})",
+            Self::NAME,
+            hex_string(&self.raw_data()).unwrap()
+        )
+    }
+}
+pub struct DepTypeBuilder(pub(crate) [u8; 1]);
+impl ::std::fmt::Debug for DepTypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}({:?})", Self::NAME, &self.0[..])
+    }
+}
+impl ::std::default::Default for DepTypeBuilder {
+    fn default() -> Self {
+        DepTypeBuilder([0; 1])
+    }
+}
+impl molecule::prelude::Entity for DepType {
+    type Builder = DepTypeBuilder;
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        DepType(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        DepTypeReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set([self.nth0()])
+    }
+}
+impl ::std::default::Default for DepType {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![0];
+        DepType::new_unchecked(v.into())
+    }
+}
+impl DepType {
+    pub const NAME: &'static str = "DepType";
+    pub fn as_reader(&self) -> DepTypeReader<'_> {
+        DepTypeReader::new_unchecked(self.as_slice())
+    }
+    pub const TOTAL_SIZE: usize = 1;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 1;
+    pub fn raw_data(&self) -> molecule::bytes::Bytes {
+        self.as_bytes()
+    }
+    pub fn nth0(&self) -> u8 {
+        self.0[0]
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for DepTypeReader<'r> {
+    type Entity = DepType;
+    fn to_entity(&self) -> Self::Entity {
+        DepType::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        DepTypeReader(slice)
+    }
+    fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+    fn verify(slice: &[u8]) -> molecule::error::VerificationResult<()> {
+        use molecule::error::VerificationError;
+        if slice.len() != 1 {
+            let err = VerificationError::TotalSizeNotMatch(Self::NAME.to_owned(), 1, slice.len());
+            Err(err)?;
+        }
+        Ok(())
+    }
+}
+impl<'r> DepTypeReader<'r> {
+    pub const NAME: &'r str = "DepTypeReader";
+    pub const TOTAL_SIZE: usize = 1;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 1;
+    pub fn raw_data(&self) -> &[u8] {
+        self.as_slice()
+    }
+    pub fn nth0(&self) -> u8 {
+        self.0[0]
+    }
+}
+impl molecule::prelude::Builder for DepTypeBuilder {
+    type Entity = DepType;
+    fn expected_length(&self) -> usize {
+        1
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(&self.0)?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner).expect("write vector should be ok");
+        DepType::new_unchecked(inner.into())
+    }
+}
+impl DepTypeBuilder {
+    pub const NAME: &'static str = "DepTypeBuilder";
+    pub fn set(mut self, v: [u8; 1]) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn nth0(mut self, v: u8) -> Self {
+        self.0[0] = v;
+        self
+    }
+}
+#[derive(Clone)]
 pub struct HeaderVec(molecule::bytes::Bytes);
 #[derive(Clone, Copy)]
 pub struct HeaderVecReader<'r>(&'r [u8]);
@@ -7802,7 +7957,7 @@ impl ::std::fmt::Display for CellDep {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "out_point", self.out_point())?;
-        write!(f, ", {}: {}", "is_dep_group", self.is_dep_group())?;
+        write!(f, ", {}: {}", "dep_type", self.dep_type())?;
         let (_, count, _) = Self::field_offsets(&self);
         if count != 2 {
             write!(f, ", ..")?;
@@ -7814,7 +7969,7 @@ impl<'r> ::std::fmt::Display for CellDepReader<'r> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "out_point", self.out_point())?;
-        write!(f, ", {}: {}", "is_dep_group", self.is_dep_group())?;
+        write!(f, ", {}: {}", "dep_type", self.dep_type())?;
         let (_, count, _) = Self::field_offsets(&self);
         if count != 2 {
             write!(f, ", ..")?;
@@ -7825,7 +7980,7 @@ impl<'r> ::std::fmt::Display for CellDepReader<'r> {
 #[derive(Debug, Default)]
 pub struct CellDepBuilder {
     pub(crate) out_point: OutPoint,
-    pub(crate) is_dep_group: Bool,
+    pub(crate) dep_type: DepType,
 }
 impl ::std::default::Default for CellDep {
     fn default() -> Self {
@@ -7857,7 +8012,7 @@ impl molecule::prelude::Entity for CellDep {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .out_point(self.out_point())
-            .is_dep_group(self.is_dep_group())
+            .dep_type(self.dep_type())
     }
 }
 impl CellDep {
@@ -7879,14 +8034,14 @@ impl CellDep {
         let end = u32::from_le(offsets[0 + 1]) as usize;
         OutPoint::new_unchecked(self.0.slice(start, end))
     }
-    pub fn is_dep_group(&self) -> Bool {
+    pub fn dep_type(&self) -> DepType {
         let (_, count, offsets) = Self::field_offsets(self);
         let start = u32::from_le(offsets[1]) as usize;
         if count == 2 {
-            Bool::new_unchecked(self.0.slice_from(start))
+            DepType::new_unchecked(self.0.slice_from(start))
         } else {
             let end = u32::from_le(offsets[1 + 1]) as usize;
-            Bool::new_unchecked(self.0.slice(start, end))
+            DepType::new_unchecked(self.0.slice(start, end))
         }
     }
 }
@@ -7938,7 +8093,7 @@ impl<'r> molecule::prelude::Reader<'r> for CellDepReader<'r> {
             Err(err)?;
         }
         OutPointReader::verify(&slice[offsets[0]..offsets[1]])?;
-        BoolReader::verify(&slice[offsets[1]..offsets[2]])?;
+        DepTypeReader::verify(&slice[offsets[1]..offsets[2]])?;
         Ok(())
     }
 }
@@ -7958,14 +8113,14 @@ impl<'r> CellDepReader<'r> {
         let end = u32::from_le(offsets[0 + 1]) as usize;
         OutPointReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn is_dep_group(&self) -> BoolReader<'_> {
+    pub fn dep_type(&self) -> DepTypeReader<'_> {
         let (_, count, offsets) = Self::field_offsets(self);
         let start = u32::from_le(offsets[1]) as usize;
         if count == 2 {
-            BoolReader::new_unchecked(&self.as_slice()[start..])
+            DepTypeReader::new_unchecked(&self.as_slice()[start..])
         } else {
             let end = u32::from_le(offsets[1 + 1]) as usize;
-            BoolReader::new_unchecked(&self.as_slice()[start..end])
+            DepTypeReader::new_unchecked(&self.as_slice()[start..end])
         }
     }
 }
@@ -7973,7 +8128,7 @@ impl molecule::prelude::Builder for CellDepBuilder {
     type Entity = CellDep;
     fn expected_length(&self) -> usize {
         let len_header = 4 + 2 * 4;
-        len_header + self.out_point.as_slice().len() + self.is_dep_group.as_slice().len()
+        len_header + self.out_point.as_slice().len() + self.dep_type.as_slice().len()
     }
     fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
         let len = (self.expected_length() as u32).to_le_bytes();
@@ -7987,11 +8142,11 @@ impl molecule::prelude::Builder for CellDepBuilder {
         {
             let tmp = (offset as u32).to_le_bytes();
             writer.write_all(&tmp[..])?;
-            offset += self.is_dep_group.as_slice().len();
+            offset += self.dep_type.as_slice().len();
         }
         let _ = offset;
         writer.write_all(self.out_point.as_slice())?;
-        writer.write_all(self.is_dep_group.as_slice())?;
+        writer.write_all(self.dep_type.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
@@ -8006,8 +8161,8 @@ impl CellDepBuilder {
         self.out_point = v;
         self
     }
-    pub fn is_dep_group(mut self, v: Bool) -> Self {
-        self.is_dep_group = v;
+    pub fn dep_type(mut self, v: DepType) -> Self {
+        self.dep_type = v;
         self
     }
 }

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -61,7 +61,9 @@ fn create_transaction(
     let inputs: Vec<CellInput> = (0..100)
         .map(|index| CellInput::new(OutPoint::new(parent.clone(), index), 0))
         .collect();
-    let cell_dep = CellDep::new(always_success_out_point.to_owned(), false);
+    let cell_dep = CellDep::new_builder()
+        .out_point(always_success_out_point.to_owned())
+        .build();
 
     TransactionBuilder::default()
         .inputs(inputs.pack())

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -265,7 +265,7 @@ pub fn test_capacity_invalid() {
 #[test]
 pub fn test_duplicate_deps() {
     let out_point = OutPoint::new(h256!("0x1"), 0);
-    let cell_dep = CellDep::new(out_point, false);
+    let cell_dep = CellDep::new_builder().out_point(out_point).build();
     let transaction = TransactionBuilder::default()
         .cell_deps(vec![cell_dep.clone(), cell_dep])
         .build();


### PR DESCRIPTION
- [x] chore: change is_dep_group(bool) to dep_type(enum)

- [x] chore: change all enum to `snake_case` in jsonrpc

  - hash_type

  - dep_type

- [x] chore: check value for all enum from network

  We can trust the serialized data from storage and the structured data from jsonrpc.
  But we should not trust the serialized data from network.

  The current serialization solution doesn't handle this, now.