### PR TITLE
[ᚬrc/v0.19] feat: Use secp256k1 referenced by hash type "type" as the default lock.

### DIFF
--- a/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
+++ b/ckb-bin/src/subcommand/cli/secp256k1_lock.rs
@@ -2,8 +2,6 @@ use super::parse_hex_data;
 use ckb_app_config::{cli, ExitCode};
 use ckb_crypto::secp::Pubkey;
 use ckb_hash::blake2b_256;
-use ckb_jsonrpc_types::ScriptHashType;
-use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use ckb_types::H160;
 use clap::ArgMatches;
 
@@ -25,26 +23,13 @@ pub fn secp256k1_lock<'m>(matches: &ArgMatches<'m>) -> Result<(), ExitCode> {
     let pubkey_hash = blake2b_256(&pubkey.serialize());
     let pubkey_blake160 = H160::from_slice(&pubkey_hash[0..20]).unwrap();
 
-    let serialized_hash_type = serde_plain::to_string(&ScriptHashType::Data).unwrap();
-
     match matches.value_of(cli::ARG_FORMAT).unwrap() {
         "toml" => {
-            println!("[block_assembler]");
-            println!("# secp256k1_blake160_sighash_all");
-            println!(
-                "code_hash = \"{:#x}\"",
-                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL
-            );
             println!("# args = [ \"ckb cli blake160 <compressed-pubkey>\" ]");
             println!("args = [ \"{:#x}\" ]", pubkey_blake160);
-            println!("# hash_type can be Data or Type depending on the lock script");
-            println!("hash_type = \"{}\"", serialized_hash_type);
         }
         "cmd" => {
-            println!(
-                "--ba-code-hash {:#x} --ba-arg {:#x} --ba-hash-type {}",
-                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL, pubkey_blake160, serialized_hash_type,
-            );
+            println!("--ba-arg {:#x}", pubkey_blake160);
         }
         _ => unreachable!(),
     }

--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -68,22 +68,22 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         check_db_compatibility(db_path);
         check_db_compatibility(indexer_db_path);
 
-        let _block_assembler_code_hash = prompt("code hash: ");
-        let _args = prompt("args: ");
-        let _data = prompt("data: ");
-        let _hash_type = prompt("hash_type: ");
+        let in_block_assembler_code_hash = prompt("code hash: ");
+        let in_args = prompt("args: ");
+        let in_data = prompt("data: ");
+        let in_hash_type = prompt("hash_type: ");
 
-        args.block_assembler_code_hash = Some(_block_assembler_code_hash.trim().to_string());
+        args.block_assembler_code_hash = Some(in_block_assembler_code_hash.trim().to_string());
 
-        args.block_assembler_args = _args
+        args.block_assembler_args = in_args
             .trim()
             .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
 
-        args.block_assembler_data = Some(_data.trim().to_string());
+        args.block_assembler_data = Some(in_data.trim().to_string());
 
-        match serde_plain::from_str::<ScriptHashType>(_hash_type.trim()).ok() {
+        match serde_plain::from_str::<ScriptHashType>(in_hash_type.trim()).ok() {
             Some(hash_type) => args.block_assembler_hash_type = hash_type,
             None => eprintln!("Invalid block assembler hash type"),
         }
@@ -108,7 +108,13 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
 
     let block_assembler = match block_assembler_code_hash {
         Some(hash) => {
-            if default_code_hash_string != *hash {
+            if ScriptHashType::Type != args.block_assembler_hash_type {
+                eprintln!(
+                    "WARN: the default lock should use hash type `{}`, you are using `{}`.\n\
+                     It will require `ckb run --ba-advanced` to enable this block assembler",
+                    default_hash_type, args.block_assembler_hash_type
+                );
+            } else if default_code_hash_string != *hash {
                 eprintln!(
                     "WARN: the default secp256k1 code hash is `{:#x}`, you are using `{}`.\n\
                      It will require `ckb run --ba-advanced` to enable this block assembler",

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -85,10 +85,10 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
                     )
                 } else {
                     info_target!(
-                        crate::LOG_TARGET_MAIN,
-                        "Miner is disabled because block assmebler is not a valid secp256k1 lock. \
-                         Edit ckb.toml or use `ckb run --ba-advanced` to use other lock scripts"
-                    );
+                    crate::LOG_TARGET_MAIN,
+                    "Miner is disabled because block assmebler is not a recommended lock format. \
+                     Edit ckb.toml or use `ckb run --ba-advanced` to use other lock scripts"
+                );
 
                     None
                 }

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,128 +2,128 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0x18e9e6d010fffd071f9c3ac87196d9789f385064ab2b9942d96b842323e2028c"
-cellbase = "0xe284ea2bd7013c06ed471108e4c5cdf06b08e84293241075b7fce4bb7eeac906"
+genesis = "0xebf5cca491c4760c1b4d9306e6aed35b17d773ab60650ed58974a84b2d0fb82c"
+cellbase = "0x24f1ca595fbeb53f265e6f994a4f0cb15ce3de001ea7ec98e39bd9381ffd247c"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0xe284ea2bd7013c06ed471108e4c5cdf06b08e84293241075b7fce4bb7eeac906"
+tx_hash = "0x24f1ca595fbeb53f265e6f994a4f0cb15ce3de001ea7ec98e39bd9381ffd247c"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0xe284ea2bd7013c06ed471108e4c5cdf06b08e84293241075b7fce4bb7eeac906"
+tx_hash = "0x24f1ca595fbeb53f265e6f994a4f0cb15ce3de001ea7ec98e39bd9381ffd247c"
 index = 2
 data_hash = "0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6"
 type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0xe284ea2bd7013c06ed471108e4c5cdf06b08e84293241075b7fce4bb7eeac906"
+tx_hash = "0x24f1ca595fbeb53f265e6f994a4f0cb15ce3de001ea7ec98e39bd9381ffd247c"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0xe284ea2bd7013c06ed471108e4c5cdf06b08e84293241075b7fce4bb7eeac906"
+tx_hash = "0x24f1ca595fbeb53f265e6f994a4f0cb15ce3de001ea7ec98e39bd9381ffd247c"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x9a0d9a0d8bb39cbe468783df7db219f8eb1a703691e3bd2f691f3d1568a3abc1"
+tx_hash = "0xc640423e9c8f53855a471c66e3d915fee4f653ac7f7e82033139d25df2ad9aad"
 index = 0
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x9a0d9a0d8bb39cbe468783df7db219f8eb1a703691e3bd2f691f3d1568a3abc1"
+tx_hash = "0xc640423e9c8f53855a471c66e3d915fee4f653ac7f7e82033139d25df2ad9aad"
 index = 1
 
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0x3492f329495f2c2068e1b72b54b10d2409b420633e084a994e9a4231b9cfce8c"
-cellbase = "0x4afcd0f5c6f6bde5a6d9240fa33515a2013b397a5ed4fd23fa5d6dbdc6f4073a"
+genesis = "0x82b930c957d4f98f8e8214d567a964e3e2814e67868ebe3e4a09243eedfe727f"
+cellbase = "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x4afcd0f5c6f6bde5a6d9240fa33515a2013b397a5ed4fd23fa5d6dbdc6f4073a"
+tx_hash = "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x4afcd0f5c6f6bde5a6d9240fa33515a2013b397a5ed4fd23fa5d6dbdc6f4073a"
+tx_hash = "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60"
 index = 2
 data_hash = "0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6"
 type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x4afcd0f5c6f6bde5a6d9240fa33515a2013b397a5ed4fd23fa5d6dbdc6f4073a"
+tx_hash = "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x4afcd0f5c6f6bde5a6d9240fa33515a2013b397a5ed4fd23fa5d6dbdc6f4073a"
+tx_hash = "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x161517cf5dc24b5a90129f3a73ef2b6a03795e6590f932bdec1a95318281e5fe"
+tx_hash = "0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x161517cf5dc24b5a90129f3a73ef2b6a03795e6590f932bdec1a95318281e5fe"
+tx_hash = "0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b"
 index = 1
 
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0xca554ac3dfb0a8e6ed70c1d1109e363cfe1c4d645857bec7a68653c8d88968d8"
-cellbase = "0x5b74744b5f4670e0d3db1ea3e8fb01bcf011733b4b7360cca57f20388bdb17be"
+genesis = "0xf2392c3a2beb661d2bbf05b3351a64f2944ce0fb0f7ffb33324cbd1af6769690"
+cellbase = "0xb44a9f674e44cfb6e4a47ea8ea52369bc245d538f84181479e94952b714c71e1"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x5b74744b5f4670e0d3db1ea3e8fb01bcf011733b4b7360cca57f20388bdb17be"
+tx_hash = "0xb44a9f674e44cfb6e4a47ea8ea52369bc245d538f84181479e94952b714c71e1"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x5b74744b5f4670e0d3db1ea3e8fb01bcf011733b4b7360cca57f20388bdb17be"
+tx_hash = "0xb44a9f674e44cfb6e4a47ea8ea52369bc245d538f84181479e94952b714c71e1"
 index = 2
 data_hash = "0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6"
 type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x5b74744b5f4670e0d3db1ea3e8fb01bcf011733b4b7360cca57f20388bdb17be"
+tx_hash = "0xb44a9f674e44cfb6e4a47ea8ea52369bc245d538f84181479e94952b714c71e1"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x5b74744b5f4670e0d3db1ea3e8fb01bcf011733b4b7360cca57f20388bdb17be"
+tx_hash = "0xb44a9f674e44cfb6e4a47ea8ea52369bc245d538f84181479e94952b714c71e1"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x795ff46a579c9c73d1f440c30a1137f7dd7e391a27db887ca1f6f007f4c5ef1a"
+tx_hash = "0x35e5149e8306605e404bc99bfaa073af91ac4f738d16ee371c458e5beb366320"
 index = 0
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x795ff46a579c9c73d1f440c30a1137f7dd7e391a27db887ca1f6f007f4c5ef1a"
+tx_hash = "0x35e5149e8306605e404bc99bfaa073af91ac4f738d16ee371c458e5beb366320"
 index = 1

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -138,7 +138,7 @@ cellbase_cache_size        = 20
 #       sed 's/41534e31204f49443a20736563703235366b310a30740201010420/PrivKey: /' | \
 #       sed 's/a00706052b8104000aa144034200/\'$'\nPubKey: /'
 #
-# Once you get your public key, generate the block assembler parameters:
+# Once you get your public key, generate the args for block assembler:
 #
 #     ckb cli secp256k1-lock <pubkey>
 #

--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -48,23 +48,23 @@ secp256k1_ripemd160_sha256_sighash_all = [
 ]
 
 [genesis.bootstrap_lock]
-code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 args = ["0xb2e61ff569acf041b3c2c17724e2379c581eeac3"]
-hash_type = "data"
+hash_type = "type"
 
 # issue 5M cell for random generated private key: d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc
 [[genesis.issued_cells]]
 capacity = 5_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 
 # issue 5M cell for random generated private key: 63d86723e08f0f813a36ce6aa123bb2289d90680ae1e99d4de8cdb334553f24d
 [[genesis.issued_cells]]
 capacity = 5_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x470dcdc5e44064909650113a274b3b36aecb6dc7"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/resource/specs/staging.toml
+++ b/resource/specs/staging.toml
@@ -48,27 +48,27 @@ secp256k1_ripemd160_sha256_sighash_all = [
 ]
 
 [genesis.bootstrap_lock]
-code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 # Lock for developers to run tests
 args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-hash_type = "data"
+hash_type = "type"
 
 # Locks for developers to run tests
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x3f1573b44218d4c12a91919a58a863be415a2bc3"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x10000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0x3492f329495f2c2068e1b72b54b10d2409b420633e084a994e9a4231b9cfce8c"
+hash = "0x82b930c957d4f98f8e8214d567a964e3e2814e67868ebe3e4a09243eedfe727f"
 
 [genesis.genesis_cell]
 message = "rylai-v8 54d710d5 feat: difficulty adjustment rfc version <zhangsoledad 2019-07-25 21:01:35 +0800>"
@@ -50,27 +50,27 @@ secp256k1_ripemd160_sha256_sighash_all = [
 ]
 
 [genesis.bootstrap_lock]
-code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 # Lock for developers to run tests
 args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-hash_type = "data"
+hash_type = "type"
 
 # Locks for developers to run tests
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x64257f00b6b63e987609fa9be2d0c86d351020fb"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x3f1573b44218d4c12a91919a58a863be415a2bc3"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c"
+lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -32,6 +32,7 @@ env_logger = "0.6"
 crossbeam-channel = "0.3"
 regex = "1"
 faketime = "0.2"
+failure = "0.1.5"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -270,7 +270,7 @@ fn cli_blake160() -> App<'static, 'static> {
 
 fn cli_secp256k1_lock() -> App<'static, 'static> {
     SubCommand::with_name(CMD_SECP256K1_LOCK)
-        .about("Prints lock structure from secp256k1 pubkey")
+        .about("Prints lock args from secp256k1 pubkey")
         .arg(
             Arg::with_name(ARG_DATA)
                 .short("d")
@@ -364,11 +364,8 @@ fn init() -> App<'static, 'static> {
                 .value_name("hash_type")
                 .takes_value(true)
                 .possible_values(&["data", "type"])
-                .default_value("data")
-                .help(
-                    "Sets hash type in [block_assembler] \
-                     [default: data]",
-                ),
+                .default_value("type")
+                .help("Sets hash type in [block_assembler]"),
         )
         .group(
             ArgGroup::with_name(GROUP_BA)

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -2,6 +2,7 @@ use crate::bytes::JsonBytes;
 use crate::{BlockNumber, Capacity, EpochNumber, ProposalShortId, Timestamp, Unsigned, Version};
 use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -30,6 +31,15 @@ impl From<core::ScriptHashType> for ScriptHashType {
         match core {
             core::ScriptHashType::Data => ScriptHashType::Data,
             core::ScriptHashType::Type => ScriptHashType::Type,
+        }
+    }
+}
+
+impl fmt::Display for ScriptHashType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            ScriptHashType::Data => write!(f, "data"),
+            ScriptHashType::Type => write!(f, "type"),
         }
     }
 }


### PR DESCRIPTION
Co-authored-by: Quake <quake@nervos.org>
Co-authored-by: Qian Linfeng <thewawar@cryptape.com>