### PR TITLE
test: next_epoch_ext overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,8 @@ dependencies = [
  "ckb-rational 0.20.0-pre",
  "ckb-resource 0.20.0-pre",
  "ckb-types 0.20.0-pre",
+ "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -17,3 +17,10 @@ ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-rational = { path = "../util/rational" }
 ckb-crypto = { path = "../util/crypto"}
 ckb-hash = { path = "../util/hash"}
+
+[dev-dependencies]
+faketime = "0.2.0"
+rand = "0.6"
+
+[profile.test]
+overflow-checks = true


### PR DESCRIPTION
I am not sure it's a bug of `next_epoch_ext` or the problem of the test case. It's occasional.

```
  spec git:(develop_bench) ✗ RUST_BACKTRACE=full cargo test test_next_epoch_ext_overflow 
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/u2/nervos/ckb/spec/Cargo.toml
workspace: /home/u2/nervos/ckb/Cargo.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running /home/u2/nervos/ckb/target/debug/deps/ckb_chain_spec-664558be550d7e85

running 1 test
test consensus::test::test_next_epoch_ext_overflow ... FAILED

failures:

---- consensus::test::test_next_epoch_ext_overflow stdout ----
thread 'consensus::test::test_next_epoch_ext_overflow' panicked at 'U256: attempt to multiply with overflow', /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/numext-fixed-uint-core-0.1.4/src/lib.rs:19:1
stack backtrace:
   0:     0x561d025f9683 - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::h6485381528590a55
                               at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:39
   1:     0x561d025f4f6b - std::sys_common::backtrace::_print::h49a82ae9552e35c7
                               at src/libstd/sys_common/backtrace.rs:71
   2:     0x561d025f8376 - std::panicking::default_hook::{{closure}}::he20974adbefcc046
                               at src/libstd/sys_common/backtrace.rs:59
                               at src/libstd/panicking.rs:197
   3:     0x561d025f809e - std::panicking::default_hook::he4af6af4ac7fef7b
                               at src/libstd/panicking.rs:208
   4:     0x561d025f8a7f - std::panicking::rust_panic_with_hook::h057ff03eb4c8000f
                               at src/libstd/panicking.rs:474
   5:     0x561d025f8601 - std::panicking::continue_panic_fmt::ha6d6ae144369025b
                               at src/libstd/panicking.rs:381
   6:     0x561d025f854e - std::panicking::begin_panic_fmt::he54eae869ed71eb1
                               at src/libstd/panicking.rs:336
   7:     0x561d0229833f - <numext_fixed_uint_core::U256 as core::ops::arith::Mul<Rhs>>::mul::hb2784b62cbf8228b
                               at /home/u2/nervos/ckb/<::std::macros::panic macros>:9
   8:     0x561d022b53d4 - <ckb_rational::RationalU256 as core::ops::arith::Div>::div::h9b956ea71d64c62e
                               at /home/u2/nervos/ckb/util/rational/src/lib.rs:168
   9:     0x561d02362869 - ckb_chain_spec::consensus::Consensus::next_epoch_ext::h1a0676880ff189cc
                               at spec/src/consensus.rs:489
  10:     0x561d0235cdf2 - ckb_chain_spec::consensus::test::test_next_epoch_ext_overflow::h5143d1618fb7ae4c
                               at spec/src/consensus.rs:644
  11:     0x561d02403919 - ckb_chain_spec::consensus::test::test_next_epoch_ext_overflow::{{closure}}::ha891f42435192457
                               at spec/src/consensus.rs:607
  12:     0x561d0237138d - core::ops::function::FnOnce::call_once::h966bc5e06b00897b
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libcore/ops/function.rs:231
  13:     0x561d0245e71e - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h6b004fa8f4fc1608
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/liballoc/boxed.rs:704
  14:     0x561d025fbb59 - __rust_maybe_catch_panic
                               at src/libpanic_unwind/lib.rs:85
  15:     0x561d02479017 - test::run_test::run_test_inner::{{closure}}::h9a4d23c41d058d37
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panicking.rs:272
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panic.rs:394
                               at src/libtest/lib.rs:1468
  16:     0x561d02453a34 - std::sys_common::backtrace::__rust_begin_short_backtrace::h3765d76361a33ff7
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/sys_common/backtrace.rs:136
  17:     0x561d02457ae4 - std::panicking::try::do_call::h6f86e980b52f74d5
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/thread/mod.rs:470
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panic.rs:315
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panicking.rs:293
  18:     0x561d025fbb59 - __rust_maybe_catch_panic
                               at src/libpanic_unwind/lib.rs:85
  19:     0x561d024580f1 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h760b8a2b155f54c3
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panicking.rs:272
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/panic.rs:394
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libstd/thread/mod.rs:469
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libcore/ops/function.rs:231
  20:     0x561d025ebe9e - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h805c3cc89d534c05
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/liballoc/boxed.rs:704
  21:     0x561d025faf1f - std::sys::unix::thread::Thread::new::thread_start::h6f10b78f26c98dc6
                               at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/liballoc/boxed.rs:704
                               at src/libstd/sys_common/thread.rs:13
                               at src/libstd/sys/unix/thread.rs:79
  22:     0x7fb4bed6c6b9 - start_thread
  23:     0x7fb4be88c41c - clone
  24:                0x0 - <unknown>


failures:
    consensus::test::test_next_epoch_ext_overflow

```

```
(diff_numerator / denominator) 

RationalU256 {
    numer: U256 ( [
        0xffffffffffffb500,
        0xffffffffffffffff,
        0xffffffffffffffff,
        0x00000833ffffffff,
    ]
    ,
    denom: U256 ( [
        0x0000000000000001,
        0x0000000000000000,
        0x0000000000000000,
        0x0000000000000000,
    ]
    ,
}, RationalU256 {
    numer: U256 ( [
        0x0000000002932e00,
        0x0000000000000000,
        0x0000000000000000,
        0x0000000000000000,
    ]
    ,
    denom: U256 ( [
        0x0000000000005db9,
        0x0000000000000000,
        0x0000000000000000,
        0x0000000000000000,
    ]
    ,
}
```