### PR TITLE
chore: Correct typo builder

### DIFF
--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -9,7 +9,7 @@ use ckb_proposal_table::{ProposalTable, ProposalView};
 use ckb_store::ChainDB;
 use ckb_store::{ChainStore, StoreConfig, COLUMNS};
 use ckb_tx_pool::{
-    BlockAssemblerConfig, PollLock, TxPoolConfig, TxPoolController, TxPoolServiceBuiler,
+    BlockAssemblerConfig, PollLock, TxPoolConfig, TxPoolController, TxPoolServiceBuilder,
 };
 use ckb_types::{
     core::{Cycle, EpochExt, HeaderView, TransactionMeta},
@@ -61,7 +61,7 @@ impl Shared {
         ));
         let snapshot_mgr = Arc::new(SnapshotMgr::new(Arc::clone(&snapshot)));
 
-        let tx_pool_builer = TxPoolServiceBuiler::new(
+        let tx_pool_builder = TxPoolServiceBuilder::new(
             tx_pool_config,
             Arc::clone(&snapshot),
             block_assembler_config,
@@ -69,7 +69,7 @@ impl Shared {
             Arc::clone(&snapshot_mgr),
         );
 
-        let tx_pool_controller = tx_pool_builer.start();
+        let tx_pool_controller = tx_pool_builder.start();
 
         let shared = Shared {
             store,

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -11,5 +11,5 @@ pub(crate) const LOG_TARGET_TX_POOL: &str = "ckb-tx-pool";
 pub use component::entry::TxEntry;
 pub use config::{BlockAssemblerConfig, TxPoolConfig};
 pub use process::PlugTarget;
-pub use service::{TxPoolController, TxPoolServiceBuiler};
+pub use service::{TxPoolController, TxPoolServiceBuilder};
 pub use tokio::sync::lock::Lock as PollLock;

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -229,23 +229,23 @@ impl TxPoolController {
     }
 }
 
-pub struct TxPoolServiceBuiler {
+pub struct TxPoolServiceBuilder {
     service: Option<TxPoolService>,
 }
 
-impl TxPoolServiceBuiler {
+impl TxPoolServiceBuilder {
     pub fn new(
         tx_pool_config: TxPoolConfig,
         snapshot: Arc<Snapshot>,
         block_assembler_config: Option<BlockAssemblerConfig>,
         txs_verify_cache: Lock<LruCache<Byte32, Cycle>>,
         snapshot_mgr: Arc<SnapshotMgr>,
-    ) -> TxPoolServiceBuiler {
+    ) -> TxPoolServiceBuilder {
         let last_txs_updated_at = Arc::new(AtomicU64::new(0));
         let tx_pool = TxPool::new(tx_pool_config, snapshot, Arc::clone(&last_txs_updated_at));
         let block_assembler = block_assembler_config.map(BlockAssembler::new);
 
-        TxPoolServiceBuiler {
+        TxPoolServiceBuilder {
             service: Some(TxPoolService::new(
                 tx_pool,
                 block_assembler,


### PR DESCRIPTION
* chore: typo `builer` -> `builder`