### PR TITLE
test: make a unit test more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -15,3 +15,4 @@ jsonrpc-core = "10.1"
 
 [dev-dependencies]
 proptest = "0.9"
+regex = "1.1"


### PR DESCRIPTION
To fill the line number and column number is a terrible thing.