### PR TITLE
chore: change `assert_error_eq` from function to macro

### DIFF
--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -228,7 +228,7 @@ fn test_transaction_conflict_in_same_block() {
             .process_block(Arc::new(block.clone()), true)
             .expect("process block ok");
     }
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Dead(OutPoint::new(tx1_hash.to_owned(), 0)),
         chain_controller
             .process_block(Arc::new(chain.blocks()[3].clone()), true)
@@ -265,7 +265,7 @@ fn test_transaction_conflict_in_different_blocks() {
             .process_block(Arc::new(block.clone()), true)
             .expect("process block ok");
     }
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Dead(OutPoint::new(tx1_hash.to_owned(), 0)),
         chain_controller
             .process_block(Arc::new(chain.blocks()[4].clone()), true)
@@ -299,7 +299,7 @@ fn test_invalid_out_point_index_in_same_block() {
             .process_block(Arc::new(block.clone()), true)
             .expect("process block ok");
     }
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Unknown(vec![OutPoint::new(tx1_hash.to_owned(), 1)]),
         chain_controller
             .process_block(Arc::new(chain.blocks()[3].clone()), true)
@@ -335,7 +335,7 @@ fn test_invalid_out_point_index_in_different_blocks() {
             .expect("process block ok");
     }
 
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Unknown(vec![OutPoint::new(tx1_hash.to_owned(), 1)]),
         chain_controller
             .process_block(Arc::new(chain.blocks()[4].clone()), true)

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -57,7 +57,7 @@ fn test_dead_cell_in_same_block() {
             .expect("process block ok");
     }
 
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Dead(OutPoint::new(tx1_hash, 0)),
         chain_controller
             .process_block(
@@ -112,7 +112,7 @@ fn test_dead_cell_in_different_block() {
             .expect("process block ok");
     }
 
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Dead(OutPoint::new(tx1_hash.to_owned(), 0)),
         chain_controller
             .process_block(
@@ -168,7 +168,7 @@ fn test_invalid_out_point_index_in_same_block() {
             .expect("process block ok");
     }
 
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Unknown(vec![OutPoint::new(tx1_hash, 1)]),
         chain_controller
             .process_block(
@@ -225,7 +225,7 @@ fn test_invalid_out_point_index_in_different_blocks() {
             .expect("process block ok");
     }
 
-    assert_error_eq(
+    assert_error_eq!(
         OutPointError::Unknown(vec![OutPoint::new(tx1_hash.to_owned(), 1)]),
         chain_controller
             .process_block(

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -311,7 +311,7 @@ mod tests {
         };
         let _ = RocksDB::open_with_check(&config, 1, VERSION_KEY, "0.1.0");
         let r = RocksDB::open_with_check(&config, 1, VERSION_KEY, "0.2.0");
-        assert_error_eq(
+        assert_error_eq!(
             r.err().unwrap(),
             internal_error("the database version is not matched, require 0.2.0 but it's 0.1.0"),
         );

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -8,7 +8,6 @@ pub mod util;
 use failure::{Backtrace, Context, Fail};
 pub use internal::{InternalError, InternalErrorKind};
 use std::fmt::{self, Display};
-pub use util::assert_error_eq;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Display)]
 pub enum ErrorKind {

--- a/error/src/util.rs
+++ b/error/src/util.rs
@@ -1,17 +1,24 @@
-use crate::Error;
-
 /// Compare two errors
 ///
 /// Used for testing only
-pub fn assert_error_eq<L, R>(l: L, r: R)
-where
-    L: Into<Error>,
-    R: Into<Error>,
-{
-    assert_eq!(
-        Into::<Error>::into(l).to_string(),
-        Into::<Error>::into(r).to_string(),
-    );
+#[macro_export]
+macro_rules! assert_error_eq {
+    ($left:expr, $right:expr) => {
+        assert_eq!(
+            Into::<$crate::Error>::into($left).to_string(),
+            Into::<$crate::Error>::into($right).to_string(),
+        );
+    };
+    ($left:expr, $right:expr,) => {
+        $crate::assert_error_eq!($left, $right);
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        assert_eq!(
+            Into::<$crate::Error>::into($left).to_string(),
+            Into::<$crate::Error>::into($right).to_string(),
+            $($arg)+,
+        );
+    }
 }
 
 #[macro_export]

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -598,7 +598,7 @@ mod tests {
         assert!(verifier.verify(100_000_000).is_ok());
 
         // Not enough cycles
-        assert_error_eq(
+        assert_error_eq!(
             verifier
                 .verify(ALWAYS_SUCCESS_SCRIPT_CYCLE - 1)
                 .unwrap_err(),
@@ -765,7 +765,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
             ScriptError::MultipleMatches,
         );
@@ -831,7 +831,7 @@ mod tests {
         let data_loader = DataLoaderWrapper::new(&store);
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
             ScriptError::ValidationFailure(-1),
         );
@@ -885,7 +885,7 @@ mod tests {
         let data_loader = DataLoaderWrapper::new(&store);
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
             ScriptError::InvalidCodeHash,
         );
@@ -1045,7 +1045,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
             ScriptError::ValidationFailure(-1),
         );
@@ -1233,7 +1233,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(500_000).unwrap_err(),
             ScriptError::ExceededMaximumCycles,
         );
@@ -1437,7 +1437,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(1_001_000).unwrap_err(),
             ScriptError::ValidationFailure(-3),
         );
@@ -1517,7 +1517,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(1_001_000).unwrap_err(),
             ScriptError::ValidationFailure(-1),
         );
@@ -1586,7 +1586,7 @@ mod tests {
 
         let verifier = TransactionScriptsVerifier::new(&rtx, &data_loader);
 
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(1_001_000).unwrap_err(),
             ScriptError::ValidationFailure(-2),
         );

--- a/util/types/src/core/cell.rs
+++ b/util/types/src/core/cell.rs
@@ -656,7 +656,7 @@ mod tests {
             &cell_provider,
             &header_checker,
         );
-        assert_error_eq(result.unwrap_err(), OutPointError::InvalidDepGroup(op_dep));
+        assert_error_eq!(result.unwrap_err(), OutPointError::InvalidDepGroup(op_dep));
     }
 
     #[test]
@@ -685,7 +685,7 @@ mod tests {
             &cell_provider,
             &header_checker,
         );
-        assert_error_eq(
+        assert_error_eq!(
             result.unwrap_err(),
             OutPointError::Unknown(vec![op_unknown]),
         );
@@ -741,7 +741,7 @@ mod tests {
             &header_checker,
         );
 
-        assert_error_eq(
+        assert_error_eq!(
             result.unwrap_err(),
             OutPointError::InvalidHeader(invalid_block_hash),
         );
@@ -784,7 +784,7 @@ mod tests {
             let block = generate_block(vec![tx2.clone(), tx1.clone()]);
             let provider = BlockCellProvider::new(&block);
 
-            assert_error_eq(
+            assert_error_eq!(
                 provider.err().unwrap(),
                 OutPointError::OutOfOrder(OutPoint::new(tx1.hash(), 0)),
             );
@@ -805,7 +805,7 @@ mod tests {
             let block = generate_block(vec![tx3.clone(), tx1.clone()]);
             let provider = BlockCellProvider::new(&block);
 
-            assert_error_eq(
+            assert_error_eq!(
                 provider.err().unwrap(),
                 OutPointError::OutOfOrder(OutPoint::new(tx1.hash(), 0)),
             );
@@ -888,7 +888,7 @@ mod tests {
             let result2 =
                 resolve_transaction(tx2, &mut seen_inputs, &cell_provider, &header_checker);
 
-            assert_error_eq(result2.unwrap_err(), OutPointError::Dead(out_point.clone()));
+            assert_error_eq!(result2.unwrap_err(), OutPointError::Dead(out_point.clone()));
         }
     }
 }

--- a/verification/src/tests/block_verifier.rs
+++ b/verification/src/tests/block_verifier.rs
@@ -110,7 +110,7 @@ pub fn test_block_without_cellbase() {
         .transaction(TransactionBuilder::default().build())
         .build();
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidQuantity,
     );
@@ -149,7 +149,7 @@ pub fn test_block_with_incorrect_cellbase_number() {
         .build();
 
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidInput,
     );
@@ -164,7 +164,7 @@ pub fn test_block_with_one_cellbase_at_last() {
         .build();
 
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidPosition,
     );
@@ -177,7 +177,7 @@ pub fn test_cellbase_with_non_empty_output_data() {
         .transaction(create_cellbase_transaction_with_non_empty_output_data())
         .build();
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidOutputData,
     );
@@ -190,7 +190,7 @@ pub fn test_cellbase_with_two_output() {
         .transaction(create_cellbase_transaction_with_two_output())
         .build();
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidQuantity,
     )
@@ -203,7 +203,7 @@ pub fn test_cellbase_with_two_output_data() {
         .transaction(create_cellbase_transaction_with_two_output_data())
         .build();
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidQuantity,
     )
@@ -219,7 +219,7 @@ pub fn test_block_with_duplicated_txs() {
         .build();
 
     let verifier = DuplicateVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         BlockErrorKind::CommitTransactionDuplicate,
     );
@@ -234,7 +234,7 @@ pub fn test_block_with_duplicated_proposals() {
         .build();
 
     let verifier = DuplicateVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         BlockErrorKind::ProposalTransactionDuplicate,
     );
@@ -252,7 +252,7 @@ pub fn test_transaction_root() {
         .build_unchecked();
 
     let verifier = MerkleRootVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         BlockErrorKind::CommitTransactionsRoot,
     );
@@ -270,7 +270,7 @@ pub fn test_proposals_root() {
         .build_unchecked();
 
     let verifier = MerkleRootVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         BlockErrorKind::CommitTransactionsRoot,
     );
@@ -288,7 +288,7 @@ pub fn test_witnesses_root() {
         .build_unchecked();
 
     let verifier = MerkleRootVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         BlockErrorKind::WitnessesMerkleRoot,
     );
@@ -303,7 +303,7 @@ pub fn test_block_with_two_cellbases() {
         .build();
 
     let verifier = CellbaseVerifier::new();
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify(&block).unwrap_err(),
         CellbaseError::InvalidQuantity,
     );
@@ -372,7 +372,7 @@ pub fn test_max_block_bytes_verifier() {
         let verifier = BlockBytesVerifier::new(
             block.data().serialized_size_without_uncle_proposals() as u64 - 1,
         );
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(&block).unwrap_err(),
             BlockErrorKind::ExceededMaximumBlockBytes,
         );
@@ -392,7 +392,7 @@ pub fn test_max_proposals_limit_verifier() {
 
     {
         let verifier = BlockProposalsLimitVerifier::new(0);
-        assert_error_eq(
+        assert_error_eq!(
             verifier.verify(&block).unwrap_err(),
             BlockErrorKind::ExceededMaximumProposalsLimit,
         );

--- a/verification/src/tests/commit_verifier.rs
+++ b/verification/src/tests/commit_verifier.rs
@@ -174,7 +174,7 @@ fn test_proposal() {
     //commit in proposal gap is invalid
     for _ in (proposed + 1)..(proposed + proposal_window.closest()) {
         let block = gen_block(&parent, txs20.clone(), vec![], vec![]);
-        assert_error_eq(
+        assert_error_eq!(
             CommitVerifier::new(&context, &block).verify().unwrap_err(),
             CommitError::Invalid,
         );
@@ -254,7 +254,7 @@ fn test_uncle_proposal() {
     for _ in (proposed + 1)..(proposed + proposal_window.closest()) {
         let block = gen_block(&parent, txs20.clone(), vec![], vec![]);
         let verifier = CommitVerifier::new(&context, &block);
-        assert_error_eq(verifier.verify().unwrap_err(), CommitError::Invalid);
+        assert_error_eq!(verifier.verify().unwrap_err(), CommitError::Invalid);
 
         //test chain forward
         let new_block = gen_block(&parent, vec![], vec![], vec![]);

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -30,7 +30,7 @@ pub fn test_version() {
         .build();
     let verifier = VersionVerifier::new(&header);
 
-    assert_error_eq(verifier.verify().unwrap_err(), BlockErrorKind::Version);
+    assert_error_eq!(verifier.verify().unwrap_err(), BlockErrorKind::Version);
 }
 
 #[cfg(not(disable_faketime))]
@@ -65,7 +65,7 @@ fn test_timestamp_too_old() {
         .build();
     let timestamp_verifier = TimestampVerifier::new(&fake_block_median_time_context, &header);
 
-    assert_error_eq(
+    assert_error_eq!(
         timestamp_verifier.verify().unwrap_err(),
         TimestampError::BlockTimeTooOld {
             min,
@@ -88,7 +88,7 @@ fn test_timestamp_too_new() {
         .timestamp(timestamp.pack())
         .build();
     let timestamp_verifier = TimestampVerifier::new(&fake_block_median_time_context, &header);
-    assert_error_eq(
+    assert_error_eq!(
         timestamp_verifier.verify().unwrap_err(),
         TimestampError::BlockTimeTooNew {
             max,
@@ -103,7 +103,7 @@ fn test_number() {
     let header = HeaderBuilder::default().number(10u64.pack()).build();
 
     let verifier = NumberVerifier::new(&parent, &header);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         NumberError {
             expected: 11,
@@ -144,7 +144,7 @@ fn test_epoch_number() {
     epoch.set_length(1);
     let fake_header_resolver = FakeHeaderResolver::new(header, epoch);
 
-    assert_error_eq(
+    assert_error_eq!(
         EpochVerifier::verify(&fake_header_resolver).unwrap_err(),
         EpochError::NumberMismatch {
             expected: 1_099_511_627_776,
@@ -166,7 +166,7 @@ fn test_epoch_difficulty() {
 
     let fake_header_resolver = FakeHeaderResolver::new(header, epoch);
 
-    assert_error_eq(
+    assert_error_eq!(
         EpochVerifier::verify(&fake_header_resolver).unwrap_err(),
         EpochError::DifficultyMismatch {
             expected: U256::from(1u64).pack(),
@@ -189,5 +189,5 @@ fn test_pow_verifier() {
     let fake_pow_engine: Arc<dyn PowEngine> = Arc::new(FakePowEngine);
     let verifier = PowVerifier::new(&header, &fake_pow_engine);
 
-    assert_error_eq(verifier.verify().unwrap_err(), PowError::InvalidNonce);
+    assert_error_eq!(verifier.verify().unwrap_err(), PowError::InvalidNonce);
 }

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -28,7 +28,7 @@ pub fn test_empty() {
     let transaction = TransactionBuilder::default().build();
     let verifier = EmptyVerifier::new(&transaction);
 
-    assert_error_eq(verifier.verify().unwrap_err(), TransactionError::Empty);
+    assert_error_eq!(verifier.verify().unwrap_err(), TransactionError::Empty);
 }
 
 #[test]
@@ -38,7 +38,7 @@ pub fn test_version() {
         .build();
     let verifier = VersionVerifier::new(&transaction);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::MismatchedVersion,
     );
@@ -58,7 +58,7 @@ pub fn test_exceeded_maximum_block_bytes() {
         .build();
     let verifier = SizeVerifier::new(&transaction, 100);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::ExceededMaximumBlockBytes,
     );
@@ -91,7 +91,7 @@ pub fn test_capacity_outofbound() {
     let dao_type_hash = build_genesis_type_id_script(OUTPUT_INDEX_DAO).calc_script_hash();
     let verifier = CapacityVerifier::new(&rtx, Some(dao_type_hash));
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::InsufficientCellCapacity,
     );
@@ -148,7 +148,7 @@ pub fn test_inputs_cellbase_maturity() {
     let cellbase_maturity = 100;
     let verifier1 = MaturityVerifier::new(&rtx, tip_number, cellbase_maturity);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier1.verify().unwrap_err(),
         TransactionError::CellbaseImmaturity,
     );
@@ -220,7 +220,7 @@ pub fn test_deps_cellbase_maturity() {
     let cellbase_maturity = 100;
     let verifier = MaturityVerifier::new(&rtx, tip_number, cellbase_maturity);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::CellbaseImmaturity,
     );
@@ -271,7 +271,7 @@ pub fn test_capacity_invalid() {
     let dao_type_hash = build_genesis_type_id_script(OUTPUT_INDEX_DAO).calc_script_hash();
     let verifier = CapacityVerifier::new(&rtx, Some(dao_type_hash));
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::OutputsSumOverflow,
     );
@@ -287,7 +287,7 @@ pub fn test_duplicate_deps() {
 
     let verifier = DuplicateDepsVerifier::new(&transaction);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::DuplicateDeps,
     );
@@ -379,7 +379,7 @@ fn test_invalid_since_verify() {
     );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
         TransactionError::InvalidSince,
     );
@@ -417,7 +417,7 @@ fn test_fraction_epoch_since_verify() {
         parent_hash.as_ref().to_owned(),
     )
     .verify();
-    assert_error_eq(result.unwrap_err(), TransactionError::Immature);
+    assert_error_eq!(result.unwrap_err(), TransactionError::Immature);
 
     let result = SinceVerifier::new(
         &rtx,
@@ -440,7 +440,7 @@ pub fn test_absolute_block_number_lock() {
     );
     let median_time_context = MockMedianTime::new(vec![0; 11]);
 
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
         TransactionError::Immature,
     );
@@ -458,7 +458,7 @@ pub fn test_absolute_epoch_number_lock() {
     );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
         TransactionError::Immature,
     );
@@ -476,7 +476,7 @@ pub fn test_relative_timestamp_lock() {
     );
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
         TransactionError::Immature,
     );
@@ -499,7 +499,7 @@ pub fn test_relative_epoch() {
 
     let median_time_context = MockMedianTime::new(vec![0; 11]);
 
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
         TransactionError::Immature,
     );
@@ -528,7 +528,7 @@ pub fn test_since_both() {
     let median_time_context =
         MockMedianTime::new(vec![0, 100_000, 1_124_000, 2_000_000, 3_000_000]);
 
-    assert_error_eq(
+    assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
         TransactionError::Immature,
     );
@@ -547,7 +547,7 @@ pub fn test_outputs_data_length_mismatch() {
         .build();
     let verifier = OutputsDataVerifier::new(&transaction);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::OutputsDataLengthMismatch,
     );

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -147,7 +147,7 @@ fn test_uncle_count() {
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::MissMatchCount {
             expected: 0,
@@ -176,7 +176,7 @@ fn test_invalid_uncle_hash_case1() {
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::InvalidHash {
             expected: Byte32::zero(),
@@ -206,7 +206,7 @@ fn test_invalid_uncle_hash_case2() {
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::InvalidHash {
             expected: uncles_hash,
@@ -234,7 +234,7 @@ fn test_double_inclusion() {
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::DoubleInclusion(block.uncles().get(0).unwrap().header().hash().to_owned()),
     );
@@ -262,7 +262,7 @@ fn test_invalid_difficulty() {
 
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::UnmatchedDifficulty,
     );
@@ -292,7 +292,7 @@ fn test_invalid_epoch() {
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
 
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::InvalidDifficultyEpoch,
     );
@@ -316,7 +316,7 @@ fn test_invalid_number() {
     let epoch = epoch(&shared, &chain1, 16);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(verifier.verify().unwrap_err(), UnclesError::InvalidNumber);
+    assert_error_eq!(verifier.verify().unwrap_err(), UnclesError::InvalidNumber);
 }
 
 // Uncle proposals_hash is invalid
@@ -342,7 +342,7 @@ fn test_uncle_proposals_hash() {
     let epoch = epoch(&shared, &chain1, block_number);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(verifier.verify().unwrap_err(), UnclesError::ProposalsHash);
+    assert_error_eq!(verifier.verify().unwrap_err(), UnclesError::ProposalsHash);
 }
 
 // Uncle contains duplicated proposals
@@ -367,7 +367,7 @@ fn test_uncle_duplicated_proposals() {
     let epoch = epoch(&shared, &chain2, 7);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::ProposalDuplicate,
     );
@@ -391,7 +391,7 @@ fn test_duplicated_uncles() {
     let epoch = epoch(&shared, &chain1, 11);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::Duplicate(block.uncles().get(1).unwrap().header().hash().to_owned()),
     );
@@ -419,7 +419,7 @@ fn test_uncle_over_count() {
     let epoch = epoch(&shared, &chain1, 11);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::OverCount {
             max: max_uncles_num as u32,
@@ -450,7 +450,7 @@ fn test_exceeded_maximum_proposals_limit() {
     let epoch = epoch(&shared, &chain1, 7);
     let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
     let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-    assert_error_eq(
+    assert_error_eq!(
         verifier.verify().unwrap_err(),
         UnclesError::ExceededMaximumProposalsLimit,
     );
@@ -472,7 +472,7 @@ fn test_descendant_limit() {
         let epoch = epoch(&shared, &chain1, 17);
         let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
         let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-        assert_error_eq(verifier.verify().unwrap_err(), UnclesError::DescendantLimit);
+        assert_error_eq!(verifier.verify().unwrap_err(), UnclesError::DescendantLimit);
     }
 
     // embedded should be ok
@@ -524,7 +524,7 @@ fn test_descendant_continuity() {
         let epoch = epoch(&shared, &chain1, 17);
         let uncle_verifier_context = UncleVerifierContext::new(&dummy_context, &epoch);
         let verifier = UnclesVerifier::new(uncle_verifier_context, &block);
-        assert_error_eq(verifier.verify().unwrap_err(), UnclesError::DescendantLimit);
+        assert_error_eq!(verifier.verify().unwrap_err(), UnclesError::DescendantLimit);
     }
 }
 


### PR DESCRIPTION
Support user-defined output when assert failed