### PR TITLE
chore: upgrade p2p and ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,10 +711,10 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-discovery 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-identify 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-ping 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-discovery 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-identify 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-ping 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2175,15 +2175,6 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "molecule"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2886,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.5"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3260,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3268,9 +3259,9 @@ dependencies = [
  "igd 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle-secio 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle-secio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-yamux 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3279,46 +3270,46 @@ dependencies = [
 
 [[package]]
 name = "tentacle-discovery"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-identify"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-ping"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-channel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tentacle 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tentacle 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tentacle-secio"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3328,9 +3319,9 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4139,7 +4130,6 @@ dependencies = [
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum molecule 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b09ea73cd407c26c32db14558caec5774c2758ff55a9c3f2b7c37678593e432"
 "checksum molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76407f4e58d5e747dbfd136b6f191923530731bdfa4b18b990fa61c0620bfaf9"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
@@ -4214,7 +4204,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
 "checksum resolve 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19526b305899bea65f26edda78a64f5313958494321ee0ab66bd94b32958614a"
-"checksum ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8cb66ed257d923d56a0c1327332543d887be3c8e8288d0e6187a5d90f9a9533c"
+"checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum rocksdb 0.12.2 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=a45fb07)" = "<none>"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -4259,11 +4249,11 @@ dependencies = [
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum tentacle 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31ad4933236844038fe195fdaaf2930e46cb05e8b8f71ab016b0554413207491"
-"checksum tentacle-discovery 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5293e6ab856f4a5e8add532a86ed16d237fbaba61f40475d252eea21a39e8ce4"
-"checksum tentacle-identify 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0cabd937af5e787693844da5de8a1fd17378fe6825ad99c560d97927811712"
-"checksum tentacle-ping 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c76eb7f4bc0c7ae7fa092ece4eb135af8da1cb4be426255924770105ed10d2a3"
-"checksum tentacle-secio 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d7fde531970cf4e7c60e51c9117823095b1d7ec8f99f1ca496d638b0ffe4dc81"
+"checksum tentacle 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bfdad84a5787aa823b284e294af505daae032f0d30e5b1631ca101ab9fe71230"
+"checksum tentacle-discovery 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ae22e56e48af2fbde8bb52ff1aed57553f34167a4f17eac7049c79056cb40196"
+"checksum tentacle-identify 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "75de9c241c9092bb02cec7479b449c0c2cd56fcbea5aeaff76a713b8b0a63732"
+"checksum tentacle-ping 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2430e402766027523c8ff6db2758299b99f4a9315b2aec340edea7018b549efe"
+"checksum tentacle-secio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "56cb8f04db717a6abc792f3469357f41635bbdd2a2f5fab8cd7527936b293625"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -17,10 +17,10 @@ tokio = "0.1.18"
 tokio-threadpool = "0.1"
 futures = "0.1"
 crossbeam-channel = "0.3"
-p2p = { version="0.2.4", package="tentacle", features = ["molc"] }
-p2p-ping = { version="0.3.6", package="tentacle-ping", features = ["molc"] }
-p2p-discovery = { version="0.2.6", package="tentacle-discovery", features = ["molc"] }
-p2p-identify = { version="0.2.7", package="tentacle-identify", features = ["molc"] }
+p2p = { version="0.2.5", package="tentacle", features = ["molc"] }
+p2p-ping = { version="0.3.7", package="tentacle-ping", features = ["molc"] }
+p2p-discovery = { version="0.2.7", package="tentacle-discovery", features = ["molc"] }
+p2p-identify = { version="0.2.8", package="tentacle-identify", features = ["molc"] }
 faketime = "0.2.0"
 lazy_static = "1.3.0"
 generic-channel = { version = "0.2.0", features = ["all"] }

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -829,7 +829,10 @@ impl NetworkService {
         let disc_meta = MetaBuilder::default()
             .id(DISCOVERY_PROTOCOL_ID.into())
             .service_handle(move || {
-                ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(disc_sender.clone())))
+                ProtocolHandle::Both(Box::new(
+                    DiscoveryProtocol::new(disc_sender.clone())
+                        .global_ip_only(!config.discovery_local_address),
+                ))
             })
             .build();
 

--- a/network/src/protocols/discovery.rs
+++ b/network/src/protocols/discovery.rs
@@ -39,6 +39,13 @@ impl DiscoveryProtocol {
             event_sender,
         }
     }
+
+    pub fn global_ip_only(mut self, global_ip_only: bool) -> Self {
+        self.discovery = self
+            .discovery
+            .map(move |protocol| protocol.global_ip_only(global_ip_only));
+        self
+    }
 }
 
 impl ServiceProtocol for DiscoveryProtocol {

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -163,7 +163,9 @@ fn net_service_start(name: String) -> Node {
     let disc_meta = MetaBuilder::default()
         .id(DISCOVERY_PROTOCOL_ID.into())
         .service_handle(move || {
-            ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(disc_sender.clone())))
+            ProtocolHandle::Both(Box::new(
+                DiscoveryProtocol::new(disc_sender.clone()).global_ip_only(false),
+            ))
         })
         .build();
 
@@ -216,18 +218,11 @@ fn net_service_start(name: String) -> Node {
     let peer_id = network_state.local_peer_id().clone();
 
     let mut listen_addr = p2p_service
-        .listen("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
         .unwrap();
     listen_addr.push(Protocol::P2p(
         Multihash::from_bytes(peer_id.into_bytes()).expect("Invalid peer id"),
     ));
-
-    // On windows, it must replace `0.0.0.0` to `1270.0.1`
-    #[cfg(windows)]
-    let listen_addr = format!("{}", listen_addr)
-        .replace("0.0.0.0", "127.0.0.1")
-        .parse()
-        .unwrap();
 
     let control = p2p_service.control().clone();
 


### PR DESCRIPTION
upgrade p2p and ring