### PR TITLE
feat: Upgrade ckb-vm to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ dependencies = [
  "ckb-store 0.25.3-pre",
  "ckb-test-chain-utils 0.25.3-pre",
  "ckb-types 0.25.3-pre",
- "ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1083,13 +1083,13 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4017,8 +4017,8 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum ckb-system-scripts 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "261dd95a93c09ea24397c85b4fbca061e1da2d6573189749aeb99fe840aaf0c9"
-"checksum ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "410eca836e677ea70f73358b53220c284836c3cbb3ecf9ee531606d926881f59"
-"checksum ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "201ab0ce4cf5644b3f0cacc9d772011f66c132d5e62ab35918413d9a6c29e6a7"
+"checksum ckb-vm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a645990a41708a9a55ea8a90c42c98d20ce9b2d2dd457f51fce33bca8854474"
+"checksum ckb-vm-definitions 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bd01bf493cff1315fd73a3be4a3ec135afe04503b81ebc1b531fcb061b42de6c"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -17,7 +17,7 @@ ckb-script-data-loader = { path = "data-loader" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.18.0", default-features = false }
+ckb-vm = { version = "0.18.1", default-features = false }
 faster-hex = "0.4"
 ckb-logger = { path = "../util/logger", optional = true }
 serde = "1.0"


### PR DESCRIPTION
Please refer to https://github.com/nervosnetwork/ckb-vm/releases/tag/0.18.1 for changes in this release.