### PR TITLE
fix: indexer store should lock the state when syncing data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "ckb-store 0.20.0-pre",
  "ckb-traits 0.20.0-pre",
  "ckb-types 0.20.0-pre",
+ "ckb-util 0.20.0-pre",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -14,6 +14,7 @@ ckb-store = { path = "../store" }
 ckb-traits = { path = "../traits" }
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 ckb-logger = { path = "../util/logger" }
+ckb-util = { path = "../util" }
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
This PR fixed an accidental bug of incorrect indexer store state when syncing indexer state and deindex an index in the same time.