### PR TITLE
refactor: change enum from `[byte; 1]` to `byte`

### DIFF
--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -23,6 +23,7 @@ use ckb_types::{
 use ckb_verification::{HeaderResolverWrapper, HeaderVerifier, Verifier};
 use criterion::{criterion_group, Criterion};
 use rand::random;
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 #[cfg(not(feature = "ci"))]
@@ -34,7 +35,8 @@ const SIZES: &[usize] = &[2usize];
 fn block_assembler_config() -> BlockAssemblerConfig {
     let (_, _, secp_script) = secp_cell();
     let args = JsonBytes::from_bytes(secp_script.args().unpack());
-    let hash_type: ScriptHashType = secp_script.hash_type().unpack();
+    let hash_type: ScriptHashType =
+        ScriptHashType::try_from(secp_script.hash_type()).expect("checked data");
 
     BlockAssemblerConfig {
         code_hash: secp_script.code_hash().unpack(),

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -230,7 +230,7 @@ lazy_static! {
         let script = Script::new_builder()
             .code_hash(CellOutput::calc_data_hash(&data))
             .args(Bytes::from(PUBKEY_HASH.as_bytes()).pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
 
         (cell, data, script)

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -183,14 +183,14 @@ fn finalize_reward() {
     let bob = ScriptBuilder::default()
         .args(bob_args)
         .code_hash(always_success_script.code_hash())
-        .hash_type(ScriptHashType::Data.pack())
+        .hash_type(ScriptHashType::Data.into())
         .build();
 
     let alice_args: packed::Bytes = Bytes::from(b"a11ce".to_vec()).pack();
     let alice = ScriptBuilder::default()
         .args(alice_args)
         .code_hash(always_success_script.code_hash())
-        .hash_type(ScriptHashType::Data.pack())
+        .hash_type(ScriptHashType::Data.into())
         .build();
 
     for i in 1..23 {

--- a/indexer/src/store.rs
+++ b/indexer/src/store.rs
@@ -660,7 +660,7 @@ mod tests {
         let (store, chain, shared) = setup("get_live_cells");
         let script1 = ScriptBuilder::default()
             .code_hash(CODE_HASH_DAO.pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let script2 = Script::default();
         store.insert_lock_hash(&script1.calc_script_hash(), None);
@@ -837,7 +837,7 @@ mod tests {
         let (store, chain, shared) = setup("get_transactions");
         let script1 = ScriptBuilder::default()
             .code_hash(CODE_HASH_DAO.pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let script2 = Script::default();
         store.insert_lock_hash(&script1.calc_script_hash(), None);
@@ -999,7 +999,7 @@ mod tests {
         let (store, chain, shared) = setup("sync_index_states");
         let script1 = ScriptBuilder::default()
             .code_hash(CODE_HASH_DAO.pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let script2 = Script::default();
         store.insert_lock_hash(&script1.calc_script_hash(), None);
@@ -1163,7 +1163,7 @@ mod tests {
         let (store, chain, shared) = setup("consume_txs_in_same_block");
         let script1 = ScriptBuilder::default()
             .code_hash(CODE_HASH_DAO.pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let script2 = Script::default();
         store.insert_lock_hash(&script1.calc_script_hash(), None);
@@ -1249,7 +1249,7 @@ mod tests {
         let (store, chain, shared) = setup("detach_blocks");
         let script1 = ScriptBuilder::default()
             .code_hash(CODE_HASH_DAO.pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let script2 = Script::default();
         store.insert_lock_hash(&script1.calc_script_hash(), None);

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -769,7 +769,7 @@ mod tests {
 
         let script = Script::new_builder()
             .args(Bytes::from(data).pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let hash = script.calc_script_hash();
         let data = hash.raw_data();
@@ -824,7 +824,7 @@ mod tests {
 
         let script = Script::new_builder()
             .args(Bytes::from(data).pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let h = script.calc_script_hash();
         let hash = h.as_bytes();

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -35,6 +35,7 @@ use ckb_types::{
 pub use error::SpecError;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
@@ -302,7 +303,7 @@ impl ChainSpec {
             .flat_map(|tx| tx.outputs().into_iter().map(move |output| output.lock()))
             .filter(|lock_script| lock_script != &genesis_cell_lock)
         {
-            match lock_script.hash_type().unpack() {
+            match ScriptHashType::try_from(lock_script.hash_type()).expect("checked data") {
                 ScriptHashType::Data => {
                     if !data_hashes.contains_key(&lock_script.code_hash()) {
                         return Err(format!(
@@ -394,7 +395,7 @@ impl ChainSpec {
         let special_issued_lock = packed::Script::new_builder()
             .args(secp_lock_arg(&Privkey::from(SPECIAL_CELL_PRIVKEY.clone())).pack())
             .code_hash(CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL.clone().pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
         let special_issued_cell = packed::CellOutput::new_builder()
             .capacity(SPECIAL_CELL_CAPACITY.pack())
@@ -578,7 +579,7 @@ pub fn build_type_id_script(input: &packed::CellInput, output_index: u64) -> pac
     let script_arg = Bytes::from(&ret[..]);
     packed::Script::new_builder()
         .code_hash(TYPE_ID_CODE_HASH.pack())
-        .hash_type(ScriptHashType::Type.pack())
+        .hash_type(ScriptHashType::Type.into())
         .args(script_arg.pack())
         .build()
 }

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -390,7 +390,7 @@ impl Node {
     pub fn always_success_script(&self) -> Script {
         Script::new_builder()
             .code_hash(self.always_success_code_hash.clone())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build()
     }
 

--- a/test/src/specs/dao/mod.rs
+++ b/test/src/specs/dao/mod.rs
@@ -90,7 +90,7 @@ fn withdraw_dao_deps(node: &Node, withdraw_header_hash: Byte32) -> (Vec<CellDep>
 fn deposit_dao_script(dao_type_hash: Byte32) -> Script {
     Script::new_builder()
         .code_hash(dao_type_hash)
-        .hash_type(ScriptHashType::Type.pack())
+        .hash_type(ScriptHashType::Type.into())
         .build()
 }
 

--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -107,7 +107,7 @@ impl Spec for SpendSatoshiCell {
         let secp_out_point = OutPoint::new(node0.dep_group_tx_hash().clone(), 1);
         let cell_dep = CellDep::new_builder()
             .out_point(secp_out_point)
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
         let output = CellOutput::new_builder()
             .capacity(satoshi_cell_occupied.pack())
@@ -177,7 +177,7 @@ fn issue_satoshi_cell(satoshi_pubkey_hash: H160) -> IssuedCell {
     let lock = Script::new_builder()
         .args(Bytes::from(&satoshi_pubkey_hash.0[..]).pack())
         .code_hash(type_lock_script_code_hash().pack())
-        .hash_type(ScriptHashType::Type.pack())
+        .hash_type(ScriptHashType::Type.into())
         .build();
     IssuedCell {
         capacity: SATOSHI_CELL_CAPACITY,

--- a/test/src/specs/indexer/genesis_issued_cells.rs
+++ b/test/src/specs/indexer/genesis_issued_cells.rs
@@ -25,7 +25,7 @@ impl Spec for GenesisIssuedCells {
                 // The second output's type_id script hash
                 h256!("0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e").pack(),
             )
-            .hash_type(ScriptHashType::Type.pack())
+            .hash_type(ScriptHashType::Type.into())
             .build()
             .calc_script_hash();
         info!("{}", lock_hash);
@@ -55,7 +55,7 @@ impl Spec for GenesisIssuedCells {
                         h256!("0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e")
                             .pack(),
                     )
-                    .hash_type(ScriptHashType::Type.pack())
+                    .hash_type(ScriptHashType::Type.into())
                     .build()
                     .into(),
             }];

--- a/test/src/specs/mining/bootstrap.rs
+++ b/test/src/specs/mining/bootstrap.rs
@@ -24,7 +24,7 @@ impl Spec for BootstrapCellbase {
         let miner = packed::Script::new_builder()
             .args(Bytes::from(vec![2, 1]).pack())
             .code_hash(h256!("0xa2").pack())
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .build();
 
         let is_bootstrap_cellbase = |blk_hash: &packed::Byte32| {

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -51,7 +51,7 @@ impl Spec for SendSecpTxUseDepGroup {
 
         let cell_dep = CellDep::new_builder()
             .out_point(secp_out_point)
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
         let output = CellOutput::new_builder()
             .capacity(capacity_bytes!(100).pack())
@@ -132,8 +132,6 @@ impl Spec for CheckTypical2In2OutTx {
     crate::name!("check_typical_2_in_2_out_tx");
 
     fn run(&self, net: &mut Net) {
-        let hash_type = ScriptHashType::Type;
-
         let node = &net.nodes[0];
 
         info!("Generate 20 block on node");
@@ -143,7 +141,7 @@ impl Spec for CheckTypical2In2OutTx {
 
         let cell_dep = CellDep::new_builder()
             .out_point(secp_out_point)
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
         let input1 = {
             let block = node.get_tip_block();
@@ -159,7 +157,7 @@ impl Spec for CheckTypical2In2OutTx {
         let lock = Script::new_builder()
             .args(self.lock_arg.pack())
             .code_hash(type_lock_script_code_hash().pack())
-            .hash_type(hash_type.pack())
+            .hash_type(ScriptHashType::Type.into())
             .build();
         let output1 = CellOutput::new_builder()
             .capacity(capacity_bytes!(100).pack())

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -680,7 +680,7 @@ mod tests {
         // Transaction use dep group
         let dep = CellDep::new_builder()
             .out_point(tx2_out_point.clone())
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
         let tx3 = TransactionBuilder::default()
             .cell_dep(dep)

--- a/tx-pool/src/process/block_template.rs
+++ b/tx-pool/src/process/block_template.rs
@@ -116,7 +116,7 @@ impl Future for BuildCellbaseProcess {
         let cellbase_lock = Script::new_builder()
             .args(self.config.args.as_bytes().pack())
             .code_hash(self.config.code_hash.pack())
-            .hash_type(hash_type.pack())
+            .hash_type(hash_type.into())
             .build();
         let cellbase_witness = CellbaseWitness::new_builder()
             .lock(cellbase_lock)

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -237,7 +237,7 @@ impl<'a, CS: ChainStore<'a>> DaoCalculator<'a, CS, DataLoaderWrapper<'a, CS>> {
                 let capacity: Result<Capacity, Error> = {
                     let output = &cell_meta.cell_output;
                     let is_dao_type_script = |type_script: Script| {
-                        type_script.hash_type().unpack() == ScriptHashType::Type
+                        type_script.hash_type() == Into::<u8>::into(ScriptHashType::Type)
                             && type_script.code_hash()
                                 == self.consensus.dao_type_hash().expect("No dao system cell")
                     };

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use ckb_types::{core, packed, prelude::*, H256};
 use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::fmt;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
@@ -66,7 +67,7 @@ impl From<Script> for packed::Script {
         packed::Script::new_builder()
             .args(args.into_bytes().pack())
             .code_hash(code_hash.pack())
-            .hash_type(hash_type.pack())
+            .hash_type(hash_type.into())
             .build()
     }
 }
@@ -76,7 +77,9 @@ impl From<packed::Script> for Script {
         Script {
             code_hash: input.code_hash().unpack(),
             args: JsonBytes::from_bytes(input.args().unpack()),
-            hash_type: input.hash_type().unpack().into(),
+            hash_type: core::ScriptHashType::try_from(input.hash_type())
+                .expect("checked data")
+                .into(),
         }
     }
 }
@@ -220,7 +223,9 @@ impl From<packed::CellDep> for CellDep {
     fn from(input: packed::CellDep) -> Self {
         CellDep {
             out_point: input.out_point().into(),
-            dep_type: input.dep_type().unpack().into(),
+            dep_type: core::DepType::try_from(input.dep_type())
+                .expect("checked data")
+                .into(),
         }
     }
 }
@@ -234,7 +239,7 @@ impl From<CellDep> for packed::CellDep {
         let dep_type: core::DepType = dep_type.into();
         packed::CellDep::new_builder()
             .out_point(out_point.into())
-            .dep_type(dep_type.pack())
+            .dep_type(dep_type.into())
             .build()
     }
 }
@@ -693,7 +698,7 @@ mod tests {
         packed::ScriptBuilder::default()
             .code_hash(Byte32::zero())
             .args(arg.pack())
-            .hash_type(core::ScriptHashType::Data.pack())
+            .hash_type(core::ScriptHashType::Data.into())
             .build()
     }
 

--- a/util/test-chain-utils/src/chain.rs
+++ b/util/test-chain-utils/src/chain.rs
@@ -37,7 +37,7 @@ lazy_static! {
             .build();
 
         let script = Script::new_builder()
-            .hash_type(ScriptHashType::Data.pack())
+            .hash_type(ScriptHashType::Data.into())
             .code_hash(CellOutput::calc_data_hash(&data))
             .build();
 

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -26,8 +26,6 @@ option CellOutputOpt (CellOutput);
 option ScriptOpt (Script);
 
 array ProposalShortId [byte; 10];
-array ScriptHashType [byte; 1];
-array DepType [byte; 1];
 
 vector HeaderVec <Header>;
 vector UncleBlockVec <UncleBlock>;
@@ -40,7 +38,7 @@ vector CellOutputVec <CellOutput>;
 
 table Script {
     code_hash:      Byte32,
-    hash_type:      ScriptHashType,
+    hash_type:      byte,
     args:           Bytes,
 }
 
@@ -62,7 +60,7 @@ table CellOutput {
 
 struct CellDep {
     out_point:      OutPoint,
-    dep_type:       DepType,
+    dep_type:       byte,
 }
 
 table RawTransaction {

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -74,39 +74,6 @@ impl<'r> Unpack<[u8; 10]> for packed::ProposalShortIdReader<'r> {
 }
 impl_conversion_for_entity_unpack!([u8; 10], ProposalShortId);
 
-impl Pack<packed::ScriptHashType> for core::ScriptHashType {
-    fn pack(&self) -> packed::ScriptHashType {
-        let v = *self as u8;
-        packed::ScriptHashType::new_unchecked(Bytes::from(vec![v]))
-    }
-}
-
-impl<'r> Unpack<core::ScriptHashType> for packed::ScriptHashTypeReader<'r> {
-    fn unpack(&self) -> core::ScriptHashType {
-        use std::convert::TryFrom;
-        core::ScriptHashType::try_from(self.as_slice()[0])
-            .expect("internal error: fail to unpack ScriptHashType")
-    }
-}
-
-impl_conversion_for_entity_unpack!(core::ScriptHashType, ScriptHashType);
-
-impl Pack<packed::DepType> for core::DepType {
-    fn pack(&self) -> packed::DepType {
-        let v = *self as u8;
-        packed::DepType::new_unchecked(Bytes::from(vec![v]))
-    }
-}
-
-impl<'r> Unpack<core::DepType> for packed::DepTypeReader<'r> {
-    fn unpack(&self) -> core::DepType {
-        use std::convert::TryFrom;
-        core::DepType::try_from(self.as_slice()[0]).expect("internal error: fail to unpack DepType")
-    }
-}
-
-impl_conversion_for_entity_unpack!(core::DepType, DepType);
-
 impl Pack<packed::Bytes> for Bytes {
     fn pack(&self) -> packed::Bytes {
         let len = (self.len() as u32).to_le_bytes();

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -32,6 +32,13 @@ impl ScriptHashType {
     }
 }
 
+impl Into<u8> for ScriptHashType {
+    #[inline]
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DepType {
     Code = 0,
@@ -53,6 +60,13 @@ impl TryFrom<u8> for DepType {
             1 => Ok(DepType::DepGroup),
             _ => Err(err_msg(format!("Invalid dep type {}", v))),
         }
+    }
+}
+
+impl Into<u8> for DepType {
+    #[inline]
+    fn into(self) -> u8 {
+        self as u8
     }
 }
 

--- a/util/types/src/core/cell.rs
+++ b/util/types/src/core/cell.rs
@@ -321,7 +321,7 @@ pub fn get_related_dep_out_points<F: Fn(&OutPoint) -> Option<Bytes>>(
         Vec::with_capacity(tx.cell_deps().len()),
         |mut out_points, dep| {
             let out_point = dep.out_point();
-            if dep.dep_type().unpack() == DepType::DepGroup {
+            if dep.dep_type() == DepType::DepGroup.into() {
                 let data = get_cell_data(&out_point)
                     .ok_or_else(|| String::from("Can not get cell data"))?;
                 let sub_out_points =
@@ -425,7 +425,7 @@ pub fn resolve_transaction<CP: CellProvider, HC: HeaderChecker, S: BuildHasher>(
     }
 
     for cell_dep in transaction.cell_deps_iter() {
-        if cell_dep.dep_type().unpack() == DepType::DepGroup {
+        if cell_dep.dep_type() == DepType::DepGroup.into() {
             if let Some((dep_group, cell_deps)) =
                 resolve_dep_group(&cell_dep.out_point(), &mut resolve_cell)?
             {
@@ -612,7 +612,7 @@ mod tests {
 
         let dep = CellDep::new_builder()
             .out_point(op_dep)
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
 
         let transaction = TransactionBuilder::default().cell_dep(dep).build();
@@ -645,7 +645,7 @@ mod tests {
 
         let dep = CellDep::new_builder()
             .out_point(op_dep.clone())
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
 
         let transaction = TransactionBuilder::default().cell_dep(dep).build();
@@ -674,7 +674,7 @@ mod tests {
 
         let dep = CellDep::new_builder()
             .out_point(op_dep.clone())
-            .dep_type(DepType::DepGroup.pack())
+            .dep_type(DepType::DepGroup.into())
             .build();
 
         let transaction = TransactionBuilder::default().cell_dep(dep).build();

--- a/util/types/src/extension/check_data.rs
+++ b/util/types/src/extension/check_data.rs
@@ -1,31 +1,19 @@
-use crate::{core, packed, prelude::*};
+use crate::{core, packed};
 
 /*
  * Blockchain
  */
 
-impl<'r> packed::ScriptHashTypeReader<'r> {
-    pub fn check_data(&self) -> bool {
-        core::ScriptHashType::verify_value(self.as_slice()[0])
-    }
-}
-
-impl<'r> packed::DepTypeReader<'r> {
-    pub fn check_data(&self) -> bool {
-        core::DepType::verify_value(self.as_slice()[0])
-    }
-}
-
 impl<'r> packed::ScriptReader<'r> {
     pub fn check_data(&self) -> bool {
-        self.hash_type().check_data()
+        core::ScriptHashType::verify_value(self.hash_type())
     }
 }
 
 impl<'r> packed::ScriptOptReader<'r> {
     pub fn check_data(&self) -> bool {
         self.to_opt()
-            .map(|i| i.hash_type().check_data())
+            .map(|i| core::ScriptHashType::verify_value(i.hash_type()))
             .unwrap_or(true)
     }
 }
@@ -44,7 +32,7 @@ impl<'r> packed::CellOutputVecReader<'r> {
 
 impl<'r> packed::CellDepReader<'r> {
     pub fn check_data(&self) -> bool {
-        self.dep_type().check_data()
+        core::DepType::verify_value(self.dep_type())
     }
 }
 
@@ -155,17 +143,13 @@ mod tests {
 
     #[test]
     fn check_data() {
-        let ht_right = packed::ScriptHashType::new_builder().set([1]).build();
-        let ht_error = packed::ScriptHashType::new_builder().set([2]).build();
-        let dt_right = packed::DepType::new_builder().set([1]).build();
-        let dt_error = packed::DepType::new_builder().set([2]).build();
+        let ht_right = 1;
+        let ht_error = 2;
+        let dt_right = 1;
+        let dt_error = 2;
 
-        let script_right = packed::Script::new_builder()
-            .hash_type(ht_right.clone())
-            .build();
-        let script_error = packed::Script::new_builder()
-            .hash_type(ht_error.clone())
-            .build();
+        let script_right = packed::Script::new_builder().hash_type(ht_right).build();
+        let script_error = packed::Script::new_builder().hash_type(ht_error).build();
 
         let script_opt_right = packed::ScriptOpt::new_builder()
             .set(Some(script_right.clone()))
@@ -195,12 +179,8 @@ mod tests {
             .type_(script_opt_right.clone())
             .build();
 
-        let cell_dep_right = packed::CellDep::new_builder()
-            .dep_type(dt_right.clone())
-            .build();
-        let cell_dep_error = packed::CellDep::new_builder()
-            .dep_type(dt_error.clone())
-            .build();
+        let cell_dep_right = packed::CellDep::new_builder().dep_type(dt_right).build();
+        let cell_dep_error = packed::CellDep::new_builder().dep_type(dt_error).build();
 
         test_check_data_via_transaction(true, &[], &[], &[]);
         test_check_data_via_transaction(true, &[&output_right1], &[&[]], &[&cell_dep_right]);

--- a/util/types/src/generated/types.rs
+++ b/util/types/src/generated/types.rs
@@ -4688,322 +4688,6 @@ impl ProposalShortIdBuilder {
     }
 }
 #[derive(Clone)]
-pub struct ScriptHashType(molecule::bytes::Bytes);
-#[derive(Clone, Copy)]
-pub struct ScriptHashTypeReader<'r>(&'r [u8]);
-impl ::std::fmt::Debug for ScriptHashType {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
-    }
-}
-impl<'r> ::std::fmt::Debug for ScriptHashTypeReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
-    }
-}
-impl ::std::fmt::Display for ScriptHashType {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(&self.raw_data()).unwrap()
-        )
-    }
-}
-impl<'r> ::std::fmt::Display for ScriptHashTypeReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(&self.raw_data()).unwrap()
-        )
-    }
-}
-pub struct ScriptHashTypeBuilder(pub(crate) [u8; 1]);
-impl ::std::fmt::Debug for ScriptHashTypeBuilder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:?})", Self::NAME, &self.0[..])
-    }
-}
-impl ::std::default::Default for ScriptHashTypeBuilder {
-    fn default() -> Self {
-        ScriptHashTypeBuilder([0; 1])
-    }
-}
-impl molecule::prelude::Entity for ScriptHashType {
-    type Builder = ScriptHashTypeBuilder;
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        ScriptHashType(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        ScriptHashTypeReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        ScriptHashTypeReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().set([self.nth0()])
-    }
-}
-impl ::std::default::Default for ScriptHashType {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![0];
-        ScriptHashType::new_unchecked(v.into())
-    }
-}
-impl ScriptHashType {
-    pub const NAME: &'static str = "ScriptHashType";
-    pub fn as_reader<'r>(&'r self) -> ScriptHashTypeReader<'r> {
-        ScriptHashTypeReader::new_unchecked(self.as_slice())
-    }
-    pub const TOTAL_SIZE: usize = 1;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 1;
-    pub fn raw_data(&self) -> molecule::bytes::Bytes {
-        self.as_bytes()
-    }
-    pub fn nth0(&self) -> u8 {
-        self.0[0]
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for ScriptHashTypeReader<'r> {
-    type Entity = ScriptHashType;
-    fn to_entity(&self) -> Self::Entity {
-        ScriptHashType::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        ScriptHashTypeReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::error::VerificationError;
-        if slice.len() != 1 {
-            let err = VerificationError::TotalSizeNotMatch(Self::NAME.to_owned(), 1, slice.len());
-            Err(err)?;
-        }
-        Ok(())
-    }
-}
-impl<'r> ScriptHashTypeReader<'r> {
-    pub const NAME: &'r str = "ScriptHashTypeReader";
-    pub const TOTAL_SIZE: usize = 1;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 1;
-    pub fn raw_data(&self) -> &'r [u8] {
-        self.as_slice()
-    }
-    pub fn nth0(&self) -> u8 {
-        self.0[0]
-    }
-}
-impl molecule::prelude::Builder for ScriptHashTypeBuilder {
-    type Entity = ScriptHashType;
-    fn expected_length(&self) -> usize {
-        1
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        writer.write_all(&self.0)?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner).expect("write vector should be ok");
-        ScriptHashType::new_unchecked(inner.into())
-    }
-}
-impl ScriptHashTypeBuilder {
-    pub const NAME: &'static str = "ScriptHashTypeBuilder";
-    pub fn set(mut self, v: [u8; 1]) -> Self {
-        self.0 = v;
-        self
-    }
-    pub fn nth0(mut self, v: u8) -> Self {
-        self.0[0] = v;
-        self
-    }
-}
-#[derive(Clone)]
-pub struct DepType(molecule::bytes::Bytes);
-#[derive(Clone, Copy)]
-pub struct DepTypeReader<'r>(&'r [u8]);
-impl ::std::fmt::Debug for DepType {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
-    }
-}
-impl<'r> ::std::fmt::Debug for DepTypeReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
-    }
-}
-impl ::std::fmt::Display for DepType {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(&self.raw_data()).unwrap()
-        )
-    }
-}
-impl<'r> ::std::fmt::Display for DepTypeReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(&self.raw_data()).unwrap()
-        )
-    }
-}
-pub struct DepTypeBuilder(pub(crate) [u8; 1]);
-impl ::std::fmt::Debug for DepTypeBuilder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:?})", Self::NAME, &self.0[..])
-    }
-}
-impl ::std::default::Default for DepTypeBuilder {
-    fn default() -> Self {
-        DepTypeBuilder([0; 1])
-    }
-}
-impl molecule::prelude::Entity for DepType {
-    type Builder = DepTypeBuilder;
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        DepType(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        DepTypeReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        DepTypeReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().set([self.nth0()])
-    }
-}
-impl ::std::default::Default for DepType {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![0];
-        DepType::new_unchecked(v.into())
-    }
-}
-impl DepType {
-    pub const NAME: &'static str = "DepType";
-    pub fn as_reader<'r>(&'r self) -> DepTypeReader<'r> {
-        DepTypeReader::new_unchecked(self.as_slice())
-    }
-    pub const TOTAL_SIZE: usize = 1;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 1;
-    pub fn raw_data(&self) -> molecule::bytes::Bytes {
-        self.as_bytes()
-    }
-    pub fn nth0(&self) -> u8 {
-        self.0[0]
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for DepTypeReader<'r> {
-    type Entity = DepType;
-    fn to_entity(&self) -> Self::Entity {
-        DepType::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        DepTypeReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::error::VerificationError;
-        if slice.len() != 1 {
-            let err = VerificationError::TotalSizeNotMatch(Self::NAME.to_owned(), 1, slice.len());
-            Err(err)?;
-        }
-        Ok(())
-    }
-}
-impl<'r> DepTypeReader<'r> {
-    pub const NAME: &'r str = "DepTypeReader";
-    pub const TOTAL_SIZE: usize = 1;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 1;
-    pub fn raw_data(&self) -> &'r [u8] {
-        self.as_slice()
-    }
-    pub fn nth0(&self) -> u8 {
-        self.0[0]
-    }
-}
-impl molecule::prelude::Builder for DepTypeBuilder {
-    type Entity = DepType;
-    fn expected_length(&self) -> usize {
-        1
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        writer.write_all(&self.0)?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner).expect("write vector should be ok");
-        DepType::new_unchecked(inner.into())
-    }
-}
-impl DepTypeBuilder {
-    pub const NAME: &'static str = "DepTypeBuilder";
-    pub fn set(mut self, v: [u8; 1]) -> Self {
-        self.0 = v;
-        self
-    }
-    pub fn nth0(mut self, v: u8) -> Self {
-        self.0[0] = v;
-        self
-    }
-}
-#[derive(Clone)]
 pub struct HeaderVec(molecule::bytes::Bytes);
 #[derive(Clone, Copy)]
 pub struct HeaderVecReader<'r>(&'r [u8]);
@@ -7270,7 +6954,7 @@ impl<'r> ::std::fmt::Display for ScriptReader<'r> {
 #[derive(Debug, Default)]
 pub struct ScriptBuilder {
     pub(crate) code_hash: Byte32,
-    pub(crate) hash_type: ScriptHashType,
+    pub(crate) hash_type: u8,
     pub(crate) args: Bytes,
 }
 impl ::std::default::Default for Script {
@@ -7332,11 +7016,10 @@ impl Script {
         let end = u32::from_le(offsets[0 + 1]) as usize;
         Byte32::new_unchecked(self.0.slice(start, end))
     }
-    pub fn hash_type(&self) -> ScriptHashType {
+    pub fn hash_type(&self) -> u8 {
         let (_, _, offsets) = Self::field_offsets(self);
-        let start = u32::from_le(offsets[1]) as usize;
-        let end = u32::from_le(offsets[1 + 1]) as usize;
-        ScriptHashType::new_unchecked(self.0.slice(start, end))
+        let offset = u32::from_le(offsets[1]) as usize;
+        self.0[offset]
     }
     pub fn args(&self) -> Bytes {
         let (_, count, offsets) = Self::field_offsets(self);
@@ -7428,7 +7111,10 @@ impl<'r> molecule::prelude::Reader<'r> for ScriptReader<'r> {
             Err(err)?;
         }
         Byte32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        ScriptHashTypeReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        if offsets[1] + 1 != offsets[2] {
+            let err = VerificationError::FieldIsBroken(Self::NAME.to_owned(), 1);
+            Err(err)?;
+        }
         BytesReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Ok(())
     }
@@ -7453,11 +7139,10 @@ impl<'r> ScriptReader<'r> {
         let end = u32::from_le(offsets[0 + 1]) as usize;
         Byte32Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn hash_type(&self) -> ScriptHashTypeReader<'r> {
+    pub fn hash_type(&self) -> u8 {
         let (_, _, offsets) = Self::field_offsets(self);
-        let start = u32::from_le(offsets[1]) as usize;
-        let end = u32::from_le(offsets[1 + 1]) as usize;
-        ScriptHashTypeReader::new_unchecked(&self.as_slice()[start..end])
+        let offset = u32::from_le(offsets[1]) as usize;
+        self.0[offset]
     }
     pub fn args(&self) -> BytesReader<'r> {
         let (_, count, offsets) = Self::field_offsets(self);
@@ -7474,10 +7159,7 @@ impl molecule::prelude::Builder for ScriptBuilder {
     type Entity = Script;
     fn expected_length(&self) -> usize {
         let len_header = 4 + 3 * 4;
-        len_header
-            + self.code_hash.as_slice().len()
-            + self.hash_type.as_slice().len()
-            + self.args.as_slice().len()
+        len_header + self.code_hash.as_slice().len() + 1 + self.args.as_slice().len()
     }
     fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
         let len = (self.expected_length() as u32).to_le_bytes();
@@ -7491,7 +7173,7 @@ impl molecule::prelude::Builder for ScriptBuilder {
         {
             let tmp = (offset as u32).to_le_bytes();
             writer.write_all(&tmp[..])?;
-            offset += self.hash_type.as_slice().len();
+            offset += 1;
         }
         {
             let tmp = (offset as u32).to_le_bytes();
@@ -7500,7 +7182,7 @@ impl molecule::prelude::Builder for ScriptBuilder {
         }
         let _ = offset;
         writer.write_all(self.code_hash.as_slice())?;
-        writer.write_all(self.hash_type.as_slice())?;
+        writer.write_all(&[self.hash_type])?;
         writer.write_all(self.args.as_slice())?;
         Ok(())
     }
@@ -7516,7 +7198,7 @@ impl ScriptBuilder {
         self.code_hash = v;
         self
     }
-    pub fn hash_type(mut self, v: ScriptHashType) -> Self {
+    pub fn hash_type(mut self, v: u8) -> Self {
         self.hash_type = v;
         self
     }
@@ -8189,7 +7871,7 @@ impl<'r> ::std::fmt::Display for CellDepReader<'r> {
 #[derive(Debug, Default)]
 pub struct CellDepBuilder {
     pub(crate) out_point: OutPoint,
-    pub(crate) dep_type: DepType,
+    pub(crate) dep_type: u8,
 }
 impl molecule::prelude::Entity for CellDep {
     type Builder = CellDepBuilder;
@@ -8237,8 +7919,8 @@ impl CellDep {
     pub fn out_point(&self) -> OutPoint {
         OutPoint::new_unchecked(self.0.slice(0, 36))
     }
-    pub fn dep_type(&self) -> DepType {
-        DepType::new_unchecked(self.0.slice(36, 37))
+    pub fn dep_type(&self) -> u8 {
+        self.0[36]
     }
 }
 impl<'r> molecule::prelude::Reader<'r> for CellDepReader<'r> {
@@ -8259,7 +7941,6 @@ impl<'r> molecule::prelude::Reader<'r> for CellDepReader<'r> {
             Err(err)?;
         }
         OutPointReader::verify(&slice[0..36], _compatible)?;
-        DepTypeReader::verify(&slice[36..37], _compatible)?;
         Ok(())
     }
 }
@@ -8271,8 +7952,8 @@ impl<'r> CellDepReader<'r> {
     pub fn out_point(&self) -> OutPointReader<'r> {
         OutPointReader::new_unchecked(&self.as_slice()[0..36])
     }
-    pub fn dep_type(&self) -> DepTypeReader<'r> {
-        DepTypeReader::new_unchecked(&self.as_slice()[36..37])
+    pub fn dep_type(&self) -> u8 {
+        self.0[36]
     }
 }
 impl molecule::prelude::Builder for CellDepBuilder {
@@ -8282,7 +7963,7 @@ impl molecule::prelude::Builder for CellDepBuilder {
     }
     fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
         writer.write_all(self.out_point.as_slice())?;
-        writer.write_all(self.dep_type.as_slice())?;
+        writer.write_all(&[self.dep_type])?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
@@ -8297,7 +7978,7 @@ impl CellDepBuilder {
         self.out_point = v;
         self
     }
-    pub fn dep_type(mut self, v: DepType) -> Self {
+    pub fn dep_type(mut self, v: u8) -> Self {
         self.dep_type = v;
         self
     }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -371,7 +371,7 @@ impl<'a> CapacityVerifier<'a> {
                     .type_()
                     .to_opt()
                     .map(|t| {
-                        t.hash_type().unpack() == ScriptHashType::Type
+                        t.hash_type() == Into::<u8>::into(ScriptHashType::Type)
                             && &t.code_hash()
                                 == self.dao_type_hash.as_ref().expect("No dao system cell")
                     })


### PR DESCRIPTION
This PR changes enum types in ckb.mol (`ScriptHashType` and `DepType`) from `[byte; 1]` to `byte`, it simplifies builder API and avoids some unnecessary conversions.