### PR TITLE
Fix invalid usage of vector builder method.

### DIFF
--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -553,7 +553,7 @@ where
     transactions[transaction_index] = modify_transaction(transactions[transaction_index].clone());
     block
         .as_advanced_builder()
-        .transactions(transactions)
+        .set_transactions(transactions)
         .build()
 }
 


### PR DESCRIPTION
In block builder, `transactions` extends transactions. In the test we really
want to replace all the transactions.