### PR TITLE
fix: Exclude primary/secondary issuance in genesis

### DIFF
--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -2,7 +2,7 @@
 
 # Spec: ckb_dev
 [ckb_dev]
-genesis = "0x9f17ada92decba53848e632f32bbc7fdddb8ca532cd48d5ae9ca49d8a7307b71"
+genesis = "0xcc9cc2e150224f74446573501a5f8197fd63e122928cd03f5fc74d1b6bda20f3"
 cellbase = "0xdf8526546bc039d307fc8fb0c18a70bbc6d7a1e94dd15e88bd0bc38433925551"
 
 [[ckb_dev.system_cells]]
@@ -33,7 +33,7 @@ index = 0
 
 # Spec: ckb_testnet
 [ckb_testnet]
-genesis = "0xbb4c6f6c9bfa834662f10d665e5f6f55bba767c02e305432660e59bc104eeddb"
+genesis = "0xd2a1844d87d509916346814c9958e3395349fe4b125cce1dee9783ae545c14ee"
 cellbase = "0xeefe2df83363193ac01fecabee0013d01f710a1124a1768e39a11788943fc7db"
 
 [[ckb_testnet.system_cells]]
@@ -64,7 +64,7 @@ index = 0
 
 # Spec: ckb_staging
 [ckb_staging]
-genesis = "0x0129da1ab40a99efa02720aef90b68517054c163af8f3f7778388cdd7eca8f19"
+genesis = "0x34fffe0510997101ee4282f3674c4cb359cb9775098b7305529d3ae8e4b33f88"
 cellbase = "0x751eceb40a755e60db06b446a2bbfb9e8576947333d1f5075caf5018a61666c0"
 
 [[ckb_staging.system_cells]]

--- a/resource/specs/testnet.toml
+++ b/resource/specs/testnet.toml
@@ -8,7 +8,7 @@ compact_target = 0x1c00e904
 uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 nonce = "0x0"
 # run `cargo run cli hashes -b` to get the genesis hash
-hash = "0xbb4c6f6c9bfa834662f10d665e5f6f55bba767c02e305432660e59bc104eeddb"
+hash = "0xd2a1844d87d509916346814c9958e3395349fe4b125cce1dee9783ae545c14ee"
 
 [genesis.genesis_cell]
 message = "rylai-v11 9d812af5 chore: update system script <zhangsoledad 2019-09-27 21:22:02 +0800>"

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -175,9 +175,17 @@ pub fn build_genesis_dao_data(
     txs: Vec<&TransactionView>,
     satoshi_pubkey_hash: &H160,
     satoshi_cell_occupied_ratio: Ratio,
+    genesis_primary_issuance: Capacity,
+    genesis_secondary_issuance: Capacity,
 ) -> Byte32 {
-    genesis_dao_data_with_satoshi_gift(txs, satoshi_pubkey_hash, satoshi_cell_occupied_ratio)
-        .expect("genesis dao data calculation error!")
+    genesis_dao_data_with_satoshi_gift(
+        txs,
+        satoshi_pubkey_hash,
+        satoshi_cell_occupied_ratio,
+        genesis_primary_issuance,
+        genesis_secondary_issuance,
+    )
+    .expect("genesis dao data calculation error!")
 }
 
 impl ConsensusBuilder {

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -239,10 +239,30 @@ impl ChainSpec {
         let cellbase_transaction = self.build_cellbase_transaction()?;
         // build transaction other than cellbase should return inputs for dao statistics
         let dep_group_transaction = self.build_dep_group_transaction(&cellbase_transaction)?;
+
+        let initial_primary_epoch_reward = self.params.initial_primary_epoch_reward.as_u64();
+        let secondary_epoch_reward = self.params.secondary_epoch_reward.as_u64();
+        let genesis_epoch_length = self.params.genesis_epoch_length;
+        let genesis_primary_issuance = Capacity::shannons({
+            if initial_primary_epoch_reward % genesis_epoch_length != 0 {
+                initial_primary_epoch_reward / genesis_epoch_length + 1
+            } else {
+                initial_primary_epoch_reward / genesis_epoch_length
+            }
+        });
+        let genesis_secondary_issuance = Capacity::shannons({
+            if secondary_epoch_reward % genesis_epoch_length != 0 {
+                secondary_epoch_reward / genesis_epoch_length + 1
+            } else {
+                secondary_epoch_reward / genesis_epoch_length
+            }
+        });
         let dao = build_genesis_dao_data(
             vec![&cellbase_transaction, &dep_group_transaction],
             &self.genesis.satoshi_gift.satoshi_pubkey_hash,
             self.genesis.satoshi_gift.satoshi_cell_occupied_ratio,
+            genesis_primary_issuance,
+            genesis_secondary_issuance,
         );
 
         let block = BlockBuilder::default()

--- a/util/dao/utils/src/lib.rs
+++ b/util/dao/utils/src/lib.rs
@@ -18,8 +18,9 @@ pub use crate::error::DaoError;
 // This is multiplied by 10**16 to make sure we have enough precision.
 pub const DEFAULT_ACCUMULATED_RATE: u64 = 10_000_000_000_000_000;
 
+// Used for testing only
 pub fn genesis_dao_data(txs: Vec<&TransactionView>) -> Result<Byte32, Error> {
-    _genesis_dao_data_with_satoshi_gift(
+    genesis_dao_data_with_satoshi_gift(
         txs,
         &H160([0u8; 20]),
         Ratio(1, 1),
@@ -29,20 +30,6 @@ pub fn genesis_dao_data(txs: Vec<&TransactionView>) -> Result<Byte32, Error> {
 }
 
 pub fn genesis_dao_data_with_satoshi_gift(
-    txs: Vec<&TransactionView>,
-    satoshi_pubkey_hash: &H160,
-    satoshi_cell_occupied_ratio: Ratio,
-) -> Result<Byte32, Error> {
-    _genesis_dao_data_with_satoshi_gift(
-        txs,
-        satoshi_pubkey_hash,
-        satoshi_cell_occupied_ratio,
-        Capacity::zero(),
-        Capacity::zero(),
-    )
-}
-
-fn _genesis_dao_data_with_satoshi_gift(
     txs: Vec<&TransactionView>,
     satoshi_pubkey_hash: &H160,
     satoshi_cell_occupied_ratio: Ratio,


### PR DESCRIPTION
Genesis block should have `primary_block_reward` and `secondary_block_reward`, as it is the first block of the first epoch.