### PR TITLE
refactor: replace non-maintained jsonrpc client

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -25,14 +25,15 @@ ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-resource = { path = "../resource" }
 tempfile = "3.0"
-jsonrpc-client-core = "0.5.0"
-jsonrpc-client-http = "0.5.0"
+reqwest = "0.9"
 rand = "0.6"
 log = "0.4"
 env_logger = "0.6"
 crossbeam-channel = "0.3"
 faketime = "0.2"
 failure = "0.1.5"
+serde_json = "1.0"
+lazy_static = "1.4.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -120,7 +120,7 @@ impl Node {
         self.guard = Some(ProcessGuard(child_process));
 
         loop {
-            let result = { self.rpc_client().inner().lock().local_node_info().call() };
+            let result = { self.rpc_client().inner().local_node_info() };
             if let Ok(local_node_info) = result {
                 self.node_id = Some(local_node_info.node_id);
                 let _ = self.rpc_client().tx_pool_info();

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -1,3 +1,8 @@
+mod id_generator;
+#[macro_use]
+mod macros;
+mod error;
+
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockNumber, BlockReward, BlockTemplate, BlockView, Capacity,
     CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle, DryRunResult,
@@ -10,91 +15,78 @@ use ckb_types::core::{
     Version as CoreVersion,
 };
 use ckb_types::{packed::Byte32, prelude::*, H256};
-use ckb_util::Mutex;
-use jsonrpc_client_core::{expand_params, jsonrpc_client, Result as JsonRpcResult};
-use jsonrpc_client_http::{HttpHandle, HttpTransport};
+use failure::Error;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
+        .gzip(true)
+        .timeout(::std::time::Duration::from_secs(30))
+        .build()
+        .expect("reqwest Client build");
+}
 
 pub struct RpcClient {
-    inner: Mutex<Inner<HttpHandle>>,
+    inner: Inner,
 }
 
 impl RpcClient {
     pub fn new(uri: &str) -> Self {
-        let transport = HttpTransport::new().standalone().unwrap();
-        let transport = transport
-            .handle(uri)
-            .expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
         Self {
-            inner: Mutex::new(Inner::new(transport)),
+            inner: Inner::new(uri),
         }
     }
 
-    pub fn inner(&self) -> &Mutex<Inner<HttpHandle>> {
+    pub fn inner(&self) -> &Inner {
         &self.inner
     }
 
     pub fn get_block(&self, hash: Byte32) -> Option<BlockView> {
         self.inner
-            .lock()
             .get_block(hash.unpack())
-            .call()
             .expect("rpc call get_block")
     }
 
     pub fn get_fork_block(&self, hash: Byte32) -> Option<BlockView> {
         self.inner
-            .lock()
             .get_fork_block(hash.unpack())
-            .call()
             .expect("rpc call get_fork_block")
     }
 
     pub fn get_block_by_number(&self, number: CoreBlockNumber) -> Option<BlockView> {
         self.inner
-            .lock()
             .get_block_by_number(number.into())
-            .call()
             .expect("rpc call get_block_by_number")
     }
 
     pub fn get_header(&self, hash: Byte32) -> Option<HeaderView> {
         self.inner
-            .lock()
             .get_header(hash.unpack())
-            .call()
             .expect("rpc call get_header")
     }
 
     pub fn get_header_by_number(&self, number: CoreBlockNumber) -> Option<HeaderView> {
         self.inner
-            .lock()
             .get_header_by_number(number.into())
-            .call()
             .expect("rpc call get_header_by_number")
     }
 
     pub fn get_transaction(&self, hash: Byte32) -> Option<TransactionWithStatus> {
         self.inner
-            .lock()
             .get_transaction(hash.unpack())
-            .call()
             .expect("rpc call get_transaction")
     }
 
     pub fn get_block_hash(&self, number: CoreBlockNumber) -> Option<Byte32> {
         self.inner
-            .lock()
             .get_block_hash(number.into())
-            .call()
             .expect("rpc call get_block_hash")
             .map(|x| x.pack())
     }
 
     pub fn get_tip_header(&self) -> HeaderView {
         self.inner
-            .lock()
             .get_tip_header()
-            .call()
             .expect("rpc call get_block_hash")
     }
 
@@ -105,66 +97,48 @@ impl RpcClient {
         to: CoreBlockNumber,
     ) -> Vec<CellOutputWithOutPoint> {
         self.inner
-            .lock()
             .get_cells_by_lock_hash(lock_hash.unpack(), from.into(), to.into())
-            .call()
             .expect("rpc call get_cells_by_lock_hash")
     }
 
     pub fn get_live_cell(&self, out_point: OutPoint, with_data: bool) -> CellWithStatus {
         self.inner
-            .lock()
             .get_live_cell(out_point, with_data)
-            .call()
             .expect("rpc call get_live_cell")
     }
 
     pub fn get_tip_block_number(&self) -> CoreBlockNumber {
         self.inner
-            .lock()
             .get_tip_block_number()
-            .call()
             .expect("rpc call get_tip_block_number")
             .into()
     }
 
     pub fn get_current_epoch(&self) -> EpochView {
         self.inner
-            .lock()
             .get_current_epoch()
-            .call()
             .expect("rpc call get_current_epoch")
     }
 
     pub fn get_epoch_by_number(&self, number: CoreEpochNumber) -> Option<EpochView> {
         self.inner
-            .lock()
             .get_epoch_by_number(number.into())
-            .call()
             .expect("rpc call get_epoch_by_number")
     }
 
     pub fn local_node_info(&self) -> Node {
         self.inner
-            .lock()
             .local_node_info()
-            .call()
             .expect("rpc call local_node_info")
     }
 
     pub fn get_peers(&self) -> Vec<Node> {
-        self.inner
-            .lock()
-            .get_peers()
-            .call()
-            .expect("rpc call get_peers")
+        self.inner.get_peers().expect("rpc call get_peers")
     }
 
     pub fn get_banned_addresses(&self) -> Vec<BannedAddr> {
         self.inner
-            .lock()
             .get_banned_addresses()
-            .call()
             .expect("rpc call get_banned_addresses")
     }
 
@@ -177,9 +151,7 @@ impl RpcClient {
         reason: Option<String>,
     ) {
         self.inner
-            .lock()
             .set_ban(address, command, ban_time, absolute, reason)
-            .call()
             .expect("rpc call set_ban")
     }
 
@@ -193,90 +165,64 @@ impl RpcClient {
         let proposals_limit = proposals_limit.map(Into::into);
         let max_version = max_version.map(Into::into);
         self.inner
-            .lock()
             .get_block_template(bytes_limit, proposals_limit, max_version)
-            .call()
             .expect("rpc call get_block_template")
     }
 
-    pub fn submit_block(&self, work_id: String, block: Block) -> JsonRpcResult<Byte32> {
-        self.inner
-            .lock()
-            .submit_block(work_id, block)
-            .call()
-            .map(|x| x.pack())
+    pub fn submit_block(&self, work_id: String, block: Block) -> Result<Byte32, Error> {
+        self.inner.submit_block(work_id, block).map(|x| x.pack())
     }
 
     pub fn get_blockchain_info(&self) -> ChainInfo {
         self.inner
-            .lock()
             .get_blockchain_info()
-            .call()
             .expect("rpc call get_blockchain_info")
     }
 
     pub fn send_transaction(&self, tx: Transaction) -> Byte32 {
         self.inner
-            .lock()
             .send_transaction(tx)
-            .call()
             .expect("rpc call send_transaction")
             .pack()
     }
 
-    pub fn send_transaction_result(&self, tx: Transaction) -> JsonRpcResult<H256> {
-        self.inner.lock().send_transaction(tx).call()
+    pub fn send_transaction_result(&self, tx: Transaction) -> Result<H256, Error> {
+        self.inner.send_transaction(tx)
     }
 
     pub fn dry_run_transaction(&self, tx: Transaction) -> DryRunResult {
         self.inner
-            .lock()
             .dry_run_transaction(tx)
-            .call()
             .expect("rpc call dry_run_transaction")
     }
 
-    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> JsonRpcResult<H256> {
-        self.inner.lock().broadcast_transaction(tx, cycles).call()
+    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> Result<H256, Error> {
+        self.inner.broadcast_transaction(tx, cycles)
     }
 
     pub fn send_alert(&self, alert: Alert) {
-        self.inner
-            .lock()
-            .send_alert(alert)
-            .call()
-            .expect("rpc call send_alert")
+        self.inner.send_alert(alert).expect("rpc call send_alert")
     }
 
     pub fn tx_pool_info(&self) -> TxPoolInfo {
-        self.inner
-            .lock()
-            .tx_pool_info()
-            .call()
-            .expect("rpc call tx_pool_info")
+        self.inner.tx_pool_info().expect("rpc call tx_pool_info")
     }
 
     pub fn add_node(&self, peer_id: String, address: String) {
         self.inner
-            .lock()
             .add_node(peer_id, address)
-            .call()
             .expect("rpc call add_node");
     }
 
     pub fn remove_node(&self, peer_id: String) {
         self.inner
-            .lock()
             .remove_node(peer_id)
-            .call()
             .expect("rpc call remove_node")
     }
 
     pub fn process_block_without_verify(&self, block: Block) -> Option<Byte32> {
         self.inner
-            .lock()
             .process_block_without_verify(block)
-            .call()
             .expect("rpc call process_block_without verify")
             .map(|x| x.pack())
     }
@@ -289,14 +235,12 @@ impl RpcClient {
         reverse_order: Option<bool>,
     ) -> Vec<LiveCell> {
         self.inner()
-            .lock()
             .get_live_cells_by_lock_hash(
                 lock_hash.unpack(),
                 page.into(),
                 per_page.into(),
                 reverse_order,
             )
-            .call()
             .expect("rpc call get_live_cells_by_lock_hash")
     }
 
@@ -308,14 +252,12 @@ impl RpcClient {
         reverse_order: Option<bool>,
     ) -> Vec<CellTransaction> {
         self.inner()
-            .lock()
             .get_transactions_by_lock_hash(
                 lock_hash.unpack(),
                 page.into(),
                 per_page.into(),
                 reverse_order,
             )
-            .call()
             .expect("rpc call get_transactions_by_lock_hash")
     }
 
@@ -325,25 +267,19 @@ impl RpcClient {
         index_from: Option<CoreBlockNumber>,
     ) -> LockHashIndexState {
         self.inner()
-            .lock()
             .index_lock_hash(lock_hash.unpack(), index_from.map(Into::into))
-            .call()
             .expect("rpc call index_lock_hash")
     }
 
     pub fn deindex_lock_hash(&self, lock_hash: Byte32) {
         self.inner()
-            .lock()
             .deindex_lock_hash(lock_hash.unpack())
-            .call()
             .expect("rpc call deindex_lock_hash")
     }
 
     pub fn get_lock_hash_index_states(&self) -> Vec<LockHashIndexState> {
         self.inner()
-            .lock()
             .get_lock_hash_index_states()
-            .call()
             .expect("rpc call get_lock_hash_index_states")
     }
 
@@ -353,90 +289,84 @@ impl RpcClient {
         hash: Byte32,
     ) -> CoreCapacity {
         self.inner()
-            .lock()
             .calculate_dao_maximum_withdraw(out_point, hash.unpack())
-            .call()
             .expect("rpc call calculate_dao_maximum_withdraw")
             .into()
     }
 
     pub fn get_cellbase_output_capacity_details(&self, hash: Byte32) -> BlockReward {
         self.inner()
-            .lock()
             .get_cellbase_output_capacity_details(hash.unpack())
-            .call()
             .expect("rpc call get_cellbase_output_capacity_details")
             .expect("get_cellbase_output_capacity_details return none")
     }
 
     pub fn estimate_fee_rate(&self, expect_confirm_blocks: Uint64) -> EstimateResult {
         self.inner()
-            .lock()
             .estimate_fee_rate(expect_confirm_blocks)
-            .call()
             .expect("rpc call estimate_fee_rate")
     }
 }
 
-jsonrpc_client!(pub struct Inner {
-    pub fn get_block(&mut self, _hash: H256) -> RpcRequest<Option<BlockView>>;
-    pub fn get_fork_block(&mut self, _hash: H256) -> RpcRequest<Option<BlockView>>;
-    pub fn get_block_by_number(&mut self, _number: BlockNumber) -> RpcRequest<Option<BlockView>>;
-    pub fn get_header(&mut self, _hash: H256) -> RpcRequest<Option<HeaderView>>;
-    pub fn get_header_by_number(&mut self, _number: BlockNumber) -> RpcRequest<Option<HeaderView>>;
-    pub fn get_transaction(&mut self, _hash: H256) -> RpcRequest<Option<TransactionWithStatus>>;
-    pub fn get_block_hash(&mut self, _number: BlockNumber) -> RpcRequest<Option<H256>>;
-    pub fn get_tip_header(&mut self) -> RpcRequest<HeaderView>;
+jsonrpc!(pub struct Inner {
+    pub fn get_block(&self, _hash: H256) -> Option<BlockView>;
+    pub fn get_fork_block(&self, _hash: H256) -> Option<BlockView>;
+    pub fn get_block_by_number(&self, _number: BlockNumber) -> Option<BlockView>;
+    pub fn get_header(&self, _hash: H256) -> Option<HeaderView>;
+    pub fn get_header_by_number(&self, _number: BlockNumber) -> Option<HeaderView>;
+    pub fn get_transaction(&self, _hash: H256) -> Option<TransactionWithStatus>;
+    pub fn get_block_hash(&self, _number: BlockNumber) -> Option<H256>;
+    pub fn get_tip_header(&self) -> HeaderView;
     pub fn get_cells_by_lock_hash(
-        &mut self,
+        &self,
         _lock_hash: H256,
         _from: BlockNumber,
         _to: BlockNumber
-    ) -> RpcRequest<Vec<CellOutputWithOutPoint>>;
-    pub fn get_live_cell(&mut self, _out_point: OutPoint, _with_data: bool) -> RpcRequest<CellWithStatus>;
-    pub fn get_tip_block_number(&mut self) -> RpcRequest<BlockNumber>;
-    pub fn get_current_epoch(&mut self) -> RpcRequest<EpochView>;
-    pub fn get_epoch_by_number(&mut self, number: EpochNumber) -> RpcRequest<Option<EpochView>>;
+    ) -> Vec<CellOutputWithOutPoint>;
+    pub fn get_live_cell(&self, _out_point: OutPoint, _with_data: bool) -> CellWithStatus;
+    pub fn get_tip_block_number(&self) -> BlockNumber;
+    pub fn get_current_epoch(&self) -> EpochView;
+    pub fn get_epoch_by_number(&self, number: EpochNumber) -> Option<EpochView>;
 
-    pub fn local_node_info(&mut self) -> RpcRequest<Node>;
-    pub fn get_peers(&mut self) -> RpcRequest<Vec<Node>>;
-    pub fn get_banned_addresses(&mut self) -> RpcRequest<Vec<BannedAddr>>;
+    pub fn local_node_info(&self) -> Node;
+    pub fn get_peers(&self) -> Vec<Node>;
+    pub fn get_banned_addresses(&self) -> Vec<BannedAddr>;
     pub fn set_ban(
-        &mut self,
+        &self,
         address: String,
         command: String,
         ban_time: Option<Timestamp>,
         absolute: Option<bool>,
         reason: Option<String>
-    ) -> RpcRequest<()>;
+    ) -> ();
 
     pub fn get_block_template(
-        &mut self,
+        &self,
         bytes_limit: Option<Uint64>,
         proposals_limit: Option<Uint64>,
         max_version: Option<Version>
-    ) -> RpcRequest<BlockTemplate>;
-    pub fn submit_block(&mut self, _work_id: String, _data: Block) -> RpcRequest<H256>;
-    pub fn get_blockchain_info(&mut self) -> RpcRequest<ChainInfo>;
-    pub fn get_peers_state(&mut self) -> RpcRequest<Vec<PeerState>>;
-    pub fn compute_transaction_hash(&mut self, tx: Transaction) -> RpcRequest<H256>;
-    pub fn dry_run_transaction(&mut self, _tx: Transaction) -> RpcRequest<DryRunResult>;
-    pub fn send_transaction(&mut self, tx: Transaction) -> RpcRequest<H256>;
-    pub fn tx_pool_info(&mut self) -> RpcRequest<TxPoolInfo>;
+    ) -> BlockTemplate;
+    pub fn submit_block(&self, _work_id: String, _data: Block) -> H256;
+    pub fn get_blockchain_info(&self) -> ChainInfo;
+    pub fn get_peers_state(&self) -> Vec<PeerState>;
+    pub fn compute_transaction_hash(&self, tx: Transaction) -> H256;
+    pub fn dry_run_transaction(&self, _tx: Transaction) -> DryRunResult;
+    pub fn send_transaction(&self, tx: Transaction) -> H256;
+    pub fn tx_pool_info(&self) -> TxPoolInfo;
 
-    pub fn send_alert(&mut self, alert: Alert) -> RpcRequest<()>;
+    pub fn send_alert(&self, alert: Alert) -> ();
 
-    pub fn add_node(&mut self, peer_id: String, address: String) -> RpcRequest<()>;
-    pub fn remove_node(&mut self, peer_id: String) -> RpcRequest<()>;
-    pub fn process_block_without_verify(&mut self, _data: Block) -> RpcRequest<Option<H256>>;
+    pub fn add_node(&self, peer_id: String, address: String) -> ();
+    pub fn remove_node(&self, peer_id: String) -> ();
+    pub fn process_block_without_verify(&self, _data: Block) -> Option<H256>;
 
-    pub fn get_live_cells_by_lock_hash(&mut self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> RpcRequest<Vec<LiveCell>>;
-    pub fn get_transactions_by_lock_hash(&mut self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> RpcRequest<Vec<CellTransaction>>;
-    pub fn index_lock_hash(&mut self, lock_hash: H256, index_from: Option<BlockNumber>) -> RpcRequest<LockHashIndexState>;
-    pub fn deindex_lock_hash(&mut self, lock_hash: H256) -> RpcRequest<()>;
-    pub fn get_lock_hash_index_states(&mut self) -> RpcRequest<Vec<LockHashIndexState>>;
-    pub fn calculate_dao_maximum_withdraw(&mut self, _out_point: OutPoint, _hash: H256) -> RpcRequest<Capacity>;
-    pub fn get_cellbase_output_capacity_details(&mut self, _hash: H256) -> RpcRequest<Option<BlockReward>>;
-    pub fn broadcast_transaction(&mut self, tx: Transaction, cycles: Cycle) -> RpcRequest<H256>;
-    pub fn estimate_fee_rate(&mut self, expect_confirm_blocks: Uint64) -> RpcRequest<EstimateResult>;
+    pub fn get_live_cells_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<LiveCell>;
+    pub fn get_transactions_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<CellTransaction>;
+    pub fn index_lock_hash(&self, lock_hash: H256, index_from: Option<BlockNumber>) -> LockHashIndexState;
+    pub fn deindex_lock_hash(&self, lock_hash: H256) -> ();
+    pub fn get_lock_hash_index_states(&self) -> Vec<LockHashIndexState>;
+    pub fn calculate_dao_maximum_withdraw(&self, _out_point: OutPoint, _hash: H256) -> Capacity;
+    pub fn get_cellbase_output_capacity_details(&self, _hash: H256) -> Option<BlockReward>;
+    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> H256;
+    pub fn estimate_fee_rate(&self, expect_confirm_blocks: Uint64) -> EstimateResult;
 });

--- a/test/src/rpc/error.rs
+++ b/test/src/rpc/error.rs
@@ -1,0 +1,19 @@
+use ckb_jsonrpc_types::error::Error as JsonRpcError;
+use std::fmt;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Error {
+    pub(in crate::rpc) inner: JsonRpcError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self.inner).expect("JsonRpcError to_string")
+        )
+    }
+}
+
+impl ::std::error::Error for Error {}

--- a/test/src/rpc/id_generator.rs
+++ b/test/src/rpc/id_generator.rs
@@ -1,0 +1,24 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug)]
+pub struct IdGenerator {
+    state: AtomicU64,
+}
+
+impl Default for IdGenerator {
+    fn default() -> Self {
+        IdGenerator {
+            state: AtomicU64::new(1),
+        }
+    }
+}
+
+impl IdGenerator {
+    pub fn new() -> IdGenerator {
+        IdGenerator::default()
+    }
+
+    pub fn next(&self) -> u64 {
+        self.state.fetch_add(1, Ordering::SeqCst)
+    }
+}

--- a/test/src/rpc/macros.rs
+++ b/test/src/rpc/macros.rs
@@ -1,0 +1,59 @@
+#[macro_export]
+macro_rules! jsonrpc {
+    (
+        $(#[$struct_attr:meta])*
+        pub struct $struct_name:ident {$(
+            $(#[$attr:meta])*
+            pub fn $method:ident(&$selff:ident $(, $arg_name:ident: $arg_ty:ty)*)
+                -> $return_ty:ty;
+        )*}
+    ) => (
+        $(#[$struct_attr])*
+        pub struct $struct_name {
+            pub client: &'static reqwest::Client,
+            pub url: reqwest::Url,
+            pub id_generator: $crate::rpc::id_generator::IdGenerator,
+        }
+
+        impl $struct_name {
+            pub fn new(uri: &str) -> Self {
+                let url = reqwest::Url::parse(uri).expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
+                let id_generator = $crate::rpc::id_generator::IdGenerator::new();
+                $struct_name { url, id_generator, client: &$crate::rpc::HTTP_CLIENT, }
+            }
+
+            $(
+                $(#[$attr])*
+                pub fn $method(&$selff $(, $arg_name: $arg_ty)*) -> Result<$return_ty, failure::Error> {
+                    let method = String::from(stringify!($method));
+                    let params = serialize_parameters!($($arg_name,)*);
+                    let id = $selff.id_generator.next();
+
+                    let mut req_json = serde_json::Map::new();
+                    req_json.insert("id".to_owned(), serde_json::json!(id));
+                    req_json.insert("jsonrpc".to_owned(), serde_json::json!("2.0"));
+                    req_json.insert("method".to_owned(), serde_json::json!(method));
+                    req_json.insert("params".to_owned(), params);
+
+                    let mut resp = $selff.client.post($selff.url.clone()).json(&req_json).send()?;
+                    let output = resp.json::<ckb_jsonrpc_types::response::Output>()?;
+                    match output {
+                        ckb_jsonrpc_types::response::Output::Success(success) => {
+                            serde_json::from_value(success.result).map_err(Into::into)
+                        },
+                        ckb_jsonrpc_types::response::Output::Failure(failure) => {
+                            Err($crate::rpc::error::Error{ inner: failure.error }.into())
+                        }
+                    }
+                }
+            )*
+        }
+    )
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! serialize_parameters {
+    () => ( serde_json::Value::Null );
+    ($($arg_name:ident,)+) => ( serde_json::to_value(($($arg_name,)+))?)
+}

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -52,9 +52,7 @@ impl ValidSince {
         assert!(
             node.rpc_client()
                 .inner()
-                .lock()
                 .send_transaction(transaction.data().into())
-                .call()
                 .is_ok(),
             "transaction is ok, tip is equal to relative since block number",
         );
@@ -80,9 +78,7 @@ impl ValidSince {
         assert!(
             node.rpc_client()
                 .inner()
-                .lock()
                 .send_transaction(transaction.data().into())
-                .call()
                 .is_ok(),
             "transaction is ok, tip is equal to absolute since block number",
         );
@@ -135,9 +131,7 @@ impl ValidSince {
             assert!(
                 node.rpc_client()
                     .inner()
-                    .lock()
                     .send_transaction(transaction.data().into())
-                    .call()
                     .is_ok(),
                 "transaction's since is greater than tip's median time",
             );
@@ -180,9 +174,7 @@ impl ValidSince {
             assert!(
                 node.rpc_client()
                     .inner()
-                    .lock()
                     .send_transaction(transaction.data().into())
-                    .call()
                     .is_ok(),
                 "transaction's since is greater than tip's median time",
             );

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -173,9 +173,7 @@ pub fn assert_send_transaction_fail(node: &Node, transaction: &TransactionView, 
     let result = node
         .rpc_client()
         .inner()
-        .lock()
-        .send_transaction(transaction.data().into())
-        .call();
+        .send_transaction(transaction.data().into());
     assert!(
         result.is_err(),
         "expect error \"{}\" but got \"Ok(())\"",

--- a/util/jsonrpc-types/src/cell.rs
+++ b/util/jsonrpc-types/src/cell.rs
@@ -9,7 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 // This is used as return value of get_cells_by_lock_hash RPC:
 // it contains both OutPoint data used for referencing a cell, as well as
 // cell's own data such as lock and capacity
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CellOutputWithOutPoint {
     pub out_point: OutPoint,
     pub block_hash: H256,
@@ -17,19 +17,19 @@ pub struct CellOutputWithOutPoint {
     pub lock: Script,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CellWithStatus {
     pub cell: Option<CellInfo>,
     pub status: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CellInfo {
     pub output: CellOutput,
     pub data: Option<CellData>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CellData {
     pub content: JsonBytes,
     pub hash: H256,

--- a/util/jsonrpc-types/src/indexer.rs
+++ b/util/jsonrpc-types/src/indexer.rs
@@ -3,20 +3,20 @@ use ckb_types::H256;
 use serde_derive::{Deserialize, Serialize};
 
 // This is used as return value of get_live_cells_by_lock_hash RPC
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LiveCell {
     pub created_by: TransactionPoint,
     pub cell_output: CellOutput,
 }
 
 // This is used as return value of get_transactions_by_lock_hash RPC
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CellTransaction {
     pub created_by: TransactionPoint,
     pub consumed_by: Option<TransactionPoint>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionPoint {
     pub block_number: BlockNumber,
     pub tx_hash: H256,


### PR DESCRIPTION
* replace https://crates.io/crates/jsonrpc-client-core
This https://crates.io/crates/jsonrpc-client-core is unruly and still uses tokio-core which is deprecated, 
the maintainers are not around to work on this project. 
https://dev.azure.com/nervosnetwork/ckb/_build/results?buildId=7366
we catch some  `Canceled` error is not being handled elegantly, lead to lock been poisoned.

* singleton http-clinet 
We don't need to instantiate http-clinet for every test-case, every simulate node.
