### PR TITLE
chore(test): Allow CI debug logs

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -435,11 +435,6 @@ impl Node {
             hash_type: ScriptHashType::Data.into(),
         });
 
-        if ::std::env::var("CI").is_ok() {
-            ckb_config.logger.filter =
-                Some(::std::env::var("CKB_LOG").unwrap_or_else(|_| "info".to_string()));
-        }
-
         modify_ckb_config(&mut ckb_config);
         fs::write(
             &ckb_config_path,


### PR DESCRIPTION
The number of logs is acceptable after #1474. 