### PR TITLE
fix: error message on calculate dao max withdraw

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -30,7 +30,11 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(cause) = self.cause() {
-            write!(f, "{}({})", self.kind(), cause)
+            if f.alternate() {
+                write!(f, "{}: {}", self.kind(), cause)
+            } else {
+                write!(f, "{}({})", self.kind(), cause)
+            }
         } else {
             write!(f, "{}", self.kind())
         }

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -66,7 +66,7 @@ impl AlertRpc for AlertRpcImpl {
                 self.notifier.lock().add(Arc::new(alert));
                 Ok(())
             }
-            Err(e) => Err(RPCError::custom(RPCError::Invalid, e.to_string())),
+            Err(e) => Err(RPCError::custom(RPCError::Invalid, format!("{:#}", e))),
         }
     }
 }

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -68,7 +68,7 @@ impl ExperimentRpc for ExperimentRpcImpl {
             Ok(capacity) => Ok(capacity.into()),
             Err(err) => {
                 error!("calculate_dao_maximum_withdraw error {:?}", err);
-                Err(Error::internal_error())
+                Err(RPCError::custom(RPCError::Invalid, format!("{:#}", err)))
             }
         }
     }

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -79,7 +79,7 @@ impl PoolRpc for PoolRpcImpl {
                         ));
                     }
                 }
-                Err(RPCError::custom(RPCError::Invalid, e.to_string()))
+                Err(RPCError::custom(RPCError::Invalid, format!("{:#}", e)))
             }
         }
     }

--- a/test/src/specs/dao/dao_tx.rs
+++ b/test/src/specs/dao/dao_tx.rs
@@ -129,7 +129,7 @@ impl Spec for WithdrawDAOWithNotMaturitySince {
             transaction.as_advanced_builder().set_inputs(inputs).build()
         };
         node0.generate_blocks(20);
-        assert_send_transaction_fail(node0, &transaction, "Script(ValidationFailure(-17))");
+        assert_send_transaction_fail(node0, &transaction, "Script: ValidationFailure(-17)");
     }
 }
 
@@ -194,7 +194,7 @@ impl Spec for WithdrawDAOWithInvalidWitness {
                     .set_witnesses(Vec::new())
                     .build();
             node0.generate_blocks(20);
-            assert_send_transaction_fail(node0, &transaction, "Dao(InvalidOutPoint)");
+            assert_send_transaction_fail(node0, &transaction, "Dao: InvalidOutPoint");
         }
 
         // TODO: DAO script does not return ERROR_WRONG_NUMBER_OF_ARGUMENTS now
@@ -220,7 +220,7 @@ impl Spec for WithdrawDAOWithInvalidWitness {
                     .set_witnesses(vec![witness])
                     .build();
             node0.generate_blocks(20);
-            assert_send_transaction_fail(node0, &transaction, "Dao(InvalidDaoFormat)");
+            assert_send_transaction_fail(node0, &transaction, "Dao: InvalidDaoFormat");
         }
 
         // Withdraw DAO with witness point to out-of-index dependency. DAO script `ckb_load_header` failed
@@ -235,7 +235,7 @@ impl Spec for WithdrawDAOWithInvalidWitness {
                     .set_witnesses(vec![witness])
                     .build();
             node0.generate_blocks(20);
-            assert_send_transaction_fail(node0, &transaction, "Dao(InvalidOutPoint)");
+            assert_send_transaction_fail(node0, &transaction, "Dao: InvalidOutPoint");
         }
     }
 }

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -44,7 +44,7 @@ impl ValidSince {
 
         // Failed to send transaction since SinceImmaturity
         for _ in 1..relative {
-            assert_send_transaction_fail(node, &transaction, "Transaction(Immature)");
+            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
             node.generate_block();
         }
 
@@ -70,7 +70,7 @@ impl ValidSince {
         // Failed to send transaction since SinceImmaturity
         let tip_number = node.rpc_client().get_tip_block_number();
         for _ in tip_number + 1..absolute {
-            assert_send_transaction_fail(node, &transaction, "Transaction(Immature)");
+            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
             node.generate_block();
         }
 
@@ -115,7 +115,7 @@ impl ValidSince {
         {
             let since = since_from_relative_timestamp(median_time_seconds + 1);
             let transaction = node.new_transaction_with_since(cellbase.hash(), since);
-            assert_send_transaction_fail(node, &transaction, "Transaction(Immature)");
+            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
         }
         {
             let since = since_from_relative_timestamp(median_time_seconds - 1);
@@ -158,7 +158,7 @@ impl ValidSince {
         {
             let since = since_from_absolute_timestamp(median_time_seconds + 1);
             let transaction = node.new_transaction_with_since(cellbase.hash(), since);
-            assert_send_transaction_fail(node, &transaction, "Transaction(Immature)");
+            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
         }
         {
             let since = since_from_absolute_timestamp(median_time_seconds - 1);
@@ -186,7 +186,7 @@ impl ValidSince {
 
         (0..relative_blocks - DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|i| {
             info!("Tx is Immature in block N + {}", i);
-            assert_send_transaction_fail(node, &tx, "Transaction(Immature)");
+            assert_send_transaction_fail(node, &tx, "Transaction: Immature");
             node.generate_block();
         });
 


### PR DESCRIPTION
fix #1389

before:
```
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"},"id":2}
```
after:
```
{"jsonrpc":"2.0","error":{"code":-3,"message":"Dao: InvalidOutPoint"},"id":2}
```