### PR TITLE
[ᚬrc/v0.19] Fix orphan block race storage

### DIFF
--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -154,7 +154,7 @@ impl BlockFetcher {
                 if self
                     .synchronizer
                     .shared()
-                    .contains_block_status(&to_fetch.hash(), BlockStatus::BLOCK_RECEIVED)
+                    .contains_block_status(&to_fetch.hash(), BlockStatus::BLOCK_STORED)
                 {
                     continue;
                 }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -121,8 +121,8 @@ impl Synchronizer {
     ) -> Result<bool, FailureError> {
         let block_hash = block.hash();
         let status = self.shared().get_block_status(&block_hash);
-        if status.contains(BlockStatus::BLOCK_RECEIVED) {
-            debug!("block {} already received", block_hash);
+        if status.contains(BlockStatus::BLOCK_STORED) {
+            debug!("block {} already stored", block_hash);
             Ok(false)
         } else if status.contains(BlockStatus::HEADER_VALID) {
             self.shared()


### PR DESCRIPTION
* Fetch blocks even if orphan_pool already cached
* Process blocks even if orphan_pool already cached

Although this change will introduce re-processing the same blocks, but it fix the data race problem between orphan_pool and storage