### PR TITLE
feat: add a new json rpc method `get_block_economic_state`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -658,6 +658,16 @@ Returns increased issuance, miner reward and total transaction fee of a block.
 #### Parameters
 
     hash - Block hash
+#### Returns
+
+    finalized_at - The hash of the block which finalized
+    issuance::primary - Primary issuance in this block
+    issuance::secondary - Secondary issuance in this block
+    miner_reward::committed - Committed fee in miner reward
+    miner_reward::proposal - Proposal fee in miner reward
+    miner_reward::primary - Primary issuance in miner reward
+    miner_reward::secondary - Secondary issuance in miner reward
+    txs_fee - The total transaction fee of all transactions in the this block
 
 #### Examples
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -16,6 +16,7 @@ NOTE: This file is auto-generated. Please don't update this file directly; inste
     *   [`get_live_cell`](#get_live_cell)
     *   [`get_transaction`](#get_transaction)
     *   [`get_cellbase_output_capacity_details`](#get_cellbase_output_capacity_details)
+    *   [`get_block_economic_state`](#get_block_economic_state)
     *   [`get_block_by_number`](#get_block_by_number)
 *   [`Experiment`](#experiment)
     *   [`dry_run_transaction`](#dry_run_transaction)
@@ -640,6 +641,51 @@ http://localhost:8114
         "secondary": "0x17b93605",
         "total": "0x18e64b61cf",
         "tx_fee": "0x0"
+    }
+}
+```
+
+### `get_block_economic_state`
+
+Returns increased issuance, miner reward and total transaction fee of a block.
+
+#### Parameters
+
+    hash - Block hash
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_block_economic_state",
+    "params": [
+        "0x02530b25ad0ff677acc365cb73de3e8cc09c7ddd58272e879252e199d08df83b"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+        "finalized_at": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "issuance": {
+            "primary": "0x18ce922bca",
+            "secondary": "0x7f02ec655"
+        },
+        "miner_reward": {
+            "committed": "0x0",
+            "primary": "0x18ce922bca",
+            "proposal": "0x0",
+            "secondary": "0x17b93605"
+        },
+        "txs_fee": "0x0"
     }
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -752,6 +752,33 @@
         ]
     },
     {
+        "description": "Returns increased issuance, miner reward and total transaction fee of a block.",
+        "method": "get_block_economic_state",
+        "module": "chain",
+        "params": [
+            "0x02530b25ad0ff677acc365cb73de3e8cc09c7ddd58272e879252e199d08df83b"
+        ],
+        "result": {
+            "finalized_at": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+            "issuance": {
+                "primary": "0x18ce922bca",
+                "secondary": "0x7f02ec655"
+            },
+            "miner_reward": {
+                "committed": "0x0",
+                "primary": "0x18ce922bca",
+                "proposal": "0x0",
+                "secondary": "0x17b93605"
+            },
+            "txs_fee": "0x0"
+        },
+        "types": [
+            {
+                "hash": "Block hash"
+            }
+        ]
+    },
+    {
         "description": "Return the transaction pool information",
         "method": "tx_pool_info",
         "module": "pool",

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -772,6 +772,32 @@
             },
             "txs_fee": "0x0"
         },
+        "returns": [
+            {
+                "finalized_at": "The hash of the block which finalized"
+            },
+            {
+                "issuance::primary": "Primary issuance in this block"
+            },
+            {
+                "issuance::secondary": "Secondary issuance in this block"
+            },
+            {
+                "miner_reward::committed": "Committed fee in miner reward"
+            },
+            {
+                "miner_reward::proposal": "Proposal fee in miner reward"
+            },
+            {
+                "miner_reward::primary": "Primary issuance in miner reward"
+            },
+            {
+                "miner_reward::secondary": "Secondary issuance in miner reward"
+            },
+            {
+                "txs_fee": "The total transaction fee of all transactions in the this block"
+            }
+        ],
         "types": [
             {
                 "hash": "Block hash"

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1,13 +1,18 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
-    BlockNumber, BlockReward, BlockView, CellOutputWithOutPoint, CellWithStatus, EpochNumber,
-    EpochView, HeaderView, OutPoint, TransactionWithStatus,
+    BlockEconomicState, BlockNumber, BlockReward, BlockView, CellOutputWithOutPoint,
+    CellWithStatus, EpochNumber, EpochView, HeaderView, OutPoint, TransactionWithStatus,
 };
 use ckb_logger::{error, warn};
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
-use ckb_types::{core::cell::CellProvider, packed, prelude::*, H256};
+use ckb_types::{
+    core::{self, cell::CellProvider},
+    packed,
+    prelude::*,
+    H256,
+};
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 
@@ -58,6 +63,9 @@ pub trait ChainRpc {
 
     #[rpc(name = "get_cellbase_output_capacity_details")]
     fn get_cellbase_output_capacity_details(&self, _hash: H256) -> Result<Option<BlockReward>>;
+
+    #[rpc(name = "get_block_economic_state")]
+    fn get_block_economic_state(&self, _hash: H256) -> Result<Option<BlockEconomicState>>;
 }
 
 pub(crate) struct ChainRpcImpl {
@@ -277,11 +285,78 @@ impl ChainRpc for ChainRpcImpl {
                         None
                     } else {
                         RewardCalculator::new(snapshot.consensus(), snapshot.as_ref())
-                            .block_reward(&parent)
+                            .block_reward_to_finalize(&parent)
                             .map(|r| r.1.into())
                             .ok()
                     }
                 })
+        }))
+    }
+
+    fn get_block_economic_state(&self, hash: H256) -> Result<Option<BlockEconomicState>> {
+        let snapshot = self.shared.snapshot();
+
+        let block_number = if let Some(block_number) = snapshot.get_block_number(&hash.pack()) {
+            block_number
+        } else {
+            return Ok(None);
+        };
+
+        let delay_length = snapshot.consensus().finalization_delay_length();
+        let finalized_at_number = block_number + delay_length;
+        if block_number == 0 || snapshot.tip_number() < finalized_at_number {
+            return Ok(None);
+        }
+
+        let block_hash = hash.pack();
+        let finalized_at = if let Some(block_hash) = snapshot.get_block_hash(finalized_at_number) {
+            block_hash
+        } else {
+            return Ok(None);
+        };
+
+        let issuance = if let Some(issuance) = snapshot
+            .get_block_epoch_index(&block_hash)
+            .and_then(|index| snapshot.get_epoch_ext(&index))
+            .and_then(|epoch_ext| {
+                let primary = epoch_ext.block_reward(block_number).ok()?;
+                let secondary = epoch_ext
+                    .secondary_block_issuance(
+                        block_number,
+                        snapshot.consensus().secondary_epoch_reward(),
+                    )
+                    .ok()?;
+                Some(core::BlockIssuance { primary, secondary })
+            }) {
+            issuance
+        } else {
+            return Ok(None);
+        };
+
+        let txs_fee = if let Some(txs_fee) =
+            snapshot.get_block_ext(&block_hash).and_then(|block_ext| {
+                block_ext
+                    .txs_fees
+                    .iter()
+                    .try_fold(core::Capacity::zero(), |acc, tx_fee| acc.safe_add(*tx_fee))
+                    .ok()
+            }) {
+            txs_fee
+        } else {
+            return Ok(None);
+        };
+
+        Ok(snapshot.get_block_header(&block_hash).and_then(|header| {
+            RewardCalculator::new(snapshot.consensus(), snapshot.as_ref())
+                .block_reward_for_target(&header)
+                .ok()
+                .map(|(_, block_reward)| core::BlockEconomicState {
+                    issuance,
+                    miner_reward: block_reward.into(),
+                    txs_fee,
+                    finalized_at,
+                })
+                .map(Into::into)
         }))
     }
 }

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -372,6 +372,12 @@ fn params_of(shared: &Shared, method: &str) -> Value {
     };
     let tip_number: Uint64 = tip.number().into();
     let tip_hash = json!(format!("{:#x}", Unpack::<H256>::unpack(&tip.hash())));
+    let target_hash = {
+        let snapshot = shared.snapshot();
+        let target_number = tip.number() - snapshot.consensus().finalization_delay_length();
+        let target_hash = snapshot.get_block_hash(target_number).unwrap();
+        json!(format!("{:#x}", target_hash))
+    };
     let (_, _, always_success_script) = always_success_cell();
     let always_success_script_hash = {
         let always_success_script_hash: H256 = always_success_script.calc_script_hash().unpack();
@@ -407,6 +413,7 @@ fn params_of(shared: &Shared, method: &str) -> Value {
             vec![json!(tip_number)]
         }
         "get_block" | "get_header" | "get_cellbase_output_capacity_details" => vec![tip_hash],
+        "get_block_economic_state" => vec![target_hash],
         "get_cells_by_lock_hash"
         | "get_live_cells_by_lock_hash"
         | "get_transactions_by_lock_hash" => {

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -4,10 +4,10 @@ mod macros;
 mod error;
 
 use ckb_jsonrpc_types::{
-    Alert, BannedAddr, Block, BlockNumber, BlockReward, BlockTemplate, BlockView, Capacity,
-    CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle, DryRunResult,
-    EpochNumber, EpochView, EstimateResult, HeaderView, LiveCell, LockHashIndexState, Node,
-    OutPoint, PeerState, Timestamp, Transaction, TransactionWithStatus, TxPoolInfo, Uint64,
+    Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockReward, BlockTemplate,
+    BlockView, Capacity, CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle,
+    DryRunResult, EpochNumber, EpochView, EstimateResult, HeaderView, LiveCell, LockHashIndexState,
+    Node, OutPoint, PeerState, Timestamp, Transaction, TransactionWithStatus, TxPoolInfo, Uint64,
     Version,
 };
 use ckb_types::core::{
@@ -300,6 +300,12 @@ impl RpcClient {
             .expect("rpc call get_cellbase_output_capacity_details")
     }
 
+    pub fn get_block_economic_state(&self, hash: Byte32) -> Option<BlockEconomicState> {
+        self.inner()
+            .get_block_economic_state(hash.unpack())
+            .expect("rpc call get_block_economic_state")
+    }
+
     pub fn estimate_fee_rate(&self, expect_confirm_blocks: Uint64) -> EstimateResult {
         self.inner()
             .estimate_fee_rate(expect_confirm_blocks)
@@ -366,6 +372,7 @@ jsonrpc!(pub struct Inner {
     pub fn get_lock_hash_index_states(&self) -> Vec<LockHashIndexState>;
     pub fn calculate_dao_maximum_withdraw(&self, _out_point: OutPoint, _hash: H256) -> Capacity;
     pub fn get_cellbase_output_capacity_details(&self, _hash: H256) -> Option<BlockReward>;
+    pub fn get_block_economic_state(&self, _hash: H256) -> Option<BlockEconomicState>;
     pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> H256;
     pub fn estimate_fee_rate(&self, expect_confirm_blocks: Uint64) -> EstimateResult;
 });

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -166,8 +166,8 @@ impl BlockAssembler {
         let candidate_number = tip.number() + 1;
 
         let tx = {
-            let (target_lock, block_reward) =
-                RewardCalculator::new(snapshot.consensus(), snapshot).block_reward(tip)?;
+            let (target_lock, block_reward) = RewardCalculator::new(snapshot.consensus(), snapshot)
+                .block_reward_to_finalize(tip)?;
             let input = CellInput::new_cellbase_input(candidate_number);
             let output = CellOutput::new_builder()
                 .capacity(block_reward.total.pack())

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -698,6 +698,90 @@ impl From<BlockReward> for core::BlockReward {
     }
 }
 
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct BlockIssuance {
+    pub primary: Capacity,
+    pub secondary: Capacity,
+}
+
+impl From<core::BlockIssuance> for BlockIssuance {
+    fn from(core: core::BlockIssuance) -> Self {
+        Self {
+            primary: core.primary.into(),
+            secondary: core.secondary.into(),
+        }
+    }
+}
+
+impl From<BlockIssuance> for core::BlockIssuance {
+    fn from(json: BlockIssuance) -> Self {
+        Self {
+            primary: json.primary.into(),
+            secondary: json.secondary.into(),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct MinerReward {
+    pub primary: Capacity,
+    pub secondary: Capacity,
+    pub committed: Capacity,
+    pub proposal: Capacity,
+}
+
+impl From<core::MinerReward> for MinerReward {
+    fn from(core: core::MinerReward) -> Self {
+        Self {
+            primary: core.primary.into(),
+            secondary: core.secondary.into(),
+            committed: core.committed.into(),
+            proposal: core.proposal.into(),
+        }
+    }
+}
+
+impl From<MinerReward> for core::MinerReward {
+    fn from(json: MinerReward) -> Self {
+        Self {
+            primary: json.primary.into(),
+            secondary: json.secondary.into(),
+            committed: json.committed.into(),
+            proposal: json.proposal.into(),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct BlockEconomicState {
+    pub issuance: BlockIssuance,
+    pub miner_reward: MinerReward,
+    pub txs_fee: Capacity,
+    pub finalized_at: H256,
+}
+
+impl From<core::BlockEconomicState> for BlockEconomicState {
+    fn from(core: core::BlockEconomicState) -> Self {
+        Self {
+            issuance: core.issuance.into(),
+            miner_reward: core.miner_reward.into(),
+            txs_fee: core.txs_fee.into(),
+            finalized_at: core.finalized_at.unpack(),
+        }
+    }
+}
+
+impl From<BlockEconomicState> for core::BlockEconomicState {
+    fn from(json: BlockEconomicState) -> Self {
+        Self {
+            issuance: json.issuance.into(),
+            miner_reward: json.miner_reward.into(),
+            txs_fee: json.txs_fee.into(),
+            finalized_at: json.finalized_at.pack(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -21,9 +21,10 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, BlockReward, BlockView, CellDep, CellInput, CellOutput, DepType, EpochView, Header,
-    HeaderView, OutPoint, Script, ScriptHashType, Status, Transaction, TransactionView,
-    TransactionWithStatus, TxStatus, UncleBlock, UncleBlockView,
+    Block, BlockEconomicState, BlockIssuance, BlockReward, BlockView, CellDep, CellInput,
+    CellOutput, DepType, EpochView, Header, HeaderView, MinerReward, OutPoint, Script,
+    ScriptHashType, Status, Transaction, TransactionView, TransactionWithStatus, TxStatus,
+    UncleBlock, UncleBlockView,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -109,7 +109,7 @@ impl Snapshot {
         &self,
         parent: &HeaderView,
     ) -> Result<(Script, BlockReward), Error> {
-        RewardCalculator::new(self.consensus(), self).block_reward(parent)
+        RewardCalculator::new(self.consensus(), self).block_reward_to_finalize(parent)
     }
 }
 

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -15,7 +15,7 @@ mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
 pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
-pub use reward::BlockReward;
+pub use reward::{BlockEconomicState, BlockIssuance, BlockReward, MinerReward};
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};
 

--- a/util/types/src/core/reward.rs
+++ b/util/types/src/core/reward.rs
@@ -1,4 +1,4 @@
-use crate::core::Capacity;
+use crate::{core::Capacity, packed::Byte32};
 
 #[derive(Debug, Default)]
 pub struct BlockReward {
@@ -7,4 +7,37 @@ pub struct BlockReward {
     pub secondary: Capacity,
     pub tx_fee: Capacity,
     pub proposal_reward: Capacity,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BlockIssuance {
+    pub primary: Capacity,
+    pub secondary: Capacity,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct MinerReward {
+    pub primary: Capacity,
+    pub secondary: Capacity,
+    pub committed: Capacity,
+    pub proposal: Capacity,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BlockEconomicState {
+    pub issuance: BlockIssuance,
+    pub miner_reward: MinerReward,
+    pub txs_fee: Capacity,
+    pub finalized_at: Byte32,
+}
+
+impl From<BlockReward> for MinerReward {
+    fn from(reward: BlockReward) -> Self {
+        Self {
+            primary: reward.primary,
+            secondary: reward.secondary,
+            committed: reward.tx_fee,
+            proposal: reward.proposal_reward,
+        }
+    }
 }

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -48,7 +48,7 @@ impl<'a, CS: ChainStore<'a>> VerifyContext<'a, CS> {
     }
 
     fn finalize_block_reward(&self, parent: &HeaderView) -> Result<(Script, BlockReward), Error> {
-        RewardCalculator::new(self.consensus, self.store).block_reward(parent)
+        RewardCalculator::new(self.consensus, self.store).block_reward_to_finalize(parent)
     }
 
     fn next_epoch_ext(&self, last_epoch: &EpochExt, header: &HeaderView) -> Option<EpochExt> {


### PR DESCRIPTION
### Purpose

Replace the JSON-RPC method [`get_cellbase_output_capacity_details`].

### Reasons

#### Remove the Ambiguity

##### Secondary Issuance

According to [CKB RFC-0015](https://github.com/nervosnetwork/rfcs/blob/dda4478/rfcs/0015-ckb-cryptoeconomics/0015-ckb-cryptoeconomics.md#collecting-state-rent-with-secondary-issuance-and-the-nervosdao):
> Then 60% of the secondary issuance goes to the miners, 35% of the issuance goes to the NervosDAO to be distributed to the locked tokens proportionally.

Only 60% of the secondary issuance goes to the miners.
But we can't see it from the response of [`get_cellbase_output_capacity_details`].

##### Transaction Fees

According to [CKB v0.25.2 Code](https://github.com/nervosnetwork/ckb/blob/dda4ed9/util/reward-calculator/src/lib.rs#L87-L215):

```rust
    /// Miner get (tx_fee - 40% of tx fee) for tx commitment.
    /// Be careful of the rounding, tx_fee - 40% of tx fee is different from 60% of tx fee.
    pub fn txs_fees(&self, target: &HeaderView) -> Result<Capacity, Error> {
        /* ... omitted ... */
    }

    /// Earliest proposer get 40% of tx fee as reward when tx committed
    ///  ... omitted ...
    pub fn proposal_reward(&self, parent: &HeaderView, target: &HeaderView) -> Result<Capacity, Error> {
        /* ... omitted ... */
    }
```

The transaction fees which paid to miner is not same as the total transaction fee of all transactions in the mined block.
The `tx_fee` in [`get_cellbase_output_capacity_details`] is only about 60% of total transaction fee in the mined block.
And transaction fees in miner reward have two part: committed fee/reward and proposal fee/reward.

#### Help for Doing Statistics

- Currently, there is no interface can query total issuance of a block.
- Currently, there is no interface can query total transaction fee of a block.

#### Simplify the Usage

Currently, if we want to know which miner mined block-N and how many rewards he received for block-N, **we have to use a magic number 11 (it's a bit obscure, and reading the source code is the only way to get it)** and call JSON-RPC 4 times:
```rust
/* pseudo-code */
let miner =  rpc
    .get_block_hash(N)
    .map(|hash| rpc.get_block(hash).cellbase().witness().parse_miner())
    .unwrap();
let reward = rpc
    .get_block_hash(N+11)
    .map(|hash| rpc.get_cellbase_output_capacity_details(hash))
    .unwrap();
```

The new JSON-RPC method will hide the magic number and return the block hash which finalized the miner reward:
```rust
/* pseudo-code */
let hash =  rpc.get_block_hash(N).unwrap();
let miner = rpc.get_block(hash).cellbase().witness().parse_miner()).unwrap();
let reward = rpc.get_block_economic_state(hash).unwrap();
```

### Further

Currently, the `Transaction Fee` on the ckb explorer is the sum of committed reward and proposal reward in miner reward of a block, not the total transaction fee of all transactions in that block.
**It's really hard to understand the `Transaction Fee` for newbies.**

For example:
- [block-14 on mainnet](https://explorer.nervos.org/block/0x5b78979ee71a7a32868e6256874571b2b59a9e40e38e6923e653db4ae5fd3d1d) has no proposal transaction, and total transaction fee of it is `66.00000000 CKB`, but the `Transaction Fee` on the ckb explorer is `39.60000000 CKB`.
- [block-334 on mainnet](https://explorer.nervos.org/block/0xbaf6c624282a7a9c5bc673ea79d6b612de822f68cb8e3f8004bf887dd11583de) has no transaction expect cellbase, but the `Transaction Fee` on the ckb explorer is `0.40522815 CKB`.

**I think we should unify the names.**
And, I didn't find any description about how to partition the total transaction fee of all transactions in a block into committed fee/reward and proposal fee/reward in [CKB RFCs](https://github.com/nervosnetwork/rfcs/tree/dda4478/rfcs).
Did I miss it?

[`get_cellbase_output_capacity_details`]: https://github.com/nervosnetwork/ckb/tree/dda4ed9/rpc#get_cellbase_output_capacity_details