### PR TITLE
chore: Bump faster-hex and blake2b-rs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "blake2b-rs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,7 +421,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -482,7 +482,7 @@ version = "0.21.0-pre"
 dependencies = [
  "ckb-fixed-hash 0.21.0-pre",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -549,7 +549,7 @@ name = "ckb-fixed-hash-core"
 version = "0.21.0-pre"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -568,7 +568,7 @@ dependencies = [
 name = "ckb-hash"
 version = "0.21.0-pre"
 dependencies = [
- "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -609,7 +609,7 @@ name = "ckb-jsonrpc-types"
 version = "0.21.0-pre"
 dependencies = [
  "ckb-types 0.21.0-pre",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,7 +697,7 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,7 +895,7 @@ dependencies = [
  "ckb-types 0.21.0-pre",
  "ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1007,7 +1007,7 @@ name = "ckb-system-scripts"
 version = "0.3.2-alpha.2+refactor-schema"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1558,6 +1558,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "faster-hex"
 version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "faster-hex"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4085,7 +4090,7 @@ dependencies = [
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-"checksum blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9527b166a2d75fc95f72e09bc57030cd115960a5357cf55f6b7af7bffe678aab"
+"checksum blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6e35e362830ef90ecea16f09b21b75d22d33a8562a679c74ab4f4fa49b4fcb87"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
@@ -4151,6 +4156,7 @@ dependencies = [
 "checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8cccaafb5aae8c282692e5590f341925edea6c696e8715ff0d973320b2646"
+"checksum faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec0ddfd1edbd5feb84f73d3068f7e5edba48b438caee3fb8e9ccb3e58cc70c5a"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -35,6 +35,6 @@ ckb-hash = { path = "../util/hash"}
 ckb-build-info = { path = "../util/build-info" }
 ckb-traits = { path = "../traits" }
 ckb-verification = { path = "../verification" }
-faster-hex = "0.3"
+faster-hex = "0.4"
 ckb-script = { path = "../script" }
 ckb-db = { path = "../db" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.3.0"
 generic-channel = { version = "0.2.0", features = ["all"] }
 bs58 = "0.2.0"
 sentry = "0.16.0"
-faster-hex = "0.3"
+faster-hex = "0.4"
 ckb-hash = {path = "../util/hash"}
 secp256k1 = {version = "0.15.0", features = ["recovery"] }
 resolve = "0.2.0"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -11,7 +11,7 @@ byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
 ckb-vm = { version = "0.15.1", features = ["asm"] }
-faster-hex = "0.3"
+faster-hex = "0.4"
 ckb-logger = { path = "../util/logger" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "1.3"
 secp256k1 = { version = "0.15.0", features = ["recovery"], optional = true }
 failure = "0.1.5"
 rand = "0.6"
-faster-hex = "0.3"
+faster-hex = "0.4"
 
 [features]
 default = [ "secp" ]

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 [dependencies]
 failure = "0.1.5"
 serde = "1.0"
-faster-hex = "0.3"
+faster-hex = "0.4"

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dependencies]
-blake2b-rs = "0.1.4"
+blake2b-rs = "0.1.5"

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -10,7 +10,7 @@ ckb-types = { path = "../types" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-faster-hex = "0.3"
+faster-hex = "0.4"
 jsonrpc-core = "10.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Related changes:

https://github.com/nervosnetwork/faster-hex/pull/9
https://github.com/nervosnetwork/blake2b-rs/pull/5