### PR TITLE
feat: no debug symbols as default and add a command to build with debug symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ members = [
 ]
 
 [profile.release]
-debug = true
 overflow-checks = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ prod-docker:
 prod-test:
 	RUSTFLAGS="--cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" cargo test ${VERBOSE} --all -- --nocapture
 
+.PHONY: prod-with-debug
+prod-with-debug:
+	devtools/release/make-with-debug-symbols prod
+
 .PHONY: docker
 docker: ## Build docker image
 	docker build -f docker/hub/Dockerfile -t nervos/ckb:$$(git describe) .

--- a/devtools/release/make-with-debug-symbols
+++ b/devtools/release/make-with-debug-symbols
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case "$OSTYPE" in
+    darwin*)
+        if ! type gsed &> /dev/null; then
+            echo "GNU sed not found! You can install via Homebrew" >&2
+            echo >&2
+            echo "    brew install gnu-sed" >&2
+            exit 1
+        fi
+        SED=gsed
+        ;;
+    *)
+        SED=sed
+        ;;
+esac
+
+function restore_manifest_file () {
+    ${SED} -i -e '/\[profile.release\]/{n;d}' Cargo.toml
+}
+
+trap restore_manifest_file EXIT
+
+function main() {
+    ${SED} -i "/\[profile.release\]/adebug = true" Cargo.toml
+    make "$@"
+}
+
+main "$@"


### PR DESCRIPTION
1. [Stable releases of cargo don't support custom profiles.](../../../rust-lang/cargo/issues/6988)

2. We can't use another manifest file in same directory since `error: the manifest-path must be a path to a Cargo.toml file`.

3. I try to put a debug version of `Cargo.toml` in another  directory, it's conflicted with the original `Cargo.toml`. Each crate should be in only one workspace.

4. Add arguments into `RUSTFLAGS` to control `rustc`, but it's unable to achieve the same effect.

   According to [The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections): `debug = true` is equivalent to `-C debuginfo=2` compiler flag.

   According to `rustc --help`, `-g` is equivalent to `-C debuginfo=2`.

   But when use `debug = true`, the size of debug symbols in executable file is bigger than `-g` (or `-C debuginfo=2`), ~~and `debug = true` will enable some other debug features, for example: `debug_assertions = true` (I found it in [rust source code](https://github.com/rust-lang/rust/blob/695fe965173795f9242dfcad6d1c07d7a17b106a/src/bootstrap/config.rs#L631-L632), but it doesn't works when I test it)~~.

   So, I think `debug = true` is better than `-g` or `-C debuginfo=2` for debugging.

   - Execute `cargo build --release` without `debug = true`.
     The size of `ckb` is 36876256 Bytes (36MB).
     After strip, it will be 26102560 Bytes (25MB).
   - Execute `cargo build --release` with `debug = true`.
     The size of `ckb` is 439163736 Bytes (419MB).
     After strip, it will be 26098544 Bytes (25MB).
   - Execute `RUSTFLAGS="-g" cargo build --release` without `debug = true`.
     The size of `ckb` is 366969536 Bytes (350MB).
     After strip, it will be 26155888 Bytes (25MB).
   - Execute `RUSTFLAGS="-C debuginfo=2" cargo build --release` without `debug = true`.
     The size of `ckb` is 26151792 Bytes (351MB).
     After strip, it will be 26098544 Bytes (25MB).

   Use same command always get the same size executable file. **It's deterministic.**

#### Appendix


<details><summary>The stripped part for stripping an executable file which compile by <code>cargo build --release</code> without <code>debug = true</code>.</summary>
<pre>
Sections:
Idx Name              Size      VMA               LMA               File off  Algn  Flags
 27 .comment          0000009a  0000000000000000  0000000000000000  018e41fa  2**0  CONTENTS, READONLY
 28 .debug_aranges    00000270  0000000000000000  0000000000000000  018e4294  2**0  CONTENTS, READONLY, DEBUGGING
 29 .debug_pubnames   0003bcbd  0000000000000000  0000000000000000  018e4504  2**0  CONTENTS, READONLY, DEBUGGING
 30 .debug_info       00150220  0000000000000000  0000000000000000  019201c1  2**0  CONTENTS, READONLY, DEBUGGING
 31 .debug_abbrev     00006993  0000000000000000  0000000000000000  01a703e1  2**0  CONTENTS, READONLY, DEBUGGING
 32 .debug_line       000a3beb  0000000000000000  0000000000000000  01a76d74  2**0  CONTENTS, READONLY, DEBUGGING
 33 .debug_frame      00001230  0000000000000000  0000000000000000  01b1a960  2**3  CONTENTS, READONLY, DEBUGGING
 34 .debug_str        000b5275  0000000000000000  0000000000000000  01b1bb90  2**0  CONTENTS, READONLY, DEBUGGING
 35 .debug_loc        001579db  0000000000000000  0000000000000000  01bd0e05  2**0  CONTENTS, READONLY, DEBUGGING
 36 .debug_macinfo    00000031  0000000000000000  0000000000000000  01d287e0  2**0  CONTENTS, READONLY, DEBUGGING
 37 .debug_pubtypes   00019c31  0000000000000000  0000000000000000  01d28811  2**0  CONTENTS, READONLY, DEBUGGING
 38 .debug_ranges     00098440  0000000000000000  0000000000000000  01d42442  2**0  CONTENTS, READONLY, DEBUGGING
</pre>
</details>

<details><summary>Size of debug symbols in executable files for different compilation conditions.</summary>
<pre>
Sections:
Idx Name               Size      VMA               LMA               File off  Algn  Flags
 // debug = true
 ... omitted ...
 29 .debug_aranges     000002a0  0000000000000000  0000000000000000  018e3294  2**0  CONTENTS, READONLY, DEBUGGING
 30 .debug_pubnames    0225e9f0  0000000000000000  0000000000000000  018e3534  2**0  CONTENTS, READONLY, DEBUGGING
 31 .debug_info        0783474a  0000000000000000  0000000000000000  03b41f24  2**0  CONTENTS, READONLY, DEBUGGING
 32 .debug_abbrev      001a9b4b  0000000000000000  0000000000000000  0b37666e  2**0  CONTENTS, READONLY, DEBUGGING
 33 .debug_line        013b5e42  0000000000000000  0000000000000000  0b5201b9  2**0  CONTENTS, READONLY, DEBUGGING
 34 .debug_frame       00001230  0000000000000000  0000000000000000  0c8d6000  2**3  CONTENTS, READONLY, DEBUGGING
 35 .debug_str         0258ab85  0000000000000000  0000000000000000  0c8d7230  2**0  CONTENTS, READONLY, DEBUGGING
 36 .debug_loc         06240092  0000000000000000  0000000000000000  0ee61db5  2**0  CONTENTS, READONLY, DEBUGGING
 37 .debug_macinfo     00000855  0000000000000000  0000000000000000  150a1e47  2**0  CONTENTS, READONLY, DEBUGGING
 38 .debug_pubtypes    02ba7a4e  0000000000000000  0000000000000000  150a269c  2**0  CONTENTS, READONLY, DEBUGGING
 39 .debug_ranges      021377a0  0000000000000000  0000000000000000  17c4a0ea  2**0  CONTENTS, READONLY, DEBUGGING
 // -g
 ... omitted ...
 29 .debug_aranges     00000270  0000000000000000  0000000000000000  018f2294  2**0  CONTENTS, READONLY, DEBUGGING
 30 .debug_pubnames    01b582ce  0000000000000000  0000000000000000  018f2504  2**0  CONTENTS, READONLY, DEBUGGING
 31 .debug_info        05ae5ecb  0000000000000000  0000000000000000  0344a7d2  2**0  CONTENTS, READONLY, DEBUGGING
 32 .debug_abbrev      0014d4d9  0000000000000000  0000000000000000  08f3069d  2**0  CONTENTS, READONLY, DEBUGGING
 33 .debug_line        010586d0  0000000000000000  0000000000000000  0907db76  2**0  CONTENTS, READONLY, DEBUGGING
 34 .debug_frame       00001230  0000000000000000  0000000000000000  0a0d6248  2**3  CONTENTS, READONLY, DEBUGGING
 35 .debug_str         01ca527f  0000000000000000  0000000000000000  0a0d7478  2**0  CONTENTS, READONLY, DEBUGGING
 36 .debug_loc         05771c55  0000000000000000  0000000000000000  0bd7c6f7  2**0  CONTENTS, READONLY, DEBUGGING
 37 .debug_macinfo     0000078b  0000000000000000  0000000000000000  114ee34c  2**0  CONTENTS, READONLY, DEBUGGING
 38 .debug_pubtypes    025cd42a  0000000000000000  0000000000000000  114eead7  2**0  CONTENTS, READONLY, DEBUGGING
 39 .debug_ranges      01e419c0  0000000000000000  0000000000000000  13abbf01  2**0  CONTENTS, READONLY, DEBUGGING
</pre>
</details>