### PR TITLE
fix: peer store persistent

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -64,7 +64,7 @@ impl NetworkConfig {
 
     pub fn peer_store_path(&self) -> PathBuf {
         let mut path = self.path.clone();
-        path.push("peer_store.db");
+        path.push("peer_store");
         path
     }
 

--- a/network/src/services/dump_peer_store.rs
+++ b/network/src/services/dump_peer_store.rs
@@ -32,6 +32,13 @@ impl DumpPeerStoreService {
     }
 }
 
+impl Drop for DumpPeerStoreService {
+    fn drop(&mut self) {
+        debug!("dump peer store before exit");
+        self.dump_peer_store();
+    }
+}
+
 impl Future for DumpPeerStoreService {
     type Item = ();
     type Error = ();
@@ -44,7 +51,6 @@ impl Future for DumpPeerStoreService {
                 }
                 Ok(Async::Ready(None)) => {
                     warn!("ckb dump peer store service stopped");
-                    self.dump_peer_store();
                     return Ok(Async::Ready(()));
                 }
                 Ok(Async::NotReady) => {

--- a/network/src/tests/peer_store_db.rs
+++ b/network/src/tests/peer_store_db.rs
@@ -10,7 +10,7 @@ use crate::{
 use std::collections::HashSet;
 
 #[test]
-fn test_ban_list() {
+fn test_peer_store_persistent() {
     let now_ms = faketime::unix_time_as_millis();
     let mut peer_store = PeerStore::default();
 

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -126,7 +126,7 @@ fn reset_data() -> App<'static, 'static> {
         .arg(
             Arg::with_name(ARG_NETWORK_PEER_STORE)
                 .long(ARG_NETWORK_PEER_STORE)
-                .help("Delete only `data/network/peer_store.db`"),
+                .help("Delete only `data/network/peer_store`"),
         )
         .arg(
             Arg::with_name(ARG_NETWORK_SECRET_KEY)


### PR DESCRIPTION
This error cause peer store persistent error:
1. peer store will not persistent at exit(will still persistent to file every 1 hour when the node is running).
2. peer store persistent failed if `tmp dir` and `ckb dir` use a different file system.

A node will connect to bootnodes on start if the above error happened, other functions are not affected.

* Fix dump error when tmp files use a different file system [detail](https://stackoverflow.com/questions/24209886/invalid-cross-device-link-error-with-boost-filesystem?answertab=votes#tab-top).
* Fix peer store do not dump data on exit.