### PR TITLE
feat: Include raw header bytes in get_block_template

### DIFF
--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -30,3 +30,5 @@ crossbeam-channel = "0.3"
 ckb-future-executor = { path = "../util/future-executor" }
 ckb-stop-handler = { path = "../util/stop-handler" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
+
+molecule = "=0.4.0"

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -1,6 +1,7 @@
 use crate::{
     BlockNumber, Byte32, Cycle, EpochNumberWithFraction, Header, ProposalShortId, Timestamp,
     Transaction, Uint32, Uint64, Version,
+    JsonBytes,
 };
 use ckb_types::{packed, prelude::*, H256};
 use serde_derive::{Deserialize, Serialize};
@@ -23,6 +24,7 @@ pub struct BlockTemplate {
     pub cellbase: CellbaseTemplate,
     pub work_id: Uint64,
     pub dao: Byte32,
+    pub raw: JsonBytes,
 }
 
 impl From<BlockTemplate> for packed::Block {


### PR DESCRIPTION
As requested and discussed by Greg from icemining.ca.

I'm open to suggestions eq. as to how to remove additional `molecule` dependency.