### PR TITLE
chore: better name for `serialized_size(..)` methods to avoid ambiguity

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -613,9 +613,9 @@ impl ChainService {
                                     if b.transactions().len() > 1 {
                                         info!(
                                             "[block_verifier] block number: {}, hash: {}, size:{}/{}, cycles: {}/{}",
-                                            b.header().number(),
-                                            b.header().hash(),
-                                            b.serialized_size(),
+                                            b.number(),
+                                            b.hash(),
+                                            b.data().serialized_size_without_uncle_proposals(),
                                             self.shared.consensus().max_block_bytes(),
                                             cycles,
                                             self.shared.consensus().max_block_cycles()

--- a/test/src/specs/mining/size_limit.rs
+++ b/test/src/specs/mining/size_limit.rs
@@ -13,7 +13,7 @@ impl Spec for TemplateSizeLimit {
         info!("Generate 1 block");
         let blank_block = node.new_block(None, None, None);
         node.submit_block(&blank_block.data());
-        let blank_block_size = blank_block.serialized_size();
+        let blank_block_size = blank_block.data().serialized_size_without_uncle_proposals();
 
         info!("Generate 6 txs");
         let mut txs_hash = Vec::new();
@@ -21,7 +21,7 @@ impl Spec for TemplateSizeLimit {
         let cellbase = &block.transactions()[0];
         let capacity = cellbase.outputs().get(0).unwrap().capacity().unpack();
         let tx = node.new_transaction_with_since_capacity(cellbase.hash(), 0, capacity);
-        let tx_size = tx.serialized_size();
+        let tx_size = tx.data().serialized_size_in_block();
         info!(
             "blank_block_size: {}, tx_size: {}",
             blank_block_size, tx_size
@@ -41,7 +41,10 @@ impl Spec for TemplateSizeLimit {
         node.generate_block();
 
         let new_block = node.new_block(None, None, None);
-        assert_eq!(new_block.serialized_size(), blank_block_size + tx_size * 6);
+        assert_eq!(
+            new_block.data().serialized_size_without_uncle_proposals(),
+            blank_block_size + tx_size * 6
+        );
         // 6 txs + 1 cellbase tx
         assert_eq!(new_block.transactions().len(), 7);
 

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -85,7 +85,7 @@ impl Spec for CyclesLimit {
 
         let tx_pool_info = node.rpc_client().tx_pool_info();
         let one_tx_cycles = tx_pool_info.total_tx_cycles.value();
-        let one_tx_size = tx.serialized_size();
+        let one_tx_size = tx.data().serialized_size_in_block();
 
         info!(
             "one_tx_cycles: {}, one_tx_size: {}",

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -306,7 +306,7 @@ impl TxPool {
     }
 
     pub fn add_tx_to_pool(&mut self, tx: TransactionView, cycles: Cycle) -> Result<Cycle, Error> {
-        let tx_size = tx.serialized_size();
+        let tx_size = tx.data().serialized_size_in_block();
         if self.reach_size_limit(tx_size) {
             Err(InternalErrorKind::TransactionPoolFull)?;
         }
@@ -672,10 +672,10 @@ impl TxPool {
         tx: TransactionView,
     ) -> Option<(Byte32, Cycle)> {
         let mut ret = None;
-        let tx_hash = tx.hash().to_owned();
+        let tx_hash = tx.hash();
         let cached_cycles = txs_verify_cache.get(&tx_hash).cloned();
         let tx_short_id = tx.proposal_short_id();
-        let tx_size = tx.serialized_size();
+        let tx_size = tx.data().serialized_size_in_block();
         if snapshot.proposals().contains_proposed(&tx_short_id) {
             if let Ok(cycles) = self.proposed_tx_and_descendants(cached_cycles, tx_size, tx) {
                 if cached_cycles.is_none() {

--- a/tx-pool/src/process/submit_txs.rs
+++ b/tx-pool/src/process/submit_txs.rs
@@ -226,7 +226,7 @@ fn resolve_tx<'a>(
     txs_provider: &'a TransactionsProvider<'a>,
     tx: TransactionView,
 ) -> Result<(ResolvedTransaction, usize, Capacity, TxStatus), Error> {
-    let tx_size = tx.serialized_size();
+    let tx_size = tx.data().serialized_size_in_block();
     if tx_pool.reach_size_limit(tx_size) {
         Err(InternalErrorKind::TransactionPoolFull)?;
     }

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -234,10 +234,6 @@ impl TransactionView {
     pub fn proposal_short_id(&self) -> packed::ProposalShortId {
         packed::ProposalShortId::from_tx_hash(&self.hash())
     }
-
-    pub fn serialized_size(&self) -> usize {
-        self.data().serialized_size()
-    }
 }
 
 macro_rules! define_header_unpacked_inner_getter {
@@ -535,10 +531,6 @@ impl BlockView {
 
     pub fn calc_witnesses_root(&self) -> packed::Byte32 {
         merkle_root(&self.tx_witness_hashes[..])
-    }
-
-    pub fn serialized_size(&self) -> usize {
-        self.data().serialized_size()
     }
 }
 

--- a/verification/src/block_verifier.rs
+++ b/verification/src/block_verifier.rs
@@ -258,7 +258,7 @@ impl BlockBytesVerifier {
         if block.is_genesis() {
             return Ok(());
         }
-        let block_bytes = block.serialized_size() as u64;
+        let block_bytes = block.data().serialized_size_without_uncle_proposals() as u64;
         if block_bytes <= self.block_bytes_limit {
             Ok(())
         } else {

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -343,12 +343,15 @@ pub fn test_cellbase_with_fee() {
 pub fn test_max_block_bytes_verifier_skip_genesis() {
     let block = BlockBuilder::default().build();
     {
-        let verifier = BlockBytesVerifier::new(block.serialized_size() as u64);
+        let verifier =
+            BlockBytesVerifier::new(block.data().serialized_size_without_uncle_proposals() as u64);
         assert!(verifier.verify(&block).is_ok());
     }
 
     {
-        let verifier = BlockBytesVerifier::new(block.serialized_size() as u64 - 1);
+        let verifier = BlockBytesVerifier::new(
+            block.data().serialized_size_without_uncle_proposals() as u64 - 1,
+        );
         assert!(verifier.verify(&block).is_ok());
     }
 }
@@ -360,12 +363,15 @@ pub fn test_max_block_bytes_verifier() {
         .build();
 
     {
-        let verifier = BlockBytesVerifier::new(block.serialized_size() as u64);
+        let verifier =
+            BlockBytesVerifier::new(block.data().serialized_size_without_uncle_proposals() as u64);
         assert!(verifier.verify(&block).is_ok());
     }
 
     {
-        let verifier = BlockBytesVerifier::new(block.serialized_size() as u64 - 1);
+        let verifier = BlockBytesVerifier::new(
+            block.data().serialized_size_without_uncle_proposals() as u64 - 1,
+        );
         assert_error_eq(
             verifier.verify(&block).unwrap_err(),
             BlockErrorKind::ExceededMaximumBlockBytes,

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -144,7 +144,7 @@ impl<'a> SizeVerifier<'a> {
     }
 
     pub fn verify(&self) -> Result<(), Error> {
-        let size = self.transaction.serialized_size() as u64;
+        let size = self.transaction.data().serialized_size_in_block() as u64;
         if size <= self.block_bytes_limit {
             Ok(())
         } else {


### PR DESCRIPTION
- `block.serialized_size()` -> `block.serialized_size_without_uncle_proposals()`
- `tx.serialized_size()` -> `tx.serialized_size_in_block()`