### PR TITLE
fix: tx sorted_keys order by relation

### DIFF
--- a/test/src/specs/indexer/basic.rs
+++ b/test/src/specs/indexer/basic.rs
@@ -62,12 +62,8 @@ impl Spec for IndexerBasic {
         node0.generate_blocks(1);
 
         let tx_pool_info = node0.rpc_client().tx_pool_info();
-        assert_eq!(
-            6,
-            tx_pool_info.pending.value() as u64
-                + tx_pool_info.proposed.value() as u64
-                + tx_pool_info.orphan.value() as u64
-        );
+        // in gap
+        assert_eq!(6, tx_pool_info.pending.value() as u64);
         node0.generate_blocks(1);
 
         let tx_pool_info = node0.rpc_client().tx_pool_info();

--- a/tx-pool/src/component/container.rs
+++ b/tx-pool/src/component/container.rs
@@ -275,9 +275,21 @@ impl SortedTxMap {
         TxLink::get_descendants(&self.links, tx_short_id)
     }
 
-    /// return sorted keys
-    pub fn sorted_keys(&self) -> impl Iterator<Item = &AncestorsScoreSortKey> {
+    /// return keys sorted by tx fee rate
+    pub fn keys_sorted_by_fee(&self) -> impl Iterator<Item = &AncestorsScoreSortKey> {
         self.sorted_index.iter().rev()
+    }
+
+    /// return keys sorted by tx fee rate and transaction relation
+    pub fn keys_sorted_by_fee_and_relation(&self) -> Vec<&AncestorsScoreSortKey> {
+        let mut keys: Vec<_> = self.keys_sorted_by_fee().collect();
+        keys.sort_by_key(|k| {
+            self.entries
+                .get(&k.id)
+                .expect("entries should consistent with sorted_index")
+                .ancestors_count
+        });
+        keys
     }
 }
 

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -241,7 +241,7 @@ impl ProposedPool {
     where
         F: FnOnce(&mut dyn Iterator<Item = &TxEntry>) -> Ret,
     {
-        let mut iter = self.inner.sorted_keys().map(|key| {
+        let mut iter = self.inner.keys_sorted_by_fee().map(|key| {
             self.inner
                 .get(&key.id)
                 .expect("proposed pool must be consistent")

--- a/tx-pool/src/process/chain_reorg.rs
+++ b/tx-pool/src/process/chain_reorg.rs
@@ -125,7 +125,7 @@ pub fn update_tx_pool_for_reorg(
     // pending ---> gap ----> proposed
     // try move gap to proposed
     let mut removed: Vec<ProposalShortId> = Vec::with_capacity(tx_pool.gap.size());
-    for key in tx_pool.gap.sorted_keys() {
+    for key in tx_pool.gap.keys_sorted_by_fee_and_relation() {
         if snapshot.proposals().contains_proposed(&key.id) {
             let entry = tx_pool.gap.get(&key.id).expect("exists");
             entries.push((
@@ -142,7 +142,7 @@ pub fn update_tx_pool_for_reorg(
 
     // try move pending to proposed
     let mut removed: Vec<ProposalShortId> = Vec::with_capacity(tx_pool.pending.size());
-    for key in tx_pool.pending.sorted_keys() {
+    for key in tx_pool.pending.keys_sorted_by_fee_and_relation() {
         let entry = tx_pool.pending.get(&key.id).expect("exists");
         if snapshot.proposals().contains_proposed(&key.id) {
             entries.push((


### PR DESCRIPTION
Before this part, https://github.com/nervosnetwork/ckb/blob/develop/test/src/specs/indexer/basic.rs#L59-L75 code's  log is that 

```
2019-10-15 11:49:52.672 +08:00 ChainService INFO ckb-chain  block: 13, hash: Byte32(0x75cddba4ee0b6b15a03be7667c3e44af045282dfc0b151699be84cd4eb275556), total_diff: 0xe00, txs: 1
2019-10-15 11:49:52.673 +08:00 http.worker3 DEBUG ckb-rpc  [block_relay] announce new block 13 Byte32(0x75cddba4ee0b6b15a03be7667c3e44af045282dfc0b151699be84cd4eb275556) 1571111392673
2019-10-15 11:49:52.675 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x569c112c72a1248a12ece2bd1c1fbdd793d9b4ea698b93c60af21fe45efd9f42)
2019-10-15 11:49:52.676 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x2ab01fcf0ab6fa29d8ce39f61285002ec69d30d70257aac9e0b216b856642b35)
2019-10-15 11:49:53.614 +08:00 NetworkRuntime-8 DEBUG ckb-sync  no peers connected
2019-10-15 11:49:52.678 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  Failed to add tx to gap Byte32(0x2ab01fcf0ab6fa29d8ce39f61285002ec69d30d70257aac9e0b216b856642b35), reason: Error { kind: Unknown([OutPoint(0x932358f16963610f3cd38fda5ed55c85b1aca0c37faeecece79fec1471b1013700000000)])

stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/internal.rs:44
   1: failure::backtrace::Backtrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/mod.rs:111
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/mod.rs:36
   4: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   5: failure::context::Context<D>::with_err
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/context.rs:105
   6: failure::Fail::context
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/lib.rs:160
   7: ckb_types::core::error::<impl core::convert::From<ckb_types::core::error::OutPointError> for ckb_error::Error>::from
             at util/types/src/core/error.rs:36
   8: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   9: ckb_types::core::cell::resolve_transaction
             at /home/u2/nervos/ckb/util/types/src/core/cell.rs:445
  10: ckb_tx_pool::pool::TxPool::resolve_tx_from_pending_and_proposed
             at tx-pool/src/pool.rs:324
  11: ckb_tx_pool::pool::TxPool::gap_tx
             at tx-pool/src/pool.rs:560
  12: ckb_tx_pool::process::chain_reorg::update_tx_pool_for_reorg
             at tx-pool/src/process/chain_reorg.rs:197
  13: <ckb_tx_pool::process::chain_reorg::ChainReorgProcess as futures::future::Future>::poll
             at tx-pool/src/process/chain_reorg.rs:57
  14: futures::future::chain::Chain<A,B,C>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/chain.rs:42
  15: <futures::future::and_then::AndThen<A,B,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/and_then.rs:32
  16: <futures::future::map::Map<A,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/map.rs:30
  17: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  18: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  19: futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  20: futures::task_impl::Spawn<T>::enter::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  21: futures::task_impl::std::set
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/std/mod.rs:83
  22: futures::task_impl::Spawn<T>::enter
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  23: futures::task_impl::Spawn<T>::poll_fn_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:291
  24: futures::task_impl::Spawn<T>::poll_future_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  25: tokio_threadpool::task::Task::run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:145
  26: core::ops::function::FnOnce::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  27: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  28: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  29: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  30: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  31: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  32: tokio_threadpool::task::Task::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:130
  33: tokio_threadpool::worker::Worker::run_task2
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:567
  34: tokio_threadpool::worker::Worker::run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:459
  35: tokio_threadpool::worker::Worker::try_steal_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:416
  36: tokio_threadpool::worker::Worker::try_run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:301
  37: tokio_threadpool::worker::Worker::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:241
  38: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:390
  39: tokio_timer::timer::handle::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:94
  40: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  41: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  42: tokio_timer::timer::handle::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:81
  43: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:382
  44: tokio_timer::clock::clock::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:141
  45: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  46: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  47: tokio_timer::clock::clock::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:124
  48: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:381
  49: tokio_reactor::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:237
  50: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  51: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  52: tokio_reactor::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:217
  53: tokio::runtime::threadpool::builder::Builder::build::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:380
  54: tokio_threadpool::callback::Callback::call
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/callback.rs:22
  55: tokio_threadpool::worker::Worker::do_run::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:127
  56: tokio_executor::global::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:209
  57: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  58: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  59: tokio_executor::global::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:178
  60: tokio_threadpool::worker::Worker::do_run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:125
  61: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  62: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  63: tokio_threadpool::worker::Worker::do_run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:116
  64: tokio_threadpool::pool::Pool::spawn_thread::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/pool/mod.rs:344
  65: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/sys_common/backtrace.rs:77
  66: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:470
  67: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  68: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  69: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  70: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  71: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  72: std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:469
  73: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  74: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
  75: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
      std::sys_common::thread::start_thread
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread::new::thread_start
             at src/libstd/sys/unix/thread.rs:79
  76: start_thread
  77: clone


OutPoint }
2019-10-15 11:49:54.378 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x932358f16963610f3cd38fda5ed55c85b1aca0c37faeecece79fec1471b10137)
2019-10-15 11:49:54.380 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  Failed to add tx to gap Byte32(0x932358f16963610f3cd38fda5ed55c85b1aca0c37faeecece79fec1471b10137), reason: Error { kind: Unknown([OutPoint(0xe8886863772aee87460dbfff3ddbb06adcc4c7286492b49a13bcc82ec667bf7800000000)])

stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/internal.rs:44
   1: failure::backtrace::Backtrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/mod.rs:111
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/mod.rs:36
   4: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   5: failure::context::Context<D>::with_err
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/context.rs:105
   6: failure::Fail::context
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/lib.rs:160
   7: ckb_types::core::error::<impl core::convert::From<ckb_types::core::error::OutPointError> for ckb_error::Error>::from
             at util/types/src/core/error.rs:36
   8: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   9: ckb_types::core::cell::resolve_transaction
             at /home/u2/nervos/ckb/util/types/src/core/cell.rs:445
  10: ckb_tx_pool::pool::TxPool::resolve_tx_from_pending_and_proposed
             at tx-pool/src/pool.rs:324
  11: ckb_tx_pool::pool::TxPool::gap_tx
             at tx-pool/src/pool.rs:560
  12: ckb_tx_pool::process::chain_reorg::update_tx_pool_for_reorg
             at tx-pool/src/process/chain_reorg.rs:197
  13: <ckb_tx_pool::process::chain_reorg::ChainReorgProcess as futures::future::Future>::poll
             at tx-pool/src/process/chain_reorg.rs:57
  14: futures::future::chain::Chain<A,B,C>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/chain.rs:42
  15: <futures::future::and_then::AndThen<A,B,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/and_then.rs:32
  16: <futures::future::map::Map<A,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/map.rs:30
  17: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  18: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  19: futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  20: futures::task_impl::Spawn<T>::enter::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  21: futures::task_impl::std::set
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/std/mod.rs:83
  22: futures::task_impl::Spawn<T>::enter
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  23: futures::task_impl::Spawn<T>::poll_fn_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:291
  24: futures::task_impl::Spawn<T>::poll_future_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  25: tokio_threadpool::task::Task::run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:145
  26: core::ops::function::FnOnce::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  27: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  28: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  29: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  30: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  31: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  32: tokio_threadpool::task::Task::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:130
  33: tokio_threadpool::worker::Worker::run_task2
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:567
  34: tokio_threadpool::worker::Worker::run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:459
  35: tokio_threadpool::worker::Worker::try_steal_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:416
  36: tokio_threadpool::worker::Worker::try_run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:301
  37: tokio_threadpool::worker::Worker::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:241
  38: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:390
  39: tokio_timer::timer::handle::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:94
  40: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  41: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  42: tokio_timer::timer::handle::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:81
  43: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:382
  44: tokio_timer::clock::clock::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:141
  45: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  46: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  47: tokio_timer::clock::clock::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:124
  48: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:381
  49: tokio_reactor::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:237
  50: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  51: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  52: tokio_reactor::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:217
  53: tokio::runtime::threadpool::builder::Builder::build::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:380
  54: tokio_threadpool::callback::Callback::call
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/callback.rs:22
  55: tokio_threadpool::worker::Worker::do_run::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:127
  56: tokio_executor::global::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:209
  57: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  58: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  59: tokio_executor::global::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:178
  60: tokio_threadpool::worker::Worker::do_run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:125
  61: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  62: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  63: tokio_threadpool::worker::Worker::do_run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:116
  64: tokio_threadpool::pool::Pool::spawn_thread::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/pool/mod.rs:344
  65: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/sys_common/backtrace.rs:77
  66: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:470
  67: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  68: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  69: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  70: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  71: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  72: std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:469
  73: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  74: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
  75: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
      std::sys_common::thread::start_thread
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread::new::thread_start
             at src/libstd/sys/unix/thread.rs:79
  76: start_thread
  77: clone


OutPoint }
2019-10-15 11:49:54.388 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xe8886863772aee87460dbfff3ddbb06adcc4c7286492b49a13bcc82ec667bf78)
2019-10-15 11:49:54.389 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  Failed to add tx to gap Byte32(0xe8886863772aee87460dbfff3ddbb06adcc4c7286492b49a13bcc82ec667bf78), reason: Error { kind: Unknown([OutPoint(0xd7e002e771e6e71f2bb82f5dea563c88b87bf0a42855e92b05619186e7b59aaf00000000)])

stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/internal.rs:44
   1: failure::backtrace::Backtrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/mod.rs:111
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/mod.rs:36
   4: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   5: failure::context::Context<D>::with_err
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/context.rs:105
   6: failure::Fail::context
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/lib.rs:160
   7: ckb_types::core::error::<impl core::convert::From<ckb_types::core::error::OutPointError> for ckb_error::Error>::from
             at util/types/src/core/error.rs:36
   8: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   9: ckb_types::core::cell::resolve_transaction
             at /home/u2/nervos/ckb/util/types/src/core/cell.rs:445
  10: ckb_tx_pool::pool::TxPool::resolve_tx_from_pending_and_proposed
             at tx-pool/src/pool.rs:324
  11: ckb_tx_pool::pool::TxPool::gap_tx
             at tx-pool/src/pool.rs:560
  12: ckb_tx_pool::process::chain_reorg::update_tx_pool_for_reorg
             at tx-pool/src/process/chain_reorg.rs:197
  13: <ckb_tx_pool::process::chain_reorg::ChainReorgProcess as futures::future::Future>::poll
             at tx-pool/src/process/chain_reorg.rs:57
  14: futures::future::chain::Chain<A,B,C>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/chain.rs:42
  15: <futures::future::and_then::AndThen<A,B,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/and_then.rs:32
  16: <futures::future::map::Map<A,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/map.rs:30
  17: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  18: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  19: futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  20: futures::task_impl::Spawn<T>::enter::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  21: futures::task_impl::std::set
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/std/mod.rs:83
  22: futures::task_impl::Spawn<T>::enter
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  23: futures::task_impl::Spawn<T>::poll_fn_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:291
  24: futures::task_impl::Spawn<T>::poll_future_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  25: tokio_threadpool::task::Task::run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:145
  26: core::ops::function::FnOnce::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  27: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  28: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  29: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  30: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  31: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  32: tokio_threadpool::task::Task::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:130
  33: tokio_threadpool::worker::Worker::run_task2
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:567
  34: tokio_threadpool::worker::Worker::run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:459
  35: tokio_threadpool::worker::Worker::try_steal_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:416
  36: tokio_threadpool::worker::Worker::try_run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:301
  37: tokio_threadpool::worker::Worker::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:241
  38: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:390
  39: tokio_timer::timer::handle::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:94
  40: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  41: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  42: tokio_timer::timer::handle::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:81
  43: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:382
  44: tokio_timer::clock::clock::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:141
  45: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  46: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  47: tokio_timer::clock::clock::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:124
  48: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:381
  49: tokio_reactor::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:237
  50: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  51: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  52: tokio_reactor::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:217
  53: tokio::runtime::threadpool::builder::Builder::build::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:380
  54: tokio_threadpool::callback::Callback::call
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/callback.rs:22
  55: tokio_threadpool::worker::Worker::do_run::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:127
  56: tokio_executor::global::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:209
  57: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  58: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  59: tokio_executor::global::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:178
  60: tokio_threadpool::worker::Worker::do_run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:125
  61: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  62: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  63: tokio_threadpool::worker::Worker::do_run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:116
  64: tokio_threadpool::pool::Pool::spawn_thread::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/pool/mod.rs:344
  65: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/sys_common/backtrace.rs:77
  66: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:470
  67: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  68: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  69: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  70: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  71: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  72: std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:469
  73: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  74: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
  75: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
      std::sys_common::thread::start_thread
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread::new::thread_start
             at src/libstd/sys/unix/thread.rs:79
  76: start_thread
  77: clone


OutPoint }
2019-10-15 11:49:54.399 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xd7e002e771e6e71f2bb82f5dea563c88b87bf0a42855e92b05619186e7b59aaf)
2019-10-15 11:49:54.400 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  Failed to add tx to gap Byte32(0xd7e002e771e6e71f2bb82f5dea563c88b87bf0a42855e92b05619186e7b59aaf), reason: Error { kind: Unknown([OutPoint(0xcfb64326fb6bd8f244e0370f350786ce932deb97d829f176687f215e487e7f0d00000000)])

stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/internal.rs:44
   1: failure::backtrace::Backtrace::new
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/mod.rs:111
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/mod.rs:36
   4: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   5: failure::context::Context<D>::with_err
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/context.rs:105
   6: failure::Fail::context
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/lib.rs:160
   7: ckb_types::core::error::<impl core::convert::From<ckb_types::core::error::OutPointError> for ckb_error::Error>::from
             at util/types/src/core/error.rs:36
   8: <T as core::convert::Into<U>>::into
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/convert.rs:544
   9: ckb_types::core::cell::resolve_transaction
             at /home/u2/nervos/ckb/util/types/src/core/cell.rs:445
  10: ckb_tx_pool::pool::TxPool::resolve_tx_from_pending_and_proposed
             at tx-pool/src/pool.rs:324
  11: ckb_tx_pool::pool::TxPool::gap_tx
             at tx-pool/src/pool.rs:560
  12: ckb_tx_pool::process::chain_reorg::update_tx_pool_for_reorg
             at tx-pool/src/process/chain_reorg.rs:197
  13: <ckb_tx_pool::process::chain_reorg::ChainReorgProcess as futures::future::Future>::poll
             at tx-pool/src/process/chain_reorg.rs:57
  14: futures::future::chain::Chain<A,B,C>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/chain.rs:42
  15: <futures::future::and_then::AndThen<A,B,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/and_then.rs:32
  16: <futures::future::map::Map<A,F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/map.rs:30
  17: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  18: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/future/mod.rs:113
  19: futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  20: futures::task_impl::Spawn<T>::enter::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  21: futures::task_impl::std::set
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/std/mod.rs:83
  22: futures::task_impl::Spawn<T>::enter
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:399
  23: futures::task_impl::Spawn<T>::poll_fn_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:291
  24: futures::task_impl::Spawn<T>::poll_future_notify
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.29/src/task_impl/mod.rs:329
  25: tokio_threadpool::task::Task::run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:145
  26: core::ops::function::FnOnce::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  27: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  28: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  29: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  30: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  31: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  32: tokio_threadpool::task::Task::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/task/mod.rs:130
  33: tokio_threadpool::worker::Worker::run_task2
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:567
  34: tokio_threadpool::worker::Worker::run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:459
  35: tokio_threadpool::worker::Worker::try_steal_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:416
  36: tokio_threadpool::worker::Worker::try_run_task
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:301
  37: tokio_threadpool::worker::Worker::run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:241
  38: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:390
  39: tokio_timer::timer::handle::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:94
  40: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  41: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  42: tokio_timer::timer::handle::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:81
  43: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:382
  44: tokio_timer::clock::clock::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:141
  45: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  46: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  47: tokio_timer::clock::clock::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:124
  48: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:381
  49: tokio_reactor::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:237
  50: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  51: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  52: tokio_reactor::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:217
  53: tokio::runtime::threadpool::builder::Builder::build::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.22/src/runtime/threadpool/builder.rs:380
  54: tokio_threadpool::callback::Callback::call
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/callback.rs:22
  55: tokio_threadpool::worker::Worker::do_run::{{closure}}::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:127
  56: tokio_executor::global::with_default::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:209
  57: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  58: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  59: tokio_executor::global::with_default
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.8/src/global.rs:178
  60: tokio_threadpool::worker::Worker::do_run::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:125
  61: std::thread::local::LocalKey<T>::try_with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:262
  62: std::thread::local::LocalKey<T>::with
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/local.rs:239
  63: tokio_threadpool::worker::Worker::do_run
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/worker/mod.rs:116
  64: tokio_threadpool::pool::Pool::spawn_thread::{{closure}}
             at /home/u2/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.14/src/pool/mod.rs:344
  65: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/sys_common/backtrace.rs:77
  66: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:470
  67: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:315
  68: std::panicking::try::do_call
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:296
  69: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  70: std::panicking::try
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panicking.rs:275
  71: std::panic::catch_unwind
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/panic.rs:394
  72: std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libstd/thread/mod.rs:469
  73: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/libcore/ops/function.rs:235
  74: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
  75: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/625451e376bb2e5283fc4741caa0a3e8a2ca4d54/src/liballoc/boxed.rs:787
      std::sys_common::thread::start_thread
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread::new::thread_start
             at src/libstd/sys/unix/thread.rs:79
  76: start_thread
  77: clone


OutPoint }
2019-10-15 11:49:54.408 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xcfb64326fb6bd8f244e0370f350786ce932deb97d829f176687f215e487e7f0d)
2019-10-15 11:49:54.425 +08:00 http.worker3 DEBUG ckb-rpc  [] submit block
2019-10-15 11:49:54.430 +08:00 ChainService INFO ckb-chain  block: 14, hash: Byte32(0x8678fd4c3802753bc6644899f6d6d78248c1011f2efb60ce3e029e6979d2a6e4), total_diff: 0xf00, txs: 1
2019-10-15 11:49:54.431 +08:00 http.worker3 DEBUG ckb-rpc  [block_relay] announce new block 14 Byte32(0x8678fd4c3802753bc6644899f6d6d78248c1011f2efb60ce3e029e6979d2a6e4) 1571111394431
2019-10-15 11:49:54.448 +08:00 GlobalRuntime-2 INFO ckb-tx-pool  [get_block_template] candidate txs count: 6, size: 1452/2157853, cycles:3222/10000000000
2019-10-15 11:49:54.488 +08:00 http.worker3 DEBUG ckb-rpc  [] submit block
2019-10-15 11:49:54.517 +08:00 ChainService INFO ckb-chain  [block_verifier] block number: 15, hash: Byte32(0xe7085b46f48cef40cab4b8eb1e0397546287f01838986e4ce18460324778bf02), size:1974/2158375, cycles: 3222/10000000000
2019-10-15 11:49:54.518 +08:00 ChainService INFO ckb-chain  block: 15, hash: Byte32(0xe7085b46f48cef40cab4b8eb1e0397546287f01838986e4ce18460324778bf02), total_diff: 0x1000, txs: 7
2019-10-15 11:49:54.520 +08:00 http.worker3 DEBUG ckb-rpc  [block_relay] announce new block 15 Byte32(0xe7085b46f48cef40cab4b8eb1e0397546287f01838986e4ce18460324778bf02) 1571111394520

```
What happened here? There are 6 transactions, tx1 -> tx2 -> tx3 -> tx4 -> tx5 -> tx6, `->` means that the before tx is the parent of the after one.

When we get transactions by `sorted_keys`, the return is that `[tx1, tx6, tx5, tx4, tx3, tx2]`.

At here https://github.com/nervosnetwork/ckb/blob/develop/tx-pool/src/process/chain_reorg.rs#L128, 
https://github.com/nervosnetwork/ckb/blob/develop/tx-pool/src/process/chain_reorg.rs#L197

These transactions are added to `gap`, but because some transactions can not be resolved, they are added to `orphan`. So after https://github.com/nervosnetwork/ckb/blob/develop/test/src/specs/indexer/basic.rs#L62-L70, there are 2 transactions in `gap`, 4 transactions in `orphan`.

When proposing stage https://github.com/nervosnetwork/ckb/blob/develop/tx-pool/src/process/chain_reorg.rs#L180, it will check the orphan again. 

<b>The whole process is weird and complicated. I think all the transactions should be in `gap` or we should put the transactions in `orphan` at firstly.</b>

At firstly I tried to fix it by modifying this part of code `https://github.com/nervosnetwork/ckb/blob/develop/tx-pool/src/process/chain_reorg.rs#L145-L162`, but after that, I found that https://github.com/nervosnetwork/ckb/blob/develop/tx-pool/src/process/chain_reorg.rs#L128-L138 had the same problem, so I gave up this way, I think the `sorted_keys` should return the ordered keys by transaction relation. 

After this PR, the log is this

```
2019-10-15 14:06:47.718 +08:00 ChainService INFO ckb-chain  block: 13, hash: Byte32(0x59cdd19f33d015c3b3cf0cd4f92e97712d926f112e9d653c65a090089aa841a1), total_diff: 0xe00, txs: 1
2019-10-15 14:06:47.719 +08:00 http.worker0 DEBUG ckb-rpc  [block_relay] announce new block 13 Byte32(0x59cdd19f33d015c3b3cf0cd4f92e97712d926f112e9d653c65a090089aa841a1) 1571119607719
2019-10-15 14:06:47.720 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x569c112c72a1248a12ece2bd1c1fbdd793d9b4ea698b93c60af21fe45efd9f42)
2019-10-15 14:06:47.721 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xcfb64326fb6bd8f244e0370f350786ce932deb97d829f176687f215e487e7f0d)
2019-10-15 14:06:47.722 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xd7e002e771e6e71f2bb82f5dea563c88b87bf0a42855e92b05619186e7b59aaf)
2019-10-15 14:06:47.723 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0xe8886863772aee87460dbfff3ddbb06adcc4c7286492b49a13bcc82ec667bf78)
2019-10-15 14:06:47.723 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x932358f16963610f3cd38fda5ed55c85b1aca0c37faeecece79fec1471b10137)
2019-10-15 14:06:47.724 +08:00 GlobalRuntime-1 DEBUG ckb-tx-pool  tx proposed, add to gap Byte32(0x2ab01fcf0ab6fa29d8ce39f61285002ec69d30d70257aac9e0b216b856642b35)
2019-10-15 14:06:47.738 +08:00 http.worker0 DEBUG ckb-rpc  [] submit block
2019-10-15 14:06:47.742 +08:00 ChainService INFO ckb-chain  block: 14, hash: Byte32(0x2c4e70c19979bc532abaf6b145a0305501fae885c9ffe37485e31325f36381a2), total_diff: 0xf00, txs: 1
2019-10-15 14:06:47.742 +08:00 http.worker0 DEBUG ckb-rpc  [block_relay] announce new block 14 Byte32(0x2c4e70c19979bc532abaf6b145a0305501fae885c9ffe37485e31325f36381a2) 1571119607742
2019-10-15 14:06:47.754 +08:00 GlobalRuntime-2 INFO ckb-tx-pool  [get_block_template] candidate txs count: 6, size: 1452/2157853, cycles:3222/10000000000
2019-10-15 14:06:47.769 +08:00 http.worker0 DEBUG ckb-rpc  [] submit block
2019-10-15 14:06:47.781 +08:00 ChainService INFO ckb-chain  [block_verifier] block number: 15, hash: Byte32(0xc73b430bcf9dac68077d860a582e0728fe60fa7ebb732856e6a02eb3a3a285fc), size:1974/2158375, cycles: 3222/10000000000
2019-10-15 14:06:47.782 +08:00 ChainService INFO ckb-chain  block: 15, hash: Byte32(0xc73b430bcf9dac68077d860a582e0728fe60fa7ebb732856e6a02eb3a3a285fc), total_diff: 0x1000, txs: 7
2019-10-15 14:06:47.782 +08:00 http.worker0 DEBUG ckb-rpc  [block_relay] announce new block 15 Byte32(0xc73b430bcf9dac68077d860a582e0728fe60fa7ebb732856e6a02eb3a3a285fc) 1571119607782
2019-10-15 14:06:48.082 +08:00 NetworkRuntime-7 DEBUG ckb-sync  no peers connected
```

Because of the `sorted_keys` returned the ordered transactions, the transactions will add to `gap` instead of `orphan`.