### PR TITLE
chore: manage internal error

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -45,7 +45,7 @@ impl ChainController {
     pub fn process_block(&self, block: Arc<BlockView>, need_verify: bool) -> Result<bool, Error> {
         Request::call(&self.process_block_sender, (block, need_verify)).unwrap_or_else(|| {
             Err(InternalErrorKind::System
-                .cause("Chain service has gone")
+                .reason("Chain service has gone")
                 .into())
         })
     }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -4,6 +4,7 @@
 //! which provides key-value store interface
 
 use ckb_error::{Error, InternalErrorKind};
+use std::fmt::{Debug, Display};
 use std::result;
 
 pub mod config;
@@ -22,6 +23,6 @@ pub use rocksdb::{DBPinnableSlice, DBVector, Error as DBError};
 pub type Col = &'static str;
 pub type Result<T> = result::Result<T, Error>;
 
-fn internal_error<S: ToString>(cause: S) -> Error {
-    InternalErrorKind::Database.cause(cause).into()
+fn internal_error<S: Display + Debug + Sync + Send + 'static>(reason: S) -> Error {
+    InternalErrorKind::Database.reason(reason).into()
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -10,7 +10,7 @@ pub use internal::{InternalError, InternalErrorKind};
 use std::fmt::{self, Display};
 pub use util::assert_error_eq;
 
-#[derive(Fail, Debug, Clone, Copy, Eq, PartialEq, Display)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Display)]
 pub enum ErrorKind {
     OutPoint,
     Transaction,

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -407,7 +407,7 @@ impl<'a, DL: DataLoader> TransactionScriptsVerifier<'a, DL> {
 }
 
 fn internal_error(error: ckb_vm::Error) -> Error {
-    InternalErrorKind::VM.cause(format!("{:?}", error)).into()
+    InternalErrorKind::VM.reason(format!("{:?}", error)).into()
 }
 
 #[cfg(test)]

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -41,7 +41,7 @@ impl Shared {
         let (tip_header, epoch) = Self::init_store(&store, &consensus)?;
         let total_difficulty = store
             .get_block_ext(&tip_header.hash())
-            .ok_or_else(|| InternalErrorKind::Database.cause("failed to get tip's block_ext"))?
+            .ok_or_else(|| InternalErrorKind::Database.reason("failed to get tip's block_ext"))?
             .total_difficulty;
         let (proposal_table, proposal_view) = Self::init_proposal_table(&store, &consensus);
         let cell_set = Self::init_cell_set(&store)?;
@@ -102,7 +102,7 @@ impl Shared {
                 Ok(())
             })
             .map_err(|err| {
-                InternalErrorKind::Database.cause(format!("failed to init cell set: {:?}", err))
+                InternalErrorKind::Database.reason(format!("failed to init cell set: {:?}", err))
             })?;
         info_target!(
             crate::LOG_TARGET_CHAIN,
@@ -163,7 +163,7 @@ impl Shared {
                     }
                 } else {
                     Err(InternalErrorKind::Database
-                        .cause("genesis does not exist in database")
+                        .reason("genesis does not exist in database")
                         .into())
                 }
             }

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -584,7 +584,7 @@ impl TxPool {
                     Ok(())
                 } else {
                     Err(InternalErrorKind::PoolTransactionDuplicated
-                        .cause(tx_hash)
+                        .reason(tx_hash)
                         .into())
                 }
             },
@@ -646,7 +646,7 @@ impl TxPool {
                     Ok(())
                 } else {
                     Err(InternalErrorKind::PoolTransactionDuplicated
-                        .cause(tx_hash)
+                        .reason(tx_hash)
                         .into())
                 }
             },

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -424,7 +424,7 @@ impl TxPoolService {
         if self.block_assembler.is_none() {
             future::Either::A(future::err(
                 InternalErrorKind::System
-                    .cause("BlockAssembler disabled")
+                    .reason("BlockAssembler disabled")
                     .into(),
             ))
         } else {

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -39,7 +39,7 @@ pub enum TransactionError {
     ExceededMaximumBlockBytes,
 }
 
-#[derive(Fail, Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Display)]
 pub enum HeaderErrorKind {
     InvalidParent,
     Pow,
@@ -58,7 +58,7 @@ pub struct BlockError {
     kind: Context<BlockErrorKind>,
 }
 
-#[derive(Fail, Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Display)]
 pub enum BlockErrorKind {
     ProposalTransactionDuplicate,
 


### PR DESCRIPTION
* chore: Use `failure::Context` to manage internal error
* chore: Remove derivation from Fail for error_kinds

NOTE: The previous implementation shows incomplete error messages. Here is an example:


```
Before: Internal(Database)

Now: Internal(Database(failed to open the database: Invalid argument: You have to open all column families. Column families not opened: 12))
```