### PR TITLE
chore: update block capacity

### DIFF
--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -72,13 +72,5 @@ lock.code_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
 lock.hash_type = "type"
 
-[params]
-epoch_reward = 1_250_000_00000000
-secondary_epoch_reward = 600_000_00000000
-# Cellbase outputs are "locked" and require 4 * MAX_EPOCH_LENGTH(1800) confirmations(approximately 16 hours)
-# before they mature sufficiently to be spendable,
-# This is to reduce the risk of later txs being reversed if a chain reorganization occurs.
-cellbase_maturity = 7_200
-
 [pow]
 func = "Eaglesong"

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -75,7 +75,6 @@ lock.hash_type = "type"
 [params]
 epoch_reward = 1_250_000_00000000
 secondary_epoch_reward = 600_000_00000000
-max_block_cycles = 10_000_000_000
 # Cellbase outputs are "locked" and require 4 * MAX_EPOCH_LENGTH(1800) confirmations(approximately 16 hours)
 # before they mature sufficiently to be spendable,
 # This is to reduce the risk of later txs being reversed if a chain reorganization occurs.

--- a/shared/src/tx_pool.rs
+++ b/shared/src/tx_pool.rs
@@ -9,7 +9,7 @@ mod proposed;
 pub use self::pool::TxPool;
 pub use self::types::{DefectEntry, PoolError, TxEntry, TxPoolConfig};
 
-const DEFAULT_BYTES_PER_CYCLES: f64 = 0.00042f64;
+const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_051f64;
 
 /// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
 /// tx_pool use vbytes to estimate transaction fee rate.

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -18,40 +18,45 @@ use std::sync::Arc;
 // TODO: add secondary reward for miner
 pub(crate) const DEFAULT_SECONDARY_EPOCH_REWARD: Capacity = capacity_bytes!(600_000);
 pub(crate) const DEFAULT_EPOCH_REWARD: Capacity = capacity_bytes!(1_250_000);
-pub(crate) const MAX_UNCLE_NUM: usize = 2;
-pub(crate) const TX_PROPOSAL_WINDOW: ProposalWindow = ProposalWindow(2, 10);
+const MAX_UNCLE_NUM: usize = 2;
+const TX_PROPOSAL_WINDOW: ProposalWindow = ProposalWindow(2, 10);
 // Cellbase outputs are "locked" and require 4 * MAX_EPOCH_LENGTH(1800) confirmations(approximately 16 hours)
 // before they mature sufficiently to be spendable,
 // This is to reduce the risk of later txs being reversed if a chain reorganization occurs.
 pub(crate) const CELLBASE_MATURITY: BlockNumber = 4 * MAX_EPOCH_LENGTH;
 // TODO: should adjust this value based on CKB average block time
-pub(crate) const MEDIAN_TIME_BLOCK_COUNT: usize = 11;
+const MEDIAN_TIME_BLOCK_COUNT: usize = 11;
 
 // dampening factor
-pub(crate) const TAU: u64 = 2;
+const TAU: u64 = 2;
 
 // o_ideal = 1/20 = 5%
-pub(crate) const ORPHAN_RATE_TARGET: RationalU256 = RationalU256::new_raw(U256::one(), u256!("20"));
-pub(crate) const GENESIS_ORPHAN_COUNT: u64 = GENESIS_EPOCH_LENGTH / 20;
+const ORPHAN_RATE_TARGET: RationalU256 = RationalU256::new_raw(U256::one(), u256!("20"));
+const GENESIS_ORPHAN_COUNT: u64 = GENESIS_EPOCH_LENGTH / 20;
 
 const MAX_BLOCK_INTERVAL: u64 = 30; // 30s
 const MIN_BLOCK_INTERVAL: u64 = 8; // 8s
+
+// cycles of a typical two-in-two-out tx
 const TWO_IN_TWO_OUT_CYCLES: Cycle = 13_300_000;
+// bytes of a typical two-in-two-out tx
 const TWO_IN_TWO_OUT_BYTES: u64 = 673;
+// count of two-in-two-out txs a block should capable to package
+// approximately equal to 50_000_000_000 / TWO_IN_TWO_OUT_CYCLES
 const TWO_IN_TWO_OUT_COUNT: u64 = 3875;
-pub(crate) const EPOCH_DURATION_TARGET: u64 = 4 * 60 * 60; // 4 hours, unit: second
-pub(crate) const MILLISECONDS_IN_A_SECOND: u64 = 1000;
-pub(crate) const MAX_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MIN_BLOCK_INTERVAL; // 1800
-pub(crate) const MIN_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MAX_BLOCK_INTERVAL; // 480
+const EPOCH_DURATION_TARGET: u64 = 4 * 60 * 60; // 4 hours, unit: second
+const MILLISECONDS_IN_A_SECOND: u64 = 1000;
+const MAX_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MIN_BLOCK_INTERVAL; // 1800
+const MIN_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MAX_BLOCK_INTERVAL; // 480
 
 // We choose 1_000 because it is largest number between MIN_EPOCH_LENGTH and MAX_EPOCH_LENGTH that
 // can divide DEFAULT_EPOCH_REWARD and can be divided by ORPHAN_RATE_TARGET_RECIP.
-pub(crate) const GENESIS_EPOCH_LENGTH: u64 = 1_000;
+const GENESIS_EPOCH_LENGTH: u64 = 1_000;
 
-pub(crate) const MAX_BLOCK_BYTES: u64 = TWO_IN_TWO_OUT_BYTES * TWO_IN_TWO_OUT_COUNT;
+const MAX_BLOCK_BYTES: u64 = TWO_IN_TWO_OUT_BYTES * TWO_IN_TWO_OUT_COUNT;
 pub(crate) const MAX_BLOCK_CYCLES: u64 = TWO_IN_TWO_OUT_CYCLES * TWO_IN_TWO_OUT_COUNT;
-pub(crate) const MAX_BLOCK_PROPOSALS_LIMIT: u64 = 3_000;
-pub(crate) const PROPOSER_REWARD_RATIO: Ratio = Ratio(4, 10);
+const MAX_BLOCK_PROPOSALS_LIMIT: u64 = 3_000;
+const PROPOSER_REWARD_RATIO: Ratio = Ratio(4, 10);
 
 #[derive(Clone, PartialEq, Debug, Eq, Copy)]
 pub struct ProposalWindow(pub BlockNumber, pub BlockNumber);

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -36,7 +36,9 @@ pub(crate) const GENESIS_ORPHAN_COUNT: u64 = GENESIS_EPOCH_LENGTH / 20;
 
 const MAX_BLOCK_INTERVAL: u64 = 30; // 30s
 const MIN_BLOCK_INTERVAL: u64 = 8; // 8s
-const TWO_IN_TWO_OUT_CYCLES: Cycle = 2_580_000;
+const TWO_IN_TWO_OUT_CYCLES: Cycle = 13_300_000;
+const TWO_IN_TWO_OUT_BYTES: u64 = 673;
+const TWO_IN_TWO_OUT_COUNT: u64 = 3875;
 pub(crate) const EPOCH_DURATION_TARGET: u64 = 4 * 60 * 60; // 4 hours, unit: second
 pub(crate) const MILLISECONDS_IN_A_SECOND: u64 = 1000;
 pub(crate) const MAX_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MIN_BLOCK_INTERVAL; // 1800
@@ -46,8 +48,8 @@ pub(crate) const MIN_EPOCH_LENGTH: u64 = EPOCH_DURATION_TARGET / MAX_BLOCK_INTER
 // can divide DEFAULT_EPOCH_REWARD and can be divided by ORPHAN_RATE_TARGET_RECIP.
 pub(crate) const GENESIS_EPOCH_LENGTH: u64 = 1_000;
 
-pub(crate) const MAX_BLOCK_BYTES: u64 = 2_000_000; // 2mb
-pub(crate) const MAX_BLOCK_CYCLES: u64 = TWO_IN_TWO_OUT_CYCLES * 200 * 8;
+pub(crate) const MAX_BLOCK_BYTES: u64 = TWO_IN_TWO_OUT_BYTES * TWO_IN_TWO_OUT_COUNT;
+pub(crate) const MAX_BLOCK_CYCLES: u64 = TWO_IN_TWO_OUT_CYCLES * TWO_IN_TWO_OUT_COUNT;
 pub(crate) const MAX_BLOCK_PROPOSALS_LIMIT: u64 = 3_000;
 pub(crate) const PROPOSER_REWARD_RATIO: Ratio = Ratio(4, 10);
 

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -52,6 +52,7 @@ pub struct ChainSpec {
 pub struct Params {
     pub epoch_reward: Capacity,
     pub secondary_epoch_reward: Capacity,
+    #[serde(default)]
     pub max_block_cycles: Cycle,
     pub cellbase_maturity: BlockNumber,
 }

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -44,6 +44,7 @@ const SPECIAL_CELL_CAPACITY: Capacity = capacity_bytes!(500);
 pub struct ChainSpec {
     pub name: String,
     pub genesis: Genesis,
+    #[serde(default)]
     pub params: Params,
     pub pow: Pow,
 }
@@ -52,9 +53,23 @@ pub struct ChainSpec {
 pub struct Params {
     pub epoch_reward: Capacity,
     pub secondary_epoch_reward: Capacity,
-    #[serde(default)]
     pub max_block_cycles: Cycle,
     pub cellbase_maturity: BlockNumber,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        use crate::consensus::{
+            CELLBASE_MATURITY, DEFAULT_EPOCH_REWARD, DEFAULT_SECONDARY_EPOCH_REWARD,
+            MAX_BLOCK_CYCLES,
+        };
+        Params {
+            epoch_reward: DEFAULT_EPOCH_REWARD,
+            secondary_epoch_reward: DEFAULT_SECONDARY_EPOCH_REWARD,
+            max_block_cycles: MAX_BLOCK_CYCLES,
+            cellbase_maturity: CELLBASE_MATURITY,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -249,7 +249,7 @@ fn all_specs() -> SpecMap {
             "send_secp_tx_use_dep_group_type_hash",
             ScriptHashType::Type,
         )),
-        Box::new(CheckTypical2In2OutTx::new()),
+        Box::new(CheckTypical2In2OutTx::default()),
         Box::new(AlertPropagation::default()),
         Box::new(IndexerBasic),
         Box::new(GenesisIssuedCells),

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -249,6 +249,7 @@ fn all_specs() -> SpecMap {
             "send_secp_tx_use_dep_group_type_hash",
             ScriptHashType::Type,
         )),
+        Box::new(CheckTypical2In2OutTx::new()),
         Box::new(AlertPropagation::default()),
         Box::new(IndexerBasic),
         Box::new(GenesisIssuedCells),

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -220,6 +220,14 @@ impl RpcClient {
         self.inner.lock().send_transaction(tx).call()
     }
 
+    pub fn dry_run_transaction(&self, tx: Transaction) -> DryRunResult {
+        self.inner
+            .lock()
+            .dry_run_transaction(tx)
+            .call()
+            .expect("rpc call dry_run_transaction")
+    }
+
     pub fn send_alert(&self, alert: Alert) {
         self.inner
             .lock()

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -18,5 +18,5 @@ pub use different_txs_with_same_input::DifferentTxsWithSameInput;
 pub use limit::{CyclesLimit, SizeLimit};
 pub use pool_reconcile::PoolReconcile;
 pub use pool_resurrect::PoolResurrect;
-pub use send_secp_tx::SendSecpTxUseDepGroup;
+pub use send_secp_tx::{CheckTypical2In2OutTx, SendSecpTxUseDepGroup};
 pub use valid_since::ValidSince;

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -9,12 +9,15 @@ use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
 use ckb_types::{
     bytes::Bytes,
     constants::TYPE_ID_CODE_HASH,
-    core::{capacity_bytes, Capacity, DepType, ScriptHashType, TransactionBuilder},
-    packed::{CellDep, CellInput, CellOutput, OutPoint, Script},
+    core::{capacity_bytes, Capacity, Cycle, DepType, ScriptHashType, TransactionBuilder},
+    packed::{CellDep, CellInput, CellOutput, OutPoint, Script, Witness},
     prelude::*,
     H256,
 };
 use log::info;
+
+const TX_2_IN_2_OUT_SIZE: usize = 673;
+const TX_2_IN_2_OUT_CYCLES: Cycle = 13290092;
 
 pub struct SendSecpTxUseDepGroup {
     // secp lock script's hash type
@@ -101,34 +104,160 @@ impl Spec for SendSecpTxUseDepGroup {
         let lock_arg = Bytes::from(&blake2b_256(&pubkey_data)[0..20]);
         let hash_type = self.hash_type;
         Box::new(move |config| {
-            let code_hash = if hash_type == ScriptHashType::Data {
-                CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL.clone()
-            } else {
-                let input = CellInput::new_cellbase_input(0);
-                // 0 => genesis cell, which contains a message and can never be spent.
-                // 1 => always success cell, define in integration.toml spec file
-                let output_index: u64 = 2;
-                let mut blake2b = new_blake2b();
-                blake2b.update(input.as_slice());
-                blake2b.update(&output_index.to_le_bytes());
-                let mut ret = [0; 32];
-                blake2b.finalize(&mut ret);
-                let script_arg = Bytes::from(&ret[..]).pack();
-                Script::new_builder()
-                    .code_hash(TYPE_ID_CODE_HASH.pack())
-                    .hash_type(ScriptHashType::Type.pack())
-                    .args(vec![script_arg].pack())
-                    .build()
-                    .calc_script_hash()
-                    .unpack()
-            };
-            let block_assembler = BlockAssemblerConfig {
-                code_hash,
-                hash_type: hash_type.into(),
-                args: vec![JsonBytes::from_bytes(lock_arg.clone())],
-                data: Default::default(),
-            };
+            let block_assembler = new_block_assembler_config(lock_arg.clone(), hash_type);
             config.block_assembler = Some(block_assembler);
         })
+    }
+}
+
+pub struct CheckTypical2In2OutTx {
+    privkey: Privkey,
+    lock_arg: Bytes,
+}
+
+impl CheckTypical2In2OutTx {
+    pub fn new() -> Self {
+        let mut generator = Generator::non_crypto_safe_prng(42);
+        let privkey = generator.gen_privkey();
+        let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
+        let lock_arg = Bytes::from(&blake2b_256(&pubkey_data)[0..20]);
+        CheckTypical2In2OutTx { privkey, lock_arg }
+    }
+}
+
+impl Spec for CheckTypical2In2OutTx {
+    crate::name!("check_typical_2_in_2_out_tx");
+
+    fn run(&self, net: Net) {
+        let hash_type = ScriptHashType::Type;
+
+        let node = &net.nodes[0];
+
+        info!("Generate 20 block on node");
+        node.generate_blocks(20);
+
+        let secp_out_point = OutPoint::new(node.dep_group_tx_hash().clone(), 0);
+
+        let cell_dep = CellDep::new_builder()
+            .out_point(secp_out_point)
+            .dep_type(DepType::DepGroup.pack())
+            .build();
+        let input1 = {
+            let block = node.get_tip_block();
+            let cellbase_hash = block.transactions()[0].hash();
+            CellInput::new(OutPoint::new(cellbase_hash, 0), 0)
+        };
+        node.generate_blocks(1);
+        let input2 = {
+            let block = node.get_tip_block();
+            let cellbase_hash = block.transactions()[0].hash();
+            CellInput::new(OutPoint::new(cellbase_hash, 0), 0)
+        };
+        let lock = Script::new_builder()
+            .args(vec![self.lock_arg.clone()].pack())
+            .code_hash(type_lock_script_code_hash().pack())
+            .hash_type(hash_type.pack())
+            .build();
+        let output1 = CellOutput::new_builder()
+            .capacity(capacity_bytes!(100).pack())
+            .lock(lock.clone())
+            .build();
+        let output2 = CellOutput::new_builder()
+            .capacity(capacity_bytes!(100).pack())
+            .lock(lock.clone())
+            .build();
+        let tx = TransactionBuilder::default()
+            .cell_dep(cell_dep.clone())
+            .input(input1.clone())
+            .input(input2.clone())
+            .output(output1.clone())
+            .output(output2.clone())
+            .output_data(Default::default())
+            .output_data(Default::default())
+            .build();
+
+        let tx_hash: H256 = tx.hash().unpack();
+        let message = H256::from(blake2b_256(&tx_hash));
+        let sig = self.privkey.sign_recoverable(&message).expect("sign");
+        let witness: Witness = vec![Bytes::from(sig.serialize()).pack()].pack();
+        let tx = tx
+            .as_advanced_builder()
+            .witness(witness.clone())
+            .witness(witness.clone())
+            .build();
+        info!("Check 2 in 2 out tx size");
+        let serialized_size = tx.data().as_slice().len();
+        assert_eq!(
+            serialized_size, TX_2_IN_2_OUT_SIZE,
+            "2 in 2 out tx serialized size changed"
+        );
+
+        info!("Check 2 in 2 out tx cycles");
+        let cycles: Cycle = node
+            .rpc_client()
+            .dry_run_transaction(tx.data().into())
+            .cycles
+            .0;
+        assert_eq!(
+            cycles, TX_2_IN_2_OUT_CYCLES,
+            "2 in 2 out tx serialized size changed"
+        );
+
+        info!("Send 1 secp tx use dep group");
+        let tx_hash = node.rpc_client().send_transaction(tx.data().into());
+        node.generate_blocks(20);
+
+        let tx_status = node
+            .rpc_client()
+            .get_transaction(tx_hash.clone())
+            .expect("get sent transaction");
+        assert!(
+            is_committed(&tx_status),
+            "ensure_committed failed {:#x}",
+            tx_hash
+        );
+    }
+
+    fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
+        let lock_arg = self.lock_arg.clone();
+        Box::new(move |config| {
+            let block_assembler =
+                new_block_assembler_config(lock_arg.clone(), ScriptHashType::Type);
+            config.block_assembler = Some(block_assembler);
+        })
+    }
+}
+
+fn type_lock_script_code_hash() -> H256 {
+    let input = CellInput::new_cellbase_input(0);
+    // 0 => genesis cell, which contains a message and can never be spent.
+    // 1 => always success cell, define in integration.toml spec file
+    let output_index: u64 = 2;
+    let mut blake2b = new_blake2b();
+    blake2b.update(input.as_slice());
+    blake2b.update(&output_index.to_le_bytes());
+    let mut ret = [0; 32];
+    blake2b.finalize(&mut ret);
+    let script_arg = Bytes::from(&ret[..]).pack();
+    Script::new_builder()
+        .code_hash(TYPE_ID_CODE_HASH.pack())
+        .hash_type(ScriptHashType::Type.pack())
+        .args(vec![script_arg].pack())
+        .build()
+        .calc_script_hash()
+        .unpack()
+}
+
+fn new_block_assembler_config(lock_arg: Bytes, hash_type: ScriptHashType) -> BlockAssemblerConfig {
+    let code_hash = if hash_type == ScriptHashType::Data {
+        CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL.clone()
+    } else {
+        type_lock_script_code_hash()
+    };
+    BlockAssemblerConfig {
+        code_hash,
+        hash_type: hash_type.into(),
+        args: vec![JsonBytes::from_bytes(lock_arg.clone())],
+        data: Default::default(),
     }
 }

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -17,7 +17,7 @@ use ckb_types::{
 use log::info;
 
 const TX_2_IN_2_OUT_SIZE: usize = 673;
-const TX_2_IN_2_OUT_CYCLES: Cycle = 13290092;
+const TX_2_IN_2_OUT_CYCLES: Cycle = 13_290_092;
 
 pub struct SendSecpTxUseDepGroup {
     // secp lock script's hash type
@@ -115,9 +115,15 @@ pub struct CheckTypical2In2OutTx {
     lock_arg: Bytes,
 }
 
+impl Default for CheckTypical2In2OutTx {
+    fn default() -> Self {
+        Self::new(42)
+    }
+}
+
 impl CheckTypical2In2OutTx {
-    pub fn new() -> Self {
-        let mut generator = Generator::non_crypto_safe_prng(42);
+    pub fn new(seed: u64) -> Self {
+        let mut generator = Generator::non_crypto_safe_prng(seed);
         let privkey = generator.gen_privkey();
         let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
         let lock_arg = Bytes::from(&blake2b_256(&pubkey_data)[0..20]);
@@ -189,7 +195,7 @@ impl Spec for CheckTypical2In2OutTx {
         let serialized_size = tx.data().as_slice().len();
         assert_eq!(
             serialized_size, TX_2_IN_2_OUT_SIZE,
-            "2 in 2 out tx serialized size changed"
+            "2 in 2 out tx serialized size changed, PLEASE UPDATE consensus"
         );
 
         info!("Check 2 in 2 out tx cycles");
@@ -200,7 +206,7 @@ impl Spec for CheckTypical2In2OutTx {
             .0;
         assert_eq!(
             cycles, TX_2_IN_2_OUT_CYCLES,
-            "2 in 2 out tx serialized size changed"
+            "2 in 2 out tx cycles changed, PLEASE UPDATE consensus"
         );
 
         info!("Send 1 secp tx use dep group");

--- a/util/crypto/src/secp/generator.rs
+++ b/util/crypto/src/secp/generator.rs
@@ -1,31 +1,55 @@
 use super::privkey::Privkey;
 use super::pubkey::Pubkey;
 use super::SECP256K1;
-use rand::{self, Rng};
+use rand::{self, Rng, SeedableRng};
 use secp256k1::{PublicKey, SecretKey};
 
-pub struct Generator;
+pub struct Generator {
+    rng: Box<dyn rand::RngCore>,
+}
 
 impl Generator {
-    pub fn random_privkey() -> Privkey {
-        Self::random_secret_key().into()
+    pub fn new() -> Self {
+        let rng = rand::thread_rng();
+        Generator { rng: Box::new(rng) }
     }
 
-    pub fn random_keypair() -> (Privkey, Pubkey) {
-        let secret_key = Self::random_secret_key();
+    /// Non crypto safe prng, should only used in tests
+    pub fn non_crypto_safe_prng(seed: u64) -> Self {
+        let rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        Generator { rng: Box::new(rng) }
+    }
+
+    fn gen_secret_key(&mut self) -> SecretKey {
+        let mut seed = vec![0; 32];
+        loop {
+            self.rng.fill(seed.as_mut_slice());
+            if let Ok(key) = SecretKey::from_slice(&seed) {
+                return key;
+            }
+        }
+    }
+
+    pub fn gen_privkey(&mut self) -> Privkey {
+        self.gen_secret_key().into()
+    }
+
+    pub fn gen_keypair(&mut self) -> (Privkey, Pubkey) {
+        let secret_key = self.gen_secret_key();
         let pubkey = PublicKey::from_secret_key(&*SECP256K1, &secret_key);
 
         (secret_key.into(), pubkey.into())
     }
 
+    pub fn random_privkey() -> Privkey {
+        Generator::new().gen_privkey()
+    }
+
+    pub fn random_keypair() -> (Privkey, Pubkey) {
+        Generator::new().gen_keypair()
+    }
+
     pub fn random_secret_key() -> SecretKey {
-        let mut seed = vec![0; 32];
-        let mut rng = rand::thread_rng();
-        loop {
-            rng.fill(seed.as_mut_slice());
-            if let Ok(key) = SecretKey::from_slice(&seed) {
-                return key;
-            }
-        }
+        Generator::new().gen_secret_key()
     }
 }

--- a/util/crypto/src/secp/generator.rs
+++ b/util/crypto/src/secp/generator.rs
@@ -8,6 +8,12 @@ pub struct Generator {
     rng: Box<dyn rand::RngCore>,
 }
 
+impl Default for Generator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Generator {
     pub fn new() -> Self {
         let rng = rand::thread_rng();


### PR DESCRIPTION
Increase the capacity of a block.

A block can contain 3875 typical 2 in 2 out txs.