### PR TITLE
fix: remove the block_ext cache

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -104,7 +104,6 @@ header_cache_size          = 4096
 cell_data_cache_size       = 128
 block_proposals_cache_size = 30
 block_tx_hashes_cache_size = 20
-block_ext_cache_size       = 20
 block_uncles_cache_size    = 10
 cellbase_cache_size        = 20
 

--- a/store/src/config.rs
+++ b/store/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BLOCK_EXT_CACHE, BLOCK_PROPOSALS_CACHE, BLOCK_TX_HASHES_CACHE, BLOCK_UNCLES_CACHE,
-    CELLBASE_CACHE, CELL_DATA_CACHE, HEADER_CACHE,
+    BLOCK_PROPOSALS_CACHE, BLOCK_TX_HASHES_CACHE, BLOCK_UNCLES_CACHE, CELLBASE_CACHE,
+    CELL_DATA_CACHE, HEADER_CACHE,
 };
 use lru_cache::LruCache;
 use serde_derive::{Deserialize, Serialize};
@@ -11,7 +11,6 @@ pub struct StoreConfig {
     pub cell_data_cache_size: usize,
     pub block_proposals_cache_size: usize,
     pub block_tx_hashes_cache_size: usize,
-    pub block_ext_cache_size: usize,
     pub block_uncles_cache_size: usize,
     pub cellbase_cache_size: usize,
 }
@@ -22,7 +21,6 @@ impl StoreConfig {
         *CELL_DATA_CACHE.lock() = LruCache::new(self.cell_data_cache_size);
         *BLOCK_PROPOSALS_CACHE.lock() = LruCache::new(self.block_proposals_cache_size);
         *BLOCK_TX_HASHES_CACHE.lock() = LruCache::new(self.block_tx_hashes_cache_size);
-        *BLOCK_EXT_CACHE.lock() = LruCache::new(self.block_ext_cache_size);
         *BLOCK_UNCLES_CACHE.lock() = LruCache::new(self.block_uncles_cache_size);
         *CELLBASE_CACHE.lock() = LruCache::new(self.cellbase_cache_size);
     }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -14,7 +14,7 @@ pub use transaction::StoreTransaction;
 use ckb_db::Col;
 use ckb_types::{
     bytes::Bytes,
-    core::{BlockExt, HeaderView, TransactionView, UncleBlockVecView},
+    core::{HeaderView, TransactionView, UncleBlockVecView},
     packed::{Byte32, ProposalShortIdVec},
 };
 use ckb_util::Mutex;
@@ -48,8 +48,6 @@ lazy_static! {
     static ref BLOCK_PROPOSALS_CACHE: Mutex<LruCache<Byte32, ProposalShortIdVec>> =
         { Mutex::new(LruCache::new(30)) };
     static ref BLOCK_TX_HASHES_CACHE: Mutex<LruCache<Byte32, Vec<Byte32>>> =
-        { Mutex::new(LruCache::new(20)) };
-    static ref BLOCK_EXT_CACHE: Mutex<LruCache<Byte32, BlockExt>> =
         { Mutex::new(LruCache::new(20)) };
     static ref BLOCK_UNCLES_CACHE: Mutex<LruCache<Byte32, UncleBlockVecView>> =
         { Mutex::new(LruCache::new(10)) };

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -1,6 +1,6 @@
 use crate::{
-    cache_enable, BLOCK_EXT_CACHE, BLOCK_PROPOSALS_CACHE, BLOCK_TX_HASHES_CACHE,
-    BLOCK_UNCLES_CACHE, CELLBASE_CACHE, CELL_DATA_CACHE, HEADER_CACHE,
+    cache_enable, BLOCK_PROPOSALS_CACHE, BLOCK_TX_HASHES_CACHE, BLOCK_UNCLES_CACHE, CELLBASE_CACHE,
+    CELL_DATA_CACHE, HEADER_CACHE,
 };
 use crate::{
     COLUMN_BLOCK_BODY, COLUMN_BLOCK_EPOCH, COLUMN_BLOCK_EXT, COLUMN_BLOCK_HEADER,
@@ -169,31 +169,12 @@ pub trait ChainStore<'a>: Send + Sync {
 
     /// Get block ext by block header hash
     fn get_block_ext(&'a self, block_hash: &packed::Byte32) -> Option<BlockExt> {
-        let cache_enable = cache_enable();
-        if cache_enable {
-            if let Some(data) = BLOCK_EXT_CACHE.lock().get_refresh(&block_hash) {
-                return Some(data.clone());
-            }
-        }
-
-        let ret = self
-            .get(COLUMN_BLOCK_EXT, block_hash.as_slice())
+        self.get(COLUMN_BLOCK_EXT, block_hash.as_slice())
             .map(|slice| {
                 packed::BlockExtReader::from_slice(&slice.as_ref()[..])
                     .should_be_ok()
                     .unpack()
-            });
-
-        if cache_enable {
-            ret.map(|data: BlockExt| {
-                BLOCK_EXT_CACHE
-                    .lock()
-                    .insert(block_hash.clone(), data.clone());
-                data
             })
-        } else {
-            ret
-        }
     }
 
     /// Get block header hash by block number


### PR DESCRIPTION
If we ran the test case `test_switch_valid_fork` separately as `cargo test test_switch_valid_fork`, the test case would fail. But when we ran `cargo test`, it passed, it was weird.

In https://github.com/nervosnetwork/ckb/blob/ba72c852d2e70176dfff0b2b3992be79dd59ef41/sync/src/tests/sync_shared_state.rs#L204-L259, there was only one store instance. After diving into it, the problem is that before we called the `get_block_ext` and cached the result, but after the fork chain became to the main chain, we called the `get_block_ext` again, it would return the stale data.

The `block_ext` is different from other data in DB, we would change it in DB, so the cache may be stale. I have not found a good way to update/clean the stale keys, so just remove it.

I think we had better not to set the `cache_enable` to `false` in any test case, this may hide some underlying bugs. I will create another PR for it.

This test case https://github.com/nervosnetwork/ckb/blob/ba72c852d2e70176dfff0b2b3992be79dd59ef41/sync/src/tests/sync_shared_state.rs#L56 is different from `test_switch_valid_fork`, but I will also try to remove the `ckb_store::set_cache_enable(false);`.