### PR TITLE
[ᚬrc/v0.22] feat: Allow setting the spec file in ckb init.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
 name = "ckb-bin"
 version = "0.22.0-pre"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-app-config 0.22.0-pre",
  "ckb-build-info 0.22.0-pre",
  "ckb-chain 0.22.0-pre",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -35,3 +35,4 @@ ckb-build-info = { path = "../util/build-info" }
 ckb-verification = { path = "../verification" }
 faster-hex = "0.4"
 ckb-db = { path = "../db" }
+base64 = "0.10.1"

--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -11,8 +11,8 @@ data_dir = "data"
 # - { file = "specs/dev.toml" }
 # - { bundled = "specs/testnet.toml" }
 spec = { file = "specs/dev.toml" } # {{
-# testnet => spec = { bundled = "specs/testnet.toml" }
-# staging => spec = { bundled = "specs/staging.toml" }
+# testnet => spec = { {spec_source} = "specs/testnet.toml" }
+# staging => spec = { {spec_source} = "specs/staging.toml" }
 # integration => spec = { file = "specs/integration.toml" }
 # }}
 

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -11,8 +11,8 @@ data_dir = "data"
 # - { file = "specs/dev.toml" }
 # - { bundled = "specs/testnet.toml" }
 spec = { file = "specs/dev.toml" } # {{
-# testnet => spec = { bundled = "specs/testnet.toml" }
-# staging => spec = { bundled = "specs/staging.toml" }
+# testnet => spec = { {spec_source} = "specs/testnet.toml" }
+# staging => spec = { {spec_source} = "specs/staging.toml" }
 # integration => spec = { file = "specs/integration.toml" }
 # }}
 

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -228,6 +228,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         Resource::bundled_ckb_config()
             .export(&context, root_dir.path())

--- a/resource/src/template.rs
+++ b/resource/src/template.rs
@@ -13,6 +13,7 @@ pub struct Template<T>(T);
 
 pub struct TemplateContext<'a> {
     pub spec: &'a str,
+    pub spec_source: &'a str,
     pub rpc_port: &'a str,
     pub p2p_port: &'a str,
     pub log_to_file: bool,
@@ -38,6 +39,7 @@ fn writeln<W: io::Write>(w: &mut W, s: &str, context: &TemplateContext) -> io::R
             .replace("{log_to_file}", &format!("{}", context.log_to_file))
             .replace("{log_to_stdout}", &format!("{}", context.log_to_stdout))
             .replace("{block_assembler}", context.block_assembler)
+            .replace("{spec_source}", context.spec_source)
     )
 }
 

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -147,17 +147,12 @@ impl Default for SatoshiGift {
 #[derive(Debug)]
 pub enum SpecLoadError {
     FileNotFound,
-    ChainNameNotAllowed(String),
     GenesisMismatch { expect: H256, actual: H256 },
 }
 
 impl SpecLoadError {
     fn file_not_found() -> Box<Self> {
         Box::new(SpecLoadError::FileNotFound)
-    }
-
-    fn chain_name_not_allowed(name: String) -> Box<Self> {
-        Box::new(SpecLoadError::ChainNameNotAllowed(name))
     }
 
     fn genesis_mismatch(expect: H256, actual: H256) -> Box<Self> {
@@ -171,11 +166,6 @@ impl fmt::Display for SpecLoadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SpecLoadError::FileNotFound => write!(f, "ChainSpec: file not found"),
-            SpecLoadError::ChainNameNotAllowed(name) => write!(
-                f,
-                "ChainSpec: name not allowed, expect ckb_dev, actual {}",
-                name
-            ),
             SpecLoadError::GenesisMismatch { expect, actual } => write!(
                 f,
                 "ChainSpec: genesis hash mismatch, expect {:#x}, actual {:#x}",
@@ -192,10 +182,6 @@ impl ChainSpec {
         }
         let config_bytes = resource.get()?;
         let mut spec: ChainSpec = toml::from_slice(&config_bytes)?;
-        if !(resource.is_bundled() || spec.name == "ckb_dev" || spec.name == "ckb_integration_test")
-        {
-            return Err(SpecLoadError::chain_name_not_allowed(spec.name.clone()));
-        }
 
         if let Some(parent) = resource.parent() {
             for r in spec.genesis.system_cells.iter_mut() {

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -260,6 +260,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         {
             Resource::bundled_ckb_config()
@@ -306,6 +307,7 @@ mod tests {
             log_to_file: false,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         {
             Resource::bundled_ckb_config()
@@ -341,6 +343,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         {
             Resource::bundled_ckb_config()
@@ -387,6 +390,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         {
             Resource::bundled_ckb_config()
@@ -431,6 +435,7 @@ mod tests {
             log_to_file: true,
             log_to_stdout: true,
             block_assembler: "",
+            spec_source: "bundled",
         };
         {
             Resource::bundled_ckb_config()

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -57,6 +57,7 @@ pub struct InitArgs {
     pub block_assembler_args: Vec<String>,
     pub block_assembler_hash_type: ScriptHashType,
     pub block_assembler_message: Option<String>,
+    pub import_spec: Option<String>,
 }
 
 pub struct ResetDataArgs {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -24,6 +24,7 @@ pub const ARG_DATA: &str = "data";
 pub const ARG_LIST_CHAINS: &str = "list-chains";
 pub const ARG_INTERACTIVE: &str = "interactive";
 pub const ARG_CHAIN: &str = "chain";
+pub const ARG_IMPORT_SPEC: &str = "import-spec";
 pub const ARG_P2P_PORT: &str = "p2p-port";
 pub const ARG_RPC_PORT: &str = "rpc-port";
 pub const ARG_FORCE: &str = "force";
@@ -300,6 +301,15 @@ fn init() -> App<'static, 'static> {
                 .long(ARG_CHAIN)
                 .default_value(DEFAULT_SPEC)
                 .help("Initializes CKB direcotry for <chain>"),
+        )
+        .arg(
+            Arg::with_name(ARG_IMPORT_SPEC)
+                .long(ARG_IMPORT_SPEC)
+                .takes_value(true)
+                .help(
+                    "Uses the specifiec file as chain spec. Specially, \
+                     The dash \"-\" denotes importing the spec from stdin encoded in base64",
+                ),
         )
         .arg(
             Arg::with_name(ARG_LOG_TO)

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -226,6 +226,8 @@ impl Setup {
             .unwrap();
         let block_assembler_message = matches.value_of(cli::ARG_BA_MESSAGE).map(str::to_string);
 
+        let import_spec = matches.value_of(cli::ARG_IMPORT_SPEC).map(str::to_string);
+
         Ok(InitArgs {
             interactive,
             root_dir,
@@ -240,6 +242,7 @@ impl Setup {
             block_assembler_args,
             block_assembler_hash_type,
             block_assembler_message,
+            import_spec,
         })
     }
 


### PR DESCRIPTION
Add a new option `ckb init --import-spec <file>`.

It allows copying the spec file in `ckb init` from `<file>`. Specially, when `<file>` is "-", read the spec file from stdin encoded in base64.