### PR TITLE
feat(Improvement): Compact Block only includes uncle blocks hash

### DIFF
--- a/sync/src/relayer/block_uncles_verifier.rs
+++ b/sync/src/relayer/block_uncles_verifier.rs
@@ -1,0 +1,37 @@
+use crate::relayer::error::{Error, Misbehavior};
+use ckb_types::{core, packed};
+
+pub struct BlockUnclesVerifier {}
+
+impl BlockUnclesVerifier {
+    pub(crate) fn verify(
+        block: &packed::CompactBlock,
+        indexes: &[u32],
+        uncles: &[core::UncleBlockView],
+    ) -> Result<(), Error> {
+        let expected_uncles = block.uncles();
+        let expected_ids: Vec<packed::Byte32> = indexes
+            .iter()
+            .filter_map(|index| expected_uncles.get(*index as usize).clone())
+            .collect();
+
+        if expected_ids.len() != uncles.len() {
+            return Err(Error::Misbehavior(Misbehavior::InvalidBlockUnclesLength {
+                expect: expected_ids.len(),
+                got: uncles.len(),
+            }));
+        }
+
+        for (expected_id, uncle) in expected_ids.into_iter().zip(uncles) {
+            let hash = uncle.hash();
+            if hash != expected_id {
+                return Err(Error::Misbehavior(Misbehavior::InvalidBlockUncles {
+                    expect: expected_id,
+                    got: hash,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/sync/src/relayer/error.rs
+++ b/sync/src/relayer/error.rs
@@ -1,4 +1,4 @@
-use ckb_types::packed::ProposalShortId;
+use ckb_types::packed::{Byte32, ProposalShortId};
 use failure::Fail;
 
 #[derive(Debug, Fail, Eq, PartialEq)]
@@ -44,10 +44,22 @@ pub enum Misbehavior {
         expected: ProposalShortId,
         actual: ProposalShortId,
     },
+    #[fail(
+        display = "block uncles' length is invalid, expect {}, but got {}",
+        expect, got
+    )]
+    InvalidBlockUnclesLength { expect: usize, got: usize },
+    #[fail(
+        display = "block unlces' hash is invalid, expect {:#?}, but got {:#?}",
+        expect, got
+    )]
+    InvalidBlockUncles { expect: Byte32, got: Byte32 },
     #[fail(display = "BlockInvalid")]
     BlockInvalid,
     #[fail(display = "HeaderInvalid")]
     HeaderInvalid,
+    #[fail(display = "UncleInvalid")]
+    InvalidUncle,
 }
 
 #[derive(Debug, Fail, Eq, PartialEq)]

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 
 // There are more test cases in block_transactions_process and compact_block_process.rs
 #[test]
-fn test_reconstruct_block() {
+fn test_missing_txs() {
     let (relayer, always_success_out_point) = build_chain(5);
     let prepare: Vec<TransactionView> = (0..20)
         .map(|i| new_transaction(&relayer, i, &always_success_out_point))
@@ -23,8 +23,8 @@ fn test_reconstruct_block() {
         let transactions: Vec<TransactionView> = prepare.iter().skip(1).cloned().collect();
         let compact = compact_block_builder.short_ids(short_ids.pack()).build();
         assert_eq!(
-            relayer.reconstruct_block(&compact, transactions),
-            Err(ReconstructionError::MissingIndexes(vec![0])),
+            relayer.reconstruct_block(&compact, transactions, &[], &[]),
+            Err(ReconstructionError::MissingIndexes(vec![0], vec![])),
         );
     }
 
@@ -42,45 +42,100 @@ fn test_reconstruct_block() {
             .collect();
         let compact = compact_block_builder.short_ids(short_ids.pack()).build();
         assert_eq!(
-            relayer.reconstruct_block(&compact, transactions),
-            Err(ReconstructionError::MissingIndexes(missing)),
+            relayer.reconstruct_block(&compact, transactions, &[], &[]),
+            Err(ReconstructionError::MissingIndexes(missing, vec![])),
         );
     }
+}
 
-    // Case: short transactions lie on pool but not proposed, can be used to reconstruct block also
+#[test]
+fn test_reconstruct_transactions_and_uncles() {
+    let (relayer, always_success_out_point) = build_chain(5);
+    let prepare: Vec<TransactionView> = (0..20)
+        .map(|i| new_transaction(&relayer, i, &always_success_out_point))
+        .collect();
+
+    let (short_transactions, prefilled) = {
+        let short_transactions: Vec<TransactionView> = prepare.iter().step_by(2).cloned().collect();
+        let prefilled: HashSet<usize> = prepare
+            .iter()
+            .enumerate()
+            .skip(1)
+            .step_by(2)
+            .map(|(i, _)| i)
+            .collect();
+        (short_transactions, prefilled)
+    };
+
+    let uncle = packed::BlockBuilder::default().build();
+    // BLOCK_VALID
+    let ext = packed::BlockExtBuilder::default()
+        .verified(Some(true).pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .transactions(prepare.into_iter().map(|v| v.data()).pack())
+        .uncles(vec![uncle.clone().as_uncle()].pack())
+        .build();
+
+    let hash = block.calc_header_hash();
+
+    let compact = packed::CompactBlock::build_from_block(&block.into_view(), &prefilled);
+
+    // Should reconstruct block successfully with pool txs
+    let (pool_transactions, short_transactions) = short_transactions.split_at(2);
+    let short_transactions: Vec<TransactionView> = short_transactions.to_vec();
+    pool_transactions.iter().for_each(|tx| {
+        // `tx` is added into pool but not be proposed, since `tx` has not been proposal yet
+        relayer
+            .tx_pool_executor
+            .verify_and_add_tx_to_pool(tx.clone())
+            .expect("adding transaction into pool");
+    });
+
     {
-        let (short_transactions, prefilled) = {
-            let short_transactions: Vec<TransactionView> =
-                prepare.iter().step_by(2).cloned().collect();
-            let prefilled: HashSet<usize> = prepare
-                .iter()
-                .enumerate()
-                .skip(1)
-                .step_by(2)
-                .map(|(i, _)| i)
-                .collect();
-            (short_transactions, prefilled)
-        };
-
-        let block = BlockBuilder::default()
-            .transactions(prepare.into_iter().map(|v| v.data()).pack())
-            .build();
-
-        let compact = packed::CompactBlock::build_from_block(&block.into_view(), &prefilled);
-
-        // Should reconstruct block successfully with pool txs
-        let (pool_transactions, short_transactions) = short_transactions.split_at(2);
-        let short_transactions: Vec<TransactionView> = short_transactions.to_vec();
-        pool_transactions.iter().for_each(|tx| {
-            // `tx` is added into pool but not be proposed, since `tx` has not been proposal yet
-            relayer
-                .tx_pool_executor
-                .verify_and_add_tx_to_pool(tx.clone())
-                .expect("adding transaction into pool");
-        });
-
-        assert!(relayer
-            .reconstruct_block(&compact, short_transactions)
-            .is_ok());
+        let uncle_view = uncle.into_view();
+        let db_txn = relayer.shared().store().begin_transaction();
+        db_txn.insert_block(&uncle_view).unwrap();
+        db_txn.attach_block(&uncle_view).unwrap();
+        db_txn.insert_block_ext(&hash, &ext.unpack()).unwrap();
+        db_txn.commit().unwrap();
     }
+
+    assert!(relayer
+        .reconstruct_block(&compact, short_transactions.clone(), &[], &[])
+        .is_ok());
+}
+
+#[test]
+fn test_reconstruct_invalid_uncles() {
+    let (relayer, _) = build_chain(5);
+
+    let uncle = packed::BlockBuilder::default().build();
+    // BLOCK_VALID
+    let ext = packed::BlockExtBuilder::default()
+        .verified(Some(false).pack())
+        .build();
+
+    let block = BlockBuilder::default()
+        .uncles(vec![uncle.clone().as_uncle()].pack())
+        .build();
+
+    let hash = block.calc_header_hash();
+
+    let compact = packed::CompactBlock::build_from_block(&block.into_view(), &Default::default());
+
+    {
+        let uncle_view = uncle.into_view();
+        let db_txn = relayer.shared().store().begin_transaction();
+        db_txn.insert_block(&uncle_view).unwrap();
+        db_txn.attach_block(&uncle_view).unwrap();
+        db_txn.insert_block_ext(&hash, &ext.unpack()).unwrap();
+        db_txn.commit().unwrap();
+    }
+
+    assert_eq!(
+        relayer.reconstruct_block(&compact, vec![], &[], &[]),
+        Err(ReconstructionError::InvalidUncle)
+    );
 }

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -579,7 +579,14 @@ impl EpochIndices {
     }
 }
 
-type PendingCompactBlockMap = HashMap<Byte32, (packed::CompactBlock, HashMap<PeerIndex, Vec<u32>>)>;
+// <CompactBlockHash, (CompactBlock, <PeerIndex, (TransactionsIndex, UnclesIndex)>)>
+type PendingCompactBlockMap = HashMap<
+    Byte32,
+    (
+        packed::CompactBlock,
+        HashMap<PeerIndex, (Vec<u32>, Vec<u32>)>,
+    ),
+>;
 
 pub struct SyncSharedState {
     shared: Shared,
@@ -1066,6 +1073,14 @@ impl SyncSharedState {
             block_status_map.remove(&b.hash());
         });
         blocks
+    }
+
+    pub fn get_orphan_block(&self, block_hash: &Byte32) -> Option<core::BlockView> {
+        self.orphan_block_pool.get_block(block_hash)
+    }
+
+    pub fn get_block(&self, block_hash: &Byte32) -> Option<core::BlockView> {
+        self.shared.store().get_block(block_hash)
     }
 
     pub fn get_block_status(&self, block_hash: &Byte32) -> BlockStatus {

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -222,7 +222,7 @@ table CompactBlock {
     header:                     Header,
     short_ids:                  ProposalShortIdVec,
     prefilled_transactions:     IndexTransactionVec,
-    uncles:                     UncleBlockVec,
+    uncles:                     Byte32Vec,
     proposals:                  ProposalShortIdVec,
 }
 
@@ -247,11 +247,13 @@ table GetRelayTransactions {
 table GetBlockTransactions {
     block_hash:                 Byte32,
     indexes:                    Uint32Vec,
+    uncle_indexes:              Uint32Vec,
 }
 
 table BlockTransactions {
     block_hash:                 Byte32,
     transactions:               TransactionVec,
+    uncles:                     UncleBlockVec,
 }
 
 table GetBlockProposal {

--- a/util/types/src/extension/shortcuts.rs
+++ b/util/types/src/extension/shortcuts.rs
@@ -204,7 +204,7 @@ impl packed::CompactBlock {
             .header(block.data().header())
             .short_ids(short_ids.pack())
             .prefilled_transactions(prefilled_transactions.pack())
-            .uncles(block.data().uncles())
+            .uncles(block.uncle_hashes.clone())
             .proposals(block.data().proposals())
             .build()
     }


### PR DESCRIPTION
The peer should already have the uncle blocks at a high probability. If the peer cannot find the uncle locally, use download uncle to get the header and proposals.