### PR TITLE
chore: replace constructor of EpochExt by builder

### DIFF
--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -656,16 +656,16 @@ mod tests {
             .transactions_root(data_hash.pack())
             .build();
 
-        let epoch = EpochExt::new(
-            u64::from(data[0]),
-            Capacity::bytes(100).unwrap(),
-            Capacity::bytes(100).unwrap(),
-            U256::one(),
-            Byte32::default(),
-            1234,
-            1000,
-            U256::one(),
-        );
+        let epoch = EpochExt::new_builder()
+            .number(u64::from(data[0]))
+            .base_block_reward(Capacity::bytes(100).unwrap())
+            .remainder_reward(Capacity::bytes(100).unwrap())
+            .previous_epoch_hash_rate(U256::one())
+            .last_block_hash_in_previous_epoch(Byte32::default())
+            .start_number(1234)
+            .length(1000)
+            .difficulty(U256::one())
+            .build();
 
         let mut correct_data = [0u8; 8];
         LittleEndian::write_u64(&mut correct_data, epoch.number());

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -165,16 +165,16 @@ impl Consensus {
             * (GENESIS_EPOCH_LENGTH + GENESIS_ORPHAN_COUNT)
             / EPOCH_DURATION_TARGET;
 
-        let genesis_epoch_ext = EpochExt::new(
-            0,                // number
-            block_reward,     // block_reward
-            remainder_reward, // remainder_reward
-            genesis_hash_rate,
-            Byte32::zero(),
-            0,                           // start
-            GENESIS_EPOCH_LENGTH,        // length
-            genesis_header.difficulty(), // difficulty,
-        );
+        let genesis_epoch_ext = EpochExt::new_builder()
+            .number(0)
+            .base_block_reward(block_reward)
+            .remainder_reward(remainder_reward)
+            .previous_epoch_hash_rate(genesis_hash_rate)
+            .last_block_hash_in_previous_epoch(Byte32::zero())
+            .start_number(0)
+            .length(GENESIS_EPOCH_LENGTH)
+            .difficulty(genesis_header.difficulty())
+            .build();
 
         Consensus {
             genesis_hash: genesis_header.hash(),
@@ -508,16 +508,16 @@ impl Consensus {
         let block_reward = Capacity::shannons(self.epoch_reward().as_u64() / next_epoch_length);
         let remainder_reward = Capacity::shannons(self.epoch_reward().as_u64() % next_epoch_length);
 
-        let epoch_ext = EpochExt::new(
-            last_epoch.number() + 1, // number
-            block_reward,
-            remainder_reward, // remainder_reward
-            adjusted_last_epoch_hash_rate,
-            header.hash(),     // last_block_hash_in_previous_epoch
-            header_number + 1, // start
-            next_epoch_length, // length
-            next_epoch_diff,   // difficulty,
-        );
+        let epoch_ext = EpochExt::new_builder()
+            .number(last_epoch.number() + 1)
+            .base_block_reward(block_reward)
+            .remainder_reward(remainder_reward)
+            .previous_epoch_hash_rate(adjusted_last_epoch_hash_rate)
+            .last_block_hash_in_previous_epoch(header.hash())
+            .start_number(header_number + 1)
+            .length(next_epoch_length)
+            .difficulty(next_epoch_diff)
+            .build();
 
         Some(epoch_ext)
     }

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -335,16 +335,16 @@ mod tests {
                 .build();
             // TODO: should make it simple after refactor get_ancestor
             for number in target_epoch_start..parent.number() {
-                let epoch_ext = EpochExt::new(
-                    number,
-                    Capacity::shannons(50_000_000_000),
-                    Capacity::shannons(1_000_128),
-                    U256::one(),
-                    h256!("0x1").pack(),
-                    target_epoch_start,
-                    2091,
-                    U256::from(1u64),
-                );
+                let epoch_ext = EpochExt::new_builder()
+                    .number(number)
+                    .base_block_reward(Capacity::shannons(50_000_000_000))
+                    .remainder_reward(Capacity::shannons(1_000_128))
+                    .previous_epoch_hash_rate(U256::one())
+                    .last_block_hash_in_previous_epoch(h256!("0x1").pack())
+                    .start_number(target_epoch_start)
+                    .length(2091)
+                    .difficulty(U256::one())
+                    .build();
 
                 let header = HeaderBuilder::default()
                     .number(number.pack())

--- a/util/types/schemas/ckb.mol
+++ b/util/types/schemas/ckb.mol
@@ -143,7 +143,7 @@ table EpochExt {
     last_block_hash_in_previous_epoch:  Byte32,
     difficulty:                         Byte32,
     number:                             Uint64,
-    block_reward:                       Uint64,
+    base_block_reward:                  Uint64,
     remainder_reward:                   Uint64,
     start_number:                       Uint64,
     length:                             Uint64,

--- a/util/types/src/conversion/storage.rs
+++ b/util/types/src/conversion/storage.rs
@@ -88,7 +88,7 @@ impl Pack<packed::EpochExt> for core::EpochExt {
     fn pack(&self) -> packed::EpochExt {
         packed::EpochExt::new_builder()
             .number(self.number().pack())
-            .block_reward(self.base_block_reward().pack())
+            .base_block_reward(self.base_block_reward().pack())
             .remainder_reward(self.remainder_reward().pack())
             .previous_epoch_hash_rate(self.previous_epoch_hash_rate().pack())
             .last_block_hash_in_previous_epoch(self.last_block_hash_in_previous_epoch().clone())
@@ -103,7 +103,7 @@ impl<'r> Unpack<core::EpochExt> for packed::EpochExtReader<'r> {
     fn unpack(&self) -> core::EpochExt {
         core::EpochExt {
             number: self.number().unpack(),
-            block_reward: self.block_reward().unpack(),
+            base_block_reward: self.base_block_reward().unpack(),
             remainder_reward: self.remainder_reward().unpack(),
             previous_epoch_hash_rate: self.previous_epoch_hash_rate().unpack(),
             last_block_hash_in_previous_epoch: self.last_block_hash_in_previous_epoch().to_entity(),

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -55,7 +55,7 @@ impl TransactionInfo {
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub struct EpochExt {
     pub(crate) number: EpochNumber,
-    pub(crate) block_reward: Capacity,
+    pub(crate) base_block_reward: Capacity,
     pub(crate) remainder_reward: Capacity,
     pub(crate) previous_epoch_hash_rate: U256,
     pub(crate) last_block_hash_in_previous_epoch: packed::Byte32,
@@ -64,29 +64,32 @@ pub struct EpochExt {
     pub(crate) difficulty: U256,
 }
 
+#[derive(Clone, Debug)]
+pub struct EpochExtBuilder(pub(crate) EpochExt);
+
 impl EpochExt {
-    pub fn number(&self) -> u64 {
+    //
+    // Simple Getters
+    //
+
+    pub fn number(&self) -> BlockNumber {
         self.number
     }
 
-    pub fn block_reward(&self, number: BlockNumber) -> Result<Capacity, FailureError> {
-        if number >= self.start_number()
-            && number < self.start_number() + self.remainder_reward.as_u64()
-        {
-            self.block_reward
-                .safe_add(Capacity::one())
-                .map_err(Into::into)
-        } else {
-            Ok(self.block_reward)
-        }
-    }
-
     pub fn base_block_reward(&self) -> &Capacity {
-        &self.block_reward
+        &self.base_block_reward
     }
 
-    pub fn is_genesis(&self) -> bool {
-        0 == self.number
+    pub fn remainder_reward(&self) -> &Capacity {
+        &self.remainder_reward
+    }
+
+    pub fn previous_epoch_hash_rate(&self) -> &U256 {
+        &self.previous_epoch_hash_rate
+    }
+
+    pub fn last_block_hash_in_previous_epoch(&self) -> packed::Byte32 {
+        self.last_block_hash_in_previous_epoch.clone()
     }
 
     pub fn start_number(&self) -> BlockNumber {
@@ -97,6 +100,41 @@ impl EpochExt {
         self.length
     }
 
+    pub fn difficulty(&self) -> &U256 {
+        &self.difficulty
+    }
+
+    //
+    // Simple Setters
+    //
+
+    pub fn set_number(&mut self, number: BlockNumber) {
+        self.number = number;
+    }
+
+    pub fn set_base_block_reward(&mut self, base_block_reward: Capacity) {
+        self.base_block_reward = base_block_reward;
+    }
+
+    pub fn set_remainder_reward(&mut self, remainder_reward: Capacity) {
+        self.remainder_reward = remainder_reward;
+    }
+
+    pub fn set_previous_epoch_hash_rate(&mut self, previous_epoch_hash_rate: U256) {
+        self.previous_epoch_hash_rate = previous_epoch_hash_rate;
+    }
+
+    pub fn set_last_block_hash_in_previous_epoch(
+        &mut self,
+        last_block_hash_in_previous_epoch: packed::Byte32,
+    ) {
+        self.last_block_hash_in_previous_epoch = last_block_hash_in_previous_epoch;
+    }
+
+    pub fn set_start_number(&mut self, start_number: BlockNumber) {
+        self.start_number = start_number;
+    }
+
     pub fn set_length(&mut self, length: BlockNumber) {
         self.length = length;
     }
@@ -105,80 +143,91 @@ impl EpochExt {
         self.difficulty = difficulty;
     }
 
-    pub fn difficulty(&self) -> &U256 {
-        &self.difficulty
+    //
+    // Normal Methods
+    //
+
+    pub fn new_builder() -> EpochExtBuilder {
+        EpochExtBuilder(EpochExt::default())
     }
 
-    pub fn remainder_reward(&self) -> &Capacity {
-        &self.remainder_reward
+    pub fn into_builder(self) -> EpochExtBuilder {
+        EpochExtBuilder(self)
     }
 
-    pub fn last_block_hash_in_previous_epoch(&self) -> packed::Byte32 {
-        self.last_block_hash_in_previous_epoch.clone()
+    pub fn is_genesis(&self) -> bool {
+        0 == self.number
     }
 
-    pub fn previous_epoch_hash_rate(&self) -> &U256 {
-        &self.previous_epoch_hash_rate
-    }
-
-    pub fn set_previous_epoch_hash_rate(&mut self, hash_rate: U256) {
-        self.previous_epoch_hash_rate = hash_rate
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        number: u64,
-        block_reward: Capacity,
-        remainder_reward: Capacity,
-        previous_epoch_hash_rate: U256,
-        last_block_hash_in_previous_epoch: packed::Byte32,
-        start_number: BlockNumber,
-        length: BlockNumber,
-        difficulty: U256,
-    ) -> EpochExt {
-        EpochExt {
-            number,
-            block_reward,
-            remainder_reward,
-            previous_epoch_hash_rate,
-            last_block_hash_in_previous_epoch,
-            start_number,
-            length,
-            difficulty,
+    pub fn block_reward(&self, number: BlockNumber) -> Result<Capacity, FailureError> {
+        if number >= self.start_number()
+            && number < self.start_number() + self.remainder_reward.as_u64()
+        {
+            self.base_block_reward
+                .safe_add(Capacity::one())
+                .map_err(Into::into)
+        } else {
+            Ok(self.base_block_reward)
         }
     }
+}
 
-    pub fn destruct(
-        self,
-    ) -> (
-        u64,
-        Capacity,
-        Capacity,
-        U256,
-        packed::Byte32,
-        BlockNumber,
-        BlockNumber,
-        U256,
-    ) {
-        let EpochExt {
-            number,
-            block_reward,
-            remainder_reward,
-            previous_epoch_hash_rate,
-            last_block_hash_in_previous_epoch,
-            start_number,
-            length,
-            difficulty,
-        } = self;
-        (
-            number,
-            block_reward,
-            remainder_reward,
-            previous_epoch_hash_rate,
-            last_block_hash_in_previous_epoch,
-            start_number,
-            length,
-            difficulty,
-        )
+impl EpochExtBuilder {
+    //
+    // Simple Setters
+    //
+
+    pub fn number(mut self, number: BlockNumber) -> Self {
+        self.0.set_number(number);
+        self
+    }
+
+    pub fn base_block_reward(mut self, base_block_reward: Capacity) -> Self {
+        self.0.set_base_block_reward(base_block_reward);
+        self
+    }
+
+    pub fn remainder_reward(mut self, remainder_reward: Capacity) -> Self {
+        self.0.set_remainder_reward(remainder_reward);
+        self
+    }
+
+    pub fn previous_epoch_hash_rate(mut self, previous_epoch_hash_rate: U256) -> Self {
+        self.0
+            .set_previous_epoch_hash_rate(previous_epoch_hash_rate);
+        self
+    }
+
+    pub fn last_block_hash_in_previous_epoch(
+        mut self,
+        last_block_hash_in_previous_epoch: packed::Byte32,
+    ) -> Self {
+        self.0
+            .set_last_block_hash_in_previous_epoch(last_block_hash_in_previous_epoch);
+        self
+    }
+
+    pub fn start_number(mut self, start_number: BlockNumber) -> Self {
+        self.0.set_start_number(start_number);
+        self
+    }
+
+    pub fn length(mut self, length: BlockNumber) -> Self {
+        self.0.set_length(length);
+        self
+    }
+
+    pub fn difficulty(mut self, difficulty: U256) -> Self {
+        self.0.set_difficulty(difficulty);
+        self
+    }
+
+    //
+    // Normal Methods
+    //
+    // The `new` methods are unnecessary. Creating `EpochExtBuilder` from `EpochExt`, it's enough.
+
+    pub fn build(self) -> EpochExt {
+        self.0
     }
 }

--- a/util/types/src/generated/types.rs
+++ b/util/types/src/generated/types.rs
@@ -10672,7 +10672,7 @@ impl ::std::fmt::Display for EpochExt {
         )?;
         write!(f, ", {}: {}", "difficulty", self.difficulty())?;
         write!(f, ", {}: {}", "number", self.number())?;
-        write!(f, ", {}: {}", "block_reward", self.block_reward())?;
+        write!(f, ", {}: {}", "base_block_reward", self.base_block_reward())?;
         write!(f, ", {}: {}", "remainder_reward", self.remainder_reward())?;
         write!(f, ", {}: {}", "start_number", self.start_number())?;
         write!(f, ", {}: {}", "length", self.length())?;
@@ -10700,7 +10700,7 @@ impl<'r> ::std::fmt::Display for EpochExtReader<'r> {
         )?;
         write!(f, ", {}: {}", "difficulty", self.difficulty())?;
         write!(f, ", {}: {}", "number", self.number())?;
-        write!(f, ", {}: {}", "block_reward", self.block_reward())?;
+        write!(f, ", {}: {}", "base_block_reward", self.base_block_reward())?;
         write!(f, ", {}: {}", "remainder_reward", self.remainder_reward())?;
         write!(f, ", {}: {}", "start_number", self.start_number())?;
         write!(f, ", {}: {}", "length", self.length())?;
@@ -10717,7 +10717,7 @@ pub struct EpochExtBuilder {
     pub(crate) last_block_hash_in_previous_epoch: Byte32,
     pub(crate) difficulty: Byte32,
     pub(crate) number: Uint64,
-    pub(crate) block_reward: Uint64,
+    pub(crate) base_block_reward: Uint64,
     pub(crate) remainder_reward: Uint64,
     pub(crate) start_number: Uint64,
     pub(crate) length: Uint64,
@@ -10759,7 +10759,7 @@ impl molecule::prelude::Entity for EpochExt {
             .last_block_hash_in_previous_epoch(self.last_block_hash_in_previous_epoch())
             .difficulty(self.difficulty())
             .number(self.number())
-            .block_reward(self.block_reward())
+            .base_block_reward(self.base_block_reward())
             .remainder_reward(self.remainder_reward())
             .start_number(self.start_number())
             .length(self.length())
@@ -10802,7 +10802,7 @@ impl EpochExt {
         let end = u32::from_le(offsets[3 + 1]) as usize;
         Uint64::new_unchecked(self.0.slice(start, end))
     }
-    pub fn block_reward(&self) -> Uint64 {
+    pub fn base_block_reward(&self) -> Uint64 {
         let (_, _, offsets) = Self::field_offsets(self);
         let start = u32::from_le(offsets[4]) as usize;
         let end = u32::from_le(offsets[4 + 1]) as usize;
@@ -10923,7 +10923,7 @@ impl<'r> EpochExtReader<'r> {
         let end = u32::from_le(offsets[3 + 1]) as usize;
         Uint64Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn block_reward(&self) -> Uint64Reader<'r> {
+    pub fn base_block_reward(&self) -> Uint64Reader<'r> {
         let (_, _, offsets) = Self::field_offsets(self);
         let start = u32::from_le(offsets[4]) as usize;
         let end = u32::from_le(offsets[4 + 1]) as usize;
@@ -10961,7 +10961,7 @@ impl molecule::prelude::Builder for EpochExtBuilder {
             + self.last_block_hash_in_previous_epoch.as_slice().len()
             + self.difficulty.as_slice().len()
             + self.number.as_slice().len()
-            + self.block_reward.as_slice().len()
+            + self.base_block_reward.as_slice().len()
             + self.remainder_reward.as_slice().len()
             + self.start_number.as_slice().len()
             + self.length.as_slice().len()
@@ -10993,7 +10993,7 @@ impl molecule::prelude::Builder for EpochExtBuilder {
         {
             let tmp = (offset as u32).to_le_bytes();
             writer.write_all(&tmp[..])?;
-            offset += self.block_reward.as_slice().len();
+            offset += self.base_block_reward.as_slice().len();
         }
         {
             let tmp = (offset as u32).to_le_bytes();
@@ -11015,7 +11015,7 @@ impl molecule::prelude::Builder for EpochExtBuilder {
         writer.write_all(self.last_block_hash_in_previous_epoch.as_slice())?;
         writer.write_all(self.difficulty.as_slice())?;
         writer.write_all(self.number.as_slice())?;
-        writer.write_all(self.block_reward.as_slice())?;
+        writer.write_all(self.base_block_reward.as_slice())?;
         writer.write_all(self.remainder_reward.as_slice())?;
         writer.write_all(self.start_number.as_slice())?;
         writer.write_all(self.length.as_slice())?;
@@ -11045,8 +11045,8 @@ impl EpochExtBuilder {
         self.number = v;
         self
     }
-    pub fn block_reward(mut self, v: Uint64) -> Self {
-        self.block_reward = v;
+    pub fn base_block_reward(mut self, v: Uint64) -> Self {
+        self.base_block_reward = v;
         self
     }
     pub fn remainder_reward(mut self, v: Uint64) -> Self {


### PR DESCRIPTION
- The constructor is too complex, it's difficult to review when we just see the invocation of `new(...)`
- The field `block_reward` is `base_block_reward` in actual, so rename it to the corrected name.