### PR TITLE
feat: Keep only one version of VM by removing ScriptConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
  "ckb-pow 0.21.0-pre",
  "ckb-resource 0.21.0-pre",
  "ckb-rpc 0.21.0-pre",
- "ckb-script 0.21.0-pre",
  "ckb-shared 0.21.0-pre",
  "ckb-store 0.21.0-pre",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -410,7 +409,6 @@ dependencies = [
  "ckb-notify 0.21.0-pre",
  "ckb-resource 0.21.0-pre",
  "ckb-rpc 0.21.0-pre",
- "ckb-script 0.21.0-pre",
  "ckb-shared 0.21.0-pre",
  "ckb-store 0.21.0-pre",
  "ckb-sync 0.21.0-pre",
@@ -893,7 +891,7 @@ dependencies = [
  "ckb-store 0.21.0-pre",
  "ckb-test-chain-utils 0.21.0-pre",
  "ckb-types 0.21.0-pre",
- "ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -923,7 +921,6 @@ dependencies = [
  "ckb-notify 0.21.0-pre",
  "ckb-proposal-table 0.21.0-pre",
  "ckb-reward-calculator 0.21.0-pre",
- "ckb-script 0.21.0-pre",
  "ckb-store 0.21.0-pre",
  "ckb-test-chain-utils 0.21.0-pre",
  "ckb-traits 0.21.0-pre",
@@ -1035,7 +1032,6 @@ version = "0.21.0-pre"
 dependencies = [
  "ckb-chain-spec 0.21.0-pre",
  "ckb-error 0.21.0-pre",
- "ckb-script 0.21.0-pre",
  "ckb-store 0.21.0-pre",
  "ckb-types 0.21.0-pre",
 ]
@@ -1115,21 +1111,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1695,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.0.22"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4108,8 +4104,8 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "27429a03ca54100bf6bdc726c09adc46a74187ac93f9ce96dc7aaa9594ebf707"
 "checksum ckb-system-scripts 0.3.2-alpha.2+refactor-schema (registry+https://github.com/rust-lang/crates.io-index)" = "956a5e5323071dfdd0ea1f9d073c8ebb8fb29ba05d57f0fff217d1ccd7c3c20f"
-"checksum ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f089b008f8fa02e44b409b2c24ee9a9f65216f24cebeccc598162d3a44a675ad"
-"checksum ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd297669e4783ddca472fa00e7d2117b2d1dcb67cca814d5dd222852b8dba088"
+"checksum ckb-vm 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf38f65a6d172254c98eec58293848fa13d4fab24505090ef5e7920729af86c4"
+"checksum ckb-vm-definitions 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdef12b0d1abb7ccc395d90b1e42cbf809dd62f0c229bf47bccb1ea458ea60ab"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
@@ -4175,7 +4171,7 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
-"checksum goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"
+"checksum goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e3fa261d919c1ae9d1e4533c4a2f99e10938603c4208d56c05bec7a872b661b0"
 "checksum h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "910a5e7be6283a9c91b3982fa5188368c8719cce2a3cf3b86048673bf9d9c36b"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -556,8 +556,7 @@ impl ChainService {
             attach_block_cell(txn, b, cell_set)?;
         }
 
-        let verify_context =
-            VerifyContext::new(txn, self.shared.consensus(), self.shared.script_config());
+        let verify_context = VerifyContext::new(txn, self.shared.consensus());
 
         let mut found_error = None;
         for (ext, b) in fork

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -36,5 +36,4 @@ ckb-build-info = { path = "../util/build-info" }
 ckb-traits = { path = "../traits" }
 ckb-verification = { path = "../verification" }
 faster-hex = "0.4"
-ckb-script = { path = "../script" }
 ckb-db = { path = "../db" }

--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -10,7 +10,6 @@ use ckb_resource::{
     Resource, TemplateContext, AVAILABLE_SPECS, CKB_CONFIG_FILE_NAME, DEFAULT_SPEC,
     MINER_CONFIG_FILE_NAME, SPEC_DEV_FILE_NAME,
 };
-use ckb_script::Runner;
 use ckb_types::{prelude::*, H256};
 
 const DEFAULT_LOCK_SCRIPT_HASH_TYPE: &str = "type";
@@ -91,8 +90,6 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         }
     }
 
-    let runner = Runner::default().to_string();
-
     // Try to find the default secp256k1 from bundled chain spec.
     let default_code_hash_option =
         ChainSpec::load_from(&Resource::bundled(format!("specs/{}.toml", args.chain)))
@@ -168,7 +165,6 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         p2p_port: &args.p2p_port,
         log_to_file: args.log_to_file,
         log_to_stdout: args.log_to_stdout,
-        runner: &runner,
         block_assembler: &block_assembler,
     };
 

--- a/ckb-bin/src/subcommand/prof.rs
+++ b/ckb-bin/src/subcommand/prof.rs
@@ -12,7 +12,6 @@ pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
     let (shared, _table) = SharedBuilder::with_db_config(&args.config.db)
         .consensus(args.consensus.clone())
         .tx_pool_config(args.config.tx_pool)
-        .script_config(args.config.script)
         .build()
         .map_err(|err| {
             eprintln!("Prof error: {:?}", err);

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -25,7 +25,6 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let (shared, table) = SharedBuilder::with_db_config(&args.config.db)
         .consensus(args.consensus)
         .tx_pool_config(args.config.tx_pool)
-        .script_config(args.config.script)
         .store_config(args.config.store)
         .build()
         .map_err(|err| {

--- a/devtools/azure/windows-dependencies.yml
+++ b/devtools/azure/windows-dependencies.yml
@@ -1,10 +1,15 @@
 parameters:
   rustup_toolchain: ''
 steps:
-- script: choco install -y llvm
+- script: |
+    choco install -y llvm
+    set "PATH=%PATH%;C:\Program Files\LLVM\bin"
+    echo "##vso[task.setvariable variable=PATH;]%PATH%;C:\Program Files\LLVM\bin"
   displayName: Install LLVM
 - script: choco install -y msys2
   displayName: Install msys2
+- script: choco install -y yasm
+  displayName: Install yasm
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
     rustup-init.exe -y --default-toolchain ${{ parameters.rustup_toolchain }}
@@ -14,4 +19,6 @@ steps:
 - script: |
     rustc --version
     cargo --version
-  displayName: Test/query rust and cargo versions
+    clang --version
+    yasm --version
+  displayName: Test/query binaries

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -94,11 +94,6 @@ max_verify_cache_size = 100_000
 max_conflict_cache_size = 1_000
 max_committed_txs_hash_cache_size = 100_000
 
-[script]
-runner = "Rust" # {{
-# _ => runner = "{runner}"
-# }}
-
 [store]
 header_cache_size          = 4096
 cell_data_cache_size       = 128

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -227,7 +227,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: true,
             log_to_stdout: true,
-            runner: "Rust",
             block_assembler: "",
         };
         Resource::bundled_ckb_config()

--- a/resource/src/template.rs
+++ b/resource/src/template.rs
@@ -17,7 +17,6 @@ pub struct TemplateContext<'a> {
     pub p2p_port: &'a str,
     pub log_to_file: bool,
     pub log_to_stdout: bool,
-    pub runner: &'a str,
     pub block_assembler: &'a str,
 }
 
@@ -38,7 +37,6 @@ fn writeln<W: io::Write>(w: &mut W, s: &str, context: &TemplateContext) -> io::R
             .replace("{p2p_port}", context.p2p_port)
             .replace("{log_to_file}", &format!("{}", context.log_to_file))
             .replace("{log_to_stdout}", &format!("{}", context.log_to_stdout))
-            .replace("{runner}", &context.runner.to_string())
             .replace("{block_assembler}", context.block_assembler)
     )
 }

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -4,7 +4,6 @@ use ckb_jsonrpc_types::{Capacity, Cycle, DryRunResult, OutPoint, Script, Transac
 use ckb_logger::error;
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::ChainStore;
-use ckb_traits::chain_provider::ChainProvider;
 use ckb_types::{
     core::cell::{resolve_transaction, CellProvider, CellStatus, HeaderChecker},
     packed,
@@ -109,9 +108,7 @@ impl<'a> DryRunner<'a> {
             Ok(resolved) => {
                 let consensus = snapshot.consensus();
                 let max_cycles = consensus.max_block_cycles;
-                match ScriptVerifier::new(&resolved, snapshot, self.shared.script_config())
-                    .verify(max_cycles)
-                {
+                match ScriptVerifier::new(&resolved, snapshot).verify(max_cycles) {
                     Ok(cycles) => Ok(DryRunResult {
                         cycles: Cycle(cycles),
                     }),

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -10,7 +10,7 @@ ckb-script-data-loader = { path = "data-loader" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.15.1", features = ["asm"] }
+ckb-vm = { version = "0.16.0", features = ["asm"] }
 faster-hex = "0.4"
 ckb-logger = { path = "../util/logger" }
 serde = "1.0"

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -4,52 +4,8 @@ mod syscalls;
 mod type_id;
 mod verify;
 
-use serde_derive::{Deserialize, Serialize};
-use std::fmt;
-
 pub use crate::error::ScriptError;
 pub use crate::verify::{ScriptGroup, ScriptGroupType, TransactionScriptsVerifier};
 
 /// re-export DataLoader
 pub use ckb_script_data_loader::DataLoader;
-
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
-pub enum Runner {
-    #[cfg(all(unix, target_pointer_width = "64"))]
-    Assembly,
-    Rust,
-}
-
-impl fmt::Display for Runner {
-    #[cfg(all(unix, target_pointer_width = "64"))]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Runner::Assembly => write!(f, "Assembly"),
-            Runner::Rust => write!(f, "Rust"),
-        }
-    }
-
-    #[cfg(not(all(unix, target_pointer_width = "64")))]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Runner::Rust => write!(f, "Rust"),
-        }
-    }
-}
-
-impl Default for Runner {
-    #[cfg(all(unix, target_pointer_width = "64"))]
-    fn default() -> Runner {
-        Runner::Assembly
-    }
-
-    #[cfg(not(all(unix, target_pointer_width = "64")))]
-    fn default() -> Runner {
-        Runner::Rust
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug, Default)]
-pub struct ScriptConfig {
-    pub runner: Runner,
-}

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -388,8 +388,6 @@ fn internal_error(error: ckb_vm::Error) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(all(unix, target_pointer_width = "64")))]
-    use crate::Runner;
     use byteorder::{ByteOrder, LittleEndian};
     use ckb_crypto::secp::{Generator, Privkey, Pubkey, Signature};
     use ckb_db::RocksDB;

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -5,7 +5,7 @@ use crate::{
         LoadWitness,
     },
     type_id::TypeIdSystemScript,
-    DataLoader, ScriptConfig, ScriptError,
+    DataLoader, ScriptError,
 };
 use ckb_error::{Error, InternalErrorKind};
 use ckb_logger::{debug, info};
@@ -20,16 +20,11 @@ use ckb_types::{
     prelude::*,
 };
 use ckb_vm::{
-    DefaultCoreMachine, DefaultMachineBuilder, SparseMemory, SupportMachine, TraceMachine,
-    WXorXMemory,
+    machine::asm::{AsmCoreMachine, AsmMachine},
+    DefaultMachineBuilder, SupportMachine,
 };
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-#[cfg(all(unix, target_pointer_width = "64"))]
-use crate::Runner;
-#[cfg(all(unix, target_pointer_width = "64"))]
-use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 
 // A script group is defined as scripts that share the same hash.
 // A script group will only be executed once per transaction, the
@@ -72,19 +67,12 @@ pub struct TransactionScriptsVerifier<'a, DL> {
     binaries_by_type_hash: HashMap<Byte32, (Bytes, bool)>,
     lock_groups: HashMap<Byte32, ScriptGroup>,
     type_groups: HashMap<Byte32, ScriptGroup>,
-
-    // On windows we won't need this config right now, but removing it
-    // on windows alone is too much effort comparing to simply allowing
-    // it here.
-    #[allow(dead_code)]
-    config: &'a ScriptConfig,
 }
 
 impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
     pub fn new(
         rtx: &'a ResolvedTransaction,
         data_loader: &'a DL,
-        config: &'a ScriptConfig,
     ) -> TransactionScriptsVerifier<'a, DL> {
         let tx_hash = rtx.transaction.hash();
         let resolved_cell_deps = &rtx.resolved_cell_deps;
@@ -154,7 +142,6 @@ impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
             binaries_by_type_hash,
             outputs,
             rtx,
-            config,
             lock_groups,
             type_groups,
             debug_printer: None,
@@ -334,7 +321,6 @@ impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
         }
     }
 
-    #[cfg(all(unix, target_pointer_width = "64"))]
     fn run(
         &self,
         program: &Bytes,
@@ -358,136 +344,31 @@ impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
                 .into_iter()
                 .map(|arg| arg.raw_data()),
         );
-        let (code, cycles) = match self.config.runner {
-            Runner::Assembly => {
-                let core_machine = AsmCoreMachine::new_with_max_cycles(max_cycles);
-                let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(core_machine)
-                    .instruction_cycle_func(Box::new(instruction_cycles))
-                    .syscall(Box::new(
-                        self.build_load_script_hash(current_script_hash.clone()),
-                    ))
-                    .syscall(Box::new(self.build_load_tx_hash()))
-                    .syscall(Box::new(self.build_load_cell(
-                        &script_group.input_indices,
-                        &script_group.output_indices,
-                    )))
-                    .syscall(Box::new(self.build_load_input(&script_group.input_indices)))
-                    .syscall(Box::new(
-                        self.build_load_header(&script_group.input_indices),
-                    ))
-                    .syscall(Box::new(
-                        self.build_load_witness(&script_group.input_indices),
-                    ))
-                    .syscall(Box::new(self.build_load_cell_data(
-                        &script_group.input_indices,
-                        &script_group.output_indices,
-                    )))
-                    .syscall(Box::new(Debugger::new(&debug_printer)))
-                    .build();
-                let mut machine = AsmMachine::new(machine, None);
-                machine
-                    .load_program(&program, &args)
-                    .map_err(internal_error)?;
-                let code = machine.run().map_err(internal_error)?;
-                (code, machine.machine.cycles())
-            }
-            Runner::Rust => {
-                let core_machine =
-                    DefaultCoreMachine::<u64, WXorXMemory<u64, SparseMemory<u64>>>::new_with_max_cycles(max_cycles);
-                let machine = DefaultMachineBuilder::<
-                    DefaultCoreMachine<u64, WXorXMemory<u64, SparseMemory<u64>>>,
-                >::new(core_machine)
-                .instruction_cycle_func(Box::new(instruction_cycles))
-                .syscall(Box::new(
-                    self.build_load_script_hash(current_script_hash.clone()),
-                ))
-                .syscall(Box::new(self.build_load_tx_hash()))
-                .syscall(Box::new(self.build_load_cell(
-                    &script_group.input_indices,
-                    &script_group.output_indices,
-                )))
-                .syscall(Box::new(self.build_load_input(&script_group.input_indices)))
-                .syscall(Box::new(
-                    self.build_load_header(&script_group.input_indices),
-                ))
-                .syscall(Box::new(
-                    self.build_load_witness(&script_group.input_indices),
-                ))
-                .syscall(Box::new(self.build_load_cell_data(
-                    &script_group.input_indices,
-                    &script_group.output_indices,
-                )))
-                .syscall(Box::new(Debugger::new(&debug_printer)))
-                .build();
-                let mut machine = TraceMachine::new(machine);
-                machine
-                    .load_program(&program, &args)
-                    .map_err(internal_error)?;
-                let code = machine.run().map_err(internal_error)?;
-                (code, machine.machine.cycles())
-            }
-        };
-        if code == 0 {
-            Ok(cycles)
-        } else {
-            Err(ScriptError::ValidationFailure(code))?
-        }
-    }
-
-    #[cfg(not(all(unix, target_pointer_width = "64")))]
-    fn run(
-        &self,
-        program: &Bytes,
-        script_group: &ScriptGroup,
-        max_cycles: Cycle,
-    ) -> Result<Cycle, Error> {
-        let current_script_hash = script_group.script.calc_script_hash();
-        let prefix = format!("script group: {}", current_script_hash);
-        let debug_printer = |message: &str| {
-            if let Some(ref printer) = self.debug_printer {
-                printer(&current_script_hash, message);
-            } else {
-                debug!("{} DEBUG OUTPUT: {}", prefix, message);
-            };
-        };
-        let mut args = vec!["verify".into()];
-        args.extend(
-            script_group
-                .script
-                .args()
-                .into_iter()
-                .map(|arg| arg.raw_data()),
-        );
-        let core_machine =
-            DefaultCoreMachine::<u64, WXorXMemory<u64, SparseMemory<u64>>>::new_with_max_cycles(
-                max_cycles,
-            );
-        let machine = DefaultMachineBuilder::<
-            DefaultCoreMachine<u64, WXorXMemory<u64, SparseMemory<u64>>>,
-        >::new(core_machine)
-        .instruction_cycle_func(Box::new(instruction_cycles))
-        .syscall(Box::new(
-            self.build_load_script_hash(current_script_hash.clone()),
-        ))
-        .syscall(Box::new(self.build_load_tx_hash()))
-        .syscall(Box::new(self.build_load_cell(
-            &script_group.input_indices,
-            &script_group.output_indices,
-        )))
-        .syscall(Box::new(self.build_load_input(&script_group.input_indices)))
-        .syscall(Box::new(
-            self.build_load_header(&script_group.input_indices),
-        ))
-        .syscall(Box::new(
-            self.build_load_witness(&script_group.input_indices),
-        ))
-        .syscall(Box::new(self.build_load_cell_data(
-            &script_group.input_indices,
-            &script_group.output_indices,
-        )))
-        .syscall(Box::new(Debugger::new(&debug_printer)))
-        .build();
-        let mut machine = TraceMachine::new(machine);
+        let core_machine = AsmCoreMachine::new_with_max_cycles(max_cycles);
+        let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(core_machine)
+            .instruction_cycle_func(Box::new(instruction_cycles))
+            .syscall(Box::new(
+                self.build_load_script_hash(current_script_hash.clone()),
+            ))
+            .syscall(Box::new(self.build_load_tx_hash()))
+            .syscall(Box::new(self.build_load_cell(
+                &script_group.input_indices,
+                &script_group.output_indices,
+            )))
+            .syscall(Box::new(self.build_load_input(&script_group.input_indices)))
+            .syscall(Box::new(
+                self.build_load_header(&script_group.input_indices),
+            ))
+            .syscall(Box::new(
+                self.build_load_witness(&script_group.input_indices),
+            ))
+            .syscall(Box::new(self.build_load_cell_data(
+                &script_group.input_indices,
+                &script_group.output_indices,
+            )))
+            .syscall(Box::new(Debugger::new(&debug_printer)))
+            .build();
+        let mut machine = AsmMachine::new(machine, None);
         machine
             .load_program(&program, &args)
             .map_err(internal_error)?;
@@ -621,10 +502,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
         assert!(verifier.verify(100).is_ok());
     }
 
@@ -684,12 +562,8 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        // Default Runner
         assert!(verifier.verify(100_000_000).is_ok());
 
         // Not enough cycles
@@ -697,85 +571,6 @@ mod tests {
             verifier.verify(100).unwrap_err(),
             internal_error(VMInternalError::InvalidCycles),
         );
-
-        // Rust Runner
-        let verifier = TransactionScriptsVerifier::new(
-            &rtx,
-            &data_loader,
-            &ScriptConfig {
-                runner: Runner::Rust,
-            },
-        );
-
-        assert!(verifier.verify(100_000_000).is_ok());
-    }
-
-    #[cfg(all(unix, target_pointer_width = "64"))]
-    #[test]
-    fn check_signature_assembly() {
-        let mut file = open_cell_verify();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let (privkey, pubkey) = random_keypair();
-        let mut args = vec![Bytes::from(b"foo".to_vec()), Bytes::from(b"bar".to_vec())];
-
-        let signature = sign_args(&args, &privkey);
-        args.push(Bytes::from(to_hex_pubkey(&pubkey)));
-        args.push(Bytes::from(to_hex_signature(&signature)));
-
-        let code_hash = blake2b_256(&buffer);
-        let dep_out_point = OutPoint::new(h256!("0x123").pack(), 8);
-        let cell_dep = CellDep::new_builder()
-            .out_point(dep_out_point.clone())
-            .build();
-        let data = Bytes::from(buffer);
-        let output = CellOutputBuilder::default()
-            .capacity(Capacity::bytes(data.len()).unwrap().pack())
-            .build();
-        let dep_cell = CellMetaBuilder::from_cell_output(output, data)
-            .transaction_info(default_transaction_info())
-            .out_point(dep_out_point.clone())
-            .build();
-
-        let script = Script::new_builder()
-            .args(args.pack())
-            .code_hash(code_hash.pack())
-            .hash_type(ScriptHashType::Data.pack())
-            .build();
-        let input = CellInput::new(OutPoint::null(), 0);
-
-        let transaction = TransactionBuilder::default()
-            .input(input.clone())
-            .cell_dep(cell_dep)
-            .build();
-
-        let output = CellOutputBuilder::default()
-            .capacity(capacity_bytes!(100).pack())
-            .lock(script)
-            .build();
-        let dummy_cell = CellMetaBuilder::from_cell_output(output.to_owned(), Bytes::new())
-            .transaction_info(default_transaction_info())
-            .build();
-
-        let rtx = ResolvedTransaction {
-            transaction: &transaction,
-            resolved_cell_deps: vec![dep_cell],
-            resolved_inputs: vec![dummy_cell],
-            resolved_dep_groups: vec![],
-        };
-        let store = new_store();
-        let data_loader = DataLoaderWrapper::new(&store);
-
-        let verifier = TransactionScriptsVerifier::new(
-            &rtx,
-            &data_loader,
-            &ScriptConfig {
-                runner: Runner::Assembly,
-            },
-        );
-
-        assert!(verifier.verify(100_000_000).is_ok());
     }
 
     #[test]
@@ -843,10 +638,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(100_000_000).is_ok());
     }
@@ -938,10 +730,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(100_000_000).unwrap_err(),
@@ -1020,10 +809,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(100).is_err());
     }
@@ -1086,10 +872,7 @@ mod tests {
 
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(100_000_000).unwrap_err(),
@@ -1143,10 +926,7 @@ mod tests {
 
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(100_000_000).unwrap_err(),
@@ -1229,10 +1009,7 @@ mod tests {
 
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(100_000_000).is_ok());
     }
@@ -1309,10 +1086,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(100_000_000).unwrap_err(),
@@ -1374,12 +1148,9 @@ mod tests {
             resolved_inputs: vec![dummy_cell],
             resolved_dep_groups: vec![],
         };
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         // Cycles can tell that both lock and type scripts are executed
         assert_eq!(verifier.verify(100_000_000).ok(), Some(2_818_104));
@@ -1440,10 +1211,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(1_001_000).is_ok());
     }
@@ -1503,10 +1271,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(500_000).unwrap_err(),
@@ -1577,10 +1342,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(1_001_000).is_ok());
     }
@@ -1639,10 +1401,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert!(verifier.verify(1_001_000).is_ok());
     }
@@ -1716,10 +1475,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(1_001_000).unwrap_err(),
@@ -1799,10 +1555,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(1_001_000).unwrap_err(),
@@ -1871,10 +1624,7 @@ mod tests {
         let store = new_store();
         let data_loader = DataLoaderWrapper::new(&store);
 
-        let config = ScriptConfig {
-            runner: Runner::default(),
-        };
-        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader, &config);
+        let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
         assert_error_eq(
             verifier.verify(1_001_000).unwrap_err(),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -18,7 +18,6 @@ faketime = "0.2"
 ckb-logger = { path = "../util/logger" }
 ckb-traits = { path = "../traits" }
 ckb-verification = { path = "../verification" }
-ckb-script = { path = "../script" }
 ckb-dao = { path = "../util/dao" }
 ckb-reward-calculator = { path = "../util/reward-calculator" }
 ckb-proposal-table = { path = "../util/proposal-table" }

--- a/shared/src/tx_pool/pool.rs
+++ b/shared/src/tx_pool/pool.rs
@@ -5,7 +5,6 @@ use crate::tx_pool::orphan::OrphanPool;
 use crate::tx_pool::pending::PendingQueue;
 use crate::tx_pool::proposed::ProposedPool;
 use ckb_logger::{error_target, trace_target};
-use ckb_script::ScriptConfig;
 use ckb_types::{
     core::{Capacity, Cycle, TransactionView},
     packed::{Byte32, OutPoint, ProposalShortId},
@@ -37,16 +36,10 @@ pub struct TxPool {
     pub(crate) total_tx_cycles: Cycle,
 
     pub snapshot: Arc<Snapshot>,
-
-    pub script_config: ScriptConfig,
 }
 
 impl TxPool {
-    pub fn new(
-        config: TxPoolConfig,
-        snapshot: Arc<Snapshot>,
-        script_config: ScriptConfig,
-    ) -> TxPool {
+    pub fn new(config: TxPoolConfig, snapshot: Arc<Snapshot>) -> TxPool {
         let conflict_cache_size = config.max_conflict_cache_size;
         let committed_txs_hash_cache_size = config.max_committed_txs_hash_cache_size;
         let last_txs_updated_at = 0u64;
@@ -63,7 +56,6 @@ impl TxPool {
             total_tx_size: 0,
             total_tx_cycles: 0,
             snapshot,
-            script_config,
         }
     }
 

--- a/shared/src/tx_pool_ext.rs
+++ b/shared/src/tx_pool_ext.rs
@@ -126,7 +126,6 @@ impl TxPool {
                     epoch_number,
                     tip_header.hash(),
                     consensus,
-                    &self.script_config,
                     snapshot,
                 )
                 .verify(max_cycles)?;

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -122,7 +122,6 @@ impl TxPoolExecutor {
                     epoch_number,
                     parent_hash.clone(),
                     &consensus,
-                    self.shared.script_config(),
                     snapshot,
                 )
                 .verify(max_block_cycles)

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -9,5 +9,4 @@ license = "MIT"
 ckb-types = { path = "../util/types" }
 ckb-chain-spec = {path = "../spec"}
 ckb-store = { path = "../store" }
-ckb-script = { path = "../script" }
 ckb-error = { path = "../error" }

--- a/traits/src/chain_provider.rs
+++ b/traits/src/chain_provider.rs
@@ -1,6 +1,5 @@
 use ckb_chain_spec::consensus::Consensus;
 use ckb_error::Error;
-use ckb_script::ScriptConfig;
 use ckb_store::ChainStore;
 use ckb_types::{
     core::{BlockReward, EpochExt, HeaderView},
@@ -11,8 +10,6 @@ pub trait ChainProvider: Sync + Send {
     type Store: ChainStore<'static>;
 
     fn store(&self) -> &Self::Store;
-
-    fn script_config(&self) -> &ScriptConfig;
 
     fn genesis_hash(&self) -> Byte32;
 

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -27,7 +27,6 @@ ckb-shared = { path = "../../shared" }
 ckb-store = { path = "../../store" }
 ckb-network-alert = { path = "../network-alert" }
 ckb-build-info = { path = "../build-info" }
-ckb-script = { path = "../../script" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -21,7 +21,6 @@ use ckb_network_alert::config::{
 };
 use ckb_resource::Resource;
 use ckb_rpc::Config as RpcConfig;
-use ckb_script::ScriptConfig;
 use ckb_shared::tx_pool::TxPoolConfig;
 use ckb_store::StoreConfig;
 
@@ -49,7 +48,6 @@ pub struct CKBAppConfig {
     pub network: NetworkConfig,
     pub rpc: RpcConfig,
     pub tx_pool: TxPoolConfig,
-    pub script: ScriptConfig,
     pub store: StoreConfig,
     pub alert_signature: Option<AlertSignatureConfig>,
     pub alert_notifier: Option<AlertNotifierConfig>,
@@ -260,7 +258,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: true,
             log_to_stdout: true,
-            runner: "Rust",
             block_assembler: "",
         };
         {
@@ -307,7 +304,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: false,
             log_to_stdout: true,
-            runner: "Rust",
             block_assembler: "",
         };
         {
@@ -343,7 +339,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: true,
             log_to_stdout: true,
-            runner: "Rust",
             block_assembler: "",
         };
         {
@@ -390,7 +385,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: true,
             log_to_stdout: true,
-            runner: "Rust",
             block_assembler: "",
         };
         {
@@ -435,7 +429,6 @@ mod tests {
             p2p_port: "8000",
             log_to_file: true,
             log_to_stdout: true,
-            runner: "Assembly",
             block_assembler: "",
         };
         {

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -9,7 +9,6 @@ use ckb_dao::DaoCalculator;
 use ckb_error::Error;
 use ckb_logger::error_target;
 use ckb_reward_calculator::RewardCalculator;
-use ckb_script::ScriptConfig;
 use ckb_store::ChainStore;
 use ckb_traits::BlockMedianTimeContext;
 use ckb_types::{
@@ -28,16 +27,11 @@ use std::collections::HashSet;
 pub struct VerifyContext<'a, CS> {
     pub(crate) store: &'a CS,
     pub(crate) consensus: &'a Consensus,
-    pub(crate) script_config: &'a ScriptConfig,
 }
 
 impl<'a, CS: ChainStore<'a>> VerifyContext<'a, CS> {
-    pub fn new(store: &'a CS, consensus: &'a Consensus, script_config: &'a ScriptConfig) -> Self {
-        VerifyContext {
-            store,
-            consensus,
-            script_config,
-        }
+    pub fn new(store: &'a CS, consensus: &'a Consensus) -> Self {
+        VerifyContext { store, consensus }
     }
 
     fn finalize_block_reward(&self, parent: &HeaderView) -> Result<(Script, BlockReward), Error> {
@@ -370,7 +364,6 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         self.epoch_number,
                         self.parent_hash.clone(),
                         self.context.consensus,
-                        self.context.script_config,
                         self.context.store,
                     )
                     .verify(self.context.consensus.max_block_cycles())

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -75,7 +75,7 @@ fn create_transaction(
 }
 
 fn dummy_context(shared: &Shared) -> VerifyContext<'_, ChainDB> {
-    VerifyContext::new(shared.store(), shared.consensus(), shared.script_config())
+    VerifyContext::new(shared.store(), shared.consensus())
 }
 
 fn start_chain(consensus: Option<Consensus>) -> (ChainController, Shared) {

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -125,7 +125,7 @@ fn prepare() -> (Shared, Vec<BlockView>, Vec<BlockView>) {
 }
 
 fn dummy_context(shared: &Shared) -> VerifyContext<'_, ChainDB> {
-    VerifyContext::new(shared.store(), shared.consensus(), shared.script_config())
+    VerifyContext::new(shared.store(), shared.consensus())
 }
 
 fn epoch(shared: &Shared, chain: &[BlockView], index: usize) -> EpochExt {


### PR DESCRIPTION
NOTE: one side effect here, is that CKB will only be able to run on
64-bit Windows, Linux and maxOS platforms with this change. We can
discuss if this will bring future problems. One alternative solution
here, is that we can still remove ScriptConfig and leave only one VM
here, then use conditional compilation to revert to Rust based VMs on
32-bit platforms, or ARM processors. This way on each platform, we are
still only supporting just one VM for simplicity