### PR TITLE
fix: fix construct_uncle in integration test

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -274,6 +274,22 @@ impl Node {
         self.submit_block(&self.new_block(None, None, None).data())
     }
 
+    // Convenient way to construct an uncle block
+    pub fn construct_uncle(&self) -> BlockView {
+        let block = self.new_block(None, None, None);
+        // Make sure the uncle block timestamp is different from
+        // the next block timestamp in main fork.
+        // Firstly construct uncle block which timestamp
+        // is less than the current time, and then generate
+        // the new block in main fork which timestamp is greater than
+        // or equal to the current time.
+        let timestamp = block.timestamp() - 1;
+        block
+            .as_advanced_builder()
+            .timestamp(timestamp.pack())
+            .build()
+    }
+
     // generate a transaction which spend tip block's cellbase and send it to pool through rpc.
     pub fn generate_transaction(&self) -> Byte32 {
         self.submit_transaction(&self.new_transaction_spend_tip_cellbase())

--- a/test/src/specs/mining/uncle.rs
+++ b/test/src/specs/mining/uncle.rs
@@ -171,14 +171,7 @@ impl Spec for PackUnclesIntoEpochStarting {
 // Convenient way to construct an uncle block
 fn construct_uncle(node: &Node) -> BlockView {
     node.generate_block(); // Ensure exit IBD mode
-
-    let block = node.new_block(None, None, None);
-    let timestamp = block.timestamp() + 10;
-    let uncle = block
-        .as_advanced_builder()
-        .timestamp(timestamp.pack())
-        .build();
-
+    let uncle = node.construct_uncle();
     node.generate_block();
 
     uncle

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -584,7 +584,7 @@ impl Spec for ForksContainSameUncle {
         net.exit_ibd_mode();
 
         info!("(1) Construct an uncle before fork point");
-        let uncle = construct_uncle(node_a);
+        let uncle = node_a.construct_uncle();
         node_a.generate_block();
         node_b.generate_block();
 
@@ -708,14 +708,4 @@ fn is_transaction_existed(node: &Node, tx_hash: Byte32) {
         .get_transaction(tx_hash)
         .expect("node should contains transaction");
     is_committed(&tx_status);
-}
-
-// Convenient way to construct an uncle block
-fn construct_uncle(node: &Node) -> BlockView {
-    let block = node.new_block(None, None, None);
-    let timestamp = block.timestamp() + 10;
-    block
-        .as_advanced_builder()
-        .timestamp(timestamp.pack())
-        .build()
 }


### PR DESCRIPTION
Fix panic of ForksContainSameUncle. The reason is that the uncle block has the same hash with the main chain block.