### PR TITLE
chore: hide the implementation details

### DIFF
--- a/util/jsonrpc-types/src/bytes.rs
+++ b/util/jsonrpc-types/src/bytes.rs
@@ -34,17 +34,13 @@ impl JsonBytes {
 
 impl From<packed::Bytes> for JsonBytes {
     fn from(input: packed::Bytes) -> Self {
-        JsonBytes::from_bytes(input.as_bytes().slice_from(4))
+        JsonBytes::from_bytes(input.raw_data())
     }
 }
 
 impl From<JsonBytes> for packed::Bytes {
     fn from(input: JsonBytes) -> Self {
-        let len = input.as_bytes().len();
-        let mut vec: Vec<u8> = Vec::with_capacity(4 + len);
-        vec.extend_from_slice(&(len as u32).to_le_bytes()[..]);
-        vec.extend_from_slice(input.as_bytes());
-        packed::Bytes::new_unchecked(Bytes::from(vec))
+        input.0.pack()
     }
 }
 

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -119,13 +119,13 @@ impl Pack<packed::Bytes> for Bytes {
 
 impl<'r> Unpack<Bytes> for packed::BytesReader<'r> {
     fn unpack(&self) -> Bytes {
-        Bytes::from(&self.as_slice()[4..])
+        Bytes::from(self.raw_data())
     }
 }
 
 impl Unpack<Bytes> for packed::Bytes {
     fn unpack(&self) -> Bytes {
-        self.as_bytes().slice_from(4)
+        self.raw_data()
     }
 }
 


### PR DESCRIPTION
Use interfaces is better than use the implementation details.