### PR TITLE
fix: fix benchmark overflow

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -98,15 +98,15 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": {
         "compact_target": "0x1e083126",
-        "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+        "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
         "epoch": "0x7080018000001",
-        "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+        "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
-        "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+        "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0x0"
     }
@@ -210,7 +210,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+    "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
 }
 ```
 
@@ -230,7 +230,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_block",
     "params": [
-        "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+        "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     ]
 }' \
 | tr -d '\n' \
@@ -245,15 +245,15 @@ http://localhost:8114
     "result": {
         "header": {
             "compact_target": "0x1e083126",
-            "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+            "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
             "epoch": "0x7080018000001",
-            "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+            "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
-            "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+            "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0x0"
         },
@@ -261,7 +261,7 @@ http://localhost:8114
         "transactions": [
             {
                 "cell_deps": [],
-                "hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3",
+                "hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17",
                 "header_deps": [],
                 "inputs": [
                     {
@@ -274,7 +274,7 @@ http://localhost:8114
                 ],
                 "outputs": [
                     {
-                        "capacity": "0x18ef9705d5",
+                        "capacity": "0x18e64b61cf",
                         "lock": {
                             "args": "0x",
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -310,7 +310,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_header",
     "params": [
-        "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+        "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     ]
 }' \
 | tr -d '\n' \
@@ -324,15 +324,15 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": {
         "compact_target": "0x1e083126",
-        "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+        "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
         "epoch": "0x7080018000001",
-        "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+        "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
-        "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+        "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0x0"
     }
@@ -366,15 +366,15 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": {
         "compact_target": "0x1e083126",
-        "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+        "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
         "epoch": "0x7080018000001",
-        "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "nonce": "0x0",
         "number": "0x400",
-        "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+        "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
         "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "timestamp": "0x5cd2b117",
-        "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+        "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
         "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "version": "0x0"
     }
@@ -415,8 +415,8 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0xb5703168925268fd7ed0712df05418a83344dbdca9fa2b0363d4e79d841421ae",
-            "capacity": "0x2effd6e712",
+            "block_hash": "0xf293d02ce5e101b160912aaf15b1b87517b7a6d572c13af9ae4101c1143b22ad",
+            "capacity": "0x2ca86f2642",
             "lock": {
                 "args": "0x",
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -424,12 +424,12 @@ http://localhost:8114
             },
             "out_point": {
                 "index": "0x0",
-                "tx_hash": "0x15fd1dcf2763f360085a62dcbb4292057bc04931b16a413d0b6a4b932caf44af"
+                "tx_hash": "0xa510932a80fda15a774203404453c5f9c0e8582f11c40f8ce5396f2460f8ccbf"
             }
         },
         {
-            "block_hash": "0x9c7ca2051e1d2ee2cf40740ac62500131830d064ab339fede3aba06d02521d41",
-            "capacity": "0x2dc7e15ccc",
+            "block_hash": "0x63b872c02b1c2bd0c1af4f73f68ac04e2a3763a71f9656a823848d346619ffde",
+            "capacity": "0x2ca86e3dd4",
             "lock": {
                 "args": "0x",
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -437,12 +437,12 @@ http://localhost:8114
             },
             "out_point": {
                 "index": "0x0",
-                "tx_hash": "0xce4ec7bc6b3ee0533fd38f675926446df4f65d68cb03095d1470446383dbe09b"
+                "tx_hash": "0x0b0fb337a9168132d3771f07e0ba055419c7e8f7bc2681a9eb445e61f44e1eb9"
             }
         },
         {
-            "block_hash": "0x809dc37198dcf7d5cb5201d24cfed2d682f890ce110b6e8d9c315813ace39867",
-            "capacity": "0x2d6528a22b",
+            "block_hash": "0x6bbdd9dc71784d500daadf391ca9035900b3ff18ed868d7d4fe4b17fdea88853",
+            "capacity": "0x2ca86d5691",
             "lock": {
                 "args": "0x",
                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -450,7 +450,7 @@ http://localhost:8114
             },
             "out_point": {
                 "index": "0x0",
-                "tx_hash": "0xfc2b1923996ac950ded04a28ea772be6dea37b98c01563019e9928766f3f2f7d"
+                "tx_hash": "0xc336a23a785f3fec8b6e29e2c00d23483f1c6ad410b6b9fc0f62baf65d5efcc7"
             }
         }
     ]
@@ -527,7 +527,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_transaction",
     "params": [
-        "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777"
+        "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
     ]
 }' \
 | tr -d '\n' \
@@ -550,15 +550,15 @@ http://localhost:8114
                     }
                 }
             ],
-            "hash": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777",
+            "hash": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
             "header_deps": [
-                "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0x0",
-                        "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                        "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                     },
                     "since": "0x0"
                 }
@@ -604,7 +604,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "get_cellbase_output_capacity_details",
     "params": [
-        "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+        "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     ]
 }' \
 | tr -d '\n' \
@@ -619,8 +619,8 @@ http://localhost:8114
     "result": {
         "primary": "0x18ce922bca",
         "proposal_reward": "0x0",
-        "secondary": "0x2104da0b",
-        "total": "0x18ef9705d5",
+        "secondary": "0x17b93605",
+        "total": "0x18e64b61cf",
         "tx_fee": "0x0"
     }
 }
@@ -657,15 +657,15 @@ http://localhost:8114
     "result": {
         "header": {
             "compact_target": "0x1e083126",
-            "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+            "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
             "epoch": "0x7080018000001",
-            "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+            "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
-            "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+            "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0x0"
         },
@@ -673,7 +673,7 @@ http://localhost:8114
         "transactions": [
             {
                 "cell_deps": [],
-                "hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3",
+                "hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17",
                 "header_deps": [],
                 "inputs": [
                     {
@@ -686,7 +686,7 @@ http://localhost:8114
                 ],
                 "outputs": [
                     {
-                        "capacity": "0x18ef9705d5",
+                        "capacity": "0x18e64b61cf",
                         "lock": {
                             "args": "0x",
                             "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -739,13 +739,13 @@ echo '{
                 }
             ],
             "header_deps": [
-                "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0x0",
-                        "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                        "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                     },
                     "since": "0x0"
                 }
@@ -819,13 +819,13 @@ echo '{
                 }
             ],
             "header_deps": [
-                "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0x0",
-                        "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                        "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                     },
                     "since": "0x0"
                 }
@@ -858,7 +858,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777"
+    "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
 }
 ```
 
@@ -883,7 +883,7 @@ echo '{
             "index": "0x0",
             "tx_hash": "0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3"
         },
-        "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+        "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     ]
 }' \
 | tr -d '\n' \
@@ -1007,7 +1007,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
-        "block_hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "block_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "block_number": "0x400",
         "lock_hash": "0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412"
     }
@@ -1039,7 +1039,7 @@ http://localhost:8114
     "jsonrpc": "2.0",
     "result": [
         {
-            "block_hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "block_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "block_number": "0x400",
             "lock_hash": "0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412"
         }
@@ -1083,7 +1083,7 @@ http://localhost:8114
     "result": [
         {
             "cell_output": {
-                "capacity": "0x2ce1348802",
+                "capacity": "0x2cb6562e4e",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1094,12 +1094,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x98",
                 "index": "0x0",
-                "tx_hash": "0x72bc04abf9021fdce48ceb0f6bf93444838d99c3e330fd6bbfcaa4a86ed51590"
+                "tx_hash": "0x2d811f9ad7f2f7319171a6da4c842dd78e36682b4ac74da4f67b97c9f7d7a02b"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce136743b",
+                "capacity": "0x2cb66b2496",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1110,12 +1110,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x99",
                 "index": "0x0",
-                "tx_hash": "0x5a47b2f04cbf272ead42ad2d532b6df85d0aa7684d25fcc9eacda94187952373"
+                "tx_hash": "0x1ccf68bf7cb96a1a7f992c27bcfea6ebfc0fe32602196569aaa0cb3cd3e9f5ea"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce1385991",
+                "capacity": "0x2cb68006e8",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1126,12 +1126,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9a",
                 "index": "0x0",
-                "tx_hash": "0x9266ea43874f058c1d1fbf3236859c59b4d775d84ecf35fc333a4bb9a9dd7b97"
+                "tx_hash": "0x74db38ad40184dd0528f4841e10599ff97bfbf2b5313754d1e96920d8523a5d4"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce13a3829",
+                "capacity": "0x2cb694d55e",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1142,12 +1142,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9b",
                 "index": "0x0",
-                "tx_hash": "0x114600c93152c671de234f5746f388ba758ba24238b3181e60dd2db9af5a62d8"
+                "tx_hash": "0xf7d0ecc70015b46c5ab1cc8462592ae612fdaada200f643f3e1ce633bcc5ad1d"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce13c1025",
+                "capacity": "0x2cb6a99016",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1158,12 +1158,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9c",
                 "index": "0x0",
-                "tx_hash": "0x0ad7933beaa38c2407e16f51c7902d07671212212f6fdce5ef561e980f92a2d1"
+                "tx_hash": "0xc3d232bb6b0e5d9a71a0978c9ab66c7a127ed37aeed6a2509dcc10d994c8c605"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce13de1aa",
+                "capacity": "0x2cb6be372c",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1174,12 +1174,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9d",
                 "index": "0x0",
-                "tx_hash": "0x12cbed669294d3cdb156d2a35f1d2452eeac8c25dd35313fcc750eb7cfedaf0f"
+                "tx_hash": "0x10139a08beae170a35fbfcece6d50561ec61e13e4c6438435c1f2021331d7c4d"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce13facd9",
+                "capacity": "0x2cb6d2cabb",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1190,12 +1190,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9e",
                 "index": "0x0",
-                "tx_hash": "0xa08caa51ead4828887ce79d9118d3aeb741042e0cebb78ac3c1955fc747dcbec"
+                "tx_hash": "0x39a083a1deb39b923a600a6f0714663085b5d2011b886b160962e20f1a28b550"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce14171d2",
+                "capacity": "0x2cb6e74ae0",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1206,12 +1206,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9f",
                 "index": "0x0",
-                "tx_hash": "0x30f0a82c5feef900a7ed6d59d48202996de500994ed2bdca42a46c8269bb59d4"
+                "tx_hash": "0x2899c066f80a04b9a168e4499760ad1d768f44a3d673779905d88edd86362ac6"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce14330b6",
+                "capacity": "0x2cb6fbb7b4",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1222,12 +1222,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa0",
                 "index": "0x0",
-                "tx_hash": "0xf259b6995e443fd0815cc76b328dab1bf2e1c72feaa493320e93a56a71c4f67b"
+                "tx_hash": "0xe2579280875a5d14538b0cc2356707792189662d5f8292541d9856ef291e81bf"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce144e9a4",
+                "capacity": "0x2cb7101155",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1238,12 +1238,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa1",
                 "index": "0x0",
-                "tx_hash": "0x612f4431167a721296a84df0d516451d1897b98cd388956b37b7ea428b5c689b"
+                "tx_hash": "0xd6121e80237c79182d55ec0efb9fa75bc9cc592f818057ced51aac6bb625e016"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce1469cba",
+                "capacity": "0x2cb72457dc",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1254,12 +1254,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa2",
                 "index": "0x0",
-                "tx_hash": "0x5eb991401219da842a67c770fba18782e5ea1965a31da53e5a70f06510038c31"
+                "tx_hash": "0x624eba1135e54a5988cb2ec70d42fa860d1d5658ed7f8d402615dff7d598e4b6"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce1484a15",
+                "capacity": "0x2cb7388b65",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1270,12 +1270,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa3",
                 "index": "0x0",
-                "tx_hash": "0x2cd590f35a8252eef8e07e10e6f8be8318e68a113940a96fea77f943539c0635"
+                "tx_hash": "0x7884b4cf85bc02cb73ec41d5cbbbf158eebca6ef855419ce57ff7c1d97b5be58"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce149f1d4",
+                "capacity": "0x2cb74cac0a",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1286,12 +1286,12 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa4",
                 "index": "0x0",
-                "tx_hash": "0x247d3b0881fd8e3f9b89c6bcecbee770c5ecbdc8c1ee2efeed5d86c99cb90874"
+                "tx_hash": "0xb613ba9b5f6177657493492dd523a63720d855ae9749887a0de881b894a1d6a6"
             }
         },
         {
             "cell_output": {
-                "capacity": "0x2ce14b9410",
+                "capacity": "0x2cb760b9e6",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1302,7 +1302,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa5",
                 "index": "0x0",
-                "tx_hash": "0xe3f2faf34c82746ef0ba7aab3a960dc4816ec8bd3f6b20fdf20fc618bc04f01b"
+                "tx_hash": "0x701f4b962c1650810800ee6ed981841692c1939a4b597e9e7a726c5db77f6164"
             }
         }
     ]
@@ -1348,7 +1348,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x98",
                 "index": "0x0",
-                "tx_hash": "0x72bc04abf9021fdce48ceb0f6bf93444838d99c3e330fd6bbfcaa4a86ed51590"
+                "tx_hash": "0x2d811f9ad7f2f7319171a6da4c842dd78e36682b4ac74da4f67b97c9f7d7a02b"
             }
         },
         {
@@ -1356,7 +1356,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x99",
                 "index": "0x0",
-                "tx_hash": "0x5a47b2f04cbf272ead42ad2d532b6df85d0aa7684d25fcc9eacda94187952373"
+                "tx_hash": "0x1ccf68bf7cb96a1a7f992c27bcfea6ebfc0fe32602196569aaa0cb3cd3e9f5ea"
             }
         },
         {
@@ -1364,7 +1364,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9a",
                 "index": "0x0",
-                "tx_hash": "0x9266ea43874f058c1d1fbf3236859c59b4d775d84ecf35fc333a4bb9a9dd7b97"
+                "tx_hash": "0x74db38ad40184dd0528f4841e10599ff97bfbf2b5313754d1e96920d8523a5d4"
             }
         },
         {
@@ -1372,7 +1372,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9b",
                 "index": "0x0",
-                "tx_hash": "0x114600c93152c671de234f5746f388ba758ba24238b3181e60dd2db9af5a62d8"
+                "tx_hash": "0xf7d0ecc70015b46c5ab1cc8462592ae612fdaada200f643f3e1ce633bcc5ad1d"
             }
         },
         {
@@ -1380,7 +1380,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9c",
                 "index": "0x0",
-                "tx_hash": "0x0ad7933beaa38c2407e16f51c7902d07671212212f6fdce5ef561e980f92a2d1"
+                "tx_hash": "0xc3d232bb6b0e5d9a71a0978c9ab66c7a127ed37aeed6a2509dcc10d994c8c605"
             }
         },
         {
@@ -1388,7 +1388,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9d",
                 "index": "0x0",
-                "tx_hash": "0x12cbed669294d3cdb156d2a35f1d2452eeac8c25dd35313fcc750eb7cfedaf0f"
+                "tx_hash": "0x10139a08beae170a35fbfcece6d50561ec61e13e4c6438435c1f2021331d7c4d"
             }
         },
         {
@@ -1396,7 +1396,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9e",
                 "index": "0x0",
-                "tx_hash": "0xa08caa51ead4828887ce79d9118d3aeb741042e0cebb78ac3c1955fc747dcbec"
+                "tx_hash": "0x39a083a1deb39b923a600a6f0714663085b5d2011b886b160962e20f1a28b550"
             }
         },
         {
@@ -1404,7 +1404,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0x9f",
                 "index": "0x0",
-                "tx_hash": "0x30f0a82c5feef900a7ed6d59d48202996de500994ed2bdca42a46c8269bb59d4"
+                "tx_hash": "0x2899c066f80a04b9a168e4499760ad1d768f44a3d673779905d88edd86362ac6"
             }
         },
         {
@@ -1412,7 +1412,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa0",
                 "index": "0x0",
-                "tx_hash": "0xf259b6995e443fd0815cc76b328dab1bf2e1c72feaa493320e93a56a71c4f67b"
+                "tx_hash": "0xe2579280875a5d14538b0cc2356707792189662d5f8292541d9856ef291e81bf"
             }
         },
         {
@@ -1420,7 +1420,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa1",
                 "index": "0x0",
-                "tx_hash": "0x612f4431167a721296a84df0d516451d1897b98cd388956b37b7ea428b5c689b"
+                "tx_hash": "0xd6121e80237c79182d55ec0efb9fa75bc9cc592f818057ced51aac6bb625e016"
             }
         },
         {
@@ -1428,7 +1428,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa2",
                 "index": "0x0",
-                "tx_hash": "0x5eb991401219da842a67c770fba18782e5ea1965a31da53e5a70f06510038c31"
+                "tx_hash": "0x624eba1135e54a5988cb2ec70d42fa860d1d5658ed7f8d402615dff7d598e4b6"
             }
         },
         {
@@ -1436,7 +1436,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa3",
                 "index": "0x0",
-                "tx_hash": "0x2cd590f35a8252eef8e07e10e6f8be8318e68a113940a96fea77f943539c0635"
+                "tx_hash": "0x7884b4cf85bc02cb73ec41d5cbbbf158eebca6ef855419ce57ff7c1d97b5be58"
             }
         },
         {
@@ -1444,7 +1444,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa4",
                 "index": "0x0",
-                "tx_hash": "0x247d3b0881fd8e3f9b89c6bcecbee770c5ecbdc8c1ee2efeed5d86c99cb90874"
+                "tx_hash": "0xb613ba9b5f6177657493492dd523a63720d855ae9749887a0de881b894a1d6a6"
             }
         },
         {
@@ -1452,7 +1452,7 @@ http://localhost:8114
             "created_by": {
                 "block_number": "0xa5",
                 "index": "0x0",
-                "tx_hash": "0xe3f2faf34c82746ef0ba7aab3a960dc4816ec8bd3f6b20fdf20fc618bc04f01b"
+                "tx_hash": "0x701f4b962c1650810800ee6ed981841692c1939a4b597e9e7a726c5db77f6164"
             }
         }
     ]
@@ -1607,14 +1607,14 @@ echo '{
         {
             "header": {
                 "compact_target": "0x1e083126",
-                "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+                "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
                 "epoch": "0x7080018000001",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+                "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
-                "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+                "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0x0"
             },
@@ -1634,7 +1634,7 @@ echo '{
                     ],
                     "outputs": [
                         {
-                            "capacity": "0x18ef9705d5",
+                            "capacity": "0x18e64b61cf",
                             "lock": {
                                 "args": "0x",
                                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1665,7 +1665,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+    "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
 }
 ```
 
@@ -1878,13 +1878,13 @@ echo '{
                 }
             ],
             "header_deps": [
-                "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
             ],
             "inputs": [
                 {
                     "previous_output": {
                         "index": "0x0",
-                        "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                        "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                     },
                     "since": "0x0"
                 }
@@ -1917,7 +1917,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777"
+    "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
 }
 ```
 

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -13,15 +13,15 @@
         "params": [],
         "result": {
             "compact_target": "0x1e083126",
-            "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+            "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
             "epoch": "0x7080018000001",
-            "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+            "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
-            "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+            "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0x0"
         }
@@ -64,7 +64,7 @@
         "params": [
             "0x400"
         ],
-        "result": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "types": [
             {
                 "block_number": "Number of a block"
@@ -76,20 +76,20 @@
         "method": "get_block",
         "module": "chain",
         "params": [
-            "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+            "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
         ],
         "result": {
             "header": {
                 "compact_target": "0x1e083126",
-                "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+                "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
                 "epoch": "0x7080018000001",
-                "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+                "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+                "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
-                "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+                "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0x0"
             },
@@ -97,7 +97,7 @@
             "transactions": [
                 {
                     "cell_deps": [],
-                    "hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3",
+                    "hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17",
                     "header_deps": [],
                     "inputs": [
                         {
@@ -110,7 +110,7 @@
                     ],
                     "outputs": [
                         {
-                            "capacity": "0x18ef9705d5",
+                            "capacity": "0x18e64b61cf",
                             "lock": {
                                 "args": "0x",
                                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -141,19 +141,19 @@
         "method": "get_header",
         "module": "chain",
         "params": [
-            "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+            "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
         ],
         "result": {
             "compact_target": "0x1e083126",
-            "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+            "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
             "epoch": "0x7080018000001",
-            "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+            "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
-            "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+            "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0x0"
         }
@@ -167,15 +167,15 @@
         ],
         "result": {
             "compact_target": "0x1e083126",
-            "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+            "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
             "epoch": "0x7080018000001",
-            "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "nonce": "0x0",
             "number": "0x400",
-            "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+            "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
             "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "timestamp": "0x5cd2b117",
-            "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+            "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
             "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "version": "0x0"
         }
@@ -191,8 +191,8 @@
         ],
         "result": [
             {
-                "block_hash": "0xb5703168925268fd7ed0712df05418a83344dbdca9fa2b0363d4e79d841421ae",
-                "capacity": "0x2effd6e712",
+                "block_hash": "0xf293d02ce5e101b160912aaf15b1b87517b7a6d572c13af9ae4101c1143b22ad",
+                "capacity": "0x2ca86f2642",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -200,12 +200,12 @@
                 },
                 "out_point": {
                     "index": "0x0",
-                    "tx_hash": "0x15fd1dcf2763f360085a62dcbb4292057bc04931b16a413d0b6a4b932caf44af"
+                    "tx_hash": "0xa510932a80fda15a774203404453c5f9c0e8582f11c40f8ce5396f2460f8ccbf"
                 }
             },
             {
-                "block_hash": "0x9c7ca2051e1d2ee2cf40740ac62500131830d064ab339fede3aba06d02521d41",
-                "capacity": "0x2dc7e15ccc",
+                "block_hash": "0x63b872c02b1c2bd0c1af4f73f68ac04e2a3763a71f9656a823848d346619ffde",
+                "capacity": "0x2ca86e3dd4",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -213,12 +213,12 @@
                 },
                 "out_point": {
                     "index": "0x0",
-                    "tx_hash": "0xce4ec7bc6b3ee0533fd38f675926446df4f65d68cb03095d1470446383dbe09b"
+                    "tx_hash": "0x0b0fb337a9168132d3771f07e0ba055419c7e8f7bc2681a9eb445e61f44e1eb9"
                 }
             },
             {
-                "block_hash": "0x809dc37198dcf7d5cb5201d24cfed2d682f890ce110b6e8d9c315813ace39867",
-                "capacity": "0x2d6528a22b",
+                "block_hash": "0x6bbdd9dc71784d500daadf391ca9035900b3ff18ed868d7d4fe4b17fdea88853",
+                "capacity": "0x2ca86d5691",
                 "lock": {
                     "args": "0x",
                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -226,7 +226,7 @@
                 },
                 "out_point": {
                     "index": "0x0",
-                    "tx_hash": "0xfc2b1923996ac950ded04a28ea772be6dea37b98c01563019e9928766f3f2f7d"
+                    "tx_hash": "0xc336a23a785f3fec8b6e29e2c00d23483f1c6ad410b6b9fc0f62baf65d5efcc7"
                 }
             }
         ],
@@ -434,13 +434,13 @@
                     }
                 ],
                 "header_deps": [
-                    "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                    "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0x0",
-                            "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                            "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                         },
                         "since": "0x0"
                     }
@@ -483,13 +483,13 @@
                     }
                 ],
                 "header_deps": [
-                    "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                    "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0x0",
-                            "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                            "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                         },
                         "since": "0x0"
                     }
@@ -512,7 +512,7 @@
                 "witnesses": []
             }
         ],
-        "result": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777",
+        "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -546,7 +546,7 @@
                 "index": "0x0",
                 "tx_hash": "0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3"
             },
-            "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+            "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
         ],
         "result": "0x4a8b4e8a4",
         "skip": true,
@@ -586,13 +586,13 @@
                     }
                 ],
                 "header_deps": [
-                    "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                    "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0x0",
-                            "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                            "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                         },
                         "since": "0x0"
                     }
@@ -615,7 +615,7 @@
                 "witnesses": []
             }
         ],
-        "result": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777",
+        "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
         "types": [
             {
                 "transaction": "The transaction object"
@@ -645,7 +645,7 @@
         "method": "get_transaction",
         "module": "chain",
         "params": [
-            "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777"
+            "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
         ],
         "result": {
             "transaction": {
@@ -658,15 +658,15 @@
                         }
                     }
                 ],
-                "hash": "0x908a14d1cf5b03e29e5db7e4f550eb3ed2505a1a090a4fb12ef8012f26385777",
+                "hash": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
                 "header_deps": [
-                    "0xb67d20579b685b872dbefcfce82aaedaaa4563fdc2a5cb6b56367db06e094feb"
+                    "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
                 ],
                 "inputs": [
                     {
                         "previous_output": {
                             "index": "0x0",
-                            "tx_hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3"
+                            "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
                         },
                         "since": "0x0"
                     }
@@ -704,13 +704,13 @@
         "method": "get_cellbase_output_capacity_details",
         "module": "chain",
         "params": [
-            "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429"
+            "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
         ],
         "result": {
             "primary": "0x18ce922bca",
             "proposal_reward": "0x0",
-            "secondary": "0x2104da0b",
-            "total": "0x18ef9705d5",
+            "secondary": "0x17b93605",
+            "total": "0x18e64b61cf",
             "tx_fee": "0x0"
         },
         "types": [
@@ -743,15 +743,15 @@
         "result": {
             "header": {
                 "compact_target": "0x1e083126",
-                "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+                "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
                 "epoch": "0x7080018000001",
-                "hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+                "hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
                 "nonce": "0x0",
                 "number": "0x400",
-                "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+                "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
                 "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "timestamp": "0x5cd2b117",
-                "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+                "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
                 "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "version": "0x0"
             },
@@ -759,7 +759,7 @@
             "transactions": [
                 {
                     "cell_deps": [],
-                    "hash": "0xc780f93f92f443ca0b698614afd1e7943e7d4fdc0c2de8dcdea30d4a3fdb02e3",
+                    "hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17",
                     "header_deps": [],
                     "inputs": [
                         {
@@ -772,7 +772,7 @@
                     ],
                     "outputs": [
                         {
-                            "capacity": "0x18ef9705d5",
+                            "capacity": "0x18e64b61cf",
                             "lock": {
                                 "args": "0x",
                                 "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -807,7 +807,7 @@
             "0x400"
         ],
         "result": {
-            "block_hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+            "block_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
             "block_number": "0x400",
             "lock_hash": "0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412"
         },
@@ -827,7 +827,7 @@
         "params": [],
         "result": [
             {
-                "block_hash": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+                "block_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
                 "block_number": "0x400",
                 "lock_hash": "0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412"
             }
@@ -845,7 +845,7 @@
         "result": [
             {
                 "cell_output": {
-                    "capacity": "0x2ce1348802",
+                    "capacity": "0x2cb6562e4e",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -856,12 +856,12 @@
                 "created_by": {
                     "block_number": "0x98",
                     "index": "0x0",
-                    "tx_hash": "0x72bc04abf9021fdce48ceb0f6bf93444838d99c3e330fd6bbfcaa4a86ed51590"
+                    "tx_hash": "0x2d811f9ad7f2f7319171a6da4c842dd78e36682b4ac74da4f67b97c9f7d7a02b"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce136743b",
+                    "capacity": "0x2cb66b2496",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -872,12 +872,12 @@
                 "created_by": {
                     "block_number": "0x99",
                     "index": "0x0",
-                    "tx_hash": "0x5a47b2f04cbf272ead42ad2d532b6df85d0aa7684d25fcc9eacda94187952373"
+                    "tx_hash": "0x1ccf68bf7cb96a1a7f992c27bcfea6ebfc0fe32602196569aaa0cb3cd3e9f5ea"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce1385991",
+                    "capacity": "0x2cb68006e8",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -888,12 +888,12 @@
                 "created_by": {
                     "block_number": "0x9a",
                     "index": "0x0",
-                    "tx_hash": "0x9266ea43874f058c1d1fbf3236859c59b4d775d84ecf35fc333a4bb9a9dd7b97"
+                    "tx_hash": "0x74db38ad40184dd0528f4841e10599ff97bfbf2b5313754d1e96920d8523a5d4"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce13a3829",
+                    "capacity": "0x2cb694d55e",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -904,12 +904,12 @@
                 "created_by": {
                     "block_number": "0x9b",
                     "index": "0x0",
-                    "tx_hash": "0x114600c93152c671de234f5746f388ba758ba24238b3181e60dd2db9af5a62d8"
+                    "tx_hash": "0xf7d0ecc70015b46c5ab1cc8462592ae612fdaada200f643f3e1ce633bcc5ad1d"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce13c1025",
+                    "capacity": "0x2cb6a99016",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -920,12 +920,12 @@
                 "created_by": {
                     "block_number": "0x9c",
                     "index": "0x0",
-                    "tx_hash": "0x0ad7933beaa38c2407e16f51c7902d07671212212f6fdce5ef561e980f92a2d1"
+                    "tx_hash": "0xc3d232bb6b0e5d9a71a0978c9ab66c7a127ed37aeed6a2509dcc10d994c8c605"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce13de1aa",
+                    "capacity": "0x2cb6be372c",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -936,12 +936,12 @@
                 "created_by": {
                     "block_number": "0x9d",
                     "index": "0x0",
-                    "tx_hash": "0x12cbed669294d3cdb156d2a35f1d2452eeac8c25dd35313fcc750eb7cfedaf0f"
+                    "tx_hash": "0x10139a08beae170a35fbfcece6d50561ec61e13e4c6438435c1f2021331d7c4d"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce13facd9",
+                    "capacity": "0x2cb6d2cabb",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -952,12 +952,12 @@
                 "created_by": {
                     "block_number": "0x9e",
                     "index": "0x0",
-                    "tx_hash": "0xa08caa51ead4828887ce79d9118d3aeb741042e0cebb78ac3c1955fc747dcbec"
+                    "tx_hash": "0x39a083a1deb39b923a600a6f0714663085b5d2011b886b160962e20f1a28b550"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce14171d2",
+                    "capacity": "0x2cb6e74ae0",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -968,12 +968,12 @@
                 "created_by": {
                     "block_number": "0x9f",
                     "index": "0x0",
-                    "tx_hash": "0x30f0a82c5feef900a7ed6d59d48202996de500994ed2bdca42a46c8269bb59d4"
+                    "tx_hash": "0x2899c066f80a04b9a168e4499760ad1d768f44a3d673779905d88edd86362ac6"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce14330b6",
+                    "capacity": "0x2cb6fbb7b4",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -984,12 +984,12 @@
                 "created_by": {
                     "block_number": "0xa0",
                     "index": "0x0",
-                    "tx_hash": "0xf259b6995e443fd0815cc76b328dab1bf2e1c72feaa493320e93a56a71c4f67b"
+                    "tx_hash": "0xe2579280875a5d14538b0cc2356707792189662d5f8292541d9856ef291e81bf"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce144e9a4",
+                    "capacity": "0x2cb7101155",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1000,12 +1000,12 @@
                 "created_by": {
                     "block_number": "0xa1",
                     "index": "0x0",
-                    "tx_hash": "0x612f4431167a721296a84df0d516451d1897b98cd388956b37b7ea428b5c689b"
+                    "tx_hash": "0xd6121e80237c79182d55ec0efb9fa75bc9cc592f818057ced51aac6bb625e016"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce1469cba",
+                    "capacity": "0x2cb72457dc",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1016,12 +1016,12 @@
                 "created_by": {
                     "block_number": "0xa2",
                     "index": "0x0",
-                    "tx_hash": "0x5eb991401219da842a67c770fba18782e5ea1965a31da53e5a70f06510038c31"
+                    "tx_hash": "0x624eba1135e54a5988cb2ec70d42fa860d1d5658ed7f8d402615dff7d598e4b6"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce1484a15",
+                    "capacity": "0x2cb7388b65",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1032,12 +1032,12 @@
                 "created_by": {
                     "block_number": "0xa3",
                     "index": "0x0",
-                    "tx_hash": "0x2cd590f35a8252eef8e07e10e6f8be8318e68a113940a96fea77f943539c0635"
+                    "tx_hash": "0x7884b4cf85bc02cb73ec41d5cbbbf158eebca6ef855419ce57ff7c1d97b5be58"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce149f1d4",
+                    "capacity": "0x2cb74cac0a",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1048,12 +1048,12 @@
                 "created_by": {
                     "block_number": "0xa4",
                     "index": "0x0",
-                    "tx_hash": "0x247d3b0881fd8e3f9b89c6bcecbee770c5ecbdc8c1ee2efeed5d86c99cb90874"
+                    "tx_hash": "0xb613ba9b5f6177657493492dd523a63720d855ae9749887a0de881b894a1d6a6"
                 }
             },
             {
                 "cell_output": {
-                    "capacity": "0x2ce14b9410",
+                    "capacity": "0x2cb760b9e6",
                     "lock": {
                         "args": "0x",
                         "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1064,7 +1064,7 @@
                 "created_by": {
                     "block_number": "0xa5",
                     "index": "0x0",
-                    "tx_hash": "0xe3f2faf34c82746ef0ba7aab3a960dc4816ec8bd3f6b20fdf20fc618bc04f01b"
+                    "tx_hash": "0x701f4b962c1650810800ee6ed981841692c1939a4b597e9e7a726c5db77f6164"
                 }
             }
         ],
@@ -1098,7 +1098,7 @@
                 "created_by": {
                     "block_number": "0x98",
                     "index": "0x0",
-                    "tx_hash": "0x72bc04abf9021fdce48ceb0f6bf93444838d99c3e330fd6bbfcaa4a86ed51590"
+                    "tx_hash": "0x2d811f9ad7f2f7319171a6da4c842dd78e36682b4ac74da4f67b97c9f7d7a02b"
                 }
             },
             {
@@ -1106,7 +1106,7 @@
                 "created_by": {
                     "block_number": "0x99",
                     "index": "0x0",
-                    "tx_hash": "0x5a47b2f04cbf272ead42ad2d532b6df85d0aa7684d25fcc9eacda94187952373"
+                    "tx_hash": "0x1ccf68bf7cb96a1a7f992c27bcfea6ebfc0fe32602196569aaa0cb3cd3e9f5ea"
                 }
             },
             {
@@ -1114,7 +1114,7 @@
                 "created_by": {
                     "block_number": "0x9a",
                     "index": "0x0",
-                    "tx_hash": "0x9266ea43874f058c1d1fbf3236859c59b4d775d84ecf35fc333a4bb9a9dd7b97"
+                    "tx_hash": "0x74db38ad40184dd0528f4841e10599ff97bfbf2b5313754d1e96920d8523a5d4"
                 }
             },
             {
@@ -1122,7 +1122,7 @@
                 "created_by": {
                     "block_number": "0x9b",
                     "index": "0x0",
-                    "tx_hash": "0x114600c93152c671de234f5746f388ba758ba24238b3181e60dd2db9af5a62d8"
+                    "tx_hash": "0xf7d0ecc70015b46c5ab1cc8462592ae612fdaada200f643f3e1ce633bcc5ad1d"
                 }
             },
             {
@@ -1130,7 +1130,7 @@
                 "created_by": {
                     "block_number": "0x9c",
                     "index": "0x0",
-                    "tx_hash": "0x0ad7933beaa38c2407e16f51c7902d07671212212f6fdce5ef561e980f92a2d1"
+                    "tx_hash": "0xc3d232bb6b0e5d9a71a0978c9ab66c7a127ed37aeed6a2509dcc10d994c8c605"
                 }
             },
             {
@@ -1138,7 +1138,7 @@
                 "created_by": {
                     "block_number": "0x9d",
                     "index": "0x0",
-                    "tx_hash": "0x12cbed669294d3cdb156d2a35f1d2452eeac8c25dd35313fcc750eb7cfedaf0f"
+                    "tx_hash": "0x10139a08beae170a35fbfcece6d50561ec61e13e4c6438435c1f2021331d7c4d"
                 }
             },
             {
@@ -1146,7 +1146,7 @@
                 "created_by": {
                     "block_number": "0x9e",
                     "index": "0x0",
-                    "tx_hash": "0xa08caa51ead4828887ce79d9118d3aeb741042e0cebb78ac3c1955fc747dcbec"
+                    "tx_hash": "0x39a083a1deb39b923a600a6f0714663085b5d2011b886b160962e20f1a28b550"
                 }
             },
             {
@@ -1154,7 +1154,7 @@
                 "created_by": {
                     "block_number": "0x9f",
                     "index": "0x0",
-                    "tx_hash": "0x30f0a82c5feef900a7ed6d59d48202996de500994ed2bdca42a46c8269bb59d4"
+                    "tx_hash": "0x2899c066f80a04b9a168e4499760ad1d768f44a3d673779905d88edd86362ac6"
                 }
             },
             {
@@ -1162,7 +1162,7 @@
                 "created_by": {
                     "block_number": "0xa0",
                     "index": "0x0",
-                    "tx_hash": "0xf259b6995e443fd0815cc76b328dab1bf2e1c72feaa493320e93a56a71c4f67b"
+                    "tx_hash": "0xe2579280875a5d14538b0cc2356707792189662d5f8292541d9856ef291e81bf"
                 }
             },
             {
@@ -1170,7 +1170,7 @@
                 "created_by": {
                     "block_number": "0xa1",
                     "index": "0x0",
-                    "tx_hash": "0x612f4431167a721296a84df0d516451d1897b98cd388956b37b7ea428b5c689b"
+                    "tx_hash": "0xd6121e80237c79182d55ec0efb9fa75bc9cc592f818057ced51aac6bb625e016"
                 }
             },
             {
@@ -1178,7 +1178,7 @@
                 "created_by": {
                     "block_number": "0xa2",
                     "index": "0x0",
-                    "tx_hash": "0x5eb991401219da842a67c770fba18782e5ea1965a31da53e5a70f06510038c31"
+                    "tx_hash": "0x624eba1135e54a5988cb2ec70d42fa860d1d5658ed7f8d402615dff7d598e4b6"
                 }
             },
             {
@@ -1186,7 +1186,7 @@
                 "created_by": {
                     "block_number": "0xa3",
                     "index": "0x0",
-                    "tx_hash": "0x2cd590f35a8252eef8e07e10e6f8be8318e68a113940a96fea77f943539c0635"
+                    "tx_hash": "0x7884b4cf85bc02cb73ec41d5cbbbf158eebca6ef855419ce57ff7c1d97b5be58"
                 }
             },
             {
@@ -1194,7 +1194,7 @@
                 "created_by": {
                     "block_number": "0xa4",
                     "index": "0x0",
-                    "tx_hash": "0x247d3b0881fd8e3f9b89c6bcecbee770c5ecbdc8c1ee2efeed5d86c99cb90874"
+                    "tx_hash": "0xb613ba9b5f6177657493492dd523a63720d855ae9749887a0de881b894a1d6a6"
                 }
             },
             {
@@ -1202,7 +1202,7 @@
                 "created_by": {
                     "block_number": "0xa5",
                     "index": "0x0",
-                    "tx_hash": "0xe3f2faf34c82746ef0ba7aab3a960dc4816ec8bd3f6b20fdf20fc618bc04f01b"
+                    "tx_hash": "0x701f4b962c1650810800ee6ed981841692c1939a4b597e9e7a726c5db77f6164"
                 }
             }
         ],
@@ -1312,10 +1312,10 @@
                 },
                 "hash": "0x076049e2cc6b9f1ed4bb27b2337c55071dabfaf0183b1b17a4965bd0372d8dec"
             },
+            "compact_target": "0x100",
             "current_time": "0x16d6269e84f",
             "cycles_limit": "0x2540be400",
             "dao": "0x004fb9e277860700b2f80165348723003d1862ec960000000028eb3d7e7a0100",
-            "compact_target": "0x100",
             "epoch": "0x3e80001000000",
             "number": "0x1",
             "parent_hash": "0xd5c495b7dd4d9d066a6a4d4356bc31955ad3199e0d856f34cfbe159c46ee335b",
@@ -1348,14 +1348,14 @@
             {
                 "header": {
                     "compact_target": "0x1e083126",
-                    "dao": "0xb54bdd7f6be90000bb52f392d41cd70024f7ef29b437000000febffacf030000",
+                    "dao": "0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000",
                     "epoch": "0x7080018000001",
                     "nonce": "0x0",
                     "number": "0x400",
-                    "parent_hash": "0x8381df265c9442d5c27559b167892c5a6a8322871112d3cc8ef45222c6624831",
+                    "parent_hash": "0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d",
                     "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "timestamp": "0x5cd2b117",
-                    "transactions_root": "0x12214693b8bd5c3d8f96e270dc8fe32b1702bd97630a9eab53a69793e6bc893f",
+                    "transactions_root": "0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c",
                     "uncles_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "version": "0x0"
                 },
@@ -1375,7 +1375,7 @@
                         ],
                         "outputs": [
                             {
-                                "capacity": "0x18ef9705d5",
+                                "capacity": "0x18e64b61cf",
                                 "lock": {
                                     "args": "0x",
                                     "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
@@ -1396,7 +1396,7 @@
                 "uncles": []
             }
         ],
-        "result": "0x567f446fa306c5d4f784bd5bae202d2de15e62c501ff5fe043a1335d062c9429",
+        "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
         "types": [
             {
                 "work_id": "the identifier to proof-of-work"

--- a/util/dao/utils/src/lib.rs
+++ b/util/dao/utils/src/lib.rs
@@ -24,7 +24,7 @@ pub fn genesis_dao_data(txs: Vec<&TransactionView>) -> Result<Byte32, Error> {
         txs,
         &H160([0u8; 20]),
         Ratio(1, 1),
-        capacity_bytes!(1000),
+        capacity_bytes!(1_000_000),
         capacity_bytes!(1000),
     )
 }


### PR DESCRIPTION
The reason is that `U` in genesis DAO is too small. When generating transactions that occupy many capacities than `U`, the DAO calculation overflow.