### PR TITLE
docs: Group methods of same module together

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -8,6 +8,9 @@ def newline(n):
         print("")
 
 
+def sort_cases_by_module(cases):
+    return sorted(cases, key=lambda case: case["module"])
+
 def print_title(case):
     print("### `{}`".format(case["method"]))
     newline(1)
@@ -97,7 +100,7 @@ def main():
 
     filepath = sys.argv[1]
     with open(filepath) as f:
-        cases = json.load(f)
+        cases = sort_cases_by_module(json.load(f))
 
     print("# CKB JSON-RPC Protocols")
     newline(2)

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -12,9 +12,6 @@
     *   [`get_header_by_number`](#get_header_by_number)
     *   [`get_cells_by_lock_hash`](#get_cells_by_lock_hash)
     *   [`get_live_cell`](#get_live_cell)
-    *   [`get_transaction`](#get_transaction)
-    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
-    *   [`get_block_by_number`](#get_block_by_number)
 *   [`Net`](#net)
     *   [`local_node_info`](#local_node_info)
     *   [`get_peers`](#get_peers)
@@ -23,9 +20,18 @@
 *   [`Stats`](#stats)
     *   [`get_blockchain_info`](#get_blockchain_info)
     *   [`get_peers_state`](#get_peers_state)
+*   [`Experiment`](#experiment)
+    *   [`dry_run_transaction`](#dry_run_transaction)
+    *   [`_compute_transaction_hash`](#_compute_transaction_hash)
 *   [`Pool`](#pool)
     *   [`send_transaction`](#send_transaction)
+*   [`Chain`](#chain)
+    *   [`get_transaction`](#get_transaction)
+    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
+*   [`Pool`](#pool)
     *   [`tx_pool_info`](#tx_pool_info)
+*   [`Chain`](#chain)
+    *   [`get_block_by_number`](#get_block_by_number)
 *   [`Indexer`](#indexer)
     *   [`index_lock_hash`](#index_lock_hash)
     *   [`get_lock_hash_index_states`](#get_lock_hash_index_states)
@@ -33,9 +39,7 @@
     *   [`get_transactions_by_lock_hash`](#get_transactions_by_lock_hash)
     *   [`deindex_lock_hash`](#deindex_lock_hash)
 *   [`Experiment`](#experiment)
-    *   [`dry_run_transaction`](#dry_run_transaction)
     *   [`_compute_script_hash`](#_compute_script_hash)
-    *   [`_compute_transaction_hash`](#_compute_transaction_hash)
 
 ## Chain
 
@@ -495,210 +499,6 @@ http://localhost:8114
 }
 ```
 
-### `get_transaction`
-
-Returns the information about a transaction requested by transaction hash.
-
-#### Parameters
-
-    hash - Hash of a transaction
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_transaction",
-    "params": [
-        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "transaction": {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        },
-        "tx_status": {
-            "block_hash": null,
-            "status": "pending"
-        }
-    }
-}
-```
-
-### `get_cellbase_output_capacity_details`
-
-Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
-
-#### Parameters
-
-    hash - Block hash
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_cellbase_output_capacity_details",
-    "params": [
-        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "primary": "69444444445",
-        "proposal_reward": "0",
-        "secondary": "748753061",
-        "total": "70193197506",
-        "tx_fee": "0"
-    }
-}
-```
-
-### `get_block_by_number`
-
-Get block by number
-
-#### Parameters
-
-    block_number - Number of a block
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_block_by_number",
-    "params": [
-        "1024"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "header": {
-            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
-            "difficulty": "0x7a1200",
-            "epoch": "1",
-            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
-            "nonce": "0",
-            "number": "1024",
-            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
-            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "timestamp": "1557311767",
-            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-            "uncles_count": "0",
-            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "version": "0",
-            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
-        },
-        "proposals": [],
-        "transactions": [
-            {
-                "cell_deps": [],
-                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                "header_deps": [],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "4294967295",
-                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                        },
-                        "since": "1024"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "70193197506",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": [
-                    {
-                        "data": [
-                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "uncles": []
-    }
-}
-```
-
 ## Net
 
 ### `local_node_info`
@@ -947,6 +747,159 @@ http://localhost:8114
 }
 ```
 
+## Experiment
+
+### `dry_run_transaction`
+
+Dry run transaction and return the execution cycles.
+
+This method will not check the transaction validity, but only run the lock script
+and type script and then return the execution cycles.
+Used to debug transaction scripts and query how many cycles the scripts consume
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "dry_run_transaction",
+    "params": [
+        {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        }
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "cycles": "12"
+    }
+}
+```
+
+### `_compute_transaction_hash`
+
+Return the transaction hash
+
+**Deprecated**: will be removed in a later version
+
+#### Parameters
+
+    transaction - The transaction object
+    version - Transaction version
+    cell_deps - Cell dependencies
+    header_deps - Header dependencies
+    inputs - Transaction inputs
+    outputs - Transaction outputs
+    witnesses - Witnesses
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "_compute_transaction_hash",
+    "params": [
+        {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        }
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+}
+```
+
 ## Pool
 
 ### `send_transaction`
@@ -1027,6 +980,125 @@ http://localhost:8114
 }
 ```
 
+## Chain
+
+### `get_transaction`
+
+Returns the information about a transaction requested by transaction hash.
+
+#### Parameters
+
+    hash - Hash of a transaction
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_transaction",
+    "params": [
+        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "transaction": {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        },
+        "tx_status": {
+            "block_hash": null,
+            "status": "pending"
+        }
+    }
+}
+```
+
+### `get_cellbase_output_capacity_details`
+
+Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
+
+#### Parameters
+
+    hash - Block hash
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_cellbase_output_capacity_details",
+    "params": [
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "primary": "69444444445",
+        "proposal_reward": "0",
+        "secondary": "748753061",
+        "total": "70193197506",
+        "tx_fee": "0"
+    }
+}
+```
+
+## Pool
+
 ### `tx_pool_info`
 
 Return the transaction pool information
@@ -1057,6 +1129,97 @@ http://localhost:8114
         "proposed": "0",
         "total_tx_cycles": "12",
         "total_tx_size": "274"
+    }
+}
+```
+
+## Chain
+
+### `get_block_by_number`
+
+Get block by number
+
+#### Parameters
+
+    block_number - Number of a block
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_block_by_number",
+    "params": [
+        "1024"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "header": {
+            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
+            "difficulty": "0x7a1200",
+            "epoch": "1",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
+            "nonce": "0",
+            "number": "1024",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
+            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1557311767",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+            "uncles_count": "0",
+            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "version": "0",
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
+        },
+        "proposals": [],
+        "transactions": [
+            {
+                "cell_deps": [],
+                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                "header_deps": [],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "4294967295",
+                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        },
+                        "since": "1024"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "70193197506",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "uncles": []
     }
 }
 ```
@@ -1292,79 +1455,6 @@ http://localhost:8114
 
 ## Experiment
 
-### `dry_run_transaction`
-
-Dry run transaction and return the execution cycles.
-
-This method will not check the transaction validity, but only run the lock script
-and type script and then return the execution cycles.
-Used to debug transaction scripts and query how many cycles the scripts consume
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "dry_run_transaction",
-    "params": [
-        {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        }
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "cycles": "12"
-    }
-}
-```
-
 ### `_compute_script_hash`
 
 Returns script hash of given transaction script
@@ -1402,83 +1492,5 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
-}
-```
-
-### `_compute_transaction_hash`
-
-Return the transaction hash
-
-**Deprecated**: will be removed in a later version
-
-#### Parameters
-
-    transaction - The transaction object
-    version - Transaction version
-    cell_deps - Cell dependencies
-    header_deps - Header dependencies
-    inputs - Transaction inputs
-    outputs - Transaction outputs
-    witnesses - Witnesses
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "_compute_transaction_hash",
-    "params": [
-        {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        }
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -12,6 +12,9 @@
     *   [`get_header_by_number`](#get_header_by_number)
     *   [`get_cells_by_lock_hash`](#get_cells_by_lock_hash)
     *   [`get_live_cell`](#get_live_cell)
+    *   [`get_transaction`](#get_transaction)
+    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
+    *   [`get_block_by_number`](#get_block_by_number)
 *   [`Net`](#net)
     *   [`local_node_info`](#local_node_info)
     *   [`get_peers`](#get_peers)
@@ -20,18 +23,9 @@
 *   [`Stats`](#stats)
     *   [`get_blockchain_info`](#get_blockchain_info)
     *   [`get_peers_state`](#get_peers_state)
-*   [`Experiment`](#experiment)
-    *   [`dry_run_transaction`](#dry_run_transaction)
-    *   [`_compute_transaction_hash`](#_compute_transaction_hash)
 *   [`Pool`](#pool)
     *   [`send_transaction`](#send_transaction)
-*   [`Chain`](#chain)
-    *   [`get_transaction`](#get_transaction)
-    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
-*   [`Pool`](#pool)
     *   [`tx_pool_info`](#tx_pool_info)
-*   [`Chain`](#chain)
-    *   [`get_block_by_number`](#get_block_by_number)
 *   [`Indexer`](#indexer)
     *   [`index_lock_hash`](#index_lock_hash)
     *   [`get_lock_hash_index_states`](#get_lock_hash_index_states)
@@ -39,7 +33,9 @@
     *   [`get_transactions_by_lock_hash`](#get_transactions_by_lock_hash)
     *   [`deindex_lock_hash`](#deindex_lock_hash)
 *   [`Experiment`](#experiment)
+    *   [`dry_run_transaction`](#dry_run_transaction)
     *   [`_compute_script_hash`](#_compute_script_hash)
+    *   [`_compute_transaction_hash`](#_compute_transaction_hash)
 
 ## Chain
 
@@ -499,6 +495,210 @@ http://localhost:8114
 }
 ```
 
+### `get_transaction`
+
+Returns the information about a transaction requested by transaction hash.
+
+#### Parameters
+
+    hash - Hash of a transaction
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_transaction",
+    "params": [
+        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "transaction": {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        },
+        "tx_status": {
+            "block_hash": null,
+            "status": "pending"
+        }
+    }
+}
+```
+
+### `get_cellbase_output_capacity_details`
+
+Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
+
+#### Parameters
+
+    hash - Block hash
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_cellbase_output_capacity_details",
+    "params": [
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "primary": "69444444445",
+        "proposal_reward": "0",
+        "secondary": "748753061",
+        "total": "70193197506",
+        "tx_fee": "0"
+    }
+}
+```
+
+### `get_block_by_number`
+
+Get block by number
+
+#### Parameters
+
+    block_number - Number of a block
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_block_by_number",
+    "params": [
+        "1024"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "header": {
+            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
+            "difficulty": "0x7a1200",
+            "epoch": "1",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
+            "nonce": "0",
+            "number": "1024",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
+            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1557311767",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+            "uncles_count": "0",
+            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "version": "0",
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
+        },
+        "proposals": [],
+        "transactions": [
+            {
+                "cell_deps": [],
+                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                "header_deps": [],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "4294967295",
+                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        },
+                        "since": "1024"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "70193197506",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "uncles": []
+    }
+}
+```
+
 ## Net
 
 ### `local_node_info`
@@ -747,159 +947,6 @@ http://localhost:8114
 }
 ```
 
-## Experiment
-
-### `dry_run_transaction`
-
-Dry run transaction and return the execution cycles.
-
-This method will not check the transaction validity, but only run the lock script
-and type script and then return the execution cycles.
-Used to debug transaction scripts and query how many cycles the scripts consume
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "dry_run_transaction",
-    "params": [
-        {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        }
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "cycles": "12"
-    }
-}
-```
-
-### `_compute_transaction_hash`
-
-Return the transaction hash
-
-**Deprecated**: will be removed in a later version
-
-#### Parameters
-
-    transaction - The transaction object
-    version - Transaction version
-    cell_deps - Cell dependencies
-    header_deps - Header dependencies
-    inputs - Transaction inputs
-    outputs - Transaction outputs
-    witnesses - Witnesses
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "_compute_transaction_hash",
-    "params": [
-        {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        }
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-}
-```
-
 ## Pool
 
 ### `send_transaction`
@@ -980,125 +1027,6 @@ http://localhost:8114
 }
 ```
 
-## Chain
-
-### `get_transaction`
-
-Returns the information about a transaction requested by transaction hash.
-
-#### Parameters
-
-    hash - Hash of a transaction
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_transaction",
-    "params": [
-        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "transaction": {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        },
-        "tx_status": {
-            "block_hash": null,
-            "status": "pending"
-        }
-    }
-}
-```
-
-### `get_cellbase_output_capacity_details`
-
-Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
-
-#### Parameters
-
-    hash - Block hash
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_cellbase_output_capacity_details",
-    "params": [
-        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "primary": "69444444445",
-        "proposal_reward": "0",
-        "secondary": "748753061",
-        "total": "70193197506",
-        "tx_fee": "0"
-    }
-}
-```
-
-## Pool
-
 ### `tx_pool_info`
 
 Return the transaction pool information
@@ -1129,97 +1057,6 @@ http://localhost:8114
         "proposed": "0",
         "total_tx_cycles": "12",
         "total_tx_size": "274"
-    }
-}
-```
-
-## Chain
-
-### `get_block_by_number`
-
-Get block by number
-
-#### Parameters
-
-    block_number - Number of a block
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_block_by_number",
-    "params": [
-        "1024"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "header": {
-            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
-            "difficulty": "0x7a1200",
-            "epoch": "1",
-            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
-            "nonce": "0",
-            "number": "1024",
-            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
-            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "timestamp": "1557311767",
-            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-            "uncles_count": "0",
-            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "version": "0",
-            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
-        },
-        "proposals": [],
-        "transactions": [
-            {
-                "cell_deps": [],
-                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                "header_deps": [],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "4294967295",
-                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                        },
-                        "since": "1024"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "70193197506",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": [
-                    {
-                        "data": [
-                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "uncles": []
     }
 }
 ```
@@ -1455,6 +1292,79 @@ http://localhost:8114
 
 ## Experiment
 
+### `dry_run_transaction`
+
+Dry run transaction and return the execution cycles.
+
+This method will not check the transaction validity, but only run the lock script
+and type script and then return the execution cycles.
+Used to debug transaction scripts and query how many cycles the scripts consume
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "dry_run_transaction",
+    "params": [
+        {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        }
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "cycles": "12"
+    }
+}
+```
+
 ### `_compute_script_hash`
 
 Returns script hash of given transaction script
@@ -1492,5 +1402,83 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
+}
+```
+
+### `_compute_transaction_hash`
+
+Return the transaction hash
+
+**Deprecated**: will be removed in a later version
+
+#### Parameters
+
+    transaction - The transaction object
+    version - Transaction version
+    cell_deps - Cell dependencies
+    header_deps - Header dependencies
+    inputs - Transaction inputs
+    outputs - Transaction outputs
+    witnesses - Witnesses
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "_compute_transaction_hash",
+    "params": [
+        {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        }
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -12,34 +12,30 @@
     *   [`get_header_by_number`](#get_header_by_number)
     *   [`get_cells_by_lock_hash`](#get_cells_by_lock_hash)
     *   [`get_live_cell`](#get_live_cell)
-*   [`Net`](#net)
-    *   [`local_node_info`](#local_node_info)
-    *   [`get_peers`](#get_peers)
-    *   [`get_banned_addresses`](#get_banned_addresses)
-    *   [`set_ban`](#set_ban)
-*   [`Stats`](#stats)
-    *   [`get_blockchain_info`](#get_blockchain_info)
-    *   [`get_peers_state`](#get_peers_state)
+    *   [`get_transaction`](#get_transaction)
+    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
+    *   [`get_block_by_number`](#get_block_by_number)
 *   [`Experiment`](#experiment)
     *   [`dry_run_transaction`](#dry_run_transaction)
     *   [`_compute_transaction_hash`](#_compute_transaction_hash)
-*   [`Pool`](#pool)
-    *   [`send_transaction`](#send_transaction)
-*   [`Chain`](#chain)
-    *   [`get_transaction`](#get_transaction)
-    *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
-*   [`Pool`](#pool)
-    *   [`tx_pool_info`](#tx_pool_info)
-*   [`Chain`](#chain)
-    *   [`get_block_by_number`](#get_block_by_number)
+    *   [`_compute_script_hash`](#_compute_script_hash)
 *   [`Indexer`](#indexer)
     *   [`index_lock_hash`](#index_lock_hash)
     *   [`get_lock_hash_index_states`](#get_lock_hash_index_states)
     *   [`get_live_cells_by_lock_hash`](#get_live_cells_by_lock_hash)
     *   [`get_transactions_by_lock_hash`](#get_transactions_by_lock_hash)
     *   [`deindex_lock_hash`](#deindex_lock_hash)
-*   [`Experiment`](#experiment)
-    *   [`_compute_script_hash`](#_compute_script_hash)
+*   [`Net`](#net)
+    *   [`local_node_info`](#local_node_info)
+    *   [`get_peers`](#get_peers)
+    *   [`get_banned_addresses`](#get_banned_addresses)
+    *   [`set_ban`](#set_ban)
+*   [`Pool`](#pool)
+    *   [`send_transaction`](#send_transaction)
+    *   [`tx_pool_info`](#tx_pool_info)
+*   [`Stats`](#stats)
+    *   [`get_blockchain_info`](#get_blockchain_info)
+    *   [`get_peers_state`](#get_peers_state)
 
 ## Chain
 
@@ -499,149 +495,13 @@ http://localhost:8114
 }
 ```
 
-## Net
+### `get_transaction`
 
-### `local_node_info`
-
-Returns the local node information.
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "local_node_info",
-    "params": []
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "addresses": [
-            {
-                "address": "/ip4/192.168.0.2/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
-                "score": "255"
-            },
-            {
-                "address": "/ip4/0.0.0.0/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
-                "score": "1"
-            }
-        ],
-        "is_outbound": null,
-        "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
-        "version": "0.0.0"
-    }
-}
-```
-
-### `get_peers`
-
-Returns the connected peers information.
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_peers",
-    "params": []
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": [
-        {
-            "addresses": [
-                {
-                    "address": "/ip4/192.168.0.3/tcp/8115",
-                    "score": "1"
-                }
-            ],
-            "is_outbound": true,
-            "node_id": "QmaaaLB4uPyDpZwTQGhV63zuYrKm4reyN2tF1j2ain4oE7",
-            "version": "unknown"
-        },
-        {
-            "addresses": [
-                {
-                    "address": "/ip4/192.168.0.4/tcp/8113",
-                    "score": "255"
-                }
-            ],
-            "is_outbound": false,
-            "node_id": "QmRuGcpVC3vE7aEoB6fhUdq9uzdHbyweCnn1sDBSjfmcbM",
-            "version": "unknown"
-        },
-        {
-            "addresses": [],
-            "node_id": "QmUddxwRqgTmT6tFujXbYPMLGLAE2Tciyv6uHGfdYFyDVa",
-            "version": "unknown"
-        }
-    ]
-}
-```
-
-### `get_banned_addresses`
-
-Returns all banned IPs/Subnets.
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_banned_addresses",
-    "params": []
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": [
-        {
-            "address": "192.168.0.2/32",
-            "ban_reason": "",
-            "ban_until": "1840546800000",
-            "created_at": "1562803123000"
-        }
-    ]
-}
-```
-
-### `set_ban`
-
-Insert or delete an IP/Subnet from the banned list
+Returns the information about a transaction requested by transaction hash.
 
 #### Parameters
 
-    address - The IP/Subnet with an optional netmask (default is /32 = single IP)
-    command - `insert` to insert an IP/Subnet to the list, `delete` to delete an IP/Subnet from the list
-    ban_time - Time in milliseconds how long (or until when if [absolute] is set) the IP is banned, optional parameter, null means using the default time of 24h
-    absolute - If set, the `ban_time` must be an absolute timestamp in milliseconds since epoch, optional parameter
-    reason - Ban reason, optional parameter
+    hash - Hash of a transaction
 
 #### Examples
 
@@ -649,43 +509,10 @@ Insert or delete an IP/Subnet from the banned list
 echo '{
     "id": 2,
     "jsonrpc": "2.0",
-    "method": "set_ban",
+    "method": "get_transaction",
     "params": [
-        "192.168.0.2",
-        "insert",
-        "1840546800000",
-        true,
-        "set_ban example"
+        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
     ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": null
-}
-```
-
-## Stats
-
-### `get_blockchain_info`
-
-Return state info of blockchain
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_blockchain_info",
-    "params": []
 }' \
 | tr -d '\n' \
 | curl -H 'content-type: application/json' -d @- \
@@ -697,27 +524,61 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "alerts": [
-            {
-                "id": "42",
-                "message": "An example alert message!",
-                "notice_until": "2524579200000",
-                "priority": "1"
-            }
-        ],
-        "chain": "main",
-        "difficulty": "0x7a1200",
-        "epoch": "1",
-        "is_initial_block_download": true,
-        "median_time": "1557311762"
+        "transaction": {
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
+        },
+        "tx_status": {
+            "block_hash": null,
+            "status": "pending"
+        }
     }
 }
 ```
 
-### `get_peers_state`
+### `get_cellbase_output_capacity_details`
 
-Deprecating in 0.12.0: Return state info of peers
+Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
 
+#### Parameters
+
+    hash - Block hash
 
 #### Examples
 
@@ -725,8 +586,10 @@ Deprecating in 0.12.0: Return state info of peers
 echo '{
     "id": 2,
     "jsonrpc": "2.0",
-    "method": "get_peers_state",
-    "params": []
+    "method": "get_cellbase_output_capacity_details",
+    "params": [
+        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
+    ]
 }' \
 | tr -d '\n' \
 | curl -H 'content-type: application/json' -d @- \
@@ -737,13 +600,102 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": [
-        {
-            "blocks_in_flight": "86",
-            "last_updated": "1557289448237",
-            "peer": "1"
-        }
+    "result": {
+        "primary": "69444444445",
+        "proposal_reward": "0",
+        "secondary": "748753061",
+        "total": "70193197506",
+        "tx_fee": "0"
+    }
+}
+```
+
+### `get_block_by_number`
+
+Get block by number
+
+#### Parameters
+
+    block_number - Number of a block
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_block_by_number",
+    "params": [
+        "1024"
     ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "header": {
+            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
+            "difficulty": "0x7a1200",
+            "epoch": "1",
+            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
+            "nonce": "0",
+            "number": "1024",
+            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
+            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1557311767",
+            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+            "uncles_count": "0",
+            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "version": "0",
+            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
+        },
+        "proposals": [],
+        "transactions": [
+            {
+                "cell_deps": [],
+                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                "header_deps": [],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "4294967295",
+                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        },
+                        "since": "1024"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "70193197506",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": [
+                    {
+                        "data": [
+                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "uncles": []
+    }
 }
 ```
 
@@ -900,23 +852,17 @@ http://localhost:8114
 }
 ```
 
-## Pool
+### `_compute_script_hash`
 
-### `send_transaction`
+Returns script hash of given transaction script
 
-Send new transaction into transaction pool
-
-If <block_hash> of <previsous_output> is not specified, loads the corresponding input cell. If <block_hash> is specified, load the corresponding input cell only if the corresponding block exist and contain this cell as output.
+**Deprecated**: will be removed in a later version
 
 #### Parameters
 
-    transaction - The transaction object
-    version - Transaction version
-    cell_deps - Cell dependencies
-    header_deps - Header dependencies
-    inputs - Transaction inputs
-    outputs - Transaction outputs
-    witnesses - Witnesses
+    args - Hex encoded arguments passed to reference cell
+    code_hash - Code hash of referenced cell
+    hash_type - data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash.
 
 #### Examples
 
@@ -924,46 +870,12 @@ If <block_hash> of <previsous_output> is not specified, loads the corresponding 
 echo '{
     "id": 2,
     "jsonrpc": "2.0",
-    "method": "send_transaction",
+    "method": "_compute_script_hash",
     "params": [
         {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
+            "args": [],
+            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+            "hash_type": "data"
         }
     ]
 }' \
@@ -976,251 +888,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-}
-```
-
-## Chain
-
-### `get_transaction`
-
-Returns the information about a transaction requested by transaction hash.
-
-#### Parameters
-
-    hash - Hash of a transaction
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_transaction",
-    "params": [
-        "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "transaction": {
-            "cell_deps": [
-                {
-                    "dep_type": "code",
-                    "out_point": {
-                        "index": "0",
-                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                    }
-                }
-            ],
-            "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-            "header_deps": [
-                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-            ],
-            "inputs": [
-                {
-                    "previous_output": {
-                        "index": "0",
-                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                    },
-                    "since": "0"
-                }
-            ],
-            "outputs": [
-                {
-                    "capacity": "100000000000",
-                    "lock": {
-                        "args": [],
-                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                        "hash_type": "data"
-                    },
-                    "type": null
-                }
-            ],
-            "outputs_data": [
-                "0x"
-            ],
-            "version": "0",
-            "witnesses": []
-        },
-        "tx_status": {
-            "block_hash": null,
-            "status": "pending"
-        }
-    }
-}
-```
-
-### `get_cellbase_output_capacity_details`
-
-Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.
-
-#### Parameters
-
-    hash - Block hash
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_cellbase_output_capacity_details",
-    "params": [
-        "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "primary": "69444444445",
-        "proposal_reward": "0",
-        "secondary": "748753061",
-        "total": "70193197506",
-        "tx_fee": "0"
-    }
-}
-```
-
-## Pool
-
-### `tx_pool_info`
-
-Return the transaction pool information
-
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "tx_pool_info",
-    "params": []
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "last_txs_updated_at": "0",
-        "orphan": "0",
-        "pending": "1",
-        "proposed": "0",
-        "total_tx_cycles": "12",
-        "total_tx_size": "274"
-    }
-}
-```
-
-## Chain
-
-### `get_block_by_number`
-
-Get block by number
-
-#### Parameters
-
-    block_number - Number of a block
-
-#### Examples
-
-```bash
-echo '{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "get_block_by_number",
-    "params": [
-        "1024"
-    ]
-}' \
-| tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- \
-http://localhost:8114
-```
-
-```json
-{
-    "id": 2,
-    "jsonrpc": "2.0",
-    "result": {
-        "header": {
-            "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
-            "difficulty": "0x7a1200",
-            "epoch": "1",
-            "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
-            "nonce": "0",
-            "number": "1024",
-            "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
-            "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "timestamp": "1557311767",
-            "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-            "uncles_count": "0",
-            "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "version": "0",
-            "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
-        },
-        "proposals": [],
-        "transactions": [
-            {
-                "cell_deps": [],
-                "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                "header_deps": [],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "4294967295",
-                            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                        },
-                        "since": "1024"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "70193197506",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": [
-                    {
-                        "data": [
-                            "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
-                        ]
-                    }
-                ]
-            }
-        ],
-        "uncles": []
-    }
+    "result": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
 }
 ```
 
@@ -1453,19 +1121,12 @@ http://localhost:8114
 }
 ```
 
-## Experiment
+## Net
 
-### `_compute_script_hash`
+### `local_node_info`
 
-Returns script hash of given transaction script
+Returns the local node information.
 
-**Deprecated**: will be removed in a later version
-
-#### Parameters
-
-    args - Hex encoded arguments passed to reference cell
-    code_hash - Code hash of referenced cell
-    hash_type - data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash.
 
 #### Examples
 
@@ -1473,12 +1134,229 @@ Returns script hash of given transaction script
 echo '{
     "id": 2,
     "jsonrpc": "2.0",
-    "method": "_compute_script_hash",
+    "method": "local_node_info",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "addresses": [
+            {
+                "address": "/ip4/192.168.0.2/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
+                "score": "255"
+            },
+            {
+                "address": "/ip4/0.0.0.0/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
+                "score": "1"
+            }
+        ],
+        "is_outbound": null,
+        "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
+        "version": "0.0.0"
+    }
+}
+```
+
+### `get_peers`
+
+Returns the connected peers information.
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_peers",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": [
+        {
+            "addresses": [
+                {
+                    "address": "/ip4/192.168.0.3/tcp/8115",
+                    "score": "1"
+                }
+            ],
+            "is_outbound": true,
+            "node_id": "QmaaaLB4uPyDpZwTQGhV63zuYrKm4reyN2tF1j2ain4oE7",
+            "version": "unknown"
+        },
+        {
+            "addresses": [
+                {
+                    "address": "/ip4/192.168.0.4/tcp/8113",
+                    "score": "255"
+                }
+            ],
+            "is_outbound": false,
+            "node_id": "QmRuGcpVC3vE7aEoB6fhUdq9uzdHbyweCnn1sDBSjfmcbM",
+            "version": "unknown"
+        },
+        {
+            "addresses": [],
+            "node_id": "QmUddxwRqgTmT6tFujXbYPMLGLAE2Tciyv6uHGfdYFyDVa",
+            "version": "unknown"
+        }
+    ]
+}
+```
+
+### `get_banned_addresses`
+
+Returns all banned IPs/Subnets.
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_banned_addresses",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": [
+        {
+            "address": "192.168.0.2/32",
+            "ban_reason": "",
+            "ban_until": "1840546800000",
+            "created_at": "1562803123000"
+        }
+    ]
+}
+```
+
+### `set_ban`
+
+Insert or delete an IP/Subnet from the banned list
+
+#### Parameters
+
+    address - The IP/Subnet with an optional netmask (default is /32 = single IP)
+    command - `insert` to insert an IP/Subnet to the list, `delete` to delete an IP/Subnet from the list
+    ban_time - Time in milliseconds how long (or until when if [absolute] is set) the IP is banned, optional parameter, null means using the default time of 24h
+    absolute - If set, the `ban_time` must be an absolute timestamp in milliseconds since epoch, optional parameter
+    reason - Ban reason, optional parameter
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "set_ban",
+    "params": [
+        "192.168.0.2",
+        "insert",
+        "1840546800000",
+        true,
+        "set_ban example"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": null
+}
+```
+
+## Pool
+
+### `send_transaction`
+
+Send new transaction into transaction pool
+
+If <block_hash> of <previsous_output> is not specified, loads the corresponding input cell. If <block_hash> is specified, load the corresponding input cell only if the corresponding block exist and contain this cell as output.
+
+#### Parameters
+
+    transaction - The transaction object
+    version - Transaction version
+    cell_deps - Cell dependencies
+    header_deps - Header dependencies
+    inputs - Transaction inputs
+    outputs - Transaction outputs
+    witnesses - Witnesses
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "send_transaction",
     "params": [
         {
-            "args": [],
-            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-            "hash_type": "data"
+            "cell_deps": [
+                {
+                    "dep_type": "code",
+                    "out_point": {
+                        "index": "0",
+                        "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                    }
+                }
+            ],
+            "header_deps": [
+                "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+            ],
+            "inputs": [
+                {
+                    "previous_output": {
+                        "index": "0",
+                        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                    },
+                    "since": "0"
+                }
+            ],
+            "outputs": [
+                {
+                    "capacity": "100000000000",
+                    "lock": {
+                        "args": [],
+                        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                        "hash_type": "data"
+                    },
+                    "type": null
+                }
+            ],
+            "outputs_data": [
+                "0x"
+            ],
+            "version": "0",
+            "witnesses": []
         }
     ]
 }' \
@@ -1491,6 +1369,116 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+}
+```
+
+### `tx_pool_info`
+
+Return the transaction pool information
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "tx_pool_info",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "last_txs_updated_at": "0",
+        "orphan": "0",
+        "pending": "1",
+        "proposed": "0",
+        "total_tx_cycles": "12",
+        "total_tx_size": "274"
+    }
+}
+```
+
+## Stats
+
+### `get_blockchain_info`
+
+Return state info of blockchain
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_blockchain_info",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "alerts": [
+            {
+                "id": "42",
+                "message": "An example alert message!",
+                "notice_until": "2524579200000",
+                "priority": "1"
+            }
+        ],
+        "chain": "main",
+        "difficulty": "0x7a1200",
+        "epoch": "1",
+        "is_initial_block_download": true,
+        "median_time": "1557311762"
+    }
+}
+```
+
+### `get_peers_state`
+
+Deprecating in 0.12.0: Return state info of peers
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_peers_state",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": [
+        {
+            "blocks_in_flight": "86",
+            "last_updated": "1557289448237",
+            "peer": "1"
+        }
+    ]
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -270,156 +270,6 @@
         ]
     },
     {
-        "description": "Returns the information about a transaction requested by transaction hash.",
-        "method": "get_transaction",
-        "module": "chain",
-        "params": [
-            "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-        ],
-        "result": {
-            "transaction": {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            },
-            "tx_status": {
-                "block_hash": null,
-                "status": "pending"
-            }
-        },
-        "types": [
-            {
-                "hash": "Hash of a transaction"
-            }
-        ]
-    },
-    {
-        "description": "Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.",
-        "method": "get_cellbase_output_capacity_details",
-        "module": "chain",
-        "params": [
-            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
-        ],
-        "result": {
-            "primary": "69444444445",
-            "proposal_reward": "0",
-            "secondary": "748753061",
-            "total": "70193197506",
-            "tx_fee": "0"
-        },
-        "types": [
-            {
-                "hash": "Block hash"
-            }
-        ]
-    },
-    {
-        "description": "Get block by number",
-        "method": "get_block_by_number",
-        "module": "chain",
-        "params": [
-            "1024"
-        ],
-        "result": {
-            "header": {
-                "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
-                "difficulty": "0x7a1200",
-                "epoch": "1",
-                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
-                "nonce": "0",
-                "number": "1024",
-                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
-                "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "timestamp": "1557311767",
-                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                "uncles_count": "0",
-                "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "version": "0",
-                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
-            },
-            "proposals": [],
-            "transactions": [
-                {
-                    "cell_deps": [],
-                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                    "header_deps": [],
-                    "inputs": [
-                        {
-                            "previous_output": {
-                                "index": "4294967295",
-                                "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                            },
-                            "since": "1024"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "capacity": "70193197506",
-                            "lock": {
-                                "args": [],
-                                "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                                "hash_type": "data"
-                            },
-                            "type": null
-                        }
-                    ],
-                    "outputs_data": [
-                        "0x"
-                    ],
-                    "version": "0",
-                    "witnesses": [
-                        {
-                            "data": [
-                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "uncles": []
-        },
-        "types": [
-            {
-                "block_number": "Number of a block"
-            }
-        ]
-    },
-    {
         "description": "Returns the local node information.",
         "method": "local_node_info",
         "module": "net",
@@ -558,6 +408,125 @@
         "skip": true
     },
     {
+        "description": "Dry run transaction and return the execution cycles.\n\nThis method will not check the transaction validity, but only run the lock script\nand type script and then return the execution cycles.\nUsed to debug transaction scripts and query how many cycles the scripts consume",
+        "method": "dry_run_transaction",
+        "module": "experiment",
+        "params": [
+            {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            }
+        ],
+        "result": {
+            "cycles": "12"
+        }
+    },
+    {
+        "description": "Return the transaction hash\n\n**Deprecated**: will be removed in a later version",
+        "method": "_compute_transaction_hash",
+        "module": "experiment",
+        "params": [
+            {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            }
+        ],
+        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+        "types": [
+            {
+                "transaction": "The transaction object"
+            },
+            {
+                "version": "Transaction version"
+            },
+            {
+                "cell_deps": "Cell dependencies"
+            },
+            {
+                "header_deps": "Header dependencies"
+            },
+            {
+                "inputs": "Transaction inputs"
+            },
+            {
+                "outputs": "Transaction outputs"
+            },
+            {
+                "witnesses": "Witnesses"
+            }
+        ]
+    },
+    {
         "description": "Send new transaction into transaction pool\n\nIf <block_hash> of <previsous_output> is not specified, loads the corresponding input cell. If <block_hash> is specified, load the corresponding input cell only if the corresponding block exist and contain this cell as output.",
         "method": "send_transaction",
         "module": "pool",
@@ -628,6 +597,85 @@
         ]
     },
     {
+        "description": "Returns the information about a transaction requested by transaction hash.",
+        "method": "get_transaction",
+        "module": "chain",
+        "params": [
+            "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+        ],
+        "result": {
+            "transaction": {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            },
+            "tx_status": {
+                "block_hash": null,
+                "status": "pending"
+            }
+        },
+        "types": [
+            {
+                "hash": "Hash of a transaction"
+            }
+        ]
+    },
+    {
+        "description": "Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.",
+        "method": "get_cellbase_output_capacity_details",
+        "module": "chain",
+        "params": [
+            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
+        ],
+        "result": {
+            "primary": "69444444445",
+            "proposal_reward": "0",
+            "secondary": "748753061",
+            "total": "70193197506",
+            "tx_fee": "0"
+        },
+        "types": [
+            {
+                "hash": "Block hash"
+            }
+        ]
+    },
+    {
         "description": "Return the transaction pool information",
         "method": "tx_pool_info",
         "module": "pool",
@@ -640,6 +688,77 @@
             "total_tx_cycles": "12",
             "total_tx_size": "274"
         }
+    },
+    {
+        "description": "Get block by number",
+        "method": "get_block_by_number",
+        "module": "chain",
+        "params": [
+            "1024"
+        ],
+        "result": {
+            "header": {
+                "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
+                "difficulty": "0x7a1200",
+                "epoch": "1",
+                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
+                "nonce": "0",
+                "number": "1024",
+                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
+                "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "timestamp": "1557311767",
+                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                "uncles_count": "0",
+                "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "version": "0",
+                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
+            },
+            "proposals": [],
+            "transactions": [
+                {
+                    "cell_deps": [],
+                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                    "header_deps": [],
+                    "inputs": [
+                        {
+                            "previous_output": {
+                                "index": "4294967295",
+                                "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                            },
+                            "since": "1024"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "capacity": "70193197506",
+                            "lock": {
+                                "args": [],
+                                "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                                "hash_type": "data"
+                            },
+                            "type": null
+                        }
+                    ],
+                    "outputs_data": [
+                        "0x"
+                    ],
+                    "version": "0",
+                    "witnesses": [
+                        {
+                            "data": [
+                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "uncles": []
+        },
+        "types": [
+            {
+                "block_number": "Number of a block"
+            }
+        ]
     },
     {
         "description": "Create index for live cells and transactions by the hash of lock script.",
@@ -791,55 +910,6 @@
         ]
     },
     {
-        "description": "Dry run transaction and return the execution cycles.\n\nThis method will not check the transaction validity, but only run the lock script\nand type script and then return the execution cycles.\nUsed to debug transaction scripts and query how many cycles the scripts consume",
-        "method": "dry_run_transaction",
-        "module": "experiment",
-        "params": [
-            {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            }
-        ],
-        "result": {
-            "cycles": "12"
-        }
-    },
-    {
         "description": "Returns script hash of given transaction script\n\n**Deprecated**: will be removed in a later version",
         "method": "_compute_script_hash",
         "module": "experiment",
@@ -860,76 +930,6 @@
             },
             {
                 "hash_type": "data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash."
-            }
-        ]
-    },
-    {
-        "description": "Return the transaction hash\n\n**Deprecated**: will be removed in a later version",
-        "method": "_compute_transaction_hash",
-        "module": "experiment",
-        "params": [
-            {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            }
-        ],
-        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-        "types": [
-            {
-                "transaction": "The transaction object"
-            },
-            {
-                "version": "Transaction version"
-            },
-            {
-                "cell_deps": "Cell dependencies"
-            },
-            {
-                "header_deps": "Header dependencies"
-            },
-            {
-                "inputs": "Transaction inputs"
-            },
-            {
-                "outputs": "Transaction outputs"
-            },
-            {
-                "witnesses": "Witnesses"
             }
         ]
     }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -270,6 +270,156 @@
         ]
     },
     {
+        "description": "Returns the information about a transaction requested by transaction hash.",
+        "method": "get_transaction",
+        "module": "chain",
+        "params": [
+            "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
+        ],
+        "result": {
+            "transaction": {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            },
+            "tx_status": {
+                "block_hash": null,
+                "status": "pending"
+            }
+        },
+        "types": [
+            {
+                "hash": "Hash of a transaction"
+            }
+        ]
+    },
+    {
+        "description": "Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.",
+        "method": "get_cellbase_output_capacity_details",
+        "module": "chain",
+        "params": [
+            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
+        ],
+        "result": {
+            "primary": "69444444445",
+            "proposal_reward": "0",
+            "secondary": "748753061",
+            "total": "70193197506",
+            "tx_fee": "0"
+        },
+        "types": [
+            {
+                "hash": "Block hash"
+            }
+        ]
+    },
+    {
+        "description": "Get block by number",
+        "method": "get_block_by_number",
+        "module": "chain",
+        "params": [
+            "1024"
+        ],
+        "result": {
+            "header": {
+                "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
+                "difficulty": "0x7a1200",
+                "epoch": "1",
+                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
+                "nonce": "0",
+                "number": "1024",
+                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
+                "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "timestamp": "1557311767",
+                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                "uncles_count": "0",
+                "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "version": "0",
+                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
+            },
+            "proposals": [],
+            "transactions": [
+                {
+                    "cell_deps": [],
+                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
+                    "header_deps": [],
+                    "inputs": [
+                        {
+                            "previous_output": {
+                                "index": "4294967295",
+                                "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                            },
+                            "since": "1024"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "capacity": "70193197506",
+                            "lock": {
+                                "args": [],
+                                "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                                "hash_type": "data"
+                            },
+                            "type": null
+                        }
+                    ],
+                    "outputs_data": [
+                        "0x"
+                    ],
+                    "version": "0",
+                    "witnesses": [
+                        {
+                            "data": [
+                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "uncles": []
+        },
+        "types": [
+            {
+                "block_number": "Number of a block"
+            }
+        ]
+    },
+    {
         "description": "Returns the local node information.",
         "method": "local_node_info",
         "module": "net",
@@ -408,125 +558,6 @@
         "skip": true
     },
     {
-        "description": "Dry run transaction and return the execution cycles.\n\nThis method will not check the transaction validity, but only run the lock script\nand type script and then return the execution cycles.\nUsed to debug transaction scripts and query how many cycles the scripts consume",
-        "method": "dry_run_transaction",
-        "module": "experiment",
-        "params": [
-            {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            }
-        ],
-        "result": {
-            "cycles": "12"
-        }
-    },
-    {
-        "description": "Return the transaction hash\n\n**Deprecated**: will be removed in a later version",
-        "method": "_compute_transaction_hash",
-        "module": "experiment",
-        "params": [
-            {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            }
-        ],
-        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-        "types": [
-            {
-                "transaction": "The transaction object"
-            },
-            {
-                "version": "Transaction version"
-            },
-            {
-                "cell_deps": "Cell dependencies"
-            },
-            {
-                "header_deps": "Header dependencies"
-            },
-            {
-                "inputs": "Transaction inputs"
-            },
-            {
-                "outputs": "Transaction outputs"
-            },
-            {
-                "witnesses": "Witnesses"
-            }
-        ]
-    },
-    {
         "description": "Send new transaction into transaction pool\n\nIf <block_hash> of <previsous_output> is not specified, loads the corresponding input cell. If <block_hash> is specified, load the corresponding input cell only if the corresponding block exist and contain this cell as output.",
         "method": "send_transaction",
         "module": "pool",
@@ -597,85 +628,6 @@
         ]
     },
     {
-        "description": "Returns the information about a transaction requested by transaction hash.",
-        "method": "get_transaction",
-        "module": "chain",
-        "params": [
-            "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece"
-        ],
-        "result": {
-            "transaction": {
-                "cell_deps": [
-                    {
-                        "dep_type": "code",
-                        "out_point": {
-                            "index": "0",
-                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
-                        }
-                    }
-                ],
-                "hash": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
-                "header_deps": [
-                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
-                ],
-                "inputs": [
-                    {
-                        "previous_output": {
-                            "index": "0",
-                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-                        },
-                        "since": "0"
-                    }
-                ],
-                "outputs": [
-                    {
-                        "capacity": "100000000000",
-                        "lock": {
-                            "args": [],
-                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                            "hash_type": "data"
-                        },
-                        "type": null
-                    }
-                ],
-                "outputs_data": [
-                    "0x"
-                ],
-                "version": "0",
-                "witnesses": []
-            },
-            "tx_status": {
-                "block_hash": null,
-                "status": "pending"
-            }
-        },
-        "types": [
-            {
-                "hash": "Hash of a transaction"
-            }
-        ]
-    },
-    {
-        "description": "Returns each component of the created CKB in this block's cellbase, which is issued to a block N - 1 - ProposalWindow.farthest, where this block's height is N.",
-        "method": "get_cellbase_output_capacity_details",
-        "module": "chain",
-        "params": [
-            "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb"
-        ],
-        "result": {
-            "primary": "69444444445",
-            "proposal_reward": "0",
-            "secondary": "748753061",
-            "total": "70193197506",
-            "tx_fee": "0"
-        },
-        "types": [
-            {
-                "hash": "Block hash"
-            }
-        ]
-    },
-    {
         "description": "Return the transaction pool information",
         "method": "tx_pool_info",
         "module": "pool",
@@ -688,77 +640,6 @@
             "total_tx_cycles": "12",
             "total_tx_size": "274"
         }
-    },
-    {
-        "description": "Get block by number",
-        "method": "get_block_by_number",
-        "module": "chain",
-        "params": [
-            "1024"
-        ],
-        "result": {
-            "header": {
-                "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
-                "difficulty": "0x7a1200",
-                "epoch": "1",
-                "hash": "0x779a50619171cd50648b65520edb59787ff5f707d1f510783c7859a2d65f6eeb",
-                "nonce": "0",
-                "number": "1024",
-                "parent_hash": "0x186a255dd4bd3789ef1aa51b5a3f6e291bd1da360f71d483bdba1e20c02a702f",
-                "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "timestamp": "1557311767",
-                "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                "uncles_count": "0",
-                "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "version": "0",
-                "witnesses_root": "0x90445a0795a2d7d4af033ec0282a8a1f68f11ffb1cd091b95c2c5515a8336e9c"
-            },
-            "proposals": [],
-            "transactions": [
-                {
-                    "cell_deps": [],
-                    "hash": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
-                    "header_deps": [],
-                    "inputs": [
-                        {
-                            "previous_output": {
-                                "index": "4294967295",
-                                "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                            },
-                            "since": "1024"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "capacity": "70193197506",
-                            "lock": {
-                                "args": [],
-                                "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-                                "hash_type": "data"
-                            },
-                            "type": null
-                        }
-                    ],
-                    "outputs_data": [
-                        "0x"
-                    ],
-                    "version": "0",
-                    "witnesses": [
-                        {
-                            "data": [
-                                "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a500"
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "uncles": []
-        },
-        "types": [
-            {
-                "block_number": "Number of a block"
-            }
-        ]
     },
     {
         "description": "Create index for live cells and transactions by the hash of lock script.",
@@ -910,6 +791,55 @@
         ]
     },
     {
+        "description": "Dry run transaction and return the execution cycles.\n\nThis method will not check the transaction validity, but only run the lock script\nand type script and then return the execution cycles.\nUsed to debug transaction scripts and query how many cycles the scripts consume",
+        "method": "dry_run_transaction",
+        "module": "experiment",
+        "params": [
+            {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            }
+        ],
+        "result": {
+            "cycles": "12"
+        }
+    },
+    {
         "description": "Returns script hash of given transaction script\n\n**Deprecated**: will be removed in a later version",
         "method": "_compute_script_hash",
         "module": "experiment",
@@ -930,6 +860,76 @@
             },
             {
                 "hash_type": "data: code_hash matches against dep cell data hash; type: code_hash matches against dep cell type hash."
+            }
+        ]
+    },
+    {
+        "description": "Return the transaction hash\n\n**Deprecated**: will be removed in a later version",
+        "method": "_compute_transaction_hash",
+        "module": "experiment",
+        "params": [
+            {
+                "cell_deps": [
+                    {
+                        "dep_type": "code",
+                        "out_point": {
+                            "index": "0",
+                            "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
+                        }
+                    }
+                ],
+                "header_deps": [
+                    "0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"
+                ],
+                "inputs": [
+                    {
+                        "previous_output": {
+                            "index": "0",
+                            "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+                        },
+                        "since": "0"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "capacity": "100000000000",
+                        "lock": {
+                            "args": [],
+                            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+                            "hash_type": "data"
+                        },
+                        "type": null
+                    }
+                ],
+                "outputs_data": [
+                    "0x"
+                ],
+                "version": "0",
+                "witnesses": []
+            }
+        ],
+        "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
+        "types": [
+            {
+                "transaction": "The transaction object"
+            },
+            {
+                "version": "Transaction version"
+            },
+            {
+                "cell_deps": "Cell dependencies"
+            },
+            {
+                "header_deps": "Header dependencies"
+            },
+            {
+                "inputs": "Transaction inputs"
+            },
+            {
+                "outputs": "Transaction outputs"
+            },
+            {
+                "witnesses": "Witnesses"
             }
         ]
     }


### PR DESCRIPTION
Do not let a module appear in multiple places.

Update: doc tool was updated to only group RPC methods by module name in the generated doc. We keep the `rpc.json` intact as the unit tests depend on that file's content order to run successfully.