### PR TITLE
chore: let sentry capture more details when failed to `get_locator`

### DIFF
--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -848,12 +848,20 @@ impl SyncSharedState {
         let mut step = 1;
         let mut locator = Vec::with_capacity(32);
         let mut index = start.number();
-        let mut base = start.hash().to_owned();
+        let mut base = start.hash();
         loop {
-            let header = self
-                .get_ancestor(&base, index)
-                .expect("index calculated in get_locator");
-            locator.push(header.hash().to_owned());
+            let header = self.get_ancestor(&base, index).unwrap_or_else(|| {
+                panic!(
+                    "index calculated in get_locator: \
+                     start: {}, base: {}, step: {}, locators({}): {:?}.",
+                    start,
+                    base,
+                    step,
+                    locator.len(),
+                    locator,
+                );
+            });
+            locator.push(header.hash());
 
             if locator.len() >= 10 {
                 step <<= 1;
@@ -867,7 +875,7 @@ impl SyncSharedState {
                 break;
             }
             index -= step;
-            base = header.hash().to_owned();
+            base = header.hash();
         }
         locator
     }


### PR DESCRIPTION
Sentry reported this `panic` in our latest release -- `v0.20.0 (rylai-v9 024408e 2019-09-07)` again.