### PR TITLE
fix: use serialized_size while calculate_txs_size_limit

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -56,7 +56,7 @@ lazy_static! {
             .unwrap();
 
         let block: Block = block_template.into();
-        block.as_slice().len() as u64
+        block.serialized_size_without_uncle_proposals() as u64
     };
 }
 

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -147,10 +147,10 @@ impl BlockAssembler {
                     .pack(),
             )
             .build();
-        let occupied = block.as_slice().len();
+        let serialized_size = block.serialized_size_without_uncle_proposals();
         let bytes_limit = bytes_limit as usize;
         bytes_limit
-            .checked_sub(occupied)
+            .checked_sub(serialized_size)
             .ok_or_else(|| Error::InvalidParams(format!("bytes_limit {}", bytes_limit)).into())
     }
 


### PR DESCRIPTION
Now for the blank block, the `serialized_size` and `as_slice().len()` are the same, but I think we should use `serialized_size`.