### PR TITLE
test: fix compact_block_missing_fresh_txs integration test

### DIFF
--- a/test/src/specs/relay/get_block_transactions_process.rs
+++ b/test/src/specs/relay/get_block_transactions_process.rs
@@ -1,6 +1,7 @@
 use crate::{Net, Spec, TestProtocol};
 use ckb_sync::NetworkProtocol;
 use ckb_types::{
+    bytes::Bytes,
     core::UncleBlockView,
     packed::{self, RelayMessage},
     prelude::*,
@@ -53,12 +54,12 @@ impl Spec for MissingUncleRequest {
             message.as_slice().into(),
         );
 
-        let (_, _, data) = net.receive();
-        let message = RelayMessage::from_slice(&data).unwrap();
-
-        assert_eq!(
-            message.to_enum().item_name(),
-            packed::BlockTransactions::NAME,
+        net.should_receive(
+            |data: &Bytes| {
+                RelayMessage::from_slice(&data)
+                    .map(|message| message.to_enum().item_name() == packed::BlockTransactions::NAME)
+                    .unwrap_or(false)
+            },
             "Node should reponse BlockTransactions message",
         );
 


### PR DESCRIPTION
There are some relayer-notify jobs in sync, see https://github.com/nervosnetwork/ckb/blob/develop/sync/src/relayer/mod.rs#L44-L46. This would dislocate the message order.