### PR TITLE
feat: satoshi's gift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ name = "block-cipher-trait"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1472,7 +1472,7 @@ name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3295,7 +3295,7 @@ name = "stream-cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4198,7 +4198,7 @@ dependencies = [
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
+"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d1a0a427708e0f861025065b4c490e501e0eb13b7fb773a75b829576f6fc8a0"
 "checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/benches/benches/benchmarks/next_epoch_ext.rs
+++ b/benches/benches/benchmarks/next_epoch_ext.rs
@@ -1,4 +1,4 @@
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_types::{
     core::{capacity_bytes, BlockBuilder, Capacity, HeaderBuilder, HeaderView, TransactionBuilder},
@@ -90,7 +90,8 @@ fn bench(c: &mut Criterion) {
                         .build();
 
                     let mut parent = genesis_block.header().clone();
-                    let consensus = Consensus::new(genesis_block, DEFAULT_EPOCH_REWARD);
+                    let consensus =
+                        ConsensusBuilder::new(genesis_block, DEFAULT_EPOCH_REWARD).build();
                     let genesis_epoch_ext = consensus.genesis_epoch_ext().clone();
 
                     let mut store = FakeStore::default();

--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -1,6 +1,6 @@
 use crate::benchmarks::util::{create_2out_transaction, create_secp_tx, secp_cell};
 use ckb_chain::chain::{ChainController, ChainService};
-use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
+use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_miner::{BlockAssembler, BlockAssemblerConfig, BlockAssemblerController};
@@ -86,9 +86,10 @@ pub fn setup_chain(
         .transactions(transactions)
         .build();
 
-    let mut consensus = Consensus::default()
-        .set_cellbase_maturity(0)
-        .set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .cellbase_maturity(0)
+        .genesis_block(genesis_block)
+        .build();
     consensus.tx_proposal_window = ProposalWindow(1, 10);
 
     let (shared, table) = SharedBuilder::default()

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -1,5 +1,5 @@
 use ckb_chain::chain::{ChainController, ChainService};
-use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
+use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_crypto::secp::Privkey;
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
@@ -69,9 +69,10 @@ pub fn new_always_success_chain(txs_size: usize, chains_num: usize) -> Chains {
         .transactions(transactions)
         .build();
 
-    let mut consensus = Consensus::default()
-        .set_cellbase_maturity(0)
-        .set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .cellbase_maturity(0)
+        .genesis_block(genesis_block)
+        .build();
     consensus.tx_proposal_window = ProposalWindow(1, 10);
 
     let mut chains = Chains::default();
@@ -281,9 +282,10 @@ pub fn new_secp_chain(txs_size: usize, chains_num: usize) -> Chains {
         .transactions(transactions)
         .build();
 
-    let mut consensus = Consensus::default()
-        .set_cellbase_maturity(0)
-        .set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .cellbase_maturity(0)
+        .genesis_block(genesis_block)
+        .build();
     consensus.tx_proposal_window = ProposalWindow(1, 10);
 
     let mut chains = Chains::default();

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -4,7 +4,7 @@ use crate::tests::util::{
     create_transaction, create_transaction_with_out_point, dao_data, start_chain, MockChain,
     MockStore,
 };
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_error::assert_error_eq;
 use ckb_shared::shared::Shared;
@@ -87,7 +87,9 @@ fn test_genesis_transaction_spend() {
         .dao(dao)
         .build();
 
-    let consensus = Consensus::default().set_genesis_block(genesis_block);
+    let consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     let (chain_controller, shared, parent) = start_chain(Some(consensus));
 
     let end = 21;
@@ -359,7 +361,9 @@ fn test_genesis_transaction_fetch() {
         .difficulty(U256::from(1000u64).pack())
         .build();
 
-    let consensus = Consensus::default().set_genesis_block(genesis_block);
+    let consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     let (_chain_controller, shared, _parent) = start_chain(Some(consensus));
 
     let out_point = OutPoint::new(root_hash, 0);
@@ -564,7 +568,9 @@ fn test_epoch_hash_rate_dampening() {
     // last_uncles_count 25
     // last_epoch_length 400
     // last_duration 7980
-    let mut consensus = Consensus::default().set_genesis_block(genesis_block.clone());
+    let mut consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block.clone())
+        .build();
     consensus.genesis_epoch_ext.set_length(400);
     consensus
         .genesis_epoch_ext
@@ -598,7 +604,9 @@ fn test_epoch_hash_rate_dampening() {
         );
     }
 
-    let mut consensus = Consensus::default().set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     consensus.genesis_epoch_ext.set_length(400);
     consensus
         .genesis_epoch_ext
@@ -647,7 +655,9 @@ fn test_orphan_rate_estimation_overflow() {
         .dao(dao)
         .build();
 
-    let mut consensus = Consensus::default().set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     consensus.genesis_epoch_ext.set_length(400);
 
     // last_difficulty 1000
@@ -699,7 +709,9 @@ fn test_next_epoch_ext() {
         .dao(dao)
         .build();
 
-    let mut consensus = Consensus::default().set_genesis_block(genesis_block);
+    let mut consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     consensus.genesis_epoch_ext.set_length(400);
 
     // last_difficulty 1000

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -2,7 +2,7 @@ use crate::tests::util::{
     calculate_reward, create_always_success_out_point, create_always_success_tx, dao_data,
     start_chain, MockStore,
 };
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_merkle_mountain_range::leaf_index_to_mmr_size;
 use ckb_shared::shared::Shared;
@@ -152,9 +152,10 @@ fn finalize_reward() {
         .dao(dao)
         .build();
 
-    let consensus = Consensus::default()
-        .set_cellbase_maturity(0)
-        .set_genesis_block(genesis_block);
+    let consensus = ConsensusBuilder::default()
+        .cellbase_maturity(0)
+        .genesis_block(genesis_block)
+        .build();
 
     let (chain_controller, shared, mut parent) = start_chain(Some(consensus));
 

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -1,5 +1,5 @@
 use crate::chain::{ChainController, ChainService};
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_merkle_mountain_range::{leaf_index_to_mmr_size, util::MemStore};
@@ -52,9 +52,10 @@ pub(crate) fn start_chain(consensus: Option<Consensus>) -> (ChainController, Sha
             .difficulty(U256::one().pack())
             .transaction(tx)
             .build();
-        Consensus::default()
-            .set_cellbase_maturity(0)
-            .set_genesis_block(genesis_block)
+        ConsensusBuilder::default()
+            .cellbase_maturity(0)
+            .genesis_block(genesis_block)
+            .build()
     });
     let (shared, table) = builder.consensus(consensus).build().unwrap();
 

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,44 +2,44 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0x56a2eca5b38fb7ea9dfb772256b22e3a8548a310b1aeaacad35ba2c0da61e788"
-cellbase = "0xcda436b589c46398456a05f2f1b3fc4b3ac42d2e78bc077ee237747cf6a9627e"
+genesis = "0x4901754ac7786835710ede43e55a707dd0f7cfc2009aef11ae1260483ed89a26"
+cellbase = "0x6ad2e9bddef6b99665f2cf69368a5aeb5f4d9f26615cf91b4637254980d32b0f"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0xcda436b589c46398456a05f2f1b3fc4b3ac42d2e78bc077ee237747cf6a9627e"
+tx_hash = "0x6ad2e9bddef6b99665f2cf69368a5aeb5f4d9f26615cf91b4637254980d32b0f"
 index = 1
 data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0xcda436b589c46398456a05f2f1b3fc4b3ac42d2e78bc077ee237747cf6a9627e"
+tx_hash = "0x6ad2e9bddef6b99665f2cf69368a5aeb5f4d9f26615cf91b4637254980d32b0f"
 index = 2
 data_hash = "0xb25d44d0608f856f13c020472e275db96ce2d24021baedb92a2c46883426e209"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0xcda436b589c46398456a05f2f1b3fc4b3ac42d2e78bc077ee237747cf6a9627e"
+tx_hash = "0x6ad2e9bddef6b99665f2cf69368a5aeb5f4d9f26615cf91b4637254980d32b0f"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_dev.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0xcda436b589c46398456a05f2f1b3fc4b3ac42d2e78bc077ee237747cf6a9627e"
+tx_hash = "0x6ad2e9bddef6b99665f2cf69368a5aeb5f4d9f26615cf91b4637254980d32b0f"
 index = 4
 data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xde7ac423660b95df1fd8879a54a98020bcbb30fc9bfcf13da757e99b30effd8d"
+tx_hash = "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091"
 index = 0
 
 [[ckb_dev.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xde7ac423660b95df1fd8879a54a98020bcbb30fc9bfcf13da757e99b30effd8d"
+tx_hash = "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091"
 index = 1
 
 
@@ -88,42 +88,42 @@ index = 1
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0xcd5add6cd99f4836d88869243ed62b16568cba2eb7a224c71d80b8ef30f27eac"
-cellbase = "0x96baf0bc950e8605a19d9c0da0e92107e8db5754edfbf319b6774f9410e62072"
+genesis = "0xb070df4f48f4d32752ae88f93aecc1f666987c461f678e437a0a1acfa8d80c8f"
+cellbase = "0x89bcc0a3d6865a461dbe6a962cf773a7c9a0e5b229f44cb2b7f6fca909f4e210"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x96baf0bc950e8605a19d9c0da0e92107e8db5754edfbf319b6774f9410e62072"
+tx_hash = "0x89bcc0a3d6865a461dbe6a962cf773a7c9a0e5b229f44cb2b7f6fca909f4e210"
 index = 1
 data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x96baf0bc950e8605a19d9c0da0e92107e8db5754edfbf319b6774f9410e62072"
+tx_hash = "0x89bcc0a3d6865a461dbe6a962cf773a7c9a0e5b229f44cb2b7f6fca909f4e210"
 index = 2
 data_hash = "0xb25d44d0608f856f13c020472e275db96ce2d24021baedb92a2c46883426e209"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x96baf0bc950e8605a19d9c0da0e92107e8db5754edfbf319b6774f9410e62072"
+tx_hash = "0x89bcc0a3d6865a461dbe6a962cf773a7c9a0e5b229f44cb2b7f6fca909f4e210"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_staging.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x96baf0bc950e8605a19d9c0da0e92107e8db5754edfbf319b6774f9410e62072"
+tx_hash = "0x89bcc0a3d6865a461dbe6a962cf773a7c9a0e5b229f44cb2b7f6fca909f4e210"
 index = 4
 data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x1ddf81e3a3d0155efa86e0d3a551cd6059966c618507bbc68474e169048ca4aa"
+tx_hash = "0x115323bbc6552b2ed4419a6146744725aa1be6af4d5b0ff86b12b9392cc37918"
 index = 0
 
 [[ckb_staging.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x1ddf81e3a3d0155efa86e0d3a551cd6059966c618507bbc68474e169048ca4aa"
+tx_hash = "0x115323bbc6552b2ed4419a6146744725aa1be6af4d5b0ff86b12b9392cc37918"
 index = 1

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -45,44 +45,44 @@ index = 1
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0x7c69755329171b3f01b4c81000904738d214b22ce85993614822c81e3fec33f7"
-cellbase = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
+genesis = "0x7feb7839f6dc69867e7afd143aec916165b13bc4b2b9d614d075a5e0086861c2"
+cellbase = "0x0aecd072f3a02905f2f903e731a0c1f72283b2c7d2c4b6e5477fc9fee9dce372"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
+tx_hash = "0x0aecd072f3a02905f2f903e731a0c1f72283b2c7d2c4b6e5477fc9fee9dce372"
 index = 1
 data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
+tx_hash = "0x0aecd072f3a02905f2f903e731a0c1f72283b2c7d2c4b6e5477fc9fee9dce372"
 index = 2
 data_hash = "0xb25d44d0608f856f13c020472e275db96ce2d24021baedb92a2c46883426e209"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
+tx_hash = "0x0aecd072f3a02905f2f903e731a0c1f72283b2c7d2c4b6e5477fc9fee9dce372"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
+tx_hash = "0x0aecd072f3a02905f2f903e731a0c1f72283b2c7d2c4b6e5477fc9fee9dce372"
 index = 4
 data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0xf6fde8eefc352944966a1e65c462c107b6e3d5abda1c867bceab1885c927854d"
+tx_hash = "0x5cfc5484ea0efcfdcf9e740eaa53c214102f7288efa115074bf5c409fcac699e"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0xf6fde8eefc352944966a1e65c462c107b6e3d5abda1c867bceab1885c927854d"
+tx_hash = "0x5cfc5484ea0efcfdcf9e740eaa53c214102f7288efa115074bf5c409fcac699e"
 index = 1
 
 

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -45,44 +45,44 @@ index = 1
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0x4193e67e1a8ff5d3a5ade1e1a1deb1c7308d0221588efd743c69c1be2d01bab1"
-cellbase = "0x1fdee4adfa5eaa89efc08f16cb792187bf689a5d69f1f59ddfb2fd02e01dc9bb"
+genesis = "0x7c69755329171b3f01b4c81000904738d214b22ce85993614822c81e3fec33f7"
+cellbase = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_blake160_sighash_all)"
-tx_hash = "0x1fdee4adfa5eaa89efc08f16cb792187bf689a5d69f1f59ddfb2fd02e01dc9bb"
+tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
 index = 1
 data_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
 type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/dao)"
-tx_hash = "0x1fdee4adfa5eaa89efc08f16cb792187bf689a5d69f1f59ddfb2fd02e01dc9bb"
+tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
 index = 2
 data_hash = "0xb25d44d0608f856f13c020472e275db96ce2d24021baedb92a2c46883426e209"
 type_hash = "0xa20df8e80518e9b2eabc1a0efb0ebe1de83f8df9c867edf99d0c5895654fcde1"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_data)"
-tx_hash = "0x1fdee4adfa5eaa89efc08f16cb792187bf689a5d69f1f59ddfb2fd02e01dc9bb"
+tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
 index = 3
 data_hash = "0x9799bee251b975b82c45a02154ce28cec89c5853ecc14d12b7b8cccfc19e0af4"
 
 [[ckb_testnet.system_cells]]
 path = "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"
-tx_hash = "0x1fdee4adfa5eaa89efc08f16cb792187bf689a5d69f1f59ddfb2fd02e01dc9bb"
+tx_hash = "0x0b85cea64a520dba3d129660c77b60cee7af28ee2b76bc18a146b084e2b919f7"
 index = 4
 data_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
 type_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_blake160_sighash_all)"]
-tx_hash = "0x75de1432d33c504d50dd7620253323f86369694475c490151a05de6ac34f8b24"
+tx_hash = "0xf6fde8eefc352944966a1e65c462c107b6e3d5abda1c867bceab1885c927854d"
 index = 0
 
 [[ckb_testnet.dep_groups]]
 included_cells = ["Bundled(specs/cells/secp256k1_data)", "Bundled(specs/cells/secp256k1_ripemd160_sha256_sighash_all)"]
-tx_hash = "0x75de1432d33c504d50dd7620253323f86369694475c490151a05de6ac34f8b24"
+tx_hash = "0xf6fde8eefc352944966a1e65c462c107b6e3d5abda1c867bceab1885c927854d"
 index = 1
 
 

--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -52,9 +52,9 @@ code_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 args = ["0xb2e61ff569acf041b3c2c17724e2379c581eeac3"]
 hash_type = "type"
 
-# issue 5M cell for random generated private key: d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc
+# issue 10M cell for random generated private key: d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc
 [[genesis.issued_cells]]
-capacity = 5_000_000_00000000
+capacity = 10_000_000_00000000
 lock.code_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 lock.args = ["0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7"]
 lock.hash_type = "type"
@@ -64,6 +64,14 @@ lock.hash_type = "type"
 capacity = 5_000_000_00000000
 lock.code_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 lock.args = ["0x470dcdc5e44064909650113a274b3b36aecb6dc7"]
+lock.hash_type = "type"
+
+# Satoshi's gift, a cell send to satoshi's lock,
+# 60% capacity of this cell is occupied.
+[[genesis.issued_cells]]
+capacity = 5_000_000_00000000
+lock.code_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
+lock.args = ["0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18"]
 lock.hash_type = "type"
 
 [params]

--- a/resource/specs/staging.toml
+++ b/resource/specs/staging.toml
@@ -69,6 +69,13 @@ capacity = 50_000_000_00000000
 lock.code_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
 lock.hash_type = "type"
+# Satoshi's gift, a cell send to satoshi's lock,
+# 60% capacity of this cell is occupied.
+[[genesis.issued_cells]]
+capacity = 50_000_000_00000000
+lock.code_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
+lock.args = ["0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18"]
+lock.hash_type = "type"
 
 [params]
 epoch_reward = 1_250_000_00000000

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x11940000000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0x4193e67e1a8ff5d3a5ade1e1a1deb1c7308d0221588efd743c69c1be2d01bab1"
+hash = "0x7c69755329171b3f01b4c81000904738d214b22ce85993614822c81e3fec33f7"
 
 [genesis.genesis_cell]
 message = "rylai-v10"
@@ -71,6 +71,13 @@ capacity = 50_000_000_00000000
 lock.code_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
 lock.args = ["0x57ccb07be6875f61d93636b0ee11b675494627d2"]
 lock.hash_type = "type"
+# Satoshi's gift, a cell send to satoshi's lock,
+# 60% capacity of this cell is occupied.
+[[genesis.issued_cells]]
+capacity = 50_000_000_00000000
+lock.code_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
+lock.args = ["0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18"]
+lock.hash_type = "data"
 
 [pow]
 func = "Eaglesong"

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ difficulty = "0x11940000000"
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = 0
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0x7c69755329171b3f01b4c81000904738d214b22ce85993614822c81e3fec33f7"
+hash = "0x7feb7839f6dc69867e7afd143aec916165b13bc4b2b9d614d075a5e0086861c2"
 
 [genesis.genesis_cell]
 message = "rylai-v10"
@@ -75,9 +75,9 @@ lock.hash_type = "type"
 # 60% capacity of this cell is occupied.
 [[genesis.issued_cells]]
 capacity = 50_000_000_00000000
-lock.code_hash = "0x88fce31aa68db1bb2d5bde7a731b7e6b2429e7aa6fdf60203f397eb8e2147794"
+lock.code_hash = "0x9cc3121726ed40c0ece7b43f7f28af712c7f13101f78699c5668341a52ddf280"
 lock.args = ["0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18"]
-lock.hash_type = "data"
+lock.hash_type = "type"
 
 [pow]
 func = "Eaglesong"

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -4,7 +4,7 @@ use crate::module::{
 };
 use crate::RpcServer;
 use ckb_chain::chain::{ChainController, ChainService};
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_indexer::{DefaultIndexerStore, IndexerConfig, IndexerStore};
@@ -81,10 +81,11 @@ fn always_success_consensus() -> Consensus {
         .dao(dao)
         .transaction(always_success_tx)
         .build();
-    Consensus::default()
-        .set_genesis_block(genesis)
-        .set_epoch_reward(Capacity::shannons(EPOCH_REWARD))
-        .set_cellbase_maturity(CELLBASE_MATURITY)
+    ConsensusBuilder::default()
+        .genesis_block(genesis)
+        .epoch_reward(Capacity::shannons(EPOCH_REWARD))
+        .cellbase_maturity(CELLBASE_MATURITY)
+        .build()
 }
 
 // Construct `Transaction` with an always-success cell

--- a/shared/tx-pool-executor/src/tx_pool_executor.rs
+++ b/shared/tx-pool-executor/src/tx_pool_executor.rs
@@ -181,7 +181,7 @@ impl TxPoolExecutor {
 mod tests {
     use super::*;
     use ckb_chain::chain::ChainService;
-    use ckb_chain_spec::consensus::Consensus;
+    use ckb_chain_spec::consensus::ConsensusBuilder;
     use ckb_error::{assert_error_eq, InternalErrorKind};
     use ckb_notify::NotifyService;
     use ckb_shared::shared::{Shared, SharedBuilder};
@@ -215,9 +215,10 @@ mod tests {
             .difficulty(U256::from(1000u64).pack())
             .transaction(always_success_tx)
             .build();
-        let consensus = Consensus::default()
-            .set_genesis_block(block.clone())
-            .set_cellbase_maturity(0);
+        let consensus = ConsensusBuilder::default()
+            .genesis_block(block.clone())
+            .cellbase_maturity(0)
+            .build();
 
         let (shared, table) = SharedBuilder::default()
             .consensus(consensus)

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -665,14 +665,15 @@ fn u256_low_u64(u: U256) -> u64 {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use ckb_resource::CODE_HASH_SECP256K1_RIPEMD160_SHA256_SIGHASH_ALL;
     use ckb_types::{
         core::{BlockBuilder, ScriptHashType, TransactionBuilder},
         h160,
-        packed::{CellOutput, Script},
+        packed::Script,
         H160,
     };
 
-    // Satoshi's lock in Bitcoin genesis.
+    // Satoshi's pubkey hash in Bitcoin genesis.
     const SATOSHI_H160: H160 = h160!("0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18");
 
     #[test]
@@ -685,12 +686,8 @@ pub mod test {
 
     #[test]
     fn test_satoshi_lock_hash() {
-        let script_code =
-            Resource::bundled("specs/cells/secp256k1_ripemd160_sha256_sighash_all".to_string())
-                .get()
-                .expect("Load secp script data failed");
         let lock = Script::new_builder()
-            .code_hash(CellOutput::calc_data_hash(&script_code))
+            .code_hash(CODE_HASH_SECP256K1_RIPEMD160_SHA256_SIGHASH_ALL.pack())
             .hash_type(ScriptHashType::Data.pack())
             .args(vec![SATOSHI_H160.0.pack()].pack())
             .build();

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -101,6 +101,230 @@ impl ProposalWindow {
     }
 }
 
+pub struct ConsensusBuilder {
+    id: String,
+    genesis_block: BlockView,
+    genesis_hash: Byte32,
+    epoch_reward: Capacity,
+    secondary_epoch_reward: Capacity,
+    max_uncles_num: usize,
+    orphan_rate_target: RationalU256,
+    epoch_duration_target: u64,
+    tx_proposal_window: ProposalWindow,
+    proposer_reward_ratio: Ratio,
+    pow: Pow,
+    cellbase_maturity: BlockNumber,
+    median_time_block_count: usize,
+    max_block_cycles: Cycle,
+    max_block_bytes: u64,
+    block_version: Version,
+    max_block_proposals_limit: u64,
+    genesis_epoch_ext: EpochExt,
+    satoshi_lock_hash: Byte32,
+    satoshi_cell_occupied_ratio: Ratio,
+}
+
+// genesis difficulty should not be zero
+impl Default for ConsensusBuilder {
+    fn default() -> Self {
+        let input = CellInput::new_cellbase_input(0);
+        let witness = Script::default().into_witness();
+        let cellbase = TransactionBuilder::default()
+            .input(input)
+            .witness(witness)
+            .build();
+        let dao = genesis_dao_data_with_satoshi_gift(
+            vec![&cellbase],
+            &SATOSHI_LOCK_HASH,
+            SATOSHI_CELL_OCCUPIED_RATIO,
+        )
+        .unwrap();
+        let genesis_block = BlockBuilder::default()
+            .difficulty(U256::one().pack())
+            .dao(dao)
+            .transaction(cellbase)
+            .build();
+
+        ConsensusBuilder::new(genesis_block, DEFAULT_EPOCH_REWARD)
+    }
+}
+
+impl ConsensusBuilder {
+    pub fn new(genesis_block: BlockView, epoch_reward: Capacity) -> Self {
+        debug_assert!(
+            genesis_block.difficulty() > U256::zero(),
+            "genesis difficulty should greater than zero"
+        );
+
+        debug_assert!(
+            !genesis_block.transactions().is_empty()
+                && !genesis_block.transactions()[0].witnesses().is_empty(),
+            "genesis block must contain the witness for cellbase"
+        );
+
+        let genesis_header = genesis_block.header();
+        let block_reward = Capacity::shannons(epoch_reward.as_u64() / GENESIS_EPOCH_LENGTH);
+        let remainder_reward = Capacity::shannons(epoch_reward.as_u64() % GENESIS_EPOCH_LENGTH);
+
+        let genesis_hash_rate = genesis_block.header().difficulty()
+            * (GENESIS_EPOCH_LENGTH + GENESIS_ORPHAN_COUNT)
+            / EPOCH_DURATION_TARGET;
+
+        let genesis_epoch_ext = EpochExt::new_builder()
+            .number(0)
+            .base_block_reward(block_reward)
+            .remainder_reward(remainder_reward)
+            .previous_epoch_hash_rate(genesis_hash_rate)
+            .last_block_hash_in_previous_epoch(Byte32::zero())
+            .start_number(0)
+            .length(GENESIS_EPOCH_LENGTH)
+            .difficulty(genesis_header.difficulty())
+            .build();
+
+        ConsensusBuilder {
+            genesis_hash: genesis_header.hash(),
+            genesis_block,
+            id: "main".to_owned(),
+            max_uncles_num: MAX_UNCLE_NUM,
+            epoch_reward,
+            orphan_rate_target: ORPHAN_RATE_TARGET,
+            epoch_duration_target: EPOCH_DURATION_TARGET,
+            secondary_epoch_reward: DEFAULT_SECONDARY_EPOCH_REWARD,
+            tx_proposal_window: TX_PROPOSAL_WINDOW,
+            pow: Pow::Dummy,
+            cellbase_maturity: CELLBASE_MATURITY,
+            median_time_block_count: MEDIAN_TIME_BLOCK_COUNT,
+            max_block_cycles: MAX_BLOCK_CYCLES,
+            max_block_bytes: MAX_BLOCK_BYTES,
+            genesis_epoch_ext,
+            block_version: BLOCK_VERSION,
+            proposer_reward_ratio: PROPOSER_REWARD_RATIO,
+            max_block_proposals_limit: MAX_BLOCK_PROPOSALS_LIMIT,
+            satoshi_lock_hash: SATOSHI_LOCK_HASH.pack(),
+            satoshi_cell_occupied_ratio: SATOSHI_CELL_OCCUPIED_RATIO,
+        }
+    }
+
+    pub fn build(self) -> Consensus {
+        let ConsensusBuilder {
+            genesis_hash,
+            genesis_block,
+            id,
+            max_uncles_num,
+            epoch_reward,
+            orphan_rate_target,
+            epoch_duration_target,
+            secondary_epoch_reward,
+            tx_proposal_window,
+            pow,
+            cellbase_maturity,
+            median_time_block_count,
+            max_block_cycles,
+            max_block_bytes,
+            genesis_epoch_ext,
+            block_version,
+            proposer_reward_ratio,
+            max_block_proposals_limit,
+            satoshi_lock_hash,
+            satoshi_cell_occupied_ratio,
+        } = self;
+        Consensus {
+            genesis_hash,
+            genesis_block,
+            id,
+            max_uncles_num,
+            epoch_reward,
+            orphan_rate_target,
+            epoch_duration_target,
+            secondary_epoch_reward,
+            tx_proposal_window,
+            pow,
+            cellbase_maturity,
+            median_time_block_count,
+            max_block_cycles,
+            max_block_bytes,
+            genesis_epoch_ext,
+            block_version,
+            proposer_reward_ratio,
+            max_block_proposals_limit,
+            satoshi_lock_hash,
+            satoshi_cell_occupied_ratio,
+        }
+    }
+
+    pub fn id(mut self, id: String) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn genesis_block(mut self, genesis_block: BlockView) -> Self {
+        debug_assert!(
+            !genesis_block.data().transactions().is_empty()
+                && !genesis_block
+                    .data()
+                    .transactions()
+                    .get(0)
+                    .unwrap()
+                    .witnesses()
+                    .is_empty(),
+            "genesis block must contain the witness for cellbase"
+        );
+        self.genesis_epoch_ext
+            .set_difficulty(genesis_block.difficulty());
+        self.genesis_hash = genesis_block.hash();
+        self.genesis_block = genesis_block;
+        self
+    }
+
+    pub fn genesis_epoch_ext(mut self, genesis_epoch_ext: EpochExt) -> Self {
+        self.genesis_epoch_ext = genesis_epoch_ext;
+        self
+    }
+
+    pub fn epoch_reward(mut self, epoch_reward: Capacity) -> Self {
+        self.epoch_reward = epoch_reward;
+        self
+    }
+
+    #[must_use]
+    pub fn secondary_epoch_reward(mut self, secondary_epoch_reward: Capacity) -> Self {
+        self.secondary_epoch_reward = secondary_epoch_reward;
+        self
+    }
+
+    #[must_use]
+    pub fn max_block_cycles(mut self, max_block_cycles: Cycle) -> Self {
+        self.max_block_cycles = max_block_cycles;
+        self
+    }
+
+    #[must_use]
+    pub fn cellbase_maturity(mut self, cellbase_maturity: BlockNumber) -> Self {
+        self.cellbase_maturity = cellbase_maturity;
+        self
+    }
+
+    pub fn tx_proposal_window(mut self, proposal_window: ProposalWindow) -> Self {
+        self.tx_proposal_window = proposal_window;
+        self
+    }
+
+    pub fn pow(mut self, pow: Pow) -> Self {
+        self.pow = pow;
+        self
+    }
+
+    pub fn satoshi_lock_hash(mut self, lock_hash: Byte32) -> Self {
+        self.satoshi_lock_hash = lock_hash;
+        self
+    }
+
+    pub fn satoshi_cell_occupied_ratio(mut self, ratio: Ratio) -> Self {
+        self.satoshi_cell_occupied_ratio = ratio;
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Consensus {
     pub id: String,
@@ -139,157 +363,12 @@ pub struct Consensus {
 // genesis difficulty should not be zero
 impl Default for Consensus {
     fn default() -> Self {
-        let input = CellInput::new_cellbase_input(0);
-        let witness = Script::default().into_witness();
-        let cellbase = TransactionBuilder::default()
-            .input(input)
-            .witness(witness)
-            .build();
-        let dao = genesis_dao_data_with_satoshi_gift(
-            vec![&cellbase],
-            &SATOSHI_LOCK_HASH,
-            SATOSHI_CELL_OCCUPIED_RATIO,
-        )
-        .unwrap();
-        let genesis_block = BlockBuilder::default()
-            .difficulty(U256::one().pack())
-            .dao(dao)
-            .transaction(cellbase)
-            .build();
-
-        Consensus::new(genesis_block, DEFAULT_EPOCH_REWARD)
+        ConsensusBuilder::default().build()
     }
 }
 
 #[allow(clippy::op_ref)]
 impl Consensus {
-    pub fn new(genesis_block: BlockView, epoch_reward: Capacity) -> Consensus {
-        debug_assert!(
-            genesis_block.difficulty() > U256::zero(),
-            "genesis difficulty should greater than zero"
-        );
-
-        debug_assert!(
-            !genesis_block.transactions().is_empty()
-                && !genesis_block.transactions()[0].witnesses().is_empty(),
-            "genesis block must contain the witness for cellbase"
-        );
-
-        let genesis_header = genesis_block.header();
-        let block_reward = Capacity::shannons(epoch_reward.as_u64() / GENESIS_EPOCH_LENGTH);
-        let remainder_reward = Capacity::shannons(epoch_reward.as_u64() % GENESIS_EPOCH_LENGTH);
-
-        let genesis_hash_rate = genesis_block.header().difficulty()
-            * (GENESIS_EPOCH_LENGTH + GENESIS_ORPHAN_COUNT)
-            / EPOCH_DURATION_TARGET;
-
-        let genesis_epoch_ext = EpochExt::new_builder()
-            .number(0)
-            .base_block_reward(block_reward)
-            .remainder_reward(remainder_reward)
-            .previous_epoch_hash_rate(genesis_hash_rate)
-            .last_block_hash_in_previous_epoch(Byte32::zero())
-            .start_number(0)
-            .length(GENESIS_EPOCH_LENGTH)
-            .difficulty(genesis_header.difficulty())
-            .build();
-
-        Consensus {
-            genesis_hash: genesis_header.hash(),
-            genesis_block,
-            id: "main".to_owned(),
-            max_uncles_num: MAX_UNCLE_NUM,
-            epoch_reward,
-            orphan_rate_target: ORPHAN_RATE_TARGET,
-            epoch_duration_target: EPOCH_DURATION_TARGET,
-            secondary_epoch_reward: DEFAULT_SECONDARY_EPOCH_REWARD,
-            tx_proposal_window: TX_PROPOSAL_WINDOW,
-            pow: Pow::Dummy,
-            cellbase_maturity: CELLBASE_MATURITY,
-            median_time_block_count: MEDIAN_TIME_BLOCK_COUNT,
-            max_block_cycles: MAX_BLOCK_CYCLES,
-            max_block_bytes: MAX_BLOCK_BYTES,
-            genesis_epoch_ext,
-            block_version: BLOCK_VERSION,
-            proposer_reward_ratio: PROPOSER_REWARD_RATIO,
-            max_block_proposals_limit: MAX_BLOCK_PROPOSALS_LIMIT,
-            satoshi_lock_hash: SATOSHI_LOCK_HASH.pack(),
-            satoshi_cell_occupied_ratio: SATOSHI_CELL_OCCUPIED_RATIO,
-        }
-    }
-
-    pub fn set_id(mut self, id: String) -> Self {
-        self.id = id;
-        self
-    }
-
-    pub fn set_genesis_block(mut self, genesis_block: BlockView) -> Self {
-        debug_assert!(
-            !genesis_block.data().transactions().is_empty()
-                && !genesis_block
-                    .data()
-                    .transactions()
-                    .get(0)
-                    .unwrap()
-                    .witnesses()
-                    .is_empty(),
-            "genesis block must contain the witness for cellbase"
-        );
-        self.genesis_epoch_ext
-            .set_difficulty(genesis_block.difficulty());
-        self.genesis_hash = genesis_block.hash();
-        self.genesis_block = genesis_block;
-        self
-    }
-
-    pub fn set_genesis_epoch_ext(mut self, genesis_epoch_ext: EpochExt) -> Self {
-        self.genesis_epoch_ext = genesis_epoch_ext;
-        self
-    }
-
-    pub fn set_epoch_reward(mut self, epoch_reward: Capacity) -> Self {
-        self.epoch_reward = epoch_reward;
-        self
-    }
-
-    #[must_use]
-    pub fn set_secondary_epoch_reward(mut self, secondary_epoch_reward: Capacity) -> Self {
-        self.secondary_epoch_reward = secondary_epoch_reward;
-        self
-    }
-
-    #[must_use]
-    pub fn set_max_block_cycles(mut self, max_block_cycles: Cycle) -> Self {
-        self.max_block_cycles = max_block_cycles;
-        self
-    }
-
-    #[must_use]
-    pub fn set_cellbase_maturity(mut self, cellbase_maturity: BlockNumber) -> Self {
-        self.cellbase_maturity = cellbase_maturity;
-        self
-    }
-
-    pub fn set_tx_proposal_window(mut self, proposal_window: ProposalWindow) -> Self {
-        self.tx_proposal_window = proposal_window;
-        self
-    }
-
-    pub fn set_pow(mut self, pow: Pow) -> Self {
-        self.pow = pow;
-        self
-    }
-
-    pub fn set_satoshi_lock_hash(mut self, lock_hash: Byte32) -> Self {
-        self.satoshi_lock_hash = lock_hash;
-        self
-    }
-
-    pub fn set_satoshi_cell_occupied_ratio(mut self, ratio: Ratio) -> Self {
-        self.satoshi_cell_occupied_ratio = ratio;
-        self
-    }
-
     pub fn genesis_block(&self) -> &BlockView {
         &self.genesis_block
     }
@@ -600,7 +679,7 @@ pub mod test {
     fn test_init_epoch_reward() {
         let cellbase = TransactionBuilder::default().witness(vec![].pack()).build();
         let genesis = BlockBuilder::default().transaction(cellbase).build();
-        let consensus = Consensus::new(genesis, capacity_bytes!(100));
+        let consensus = ConsensusBuilder::new(genesis, capacity_bytes!(100)).build();
         assert_eq!(capacity_bytes!(100), consensus.epoch_reward);
     }
 

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -9,7 +9,9 @@
 //! we must put nested config struct in the tail to make it serializable,
 //! details https://docs.rs/toml/0.5.0/toml/ser/index.html
 
-use crate::consensus::{Consensus, SATOSHI_CELL_OCCUPIED_RATIO, SATOSHI_LOCK_HASH};
+use crate::consensus::{
+    Consensus, ConsensusBuilder, SATOSHI_CELL_OCCUPIED_RATIO, SATOSHI_LOCK_HASH,
+};
 use ckb_crypto::secp::Privkey;
 use ckb_dao_utils::genesis_dao_data_with_satoshi_gift;
 use ckb_hash::{blake2b_256, new_blake2b};
@@ -208,14 +210,15 @@ impl ChainSpec {
         let genesis_block = self.genesis.build_block()?;
         self.verify_genesis_hash(&genesis_block)?;
 
-        let consensus = Consensus::new(genesis_block, self.params.epoch_reward)
-            .set_id(self.name.clone())
-            .set_cellbase_maturity(self.params.cellbase_maturity)
-            .set_secondary_epoch_reward(self.params.secondary_epoch_reward)
-            .set_max_block_cycles(self.params.max_block_cycles)
-            .set_pow(self.pow.clone())
-            .set_satoshi_lock_hash(self.genesis.satoshi_gift.satoshi_lock_hash.pack())
-            .set_satoshi_cell_occupied_ratio(self.genesis.satoshi_gift.satoshi_cell_occupied_ratio);
+        let consensus = ConsensusBuilder::new(genesis_block, self.params.epoch_reward)
+            .id(self.name.clone())
+            .cellbase_maturity(self.params.cellbase_maturity)
+            .secondary_epoch_reward(self.params.secondary_epoch_reward)
+            .max_block_cycles(self.params.max_block_cycles)
+            .pow(self.pow.clone())
+            .satoshi_lock_hash(self.genesis.satoshi_gift.satoshi_lock_hash.pack())
+            .satoshi_cell_occupied_ratio(self.genesis.satoshi_gift.satoshi_cell_occupied_ratio)
+            .build();
 
         Ok(consensus)
     }

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -1,6 +1,6 @@
 use crate::{Relayer, SyncSharedState};
 use ckb_chain::chain::ChainService;
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_network::{
     Behaviour, CKBProtocolContext, Error, Peer, PeerIndex, ProtocolId, TargetSession,
 };
@@ -109,9 +109,10 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
             .difficulty(U256::from(1000u64).pack())
             .transaction(always_success_tx)
             .build();
-        let consensus = Consensus::default()
-            .set_genesis_block(genesis)
-            .set_cellbase_maturity(0);
+        let consensus = ConsensusBuilder::default()
+            .genesis_block(genesis)
+            .cellbase_maturity(0)
+            .build();
         SharedBuilder::default()
             .consensus(consensus)
             .build()

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -499,7 +499,7 @@ mod tests {
     use super::*;
     use crate::{types::HeaderView, types::PeerState, SyncSharedState, MAX_TIP_AGE};
     use ckb_chain::chain::ChainService;
-    use ckb_chain_spec::consensus::Consensus;
+    use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
     use ckb_dao::DaoCalculator;
     use ckb_merkle_mountain_range::leaf_index_to_mmr_size;
     use ckb_network::{
@@ -1160,7 +1160,7 @@ mod tests {
             .difficulty(U256::from(2u64).pack())
             .transaction(consensus.genesis_block().transactions()[0].clone())
             .build();
-        let consensus = consensus.set_genesis_block(block);
+        let consensus = ConsensusBuilder::default().genesis_block(block).build();
 
         let (chain_controller, shared, _notify) = start_chain(Some(consensus), None);
 

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -5,7 +5,7 @@ use crate::synchronizer::{
 use crate::tests::TestNode;
 use crate::{NetworkProtocol, SyncSharedState, Synchronizer};
 use ckb_chain::chain::ChainService;
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_merkle_mountain_range::leaf_index_to_mmr_size;
@@ -102,9 +102,10 @@ fn setup_node(thread_name: &str, height: u64) -> (TestNode, Shared) {
         .transaction(always_success_tx)
         .build();
 
-    let consensus = Consensus::default()
-        .set_genesis_block(block.clone())
-        .set_cellbase_maturity(0);
+    let consensus = ConsensusBuilder::default()
+        .genesis_block(block.clone())
+        .cellbase_maturity(0)
+        .build();
     let (shared, table) = SharedBuilder::default()
         .consensus(consensus)
         .build()

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -21,6 +21,7 @@ ckb-rpc= { path = "../rpc" }
 ckb-network-alert = { path = "../util/network-alert" }
 ckb-crypto = { path = "../util/crypto" }
 ckb-dao = { path = "../util/dao" }
+ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-resource = { path = "../resource" }
 ckb-merkle-mountain-range = { path = "../util/merkle-mountain-range" }
@@ -33,6 +34,7 @@ env_logger = "0.6"
 crossbeam-channel = "0.3"
 faketime = "0.2"
 failure = "0.1.5"
+lazy_static = "1.4"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -34,7 +34,8 @@ env_logger = "0.6"
 crossbeam-channel = "0.3"
 faketime = "0.2"
 failure = "0.1.5"
-lazy_static = "1.4"
+ripemd160 = "0.8.0"
+sha2 = "0.8.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -217,7 +217,7 @@ fn all_specs() -> SpecMap {
         Box::new(WithdrawDAOWithOverflowCapacity),
         Box::new(WithdrawDAOWithInvalidWitness),
         Box::new(DAOWithSatoshiCellOccupied),
-        Box::new(SpendSatoshiCell),
+        Box::new(SpendSatoshiCell::new()),
         Box::new(MiningBasic),
         Box::new(BootstrapCellbase),
         Box::new(TemplateSizeLimit),

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -216,6 +216,8 @@ fn all_specs() -> SpecMap {
         Box::new(WithdrawDAOWithNotMaturitySince),
         Box::new(WithdrawDAOWithOverflowCapacity),
         Box::new(WithdrawDAOWithInvalidWitness),
+        Box::new(DAOWithSatoshiCellOccupied),
+        Box::new(SpendSatoshiCell),
         Box::new(MiningBasic),
         Box::new(BootstrapCellbase),
         Box::new(TemplateSizeLimit),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -29,6 +29,7 @@ pub struct Node {
     always_success_code_hash: Byte32,
     guard: Option<ProcessGuard>,
     consensus: Option<Consensus>,
+    spec: Option<ChainSpec>,
 }
 
 struct ProcessGuard(pub Child);
@@ -58,6 +59,7 @@ impl Node {
             dep_group_tx_hash: Default::default(),
             always_success_code_hash: Default::default(),
             consensus: None,
+            spec: None,
         }
     }
 
@@ -67,6 +69,10 @@ impl Node {
 
     pub fn consensus(&self) -> &Consensus {
         self.consensus.as_ref().expect("uninitialized consensus")
+    }
+
+    pub fn spec(&self) -> &ChainSpec {
+        self.spec.as_ref().expect("uninitialized spec")
     }
 
     pub fn p2p_port(&self) -> u16 {
@@ -384,6 +390,7 @@ impl Node {
         );
 
         self.consensus = Some(consensus);
+        self.spec = Some(spec.clone());
 
         // write to dir
         fs::write(

--- a/test/src/specs/dao/dao_tx.rs
+++ b/test/src/specs/dao/dao_tx.rs
@@ -1,19 +1,12 @@
-use crate::utils::{assert_send_transaction_fail, is_committed};
+use super::*;
+use crate::utils::assert_send_transaction_fail;
 use crate::{Net, Node, Spec};
-use ckb_resource::CODE_HASH_DAO;
-use ckb_test_chain_utils::always_success_cell;
 use ckb_types::{
     bytes::Bytes,
-    core::{BlockNumber, Capacity, ScriptHashType, TransactionBuilder, TransactionView},
-    packed::{self, Byte32, CellDep, CellInput, CellOutput, OutPoint, Script},
+    core::Capacity,
+    packed::{self, CellInput, OutPoint},
     prelude::*,
 };
-
-const SYSTEM_CELL_ALWAYS_SUCCESS_INDEX: u32 = 1;
-const SYSTEM_CELL_DAO_INDEX: u32 = 3;
-const WITHDRAW_WINDOW_LEFT: u64 = 10;
-// The second witness
-const WITHDRAW_HEADER_INDEX: u64 = 1;
 
 pub struct DepositDAO;
 
@@ -240,154 +233,4 @@ impl Spec for WithdrawDAOWithInvalidWitness {
             assert_send_transaction_fail(node0, &transaction, "Script(ValidationFailure(1))");
         }
     }
-}
-
-// Send the given transaction and ensure it being committed
-fn ensure_committed(node: &Node, transaction: &TransactionView) -> (OutPoint, Byte32) {
-    // Ensure the transaction's cellbase-maturity and since-maturity
-    node.generate_blocks(20);
-
-    let tx_hash = node
-        .rpc_client()
-        .send_transaction(transaction.data().into());
-
-    // Ensure the sent transaction is beyond the proposal-window
-    node.generate_blocks(20);
-
-    let tx_status = node
-        .rpc_client()
-        .get_transaction(tx_hash.clone())
-        .expect("get sent transaction");
-    assert!(
-        is_committed(&tx_status),
-        "ensure_committed failed {}",
-        tx_hash
-    );
-
-    let block_hash = tx_status.tx_status.block_hash.unwrap();
-    (OutPoint::new(tx_hash, 0), block_hash.pack())
-}
-
-fn tip_cellbase_input(node: &Node) -> (CellInput, Byte32, Capacity) {
-    let tip_block = node.get_tip_block();
-    let cellbase = tip_block.transactions()[0].clone();
-    let block_hash = tip_block.hash();
-    let tx_hash = cellbase.hash();
-    let previous_out_point = OutPoint::new(tx_hash, 0);
-    let capacity = cellbase.outputs_capacity().unwrap();
-    (CellInput::new(previous_out_point, 0), block_hash, capacity)
-}
-
-// deps = [always-success-cell, dao-cell]
-fn deposit_dao_deps(node: &Node) -> (Vec<CellDep>, Vec<Byte32>) {
-    let genesis_block = node.get_block_by_number(0);
-    let genesis_tx = &genesis_block.transactions()[0];
-
-    // Reference to AlwaysSuccess lock_script, to unlock the cellbase
-    let always_dep = CellDep::new_builder()
-        .out_point(OutPoint::new(
-            genesis_tx.hash(),
-            SYSTEM_CELL_ALWAYS_SUCCESS_INDEX,
-        ))
-        .build();
-    // Reference to DAO type_script
-    let dao_dep = CellDep::new_builder()
-        .out_point(OutPoint::new(genesis_tx.hash(), SYSTEM_CELL_DAO_INDEX))
-        .build();
-
-    (vec![always_dep, dao_dep], vec![genesis_block.hash()])
-}
-
-// cell deps = [always-success-cell, dao-cell]
-// header deps = [genesis-header-hash, withdraw-header-hash]
-fn withdraw_dao_deps(node: &Node, withdraw_header_hash: Byte32) -> (Vec<CellDep>, Vec<Byte32>) {
-    let (cell_deps, mut header_deps) = deposit_dao_deps(node);
-    header_deps.push(withdraw_header_hash);
-    (cell_deps, header_deps)
-}
-
-fn deposit_dao_script() -> Script {
-    Script::new_builder()
-        .code_hash(CODE_HASH_DAO.pack())
-        .hash_type(ScriptHashType::Data.pack())
-        .build()
-}
-
-// Deposit `capacity` into DAO. The target output's type script == dao-script
-fn deposit_dao_output(capacity: Capacity) -> (CellOutput, Bytes) {
-    let always_success_script = always_success_cell().2.clone();
-    let data = Bytes::from(vec![1; 10]);
-    let cell_output = CellOutput::new_builder()
-        .capacity(capacity.pack())
-        .lock(always_success_script)
-        .type_(Some(deposit_dao_script()).pack())
-        .build();
-    (cell_output, data)
-}
-
-// Withdraw `capacity` from DAO. the target output's type script is NONE
-fn withdraw_dao_output(capacity: Capacity) -> (CellOutput, Bytes) {
-    let always_success_script = always_success_cell().2.clone();
-    let data = Bytes::from(vec![1; 10]);
-    let cell_output = CellOutput::new_builder()
-        .capacity(capacity.pack())
-        .lock(always_success_script)
-        .build();
-    (cell_output, data)
-}
-
-fn absolute_minimal_since(node: &Node) -> BlockNumber {
-    node.get_tip_block_number() + WITHDRAW_WINDOW_LEFT
-}
-
-// Construct a deposit dao transaction, which consumes the tip-cellbase as the input,
-// generates the output with always-success-script as lock script, dao-script as type script
-fn deposit_dao_transaction(node: &Node) -> TransactionView {
-    let (input, block_hash, input_capacity) = tip_cellbase_input(node);
-    let (output, output_data) = deposit_dao_output(input_capacity);
-    let (cell_deps, mut header_deps) = deposit_dao_deps(node);
-    header_deps.push(block_hash);
-    TransactionBuilder::default()
-        .cell_deps(cell_deps)
-        .header_deps(header_deps.into_iter())
-        .input(input)
-        .output(output)
-        .output_data(output_data.pack())
-        .build()
-}
-
-// Construct a withdraw dao transaction, which consumes the tip-cellbase and a given deposited cell
-// as the inputs, generates the output with always-success-script as lock script, none type script
-fn withdraw_dao_transaction(
-    node: &Node,
-    out_point: OutPoint,
-    block_hash: Byte32,
-) -> TransactionView {
-    let withdraw_header_hash = node.get_tip_block().hash();
-    let deposited_input = {
-        let minimal_since = absolute_minimal_since(node);
-        CellInput::new(out_point.clone(), minimal_since)
-    };
-    let (output, output_data) = {
-        let input_capacities = node
-            .rpc_client()
-            .calculate_dao_maximum_withdraw(out_point.into(), withdraw_header_hash.clone());
-        withdraw_dao_output(input_capacities)
-    };
-    let (cell_deps, mut header_deps) = withdraw_dao_deps(node, withdraw_header_hash);
-    header_deps.push(block_hash);
-    // Put the withdraw_header_index into the 2nd witness
-    let withdraw_dao_witness = vec![
-        Bytes::new().pack(),
-        Bytes::from(WITHDRAW_HEADER_INDEX.to_le_bytes().to_vec()).pack(),
-    ]
-    .pack();
-    TransactionBuilder::default()
-        .cell_deps(cell_deps)
-        .header_deps(header_deps.into_iter())
-        .input(deposited_input)
-        .output(output)
-        .output_data(output_data.pack())
-        .witness(withdraw_dao_witness)
-        .build()
 }

--- a/test/src/specs/dao/mod.rs
+++ b/test/src/specs/dao/mod.rs
@@ -1,0 +1,176 @@
+mod dao_tx;
+mod satoshi_dao_occupied;
+
+pub use dao_tx::{
+    DepositDAO, WithdrawAndDepositDAOWithinSameTx, WithdrawDAO, WithdrawDAOWithInvalidWitness,
+    WithdrawDAOWithNotMaturitySince, WithdrawDAOWithOverflowCapacity,
+};
+
+pub use satoshi_dao_occupied::{DAOWithSatoshiCellOccupied, SpendSatoshiCell};
+
+use crate::utils::is_committed;
+use crate::Node;
+use ckb_resource::CODE_HASH_DAO;
+use ckb_test_chain_utils::always_success_cell;
+use ckb_types::{
+    bytes::Bytes,
+    core::{BlockNumber, Capacity, ScriptHashType, TransactionBuilder, TransactionView},
+    packed::{Byte32, CellDep, CellInput, CellOutput, OutPoint, Script},
+    prelude::*,
+};
+
+const SYSTEM_CELL_ALWAYS_SUCCESS_INDEX: u32 = 1;
+const SYSTEM_CELL_DAO_INDEX: u32 = 3;
+const WITHDRAW_WINDOW_LEFT: u64 = 10;
+// The second witness
+const WITHDRAW_HEADER_INDEX: u64 = 1;
+
+// Send the given transaction and ensure it being committed
+fn ensure_committed(node: &Node, transaction: &TransactionView) -> (OutPoint, Byte32) {
+    // Ensure the transaction's cellbase-maturity and since-maturity
+    node.generate_blocks(20);
+
+    let tx_hash = node
+        .rpc_client()
+        .send_transaction(transaction.data().into());
+
+    // Ensure the sent transaction is beyond the proposal-window
+    node.generate_blocks(20);
+
+    let tx_status = node
+        .rpc_client()
+        .get_transaction(tx_hash.clone())
+        .expect("get sent transaction");
+    assert!(
+        is_committed(&tx_status),
+        "ensure_committed failed {}",
+        tx_hash
+    );
+
+    let block_hash = tx_status.tx_status.block_hash.unwrap();
+    (OutPoint::new(tx_hash, 0), block_hash.pack())
+}
+
+fn tip_cellbase_input(node: &Node) -> (CellInput, Byte32, Capacity) {
+    let tip_block = node.get_tip_block();
+    let cellbase = tip_block.transactions()[0].clone();
+    let block_hash = tip_block.hash();
+    let tx_hash = cellbase.hash();
+    let previous_out_point = OutPoint::new(tx_hash, 0);
+    let capacity = cellbase.outputs_capacity().unwrap();
+    (CellInput::new(previous_out_point, 0), block_hash, capacity)
+}
+
+// deps = [always-success-cell, dao-cell]
+fn deposit_dao_deps(node: &Node) -> (Vec<CellDep>, Vec<Byte32>) {
+    let genesis_block = node.get_block_by_number(0);
+    let genesis_tx = &genesis_block.transactions()[0];
+
+    // Reference to AlwaysSuccess lock_script, to unlock the cellbase
+    let always_dep = CellDep::new_builder()
+        .out_point(OutPoint::new(
+            genesis_tx.hash(),
+            SYSTEM_CELL_ALWAYS_SUCCESS_INDEX,
+        ))
+        .build();
+    // Reference to DAO type_script
+    let dao_dep = CellDep::new_builder()
+        .out_point(OutPoint::new(genesis_tx.hash(), SYSTEM_CELL_DAO_INDEX))
+        .build();
+
+    (vec![always_dep, dao_dep], vec![genesis_block.hash()])
+}
+
+// cell deps = [always-success-cell, dao-cell]
+// header deps = [genesis-header-hash, withdraw-header-hash]
+fn withdraw_dao_deps(node: &Node, withdraw_header_hash: Byte32) -> (Vec<CellDep>, Vec<Byte32>) {
+    let (cell_deps, mut header_deps) = deposit_dao_deps(node);
+    header_deps.push(withdraw_header_hash);
+    (cell_deps, header_deps)
+}
+
+fn deposit_dao_script() -> Script {
+    Script::new_builder()
+        .code_hash(CODE_HASH_DAO.pack())
+        .hash_type(ScriptHashType::Data.pack())
+        .build()
+}
+
+// Deposit `capacity` into DAO. The target output's type script == dao-script
+fn deposit_dao_output(capacity: Capacity) -> (CellOutput, Bytes) {
+    let always_success_script = always_success_cell().2.clone();
+    let data = Bytes::from(vec![1; 10]);
+    let cell_output = CellOutput::new_builder()
+        .capacity(capacity.pack())
+        .lock(always_success_script)
+        .type_(Some(deposit_dao_script()).pack())
+        .build();
+    (cell_output, data)
+}
+
+// Withdraw `capacity` from DAO. the target output's type script is NONE
+fn withdraw_dao_output(capacity: Capacity) -> (CellOutput, Bytes) {
+    let always_success_script = always_success_cell().2.clone();
+    let data = Bytes::from(vec![1; 10]);
+    let cell_output = CellOutput::new_builder()
+        .capacity(capacity.pack())
+        .lock(always_success_script)
+        .build();
+    (cell_output, data)
+}
+
+fn absolute_minimal_since(node: &Node) -> BlockNumber {
+    node.get_tip_block_number() + WITHDRAW_WINDOW_LEFT
+}
+
+// Construct a deposit dao transaction, which consumes the tip-cellbase as the input,
+// generates the output with always-success-script as lock script, dao-script as type script
+fn deposit_dao_transaction(node: &Node) -> TransactionView {
+    let (input, block_hash, input_capacity) = tip_cellbase_input(node);
+    let (output, output_data) = deposit_dao_output(input_capacity);
+    let (cell_deps, mut header_deps) = deposit_dao_deps(node);
+    header_deps.push(block_hash);
+    TransactionBuilder::default()
+        .cell_deps(cell_deps)
+        .header_deps(header_deps.into_iter())
+        .input(input)
+        .output(output)
+        .output_data(output_data.pack())
+        .build()
+}
+
+// Construct a withdraw dao transaction, which consumes the tip-cellbase and a given deposited cell
+// as the inputs, generates the output with always-success-script as lock script, none type script
+fn withdraw_dao_transaction(
+    node: &Node,
+    out_point: OutPoint,
+    block_hash: Byte32,
+) -> TransactionView {
+    let withdraw_header_hash = node.get_tip_block().hash();
+    let deposited_input = {
+        let minimal_since = absolute_minimal_since(node);
+        CellInput::new(out_point.clone(), minimal_since)
+    };
+    let (output, output_data) = {
+        let input_capacities = node
+            .rpc_client()
+            .calculate_dao_maximum_withdraw(out_point.into(), withdraw_header_hash.clone());
+        withdraw_dao_output(input_capacities)
+    };
+    let (cell_deps, mut header_deps) = withdraw_dao_deps(node, withdraw_header_hash);
+    header_deps.push(block_hash);
+    // Put the withdraw_header_index into the 2nd witness
+    let withdraw_dao_witness = vec![
+        Bytes::new().pack(),
+        Bytes::from(WITHDRAW_HEADER_INDEX.to_le_bytes().to_vec()).pack(),
+    ]
+    .pack();
+    TransactionBuilder::default()
+        .cell_deps(cell_deps)
+        .header_deps(header_deps.into_iter())
+        .input(deposited_input)
+        .output(output)
+        .output_data(output_data.pack())
+        .witness(withdraw_dao_witness)
+        .build()
+}

--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -2,22 +2,20 @@ use super::*;
 use crate::utils::is_committed;
 use crate::{Net, Spec};
 use ckb_chain_spec::{ChainSpec, IssuedCell};
+use ckb_crypto::secp::{Generator, Privkey, Pubkey};
 use ckb_dao_utils::extract_dao_data;
+use ckb_hash::new_blake2b;
 use ckb_test_chain_utils::always_success_cell;
 use ckb_types::{
     bytes::Bytes,
-    core::{Capacity, Ratio},
+    constants::TYPE_ID_CODE_HASH,
+    core::{Capacity, DepType, Ratio},
     prelude::*,
-    H256,
+    H160, H256,
 };
-use lazy_static::lazy_static;
 
 const SATOSHI_CELL_CAPACITY: Capacity = Capacity::shannons(10_000_000_000_000_000);
 const CELLBASE_USED_BYTES: usize = 41;
-const SATOSHI_CELL_OCCUPIED_RATIO: Ratio = Ratio(6, 10);
-lazy_static! {
-    static ref SATOSHI_LOCK_HASH: H256 = { always_success_cell().2.calc_script_hash().unpack() };
-}
 
 pub struct DAOWithSatoshiCellOccupied;
 
@@ -51,13 +49,39 @@ impl Spec for DAOWithSatoshiCellOccupied {
 
     fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
         Box::new(|spec_config| {
-            let satoshi_cell = issue_satoshi_cell();
+            let satoshi_cell = issue_satoshi_cell(H160([0u8; 20]));
             spec_config.genesis.issued_cells.push(satoshi_cell);
         })
     }
 }
 
-pub struct SpendSatoshiCell;
+pub struct SpendSatoshiCell {
+    privkey: Privkey,
+    pubkey: Pubkey,
+    satoshi_pubkey_hash: H160,
+    satoshi_cell_occupied_ratio: Ratio,
+}
+
+impl Default for SpendSatoshiCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SpendSatoshiCell {
+    pub fn new() -> Self {
+        let (privkey, pubkey) = Generator::random_keypair();
+        let satoshi_pubkey_hash = pubkey_hash160(&pubkey.serialize());
+        let satoshi_cell_occupied_ratio = Ratio(6, 10);
+
+        SpendSatoshiCell {
+            privkey,
+            pubkey,
+            satoshi_pubkey_hash,
+            satoshi_cell_occupied_ratio,
+        }
+    }
+}
 
 impl Spec for SpendSatoshiCell {
     crate::name!("spend_satoshi_cell");
@@ -79,11 +103,10 @@ impl Spec for SpendSatoshiCell {
             OutPoint::new(cellbase.hash(), (cellbase.outputs().len() - 1) as u32),
             0,
         );
-        let always_dep = CellDep::new_builder()
-            .out_point(OutPoint::new(
-                cellbase.hash(),
-                SYSTEM_CELL_ALWAYS_SUCCESS_INDEX,
-            ))
+        let secp_out_point = OutPoint::new(node0.dep_group_tx_hash().clone(), 1);
+        let cell_dep = CellDep::new_builder()
+            .out_point(secp_out_point)
+            .dep_type(DepType::DepGroup.pack())
             .build();
         let output = CellOutput::new_builder()
             .capacity(satoshi_cell_occupied.pack())
@@ -91,11 +114,22 @@ impl Spec for SpendSatoshiCell {
             .build();
 
         let transaction = TransactionBuilder::default()
-            .cell_deps(vec![always_dep])
+            .cell_deps(vec![cell_dep])
             .input(satoshi_input)
             .output(output)
             .output_data(Bytes::new().pack())
             .build();
+        let tx_hash = transaction.hash();
+        let sig = self
+            .privkey
+            .sign_recoverable(&tx_hash.unpack())
+            .expect("sign");
+        let witness = vec![
+            Bytes::from(sig.serialize()).pack(),
+            Bytes::from(self.pubkey.serialize()).pack(),
+        ]
+        .pack();
+        let transaction = transaction.as_advanced_builder().witness(witness).build();
 
         node0.generate_blocks(1);
         let tx_hash = node0
@@ -125,19 +159,66 @@ impl Spec for SpendSatoshiCell {
     }
 
     fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
-        Box::new(|spec_config| {
-            spec_config.genesis.issued_cells.push(issue_satoshi_cell());
-            spec_config.genesis.satoshi_gift.satoshi_lock_hash = SATOSHI_LOCK_HASH.clone();
+        let satoshi_pubkey_hash = self.satoshi_pubkey_hash.clone();
+        let satoshi_cell_occupied_ratio = self.satoshi_cell_occupied_ratio;
+        Box::new(move |spec_config| {
+            spec_config
+                .genesis
+                .issued_cells
+                .push(issue_satoshi_cell(satoshi_pubkey_hash.clone()));
+            spec_config.genesis.satoshi_gift.satoshi_pubkey_hash = satoshi_pubkey_hash.clone();
             spec_config.genesis.satoshi_gift.satoshi_cell_occupied_ratio =
-                SATOSHI_CELL_OCCUPIED_RATIO;
+                satoshi_cell_occupied_ratio;
         })
     }
 }
 
-fn issue_satoshi_cell() -> IssuedCell {
-    let lock = always_success_cell().2.clone();
+fn issue_satoshi_cell(satoshi_pubkey_hash: H160) -> IssuedCell {
+    let lock = Script::new_builder()
+        .args(vec![Bytes::from(&satoshi_pubkey_hash.0[..]).pack()].pack())
+        .code_hash(type_lock_script_code_hash().pack())
+        .hash_type(ScriptHashType::Type.pack())
+        .build();
     IssuedCell {
         capacity: SATOSHI_CELL_CAPACITY,
         lock: lock.into(),
     }
+}
+
+fn type_lock_script_code_hash() -> H256 {
+    let input = CellInput::new_cellbase_input(0);
+    // 0 => genesis cell, which contains a message and can never be spent.
+    // 1 => always success cell
+    // ....
+    // 5 => secp256k1_ripemd160_sha256_sighash_all cell
+    // define in integration.toml spec file
+    let output_index: u64 = 5;
+    let mut blake2b = new_blake2b();
+    blake2b.update(input.as_slice());
+    blake2b.update(&output_index.to_le_bytes());
+    let mut ret = [0; 32];
+    blake2b.finalize(&mut ret);
+    let script_arg = Bytes::from(&ret[..]).pack();
+    Script::new_builder()
+        .code_hash(TYPE_ID_CODE_HASH.pack())
+        .hash_type(ScriptHashType::Type.pack())
+        .args(vec![script_arg].pack())
+        .build()
+        .calc_script_hash()
+        .unpack()
+}
+
+fn pubkey_hash160(data: &[u8]) -> H160 {
+    fn ripemd160(data: &[u8]) -> H160 {
+        use ripemd160::{Digest, Ripemd160};
+        let digest = Ripemd160::digest(data);
+        H160(digest.into())
+    }
+
+    fn sha256(data: &[u8]) -> H256 {
+        use sha2::{Digest, Sha256};
+        let digest: [u8; 32] = Sha256::digest(data).into();
+        H256(digest)
+    }
+    ripemd160(sha256(data).as_bytes())
 }

--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::utils::is_committed;
+use crate::{Net, Spec};
+use ckb_chain_spec::{ChainSpec, IssuedCell};
+use ckb_dao_utils::extract_dao_data;
+use ckb_test_chain_utils::always_success_cell;
+use ckb_types::{
+    bytes::Bytes,
+    core::{Capacity, Ratio},
+    prelude::*,
+    H256,
+};
+use lazy_static::lazy_static;
+
+const SATOSHI_CELL_CAPACITY: Capacity = Capacity::shannons(10_000_000_000_000_000);
+const CELLBASE_USED_BYTES: usize = 41;
+const SATOSHI_CELL_OCCUPIED_RATIO: Ratio = Ratio(6, 10);
+lazy_static! {
+    static ref SATOSHI_LOCK_HASH: H256 = { always_success_cell().2.calc_script_hash().unpack() };
+}
+
+pub struct DAOWithSatoshiCellOccupied;
+
+impl Spec for DAOWithSatoshiCellOccupied {
+    crate::name!("dao_with_satoshi_cell_occupied");
+
+    fn run(&self, net: Net) {
+        let node0 = &net.nodes[0];
+        // try deposit then withdraw dao
+        node0.generate_blocks(2);
+        let deposited = {
+            let transaction = deposit_dao_transaction(node0);
+            ensure_committed(node0, &transaction)
+        };
+        let transaction = withdraw_dao_transaction(node0, deposited.0.clone(), deposited.1.clone());
+        node0.generate_blocks(20);
+        let tx_hash = node0
+            .rpc_client()
+            .send_transaction(transaction.data().into());
+        node0.generate_blocks(3);
+        let tx_status = node0
+            .rpc_client()
+            .get_transaction(tx_hash.clone())
+            .expect("get sent transaction");
+        assert!(
+            is_committed(&tx_status),
+            "ensure_committed failed {:#x}",
+            tx_hash
+        );
+    }
+
+    fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
+        Box::new(|spec_config| {
+            let satoshi_cell = issue_satoshi_cell();
+            spec_config.genesis.issued_cells.push(satoshi_cell);
+        })
+    }
+}
+
+pub struct SpendSatoshiCell;
+
+impl Spec for SpendSatoshiCell {
+    crate::name!("spend_satoshi_cell");
+
+    fn run(&self, net: Net) {
+        let node0 = &net.nodes[0];
+        let satoshi_cell_occupied = SATOSHI_CELL_CAPACITY
+            .safe_mul_ratio(node0.consensus().satoshi_cell_occupied_ratio)
+            .unwrap();
+        // check genesis blocks dao
+        let genesis = node0.get_block_by_number(0);
+        let (_ar, _c, u) = extract_dao_data(genesis.header().dao()).expect("extract dao");
+        // u - used capacity should includes virtual occupied
+        assert!(u > satoshi_cell_occupied);
+
+        // Build tx to spent virtual occupied capacity
+        let cellbase = &genesis.transactions()[0];
+        let satoshi_input = CellInput::new(
+            OutPoint::new(cellbase.hash(), (cellbase.outputs().len() - 1) as u32),
+            0,
+        );
+        let always_dep = CellDep::new_builder()
+            .out_point(OutPoint::new(
+                cellbase.hash(),
+                SYSTEM_CELL_ALWAYS_SUCCESS_INDEX,
+            ))
+            .build();
+        let output = CellOutput::new_builder()
+            .capacity(satoshi_cell_occupied.pack())
+            .lock(always_success_cell().2.clone())
+            .build();
+
+        let transaction = TransactionBuilder::default()
+            .cell_deps(vec![always_dep])
+            .input(satoshi_input)
+            .output(output)
+            .output_data(Bytes::new().pack())
+            .build();
+
+        node0.generate_blocks(1);
+        let tx_hash = node0
+            .rpc_client()
+            .send_transaction(transaction.data().into());
+        node0.generate_blocks(3);
+        // cellbase occupied capacity minus satoshi cell
+        let cellbase_used_capacity =
+            Capacity::bytes(CELLBASE_USED_BYTES * node0.spec().genesis.system_cells.len()).unwrap();
+        let tx_status = node0
+            .rpc_client()
+            .get_transaction(tx_hash.clone())
+            .expect("get sent transaction");
+        assert!(
+            is_committed(&tx_status),
+            "ensure_committed failed {:#x}",
+            tx_hash
+        );
+        let tip = node0.get_tip_block();
+        // check tip dao, expect u correct
+        let (_ar, _c, new_u) = extract_dao_data(tip.header().dao()).expect("extract dao");
+        assert_eq!(
+            Ok(new_u),
+            u.safe_sub(satoshi_cell_occupied)
+                .and_then(|c| c.safe_add(cellbase_used_capacity))
+        );
+    }
+
+    fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
+        Box::new(|spec_config| {
+            spec_config.genesis.issued_cells.push(issue_satoshi_cell());
+            spec_config.genesis.satoshi_gift.satoshi_lock_hash = SATOSHI_LOCK_HASH.clone();
+            spec_config.genesis.satoshi_gift.satoshi_cell_occupied_ratio =
+                SATOSHI_CELL_OCCUPIED_RATIO;
+        })
+    }
+}
+
+fn issue_satoshi_cell() -> IssuedCell {
+    let lock = always_success_cell().2.clone();
+    IssuedCell {
+        capacity: SATOSHI_CELL_CAPACITY,
+        lock: lock.into(),
+    }
+}

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -1,4 +1,5 @@
 mod alert;
+mod dao;
 mod indexer;
 mod mining;
 mod p2p;
@@ -7,6 +8,7 @@ mod sync;
 mod tx_pool;
 
 pub use alert::*;
+pub use dao::*;
 pub use indexer::*;
 pub use mining::*;
 pub use p2p::*;

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -1,5 +1,4 @@
 mod cellbase_maturity;
-mod dao;
 mod depend_tx_in_same_block;
 mod different_txs_with_same_input;
 mod limit;
@@ -10,10 +9,6 @@ mod send_secp_tx;
 mod valid_since;
 
 pub use cellbase_maturity::CellbaseMaturity;
-pub use dao::{
-    DepositDAO, WithdrawAndDepositDAOWithinSameTx, WithdrawDAO, WithdrawDAOWithInvalidWitness,
-    WithdrawDAOWithNotMaturitySince, WithdrawDAOWithOverflowCapacity,
-};
 pub use depend_tx_in_same_block::DepentTxInSameBlock;
 pub use different_txs_with_same_input::DifferentTxsWithSameInput;
 pub use limit::{CyclesLimit, SizeLimit};

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -7,8 +7,7 @@ use ckb_store::{data_loader_wrapper::DataLoaderWrapper, ChainStore};
 use ckb_types::{
     core::{
         cell::{CellMeta, ResolvedTransaction},
-        ckb_occupied_capacity::Result as CapacityResult,
-        BlockNumber, Capacity, EpochExt, HeaderView,
+        BlockNumber, Capacity, CapacityResult, EpochExt, HeaderView,
     },
     packed::{Byte32, CellOutput, OutPoint},
     prelude::*,

--- a/util/dao/utils/src/lib.rs
+++ b/util/dao/utils/src/lib.rs
@@ -6,9 +6,10 @@ mod error;
 use byteorder::{ByteOrder, LittleEndian};
 use ckb_error::Error;
 use ckb_types::{
-    core::{Capacity, TransactionView},
+    core::{Capacity, Ratio, TransactionView},
     packed::{Byte32, OutPoint},
     prelude::*,
+    H256,
 };
 use std::collections::HashSet;
 
@@ -22,11 +23,19 @@ pub const DAO_VERSION: u8 = 1;
 pub const DAO_SIZE: usize = 32;
 
 pub fn genesis_dao_data(txs: Vec<&TransactionView>) -> Result<Byte32, Error> {
+    genesis_dao_data_with_satoshi_gift(txs, &H256([0u8; 32]), Ratio(1, 1))
+}
+
+pub fn genesis_dao_data_with_satoshi_gift(
+    txs: Vec<&TransactionView>,
+    satoshi_lock_hash: &H256,
+    satoshi_cell_occupied_ratio: Ratio,
+) -> Result<Byte32, Error> {
     let dead_cells = txs
         .iter()
         .flat_map(|tx| tx.inputs().into_iter().map(|input| input.previous_output()))
         .collect::<HashSet<_>>();
-    let statistics_outputs = |tx: &TransactionView| -> Result<_, Error> {
+    let statistics_outputs = |tx_index, tx: &TransactionView| -> Result<_, Error> {
         let c = tx
             .data()
             .raw()
@@ -43,23 +52,30 @@ pub fn genesis_dao_data(txs: Vec<&TransactionView>) -> Result<Byte32, Error> {
             .enumerate()
             .filter(|(index, _)| !dead_cells.contains(&OutPoint::new(tx.hash(), *index as u32)))
             .try_fold(Capacity::zero(), |capacity, (_, (output, data))| {
-                Capacity::bytes(data.len()).and_then(|data_capacity| {
-                    output
-                        .occupied_capacity(data_capacity)
-                        .and_then(|c| capacity.safe_add(c))
-                })
+                // detect satoshi gift cell
+                if tx_index == 0 && output.lock().calc_script_hash() == satoshi_lock_hash.pack() {
+                    Unpack::<Capacity>::unpack(&output.capacity())
+                        .safe_mul_ratio(satoshi_cell_occupied_ratio)
+                } else {
+                    Capacity::bytes(data.len()).and_then(|data_capacity| {
+                        output
+                            .occupied_capacity(data_capacity)
+                            .and_then(|c| capacity.safe_add(c))
+                    })
+                }
             })?;
         Ok((c, u))
     };
 
-    let result: Result<_, Error> =
-        txs.into_iter()
-            .try_fold((Capacity::zero(), Capacity::zero()), |(c, u), tx| {
-                let (tx_c, tx_u) = statistics_outputs(tx)?;
-                let c = c.safe_add(tx_c)?;
-                let u = u.safe_add(tx_u)?;
-                Ok((c, u))
-            });
+    let result: Result<_, Error> = txs.into_iter().enumerate().try_fold(
+        (Capacity::zero(), Capacity::zero()),
+        |(c, u), (tx_index, tx)| {
+            let (tx_c, tx_u) = statistics_outputs(tx_index, tx)?;
+            let c = c.safe_add(tx_c)?;
+            let u = u.safe_add(tx_u)?;
+            Ok((c, u))
+        },
+    );
     let (c, u) = result?;
     Ok(pack_dao_data(DEFAULT_ACCUMULATED_RATE, c, u))
 }

--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -6,7 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 )]
 pub struct Capacity(u64);
 
-#[derive(Clone, PartialEq, Debug, Eq, Copy)]
+#[derive(Clone, PartialEq, Debug, Eq, Copy, Deserialize, Serialize)]
 pub struct Ratio(pub u64, pub u64);
 
 impl Ratio {

--- a/util/reward-calculator/src/lib.rs
+++ b/util/reward-calculator/src/lib.rs
@@ -236,7 +236,7 @@ impl<'a, CS: ChainStore<'a>> RewardCalculator<'a, CS> {
 #[cfg(test)]
 mod tests {
     use super::RewardCalculator;
-    use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
+    use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder, ProposalWindow};
     use ckb_db::RocksDB;
     use ckb_occupied_capacity::AsCapacity;
     use ckb_store::{ChainDB, ChainStore, COLUMNS};
@@ -355,7 +355,9 @@ mod tests {
         let db = RocksDB::open_tmp(COLUMNS);
         let store = ChainDB::new(db);
 
-        let consensus = Consensus::default().set_tx_proposal_window(ProposalWindow(2, 5));
+        let consensus = ConsensusBuilder::default()
+            .tx_proposal_window(ProposalWindow(2, 5))
+            .build();
 
         let tx1 = TransactionBuilder::default().version(100u32.pack()).build();
         let tx2 = TransactionBuilder::default().version(200u32.pack()).build();

--- a/util/test-chain-utils/src/chain.rs
+++ b/util/test-chain-utils/src/chain.rs
@@ -1,4 +1,4 @@
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_types::{
     bytes::Bytes,
@@ -58,9 +58,10 @@ pub fn always_success_consensus() -> Consensus {
         .dao(dao)
         .transaction(always_success_tx)
         .build();
-    Consensus::default()
-        .set_genesis_block(genesis)
-        .set_cellbase_maturity(0)
+    ConsensusBuilder::default()
+        .genesis_block(genesis)
+        .cellbase_maturity(0)
+        .build()
 }
 
 pub fn always_success_cellbase(block_number: BlockNumber, reward: Capacity) -> TransactionView {

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -50,6 +50,10 @@ impl TransactionInfo {
     pub fn is_cellbase(&self) -> bool {
         self.index == 0
     }
+
+    pub fn is_genesis(&self) -> bool {
+        self.block_number == 0
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Default)]

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -19,7 +19,7 @@ pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};
 
-pub use ckb_occupied_capacity::{capacity_bytes, Capacity, Ratio};
+pub use ckb_occupied_capacity::{self, capacity_bytes, Capacity, Ratio};
 pub type PublicKey = ckb_fixed_hash::H512;
 pub type BlockNumber = u64;
 pub type EpochNumber = u64;

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -19,7 +19,7 @@ pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};
 
-pub use ckb_occupied_capacity::{self, capacity_bytes, Capacity, Ratio};
+pub use ckb_occupied_capacity::{capacity_bytes, Capacity, Ratio, Result as CapacityResult};
 pub type PublicKey = ckb_fixed_hash::H512;
 pub type BlockNumber = u64;
 pub type EpochNumber = u64;

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -1,7 +1,7 @@
 use super::super::contextual_block_verifier::{CommitVerifier, VerifyContext};
 use crate::CommitError;
 use ckb_chain::chain::{ChainController, ChainService};
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_error::assert_error_eq;
 use ckb_notify::NotifyService;
 use ckb_shared::shared::{Shared, SharedBuilder};
@@ -119,7 +119,9 @@ fn setup_env() -> (ChainController, Shared, Byte32, Script, OutPoint) {
         .build();
     let tx_hash = tx.data().calc_tx_hash();
     let genesis_block = BlockBuilder::default().transaction(tx).build();
-    let consensus = Consensus::default().set_genesis_block(genesis_block);
+    let consensus = ConsensusBuilder::default()
+        .genesis_block(genesis_block)
+        .build();
     let (chain_controller, shared) = start_chain(Some(consensus));
     (
         chain_controller,


### PR DESCRIPTION
This PR allows a special cell "satoshi's gift" in the genesis block. When the mainnet launching, this cell will issue 1/4 of total genesis capacity, and 60% capacity of the cell will be calculated as occupied, this affects the Nervos DAO contract interests.

Satoshi's gift cell, as the name, the lock script of this cell verifies an `H160(pubkey)` that satoshi used in Bitcoin's genesis, satoshi can use the private key to sign a tx to spent the cell on CKB.

Major changes:
* Add a new option `SatoshiGift` on genesis configuration.
* Nervos dao contract calculate the satoshi's gift cell's occupied.
* issue a satoshi's cell in `testnet.toml`
