### PR TITLE
feat: Upgrade CKB VM to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
  "ckb-store 0.23.0-pre",
  "ckb-test-chain-utils 0.23.0-pre",
  "ckb-types 0.23.0-pre",
- "ckb-vm 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1102,13 +1102,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1116,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1391,6 +1392,19 @@ dependencies = [
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4000,8 +4014,8 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum ckb-system-scripts 0.4.0-alpha.9+expand-nonce (registry+https://github.com/rust-lang/crates.io-index)" = "d02e7a324dacab78847f233e813f22871710fc254ce325dc00e68b9202f5a1f3"
-"checksum ckb-vm 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b95ed9373dd7af32ec8c7d450b5fd5d1b4c7f1ce49ba1bf0f59956b00d588224"
-"checksum ckb-vm-definitions 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55c0c2211e4174e54d5e73a353cd8834c5cd2395dfaeb6b88f05ab435b5a761b"
+"checksum ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "410eca836e677ea70f73358b53220c284836c3cbb3ecf9ee531606d926881f59"
+"checksum ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "201ab0ce4cf5644b3f0cacc9d772011f66c132d5e62ab35918413d9a6c29e6a7"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
@@ -4029,6 +4043,7 @@ dependencies = [
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
+"checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -17,7 +17,7 @@ ckb-script-data-loader = { path = "data-loader" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.17.0", features = ["detect-asm"] }
+ckb-vm = { version = "0.18.0", features = ["detect-asm"] }
 faster-hex = "0.4"
 ckb-logger = { path = "../util/logger", optional = true }
 serde = "1.0"


### PR DESCRIPTION
See https://github.com/nervosnetwork/ckb-vm/releases/tag/0.18.0 for
changes in CKB VM 0.18.0