### PR TITLE
feat: Upgrade rocksdb with ReadOnlyDB changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
  "ckb-error 0.24.0-pre",
  "ckb-logger 0.24.0-pre",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.12.2 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c)",
+ "rocksdb 0.12.2 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.2.4"
-source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c#ac1af8c619da3a1612f18149de46fd44a5bf1244"
+source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc#6cfc2cc601ee856966c5d688c425f2e006243742"
 dependencies = [
  "bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2872,10 +2872,10 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.12.2"
-source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c#ac1af8c619da3a1612f18149de46fd44a5bf1244"
+source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc#6cfc2cc601ee856966c5d688c425f2e006243742"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb-sys 6.2.4 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c)",
+ "librocksdb-sys 6.2.4 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc)",
 ]
 
 [[package]]
@@ -4080,7 +4080,7 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum librocksdb-sys 6.2.4 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c)" = "<none>"
+"checksum librocksdb-sys 6.2.4 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc)" = "<none>"
 "checksum linked-hash-map 0.5.1 (git+https://github.com/nervosnetwork/linked-hash-map?rev=df27f21)" = "<none>"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
@@ -4177,7 +4177,7 @@ dependencies = [
 "checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
 "checksum resolve 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19526b305899bea65f26edda78a64f5313958494321ee0ab66bd94b32958614a"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
-"checksum rocksdb 0.12.2 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=ac1af8c)" = "<none>"
+"checksum rocksdb 0.12.2 (git+https://github.com/nervosnetwork/rust-rocksdb?rev=6cfc2cc)" = "<none>"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9591f190d2852720b679c21f66ad929f9f1d7bb09d1193c26167586029d8489c"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -16,4 +16,4 @@ libc = "0.2"
 
 [dependencies.rocksdb]
 git = "https://github.com/nervosnetwork/rust-rocksdb"
-rev = "ac1af8c"
+rev = "6cfc2cc"


### PR DESCRIPTION
See https://github.com/nervosnetwork/rust-rocksdb/pull/1 for changes for the rocksdb library.

While this won't affect CKB, it provides a different rocksdb version that can aid ReadOnly mode when using ckb packages.