### PR TITLE
feat: Include fractions in epoch number representations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "ckb-hash 0.21.0-pre",
  "ckb-merkle-mountain-range 0.21.0-pre",
  "ckb-occupied-capacity 0.21.0-pre",
+ "ckb-rational 0.21.0-pre",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/src/cell.rs
+++ b/chain/src/cell.rs
@@ -30,7 +30,7 @@ pub fn attach_block_cell(
         let meta = if tx.is_cellbase() {
             TransactionMeta::new_cellbase(
                 block.number(),
-                block.epoch(),
+                block.epoch().number(),
                 block.hash(),
                 outputs_len,
                 false,
@@ -38,7 +38,7 @@ pub fn attach_block_cell(
         } else {
             TransactionMeta::new(
                 block.number(),
-                block.epoch(),
+                block.epoch().number(),
                 block.hash(),
                 outputs_len,
                 false,
@@ -76,7 +76,7 @@ pub fn detach_block_cell(
                     let mut meta = if tx.is_cellbase() {
                         TransactionMeta::new_cellbase(
                             header.number(),
-                            header.epoch(),
+                            header.epoch().number(),
                             header.hash(),
                             tx.outputs().len(),
                             true, // init with all dead
@@ -84,7 +84,7 @@ pub fn detach_block_cell(
                     } else {
                         TransactionMeta::new(
                             header.number(),
-                            header.epoch(),
+                            header.epoch().number(),
                             header.hash(),
                             tx.outputs().len(),
                             true, // init with all dead

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -17,8 +17,8 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMeta, CellProvider, CellStatus},
-        BlockBuilder, BlockView, Capacity, EpochExt, HeaderView, TransactionBuilder,
-        TransactionInfo,
+        BlockBuilder, BlockView, Capacity, EpochExt, EpochNumberWithFraction, HeaderView,
+        TransactionBuilder, TransactionInfo,
     },
     packed::{CellInput, CellOutputBuilder, OutPoint, Script},
     U256,
@@ -192,7 +192,12 @@ fn test_transaction_spend_in_same_block() {
             cell_output: tx2_output,
             data_bytes: tx2_output_data.len() as u64,
             out_point: OutPoint::new(tx2_hash.clone(), 0),
-            transaction_info: Some(TransactionInfo::new(parent_number4, 0, parent_hash4, 2)),
+            transaction_info: Some(TransactionInfo::new(
+                parent_number4,
+                EpochNumberWithFraction::from_full_value(0),
+                parent_hash4,
+                2
+            )),
             mem_cell_data: None,
         })
     );

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -94,11 +94,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x1",
-        "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+        "epoch": "0x10369",
+        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+    "result": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
 }
 ```
 
@@ -227,7 +227,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
     ]
 }' \
 | tr -d '\n' \
@@ -244,11 +244,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
-            "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "epoch": "0x10369",
+            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -314,7 +314,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
     ]
 }' \
 | tr -d '\n' \
@@ -330,11 +330,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x1",
-        "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+        "epoch": "0x10369",
+        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -375,11 +375,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x1",
-        "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+        "epoch": "0x10369",
+        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -425,7 +425,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0xe853f0935dbb7cd7a4da8204a2f6229c65397d5b2f9b35de49ac5116c5c39458",
+            "block_hash": "0x5719a5b587880d0bf7db894df71f9c7b55b3445b13ed9897ae5b0b8bd0cd544a",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -438,7 +438,7 @@ http://localhost:8114
             }
         },
         {
-            "block_hash": "0x2d1a3d787972f59aef480eeb90c469f2c3414b757ebca15186bb2f520b9ec269",
+            "block_hash": "0xfee7168e75240606631ae955fe82b2e5a412e5fed9fe034f27385e3ea86e79a2",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -600,7 +600,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_cellbase_output_capacity_details",
     "params": [
-        "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
     ]
 }' \
 | tr -d '\n' \
@@ -655,11 +655,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
-            "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "epoch": "0x10369",
+            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -886,7 +886,7 @@ echo '{
             "index": "0x0",
             "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
         },
-        "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
     ]
 }' \
 | tr -d '\n' \
@@ -975,7 +975,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+        "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
         "block_number": "0x400",
         "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
     }
@@ -1007,7 +1007,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         }
@@ -1493,7 +1493,7 @@ http://localhost:8114
         ],
         "chain": "main",
         "difficulty": "0x7a1200",
-        "epoch": "0x1",
+        "epoch": "0x10369",
         "is_initial_block_download": true,
         "median_time": "0x5cd2b105"
     }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -94,11 +94,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x708000000010369",
-        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+        "epoch": "0x7080018000001",
+        "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+        "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+    "result": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
 }
 ```
 
@@ -227,7 +227,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+        "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
     ]
 }' \
 | tr -d '\n' \
@@ -244,11 +244,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
-            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "epoch": "0x7080018000001",
+            "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+            "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -314,7 +314,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+        "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
     ]
 }' \
 | tr -d '\n' \
@@ -330,11 +330,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x708000000010369",
-        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+        "epoch": "0x7080018000001",
+        "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+        "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -375,11 +375,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x708000000010369",
-        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+        "epoch": "0x7080018000001",
+        "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+        "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -425,7 +425,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0xa8b00d0b9cf7ae84499d5117ab539682804bc37f340bb08d1de478463cefa9d1",
+            "block_hash": "0x018e21fcdd662d2ba3d7789f8c4c82220969a5006c3429ff18c2a042da6f0dc7",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -438,7 +438,7 @@ http://localhost:8114
             }
         },
         {
-            "block_hash": "0x388a885872e6d76fc3557f2b4399175cb7edaa4be335bf4683ce86fe138be01c",
+            "block_hash": "0x6f46ea2e083127afa9e2d4fbbc61f3ed41b0d8da99012704e789a6bb2bf9542a",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -600,7 +600,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_cellbase_output_capacity_details",
     "params": [
-        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+        "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
     ]
 }' \
 | tr -d '\n' \
@@ -655,11 +655,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
-            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "epoch": "0x7080018000001",
+            "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+            "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -886,7 +886,7 @@ echo '{
             "index": "0x0",
             "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
         },
-        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+        "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
     ]
 }' \
 | tr -d '\n' \
@@ -975,7 +975,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+        "block_hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
         "block_number": "0x400",
         "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
     }
@@ -1007,7 +1007,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "block_hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         }
@@ -1493,7 +1493,7 @@ http://localhost:8114
         ],
         "chain": "main",
         "difficulty": "0x7a1200",
-        "epoch": "0x708000000010369",
+        "epoch": "0x7080018000001",
         "is_initial_block_download": true,
         "median_time": "0x5cd2b105"
     }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -94,11 +94,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x10369",
-        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+        "epoch": "0x708000000010369",
+        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+    "result": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
 }
 ```
 
@@ -227,7 +227,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
     ]
 }' \
 | tr -d '\n' \
@@ -244,11 +244,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
-            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "epoch": "0x708000000010369",
+            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -314,7 +314,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
     ]
 }' \
 | tr -d '\n' \
@@ -330,11 +330,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x10369",
-        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+        "epoch": "0x708000000010369",
+        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -375,11 +375,11 @@ http://localhost:8114
         "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
         "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
         "difficulty": "0x7a1200",
-        "epoch": "0x10369",
-        "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+        "epoch": "0x708000000010369",
+        "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+        "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
         "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -425,7 +425,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x5719a5b587880d0bf7db894df71f9c7b55b3445b13ed9897ae5b0b8bd0cd544a",
+            "block_hash": "0xa8b00d0b9cf7ae84499d5117ab539682804bc37f340bb08d1de478463cefa9d1",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -438,7 +438,7 @@ http://localhost:8114
             }
         },
         {
-            "block_hash": "0xfee7168e75240606631ae955fe82b2e5a412e5fed9fe034f27385e3ea86e79a2",
+            "block_hash": "0x388a885872e6d76fc3557f2b4399175cb7edaa4be335bf4683ce86fe138be01c",
             "capacity": "0x1d1a94a200",
             "lock": {
                 "args": [],
@@ -600,7 +600,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_cellbase_output_capacity_details",
     "params": [
-        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
     ]
 }' \
 | tr -d '\n' \
@@ -655,11 +655,11 @@ http://localhost:8114
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
-            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "epoch": "0x708000000010369",
+            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -886,7 +886,7 @@ echo '{
             "index": "0x0",
             "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
         },
-        "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+        "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
     ]
 }' \
 | tr -d '\n' \
@@ -975,7 +975,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+        "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
         "block_number": "0x400",
         "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
     }
@@ -1007,7 +1007,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         }
@@ -1493,7 +1493,7 @@ http://localhost:8114
         ],
         "chain": "main",
         "difficulty": "0x7a1200",
-        "epoch": "0x10369",
+        "epoch": "0x708000000010369",
         "is_initial_block_download": true,
         "median_time": "0x5cd2b105"
     }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -15,11 +15,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
-            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "epoch": "0x7080018000001",
+            "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+            "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -67,7 +67,7 @@
         "params": [
             "0x400"
         ],
-        "result": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+        "result": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -79,18 +79,18 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+            "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
         ],
         "result": {
             "header": {
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x708000000010369",
-                "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+                "epoch": "0x7080018000001",
+                "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+                "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -151,17 +151,17 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+            "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
         ],
         "result": {
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
-            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "epoch": "0x7080018000001",
+            "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+            "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -182,11 +182,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
-            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "epoch": "0x7080018000001",
+            "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+            "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@
         ],
         "result": [
             {
-                "block_hash": "0xa8b00d0b9cf7ae84499d5117ab539682804bc37f340bb08d1de478463cefa9d1",
+                "block_hash": "0x018e21fcdd662d2ba3d7789f8c4c82220969a5006c3429ff18c2a042da6f0dc7",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -220,7 +220,7 @@
                 }
             },
             {
-                "block_hash": "0x388a885872e6d76fc3557f2b4399175cb7edaa4be335bf4683ce86fe138be01c",
+                "block_hash": "0x6f46ea2e083127afa9e2d4fbbc61f3ed41b0d8da99012704e789a6bb2bf9542a",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -399,7 +399,7 @@
             ],
             "chain": "main",
             "difficulty": "0x7a1200",
-            "epoch": "0x708000000010369",
+            "epoch": "0x7080018000001",
             "is_initial_block_download": true,
             "median_time": "0x5cd2b105"
         }
@@ -546,7 +546,7 @@
                 "index": "0x0",
                 "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
             },
-            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+            "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
         ],
         "result": "0x4a8b4e8a4",
         "skip": true,
@@ -693,7 +693,7 @@
         "method": "get_cellbase_output_capacity_details",
         "module": "chain",
         "params": [
-            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
+            "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc"
         ],
         "result": {
             "primary": "0x102b36211d",
@@ -734,11 +734,11 @@
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x708000000010369",
-                "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+                "epoch": "0x7080018000001",
+                "hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
+                "parent_hash": "0xd3dfe8155aac028362c5a890e621cf2c145211406d5b6856ed946837531321be",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -803,7 +803,7 @@
             "0x400"
         ],
         "result": {
-            "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+            "block_hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         },
@@ -823,7 +823,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
+                "block_hash": "0x2d2106fe33aaa4fd59359ccf11cb0e541182646667e0e9678eb1f69cff1e72fc",
                 "block_number": "0x400",
                 "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
             }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -15,11 +15,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
-            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "epoch": "0x708000000010369",
+            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -67,7 +67,7 @@
         "params": [
             "0x400"
         ],
-        "result": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+        "result": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -79,18 +79,18 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
         ],
         "result": {
             "header": {
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x10369",
-                "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+                "epoch": "0x708000000010369",
+                "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+                "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -151,17 +151,17 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
         ],
         "result": {
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
-            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "epoch": "0x708000000010369",
+            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -182,11 +182,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
-            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "epoch": "0x708000000010369",
+            "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+            "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@
         ],
         "result": [
             {
-                "block_hash": "0x5719a5b587880d0bf7db894df71f9c7b55b3445b13ed9897ae5b0b8bd0cd544a",
+                "block_hash": "0xa8b00d0b9cf7ae84499d5117ab539682804bc37f340bb08d1de478463cefa9d1",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -220,7 +220,7 @@
                 }
             },
             {
-                "block_hash": "0xfee7168e75240606631ae955fe82b2e5a412e5fed9fe034f27385e3ea86e79a2",
+                "block_hash": "0x388a885872e6d76fc3557f2b4399175cb7edaa4be335bf4683ce86fe138be01c",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -399,7 +399,7 @@
             ],
             "chain": "main",
             "difficulty": "0x7a1200",
-            "epoch": "0x10369",
+            "epoch": "0x708000000010369",
             "is_initial_block_download": true,
             "median_time": "0x5cd2b105"
         }
@@ -546,7 +546,7 @@
                 "index": "0x0",
                 "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
             },
-            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
         ],
         "result": "0x4a8b4e8a4",
         "skip": true,
@@ -693,7 +693,7 @@
         "method": "get_cellbase_output_capacity_details",
         "module": "chain",
         "params": [
-            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
+            "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d"
         ],
         "result": {
             "primary": "0x102b36211d",
@@ -734,11 +734,11 @@
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x10369",
-                "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+                "epoch": "0x708000000010369",
+                "hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
+                "parent_hash": "0x8c32c72b9a19ab96c3711fd124c33e6250f4be723c55eb243cd0529f1f2291d7",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -803,7 +803,7 @@
             "0x400"
         ],
         "result": {
-            "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+            "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         },
@@ -823,7 +823,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
+                "block_hash": "0x760b1f51a62d472bf21267f23153ff914f354fc35d57ff66059651b63005bd0d",
                 "block_number": "0x400",
                 "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
             }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -15,11 +15,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
-            "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "epoch": "0x10369",
+            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -67,7 +67,7 @@
         "params": [
             "0x400"
         ],
-        "result": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+        "result": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -79,18 +79,18 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
         ],
         "result": {
             "header": {
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x1",
-                "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+                "epoch": "0x10369",
+                "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+                "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -151,17 +151,17 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
         ],
         "result": {
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
-            "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "epoch": "0x10369",
+            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -182,11 +182,11 @@
             "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
             "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
-            "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "epoch": "0x10369",
+            "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+            "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
             "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -207,7 +207,7 @@
         ],
         "result": [
             {
-                "block_hash": "0xe853f0935dbb7cd7a4da8204a2f6229c65397d5b2f9b35de49ac5116c5c39458",
+                "block_hash": "0x5719a5b587880d0bf7db894df71f9c7b55b3445b13ed9897ae5b0b8bd0cd544a",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -220,7 +220,7 @@
                 }
             },
             {
-                "block_hash": "0x2d1a3d787972f59aef480eeb90c469f2c3414b757ebca15186bb2f520b9ec269",
+                "block_hash": "0xfee7168e75240606631ae955fe82b2e5a412e5fed9fe034f27385e3ea86e79a2",
                 "capacity": "0x1d1a94a200",
                 "lock": {
                     "args": [],
@@ -399,7 +399,7 @@
             ],
             "chain": "main",
             "difficulty": "0x7a1200",
-            "epoch": "0x1",
+            "epoch": "0x10369",
             "is_initial_block_download": true,
             "median_time": "0x5cd2b105"
         }
@@ -546,7 +546,7 @@
                 "index": "0x0",
                 "tx_hash": "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141"
             },
-            "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
         ],
         "result": "0x4a8b4e8a4",
         "skip": true,
@@ -693,7 +693,7 @@
         "method": "get_cellbase_output_capacity_details",
         "module": "chain",
         "params": [
-            "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1"
+            "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734"
         ],
         "result": {
             "primary": "0x102b36211d",
@@ -734,11 +734,11 @@
                 "chain_root": "0x9f5ebec9c725c99487ec6d07e8ff0963ac5f8a75fcc15d26df1787353e980e4f",
                 "dao": "0x0100000000000000005827f2ba13b000d77fa3d595aa00000061eb7ada030000",
                 "difficulty": "0x7a1200",
-                "epoch": "0x1",
-                "hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+                "epoch": "0x10369",
+                "hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x30a78d902d7c89ae41feaeb4652c79439e2224a3a32bc0f12059f71d86239d03",
+                "parent_hash": "0x2ac433a26b5ebf2a35f1c3cd001f8514a79e78fe041c04e5c26e0cd2265e5784",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
                 "transactions_root": "0x8ad0468383d0085e26d9c3b9b648623e4194efc53a03b7cd1a79e92700687f1e",
@@ -803,7 +803,7 @@
             "0x400"
         ],
         "result": {
-            "block_hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+            "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
             "block_number": "0x400",
             "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         },
@@ -823,7 +823,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0xd629a10a08fb0f43fcb97e948fc2b6eb70ebd28536490fe3864b0e40d08397d1",
+                "block_hash": "0x8b15dfd60c899c720291abfcffd35e9d4d2b7bdcab6b3313f4fce90ed5f3a734",
                 "block_number": "0x400",
                 "lock_hash": "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
             }

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -141,7 +141,7 @@ fn next_block(shared: &Shared, parent: &HeaderView) -> BlockView {
         .transaction(cellbase)
         .parent_hash(parent.hash().to_owned())
         .number((parent.number() + 1).pack())
-        .epoch(epoch.number().pack())
+        .epoch(epoch.number_with_fraction(parent.number() + 1).pack())
         .timestamp((parent.timestamp() + 1).pack())
         .difficulty(epoch.difficulty().pack())
         .dao(dao)

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -98,7 +98,7 @@ impl ChainDB {
         };
 
         let block_number = genesis.number();
-        let epoch_number = genesis.epoch();
+        let epoch_with_fraction = genesis.epoch();
         let block_hash = genesis.hash();
 
         for tx in genesis.transactions().iter() {
@@ -106,7 +106,7 @@ impl ChainDB {
             let tx_meta = if tx.is_cellbase() {
                 TransactionMeta::new_cellbase(
                     block_number,
-                    epoch_number,
+                    epoch_with_fraction.number(),
                     block_hash.clone(),
                     outputs_len,
                     false,
@@ -114,7 +114,7 @@ impl ChainDB {
             } else {
                 TransactionMeta::new(
                     block_number,
-                    epoch_number,
+                    epoch_with_fraction.number(),
                     block_hash.clone(),
                     outputs_len,
                     false,

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -52,7 +52,7 @@ pub(crate) fn new_header_builder(shared: &Shared, parent: &HeaderView) -> Header
         .parent_hash(parent_hash.to_owned())
         .number((parent.number() + 1).pack())
         .timestamp((parent.timestamp() + 1).pack())
-        .epoch(epoch.number().pack())
+        .epoch(epoch.number_with_fraction(parent.number() + 1).pack())
         .difficulty(epoch.difficulty().pack())
 }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -599,7 +599,7 @@ mod tests {
             .transaction(cellbase)
             .parent_hash(parent_header.hash().to_owned())
             .timestamp(now.pack())
-            .epoch(epoch.number().pack())
+            .epoch(epoch.number_with_fraction(number).pack())
             .number(number.pack())
             .difficulty(epoch.difficulty().pack())
             .nonce(nonce.pack())

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -160,7 +160,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
             .transaction(cellbase)
             .parent_hash(block.header().hash().to_owned())
             .number(number.pack())
-            .epoch(epoch.number().pack())
+            .epoch(epoch.number_with_fraction(number).pack())
             .timestamp(timestamp.pack())
             .difficulty(epoch.difficulty().pack())
             .dao(dao)

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -81,7 +81,7 @@ pub fn inherit_block(shared: &Shared, parent_hash: &Byte32) -> BlockBuilder {
         .parent_hash(parent_hash.to_owned())
         .number((parent.header().number() + 1).pack())
         .timestamp((parent.header().timestamp() + 1).pack())
-        .epoch(epoch.number().pack())
+        .epoch(epoch.number_with_fraction(parent_number + 1).pack())
         .difficulty(epoch.difficulty().pack())
         .dao(dao)
         .chain_root(chain_root)

--- a/test/src/specs/relay/compact_block.rs
+++ b/test/src/specs/relay/compact_block.rs
@@ -419,6 +419,12 @@ impl Spec for CompactBlockRelayParentOfOrphanBlock {
                     .parent_hash(parent.hash())
                     .dao(dao)
                     .chain_root(chain_root)
+                    .epoch(
+                        consensus
+                            .genesis_epoch_ext()
+                            .number_with_fraction(parent.header().number() + 1)
+                            .pack(),
+                    )
                     .build(),
             )
             .build();

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -208,7 +208,7 @@ impl BlockAssembler {
             }
             let parent_hash = uncle.header().parent_hash();
             if &uncle.difficulty() != current_epoch_ext.difficulty()
-                || uncle.epoch() != epoch_number
+                || uncle.epoch().number() != epoch_number
                 || snapshot.get_block_number(&uncle.hash()).is_some()
                 || snapshot.is_uncle(&uncle.hash())
                 || !(uncles.iter().any(|u| u.hash() == parent_hash)

--- a/tx-pool/src/process/block_template.rs
+++ b/tx-pool/src/process/block_template.rs
@@ -288,7 +288,10 @@ impl Future for BlockTemplateBuilder {
                 difficulty: self.current_epoch.difficulty().clone(),
                 current_time: current_time.into(),
                 number: candidate_number.into(),
-                epoch: self.current_epoch.number().into(),
+                epoch: self
+                    .current_epoch
+                    .number_with_fraction(candidate_number)
+                    .into(),
                 parent_hash: tip_hash.unpack(),
                 cycles_limit: cycles_limit.into(),
                 bytes_limit: bytes_limit.into(),

--- a/tx-pool/src/process/submit_txs.rs
+++ b/tx-pool/src/process/submit_txs.rs
@@ -293,7 +293,7 @@ fn verify_rtxs(
                     &tx,
                     snapshot,
                     tip_number + 1,
-                    epoch_number,
+                    epoch_number.clone(),
                     tip_header.hash(),
                     consensus,
                 )
@@ -304,7 +304,7 @@ fn verify_rtxs(
                     &tx,
                     snapshot,
                     tip_number + 1,
-                    epoch_number,
+                    epoch_number.clone(),
                     tip_header.hash(),
                     consensus,
                     snapshot,

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BlockNumber, Byte32, Cycle, DetailedEpochNumber, Header, ProposalShortId, Timestamp,
+    BlockNumber, Byte32, Cycle, EpochNumberWithFraction, Header, ProposalShortId, Timestamp,
     Transaction, Uint64, Version,
 };
 use ckb_types::{packed, prelude::*, H256, U256};
@@ -12,7 +12,7 @@ pub struct BlockTemplate {
     pub difficulty: U256,
     pub current_time: Timestamp,
     pub number: BlockNumber,
-    pub epoch: DetailedEpochNumber,
+    pub epoch: EpochNumberWithFraction,
     pub parent_hash: H256,
     pub cycles_limit: Cycle,
     pub bytes_limit: Uint64,

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BlockNumber, Byte32, Cycle, EpochNumberWithFraction, Header, ProposalShortId, Timestamp,
+    BlockNumber, Byte32, Cycle, DetailedEpochNumber, Header, ProposalShortId, Timestamp,
     Transaction, Uint64, Version,
 };
 use ckb_types::{packed, prelude::*, H256, U256};
@@ -12,7 +12,7 @@ pub struct BlockTemplate {
     pub difficulty: U256,
     pub current_time: Timestamp,
     pub number: BlockNumber,
-    pub epoch: EpochNumberWithFraction,
+    pub epoch: DetailedEpochNumber,
     pub parent_hash: H256,
     pub cycles_limit: Cycle,
     pub bytes_limit: Uint64,

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockNumber, Byte32, Cycle, EpochNumber, EpochNumberWithFraction, Header, ProposalShortId, Timestamp, Transaction,
-    Uint64, Version,
+    BlockNumber, Byte32, Cycle, EpochNumberWithFraction, Header, ProposalShortId, Timestamp,
+    Transaction, Uint64, Version,
 };
 use ckb_types::{packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BlockNumber, Byte32, Cycle, EpochNumber, Header, ProposalShortId, Timestamp, Transaction,
+    BlockNumber, Byte32, Cycle, EpochNumber, EpochNumberWithFraction, Header, ProposalShortId, Timestamp, Transaction,
     Uint64, Version,
 };
 use ckb_types::{packed, prelude::*, H256, U256};
@@ -12,7 +12,7 @@ pub struct BlockTemplate {
     pub difficulty: U256,
     pub current_time: Timestamp,
     pub number: BlockNumber,
-    pub epoch: EpochNumber,
+    pub epoch: EpochNumberWithFraction,
     pub parent_hash: H256,
     pub cycles_limit: Cycle,
     pub bytes_limit: Uint64,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1,7 +1,7 @@
 use crate::bytes::JsonBytes;
 use crate::{
-    BlockNumber, Byte32, Capacity, EpochNumber, EpochNumberWithFraction, ProposalShortId,
-    Timestamp, Uint32, Uint64, Version,
+    BlockNumber, Byte32, Capacity, DetailedEpochNumber, EpochNumber, ProposalShortId, Timestamp,
+    Uint32, Uint64, Version,
 };
 use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};
@@ -413,7 +413,7 @@ pub struct Header {
     pub parent_hash: H256,
     pub timestamp: Timestamp,
     pub number: BlockNumber,
-    pub epoch: EpochNumberWithFraction,
+    pub epoch: DetailedEpochNumber,
     pub transactions_root: H256,
     pub witnesses_root: H256,
     pub proposals_hash: H256,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1,7 +1,7 @@
 use crate::bytes::JsonBytes;
 use crate::{
-    BlockNumber, Byte32, Capacity, DetailedEpochNumber, EpochNumber, ProposalShortId, Timestamp,
-    Uint32, Uint64, Version,
+    BlockNumber, Byte32, Capacity, EpochNumber, EpochNumberWithFraction, ProposalShortId,
+    Timestamp, Uint32, Uint64, Version,
 };
 use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};
@@ -413,7 +413,7 @@ pub struct Header {
     pub parent_hash: H256,
     pub timestamp: Timestamp,
     pub number: BlockNumber,
-    pub epoch: DetailedEpochNumber,
+    pub epoch: EpochNumberWithFraction,
     pub transactions_root: H256,
     pub witnesses_root: H256,
     pub proposals_hash: H256,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1,6 +1,7 @@
 use crate::bytes::JsonBytes;
 use crate::{
-    BlockNumber, Byte32, Capacity, EpochNumber, EpochNumberWithFraction, ProposalShortId, Timestamp, Uint32, Uint64, Version,
+    BlockNumber, Byte32, Capacity, EpochNumber, EpochNumberWithFraction, ProposalShortId,
+    Timestamp, Uint32, Uint64, Version,
 };
 use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1,6 +1,6 @@
 use crate::bytes::JsonBytes;
 use crate::{
-    BlockNumber, Byte32, Capacity, EpochNumber, ProposalShortId, Timestamp, Uint32, Uint64, Version,
+    BlockNumber, Byte32, Capacity, EpochNumber, EpochNumberWithFraction, ProposalShortId, Timestamp, Uint32, Uint64, Version,
 };
 use ckb_types::{core, packed, prelude::*, H256, U256};
 use serde_derive::{Deserialize, Serialize};
@@ -412,7 +412,7 @@ pub struct Header {
     pub parent_hash: H256,
     pub timestamp: Timestamp,
     pub number: BlockNumber,
-    pub epoch: EpochNumber,
+    pub epoch: EpochNumberWithFraction,
     pub transactions_root: H256,
     pub witnesses_root: H256,
     pub proposals_hash: H256,

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -38,6 +38,6 @@ pub use self::uint32::Uint32;
 pub use self::uint64::Uint64;
 pub use jsonrpc_core::types::{error, id, params, request, response, version};
 pub use primitive::{
-    BlockNumber, Capacity, Cycle, EpochNumber, EpochNumberWithFraction, Timestamp, Version,
+    BlockNumber, Capacity, Cycle, DetailedEpochNumber, EpochNumber, Timestamp, Version,
 };
 pub use serde_derive::{Deserialize, Serialize};

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -37,5 +37,7 @@ pub use self::sync::PeerState;
 pub use self::uint32::Uint32;
 pub use self::uint64::Uint64;
 pub use jsonrpc_core::types::{error, id, params, request, response, version};
-pub use primitive::{BlockNumber, Capacity, Cycle, EpochNumber, Timestamp, Version};
+pub use primitive::{
+    BlockNumber, Capacity, Cycle, EpochNumber, EpochNumberWithFraction, Timestamp, Version,
+};
 pub use serde_derive::{Deserialize, Serialize};

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -38,6 +38,6 @@ pub use self::uint32::Uint32;
 pub use self::uint64::Uint64;
 pub use jsonrpc_core::types::{error, id, params, request, response, version};
 pub use primitive::{
-    BlockNumber, Capacity, Cycle, DetailedEpochNumber, EpochNumber, Timestamp, Version,
+    BlockNumber, Capacity, Cycle, EpochNumber, EpochNumberWithFraction, Timestamp, Version,
 };
 pub use serde_derive::{Deserialize, Serialize};

--- a/util/jsonrpc-types/src/primitive.rs
+++ b/util/jsonrpc-types/src/primitive.rs
@@ -2,6 +2,7 @@ use crate::{Uint32, Uint64};
 
 pub type BlockNumber = Uint64;
 pub type EpochNumber = Uint64;
+pub type EpochNumberWithFraction = Uint64;
 pub type Capacity = Uint64;
 pub type Cycle = Uint64;
 pub type Timestamp = Uint64;

--- a/util/jsonrpc-types/src/primitive.rs
+++ b/util/jsonrpc-types/src/primitive.rs
@@ -2,7 +2,7 @@ use crate::{Uint32, Uint64};
 
 pub type BlockNumber = Uint64;
 pub type EpochNumber = Uint64;
-pub type DetailedEpochNumber = Uint64;
+pub type EpochNumberWithFraction = Uint64;
 pub type Capacity = Uint64;
 pub type Cycle = Uint64;
 pub type Timestamp = Uint64;

--- a/util/jsonrpc-types/src/primitive.rs
+++ b/util/jsonrpc-types/src/primitive.rs
@@ -2,7 +2,7 @@ use crate::{Uint32, Uint64};
 
 pub type BlockNumber = Uint64;
 pub type EpochNumber = Uint64;
-pub type EpochNumberWithFraction = Uint64;
+pub type DetailedEpochNumber = Uint64;
 pub type Capacity = Uint64;
 pub type Cycle = Uint64;
 pub type Timestamp = Uint64;

--- a/util/jsonrpc-types/src/uint64.rs
+++ b/util/jsonrpc-types/src/uint64.rs
@@ -25,9 +25,9 @@ impl From<core::Capacity> for Uint64 {
     }
 }
 
-impl From<core::EpochNumberWithFraction> for Uint64 {
-    fn from(value: core::EpochNumberWithFraction) -> Self {
-        Uint64(value.0)
+impl From<core::DetailedEpochNumber> for Uint64 {
+    fn from(value: core::DetailedEpochNumber) -> Self {
+        Uint64(value.full_value())
     }
 }
 

--- a/util/jsonrpc-types/src/uint64.rs
+++ b/util/jsonrpc-types/src/uint64.rs
@@ -25,8 +25,8 @@ impl From<core::Capacity> for Uint64 {
     }
 }
 
-impl From<core::DetailedEpochNumber> for Uint64 {
-    fn from(value: core::DetailedEpochNumber) -> Self {
+impl From<core::EpochNumberWithFraction> for Uint64 {
+    fn from(value: core::EpochNumberWithFraction) -> Self {
         Uint64(value.full_value())
     }
 }

--- a/util/jsonrpc-types/src/uint64.rs
+++ b/util/jsonrpc-types/src/uint64.rs
@@ -25,6 +25,12 @@ impl From<core::Capacity> for Uint64 {
     }
 }
 
+impl From<core::EpochNumberWithFraction> for Uint64 {
+    fn from(value: core::EpochNumberWithFraction) -> Self {
+        Uint64(value.0)
+    }
+}
+
 impl From<Uint64> for core::Capacity {
     fn from(value: Uint64) -> Self {
         core::Capacity::shannons(value.value())

--- a/util/rational/src/lib.rs
+++ b/util/rational/src/lib.rs
@@ -2,10 +2,11 @@
 mod tests;
 
 use numext_fixed_uint::U256;
+use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RationalU256 {
     /// Numerator.
     numer: U256,
@@ -397,5 +398,20 @@ impl Sub<U256> for &RationalU256 {
     #[inline]
     fn sub(self, rhs: U256) -> RationalU256 {
         self.sub(&rhs)
+    }
+}
+
+impl PartialOrd for RationalU256 {
+    fn partial_cmp(&self, other: &RationalU256) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RationalU256 {
+    fn cmp(&self, other: &RationalU256) -> Ordering {
+        let gcd = self.denom.gcd(&other.denom);
+        let lhs = &self.numer * (&other.denom / &gcd);
+        let rhs = &other.numer * (&self.denom / &gcd);
+        lhs.cmp(&rhs)
     }
 }

--- a/util/test-chain-utils/src/median_time.rs
+++ b/util/test-chain-utils/src/median_time.rs
@@ -1,6 +1,6 @@
 use ckb_traits::BlockMedianTimeContext;
 use ckb_types::{
-    core::{BlockNumber, EpochNumber, TransactionInfo},
+    core::{BlockNumber, EpochNumberWithFraction, TransactionInfo},
     packed::Byte32,
     prelude::*,
 };
@@ -44,13 +44,13 @@ impl MockMedianTime {
 
     pub fn get_transaction_info(
         block_number: BlockNumber,
-        epoch_number: EpochNumber,
+        block_epoch: EpochNumberWithFraction,
         index: usize,
     ) -> TransactionInfo {
         let block_hash = Self::get_block_hash(block_number);
         TransactionInfo {
             block_number,
-            block_epoch: epoch_number,
+            block_epoch,
             block_hash,
             index,
         }

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -18,3 +18,4 @@ crossbeam-channel = "0.3"
 bit-vec = "0.5.1"
 failure = "0.1.5"
 ckb-error = { path = "../../error" }
+ckb-rational = { path = "../rational" }

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -129,18 +129,18 @@ impl Unpack<Bytes> for packed::Bytes {
     }
 }
 
-impl Pack<packed::Uint64> for core::DetailedEpochNumber {
+impl Pack<packed::Uint64> for core::EpochNumberWithFraction {
     fn pack(&self) -> packed::Uint64 {
         self.full_value().pack()
     }
 }
 
-impl<'r> Unpack<core::DetailedEpochNumber> for packed::Uint64Reader<'r> {
-    fn unpack(&self) -> core::DetailedEpochNumber {
-        core::DetailedEpochNumber::from_full_value(self.unpack())
+impl<'r> Unpack<core::EpochNumberWithFraction> for packed::Uint64Reader<'r> {
+    fn unpack(&self) -> core::EpochNumberWithFraction {
+        core::EpochNumberWithFraction::from_full_value(self.unpack())
     }
 }
-impl_conversion_for_entity_unpack!(core::DetailedEpochNumber, Uint64);
+impl_conversion_for_entity_unpack!(core::EpochNumberWithFraction, Uint64);
 
 impl_conversion_for_option!(H256, Byte32Opt, Byte32OptReader);
 impl_conversion_for_vector!(Capacity, Uint64Vec, Uint64VecReader);

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -129,18 +129,18 @@ impl Unpack<Bytes> for packed::Bytes {
     }
 }
 
-impl Pack<packed::Uint64> for core::EpochNumberWithFraction {
+impl Pack<packed::Uint64> for core::DetailedEpochNumber {
     fn pack(&self) -> packed::Uint64 {
-        self.0.pack()
+        self.full_value().pack()
     }
 }
 
-impl<'r> Unpack<core::EpochNumberWithFraction> for packed::Uint64Reader<'r> {
-    fn unpack(&self) -> core::EpochNumberWithFraction {
-        core::EpochNumberWithFraction(self.unpack())
+impl<'r> Unpack<core::DetailedEpochNumber> for packed::Uint64Reader<'r> {
+    fn unpack(&self) -> core::DetailedEpochNumber {
+        core::DetailedEpochNumber::from_full_value(self.unpack())
     }
 }
-impl_conversion_for_entity_unpack!(core::EpochNumberWithFraction, Uint64);
+impl_conversion_for_entity_unpack!(core::DetailedEpochNumber, Uint64);
 
 impl_conversion_for_option!(H256, Byte32Opt, Byte32OptReader);
 impl_conversion_for_vector!(Capacity, Uint64Vec, Uint64VecReader);

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -129,6 +129,19 @@ impl Unpack<Bytes> for packed::Bytes {
     }
 }
 
+impl Pack<packed::Uint64> for core::EpochNumberWithFraction {
+    fn pack(&self) -> packed::Uint64 {
+        self.0.pack()
+    }
+}
+
+impl<'r> Unpack<core::EpochNumberWithFraction> for packed::Uint64Reader<'r> {
+    fn unpack(&self) -> core::EpochNumberWithFraction {
+        core::EpochNumberWithFraction(self.unpack())
+    }
+}
+impl_conversion_for_entity_unpack!(core::EpochNumberWithFraction, Uint64);
+
 impl_conversion_for_option!(H256, Byte32Opt, Byte32OptReader);
 impl_conversion_for_vector!(Capacity, Uint64Vec, Uint64VecReader);
 impl_conversion_for_vector!(Bytes, BytesVec, BytesVecReader);

--- a/util/types/src/core/cell.rs
+++ b/util/types/src/core/cell.rs
@@ -258,7 +258,7 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
                         out_point: out_point.clone(),
                         transaction_info: Some(TransactionInfo {
                             block_number: header.number(),
-                            block_epoch: header.epoch(),
+                            block_epoch: header.epoch().number(),
                             block_hash: self.block.hash(),
                             index: *i,
                         }),

--- a/util/types/src/core/cell.rs
+++ b/util/types/src/core/cell.rs
@@ -258,7 +258,7 @@ impl<'a> CellProvider for BlockCellProvider<'a> {
                         out_point: out_point.clone(),
                         transaction_info: Some(TransactionInfo {
                             block_number: header.number(),
-                            block_epoch: header.epoch().number(),
+                            block_epoch: header.epoch(),
                             block_hash: self.block.hash(),
                             index: *i,
                         }),
@@ -485,7 +485,10 @@ impl ResolvedTransaction {
 mod tests {
     use super::*;
     use crate::{
-        core::{capacity_bytes, BlockBuilder, BlockView, Capacity, TransactionBuilder},
+        core::{
+            capacity_bytes, BlockBuilder, BlockView, Capacity, EpochNumberWithFraction,
+            TransactionBuilder,
+        },
         h256,
         packed::{Byte32, CellDep, CellInput},
         H256,
@@ -539,7 +542,7 @@ mod tests {
         CellMeta {
             transaction_info: Some(TransactionInfo {
                 block_number: 1,
-                block_epoch: 1,
+                block_epoch: EpochNumberWithFraction::new(1, 1, 10),
                 block_hash: Byte32::zero(),
                 index: 1,
             }),

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -282,10 +282,10 @@ impl EpochNumberWithFraction {
     }
 
     pub fn number(&self) -> u64 {
-        (self.0 >> 16) & ((1u64 << 40) - 1)
+        (self.0 >> Self::FRACTION_BITS) & Self::NUMBER_MASK
     }
 
     pub fn fraction(&self) -> u64 {
-        u64::from(self.0 as u16)
+        self.0 & Self::FRACTION_MASK
     }
 }

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -14,7 +14,7 @@ mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
-pub use extras::{BlockExt, DetailedEpochNumber, EpochExt, TransactionInfo};
+pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
 pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -14,7 +14,7 @@ mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
-pub use extras::{BlockExt, EpochExt, TransactionInfo};
+pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
 pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -14,7 +14,7 @@ mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
-pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
+pub use extras::{BlockExt, DetailedEpochNumber, EpochExt, TransactionInfo};
 pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -6,7 +6,7 @@ use ckb_occupied_capacity::Result as CapacityResult;
 
 use crate::{
     bytes::Bytes,
-    core::{BlockNumber, Capacity, DetailedEpochNumber, Version},
+    core::{BlockNumber, Capacity, EpochNumberWithFraction, Version},
     packed,
     prelude::*,
     utilities::merkle_root,
@@ -265,7 +265,7 @@ impl HeaderView {
     define_header_unpacked_inner_getter!(difficulty, U256);
     define_header_unpacked_inner_getter!(timestamp, u64);
     define_header_unpacked_inner_getter!(uncles_count, u32);
-    define_header_unpacked_inner_getter!(epoch, DetailedEpochNumber);
+    define_header_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_header_packed_inner_getter!(parent_hash, Byte32);
     define_header_packed_inner_getter!(transactions_root, Byte32);
@@ -317,7 +317,7 @@ impl UncleBlockView {
     define_uncle_unpacked_inner_getter!(difficulty, U256);
     define_uncle_unpacked_inner_getter!(timestamp, u64);
     define_uncle_unpacked_inner_getter!(uncles_count, u32);
-    define_uncle_unpacked_inner_getter!(epoch, DetailedEpochNumber);
+    define_uncle_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_uncle_packed_inner_getter!(parent_hash, Byte32);
     define_uncle_packed_inner_getter!(transactions_root, Byte32);
@@ -430,7 +430,7 @@ impl BlockView {
     define_block_unpacked_inner_getter!(difficulty, U256);
     define_block_unpacked_inner_getter!(timestamp, u64);
     define_block_unpacked_inner_getter!(uncles_count, u32);
-    define_block_unpacked_inner_getter!(epoch, DetailedEpochNumber);
+    define_block_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_block_packed_inner_getter!(parent_hash, Byte32);
     define_block_packed_inner_getter!(transactions_root, Byte32);

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -6,7 +6,7 @@ use ckb_occupied_capacity::Result as CapacityResult;
 
 use crate::{
     bytes::Bytes,
-    core::{BlockNumber, Capacity, EpochNumber, Version},
+    core::{BlockNumber, Capacity, EpochNumberWithFraction, Version},
     packed,
     prelude::*,
     utilities::merkle_root,
@@ -265,7 +265,7 @@ impl HeaderView {
     define_header_unpacked_inner_getter!(difficulty, U256);
     define_header_unpacked_inner_getter!(timestamp, u64);
     define_header_unpacked_inner_getter!(uncles_count, u32);
-    define_header_unpacked_inner_getter!(epoch, EpochNumber);
+    define_header_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_header_packed_inner_getter!(parent_hash, Byte32);
     define_header_packed_inner_getter!(transactions_root, Byte32);
@@ -317,7 +317,7 @@ impl UncleBlockView {
     define_uncle_unpacked_inner_getter!(difficulty, U256);
     define_uncle_unpacked_inner_getter!(timestamp, u64);
     define_uncle_unpacked_inner_getter!(uncles_count, u32);
-    define_uncle_unpacked_inner_getter!(epoch, EpochNumber);
+    define_uncle_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_uncle_packed_inner_getter!(parent_hash, Byte32);
     define_uncle_packed_inner_getter!(transactions_root, Byte32);
@@ -430,7 +430,7 @@ impl BlockView {
     define_block_unpacked_inner_getter!(difficulty, U256);
     define_block_unpacked_inner_getter!(timestamp, u64);
     define_block_unpacked_inner_getter!(uncles_count, u32);
-    define_block_unpacked_inner_getter!(epoch, EpochNumber);
+    define_block_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
 
     define_block_packed_inner_getter!(parent_hash, Byte32);
     define_block_packed_inner_getter!(transactions_root, Byte32);

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -6,7 +6,7 @@ use ckb_occupied_capacity::Result as CapacityResult;
 
 use crate::{
     bytes::Bytes,
-    core::{BlockNumber, Capacity, EpochNumberWithFraction, Version},
+    core::{BlockNumber, Capacity, DetailedEpochNumber, Version},
     packed,
     prelude::*,
     utilities::merkle_root,
@@ -265,7 +265,7 @@ impl HeaderView {
     define_header_unpacked_inner_getter!(difficulty, U256);
     define_header_unpacked_inner_getter!(timestamp, u64);
     define_header_unpacked_inner_getter!(uncles_count, u32);
-    define_header_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
+    define_header_unpacked_inner_getter!(epoch, DetailedEpochNumber);
 
     define_header_packed_inner_getter!(parent_hash, Byte32);
     define_header_packed_inner_getter!(transactions_root, Byte32);
@@ -317,7 +317,7 @@ impl UncleBlockView {
     define_uncle_unpacked_inner_getter!(difficulty, U256);
     define_uncle_unpacked_inner_getter!(timestamp, u64);
     define_uncle_unpacked_inner_getter!(uncles_count, u32);
-    define_uncle_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
+    define_uncle_unpacked_inner_getter!(epoch, DetailedEpochNumber);
 
     define_uncle_packed_inner_getter!(parent_hash, Byte32);
     define_uncle_packed_inner_getter!(transactions_root, Byte32);
@@ -430,7 +430,7 @@ impl BlockView {
     define_block_unpacked_inner_getter!(difficulty, U256);
     define_block_unpacked_inner_getter!(timestamp, u64);
     define_block_unpacked_inner_getter!(uncles_count, u32);
-    define_block_unpacked_inner_getter!(epoch, EpochNumberWithFraction);
+    define_block_unpacked_inner_getter!(epoch, DetailedEpochNumber);
 
     define_block_packed_inner_getter!(parent_hash, Byte32);
     define_block_packed_inner_getter!(transactions_root, Byte32);

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -16,7 +16,7 @@ use ckb_types::{
     core::error::OutPointError,
     core::{
         cell::{HeaderChecker, ResolvedTransaction},
-        BlockNumber, BlockReward, BlockView, Capacity, Cycle, EpochExt, EpochNumberWithFraction,
+        BlockNumber, BlockReward, BlockView, Capacity, Cycle, DetailedEpochNumber, EpochExt,
         HeaderView, TransactionView,
     },
     packed::{Byte32, Script},
@@ -311,7 +311,7 @@ impl<'a, 'b, 'c, CS: ChainStore<'a>> DaoHeaderVerifier<'a, 'b, 'c, CS> {
 struct BlockTxsVerifier<'a, CS> {
     context: &'a VerifyContext<'a, CS>,
     block_number: BlockNumber,
-    epoch_number_with_fraction: EpochNumberWithFraction,
+    detailed_epoch_number: DetailedEpochNumber,
     parent_hash: Byte32,
     resolved: &'a [ResolvedTransaction],
 }
@@ -321,14 +321,14 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         block_number: BlockNumber,
-        epoch_number_with_fraction: EpochNumberWithFraction,
+        detailed_epoch_number: DetailedEpochNumber,
         parent_hash: Byte32,
         resolved: &'a [ResolvedTransaction],
     ) -> Self {
         BlockTxsVerifier {
             context,
             block_number,
-            epoch_number_with_fraction,
+            detailed_epoch_number,
             parent_hash,
             resolved,
         }
@@ -375,7 +375,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.epoch_number_with_fraction.clone(),
+                        self.detailed_epoch_number.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                     )
@@ -393,7 +393,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.epoch_number_with_fraction.clone(),
+                        self.detailed_epoch_number.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                         self.context.store,

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -16,7 +16,7 @@ use ckb_types::{
     core::error::OutPointError,
     core::{
         cell::{HeaderChecker, ResolvedTransaction},
-        BlockNumber, BlockReward, BlockView, Capacity, Cycle, DetailedEpochNumber, EpochExt,
+        BlockNumber, BlockReward, BlockView, Capacity, Cycle, EpochExt, EpochNumberWithFraction,
         HeaderView, TransactionView,
     },
     packed::{Byte32, Script},
@@ -311,7 +311,7 @@ impl<'a, 'b, 'c, CS: ChainStore<'a>> DaoHeaderVerifier<'a, 'b, 'c, CS> {
 struct BlockTxsVerifier<'a, CS> {
     context: &'a VerifyContext<'a, CS>,
     block_number: BlockNumber,
-    detailed_epoch_number: DetailedEpochNumber,
+    epoch_number_with_fraction: EpochNumberWithFraction,
     parent_hash: Byte32,
     resolved: &'a [ResolvedTransaction],
 }
@@ -321,14 +321,14 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         block_number: BlockNumber,
-        detailed_epoch_number: DetailedEpochNumber,
+        epoch_number_with_fraction: EpochNumberWithFraction,
         parent_hash: Byte32,
         resolved: &'a [ResolvedTransaction],
     ) -> Self {
         BlockTxsVerifier {
             context,
             block_number,
-            detailed_epoch_number,
+            epoch_number_with_fraction,
             parent_hash,
             resolved,
         }
@@ -375,7 +375,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.detailed_epoch_number.clone(),
+                        self.epoch_number_with_fraction.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                     )
@@ -393,7 +393,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.detailed_epoch_number.clone(),
+                        self.epoch_number_with_fraction.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                         self.context.store,

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -16,8 +16,8 @@ use ckb_types::{
     core::error::OutPointError,
     core::{
         cell::{HeaderChecker, ResolvedTransaction},
-        BlockNumber, BlockReward, BlockView, Capacity, Cycle, EpochExt, EpochNumber, HeaderView,
-        TransactionView,
+        BlockNumber, BlockReward, BlockView, Capacity, Cycle, EpochExt, EpochNumberWithFraction,
+        HeaderView, TransactionView,
     },
     packed::{Byte32, Script},
 };
@@ -311,7 +311,7 @@ impl<'a, 'b, 'c, CS: ChainStore<'a>> DaoHeaderVerifier<'a, 'b, 'c, CS> {
 struct BlockTxsVerifier<'a, CS> {
     context: &'a VerifyContext<'a, CS>,
     block_number: BlockNumber,
-    epoch_number: EpochNumber,
+    epoch_number_with_fraction: EpochNumberWithFraction,
     parent_hash: Byte32,
     resolved: &'a [ResolvedTransaction],
 }
@@ -321,14 +321,14 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         block_number: BlockNumber,
-        epoch_number: EpochNumber,
+        epoch_number_with_fraction: EpochNumberWithFraction,
         parent_hash: Byte32,
         resolved: &'a [ResolvedTransaction],
     ) -> Self {
         BlockTxsVerifier {
             context,
             block_number,
-            epoch_number,
+            epoch_number_with_fraction,
             parent_hash,
             resolved,
         }
@@ -375,7 +375,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.epoch_number,
+                        self.epoch_number_with_fraction.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                     )
@@ -393,7 +393,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         &tx,
                         self.context,
                         self.block_number,
-                        self.epoch_number,
+                        self.epoch_number_with_fraction.clone(),
                         self.parent_hash.clone(),
                         self.context.consensus,
                         self.context.store,

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -148,8 +148,8 @@ impl<T: HeaderResolver> EpochVerifier<T> {
         let epoch_with_fraction = epoch.number_with_fraction(block_number);
         if actual_epoch_with_fraction != epoch_with_fraction {
             Err(EpochError::NumberMismatch {
-                expected: epoch_with_fraction.0,
-                actual: actual_epoch_with_fraction.0,
+                expected: epoch_with_fraction.full_value(),
+                actual: actual_epoch_with_fraction.full_value(),
             })?;
         }
         let actual_difficulty = target.header().difficulty();

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -142,11 +142,14 @@ pub struct EpochVerifier<T> {
 impl<T: HeaderResolver> EpochVerifier<T> {
     pub fn verify(target: &T) -> Result<(), Error> {
         let epoch = target.epoch().ok_or_else(|| EpochError::AncestorNotFound)?;
-        let actual_epoch_number = target.header().epoch();
-        if actual_epoch_number != epoch.number() {
+        let header = target.header();
+        let actual_epoch_with_fraction = header.epoch();
+        let block_number = header.number();
+        let epoch_with_fraction = epoch.number_with_fraction(block_number);
+        if actual_epoch_with_fraction != epoch_with_fraction {
             Err(EpochError::NumberMismatch {
-                expected: epoch.number(),
-                actual: actual_epoch_number,
+                expected: epoch_with_fraction.0,
+                actual: actual_epoch_with_fraction.0,
             })?;
         }
         let actual_difficulty = target.header().difficulty();

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -147,8 +147,8 @@ fn test_epoch_number() {
     assert_error_eq(
         EpochVerifier::verify(&fake_header_resolver).unwrap_err(),
         EpochError::NumberMismatch {
-            expected: 281_474_976_710_656,
-            actual: 2,
+            expected: 1_099_511_627_776,
+            actual: 1_099_511_627_778,
         },
     )
 }

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -140,7 +140,9 @@ impl HeaderResolver for FakeHeaderResolver {
 #[test]
 fn test_epoch_number() {
     let header = HeaderBuilder::default().epoch(2u64.pack()).build();
-    let fake_header_resolver = FakeHeaderResolver::new(header, EpochExt::default());
+    let mut epoch = EpochExt::default();
+    epoch.set_length(1);
+    let fake_header_resolver = FakeHeaderResolver::new(header, epoch);
 
     assert_error_eq(
         EpochVerifier::verify(&fake_header_resolver).unwrap_err(),
@@ -158,6 +160,7 @@ fn test_epoch_difficulty() {
         .build();
     let mut epoch = EpochExt::default();
     epoch.set_difficulty(U256::from(1u64));
+    epoch.set_length(1);
     let fake_header_resolver = FakeHeaderResolver::new(header, epoch);
 
     assert_error_eq(

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -147,7 +147,7 @@ fn test_epoch_number() {
     assert_error_eq(
         EpochVerifier::verify(&fake_header_resolver).unwrap_err(),
         EpochError::NumberMismatch {
-            expected: 0,
+            expected: 281_474_976_710_656,
             actual: 2,
         },
     )
@@ -155,12 +155,15 @@ fn test_epoch_number() {
 
 #[test]
 fn test_epoch_difficulty() {
-    let header = HeaderBuilder::default()
-        .difficulty(U256::from(2u64).pack())
-        .build();
     let mut epoch = EpochExt::default();
     epoch.set_difficulty(U256::from(1u64));
     epoch.set_length(1);
+
+    let header = HeaderBuilder::default()
+        .epoch(epoch.number_with_fraction(0).pack())
+        .difficulty(U256::from(2u64).pack())
+        .build();
+
     let fake_header_resolver = FakeHeaderResolver::new(header, epoch);
 
     assert_error_eq(

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -13,7 +13,7 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMetaBuilder, ResolvedTransaction},
-        BlockNumber, Capacity, DetailedEpochNumber, EpochNumber, ScriptHashType,
+        BlockNumber, Capacity, EpochNumber, EpochNumberWithFraction, ScriptHashType,
         TransactionBuilder, TransactionInfo, TransactionView, Version,
     },
     h256,
@@ -141,7 +141,11 @@ pub fn test_inputs_cellbase_maturity() {
         resolved_dep_groups: Vec::new(),
         resolved_inputs: vec![
             CellMetaBuilder::from_cell_output(output.clone(), Bytes::new())
-                .transaction_info(MockMedianTime::get_transaction_info(30, 0, 0))
+                .transaction_info(MockMedianTime::get_transaction_info(
+                    30,
+                    EpochNumberWithFraction::new(0, 0, 10),
+                    0,
+                ))
                 .build(),
         ],
     };
@@ -173,7 +177,11 @@ fn test_ignore_genesis_cellbase_maturity() {
         resolved_dep_groups: Vec::new(),
         resolved_inputs: vec![
             CellMetaBuilder::from_cell_output(output.clone(), Bytes::new())
-                .transaction_info(MockMedianTime::get_transaction_info(0, 0, 0))
+                .transaction_info(MockMedianTime::get_transaction_info(
+                    0,
+                    EpochNumberWithFraction::new(0, 0, 10),
+                    0,
+                ))
                 .build(),
         ],
     };
@@ -196,10 +204,18 @@ pub fn test_deps_cellbase_maturity() {
         transaction,
         resolved_cell_deps: vec![
             CellMetaBuilder::from_cell_output(output.clone(), Bytes::new())
-                .transaction_info(MockMedianTime::get_transaction_info(30, 0, 0))
+                .transaction_info(MockMedianTime::get_transaction_info(
+                    30,
+                    EpochNumberWithFraction::new(0, 0, 10),
+                    0,
+                ))
                 .build(),
             CellMetaBuilder::from_cell_output(output.clone(), Bytes::new())
-                .transaction_info(MockMedianTime::get_transaction_info(40, 0, 1))
+                .transaction_info(MockMedianTime::get_transaction_info(
+                    40,
+                    EpochNumberWithFraction::new(0, 0, 10),
+                    1,
+                ))
                 .build(),
         ],
         resolved_inputs: Vec::new(),
@@ -296,7 +312,7 @@ where
         rtx,
         block_median_time_context,
         block_number,
-        DetailedEpochNumber::new(epoch_number, 0, 10),
+        EpochNumberWithFraction::new(epoch_number, 0, 10),
         parent_hash.as_ref().to_owned(),
     )
     .verify()
@@ -362,8 +378,10 @@ fn create_resolve_tx_with_transaction_info(
 fn test_invalid_since_verify() {
     // use remain flags
     let tx = create_tx_with_lock(0x0100_0000_0000_0001);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq(
@@ -373,11 +391,25 @@ fn test_invalid_since_verify() {
 }
 
 #[test]
-fn test_fraction_epoch_since_verify() {
+fn test_invalid_zero_length_since() {
     // use remain flags
-    let tx = create_tx_with_lock(0x2000_0000_0010_0100);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let tx = create_tx_with_lock(0xa000_0000_0000_0000);
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
+
+    let median_time_context = MockMedianTime::new(vec![0; 11]);
+    assert!(verify_since(&rtx, &median_time_context, 5, 1).is_ok(),);
+}
+
+#[test]
+fn test_fraction_epoch_since_verify() {
+    let tx = create_tx_with_lock(0x2000_0a00_0500_0010);
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     let block_number = 1000;
     let parent_hash = Arc::new(MockMedianTime::get_block_hash(block_number - 1));
@@ -386,7 +418,7 @@ fn test_fraction_epoch_since_verify() {
         &rtx,
         &median_time_context,
         block_number,
-        DetailedEpochNumber::new(16, 200, 10),
+        EpochNumberWithFraction::new(16, 1, 10),
         parent_hash.as_ref().to_owned(),
     )
     .verify();
@@ -396,7 +428,7 @@ fn test_fraction_epoch_since_verify() {
         &rtx,
         &median_time_context,
         block_number,
-        DetailedEpochNumber::new(16, 256, 10),
+        EpochNumberWithFraction::new(16, 5, 10),
         parent_hash.as_ref().to_owned(),
     )
     .verify();
@@ -407,8 +439,10 @@ fn test_fraction_epoch_since_verify() {
 pub fn test_absolute_block_number_lock() {
     // absolute lock until block number 0xa
     let tx = create_tx_with_lock(0x0000_0000_0000_000a);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
     let median_time_context = MockMedianTime::new(vec![0; 11]);
 
     assert_error_eq(
@@ -422,9 +456,11 @@ pub fn test_absolute_block_number_lock() {
 #[test]
 pub fn test_absolute_epoch_number_lock() {
     // absolute lock until epoch number 0xa
-    let tx = create_tx_with_lock(0x2000_0000_000a_0000);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let tx = create_tx_with_lock(0x2000_0100_0000_000a);
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq(
@@ -439,8 +475,10 @@ pub fn test_absolute_epoch_number_lock() {
 pub fn test_relative_timestamp_lock() {
     // relative lock timestamp lock
     let tx = create_tx_with_lock(0xc000_0000_0000_0002);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq(
@@ -458,9 +496,11 @@ pub fn test_relative_timestamp_lock() {
 #[test]
 pub fn test_relative_epoch() {
     // next epoch
-    let tx = create_tx_with_lock(0xa000_0000_0001_0000);
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 1, 1));
+    let tx = create_tx_with_lock(0xa000_1000_0000_0002);
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
 
@@ -484,8 +524,10 @@ pub fn test_since_both() {
         ])
         .build();
 
-    let rtx =
-        create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
+    let rtx = create_resolve_tx_with_transaction_info(
+        &tx,
+        MockMedianTime::get_transaction_info(1, EpochNumberWithFraction::new(0, 0, 10), 1),
+    );
     // spent after 1024 seconds and 4 blocks (less than 10 blocks)
     // fake median time: 1124
     let median_time_context =

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -13,8 +13,8 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMetaBuilder, ResolvedTransaction},
-        BlockNumber, Capacity, ScriptHashType, TransactionBuilder, TransactionInfo,
-        TransactionView, Version,
+        BlockNumber, Capacity, EpochNumber, EpochNumberWithFraction, ScriptHashType,
+        TransactionBuilder, TransactionInfo, TransactionView, Version,
     },
     h256,
     packed::{CellDep, CellInput, CellOutput, OutPoint, Script},
@@ -286,7 +286,7 @@ fn verify_since<'a, M>(
     rtx: &'a ResolvedTransaction,
     block_median_time_context: &'a M,
     block_number: BlockNumber,
-    epoch_number: BlockNumber,
+    epoch_number: EpochNumber,
 ) -> Result<(), Error>
 where
     M: BlockMedianTimeContext,
@@ -296,7 +296,7 @@ where
         rtx,
         block_median_time_context,
         block_number,
-        epoch_number,
+        EpochNumberWithFraction::new(epoch_number, 0),
         parent_hash.as_ref().to_owned(),
     )
     .verify()
@@ -391,7 +391,7 @@ pub fn test_absolute_block_number_lock() {
 #[test]
 pub fn test_absolute_epoch_number_lock() {
     // absolute lock until epoch number 0xa
-    let tx = create_tx_with_lock(0x2000_0000_0000_000a);
+    let tx = create_tx_with_lock(0x2000_0000_000a_0000);
     let rtx =
         create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 0, 1));
 
@@ -427,7 +427,7 @@ pub fn test_relative_timestamp_lock() {
 #[test]
 pub fn test_relative_epoch() {
     // next epoch
-    let tx = create_tx_with_lock(0xa000_0000_0000_0001);
+    let tx = create_tx_with_lock(0xa000_0000_0001_0000);
     let rtx =
         create_resolve_tx_with_transaction_info(&tx, MockMedianTime::get_transaction_info(1, 1, 1));
 

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -29,7 +29,7 @@ fn gen_block(parent_header: &HeaderView, nonce: u64, epoch: &EpochExt) -> BlockV
         .proposal(ProposalShortId::from_slice(&[1; 10]).unwrap())
         .parent_hash(parent_header.hash())
         .timestamp(now.pack())
-        .epoch(epoch.number().pack())
+        .epoch(epoch.number_with_fraction(number).pack())
         .number(number.pack())
         .difficulty(epoch.difficulty().pack())
         .nonce(nonce.pack())

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -9,7 +9,7 @@ use ckb_types::{
     constants::TX_VERSION,
     core::{
         cell::{CellMeta, ResolvedTransaction},
-        BlockNumber, Capacity, Cycle, EpochNumberWithFraction, TransactionView,
+        BlockNumber, Capacity, Cycle, DetailedEpochNumber, TransactionView,
     },
     packed::Byte32,
     prelude::*,
@@ -31,7 +31,7 @@ where
         rtx: &'a ResolvedTransaction,
         median_time_context: &'a M,
         block_number: BlockNumber,
-        epoch_number_with_fraction: EpochNumberWithFraction,
+        detailed_epoch_number: DetailedEpochNumber,
         parent_hash: Byte32,
         consensus: &'a Consensus,
     ) -> Self {
@@ -41,7 +41,7 @@ where
                 rtx,
                 median_time_context,
                 block_number,
-                epoch_number_with_fraction,
+                detailed_epoch_number,
                 parent_hash,
             ),
         }
@@ -76,7 +76,7 @@ where
         rtx: &'a ResolvedTransaction,
         median_time_context: &'a M,
         block_number: BlockNumber,
-        epoch_number_with_fraction: EpochNumberWithFraction,
+        detailed_epoch_number: DetailedEpochNumber,
         parent_hash: Byte32,
         consensus: &'a Consensus,
         chain_store: &'a CS,
@@ -94,7 +94,7 @@ where
                 rtx,
                 median_time_context,
                 block_number,
-                epoch_number_with_fraction,
+                detailed_epoch_number,
                 parent_hash,
             ),
         }
@@ -331,7 +331,7 @@ const REMAIN_FLAGS_BITS: u64 = 0x1f00_0000_0000_0000;
 
 enum SinceMetric {
     BlockNumber(u64),
-    EpochNumberWithFraction(u64),
+    DetailedEpochNumber(u64),
     Timestamp(u64),
 }
 
@@ -360,7 +360,9 @@ impl Since {
             //0b0000_0000
             0x0000_0000_0000_0000 => Some(SinceMetric::BlockNumber(value)),
             //0b0010_0000
-            0x2000_0000_0000_0000 => Some(SinceMetric::EpochNumberWithFraction(value)),
+            0x2000_0000_0000_0000 => Some(SinceMetric::DetailedEpochNumber(
+                value & DetailedEpochNumber::NUMBER_WITH_FRACTION_MASK,
+            )),
             //0b0100_0000
             0x4000_0000_0000_0000 => Some(SinceMetric::Timestamp(value * 1000)),
             _ => None,
@@ -373,7 +375,7 @@ pub struct SinceVerifier<'a, M> {
     rtx: &'a ResolvedTransaction,
     block_median_time_context: &'a M,
     block_number: BlockNumber,
-    epoch_number_with_fraction: EpochNumberWithFraction,
+    detailed_epoch_number: DetailedEpochNumber,
     parent_hash: Byte32,
     median_timestamps_cache: RefCell<LruCache<Byte32, u64>>,
 }
@@ -386,7 +388,7 @@ where
         rtx: &'a ResolvedTransaction,
         block_median_time_context: &'a M,
         block_number: BlockNumber,
-        epoch_number_with_fraction: EpochNumberWithFraction,
+        detailed_epoch_number: DetailedEpochNumber,
         parent_hash: Byte32,
     ) -> Self {
         let median_timestamps_cache = RefCell::new(LruCache::new(rtx.resolved_inputs.len()));
@@ -394,7 +396,7 @@ where
             rtx,
             block_median_time_context,
             block_number,
-            epoch_number_with_fraction,
+            detailed_epoch_number,
             parent_hash,
             median_timestamps_cache,
         }
@@ -427,8 +429,8 @@ where
                         Err(TransactionError::Immature)?;
                     }
                 }
-                Some(SinceMetric::EpochNumberWithFraction(epoch_number_with_fraction)) => {
-                    if self.epoch_number_with_fraction.0 < epoch_number_with_fraction {
+                Some(SinceMetric::DetailedEpochNumber(detailed_epoch_number)) => {
+                    if self.detailed_epoch_number.number_with_fraction() < detailed_epoch_number {
                         Err(TransactionError::Immature)?;
                     }
                 }
@@ -458,9 +460,9 @@ where
                         Err(TransactionError::Immature)?;
                     }
                 }
-                Some(SinceMetric::EpochNumberWithFraction(epoch_number_with_fraction)) => {
-                    if self.epoch_number_with_fraction.0
-                        < info.block_epoch + epoch_number_with_fraction
+                Some(SinceMetric::DetailedEpochNumber(detailed_epoch_number)) => {
+                    if self.detailed_epoch_number.number_with_fraction()
+                        < info.block_epoch + detailed_epoch_number
                     {
                         Err(TransactionError::Immature)?;
                     }

--- a/verification/src/uncles_verifier.rs
+++ b/verification/src/uncles_verifier.rs
@@ -88,7 +88,7 @@ where
                 Err(UnclesError::UnmatchedDifficulty)?;
             }
 
-            if self.provider.epoch().number() != uncle.epoch() {
+            if self.provider.epoch().number() != uncle.epoch().number() {
                 Err(UnclesError::InvalidDifficultyEpoch)?;
             }
 


### PR DESCRIPTION
This change introduce fractions in 2 places where epoch numbers might
be used:

* The epoch field in the header
* Cell input's since part when using epoch values

Here we use a rational number format to represent epoch number.
The lower 54 bits of the epoch number field are split into 3
parts(listed in the order from higher bits to lower bits):

* The highest 16 bits represent the epoch length
* The next 16 bits represent the current block index in the epoch
* The lowest 24 bits represent the current epoch number

Different from previous solution, with a rational number format the
precision can be guaranteed.

Assuming we are at block number 11555, epoch 50, and epoch 50 starts
from block 11000, has a length of 1000. The epoch number for this
particular block will then be 9326559282, which is calculated
in the following way:

```
50 | ((11555 - 11000) << 24) | (1000 << 16)
```

This way, we can alleviate the trouble that CKB uses variable epoch
length. The actual contract or dapps can just read this epoch number
with fractions and perform numerical operations as normal.