### PR TITLE
feat: cellbase output data must be empty

### DIFF
--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -46,7 +46,6 @@ fn block_assembler_config() -> BlockAssemblerConfig {
         code_hash: secp_script.code_hash().unpack(),
         hash_type: hash_type.into(),
         args,
-        data: JsonBytes::default(),
     }
 }
 

--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -72,7 +72,6 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
 
         let in_block_assembler_code_hash = prompt("code hash: ");
         let in_args = prompt("args: ");
-        let in_data = prompt("data: ");
         let in_hash_type = prompt("hash_type: ");
 
         args.block_assembler_code_hash = Some(in_block_assembler_code_hash.trim().to_string());
@@ -82,8 +81,6 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
             .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
-
-        args.block_assembler_data = Some(in_data.trim().to_string());
 
         match serde_plain::from_str::<ScriptHashType>(in_hash_type.trim()).ok() {
             Some(hash_type) => args.block_assembler_hash_type = hash_type,
@@ -142,12 +139,9 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
                 "[block_assembler]\n\
                  code_hash = \"{}\"\n\
                  args = [ \"{}\" ]\n\
-                 data = \"{}\"\n\
                  hash_type = \"{}\"",
                 hash,
                 args.block_assembler_args.join("\", \""),
-                args.block_assembler_data
-                    .unwrap_or_else(|| "0x".to_string()),
                 serde_plain::to_string(&args.block_assembler_hash_type).unwrap(),
             )
         }
@@ -158,7 +152,6 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
                  # [block_assembler]\n\
                  # code_hash = \"{}\"\n\
                  # args = [ \"ckb cli blake160 <compressed-pubkey>\" ]\n\
-                 # data = \"A 0x-prefixed hex string\"\n\
                  # hash_type = \"{}\"",
                 default_code_hash_option.unwrap_or_default(),
                 DEFAULT_LOCK_SCRIPT_HASH_TYPE,

--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -28,6 +28,4 @@ pub struct BlockAssemblerConfig {
     pub code_hash: H256,
     pub hash_type: ScriptHashType,
     pub args: Vec<JsonBytes>,
-    #[serde(default)]
-    pub data: JsonBytes,
 }

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -152,14 +152,6 @@ cellbase_cache_size        = 20
 #
 #     ckb init $(ckb cli secp256k1-lock <pubkey> --format cmd)
 #
-# Also, ckb allows the miners to add any data to the cellbase that they have dug out.
-# The data must be A 0x-prefixed hex string.
-#
-# note: The data field is optional.
-#
-# **WARNING**: if data is larger than the capacity value of the current cellbase,
-# it will be truncated
-#
 # # {{
 # _ => {block_assembler}
 # }}

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -3,7 +3,6 @@ use crate::utils::{temp_path, wait_until};
 use ckb_app_config::{BlockAssemblerConfig, CKBAppConfig};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_chain_spec::ChainSpec;
-use ckb_jsonrpc_types::JsonBytes;
 use ckb_types::{
     core::{
         self, capacity_bytes, BlockBuilder, BlockNumber, BlockView, Capacity, ScriptHashType,
@@ -405,7 +404,6 @@ impl Node {
         ckb_config.block_assembler = Some(BlockAssemblerConfig {
             code_hash: self.always_success_code_hash.unpack(),
             args: Default::default(),
-            data: JsonBytes::default(),
             hash_type: ScriptHashType::Data.into(),
         });
 

--- a/test/src/specs/mining/bootstrap.rs
+++ b/test/src/specs/mining/bootstrap.rs
@@ -66,14 +66,6 @@ impl Spec for BootstrapCellbase {
                     .to_entity()
                     .lock()
                     == miner
-                && Unpack::<Bytes>::unpack(
-                    &blk.transactions()[0]
-                        .outputs_data()
-                        .as_reader()
-                        .get(0)
-                        .unwrap()
-                        .to_entity()
-                ) == Bytes::from(vec![1; 30])
         )
     }
 
@@ -96,7 +88,6 @@ impl Spec for BootstrapCellbase {
                     JsonBytes::from_bytes(Bytes::from(vec![2])),
                     JsonBytes::from_bytes(Bytes::from(vec![1])),
                 ],
-                data: JsonBytes::from_bytes(Bytes::from(vec![1; 30])),
                 hash_type: ScriptHashType::Data.into(),
             });
         })

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -264,6 +264,5 @@ fn new_block_assembler_config(lock_arg: Bytes, hash_type: ScriptHashType) -> Blo
         code_hash,
         hash_type: hash_type.into(),
         args: vec![JsonBytes::from_bytes(lock_arg.clone())],
-        data: Default::default(),
     }
 }

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -59,7 +59,6 @@ pub struct InitArgs {
     pub block_assembler_code_hash: Option<String>,
     pub block_assembler_args: Vec<String>,
     pub block_assembler_hash_type: ScriptHashType,
-    pub block_assembler_data: Option<String>,
 }
 
 pub struct ResetDataArgs {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -32,7 +32,6 @@ pub const ARG_BUNDLED: &str = "bundled";
 pub const ARG_BA_CODE_HASH: &str = "ba-code-hash";
 pub const ARG_BA_ARG: &str = "ba-arg";
 pub const ARG_BA_HASH_TYPE: &str = "ba-hash-type";
-pub const ARG_BA_DATA: &str = "ba-data";
 pub const ARG_BA_ADVANCED: &str = "ba-advanced";
 pub const ARG_FROM: &str = "from";
 pub const ARG_TO: &str = "to";
@@ -373,14 +372,6 @@ fn init() -> App<'static, 'static> {
                 .multiple(true),
         )
         .arg(
-            Arg::with_name(ARG_BA_DATA)
-                .long(ARG_BA_DATA)
-                .value_name("data")
-                .validator(is_hex)
-                .requires(GROUP_BA)
-                .help("Sets data in [block_assembler]"),
-        )
-        .arg(
             Arg::with_name("export-specs")
                 .long("export-specs")
                 .hidden(true),
@@ -420,50 +411,6 @@ fn is_hex(hex: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn ba_data_requires_ba_arg_or_ba_code_hash() {
-        let ok_ba_arg = basic_app().get_matches_from_safe(&[
-            "ckb",
-            "init",
-            "--ba-data",
-            "0x00",
-            "--ba-arg",
-            "0x00",
-        ]);
-        let ok_ba_code_hash = basic_app().get_matches_from_safe(&[
-            "ckb",
-            "init",
-            "--ba-data",
-            "0x00",
-            "--ba-code-hash",
-            "0x00",
-        ]);
-        let err = basic_app().get_matches_from_safe(&["ckb", "init", "--ba-data", "0x00"]);
-
-        assert!(
-            ok_ba_arg.is_ok(),
-            "--ba-data is ok with --ba-arg, but gets error: {:?}",
-            ok_ba_arg.err()
-        );
-        assert!(
-            ok_ba_code_hash.is_ok(),
-            "--ba-data is ok with --ba-code-hash, but gets error: {:?}",
-            ok_ba_code_hash.err()
-        );
-        assert!(
-            err.is_err(),
-            "--ba-data requires --ba-arg or --ba-code-hash"
-        );
-
-        let err = err.err().unwrap();
-        assert_eq!(clap::ErrorKind::MissingRequiredArgument, err.kind);
-        assert!(err
-            .message
-            .contains("The following required arguments were not provided"));
-        assert!(err.message.contains("--ba-arg"));
-        assert!(err.message.contains("--ba-code-hash"));
-    }
 
     #[test]
     fn ba_arg_and_ba_code_hash() {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -229,7 +229,6 @@ impl Setup {
             .value_of(cli::ARG_BA_HASH_TYPE)
             .and_then(|hash_type| serde_plain::from_str::<ScriptHashType>(hash_type).ok())
             .unwrap();
-        let block_assembler_data = matches.value_of(cli::ARG_BA_DATA).map(str::to_string);
 
         Ok(InitArgs {
             interactive,
@@ -244,7 +243,6 @@ impl Setup {
             block_assembler_code_hash,
             block_assembler_args,
             block_assembler_hash_type,
-            block_assembler_data,
         })
     }
 

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -65,9 +65,20 @@ impl CellbaseVerifier {
             return Err(Error::Cellbase(CellbaseError::InvalidPosition));
         }
 
-        // cellbase outputs len must eq 1
-        if cellbase_transaction.outputs().len() != 1 {
+        // cellbase outputs/outputs_data len must eq 1
+        if cellbase_transaction.outputs().len() != 1
+            || cellbase_transaction.outputs_data().len() != 1
+        {
             return Err(Error::Cellbase(CellbaseError::InvalidQuantity));
+        }
+
+        // cellbase output data must empty
+        if !cellbase_transaction
+            .outputs_data()
+            .get_unchecked(0)
+            .is_empty()
+        {
+            return Err(Error::Cellbase(CellbaseError::InvalidOutputData));
         }
 
         if cellbase_transaction

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -94,6 +94,7 @@ pub enum CellbaseError {
     InvalidTypeScript,
     InvalidQuantity,
     InvalidPosition,
+    InvalidOutputData,
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -41,6 +41,51 @@ fn create_cellbase_transaction_with_capacity(capacity: Capacity) -> TransactionV
         .build()
 }
 
+fn create_cellbase_transaction_with_non_empty_output_data() -> TransactionView {
+    TransactionBuilder::default()
+        .input(CellInput::new_cellbase_input(0))
+        .output(
+            CellOutputBuilder::default()
+                .capacity(capacity_bytes!(100).pack())
+                .build(),
+        )
+        .output_data(Bytes::from("123").pack())
+        .witness(Script::default().into_witness())
+        .build()
+}
+
+fn create_cellbase_transaction_with_two_output() -> TransactionView {
+    TransactionBuilder::default()
+        .input(CellInput::new_cellbase_input(0))
+        .output(
+            CellOutputBuilder::default()
+                .capacity(capacity_bytes!(100).pack())
+                .build(),
+        )
+        .output(
+            CellOutputBuilder::default()
+                .capacity(capacity_bytes!(100).pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .witness(Script::default().into_witness())
+        .build()
+}
+
+fn create_cellbase_transaction_with_two_output_data() -> TransactionView {
+    TransactionBuilder::default()
+        .input(CellInput::new_cellbase_input(0))
+        .output(
+            CellOutputBuilder::default()
+                .capacity(capacity_bytes!(100).pack())
+                .build(),
+        )
+        .output_data(Bytes::new().pack())
+        .output_data(Bytes::new().pack())
+        .witness(Script::default().into_witness())
+        .build()
+}
+
 fn create_cellbase_transaction() -> TransactionView {
     create_cellbase_transaction_with_capacity(capacity_bytes!(100))
 }
@@ -122,6 +167,45 @@ pub fn test_block_with_one_cellbase_at_last() {
         verifier.verify(&block),
         Err(VerifyError::Cellbase(CellbaseError::InvalidPosition))
     );
+}
+
+#[test]
+pub fn test_cellbase_with_non_empty_output_data() {
+    let block = BlockBuilder::default()
+        .header(HeaderBuilder::default().number(2u64.pack()).build())
+        .transaction(create_cellbase_transaction_with_non_empty_output_data())
+        .build();
+    let verifier = CellbaseVerifier::new();
+    assert_eq!(
+        verifier.verify(&block),
+        Err(VerifyError::Cellbase(CellbaseError::InvalidOutputData))
+    )
+}
+
+#[test]
+pub fn test_cellbase_with_two_output() {
+    let block = BlockBuilder::default()
+        .header(HeaderBuilder::default().number(2u64.pack()).build())
+        .transaction(create_cellbase_transaction_with_two_output())
+        .build();
+    let verifier = CellbaseVerifier::new();
+    assert_eq!(
+        verifier.verify(&block),
+        Err(VerifyError::Cellbase(CellbaseError::InvalidQuantity))
+    )
+}
+
+#[test]
+pub fn test_cellbase_with_two_output_data() {
+    let block = BlockBuilder::default()
+        .header(HeaderBuilder::default().number(2u64.pack()).build())
+        .transaction(create_cellbase_transaction_with_two_output_data())
+        .build();
+    let verifier = CellbaseVerifier::new();
+    assert_eq!(
+        verifier.verify(&block),
+        Err(VerifyError::Cellbase(CellbaseError::InvalidQuantity))
+    )
 }
 
 #[test]


### PR DESCRIPTION
Because the ckb reward is delayed, the ownership of the cellbase of the current block is not the miner who digs out the block, so cellbase's output data must be disabled.