### PR TITLE
chore: Verify output length when cellbase is validated

### DIFF
--- a/util/types/src/extension/shortcuts.rs
+++ b/util/types/src/extension/shortcuts.rs
@@ -117,7 +117,6 @@ impl packed::Transaction {
     pub fn is_cellbase(&self) -> bool {
         let raw_tx = self.raw();
         raw_tx.inputs().len() == 1
-            && raw_tx.outputs().len() == 1
             && self.witnesses().len() == 1
             && raw_tx
                 .inputs()

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -65,6 +65,11 @@ impl CellbaseVerifier {
             return Err(Error::Cellbase(CellbaseError::InvalidPosition));
         }
 
+        // cellbase outputs len must eq 1
+        if cellbase_transaction.outputs().len() != 1 {
+            return Err(Error::Cellbase(CellbaseError::InvalidQuantity));
+        }
+
         if cellbase_transaction
             .witnesses()
             .get(0)


### PR DESCRIPTION
Verify output length when cellbase is validated.

`is_cellbase` don't care about it's output length