### PR TITLE
chore: omit calculate_dao_maximum_withdraw log

### DIFF
--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -66,10 +66,7 @@ impl ExperimentRpc for ExperimentRpcImpl {
         let calculator = DaoCalculator::new(consensus, snapshot);
         match calculator.maximum_withdraw(&out_point.into(), &hash.pack()) {
             Ok(capacity) => Ok(capacity.into()),
-            Err(err) => {
-                error!("calculate_dao_maximum_withdraw error {:?}", err);
-                Err(RPCError::custom(RPCError::Invalid, format!("{:#}", err)))
-            }
+            Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:#}", err))),
         }
     }
 


### PR DESCRIPTION
Neuron will request `calculate_dao_maximum_withdraw` to calculate NervosDAO interest. So when a fresh node does not synchronize completely, a `calculate_dao_maximum_withdraw` request may trigger an error.
It is unnecessary to write this error into logs.