### PR TITLE
[HOLD] test: Add cases of tx_hash collision

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -297,6 +297,9 @@ fn all_specs() -> SpecMap {
         Box::new(ProposeTransactionButParentNot),
         Box::new(ProposalExpireRuleForCommittingAndExpiredAtOneTime),
         Box::new(ReorgHandleProposals),
+        // Box::new(TransactionHashCollisionDifferentWitnessHashes1),
+        // Box::new(TransactionHashCollisionDifferentWitnessHashes2),
+        // Box::new(TransactionHashCollisionDifferentWitnessHashes3),
     ];
     specs.into_iter().map(|spec| (spec.name(), spec)).collect()
 }

--- a/test/src/specs/tx_pool/collision.rs
+++ b/test/src/specs/tx_pool/collision.rs
@@ -1,0 +1,105 @@
+use crate::utils::{blank, commit, propose};
+use crate::{Net, Node, Spec};
+use ckb_types::core::TransactionView;
+
+// Convention:
+//   * `tx1` and `tx2` are cousin transactions, with the same transaction content, expect the
+//   witnesses. Hence `tx1` and `tx2` have the same tx_hash/proposal-id but different witness_hash.
+
+pub struct TransactionHashCollisionDifferentWitnessHashes1;
+
+impl Spec for TransactionHashCollisionDifferentWitnessHashes1 {
+    crate::name!("transaction_hash_collision_different_witness_hashes_1");
+
+    // Case: `tx1` and `tx2` have the same tx_hash, but different witness_hash. We submit them two
+    // into txpool, and then try to propose/commit `tx1`.
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        let window = node.consensus().tx_proposal_window();
+        let (tx1, tx2) = cousin_txs_with_same_hash_different_witness_hash(node);
+
+        // Prepare Phase: Send both `tx1` and `tx2` into pool
+        node.submit_transaction(&tx1);
+        node.submit_transaction(&tx2);
+
+        // Commit Phase: Commit `tx1`. It should be ok.
+        node.submit_block(&propose(node, &[&tx1]));
+        (0..=window.closest()).for_each(|_| {
+            node.submit_block(&blank(node));
+        });
+        node.submit_block(&commit(node, &[&tx1]));
+    }
+}
+
+pub struct TransactionHashCollisionDifferentWitnessHashes2;
+
+impl Spec for TransactionHashCollisionDifferentWitnessHashes2 {
+    crate::name!("transaction_hash_collision_different_witness_hashes_2");
+
+    // Case: The difference to TransactionHashCollisionDifferentWitnessHashes1 is that at the
+    // prepare phase, this case only puts `tx1` into the txpool, but the former puts both `tx1`
+    // and `tx2` into the txpool.
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        let window = node.consensus().tx_proposal_window();
+        let (tx1, tx2) = cousin_txs_with_same_hash_different_witness_hash(node);
+
+        // Prepare Phase: Only send `tx1` into the pool, not `tx2`.
+        node.submit_transaction(&tx1);
+
+        // Commit Phase: Commit `tx2`. It should be ok.
+        node.submit_block(&propose(node, &[&tx1]));
+        (0..=window.closest()).for_each(|_| {
+            node.submit_block(&blank(node));
+        });
+        node.submit_block(&commit(node, &[&tx2]));
+    }
+}
+
+pub struct TransactionHashCollisionDifferentWitnessHashes3;
+
+impl Spec for TransactionHashCollisionDifferentWitnessHashes3 {
+    crate::name!("transaction_hash_collision_different_witness_hashes_3");
+
+    // Case: The difference to TransactionHashCollisionDifferentWitnessHashes1 is that at the
+    // commit phase, this case tries to commit both `tx1` and `tx2`, which is expected to be failed
+    // as double spending.
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        let window = node.consensus().tx_proposal_window();
+        let (tx1, tx2) = cousin_txs_with_same_hash_different_witness_hash(node);
+
+        // Prepare Phase: Send both `tx1` and `tx2` into pool
+        node.submit_transaction(&tx1);
+        node.submit_transaction(&tx2);
+
+        // Commit Phase: Commit both `tx1` and `tx2`. It should be failed as double spending.
+        node.submit_block(&propose(node, &[&tx1]));
+        (0..=window.closest()).for_each(|_| {
+            node.submit_block(&blank(node));
+        });
+        let ret = node
+            .rpc_client()
+            .submit_block("".to_string(), commit(node, &[&tx1, &tx2]).data().into());
+        assert!(ret.is_err(), "{:?}", ret);
+    }
+}
+
+fn cousin_txs_with_same_hash_different_witness_hash(
+    node: &Node,
+) -> (TransactionView, TransactionView) {
+    let window = node.consensus().tx_proposal_window();
+    let start_issue = window.farthest() + 2;
+    node.generate_blocks((start_issue.saturating_sub(node.get_tip_block_number())) as usize);
+
+    let tx1 = node.new_transaction_spend_tip_cellbase();
+    let tx2 = tx1
+        .as_advanced_builder()
+        .witness(Default::default())
+        .build();
+    assert_eq!(tx1.hash(), tx2.hash());
+    assert_eq!(tx1.proposal_short_id(), tx2.proposal_short_id());
+    assert_ne!(tx1.witness_hash(), tx2.witness_hash());
+
+    (tx1, tx2)
+}

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -1,4 +1,5 @@
 mod cellbase_maturity;
+mod collision;
 mod depend_tx_in_same_block;
 mod descendant;
 mod different_txs_with_same_input;
@@ -14,6 +15,7 @@ mod utils;
 mod valid_since;
 
 pub use cellbase_maturity::*;
+pub use collision::*;
 pub use depend_tx_in_same_block::*;
 pub use descendant::*;
 pub use different_txs_with_same_input::*;


### PR DESCRIPTION
Add some test-cases about tx_hash collision.

There are some bugs in txpool, to make the added cases fail to run. But I did not fix that, just comment on the cases.