### PR TITLE
fix: block header should keep consistency with ext in storage

### DIFF
--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -385,6 +385,14 @@ pub trait ChainStore<'a>: Send + Sync {
         self.get(COLUMN_UNCLES, hash.as_slice()).is_some()
     }
 
+    /// Get header by uncle header hash
+    fn get_uncle_header(&'a self, hash: &packed::Byte32) -> Option<HeaderView> {
+        self.get(COLUMN_UNCLES, hash.as_slice()).map(|slice| {
+            let reader = packed::HeaderViewReader::from_slice(&slice.as_ref()).should_be_ok();
+            Unpack::<HeaderView>::unpack(&reader)
+        })
+    }
+
     fn block_exists(&'a self, hash: &packed::Byte32) -> bool {
         self.get(COLUMN_BLOCK_HEADER, hash.as_slice()).is_some()
     }

--- a/store/src/transaction.rs
+++ b/store/src/transaction.rs
@@ -147,9 +147,8 @@ impl StoreTransaction {
         let block_number: packed::Uint64 = block.number().pack();
         self.insert_raw(COLUMN_INDEX, block_number.as_slice(), block_hash.as_slice())?;
         for uncle in block.uncles().into_iter() {
-            self.insert_raw(COLUMN_UNCLES, &uncle.hash().as_slice(), &[])?;
             self.insert_raw(
-                COLUMN_BLOCK_HEADER,
+                COLUMN_UNCLES,
                 &uncle.hash().as_slice(),
                 &uncle.header().pack().as_slice(),
             )?;

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -179,6 +179,7 @@ fn all_specs() -> SpecMap {
         Box::new(BlockSyncForks),
         Box::new(BlockSyncDuplicatedAndReconnect),
         Box::new(BlockSyncOrphanBlocks),
+        Box::new(BlockSyncWithUncle),
         Box::new(SyncTimeout),
         Box::new(ChainContainsInvalidBlock),
         Box::new(ForkContainsInvalidBlock),

--- a/util/types/src/core/advanced_builders.rs
+++ b/util/types/src/core/advanced_builders.rs
@@ -8,7 +8,7 @@ use crate::{constants, core, packed, prelude::*, H256, U256};
  * Definitions
  */
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TransactionBuilder {
     pub(crate) version: packed::Uint32,
     pub(crate) cell_deps: Vec<packed::CellDep>,
@@ -19,7 +19,7 @@ pub struct TransactionBuilder {
     pub(crate) outputs_data: Vec<packed::Bytes>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HeaderBuilder {
     // RawHeader
     pub(crate) version: packed::Uint32,
@@ -38,7 +38,7 @@ pub struct HeaderBuilder {
     pub(crate) nonce: packed::Uint64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BlockBuilder {
     pub(crate) header: HeaderBuilder,
     // Others

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -101,19 +101,15 @@ impl<'a, 'b, CS: ChainStore<'a>> UncleProvider for UncleVerifierContext<'a, 'b, 
         let uncle_number = uncle.number();
         let store = self.context.store;
 
-        let number_continuity = |parent_hash| {
-            store
+        if store.get_block_number(&parent_hash).is_some() {
+            return store
                 .get_block_header(&parent_hash)
                 .map(|parent| (parent.number() + 1) == uncle_number)
-                .unwrap_or(false)
-        };
-
-        if store.get_block_number(&parent_hash).is_some() {
-            return number_continuity(parent_hash);
+                .unwrap_or(false);
         }
 
-        if store.is_uncle(&parent_hash) {
-            return number_continuity(parent_hash);
+        if let Some(uncle_parent) = store.get_uncle_header(&parent_hash) {
+            return (uncle_parent.number() + 1) == uncle_number;
         }
 
         false


### PR DESCRIPTION
fix the issue from https://github.com/nervosnetwork/ckb/pull/1478,
PR#1478 stored uncle header in `COLUMN_BLOCK_HEADER`, broken conventional consistency.
many codes rely on header-body-ext consistency.