### PR TITLE
feat: Change return type of RPC submit block 

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -239,7 +239,7 @@ impl Node {
     pub fn submit_block(&self, block: &Block) -> Byte32 {
         self.rpc_client()
             .submit_block("".to_owned(), block.clone().into())
-            .expect("submit_block result none")
+            .expect("submit_block failed")
     }
 
     pub fn process_block_without_verify(&self, block: &BlockView) -> Byte32 {

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -190,12 +190,11 @@ impl RpcClient {
             .expect("rpc call get_block_template")
     }
 
-    pub fn submit_block(&self, work_id: String, block: Block) -> Option<Byte32> {
+    pub fn submit_block(&self, work_id: String, block: Block) -> JsonRpcResult<Byte32> {
         self.inner
             .lock()
             .submit_block(work_id, block)
             .call()
-            .expect("rpc call submit_block")
             .map(|x| x.pack())
     }
 
@@ -386,7 +385,7 @@ jsonrpc_client!(pub struct Inner {
         proposals_limit: Option<Uint64>,
         max_version: Option<Version>
     ) -> RpcRequest<BlockTemplate>;
-    pub fn submit_block(&mut self, _work_id: String, _data: Block) -> RpcRequest<Option<H256>>;
+    pub fn submit_block(&mut self, _work_id: String, _data: Block) -> RpcRequest<H256>;
     pub fn get_blockchain_info(&mut self) -> RpcRequest<ChainInfo>;
     pub fn get_peers_state(&mut self) -> RpcRequest<Vec<PeerState>>;
     pub fn compute_transaction_hash(&mut self, tx: Transaction) -> RpcRequest<H256>;


### PR DESCRIPTION
feat: Change return type of RPC `submit_block` from `Result<Option<H256>>` to `Result<H256>`
feat: Announce only new block