### PR TITLE
feat: Refactor serialization schema for performance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "ckb-pow 0.20.0-pre",
  "ckb-shared 0.20.0-pre",
  "ckb-store 0.20.0-pre",
- "ckb-system-scripts 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-test-chain-utils 0.20.0-pre",
  "ckb-traits 0.20.0-pre",
  "ckb-types 0.20.0-pre",
@@ -778,7 +778,7 @@ dependencies = [
 name = "ckb-resource"
 version = "0.20.0-pre"
 dependencies = [
- "ckb-system-scripts 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-types 0.20.0-pre",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.3.1"
+version = "0.3.2-alpha.1+refactor-schema"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3990,7 +3990,7 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
-"checksum ckb-system-scripts 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81a1f8f5b76c84f28da4d35260601b0119f12f80e0d4694c332c546b014aa672"
+"checksum ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)" = "23c52ab3f37458f49efba22fb7f0fac7e7f20ebb87c729378ca550a1b66007b2"
 "checksum ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f089b008f8fa02e44b409b2c24ee9a9f65216f24cebeccc598162d3a44a675ad"
 "checksum ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd297669e4783ddca472fa00e7d2117b2d1dcb67cca814d5dd222852b8dba088"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "ckb-pow 0.20.0-pre",
  "ckb-shared 0.20.0-pre",
  "ckb-store 0.20.0-pre",
- "ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-system-scripts 0.3.2-alpha.2+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-test-chain-utils 0.20.0-pre",
  "ckb-traits 0.20.0-pre",
  "ckb-types 0.20.0-pre",
@@ -778,7 +778,7 @@ dependencies = [
 name = "ckb-resource"
 version = "0.20.0-pre"
 dependencies = [
- "ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-system-scripts 0.3.2-alpha.2+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-types 0.20.0-pre",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.3.2-alpha.1+refactor-schema"
+version = "0.3.2-alpha.2+refactor-schema"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3990,7 +3990,7 @@ dependencies = [
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
-"checksum ckb-system-scripts 0.3.2-alpha.1+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)" = "23c52ab3f37458f49efba22fb7f0fac7e7f20ebb87c729378ca550a1b66007b2"
+"checksum ckb-system-scripts 0.3.2-alpha.2+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)" = "956a5e5323071dfdd0ea1f9d073c8ebb8fb29ba05d57f0fff217d1ccd7c3c20f"
 "checksum ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f089b008f8fa02e44b409b2c24ee9a9f65216f24cebeccc598162d3a44a675ad"
 "checksum ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd297669e4783ddca472fa00e7d2117b2d1dcb67cca814d5dd222852b8dba088"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -26,7 +26,7 @@ ckb-occupied-capacity = { path = "../util/occupied-capacity"}
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-dao = { path = "../util/dao" }
-ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"
+ckb-system-scripts = "= 0.3.2-alpha.1"
 lazy_static = "1.3.0"
 ckb-crypto = { path = "../util/crypto" }
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -26,7 +26,7 @@ ckb-occupied-capacity = { path = "../util/occupied-capacity"}
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-dao = { path = "../util/dao" }
-ckb-system-scripts = "= 0.3.2-alpha.1"
+ckb-system-scripts = "= 0.3.2-alpha.2"
 lazy_static = "1.3.0"
 ckb-crypto = { path = "../util/crypto" }
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -26,7 +26,7 @@ ckb-occupied-capacity = { path = "../util/occupied-capacity"}
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-dao = { path = "../util/dao" }
-ckb-system-scripts = { version = "= 0.3.1" }
+ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"
 lazy_static = "1.3.0"
 ckb-crypto = { path = "../util/crypto" }
 

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,128 +2,128 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0xa809b98db986892d7bdb075d58ac6ed0df14a457fb5b1036f782104d9dd62920"
-cellbase = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
+genesis = "0x8b155e962d81804629cab4b5b6ee77db6571e905d01e6ab8b8e448c8ec560ab1"
+cellbase = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
+tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
+tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
 index = 2
-data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
+data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
+tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
+tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x30dc96e587942816db20cefb2f581d60540233458d5a33ee36d0356d5f7a9f3e"
+tx_hash = "0x9bf41a80fae03a776e8ea40adf98dc5cbad8d83e2d78b306f5168029958c7ef3"
 index = 0
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x30dc96e587942816db20cefb2f581d60540233458d5a33ee36d0356d5f7a9f3e"
+tx_hash = "0x9bf41a80fae03a776e8ea40adf98dc5cbad8d83e2d78b306f5168029958c7ef3"
 index = 1
 
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0xc86511ddb20858dfaa01e88c09d5795165aed370f7cecaafc3dd693bf6e12517"
-cellbase = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
+genesis = "0x012a815fa4dbe09e10c7ee0595cca090b848fbbb3b93234dafca617cdd6f6bca"
+cellbase = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
+tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
+tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
 index = 2
-data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
+data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
+tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
+tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x90b22841d0aa52684fc8693a4f2c5cd8a01cab937d0af5300b161ea2de8aec29"
+tx_hash = "0xb1fa04ef8167def4d1a0a12c16f8671b2dd72f87aadcf62292d62340cc5ab37d"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x90b22841d0aa52684fc8693a4f2c5cd8a01cab937d0af5300b161ea2de8aec29"
+tx_hash = "0xb1fa04ef8167def4d1a0a12c16f8671b2dd72f87aadcf62292d62340cc5ab37d"
 index = 1
 
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0xf22c50f5c4944f76be3e0892c599a25bcf14fe782ef8c5debf3e78f709e6affc"
-cellbase = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
+genesis = "0x072dd76ed34ad86edfb804ff7bba561365c58d446eed9a16ed5ad7a4dc186b00"
+cellbase = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
+tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
+tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
 index = 2
-data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
+data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
+tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
+tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xe6ee1902a43cf1d85e044363c010a1eecdf9fcdd1f26b21a6cb98f962660765d"
+tx_hash = "0x73bcf012cf9bc43cd09af6d952eae234569555e6c22a868b6f63f23fab2d26ad"
 index = 0
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xe6ee1902a43cf1d85e044363c010a1eecdf9fcdd1f26b21a6cb98f962660765d"
+tx_hash = "0x73bcf012cf9bc43cd09af6d952eae234569555e6c22a868b6f63f23fab2d26ad"
 index = 1

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,128 +2,128 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0x8b155e962d81804629cab4b5b6ee77db6571e905d01e6ab8b8e448c8ec560ab1"
-cellbase = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
+genesis = "0xe8f50f2d05b0f8d62fcb3e07378b8c5e24cb0e6b93d37161a1cf4c85b8e38b40"
+cellbase = "0x225601d4eeba6f37f610c5d36448f59670e68a5670dae0e103be5125fcadab06"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
+tx_hash = "0x225601d4eeba6f37f610c5d36448f59670e68a5670dae0e103be5125fcadab06"
 index = 1
-data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
+data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
+tx_hash = "0x225601d4eeba6f37f610c5d36448f59670e68a5670dae0e103be5125fcadab06"
 index = 2
-data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
+data_hash = "0x64dce4af48b54197a188b2deb6c3ad99347dd680ffe0d0c85061a92012d7665b"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
+tx_hash = "0x225601d4eeba6f37f610c5d36448f59670e68a5670dae0e103be5125fcadab06"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0xe9a47e86881514d45d0a5ad8cdebf356fccd70c2983e8e369747e97536ab7419"
+tx_hash = "0x225601d4eeba6f37f610c5d36448f59670e68a5670dae0e103be5125fcadab06"
 index = 4
-data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
+data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x9bf41a80fae03a776e8ea40adf98dc5cbad8d83e2d78b306f5168029958c7ef3"
+tx_hash = "0x1dc45c88b8a5c7aff0f16afe99240e52d9862f76d5b6d9a26ebaf59719c646b7"
 index = 0
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x9bf41a80fae03a776e8ea40adf98dc5cbad8d83e2d78b306f5168029958c7ef3"
+tx_hash = "0x1dc45c88b8a5c7aff0f16afe99240e52d9862f76d5b6d9a26ebaf59719c646b7"
 index = 1
 
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0x012a815fa4dbe09e10c7ee0595cca090b848fbbb3b93234dafca617cdd6f6bca"
-cellbase = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
+genesis = "0x2398812c881c42133b5bf1bf574dae7fb93c8b321cdd224b703b9accd1e715e8"
+cellbase = "0xb61bbe623732377dccc2cf990b867d0ba1b15e85bfbd96c5eda56c9c93ac1371"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
+tx_hash = "0xb61bbe623732377dccc2cf990b867d0ba1b15e85bfbd96c5eda56c9c93ac1371"
 index = 1
-data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
+data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
+tx_hash = "0xb61bbe623732377dccc2cf990b867d0ba1b15e85bfbd96c5eda56c9c93ac1371"
 index = 2
-data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
+data_hash = "0x64dce4af48b54197a188b2deb6c3ad99347dd680ffe0d0c85061a92012d7665b"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
+tx_hash = "0xb61bbe623732377dccc2cf990b867d0ba1b15e85bfbd96c5eda56c9c93ac1371"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x2856ed95538a51243e108f14afb6209ed0801f3f9b89257885e72ff5bc8662d0"
+tx_hash = "0xb61bbe623732377dccc2cf990b867d0ba1b15e85bfbd96c5eda56c9c93ac1371"
 index = 4
-data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
+data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xb1fa04ef8167def4d1a0a12c16f8671b2dd72f87aadcf62292d62340cc5ab37d"
+tx_hash = "0xbaffa683af85c922b3625d0dc2fa08a04b2aa967ee2e90582a3cd0ef36503697"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xb1fa04ef8167def4d1a0a12c16f8671b2dd72f87aadcf62292d62340cc5ab37d"
+tx_hash = "0xbaffa683af85c922b3625d0dc2fa08a04b2aa967ee2e90582a3cd0ef36503697"
 index = 1
 
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0x072dd76ed34ad86edfb804ff7bba561365c58d446eed9a16ed5ad7a4dc186b00"
-cellbase = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
+genesis = "0xc71e44c6bea4a125042bb36080583c63ab3c5c0283d36875a0383597b0d72749"
+cellbase = "0x844e5add1cd674381ae0c989793c093763b906115387336cefa9b896d1f6c3fa"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
+tx_hash = "0x844e5add1cd674381ae0c989793c093763b906115387336cefa9b896d1f6c3fa"
 index = 1
-data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
+data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
+tx_hash = "0x844e5add1cd674381ae0c989793c093763b906115387336cefa9b896d1f6c3fa"
 index = 2
-data_hash = "0xcb99e73e975435a69dd6f8950a4353d4f36dfa6b167b2e8f9f9a50686fdf16a2"
+data_hash = "0x64dce4af48b54197a188b2deb6c3ad99347dd680ffe0d0c85061a92012d7665b"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
+tx_hash = "0x844e5add1cd674381ae0c989793c093763b906115387336cefa9b896d1f6c3fa"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x494ebbe5b90c3eb410e36466015aa8f4300515047acd0178e7f9b50ec63abe5b"
+tx_hash = "0x844e5add1cd674381ae0c989793c093763b906115387336cefa9b896d1f6c3fa"
 index = 4
-data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
+data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x73bcf012cf9bc43cd09af6d952eae234569555e6c22a868b6f63f23fab2d26ad"
+tx_hash = "0x434074f5fe31804495ab9917687a7eb914ab36bccbc4460edf432864b089a4b0"
 index = 0
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x73bcf012cf9bc43cd09af6d952eae234569555e6c22a868b6f63f23fab2d26ad"
+tx_hash = "0x434074f5fe31804495ab9917687a7eb914ab36bccbc4460edf432864b089a4b0"
 index = 1

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,128 +2,128 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0x0eb242ffa9365d1fa9e76a5c218fc6eb0aa53839ae7b3c50061cc362db970eef"
-cellbase = "0x5f7de5cd4bffca98d3bf5ab4ef452e74301b7159e72958fa8abb468be38be02f"
+genesis = "0xa809b98db986892d7bdb075d58ac6ed0df14a457fb5b1036f782104d9dd62920"
+cellbase = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x5f7de5cd4bffca98d3bf5ab4ef452e74301b7159e72958fa8abb468be38be02f"
+tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
-type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
+type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x5f7de5cd4bffca98d3bf5ab4ef452e74301b7159e72958fa8abb468be38be02f"
+tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
 index = 2
 data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
-type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
+type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x5f7de5cd4bffca98d3bf5ab4ef452e74301b7159e72958fa8abb468be38be02f"
+tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x5f7de5cd4bffca98d3bf5ab4ef452e74301b7159e72958fa8abb468be38be02f"
+tx_hash = "0x082f9a04bfe0b11827984dea1befbbdfafc0674cf3c75609ad71bacd164f73ef"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
-type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
+type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xcc92e9ca6a52e0e1953d08783f6957c429d06c4aff753478bfe4d9a111217a43"
+tx_hash = "0x30dc96e587942816db20cefb2f581d60540233458d5a33ee36d0356d5f7a9f3e"
 index = 0
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xcc92e9ca6a52e0e1953d08783f6957c429d06c4aff753478bfe4d9a111217a43"
+tx_hash = "0x30dc96e587942816db20cefb2f581d60540233458d5a33ee36d0356d5f7a9f3e"
 index = 1
 
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0x38ebae6994fcd096bbd73f07d2a87d78134ffa6701af6d0fc55328e9087a167e"
-cellbase = "0x3ed06beefdddd236e0420852eddf450d3dd19d5201a35b84383636a285dee9d6"
+genesis = "0xc86511ddb20858dfaa01e88c09d5795165aed370f7cecaafc3dd693bf6e12517"
+cellbase = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x3ed06beefdddd236e0420852eddf450d3dd19d5201a35b84383636a285dee9d6"
+tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
-type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
+type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x3ed06beefdddd236e0420852eddf450d3dd19d5201a35b84383636a285dee9d6"
+tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
 index = 2
 data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
-type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
+type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x3ed06beefdddd236e0420852eddf450d3dd19d5201a35b84383636a285dee9d6"
+tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x3ed06beefdddd236e0420852eddf450d3dd19d5201a35b84383636a285dee9d6"
+tx_hash = "0xe02de5d76967b08267a03e847f77cad5934647b1a6e3ad60ec6d2b1b8386f3e1"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
-type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
+type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x0b83583146238680dd239598f10d70e9ea6f14ba15c77ef363ffdc792918f818"
+tx_hash = "0x90b22841d0aa52684fc8693a4f2c5cd8a01cab937d0af5300b161ea2de8aec29"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x0b83583146238680dd239598f10d70e9ea6f14ba15c77ef363ffdc792918f818"
+tx_hash = "0x90b22841d0aa52684fc8693a4f2c5cd8a01cab937d0af5300b161ea2de8aec29"
 index = 1
 
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0xdc7407d1f62da8845a5a0de3048d110a773b6c23a44b16018636289cb5267fb8"
-cellbase = "0x6cca5defb2c574a4ce25d00acd33420c6129a06f2e6538b76add6b21bfb29372"
+genesis = "0xf22c50f5c4944f76be3e0892c599a25bcf14fe782ef8c5debf3e78f709e6affc"
+cellbase = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x6cca5defb2c574a4ce25d00acd33420c6129a06f2e6538b76add6b21bfb29372"
+tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
 index = 1
 data_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
-type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
+type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x6cca5defb2c574a4ce25d00acd33420c6129a06f2e6538b76add6b21bfb29372"
+tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
 index = 2
 data_hash = "0x1a9c250a67811e9ebf060c6f294b0591b4adef1dbd0544b9fbd6aa512e4d9d88"
-type_hash = "0x6dd30a6d01bcc3ba014b9549b23ecef4aa453c2518fd047a360b3913095a6f8e"
+type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x6cca5defb2c574a4ce25d00acd33420c6129a06f2e6538b76add6b21bfb29372"
+tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x6cca5defb2c574a4ce25d00acd33420c6129a06f2e6538b76add6b21bfb29372"
+tx_hash = "0x59038368d582e556ddc21412aa68f5c135087327f3abe23318ffde14548791b2"
 index = 4
 data_hash = "0x1acf88382192fbf76fc5a457a11cc393a90d84a46c5e0d7ceebfd1d0dec871e4"
-type_hash = "0x4c70007442df0a8f9314f3830f76e9d93aca01b692d06d16d16ba424d7be5fe0"
+type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xd0f77a68edefada12a8f3e9dc64c466998b65b2ade22176fdffa5de4ffc65308"
+tx_hash = "0xe6ee1902a43cf1d85e044363c010a1eecdf9fcdd1f26b21a6cb98f962660765d"
 index = 0
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xd0f77a68edefada12a8f3e9dc64c466998b65b2ade22176fdffa5de4ffc65308"
+tx_hash = "0xe6ee1902a43cf1d85e044363c010a1eecdf9fcdd1f26b21a6cb98f962660765d"
 index = 1

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -258,6 +258,8 @@ impl BlockAssembler {
             )
             .build();
         let occupied = block.as_slice().len();
+        // Uncomment this line to get the correct BASIC_BLOCK_SIZE in block_assember tests.
+        // dbg!(occupied);
         let bytes_limit = bytes_limit as usize;
         bytes_limit
             .checked_sub(occupied)
@@ -553,7 +555,7 @@ mod tests {
     use ckb_verification::{BlockVerifier, HeaderResolverWrapper, HeaderVerifier, Verifier};
     use std::sync::Arc;
 
-    const BASIC_BLOCK_SIZE: u64 = 646;
+    const BASIC_BLOCK_SIZE: u64 = 550;
 
     fn start_chain(
         consensus: Option<Consensus>,

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -13,10 +13,10 @@ tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"
+ckb-system-scripts = "= 0.3.2-alpha.1"
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"
+ckb-system-scripts = "= 0.3.2-alpha.1"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -13,10 +13,10 @@ tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = "= 0.3.2-alpha.1"
+ckb-system-scripts = "= 0.3.2-alpha.2"
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = "= 0.3.2-alpha.1"
+ckb-system-scripts = "= 0.3.2-alpha.2"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -13,10 +13,10 @@ tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = { version = "= 0.3.1" }
+ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
 ckb-types = { path = "../util/types" }
-ckb-system-scripts = { version = "= 0.3.1" }
+ckb-system-scripts = "= 0.3.2-alpha.1+refactor-schema"

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x10000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0x012a815fa4dbe09e10c7ee0595cca090b848fbbb3b93234dafca617cdd6f6bca"
+hash = "0x2398812c881c42133b5bf1bf574dae7fb93c8b321cdd224b703b9accd1e715e8"
 
 [genesis.genesis_cell]
 message = "rylai-v9"

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x10000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0x38ebae6994fcd096bbd73f07d2a87d78134ffa6701af6d0fc55328e9087a167e"
+hash = "0xc86511ddb20858dfaa01e88c09d5795165aed370f7cecaafc3dd693bf6e12517"
 
 [genesis.genesis_cell]
 message = "rylai-v9"

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x10000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0xc86511ddb20858dfaa01e88c09d5795165aed370f7cecaafc3dd693bf6e12517"
+hash = "0x012a815fa4dbe09e10c7ee0595cca090b848fbbb3b93234dafca617cdd6f6bca"
 
 [genesis.genesis_cell]
 message = "rylai-v9"

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -97,17 +97,17 @@ http://localhost:8114
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
         "epoch": "1",
-        "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+        "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
         "nonce": "0",
         "number": "1024",
-        "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+        "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "1557311767",
-        "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+        "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+        "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
     }
 }
 ```
@@ -209,7 +209,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+    "result": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
 }
 ```
 
@@ -229,7 +229,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
     ]
 }' \
 | tr -d '\n' \
@@ -246,23 +246,23 @@ http://localhost:8114
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
             "epoch": "1",
-            "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "nonce": "0",
             "number": "1024",
-            "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "1557311767",
-            "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
         },
         "proposals": [],
         "transactions": [
             {
                 "cell_deps": [],
-                "hash": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                 "header_deps": [],
                 "inputs": [
                     {
@@ -315,7 +315,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
     ]
 }' \
 | tr -d '\n' \
@@ -331,17 +331,17 @@ http://localhost:8114
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
         "epoch": "1",
-        "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+        "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
         "nonce": "0",
         "number": "1024",
-        "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+        "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "1557311767",
-        "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+        "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+        "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
     }
 }
 ```
@@ -375,17 +375,17 @@ http://localhost:8114
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
         "epoch": "1",
-        "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+        "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
         "nonce": "0",
         "number": "1024",
-        "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+        "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "1557311767",
-        "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+        "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
         "uncles_count": "0",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0",
-        "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+        "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
     }
 }
 ```
@@ -424,7 +424,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x08e7c5d62c39ad21154e3ecda9a5eca348f120c779ac7e2cae39b998ffd2f609",
+            "block_hash": "0xd69bb77f60fa296f1313ed2625027570c3c7bc1b23bc23616a0b459cbe60a863",
             "capacity": "125000000000",
             "lock": {
                 "args": [],
@@ -433,11 +433,11 @@ http://localhost:8114
             },
             "out_point": {
                 "index": "0",
-                "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
             }
         },
         {
-            "block_hash": "0x2289a0cec6d3502a04aaa489acafd2dfb7345b257c943092c449f13283b6ee6c",
+            "block_hash": "0x2d418625e49a3969d4cbb1c8deed69d179b8007c5e9801058350e9de49592e06",
             "capacity": "125000000000",
             "lock": {
                 "args": [],
@@ -446,7 +446,7 @@ http://localhost:8114
             },
             "out_point": {
                 "index": "0",
-                "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
             }
         }
     ]
@@ -471,7 +471,7 @@ echo '{
     "params": [
         {
             "index": "0",
-            "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
         }
     ]
 }' \
@@ -772,18 +772,18 @@ echo '{
                     "dep_type": "code",
                     "out_point": {
                         "index": "0",
-                        "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                     }
                 }
             ],
             "header_deps": [
-                "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0",
-                        "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                     },
                     "since": "0"
                 }
@@ -852,18 +852,18 @@ echo '{
                     "dep_type": "code",
                     "out_point": {
                         "index": "0",
-                        "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                     }
                 }
             ],
             "header_deps": [
-                "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0",
-                        "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                     },
                     "since": "0"
                 }
@@ -896,7 +896,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915"
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
 }
 ```
 
@@ -932,18 +932,18 @@ echo '{
                     "dep_type": "code",
                     "out_point": {
                         "index": "0",
-                        "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                     }
                 }
             ],
             "header_deps": [
-                "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0",
-                        "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                     },
                     "since": "0"
                 }
@@ -976,7 +976,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915"
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
 }
 ```
 
@@ -998,7 +998,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_transaction",
     "params": [
-        "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915"
+        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
     ]
 }' \
 | tr -d '\n' \
@@ -1017,19 +1017,19 @@ http://localhost:8114
                     "dep_type": "code",
                     "out_point": {
                         "index": "0",
-                        "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                     }
                 }
             ],
-            "hash": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915",
+            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
             "header_deps": [
-                "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0",
-                        "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                     },
                     "since": "0"
                 }
@@ -1075,7 +1075,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_cellbase_output_capacity_details",
     "params": [
-        "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
     ]
 }' \
 | tr -d '\n' \
@@ -1128,7 +1128,7 @@ http://localhost:8114
         "pending": "1",
         "proposed": "0",
         "total_tx_cycles": "12",
-        "total_tx_size": "330"
+        "total_tx_size": "274"
     }
 }
 ```
@@ -1168,23 +1168,23 @@ http://localhost:8114
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
             "epoch": "1",
-            "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "nonce": "0",
             "number": "1024",
-            "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "1557311767",
-            "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
         },
         "proposals": [],
         "transactions": [
             {
                 "cell_deps": [],
-                "hash": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                 "header_deps": [],
                 "inputs": [
                     {
@@ -1257,7 +1257,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+        "block_hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
         "block_number": "1024",
         "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
     }
@@ -1289,7 +1289,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "block_hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "block_number": "1024",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         }
@@ -1344,7 +1344,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "1",
                 "index": "0",
-                "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
             }
         },
         {
@@ -1360,7 +1360,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "2",
                 "index": "0",
-                "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
             }
         }
     ]
@@ -1406,7 +1406,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "1",
                 "index": "0",
-                "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
             }
         },
         {
@@ -1414,7 +1414,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "2",
                 "index": "0",
-                "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
             }
         }
     ]

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -15,17 +15,17 @@
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
             "epoch": "1",
-            "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "nonce": "0",
             "number": "1024",
-            "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "1557311767",
-            "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
         }
     },
     {
@@ -66,7 +66,7 @@
         "params": [
             "1024"
         ],
-        "result": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+        "result": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -78,30 +78,30 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
         ],
         "result": {
             "header": {
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
                 "epoch": "1",
-                "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
                 "nonce": "0",
                 "number": "1024",
-                "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "1557311767",
-                "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                 "uncles_count": "0",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0",
-                "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
             },
             "proposals": [],
             "transactions": [
                 {
                     "cell_deps": [],
-                    "hash": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                     "header_deps": [],
                     "inputs": [
                         {
@@ -149,23 +149,23 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
         ],
         "result": {
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
             "epoch": "1",
-            "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "nonce": "0",
             "number": "1024",
-            "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "1557311767",
-            "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
         }
     },
     {
@@ -179,17 +179,17 @@
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
             "epoch": "1",
-            "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "nonce": "0",
             "number": "1024",
-            "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "1557311767",
-            "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
             "uncles_count": "0",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0",
-            "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
         }
     },
     {
@@ -203,7 +203,7 @@
         ],
         "result": [
             {
-                "block_hash": "0x08e7c5d62c39ad21154e3ecda9a5eca348f120c779ac7e2cae39b998ffd2f609",
+                "block_hash": "0xd69bb77f60fa296f1313ed2625027570c3c7bc1b23bc23616a0b459cbe60a863",
                 "capacity": "125000000000",
                 "lock": {
                     "args": [],
@@ -212,11 +212,11 @@
                 },
                 "out_point": {
                     "index": "0",
-                    "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                    "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                 }
             },
             {
-                "block_hash": "0x2289a0cec6d3502a04aaa489acafd2dfb7345b257c943092c449f13283b6ee6c",
+                "block_hash": "0x2d418625e49a3969d4cbb1c8deed69d179b8007c5e9801058350e9de49592e06",
                 "capacity": "125000000000",
                 "lock": {
                     "args": [],
@@ -225,7 +225,7 @@
                 },
                 "out_point": {
                     "index": "0",
-                    "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                    "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
                 }
             }
         ],
@@ -248,7 +248,7 @@
         "params": [
             {
                 "index": "0",
-                "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
             }
         ],
         "result": {
@@ -418,18 +418,18 @@
                         "dep_type": "code",
                         "out_point": {
                             "index": "0",
-                            "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                         }
                     }
                 ],
                 "header_deps": [
-                    "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0",
-                            "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                         },
                         "since": "0"
                     }
@@ -467,18 +467,18 @@
                         "dep_type": "code",
                         "out_point": {
                             "index": "0",
-                            "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                         }
                     }
                 ],
                 "header_deps": [
-                    "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0",
-                            "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                         },
                         "since": "0"
                     }
@@ -501,7 +501,7 @@
                 "witnesses": []
             }
         ],
-        "result": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915",
+        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -537,18 +537,18 @@
                         "dep_type": "code",
                         "out_point": {
                             "index": "0",
-                            "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                         }
                     }
                 ],
                 "header_deps": [
-                    "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0",
-                            "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                         },
                         "since": "0"
                     }
@@ -571,7 +571,7 @@
                 "witnesses": []
             }
         ],
-        "result": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915",
+        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -601,7 +601,7 @@
         "method": "get_transaction",
         "module": "chain",
         "params": [
-            "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915"
+            "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
         ],
         "result": {
             "transaction": {
@@ -610,19 +610,19 @@
                         "dep_type": "code",
                         "out_point": {
                             "index": "0",
-                            "tx_hash": "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452"
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
                         }
                     }
                 ],
-                "hash": "0x8417504c8c10d6fff33530e05d9892c702fcb78bae084436d24f9ec1be66d915",
+                "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
                 "header_deps": [
-                    "0x67e2eb7e296164df6149726b3fdea7f909a5ce470804cb99fca83c25f8833316"
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0",
-                            "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                         },
                         "since": "0"
                     }
@@ -660,7 +660,7 @@
         "method": "get_cellbase_output_capacity_details",
         "module": "chain",
         "params": [
-            "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d"
+            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
         ],
         "result": {
             "primary": "69444444445",
@@ -686,7 +686,7 @@
             "pending": "1",
             "proposed": "0",
             "total_tx_cycles": "12",
-            "total_tx_size": "330"
+            "total_tx_size": "274"
         }
     },
     {
@@ -701,23 +701,23 @@
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
                 "epoch": "1",
-                "hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
                 "nonce": "0",
                 "number": "1024",
-                "parent_hash": "0xad8da519213697b7c82e901fbad7e00a7916d0410a964bdc59eb6919d365977c",
+                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "1557311767",
-                "transactions_root": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                 "uncles_count": "0",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0",
-                "witnesses_root": "0xa4f21cab21d42d59afc846c9965f290d70f9340cdea3c62bed51cd5249b985db"
+                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
             },
             "proposals": [],
             "transactions": [
                 {
                     "cell_deps": [],
-                    "hash": "0x2d6ebb50df4545fca4465db5cf90f68f5d4ef32e2b633204c13401fa5bffc3a4",
+                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
                     "header_deps": [],
                     "inputs": [
                         {
@@ -769,7 +769,7 @@
             "1024"
         ],
         "result": {
-            "block_hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+            "block_hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
             "block_number": "1024",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         },
@@ -789,7 +789,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0x52dde711b00bb11027623a4ef95d1e5aca8287bddefb0d2f0e63e28ab763117d",
+                "block_hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
                 "block_number": "1024",
                 "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
             }
@@ -818,7 +818,7 @@
                 "created_by": {
                     "block_number": "1",
                     "index": "0",
-                    "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                    "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                 }
             },
             {
@@ -834,7 +834,7 @@
                 "created_by": {
                     "block_number": "2",
                     "index": "0",
-                    "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                    "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
                 }
             }
         ],
@@ -868,7 +868,7 @@
                 "created_by": {
                     "block_number": "1",
                     "index": "0",
-                    "tx_hash": "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3"
+                    "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
                 }
             },
             {
@@ -876,7 +876,7 @@
                 "created_by": {
                     "block_number": "2",
                     "index": "0",
-                    "tx_hash": "0x42e9a053cd182e670911486e11303b52e55f2c0c2efbf42d272027f9bef50796"
+                    "tx_hash": "0x2e32fd60f965075a9a532c670b6d5475a2417e88872b74069e8076e58906b7bf"
                 }
             }
         ],

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -38,9 +38,9 @@ const MAX_BLOCK_INTERVAL: u64 = 30; // 30s
 const MIN_BLOCK_INTERVAL: u64 = 8; // 8s
 
 // cycles of a typical two-in-two-out tx
-const TWO_IN_TWO_OUT_CYCLES: Cycle = 13_300_000;
+const TWO_IN_TWO_OUT_CYCLES: Cycle = 13_335_200;
 // bytes of a typical two-in-two-out tx
-const TWO_IN_TWO_OUT_BYTES: u64 = 673;
+const TWO_IN_TWO_OUT_BYTES: u64 = 589;
 // count of two-in-two-out txs a block should capable to package
 // approximately equal to 50_000_000_000 / TWO_IN_TWO_OUT_CYCLES
 const TWO_IN_TWO_OUT_COUNT: u64 = 3875;

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -465,4 +465,14 @@ impl Node {
         assert_eq!(tx_pool_info.total_tx_size.0, total_tx_size);
         assert_eq!(tx_pool_info.total_tx_cycles.0, total_tx_cycles);
     }
+
+    pub fn assert_tx_pool_cycles(&self, total_tx_cycles: u64) {
+        let tx_pool_info = self.rpc_client().tx_pool_info();
+        assert_eq!(tx_pool_info.total_tx_cycles.0, total_tx_cycles);
+    }
+
+    pub fn assert_tx_pool_serialized_size(&self, total_tx_size: u64) {
+        let tx_pool_info = self.rpc_client().tx_pool_info();
+        assert_eq!(tx_pool_info.total_tx_size.0, total_tx_size);
+    }
 }

--- a/test/src/specs/mining/size_limit.rs
+++ b/test/src/specs/mining/size_limit.rs
@@ -32,7 +32,7 @@ impl Spec for TemplateSizeLimit {
         let _ = node.generate_block(); // skip
 
         let new_block = node.new_block(None, None, None);
-        assert_eq!(new_block.serialized_size(), 2430);
+        assert_eq!(new_block.serialized_size(), 550 + 242 * 6);
         assert_eq!(new_block.transactions().len(), 7);
 
         let new_block = node.new_block(Some(1000), None, None);

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -34,19 +34,18 @@ impl Spec for SizeLimit {
             .unwrap_err();
         assert_regex_match(&error.to_string(), r"LimitReached");
 
-        // 298 * 5
-        // 12 * 5
-        node.assert_tx_pool_statics(1490, 60);
+        // 242 * 5
+        node.assert_tx_pool_serialized_size(242 * 5);
         (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {
             node.generate_block();
         });
         node.generate_block();
-        node.assert_tx_pool_statics(0, 0);
+        node.assert_tx_pool_serialized_size(0);
     }
 
     fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {
         Box::new(|config| {
-            config.tx_pool.max_mem_size = 1490;
+            config.tx_pool.max_mem_size = 242 * 5;
             config.tx_pool.max_cycles = 200_000_000_000;
         })
     }
@@ -84,14 +83,13 @@ impl Spec for CyclesLimit {
             .unwrap_err();
         assert_regex_match(&error.to_string(), r"LimitReached");
 
-        // 298 * 5
         // 12 * 5
-        node.assert_tx_pool_statics(1490, 60);
+        node.assert_tx_pool_cycles(60);
         (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {
             node.generate_block();
         });
         node.generate_block();
-        node.assert_tx_pool_statics(0, 0);
+        node.assert_tx_pool_cycles(0);
     }
 
     fn modify_ckb_config(&self) -> Box<dyn Fn(&mut CKBAppConfig) -> ()> {

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -16,8 +16,8 @@ use ckb_types::{
 };
 use log::info;
 
-const TX_2_IN_2_OUT_SIZE: usize = 673;
-const TX_2_IN_2_OUT_CYCLES: Cycle = 13_277_216;
+const TX_2_IN_2_OUT_SIZE: usize = 589;
+const TX_2_IN_2_OUT_CYCLES: Cycle = 13_335_200;
 
 pub struct SendSecpTxUseDepGroup {
     // secp lock script's hash type

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -43,12 +43,12 @@ table Script {
     args:           BytesVec,
 }
 
-table OutPoint {
+struct OutPoint {
     tx_hash:        Byte32,
     index:          Uint32,
 }
 
-table CellInput {
+struct CellInput {
     previous_output: OutPoint,
     since:           Uint64,
 }
@@ -59,7 +59,7 @@ table CellOutput {
     type_:          ScriptOpt,
 }
 
-table CellDep {
+struct CellDep {
     out_point:      OutPoint,
     dep_type:       DepType,
 }
@@ -80,7 +80,7 @@ table Transaction {
     witnesses:      WitnessVec,
 }
 
-table RawHeader {
+struct RawHeader {
     version:                Uint32,
     parent_hash:            Byte32,
     timestamp:              Uint64,
@@ -95,7 +95,7 @@ table RawHeader {
     dao:                    Byte32,
 }
 
-table Header {
+struct Header {
     raw:                    RawHeader,
     nonce:                  Uint64,
 }

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -49,8 +49,8 @@ struct OutPoint {
 }
 
 struct CellInput {
-    previous_output: OutPoint,
     since:           Uint64,
+    previous_output: OutPoint,
 }
 
 table CellOutput {
@@ -82,16 +82,16 @@ table Transaction {
 
 struct RawHeader {
     version:                Uint32,
-    parent_hash:            Byte32,
+    uncles_count:           Uint32,
     timestamp:              Uint64,
     number:                 Uint64,
+    epoch:                  Uint64,
+    parent_hash:            Byte32,
     transactions_root:      Byte32,
     witnesses_root:         Byte32,
     proposals_hash:         Byte32,
     difficulty:             Byte32,
     uncles_hash:            Byte32,
-    uncles_count:           Uint32,
-    epoch:                  Uint64,
     dao:                    Byte32,
 }
 
@@ -115,38 +115,38 @@ table Block {
 /* Types for Storage */
 
 table HeaderView {
-    data:               Header,
     hash:               Byte32,
+    data:               Header,
 }
 
 table UncleBlockVecView {
-    data:               UncleBlockVec,
     hashes:             Byte32Vec,
+    data:               UncleBlockVec,
 }
 
 table TransactionView {
-    data:               Transaction,
     hash:               Byte32,
     witness_hash:       Byte32,
+    data:               Transaction,
 }
 
 table BlockExt {
-    received_at:        Uint64,
     total_difficulty:   Byte32,
     total_uncles_count: Uint64,
-    verified:           BoolOpt,
+    received_at:        Uint64,
     txs_fees:           Uint64Vec,
+    verified:           BoolOpt,
 }
 
 table EpochExt {
+    previous_epoch_hash_rate:           Byte32,
+    last_block_hash_in_previous_epoch:  Byte32,
+    difficulty:                         Byte32,
     number:                             Uint64,
     block_reward:                       Uint64,
     remainder_reward:                   Uint64,
-    previous_epoch_hash_rate:           Byte32,
-    last_block_hash_in_previous_epoch:  Byte32,
     start_number:                       Uint64,
     length:                             Uint64,
-    difficulty:                         Byte32,
 }
 
 struct TransactionKey {
@@ -155,38 +155,38 @@ struct TransactionKey {
 }
 
 table TransactionInfo {
-    key:            TransactionKey,
     block_number:   Uint64,
     block_epoch:    Uint64,
+    key:            TransactionKey,
 }
 
 table TransactionMeta {
+    block_hash:     Byte32,
     block_number:   Uint64,
     epoch_number:   Uint64,
-    block_hash:     Byte32,
     len:            Uint32,
     bits:           Bytes,
     cellbase:       Bool,
 }
 
 struct CellMeta {
-    capacity:       Uint64,
     data_hash:      Byte32,
+    capacity:       Uint64,
 }
 
 /* Types for Indexer */
 
 table TransactionPoint {
-    block_number:   Uint64,
     tx_hash:        Byte32,
+    block_number:   Uint64,
     index:          Uint32,
 }
 
 option TransactionPointOpt (TransactionPoint);
 
 table LockHashCellOutput {
-    block_number:   Uint64,
     lock_hash:      Byte32,
+    block_number:   Uint64,
     cell_output:    CellOutputOpt,
 }
 
@@ -299,8 +299,8 @@ table SendBlock {
 
 table SetFilter {
     hash_seed:              Uint32,
-    num_hashes:             byte,
     filter:                 Bytes,
+    num_hashes:             byte,
 }
 
 table AddFilter {
@@ -331,13 +331,13 @@ table Time {
 }
 
 table RawAlert {
+    notice_until:   Uint64,
     id:             Uint32,
     cancel:         Uint32,
+    priority:       Uint32,
+    message:        Bytes,
     min_version:    BytesOpt,
     max_version:    BytesOpt,
-    priority:       Uint32,
-    notice_until:   Uint64,
-    message:        Bytes,
 }
 
 table Alert {
@@ -346,7 +346,7 @@ table Alert {
 }
 
 table Identify {
-    name:                       Bytes,          // Network Name
     flag:                       Uint64,         // Flag
+    name:                       Bytes,          // Network Name
     client_version:             Bytes,
 }


### PR DESCRIPTION
This PR contains 3 commits. The first two update the schema:

- Use struct instead of table to serialize on-chain data to make the
  serialized data more compact.
- Reorder the fields to make the structure alignment friendly.

The last one regenerates code from the schema and updates all the hashes.