### PR TITLE
feat: Check system cells lock script when build genesis block

### DIFF
--- a/test/src/specs/indexer/genesis_issued_cells.rs
+++ b/test/src/specs/indexer/genesis_issued_cells.rs
@@ -21,8 +21,11 @@ impl Spec for GenesisIssuedCells {
 
         let lock_hash = Script::new_builder()
             .args(vec![Bytes::from(vec![1]).pack(), Bytes::from(vec![2]).pack()].pack())
-            .code_hash(h256!("0xa1").pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .code_hash(
+                // The second output's type_id script hash
+                h256!("0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1").pack(),
+            )
+            .hash_type(ScriptHashType::Type.pack())
             .build()
             .calc_script_hash();
         info!("{}", lock_hash);
@@ -47,8 +50,12 @@ impl Spec for GenesisIssuedCells {
                 capacity: capacity_bytes!(5_000),
                 lock: Script::new_builder()
                     .args(vec![Bytes::from(vec![1]).pack(), Bytes::from(vec![2]).pack()].pack())
-                    .code_hash(h256!("0xa1").pack())
-                    .hash_type(ScriptHashType::Data.pack())
+                    .code_hash(
+                        // The second output's type_id script hash
+                        h256!("0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1")
+                            .pack(),
+                    )
+                    .hash_type(ScriptHashType::Type.pack())
                     .build()
                     .into(),
             }];


### PR DESCRIPTION
Besides genesis message cell's lock script, all other cells' lock scripts must exists in genesis block.