### PR TITLE
refactor: enhance the binary packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
       os: osx
       env: REL_PKG=x86_64-apple-darwin.zip
       script:
-        - make prod
+        - make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include prod
         - openssl aes-256-cbc -K $encrypted_82dff4145bbf_key -iv $encrypted_82dff4145bbf_iv -in devtools/ci/travis-secret.asc.enc -out devtools/ci/travis-secret.asc -d
         - gpg --import devtools/ci/travis-secret.asc
         - devtools/ci/package.sh target/release/ckb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,7 @@ jobs:
       - powershell: |
           mkdir ckb_$(Build.SourceBranchName)_x86_64-pc-windows-msvc
           cp -r target/release/ckb.exe,README.md,CHANGELOG.md,COPYING,docs ckb_$(Build.SourceBranchName)_x86_64-pc-windows-msvc
+          cp devtools/windows/ckb-init-mainnet.bat,devtools/windows/ckb-reinit-mainnet.bat,devtools/windows/ckb-run.bat ckb_$(Build.SourceBranchName)_x86_64-pc-windows-msvc
           cp rpc/README.md ckb_$(Build.SourceBranchName)_x86_64-pc-windows-msvc/docs/rpc.md
           unzip ckb-cli_$(CKBClientVersion)_x86_64-pc-windows-msvc.zip
           mv ckb-cli_$(CKBClientVersion)_x86_64-pc-windows-msvc/ckb-cli.exe ckb_$(Build.SourceBranchName)_x86_64-pc-windows-msvc/

--- a/devtools/windows/ckb-init-mainnet.bat
+++ b/devtools/windows/ckb-init-mainnet.bat
@@ -1,0 +1,5 @@
+@ECHO off
+CLS
+PUSHD %~dp0
+ckb init --chain mainnet
+PAUSE

--- a/devtools/windows/ckb-reinit-mainnet.bat
+++ b/devtools/windows/ckb-reinit-mainnet.bat
@@ -1,0 +1,5 @@
+@ECHO off
+CLS
+PUSHD %~dp0
+ckb init --chain mainnet --force
+PAUSE

--- a/devtools/windows/ckb-run.bat
+++ b/devtools/windows/ckb-run.bat
@@ -1,0 +1,5 @@
+@ECHO off
+CLS
+PUSHD %~dp0
+ckb run
+PAUSE

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,6 +20,9 @@ ckb init
 
 See how to [configure CKB](configure.md) if you like to tweak the options.
 
+Windows users can double click `ckb-init-mainnet.bat` to initialize a mainnet
+node directory.
+
 ## Start Node
 
 Start the node from the directory
@@ -29,6 +32,8 @@ ckb run
 ```
 
 Restarting in the same directory will reuse the data.
+
+Windows users can double click `ckb-run.bat` to start the node.
 
 ## Use RPC
 


### PR DESCRIPTION
- Static link openssl in macOS package, so it will not require openssl as a runtime dependency.
- Add bat files in Windows package to ease starting a node in Windows.