### PR TITLE
chore: remove dup deps in Cargo.toml

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -17,6 +17,3 @@ libc = "0.2"
 [dependencies.rocksdb]
 git = "https://github.com/nervosnetwork/rust-rocksdb"
 rev = "a45fb07"
-
-[dev-dependencies]
-tempfile = "3.0"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -29,5 +29,4 @@ proptest = "0.9"
 ckb-chain = { path = "../chain" }
 ckb-chain-spec = { path = "../spec" }
 ckb-db = { path = "../db" }
-ckb-pow = { path = "../pow" }
 ckb-dao-utils = { path = "../util/dao/utils" }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -12,6 +12,3 @@ ckb-hash = { path = "../util/hash"}
 serde = "1.0"
 serde_derive = "1.0"
 eaglesong = "0.1"
-
-[dev-dependencies]
-ckb-hash = { path = "../util/hash" }

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -14,7 +14,6 @@ ckb-chain-spec = {path = "../../spec"}
 ckb-error = { path = "../../error" }
 
 [dev-dependencies]
-ckb-chain-spec = { path = "../../spec" }
 ckb-db = { path = "../../db" }
 ckb-script = { path = "../../script" }
 ckb-occupied-capacity = { path = "../occupied-capacity" }


### PR DESCRIPTION
`dev-dependencies` does not need to keep the crates in `dependencies`.