### PR TITLE
refactor: Enforce txpool consistency

### DIFF
--- a/tx-pool/src/component/mod.rs
+++ b/tx-pool/src/component/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod container;
 pub(crate) mod orphan;
 pub(crate) mod pending;
 pub(crate) mod proposed;
+pub(crate) mod relative;
 
 pub use self::entry::{DefectEntry, TxEntry};
 

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -1,5 +1,6 @@
 use crate::component::container::{AncestorsScoreSortKey, SortedTxMap};
 use crate::component::entry::TxEntry;
+use crate::component::relative::RelativeTraversal;
 use crate::fee_rate::FeeRate;
 use ckb_types::{
     core::{

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -1,5 +1,6 @@
 use crate::component::container::SortedTxMap;
 use crate::component::entry::TxEntry;
+use crate::component::relative::RelativeTraversal;
 use ckb_types::{
     bytes::Bytes,
     core::{

--- a/tx-pool/src/component/relative.rs
+++ b/tx-pool/src/component/relative.rs
@@ -1,0 +1,80 @@
+use crate::component::container::SortedTxMap;
+use ckb_types::packed::ProposalShortId;
+use std::collections::HashSet;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Relation {
+    Ancestor,
+    Descendant,
+}
+
+/// This crate is used for recursively searching in-pool ancestors or descendants
+pub(crate) trait RelativeTraversal {
+    fn get_relative_ids(
+        &self,
+        id: &ProposalShortId,
+        relation: Relation,
+    ) -> HashSet<ProposalShortId>;
+
+    fn get_parents(&self, id: &ProposalShortId) -> &HashSet<ProposalShortId>;
+
+    fn get_children(&self, id: &ProposalShortId) -> &HashSet<ProposalShortId>;
+
+    fn get_ancestors(&self, id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        self.get_relative_ids(id, Relation::Ancestor)
+    }
+
+    fn get_descendants(&self, id: &ProposalShortId) -> HashSet<ProposalShortId> {
+        self.get_relative_ids(id, Relation::Descendant)
+    }
+}
+
+impl RelativeTraversal for SortedTxMap {
+    fn get_parents(&self, id: &ProposalShortId) -> &HashSet<ProposalShortId> {
+        &self
+            .get_link(id)
+            .expect("found inconsistency when get_parents")
+            .parents
+    }
+
+    fn get_children(&self, id: &ProposalShortId) -> &HashSet<ProposalShortId> {
+        &self
+            .get_link(id)
+            .expect("found inconsistency when get_children")
+            .children
+    }
+
+    fn get_relative_ids(
+        &self,
+        id: &ProposalShortId,
+        relation: Relation,
+    ) -> HashSet<ProposalShortId> {
+        let mut queue = get_direct_ids(self, id, relation).clone();
+        let mut relatives = HashSet::with_capacity(queue.len());
+        while !queue.is_empty() {
+            let relative_id = queue.iter().next().expect("checked above").clone();
+            queue.remove(&relative_id);
+            relatives.insert(relative_id.clone());
+
+            // Recursively search the next relative entries
+            for direct_id in get_direct_ids(self, &relative_id, relation) {
+                if !relatives.contains(direct_id) {
+                    queue.insert(direct_id.clone());
+                }
+            }
+        }
+
+        relatives
+    }
+}
+
+fn get_direct_ids<'a, T: RelativeTraversal>(
+    container: &'a T,
+    id: &ProposalShortId,
+    relation: Relation,
+) -> &'a HashSet<ProposalShortId> {
+    match relation {
+        Relation::Ancestor => container.get_parents(id),
+        Relation::Descendant => container.get_children(id),
+    }
+}


### PR DESCRIPTION
This refactoring PR intends to reduce the probability of inconsistency between `SortedTxMap::entries` and `SortedTxMap::links`.

1. Merge entries and links into one hashmap: The `SortedTxMap.entries` and `SortedTxMap.links` must keep consistent. The previous code enforces the consistency carefully and correctly, but I think that merging them into one slot, so that it reduces the probability of inconsistency, is a better management way.
2. Create a trait `RelativeTraversal`, a helper to traverse all the in-pool ancestors and descendants of the target proposal-id.
3. Try to wrap some update operations into functions to reduce the error probability.