### PR TITLE
fix: avoids creating tmp folder for db initialization

### DIFF
--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -250,7 +250,10 @@ impl SharedBuilder {
         let db = RocksDB::open(config, COLUMNS);
         SharedBuilder {
             db,
-            ..Default::default()
+            consensus: None,
+            tx_pool_config: None,
+            store_config: None,
+            block_assembler_config: None,
         }
     }
 }


### PR DESCRIPTION
fix issue: ckb will crash when running on an os which tmpfs is full or doesn't exist.

cause: The `ShareBuilder` will try to create an empty tmp folder for rocksdb in the `Default` trait implementation: https://github.com/nervosnetwork/ckb/blob/a45618c1b32d0d0a42a97f4f1491039fd7228155/shared/src/shared.rs#L239 , demo:  https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2b4046c1197c8538651932d862ea3772

before this fix, we will always see the log when starting ckb node:
```
2019-10-28 11:09:31.014 +09:00 main INFO ckb-db  Initialize a new database
```