### PR TITLE
feat: prepare for POA testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,10 @@ name = "ckb-pow"
 version = "0.25.3-pre"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-crypto 0.25.3-pre",
  "ckb-hash 0.25.3-pre",
+ "ckb-jsonrpc-types 0.25.3-pre",
+ "ckb-logger 0.25.3-pre",
  "ckb-types 0.25.3-pre",
  "eaglesong 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1035,7 +1038,7 @@ dependencies = [
  "ckb-rational 0.25.3-pre",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merkle-cbt 0.2.1 (git+https://github.com/jjyr/merkle-tree.git?branch=fix-merkle-proof)",
  "molecule 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2058,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "merkle-cbt"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jjyr/merkle-tree.git?branch=fix-merkle-proof#09e1d8a120041fa45c7fa6a09ad45a17ce1b8905"
 
 [[package]]
 name = "mime"
@@ -4101,7 +4104,7 @@ dependencies = [
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
-"checksum merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d589b5a7ca642540e7ccfbca3bcd0aa18693eb9287e2a6b17c79b1d062d52863"
+"checksum merkle-cbt 0.2.1 (git+https://github.com/jjyr/merkle-tree.git?branch=fix-merkle-proof)" = "<none>"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"

--- a/benches/benches/benchmarks/next_epoch_ext.rs
+++ b/benches/benches/benchmarks/next_epoch_ext.rs
@@ -2,8 +2,8 @@ use ckb_chain_spec::consensus::{build_genesis_epoch_ext, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_types::{
     core::{
-        capacity_bytes, BlockBuilder, BlockView, Capacity, HeaderBuilder, HeaderView,
-        TransactionBuilder,
+        capacity_bytes, BlockBuilder, BlockView, Capacity, HeaderBuilder, HeaderContextType,
+        HeaderView, TransactionBuilder,
     },
     packed::{Byte32, CellInput, Script},
     prelude::*,
@@ -87,7 +87,7 @@ fn bench(c: &mut Criterion) {
                         .build();
 
                     let input = CellInput::new_cellbase_input(0);
-                    let witness = Script::default().into_witness();
+                    let witness = Script::default().into_witness(HeaderContextType::NoneContext);
                     let cellbase = TransactionBuilder::default()
                         .input(input)
                         .witness(witness)

--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -12,7 +12,8 @@ use ckb_tx_pool::{BlockAssemblerConfig, FeeRate, TxPoolConfig};
 use ckb_types::{
     bytes::Bytes,
     core::{
-        capacity_bytes, BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, ScriptHashType,
+        capacity_bytes, BlockBuilder, BlockView, BuildHeaderContext, Capacity,
+        EpochNumberWithFraction, HeaderContext, HeaderContextType, ScriptHashType,
         TransactionBuilder, TransactionView,
     },
     packed::{Block, CellDep, CellInput, CellOutput, Header, OutPoint},
@@ -156,7 +157,10 @@ fn bench(c: &mut Criterion) {
                         let block = raw_block.as_builder().header(header).build().into_view();
 
                         let header_view = block.header();
-                        let resolver = HeaderResolverWrapper::new(&header_view, snapshot);
+                        let header_ctx = block
+                            .data()
+                            .build_header_context(HeaderContextType::NoneContext);
+                        let resolver = HeaderResolverWrapper::new(&header_ctx, snapshot);
                         let header_verifier = HeaderVerifier::new(snapshot, &shared.consensus());
                         header_verifier.verify(&resolver).expect("header verified");
 

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -15,8 +15,8 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{resolve_transaction, OverlayCellProvider, TransactionsProvider},
-        BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, HeaderView, ScriptHashType,
-        TransactionBuilder, TransactionView,
+        BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, HeaderContextType, HeaderView,
+        ScriptHashType, TransactionBuilder, TransactionView,
     },
     h160, h256,
     packed::{
@@ -92,7 +92,7 @@ pub fn new_always_success_chain(txs_size: usize, chains_num: usize) -> Chains {
 pub fn create_always_success_tx() -> TransactionView {
     let (ref always_success_cell, ref always_success_cell_data, ref script) = always_success_cell();
     TransactionBuilder::default()
-        .witness(script.clone().into_witness())
+        .witness(script.clone().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.pack())
@@ -105,7 +105,11 @@ pub fn create_always_success_cellbase(shared: &Shared, parent: &HeaderView) -> T
 
     let builder = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(parent.number() + 1))
-        .witness(always_success_script.clone().into_witness());
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        );
 
     if (parent.number() + 1) <= shared.consensus().finalization_delay_length() {
         builder.build()
@@ -253,7 +257,7 @@ pub fn create_secp_tx() -> TransactionView {
     let outputs = vec![secp_data_cell.clone(), secp_cell.clone()];
     let outputs_data = vec![secp_data_cell_data.pack(), secp_cell_data.pack()];
     TransactionBuilder::default()
-        .witness(script.clone().into_witness())
+        .witness(script.clone().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .outputs(outputs)
         .outputs_data(outputs_data)
@@ -317,7 +321,11 @@ pub fn create_secp_cellbase(shared: &Shared, parent: &HeaderView) -> Transaction
 
     let builder = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(parent.number() + 1))
-        .witness(secp_script.clone().into_witness());
+        .witness(
+            secp_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        );
 
     if (parent.number() + 1) <= shared.consensus().finalization_delay_length() {
         builder.build()

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -16,8 +16,8 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMeta, CellProvider, CellStatus},
-        BlockBuilder, BlockView, Capacity, EpochExt, HeaderView, TransactionBuilder,
-        TransactionInfo,
+        BlockBuilder, BlockView, Capacity, EpochExt, HeaderContextType, HeaderView,
+        TransactionBuilder, TransactionInfo,
     },
     packed::{CellInput, CellOutputBuilder, OutPoint, Script},
     utilities::{compact_to_difficulty, difficulty_to_compact},
@@ -62,7 +62,7 @@ fn repeat_process_block() {
 fn test_genesis_transaction_spend() {
     // let data: Vec<packed::Bytes> = ;
     let tx = TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .outputs(vec![
             CellOutputBuilder::default()
@@ -353,7 +353,7 @@ fn test_invalid_out_point_index_in_different_blocks() {
 #[test]
 fn test_genesis_transaction_fetch() {
     let tx = TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .outputs(vec![
             CellOutputBuilder::default()
@@ -567,7 +567,7 @@ fn prepare_context_chain(
 #[test]
 fn test_epoch_hash_rate_dampening() {
     let cellbase = TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .build();
     let dao = genesis_dao_data(vec![&cellbase]).unwrap();
@@ -657,7 +657,7 @@ fn test_epoch_hash_rate_dampening() {
 #[test]
 fn test_orphan_rate_estimation_overflow() {
     let cellbase = TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .build();
     let dao = genesis_dao_data(vec![&cellbase]).unwrap();
@@ -711,7 +711,7 @@ fn test_orphan_rate_estimation_overflow() {
 #[test]
 fn test_next_epoch_ext() {
     let cellbase = TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .build();
     let dao = genesis_dao_data(vec![&cellbase]).unwrap();

--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -12,8 +12,8 @@ use ckb_tx_pool::{BlockAssemblerConfig, PlugTarget, TxEntry};
 use ckb_types::{
     bytes::Bytes,
     core::{
-        BlockBuilder, BlockNumber, BlockView, Capacity, EpochExt, HeaderBuilder, HeaderView,
-        TransactionBuilder, TransactionView,
+        BlockBuilder, BlockNumber, BlockView, BuildHeaderContext, Capacity, EpochExt,
+        HeaderBuilder, HeaderContextType, HeaderView, TransactionBuilder, TransactionView,
     },
     h256,
     packed::{Block, CellInput, CellOutput, CellOutputBuilder, OutPoint},
@@ -73,8 +73,10 @@ fn test_get_block_template() {
     let block: Block = block_template.into();
     let block = block.as_advanced_builder().build();
     let header = block.header();
-
-    let resolver = HeaderResolverWrapper::new(&header, shared.store());
+    let header_ctx = block
+        .data()
+        .build_header_context(HeaderContextType::NoneContext);
+    let resolver = HeaderResolverWrapper::new(&header_ctx, shared.store());
     let header_verify_result = {
         let snapshot: &Snapshot = &shared.snapshot();
         let header_verifier = HeaderVerifier::new(snapshot, &shared.consensus());

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -11,8 +11,9 @@ use ckb_types::prelude::*;
 use ckb_types::{
     bytes::Bytes,
     core::{
-        capacity_bytes, BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, HeaderView,
-        ScriptHashType, TransactionBuilder, TransactionView, UncleBlockView,
+        capacity_bytes, BlockBuilder, BlockView, Capacity, EpochNumberWithFraction,
+        HeaderContextType, HeaderView, ScriptHashType, TransactionBuilder, TransactionView,
+        UncleBlockView,
     },
     packed::{
         self, CellDep, CellInput, CellOutputBuilder, OutPoint, ProposalShortId, Script,
@@ -37,7 +38,7 @@ pub(crate) fn create_cellbase(
     let capacity = calculate_reward(store, consensus, parent);
     let builder = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(number))
-        .witness(miner_lock.into_witness());
+        .witness(miner_lock.into_witness(HeaderContextType::NoneContext));
 
     if (parent.number() + 1) <= consensus.finalization_delay_length() {
         builder.build()

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -13,8 +13,8 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{resolve_transaction, OverlayCellProvider, TransactionsProvider},
-        BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, HeaderView, TransactionBuilder,
-        TransactionView,
+        BlockBuilder, BlockView, Capacity, EpochNumberWithFraction, HeaderContextType, HeaderView,
+        TransactionBuilder, TransactionView,
     },
     packed::{self, Byte32, CellDep, CellInput, CellOutput, CellOutputBuilder, OutPoint},
     utilities::{difficulty_to_compact, DIFF_TWO},
@@ -27,7 +27,7 @@ const MIN_CAP: Capacity = capacity_bytes!(60);
 pub(crate) fn create_always_success_tx() -> TransactionView {
     let (ref always_success_cell, ref always_success_cell_data, ref script) = always_success_cell();
     TransactionBuilder::default()
-        .witness(script.clone().into_witness())
+        .witness(script.clone().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.pack())
@@ -116,7 +116,11 @@ pub(crate) fn create_cellbase(
     let capacity = calculate_reward(store, consensus, parent);
     let builder = TransactionBuilder::default()
         .input(CellInput::new_cellbase_input(parent.number() + 1))
-        .witness(always_success_script.clone().into_witness());
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        );
 
     if (parent.number() + 1) <= consensus.finalization_delay_length() {
         builder.build()

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -8,9 +8,10 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 serde = "1.0"
 serde_derive = "1.0"
 eaglesong = "0.1"
-
-[dev-dependencies]
 ckb-hash = { path = "../util/hash"}
+ckb-crypto = { path = "../util/crypto" }
+ckb-logger = { path = "../util/logger" }

--- a/pow/src/dummy.rs
+++ b/pow/src/dummy.rs
@@ -1,10 +1,10 @@
 use super::PowEngine;
-use ckb_types::packed::Header;
+use ckb_types::core::HeaderContext;
 
 pub struct DummyPowEngine;
 
 impl PowEngine for DummyPowEngine {
-    fn verify(&self, _header: &Header) -> bool {
+    fn verify(&self, _header_ctx: &HeaderContext) -> bool {
         true
     }
 }

--- a/pow/src/eaglesong.rs
+++ b/pow/src/eaglesong.rs
@@ -1,11 +1,14 @@
 use super::PowEngine;
-use ckb_types::{packed::Header, prelude::*, utilities::compact_to_target, U256};
+use ckb_types::{
+    core::HeaderContext, packed::Header, prelude::*, utilities::compact_to_target, U256,
+};
 use eaglesong::eaglesong;
 
 pub struct EaglesongPowEngine;
 
 impl PowEngine for EaglesongPowEngine {
-    fn verify(&self, header: &Header) -> bool {
+    fn verify(&self, header_ctx: &HeaderContext) -> bool {
+        let header = header_ctx.header().data();
         let input =
             crate::pow_message(&header.as_reader().calc_pow_hash(), header.nonce().unpack());
         let mut output = [0u8; 32];

--- a/pow/src/poa.rs
+++ b/pow/src/poa.rs
@@ -1,0 +1,150 @@
+use super::PowEngine;
+use ckb_crypto::secp::{Message, Signature};
+use ckb_hash::blake2b_256;
+use ckb_jsonrpc_types::JsonBytes;
+use ckb_types::{
+    bytes::Bytes,
+    core::HeaderContext,
+    packed,
+    prelude::*,
+    utilities::{merkle_root, MerkleProof},
+    H160, H256,
+};
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
+pub struct POAEngineConfig {
+    pub pubkey_hash: JsonBytes,
+}
+
+pub struct POAEngine {
+    config: POAEngineConfig,
+}
+
+impl POAEngine {
+    pub fn new(config: POAEngineConfig) -> Self {
+        POAEngine { config }
+    }
+}
+
+impl PowEngine for POAEngine {
+    fn verify(&self, header_ctx: &HeaderContext) -> bool {
+        let cellbase = match header_ctx.cellbase() {
+            Some(cb) => cb,
+            None => {
+                return false;
+            }
+        };
+
+        let witness: Bytes = match cellbase.witnesses().get(0) {
+            Some(w) => w.unpack(),
+            None => {
+                return false;
+            }
+        };
+        let cellbase_witness = match packed::CellbaseExtWitness::from_slice(&witness) {
+            Ok(w) => w,
+            Err(_) => {
+                return false;
+            }
+        };
+
+        let poa_witness = match packed::POAWitness::from_slice(&Unpack::<Bytes>::unpack(
+            &cellbase_witness.extension(),
+        )) {
+            Ok(w) => w,
+            Err(_) => {
+                return false;
+            }
+        };
+        // verify merkle proof
+        let proof_leaves = &[cellbase.calc_witness_hash()];
+        let merkle_proof = match MerkleProof::build_proof(
+            vec![0],
+            proof_leaves,
+            poa_witness.witnesses_root_proof().into_iter().collect(),
+            poa_witness.transactions_count().unpack(),
+        ) {
+            Some(proof) => proof,
+            None => {
+                return false;
+            }
+        };
+        let witness_root = match merkle_proof.root(proof_leaves) {
+            Some(root) => root,
+            None => {
+                return false;
+            }
+        };
+        let tx_root = merkle_root(&[poa_witness.raw_transactions_root(), witness_root]);
+        if tx_root != header_ctx.header().transactions_root() {
+            return false;
+        }
+
+        // remove signature from cellbase
+        let cellbase_without_signature = {
+            let poa_witness_without_signature = poa_witness
+                .clone()
+                .as_builder()
+                .signature(packed::Byte65::new_unchecked(vec![0u8; 65].into()))
+                .build();
+            let cellbase_witness_without_signature = cellbase_witness
+                .clone()
+                .as_builder()
+                .extension(poa_witness_without_signature.as_bytes().pack())
+                .build();
+            cellbase
+                .clone()
+                .as_advanced_builder()
+                .set_witnesses(vec![cellbase_witness_without_signature.as_bytes().pack()])
+                .build()
+        };
+
+        // calculate message
+        // 1. use cellbase without signature to calculate a new witness_root
+        // 2. calculate tx_root from new witness_root
+        // 3. replace exists tx_root of header
+        // 4. use header hash as message
+        let witness_root = match merkle_proof.root(&[cellbase_without_signature.witness_hash()]) {
+            Some(root) => root,
+            None => {
+                return false;
+            }
+        };
+        let tx_root = merkle_root(&[poa_witness.raw_transactions_root(), witness_root.clone()]);
+        let block_hash = header_ctx
+            .header()
+            .data()
+            .as_advanced_builder()
+            .transactions_root(tx_root.clone())
+            .build()
+            .hash();
+        let message = match Message::from_slice(block_hash.as_slice()) {
+            Ok(m) => m,
+            Err(_) => {
+                return false;
+            }
+        };
+
+        // verify signature
+        let signature = match Signature::from_slice(poa_witness.signature().as_slice()) {
+            Ok(s) => s,
+            Err(_) => {
+                return false;
+            }
+        };
+        let pubkey = match signature.recover(&message) {
+            Ok(k) => k,
+            Err(_) => {
+                return false;
+            }
+        };
+        let pubkey_hash = blake2b_160(pubkey.serialize());
+        self.config.pubkey_hash.as_bytes() == pubkey_hash.as_bytes()
+    }
+}
+
+pub fn blake2b_160<T: AsRef<[u8]>>(s: T) -> H160 {
+    let result = blake2b_256(s);
+    H160::from_slice(&result[..20]).expect("H160")
+}

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -24,7 +24,8 @@ use ckb_tx_pool::FeeRate;
 use ckb_types::{
     core::{
         capacity_bytes, cell::resolve_transaction, BlockBuilder, BlockView, Capacity,
-        EpochNumberWithFraction, HeaderView, TransactionBuilder, TransactionView,
+        EpochNumberWithFraction, HeaderContextType, HeaderView, TransactionBuilder,
+        TransactionView,
     },
     h256,
     packed::{
@@ -100,7 +101,11 @@ fn always_success_transaction() -> TransactionView {
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.to_owned().pack())
-        .witness(always_success_script.clone().into_witness())
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        )
         .build()
 }
 

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -12,7 +12,8 @@ use ckb_types::{
     constants::{BLOCK_VERSION, TX_VERSION},
     core::{
         BlockBuilder, BlockNumber, BlockView, Capacity, Cycle, EpochExt, EpochNumber,
-        EpochNumberWithFraction, HeaderView, Ratio, TransactionBuilder, TransactionView, Version,
+        EpochNumberWithFraction, HeaderContextType, HeaderView, Ratio, TransactionBuilder,
+        TransactionView, Version,
     },
     h160, h256,
     packed::{Byte32, CellInput, CellOutput, Script},
@@ -130,7 +131,7 @@ impl Default for ConsensusBuilder {
                 .expect("default occupied");
             empty_output.as_builder().capacity(occupied.pack()).build()
         };
-        let witness = Script::default().into_witness();
+        let witness = Script::default().into_witness(HeaderContextType::NoneContext);
         let cellbase = TransactionBuilder::default()
             .input(input)
             .output(output)
@@ -755,6 +756,13 @@ impl Consensus {
                     .map(|script| script.calc_script_hash())
             })
             .expect("Can not find secp script")
+    }
+
+    pub fn header_context_type(&self) -> HeaderContextType {
+        match self.pow {
+            Pow::POA(_) => HeaderContextType::Cellbase,
+            _ => HeaderContextType::NoneContext,
+        }
     }
 
     fn primary_epoch_reward_of_next_epoch(&self, epoch: &EpochExt) -> Capacity {

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -25,7 +25,8 @@ use ckb_types::{
     bytes::Bytes,
     core::{
         capacity_bytes, BlockBuilder, BlockNumber, BlockView, Capacity, Cycle, EpochNumber,
-        EpochNumberWithFraction, Ratio, ScriptHashType, TransactionBuilder, TransactionView,
+        EpochNumberWithFraction, HeaderContextType, Ratio, ScriptHashType, TransactionBuilder,
+        TransactionView,
     },
     h256, packed,
     prelude::*,
@@ -245,6 +246,13 @@ impl ChainSpec {
 
     pub fn pow_engine(&self) -> Arc<dyn PowEngine> {
         self.pow.engine()
+    }
+
+    pub fn header_context_type(&self) -> HeaderContextType {
+        match self.pow {
+            Pow::POA(_) => HeaderContextType::Cellbase,
+            _ => HeaderContextType::NoneContext,
+        }
     }
 
     fn verify_genesis_hash(&self, genesis: &BlockView) -> Result<(), Box<dyn Error>> {
@@ -500,7 +508,7 @@ impl ChainSpec {
         let tx = TransactionBuilder::default()
             .input(input)
             .outputs(outputs)
-            .witness(script.into_witness())
+            .witness(script.into_witness(self.header_context_type()))
             .outputs_data(
                 outputs_data
                     .iter()

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -4,6 +4,7 @@
 //! https://github.com/nervosnetwork/rfcs/tree/master/rfcs/0000-block-sync-protocol
 
 mod block_status;
+mod send_headers_message;
 mod net_time_checker;
 mod orphan_block_pool;
 mod relayer;

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -8,7 +8,7 @@ use ckb_shared::Snapshot;
 use ckb_store::ChainStore;
 use ckb_traits::BlockMedianTimeContext;
 use ckb_types::{
-    core::{self, BlockNumber},
+    core::{self, BlockNumber, BuildHeaderContext, HeaderContext},
     packed,
     prelude::*,
 };
@@ -170,7 +170,9 @@ impl<'a> CompactBlockProcess<'a> {
                             })
                     }
                 };
-                let resolver = snapshot.new_header_resolver(&header, parent.into_inner());
+                let header_ctx = compact_block
+                    .build_header_context(self.relayer.shared.consensus().header_context_type());
+                let resolver = snapshot.new_header_resolver(&header_ctx, parent.into_inner());
                 let median_time_context = CompactBlockMedianTimeView {
                     fn_get_pending_header: Box::new(fn_get_pending_header),
                     snapshot: snapshot.store(),

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -13,7 +13,7 @@ use ckb_types::{
     bytes::Bytes,
     core::{
         capacity_bytes, BlockBuilder, BlockNumber, Capacity, EpochNumberWithFraction,
-        HeaderBuilder, HeaderView, TransactionBuilder, TransactionView,
+        HeaderBuilder, HeaderContextType, HeaderView, TransactionBuilder, TransactionView,
     },
     packed::{
         CellDep, CellInput, CellOutputBuilder, IndexTransaction, IndexTransactionBuilder, OutPoint,
@@ -100,7 +100,11 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.pack())
-        .witness(always_success_script.clone().into_witness())
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        )
         .build();
     let always_success_out_point = OutPoint::new(always_success_tx.hash(), 0);
 
@@ -140,7 +144,7 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
                     .build(),
             )
             .output_data(Bytes::new().pack())
-            .witness(Script::default().into_witness())
+            .witness(Script::default().into_witness(HeaderContextType::NoneContext))
             .build();
         let header = new_header_builder(&shared, &parent.header()).build();
         let block = BlockBuilder::default()

--- a/sync/src/send_headers_message.rs
+++ b/sync/src/send_headers_message.rs
@@ -1,0 +1,51 @@
+use crate::block_status::BlockStatus;
+use crate::synchronizer::Synchronizer;
+use crate::types::SyncSnapshot;
+use crate::MAX_HEADERS_LEN;
+use ckb_error::{Error, ErrorKind};
+use ckb_logger::{debug, log_enabled, warn, Level};
+use ckb_network::{CKBProtocolContext, PeerIndex};
+use ckb_traits::BlockMedianTimeContext;
+use ckb_types::{
+    bytes::Bytes,
+    core::{self, BlockNumber, HeaderContext},
+    packed::{self, Byte32},
+    prelude::*,
+};
+use ckb_verification::{HeaderError, HeaderErrorKind, HeaderResolver, HeaderVerifier, Verifier};
+use failure::Error as FailureError;
+
+pub enum SendHeadersMessage<'a> {
+    POW(packed::SendHeadersReader<'a>),
+    POA(packed::SendPOAHeadersReader<'a>),
+}
+
+impl<'a> From<packed::SendHeadersReader<'a>> for SendHeadersMessage<'a> {
+    fn from(reader: packed::SendHeadersReader<'a>) -> SendHeadersMessage<'a> {
+        SendHeadersMessage::POW(reader)
+    }
+}
+
+impl<'a> SendHeadersMessage<'a> {
+    pub fn headers(&self) -> Vec<HeaderContext> {
+        match self {
+            Self::POW(message) => message
+                .headers()
+                .to_entity()
+                .into_iter()
+                .map(|header| HeaderContext::new(header.into_view()))
+                .collect(),
+            Self::POA(message) => message
+                .headers()
+                .to_entity()
+                .into_iter()
+                .map(|poa_header| {
+                    HeaderContext::with_cellbase(
+                        poa_header.header().into_view(),
+                        poa_header.cellbase(),
+                    )
+                })
+                .collect(),
+        }
+    }
+}

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -14,7 +14,10 @@ use ckb_test_chain_utils::always_success_cell;
 use ckb_types::prelude::*;
 use ckb_types::{
     bytes::Bytes,
-    core::{cell::resolve_transaction, BlockBuilder, EpochNumberWithFraction, TransactionBuilder},
+    core::{
+        cell::resolve_transaction, BlockBuilder, EpochNumberWithFraction, HeaderContextType,
+        TransactionBuilder,
+    },
     packed::{self, CellInput, CellOutputBuilder, OutPoint},
     utilities::difficulty_to_compact,
     U256,
@@ -80,7 +83,11 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
     let (always_success_cell, always_success_cell_data, always_success_script) =
         always_success_cell();
     let always_success_tx = TransactionBuilder::default()
-        .witness(always_success_script.clone().into_witness())
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        )
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.pack())
@@ -121,7 +128,11 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
 
         let builder = TransactionBuilder::default()
             .input(CellInput::new_cellbase_input(number))
-            .witness(always_success_script.to_owned().into_witness());
+            .witness(
+                always_success_script
+                    .to_owned()
+                    .into_witness(HeaderContextType::NoneContext),
+            );
 
         let cellbase = if number <= snapshot.consensus().finalization_delay_length() {
             builder.build()

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -24,6 +24,7 @@ ckb-dao = { path = "../util/dao" }
 ckb-dao-utils = { path = "../util/dao/utils" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 ckb-resource = { path = "../resource" }
+ckb-pow = { path = "../pow" }
 tempfile = "3.0"
 reqwest = "0.9"
 rand = "0.6"

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -360,6 +360,8 @@ fn all_specs() -> SpecMap {
         Box::new(ConflictInProposed),
         Box::new(DAOVerify),
         Box::new(AvoidDuplicatedProposalsWithUncles),
+        // POA specs
+        Box::new(POAMining::new()),
     ];
     specs.into_iter().map(|spec| (spec.name(), spec)).collect()
 }

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -7,6 +7,7 @@ mod p2p;
 mod relay;
 mod sync;
 mod tx_pool;
+mod poa;
 
 pub use alert::*;
 pub use consensus::*;
@@ -17,6 +18,7 @@ pub use p2p::*;
 pub use relay::*;
 pub use sync::*;
 pub use tx_pool::*;
+pub use poa::*;
 
 use crate::Net;
 use ckb_app_config::CKBAppConfig;

--- a/test/src/specs/poa/mining.rs
+++ b/test/src/specs/poa/mining.rs
@@ -1,0 +1,122 @@
+use crate::{Net, Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use ckb_chain_spec::ChainSpec;
+use ckb_jsonrpc_types::{BlockTemplate, JsonBytes};
+use ckb_types::{core::BlockView, packed::{ProposalShortId, POAWitness, Byte65, Byte32, CellbaseExtWitness, CellbaseWitness}, prelude::*, bytes::Bytes, utilities::{merkle_root, CBMT}};
+use ckb_pow::{Pow, POAEngineConfig};
+use ckb_crypto::secp::{Generator, Privkey, Message, Signature};
+use ckb_hash::blake2b_256;
+use log::info;
+use std::convert::Into;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub struct POAMining {
+    pubkey_hash: Bytes,
+    privkey: Privkey,
+}
+
+impl Spec for POAMining {
+    crate::name!("poa_mining");
+
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        self.test_basic(node);
+        self.reject_dummy_block(node);
+    }
+
+    fn modify_chain_spec(&self) -> Box<dyn Fn(&mut ChainSpec) -> ()> {
+        let pubkey_hash = JsonBytes::from_bytes(self.pubkey_hash.clone());
+        Box::new(move |spec_config| {
+            spec_config.pow = Pow::POA(POAEngineConfig{ pubkey_hash: pubkey_hash.clone() });
+        })
+    }
+}
+
+impl POAMining {
+    pub fn new() -> Self {
+        let mut generator = Generator::new();
+        let privkey = generator.gen_privkey();
+        let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
+        let pubkey_hash = Bytes::from(&blake2b_256(&pubkey_data)[0..20]);
+        POAMining {
+            pubkey_hash,
+            privkey
+        }
+    }
+
+    pub fn test_basic(&self, node: &Node) {
+        for _ in 0..(DEFAULT_TX_PROPOSAL_WINDOW.1 + 2) {
+            generate_poa_block(node, &self.privkey);
+        }
+        info!("Use generated block's cellbase as tx input");
+        let transaction_hash = node.generate_transaction();
+        let block1_hash = 
+            generate_poa_block(node, &self.privkey);
+        let _ = generate_poa_block(node, &self.privkey); // skip
+        let block3_hash = generate_poa_block(node, &self.privkey);
+
+        let block1: BlockView = node.rpc_client().get_block(block1_hash).unwrap().into();
+        let block3: BlockView = node.rpc_client().get_block(block3_hash).unwrap().into();
+
+        info!("Generated tx should be included in next block's proposal txs");
+        assert!(block1
+            .union_proposal_ids_iter()
+            .any(|id| ProposalShortId::from_tx_hash(&transaction_hash).eq(&id)));
+
+        info!("Generated tx should be included in next + n block's commit txs, current n = 2");
+        assert!(block3
+            .transactions()
+            .into_iter()
+            .any(|tx| transaction_hash.eq(&tx.hash())));
+    }
+
+    pub fn reject_dummy_block(&self, node: &Node){
+        let block = node.new_block(None, None, None);
+        let result = node.rpc_client()
+            .submit_block("".to_owned(), block.data().into());
+        info!("Dummy block should be rejected");
+        assert!(result.is_err());
+    }
+}
+
+// generate a new poa block and submit it through rpc.
+// 1. sign block hash
+// 2. construct POAWitness
+// 3. reconstruct cellbase and block
+pub fn generate_poa_block(node: &Node, privkey: &Privkey) -> Byte32 {
+    let block = node.new_block(None, None, None);
+    let raw_tx_root = merkle_root(&block.transactions().into_iter().map(|tx|tx.hash()).collect::<Vec<_>>());
+    let proof = CBMT::build_merkle_proof(&block.transactions().into_iter().map(|tx|tx.witness_hash()).collect::<Vec<_>>(), &[0]).unwrap();
+    let poa_witness = POAWitness::new_builder().witnesses_root_proof(proof.lemmas().to_vec().pack()).raw_transactions_root(raw_tx_root.clone()).transactions_count((block.transactions().len() as u32).pack()).build();
+    let cellbase_without_signature = {
+        let cellbase = block.transactions()[0].data();
+        let cellbase_witness: Bytes = cellbase.witnesses().get(0).unwrap().unpack();
+        let witness = CellbaseExtWitness::from_slice(&cellbase_witness).unwrap().as_builder().extension(poa_witness.as_bytes().pack()).build();
+        cellbase.as_advanced_builder().set_witnesses(vec![witness.as_bytes().pack()]).build()
+    };
+    let message : Message = {
+        let mut txs = vec![cellbase_without_signature];
+        txs.extend(block.transactions().into_iter().skip(1));
+        let witness_root = merkle_root(&txs.iter().map(|tx| tx.witness_hash()).collect::<Vec<_>>());
+        let tx_root = merkle_root(&[raw_tx_root.clone(), witness_root]);
+    let block = block.as_advanced_builder().set_transactions(txs).transactions_root(tx_root).build();
+        let block_hash: [u8;32] = block.hash().unpack();
+        block_hash.into()
+    };
+    let signature = privkey.sign_recoverable(&message).unwrap();
+    let poa_witness = 
+        poa_witness.as_builder().signature(Byte65::new_unchecked(signature.serialize().into())).build()
+    ;
+    let new_cellbase = {
+        let cellbase = block.transactions()[0].data();
+        let cellbase_witness: Bytes = cellbase.witnesses().get(0).unwrap().unpack();
+        let witness = CellbaseExtWitness::from_slice(&cellbase_witness).unwrap().as_builder().extension(poa_witness.as_bytes().pack()).build();
+        cellbase.as_advanced_builder().set_witnesses(vec![witness.as_bytes().pack()]).build()
+    };
+    let mut txs = vec![new_cellbase];
+    txs.extend(block.transactions().into_iter().skip(1));
+    let witness_root = merkle_root(&txs.iter().map(|tx| tx.witness_hash()).collect::<Vec<_>>());
+    let tx_root = merkle_root(&[raw_tx_root, witness_root]);
+    let block = block.as_advanced_builder().set_transactions(txs).transactions_root(tx_root).build();
+    node.submit_block(&block)
+}

--- a/test/src/specs/poa/mod.rs
+++ b/test/src/specs/poa/mod.rs
@@ -1,0 +1,3 @@
+mod mining;
+
+pub use mining::*;

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -161,7 +161,7 @@ impl BlockAssembler {
     pub(crate) fn build_cellbase(
         snapshot: &Snapshot,
         tip: &HeaderView,
-        cellbase_witness: CellbaseWitness,
+        cellbase_witness: Bytes,
     ) -> Result<TransactionView, FailureError> {
         let candidate_number = tip.number() + 1;
 
@@ -174,7 +174,7 @@ impl BlockAssembler {
                 .lock(target_lock)
                 .build();
 
-            let witness = cellbase_witness.as_bytes().pack();
+            let witness = cellbase_witness.pack();
             let no_finalization_target =
                 candidate_number <= snapshot.consensus().finalization_delay_length();
             let tx_builder = TransactionBuilder::default().input(input).witness(witness);

--- a/util/test-chain-utils/src/chain.rs
+++ b/util/test-chain-utils/src/chain.rs
@@ -8,8 +8,8 @@ use ckb_resource::Resource;
 use ckb_types::{
     bytes::Bytes,
     core::{
-        BlockBuilder, BlockNumber, Capacity, EpochNumberWithFraction, ScriptHashType,
-        TransactionBuilder, TransactionView,
+        BlockBuilder, BlockNumber, Capacity, EpochNumberWithFraction, HeaderContextType,
+        ScriptHashType, TransactionBuilder, TransactionView,
     },
     packed::{CellInput, CellOutput, OutPoint, Script},
     prelude::*,
@@ -56,7 +56,11 @@ pub fn always_success_consensus() -> Consensus {
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .output_data(always_success_cell_data.pack())
-        .witness(always_success_script.clone().into_witness())
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        )
         .build();
     let dao = genesis_dao_data(vec![&always_success_tx]).unwrap();
     let genesis = BlockBuilder::default()
@@ -79,7 +83,9 @@ pub fn always_success_cellbase(
     let (_, _, always_success_script) = always_success_cell();
     let input = CellInput::new_cellbase_input(block_number);
 
-    let witness = always_success_script.to_owned().into_witness();
+    let witness = always_success_script
+        .to_owned()
+        .into_witness(HeaderContextType::NoneContext);
     let data = Bytes::new();
 
     let builder = TransactionBuilder::default().input(input).witness(witness);

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -10,7 +10,7 @@ molecule = "=0.4.0"
 ckb-fixed-hash = { path = "../fixed-hash" }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 bytes = { version="0.4.12", features = ["serde"] }
-merkle-cbt = "0.2"
+merkle-cbt = { git = "https://github.com/jjyr/merkle-tree.git", branch = "fix-merkle-proof" }
 ckb-occupied-capacity = { path = "../occupied-capacity" }
 ckb-hash = { path = "../hash" }
 crossbeam-channel = "0.3"

--- a/util/types/schemas/blockchain.mol
+++ b/util/types/schemas/blockchain.mol
@@ -3,7 +3,9 @@
 array Uint32 [byte; 4];
 array Uint64 [byte; 8];
 array Uint128 [byte; 16];
+array Byte20 [byte; 20];
 array Byte32 [byte; 32];
+array Byte65 [byte; 65];
 array Uint256 [byte; 32];
 
 vector Bytes <byte>;
@@ -105,4 +107,18 @@ table WitnessArgs {
     lock:                   BytesOpt,          // Lock args
     input_type:             BytesOpt,          // Type args for input
     output_type:            BytesOpt,          // Type args for output
+}
+
+/* Used for POA testnet */
+table CellbaseExtWitness {
+    lock:    Script,
+    message: Bytes,
+    extension: Bytes,
+}
+
+table POAWitness {
+    signature:              Byte65,
+    transactions_count:     Uint32,
+    raw_transactions_root:  Byte32,            // raw transactions root
+    witnesses_root_proof:   Byte32Vec,         // witnesses root merkle proof of cellbase
 }

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -184,6 +184,21 @@ union SyncMessage {
     InIBD,
 }
 
+/* -- Obsolete SyncMessage -- */
+table SetFilter {
+}
+
+table AddFilter {
+}
+
+table ClearFilter {
+}
+
+table FilteredBlock {
+}
+/* -- Obsolete SyncMessage -- */
+
+
 table GetHeaders {
     hash_stop:              Byte32,
     block_locator_hashes:   Byte32Vec,
@@ -199,25 +214,6 @@ table SendHeaders {
 
 table SendBlock {
     block:                  Block,
-}
-
-table SetFilter {
-    hash_seed:              Uint32,
-    filter:                 Bytes,
-    num_hashes:             byte,
-}
-
-table AddFilter {
-    filter:                 Bytes,
-}
-
-table ClearFilter {
-}
-
-table FilteredBlock {
-    header:                 Header,
-    transactions:           TransactionVec,
-    proof:                  MerkleProof,
 }
 
 table MerkleProof {

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -19,6 +19,14 @@ option CellOutputOpt (CellOutput);
 vector HeaderVec <Header>;
 vector OutPointVec <OutPoint>;
 
+/* Extension Types for POA Chain */
+table POAHeader {
+    header:                     Header,
+    cellbase:                   Transaction, // cellbase
+}
+
+vector POAHeaderVec <POAHeader>;
+
 /* Types for Storage */
 
 table HeaderView {
@@ -177,7 +185,7 @@ union SyncMessage {
     SendHeaders,
     GetBlocks,
     SendBlock,
-    SetFilter,
+    SendPOAHeaders, // only used in POA testnet
     AddFilter,
     ClearFilter,
     FilteredBlock,
@@ -185,9 +193,6 @@ union SyncMessage {
 }
 
 /* -- Obsolete SyncMessage -- */
-table SetFilter {
-}
-
 table AddFilter {
 }
 
@@ -222,6 +227,11 @@ table MerkleProof {
 }
 
 table InIBD {
+}
+
+/* Types for POA Network/Sync */
+table SendPOAHeaders {
+    headers: POAHeaderVec,
 }
 
 /* Types for Network/Others */

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytes::Bytes,
     core::{self, Capacity},
-    packed,
+    packed::{self},
     prelude::*,
     H256, U256,
 };
@@ -126,3 +126,4 @@ impl_conversion_for_packed_iterator_pack!(CellInput, CellInputVec);
 impl_conversion_for_packed_iterator_pack!(UncleBlock, UncleBlockVec);
 impl_conversion_for_packed_iterator_pack!(Header, HeaderVec);
 impl_conversion_for_packed_iterator_pack!(Byte32, Byte32Vec);
+impl_conversion_for_packed_iterator_pack!(POAHeader, POAHeaderVec);

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -14,7 +14,10 @@ mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
-pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
+pub use extras::{
+    BlockExt, BuildHeaderContext, EpochExt, EpochNumberWithFraction, HeaderContext,
+    HeaderContextType, TransactionInfo,
+};
 pub use reward::BlockReward;
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
 pub use views::{BlockView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView};

--- a/util/types/src/extension/std_traits.rs
+++ b/util/types/src/extension/std_traits.rs
@@ -19,6 +19,7 @@ macro_rules! impl_std_cmp_eq_and_hash {
     };
 }
 
+impl_std_cmp_eq_and_hash!(Byte20);
 impl_std_cmp_eq_and_hash!(Byte32);
 impl_std_cmp_eq_and_hash!(Uint256);
 impl_std_cmp_eq_and_hash!(ProposalShortId);

--- a/util/types/src/generated/blockchain.rs
+++ b/util/types/src/generated/blockchain.rs
@@ -826,6 +826,421 @@ impl molecule::prelude::Builder for Uint128Builder {
     }
 }
 #[derive(Clone)]
+pub struct Byte20(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for Byte20 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for Byte20 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for Byte20 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        let raw_data = hex_string(&self.raw_data()).unwrap();
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl ::std::default::Default for Byte20 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        Byte20::new_unchecked(v.into())
+    }
+}
+impl Byte20 {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 20;
+    pub fn nth0(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(0, 1))
+    }
+    pub fn nth1(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(1, 2))
+    }
+    pub fn nth2(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(2, 3))
+    }
+    pub fn nth3(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(3, 4))
+    }
+    pub fn nth4(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(4, 5))
+    }
+    pub fn nth5(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(5, 6))
+    }
+    pub fn nth6(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(6, 7))
+    }
+    pub fn nth7(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(7, 8))
+    }
+    pub fn nth8(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(8, 9))
+    }
+    pub fn nth9(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(9, 10))
+    }
+    pub fn nth10(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(10, 11))
+    }
+    pub fn nth11(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(11, 12))
+    }
+    pub fn nth12(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(12, 13))
+    }
+    pub fn nth13(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(13, 14))
+    }
+    pub fn nth14(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(14, 15))
+    }
+    pub fn nth15(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(15, 16))
+    }
+    pub fn nth16(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(16, 17))
+    }
+    pub fn nth17(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(17, 18))
+    }
+    pub fn nth18(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(18, 19))
+    }
+    pub fn nth19(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(19, 20))
+    }
+    pub fn raw_data(&self) -> molecule::bytes::Bytes {
+        self.as_bytes()
+    }
+    pub fn as_reader<'r>(&'r self) -> Byte20Reader<'r> {
+        Byte20Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Byte20 {
+    type Builder = Byte20Builder;
+    const NAME: &'static str = "Byte20";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Byte20(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte20Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte20Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set([
+            self.nth0(),
+            self.nth1(),
+            self.nth2(),
+            self.nth3(),
+            self.nth4(),
+            self.nth5(),
+            self.nth6(),
+            self.nth7(),
+            self.nth8(),
+            self.nth9(),
+            self.nth10(),
+            self.nth11(),
+            self.nth12(),
+            self.nth13(),
+            self.nth14(),
+            self.nth15(),
+            self.nth16(),
+            self.nth17(),
+            self.nth18(),
+            self.nth19(),
+        ])
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Byte20Reader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for Byte20Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for Byte20Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for Byte20Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        let raw_data = hex_string(&self.raw_data()).unwrap();
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl<'r> Byte20Reader<'r> {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 20;
+    pub fn nth0(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[0..1])
+    }
+    pub fn nth1(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[1..2])
+    }
+    pub fn nth2(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[2..3])
+    }
+    pub fn nth3(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[3..4])
+    }
+    pub fn nth4(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[4..5])
+    }
+    pub fn nth5(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[5..6])
+    }
+    pub fn nth6(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[6..7])
+    }
+    pub fn nth7(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[7..8])
+    }
+    pub fn nth8(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[8..9])
+    }
+    pub fn nth9(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[9..10])
+    }
+    pub fn nth10(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[10..11])
+    }
+    pub fn nth11(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[11..12])
+    }
+    pub fn nth12(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[12..13])
+    }
+    pub fn nth13(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[13..14])
+    }
+    pub fn nth14(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[14..15])
+    }
+    pub fn nth15(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[15..16])
+    }
+    pub fn nth16(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[16..17])
+    }
+    pub fn nth17(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[17..18])
+    }
+    pub fn nth18(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[18..19])
+    }
+    pub fn nth19(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[19..20])
+    }
+    pub fn raw_data(&self) -> &'r [u8] {
+        self.as_slice()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Byte20Reader<'r> {
+    type Entity = Byte20;
+    const NAME: &'static str = "Byte20Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Byte20Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len != Self::TOTAL_SIZE {
+            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
+        }
+        Ok(())
+    }
+}
+pub struct Byte20Builder(pub(crate) [Byte; 20]);
+impl ::std::fmt::Debug for Byte20Builder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:?})", Self::NAME, &self.0[..])
+    }
+}
+impl ::std::default::Default for Byte20Builder {
+    fn default() -> Self {
+        Byte20Builder([
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+        ])
+    }
+}
+impl Byte20Builder {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 20;
+    pub fn set(mut self, v: [Byte; 20]) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn nth0(mut self, v: Byte) -> Self {
+        self.0[0] = v;
+        self
+    }
+    pub fn nth1(mut self, v: Byte) -> Self {
+        self.0[1] = v;
+        self
+    }
+    pub fn nth2(mut self, v: Byte) -> Self {
+        self.0[2] = v;
+        self
+    }
+    pub fn nth3(mut self, v: Byte) -> Self {
+        self.0[3] = v;
+        self
+    }
+    pub fn nth4(mut self, v: Byte) -> Self {
+        self.0[4] = v;
+        self
+    }
+    pub fn nth5(mut self, v: Byte) -> Self {
+        self.0[5] = v;
+        self
+    }
+    pub fn nth6(mut self, v: Byte) -> Self {
+        self.0[6] = v;
+        self
+    }
+    pub fn nth7(mut self, v: Byte) -> Self {
+        self.0[7] = v;
+        self
+    }
+    pub fn nth8(mut self, v: Byte) -> Self {
+        self.0[8] = v;
+        self
+    }
+    pub fn nth9(mut self, v: Byte) -> Self {
+        self.0[9] = v;
+        self
+    }
+    pub fn nth10(mut self, v: Byte) -> Self {
+        self.0[10] = v;
+        self
+    }
+    pub fn nth11(mut self, v: Byte) -> Self {
+        self.0[11] = v;
+        self
+    }
+    pub fn nth12(mut self, v: Byte) -> Self {
+        self.0[12] = v;
+        self
+    }
+    pub fn nth13(mut self, v: Byte) -> Self {
+        self.0[13] = v;
+        self
+    }
+    pub fn nth14(mut self, v: Byte) -> Self {
+        self.0[14] = v;
+        self
+    }
+    pub fn nth15(mut self, v: Byte) -> Self {
+        self.0[15] = v;
+        self
+    }
+    pub fn nth16(mut self, v: Byte) -> Self {
+        self.0[16] = v;
+        self
+    }
+    pub fn nth17(mut self, v: Byte) -> Self {
+        self.0[17] = v;
+        self
+    }
+    pub fn nth18(mut self, v: Byte) -> Self {
+        self.0[18] = v;
+        self
+    }
+    pub fn nth19(mut self, v: Byte) -> Self {
+        self.0[19] = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Byte20Builder {
+    type Entity = Byte20;
+    const NAME: &'static str = "Byte20Builder";
+    fn expected_length(&self) -> usize {
+        Self::TOTAL_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(self.0[0].as_slice())?;
+        writer.write_all(self.0[1].as_slice())?;
+        writer.write_all(self.0[2].as_slice())?;
+        writer.write_all(self.0[3].as_slice())?;
+        writer.write_all(self.0[4].as_slice())?;
+        writer.write_all(self.0[5].as_slice())?;
+        writer.write_all(self.0[6].as_slice())?;
+        writer.write_all(self.0[7].as_slice())?;
+        writer.write_all(self.0[8].as_slice())?;
+        writer.write_all(self.0[9].as_slice())?;
+        writer.write_all(self.0[10].as_slice())?;
+        writer.write_all(self.0[11].as_slice())?;
+        writer.write_all(self.0[12].as_slice())?;
+        writer.write_all(self.0[13].as_slice())?;
+        writer.write_all(self.0[14].as_slice())?;
+        writer.write_all(self.0[15].as_slice())?;
+        writer.write_all(self.0[16].as_slice())?;
+        writer.write_all(self.0[17].as_slice())?;
+        writer.write_all(self.0[18].as_slice())?;
+        writer.write_all(self.0[19].as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Byte20::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct Byte32(molecule::bytes::Bytes);
 impl ::std::fmt::LowerHex for Byte32 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -1397,6 +1812,1010 @@ impl molecule::prelude::Builder for Byte32Builder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         Byte32::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct Byte65(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for Byte65 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for Byte65 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for Byte65 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        let raw_data = hex_string(&self.raw_data()).unwrap();
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl ::std::default::Default for Byte65 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+        ];
+        Byte65::new_unchecked(v.into())
+    }
+}
+impl Byte65 {
+    pub const TOTAL_SIZE: usize = 65;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 65;
+    pub fn nth0(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(0, 1))
+    }
+    pub fn nth1(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(1, 2))
+    }
+    pub fn nth2(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(2, 3))
+    }
+    pub fn nth3(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(3, 4))
+    }
+    pub fn nth4(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(4, 5))
+    }
+    pub fn nth5(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(5, 6))
+    }
+    pub fn nth6(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(6, 7))
+    }
+    pub fn nth7(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(7, 8))
+    }
+    pub fn nth8(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(8, 9))
+    }
+    pub fn nth9(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(9, 10))
+    }
+    pub fn nth10(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(10, 11))
+    }
+    pub fn nth11(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(11, 12))
+    }
+    pub fn nth12(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(12, 13))
+    }
+    pub fn nth13(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(13, 14))
+    }
+    pub fn nth14(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(14, 15))
+    }
+    pub fn nth15(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(15, 16))
+    }
+    pub fn nth16(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(16, 17))
+    }
+    pub fn nth17(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(17, 18))
+    }
+    pub fn nth18(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(18, 19))
+    }
+    pub fn nth19(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(19, 20))
+    }
+    pub fn nth20(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(20, 21))
+    }
+    pub fn nth21(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(21, 22))
+    }
+    pub fn nth22(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(22, 23))
+    }
+    pub fn nth23(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(23, 24))
+    }
+    pub fn nth24(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(24, 25))
+    }
+    pub fn nth25(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(25, 26))
+    }
+    pub fn nth26(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(26, 27))
+    }
+    pub fn nth27(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(27, 28))
+    }
+    pub fn nth28(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(28, 29))
+    }
+    pub fn nth29(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(29, 30))
+    }
+    pub fn nth30(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(30, 31))
+    }
+    pub fn nth31(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(31, 32))
+    }
+    pub fn nth32(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(32, 33))
+    }
+    pub fn nth33(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(33, 34))
+    }
+    pub fn nth34(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(34, 35))
+    }
+    pub fn nth35(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(35, 36))
+    }
+    pub fn nth36(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(36, 37))
+    }
+    pub fn nth37(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(37, 38))
+    }
+    pub fn nth38(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(38, 39))
+    }
+    pub fn nth39(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(39, 40))
+    }
+    pub fn nth40(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(40, 41))
+    }
+    pub fn nth41(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(41, 42))
+    }
+    pub fn nth42(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(42, 43))
+    }
+    pub fn nth43(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(43, 44))
+    }
+    pub fn nth44(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(44, 45))
+    }
+    pub fn nth45(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(45, 46))
+    }
+    pub fn nth46(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(46, 47))
+    }
+    pub fn nth47(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(47, 48))
+    }
+    pub fn nth48(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(48, 49))
+    }
+    pub fn nth49(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(49, 50))
+    }
+    pub fn nth50(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(50, 51))
+    }
+    pub fn nth51(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(51, 52))
+    }
+    pub fn nth52(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(52, 53))
+    }
+    pub fn nth53(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(53, 54))
+    }
+    pub fn nth54(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(54, 55))
+    }
+    pub fn nth55(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(55, 56))
+    }
+    pub fn nth56(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(56, 57))
+    }
+    pub fn nth57(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(57, 58))
+    }
+    pub fn nth58(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(58, 59))
+    }
+    pub fn nth59(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(59, 60))
+    }
+    pub fn nth60(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(60, 61))
+    }
+    pub fn nth61(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(61, 62))
+    }
+    pub fn nth62(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(62, 63))
+    }
+    pub fn nth63(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(63, 64))
+    }
+    pub fn nth64(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(64, 65))
+    }
+    pub fn raw_data(&self) -> molecule::bytes::Bytes {
+        self.as_bytes()
+    }
+    pub fn as_reader<'r>(&'r self) -> Byte65Reader<'r> {
+        Byte65Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Byte65 {
+    type Builder = Byte65Builder;
+    const NAME: &'static str = "Byte65";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Byte65(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte65Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte65Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set([
+            self.nth0(),
+            self.nth1(),
+            self.nth2(),
+            self.nth3(),
+            self.nth4(),
+            self.nth5(),
+            self.nth6(),
+            self.nth7(),
+            self.nth8(),
+            self.nth9(),
+            self.nth10(),
+            self.nth11(),
+            self.nth12(),
+            self.nth13(),
+            self.nth14(),
+            self.nth15(),
+            self.nth16(),
+            self.nth17(),
+            self.nth18(),
+            self.nth19(),
+            self.nth20(),
+            self.nth21(),
+            self.nth22(),
+            self.nth23(),
+            self.nth24(),
+            self.nth25(),
+            self.nth26(),
+            self.nth27(),
+            self.nth28(),
+            self.nth29(),
+            self.nth30(),
+            self.nth31(),
+            self.nth32(),
+            self.nth33(),
+            self.nth34(),
+            self.nth35(),
+            self.nth36(),
+            self.nth37(),
+            self.nth38(),
+            self.nth39(),
+            self.nth40(),
+            self.nth41(),
+            self.nth42(),
+            self.nth43(),
+            self.nth44(),
+            self.nth45(),
+            self.nth46(),
+            self.nth47(),
+            self.nth48(),
+            self.nth49(),
+            self.nth50(),
+            self.nth51(),
+            self.nth52(),
+            self.nth53(),
+            self.nth54(),
+            self.nth55(),
+            self.nth56(),
+            self.nth57(),
+            self.nth58(),
+            self.nth59(),
+            self.nth60(),
+            self.nth61(),
+            self.nth62(),
+            self.nth63(),
+            self.nth64(),
+        ])
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Byte65Reader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for Byte65Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for Byte65Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for Byte65Reader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        let raw_data = hex_string(&self.raw_data()).unwrap();
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl<'r> Byte65Reader<'r> {
+    pub const TOTAL_SIZE: usize = 65;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 65;
+    pub fn nth0(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[0..1])
+    }
+    pub fn nth1(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[1..2])
+    }
+    pub fn nth2(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[2..3])
+    }
+    pub fn nth3(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[3..4])
+    }
+    pub fn nth4(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[4..5])
+    }
+    pub fn nth5(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[5..6])
+    }
+    pub fn nth6(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[6..7])
+    }
+    pub fn nth7(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[7..8])
+    }
+    pub fn nth8(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[8..9])
+    }
+    pub fn nth9(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[9..10])
+    }
+    pub fn nth10(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[10..11])
+    }
+    pub fn nth11(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[11..12])
+    }
+    pub fn nth12(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[12..13])
+    }
+    pub fn nth13(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[13..14])
+    }
+    pub fn nth14(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[14..15])
+    }
+    pub fn nth15(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[15..16])
+    }
+    pub fn nth16(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[16..17])
+    }
+    pub fn nth17(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[17..18])
+    }
+    pub fn nth18(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[18..19])
+    }
+    pub fn nth19(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[19..20])
+    }
+    pub fn nth20(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[20..21])
+    }
+    pub fn nth21(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[21..22])
+    }
+    pub fn nth22(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[22..23])
+    }
+    pub fn nth23(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[23..24])
+    }
+    pub fn nth24(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[24..25])
+    }
+    pub fn nth25(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[25..26])
+    }
+    pub fn nth26(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[26..27])
+    }
+    pub fn nth27(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[27..28])
+    }
+    pub fn nth28(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[28..29])
+    }
+    pub fn nth29(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[29..30])
+    }
+    pub fn nth30(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[30..31])
+    }
+    pub fn nth31(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[31..32])
+    }
+    pub fn nth32(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[32..33])
+    }
+    pub fn nth33(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[33..34])
+    }
+    pub fn nth34(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[34..35])
+    }
+    pub fn nth35(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[35..36])
+    }
+    pub fn nth36(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[36..37])
+    }
+    pub fn nth37(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[37..38])
+    }
+    pub fn nth38(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[38..39])
+    }
+    pub fn nth39(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[39..40])
+    }
+    pub fn nth40(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[40..41])
+    }
+    pub fn nth41(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[41..42])
+    }
+    pub fn nth42(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[42..43])
+    }
+    pub fn nth43(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[43..44])
+    }
+    pub fn nth44(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[44..45])
+    }
+    pub fn nth45(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[45..46])
+    }
+    pub fn nth46(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[46..47])
+    }
+    pub fn nth47(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[47..48])
+    }
+    pub fn nth48(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[48..49])
+    }
+    pub fn nth49(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[49..50])
+    }
+    pub fn nth50(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[50..51])
+    }
+    pub fn nth51(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[51..52])
+    }
+    pub fn nth52(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[52..53])
+    }
+    pub fn nth53(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[53..54])
+    }
+    pub fn nth54(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[54..55])
+    }
+    pub fn nth55(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[55..56])
+    }
+    pub fn nth56(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[56..57])
+    }
+    pub fn nth57(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[57..58])
+    }
+    pub fn nth58(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[58..59])
+    }
+    pub fn nth59(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[59..60])
+    }
+    pub fn nth60(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[60..61])
+    }
+    pub fn nth61(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[61..62])
+    }
+    pub fn nth62(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[62..63])
+    }
+    pub fn nth63(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[63..64])
+    }
+    pub fn nth64(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[64..65])
+    }
+    pub fn raw_data(&self) -> &'r [u8] {
+        self.as_slice()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Byte65Reader<'r> {
+    type Entity = Byte65;
+    const NAME: &'static str = "Byte65Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Byte65Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len != Self::TOTAL_SIZE {
+            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
+        }
+        Ok(())
+    }
+}
+pub struct Byte65Builder(pub(crate) [Byte; 65]);
+impl ::std::fmt::Debug for Byte65Builder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:?})", Self::NAME, &self.0[..])
+    }
+}
+impl ::std::default::Default for Byte65Builder {
+    fn default() -> Self {
+        Byte65Builder([
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+        ])
+    }
+}
+impl Byte65Builder {
+    pub const TOTAL_SIZE: usize = 65;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 65;
+    pub fn set(mut self, v: [Byte; 65]) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn nth0(mut self, v: Byte) -> Self {
+        self.0[0] = v;
+        self
+    }
+    pub fn nth1(mut self, v: Byte) -> Self {
+        self.0[1] = v;
+        self
+    }
+    pub fn nth2(mut self, v: Byte) -> Self {
+        self.0[2] = v;
+        self
+    }
+    pub fn nth3(mut self, v: Byte) -> Self {
+        self.0[3] = v;
+        self
+    }
+    pub fn nth4(mut self, v: Byte) -> Self {
+        self.0[4] = v;
+        self
+    }
+    pub fn nth5(mut self, v: Byte) -> Self {
+        self.0[5] = v;
+        self
+    }
+    pub fn nth6(mut self, v: Byte) -> Self {
+        self.0[6] = v;
+        self
+    }
+    pub fn nth7(mut self, v: Byte) -> Self {
+        self.0[7] = v;
+        self
+    }
+    pub fn nth8(mut self, v: Byte) -> Self {
+        self.0[8] = v;
+        self
+    }
+    pub fn nth9(mut self, v: Byte) -> Self {
+        self.0[9] = v;
+        self
+    }
+    pub fn nth10(mut self, v: Byte) -> Self {
+        self.0[10] = v;
+        self
+    }
+    pub fn nth11(mut self, v: Byte) -> Self {
+        self.0[11] = v;
+        self
+    }
+    pub fn nth12(mut self, v: Byte) -> Self {
+        self.0[12] = v;
+        self
+    }
+    pub fn nth13(mut self, v: Byte) -> Self {
+        self.0[13] = v;
+        self
+    }
+    pub fn nth14(mut self, v: Byte) -> Self {
+        self.0[14] = v;
+        self
+    }
+    pub fn nth15(mut self, v: Byte) -> Self {
+        self.0[15] = v;
+        self
+    }
+    pub fn nth16(mut self, v: Byte) -> Self {
+        self.0[16] = v;
+        self
+    }
+    pub fn nth17(mut self, v: Byte) -> Self {
+        self.0[17] = v;
+        self
+    }
+    pub fn nth18(mut self, v: Byte) -> Self {
+        self.0[18] = v;
+        self
+    }
+    pub fn nth19(mut self, v: Byte) -> Self {
+        self.0[19] = v;
+        self
+    }
+    pub fn nth20(mut self, v: Byte) -> Self {
+        self.0[20] = v;
+        self
+    }
+    pub fn nth21(mut self, v: Byte) -> Self {
+        self.0[21] = v;
+        self
+    }
+    pub fn nth22(mut self, v: Byte) -> Self {
+        self.0[22] = v;
+        self
+    }
+    pub fn nth23(mut self, v: Byte) -> Self {
+        self.0[23] = v;
+        self
+    }
+    pub fn nth24(mut self, v: Byte) -> Self {
+        self.0[24] = v;
+        self
+    }
+    pub fn nth25(mut self, v: Byte) -> Self {
+        self.0[25] = v;
+        self
+    }
+    pub fn nth26(mut self, v: Byte) -> Self {
+        self.0[26] = v;
+        self
+    }
+    pub fn nth27(mut self, v: Byte) -> Self {
+        self.0[27] = v;
+        self
+    }
+    pub fn nth28(mut self, v: Byte) -> Self {
+        self.0[28] = v;
+        self
+    }
+    pub fn nth29(mut self, v: Byte) -> Self {
+        self.0[29] = v;
+        self
+    }
+    pub fn nth30(mut self, v: Byte) -> Self {
+        self.0[30] = v;
+        self
+    }
+    pub fn nth31(mut self, v: Byte) -> Self {
+        self.0[31] = v;
+        self
+    }
+    pub fn nth32(mut self, v: Byte) -> Self {
+        self.0[32] = v;
+        self
+    }
+    pub fn nth33(mut self, v: Byte) -> Self {
+        self.0[33] = v;
+        self
+    }
+    pub fn nth34(mut self, v: Byte) -> Self {
+        self.0[34] = v;
+        self
+    }
+    pub fn nth35(mut self, v: Byte) -> Self {
+        self.0[35] = v;
+        self
+    }
+    pub fn nth36(mut self, v: Byte) -> Self {
+        self.0[36] = v;
+        self
+    }
+    pub fn nth37(mut self, v: Byte) -> Self {
+        self.0[37] = v;
+        self
+    }
+    pub fn nth38(mut self, v: Byte) -> Self {
+        self.0[38] = v;
+        self
+    }
+    pub fn nth39(mut self, v: Byte) -> Self {
+        self.0[39] = v;
+        self
+    }
+    pub fn nth40(mut self, v: Byte) -> Self {
+        self.0[40] = v;
+        self
+    }
+    pub fn nth41(mut self, v: Byte) -> Self {
+        self.0[41] = v;
+        self
+    }
+    pub fn nth42(mut self, v: Byte) -> Self {
+        self.0[42] = v;
+        self
+    }
+    pub fn nth43(mut self, v: Byte) -> Self {
+        self.0[43] = v;
+        self
+    }
+    pub fn nth44(mut self, v: Byte) -> Self {
+        self.0[44] = v;
+        self
+    }
+    pub fn nth45(mut self, v: Byte) -> Self {
+        self.0[45] = v;
+        self
+    }
+    pub fn nth46(mut self, v: Byte) -> Self {
+        self.0[46] = v;
+        self
+    }
+    pub fn nth47(mut self, v: Byte) -> Self {
+        self.0[47] = v;
+        self
+    }
+    pub fn nth48(mut self, v: Byte) -> Self {
+        self.0[48] = v;
+        self
+    }
+    pub fn nth49(mut self, v: Byte) -> Self {
+        self.0[49] = v;
+        self
+    }
+    pub fn nth50(mut self, v: Byte) -> Self {
+        self.0[50] = v;
+        self
+    }
+    pub fn nth51(mut self, v: Byte) -> Self {
+        self.0[51] = v;
+        self
+    }
+    pub fn nth52(mut self, v: Byte) -> Self {
+        self.0[52] = v;
+        self
+    }
+    pub fn nth53(mut self, v: Byte) -> Self {
+        self.0[53] = v;
+        self
+    }
+    pub fn nth54(mut self, v: Byte) -> Self {
+        self.0[54] = v;
+        self
+    }
+    pub fn nth55(mut self, v: Byte) -> Self {
+        self.0[55] = v;
+        self
+    }
+    pub fn nth56(mut self, v: Byte) -> Self {
+        self.0[56] = v;
+        self
+    }
+    pub fn nth57(mut self, v: Byte) -> Self {
+        self.0[57] = v;
+        self
+    }
+    pub fn nth58(mut self, v: Byte) -> Self {
+        self.0[58] = v;
+        self
+    }
+    pub fn nth59(mut self, v: Byte) -> Self {
+        self.0[59] = v;
+        self
+    }
+    pub fn nth60(mut self, v: Byte) -> Self {
+        self.0[60] = v;
+        self
+    }
+    pub fn nth61(mut self, v: Byte) -> Self {
+        self.0[61] = v;
+        self
+    }
+    pub fn nth62(mut self, v: Byte) -> Self {
+        self.0[62] = v;
+        self
+    }
+    pub fn nth63(mut self, v: Byte) -> Self {
+        self.0[63] = v;
+        self
+    }
+    pub fn nth64(mut self, v: Byte) -> Self {
+        self.0[64] = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Byte65Builder {
+    type Entity = Byte65;
+    const NAME: &'static str = "Byte65Builder";
+    fn expected_length(&self) -> usize {
+        Self::TOTAL_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(self.0[0].as_slice())?;
+        writer.write_all(self.0[1].as_slice())?;
+        writer.write_all(self.0[2].as_slice())?;
+        writer.write_all(self.0[3].as_slice())?;
+        writer.write_all(self.0[4].as_slice())?;
+        writer.write_all(self.0[5].as_slice())?;
+        writer.write_all(self.0[6].as_slice())?;
+        writer.write_all(self.0[7].as_slice())?;
+        writer.write_all(self.0[8].as_slice())?;
+        writer.write_all(self.0[9].as_slice())?;
+        writer.write_all(self.0[10].as_slice())?;
+        writer.write_all(self.0[11].as_slice())?;
+        writer.write_all(self.0[12].as_slice())?;
+        writer.write_all(self.0[13].as_slice())?;
+        writer.write_all(self.0[14].as_slice())?;
+        writer.write_all(self.0[15].as_slice())?;
+        writer.write_all(self.0[16].as_slice())?;
+        writer.write_all(self.0[17].as_slice())?;
+        writer.write_all(self.0[18].as_slice())?;
+        writer.write_all(self.0[19].as_slice())?;
+        writer.write_all(self.0[20].as_slice())?;
+        writer.write_all(self.0[21].as_slice())?;
+        writer.write_all(self.0[22].as_slice())?;
+        writer.write_all(self.0[23].as_slice())?;
+        writer.write_all(self.0[24].as_slice())?;
+        writer.write_all(self.0[25].as_slice())?;
+        writer.write_all(self.0[26].as_slice())?;
+        writer.write_all(self.0[27].as_slice())?;
+        writer.write_all(self.0[28].as_slice())?;
+        writer.write_all(self.0[29].as_slice())?;
+        writer.write_all(self.0[30].as_slice())?;
+        writer.write_all(self.0[31].as_slice())?;
+        writer.write_all(self.0[32].as_slice())?;
+        writer.write_all(self.0[33].as_slice())?;
+        writer.write_all(self.0[34].as_slice())?;
+        writer.write_all(self.0[35].as_slice())?;
+        writer.write_all(self.0[36].as_slice())?;
+        writer.write_all(self.0[37].as_slice())?;
+        writer.write_all(self.0[38].as_slice())?;
+        writer.write_all(self.0[39].as_slice())?;
+        writer.write_all(self.0[40].as_slice())?;
+        writer.write_all(self.0[41].as_slice())?;
+        writer.write_all(self.0[42].as_slice())?;
+        writer.write_all(self.0[43].as_slice())?;
+        writer.write_all(self.0[44].as_slice())?;
+        writer.write_all(self.0[45].as_slice())?;
+        writer.write_all(self.0[46].as_slice())?;
+        writer.write_all(self.0[47].as_slice())?;
+        writer.write_all(self.0[48].as_slice())?;
+        writer.write_all(self.0[49].as_slice())?;
+        writer.write_all(self.0[50].as_slice())?;
+        writer.write_all(self.0[51].as_slice())?;
+        writer.write_all(self.0[52].as_slice())?;
+        writer.write_all(self.0[53].as_slice())?;
+        writer.write_all(self.0[54].as_slice())?;
+        writer.write_all(self.0[55].as_slice())?;
+        writer.write_all(self.0[56].as_slice())?;
+        writer.write_all(self.0[57].as_slice())?;
+        writer.write_all(self.0[58].as_slice())?;
+        writer.write_all(self.0[59].as_slice())?;
+        writer.write_all(self.0[60].as_slice())?;
+        writer.write_all(self.0[61].as_slice())?;
+        writer.write_all(self.0[62].as_slice())?;
+        writer.write_all(self.0[63].as_slice())?;
+        writer.write_all(self.0[64].as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Byte65::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]
@@ -2212,15 +3631,18 @@ impl ::std::iter::IntoIterator for Bytes {
 }
 #[derive(Clone)]
 pub struct BytesOpt(molecule::bytes::Bytes);
-impl ::std::fmt::Debug for BytesOpt {
+impl ::std::fmt::LowerHex for BytesOpt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         use molecule::faster_hex::hex_string;
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for BytesOpt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
 impl ::std::fmt::Display for BytesOpt {
@@ -2283,15 +3705,18 @@ impl molecule::prelude::Entity for BytesOpt {
 }
 #[derive(Clone, Copy)]
 pub struct BytesOptReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::Debug for BytesOptReader<'r> {
+impl<'r> ::std::fmt::LowerHex for BytesOptReader<'r> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         use molecule::faster_hex::hex_string;
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for BytesOptReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
 impl<'r> ::std::fmt::Display for BytesOptReader<'r> {
@@ -8323,15 +9748,18 @@ impl molecule::prelude::Builder for CellbaseWitnessBuilder {
 }
 #[derive(Clone)]
 pub struct WitnessArgs(molecule::bytes::Bytes);
-impl ::std::fmt::Debug for WitnessArgs {
+impl ::std::fmt::LowerHex for WitnessArgs {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         use molecule::faster_hex::hex_string;
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for WitnessArgs {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
 impl ::std::fmt::Display for WitnessArgs {
@@ -8430,15 +9858,18 @@ impl molecule::prelude::Entity for WitnessArgs {
 }
 #[derive(Clone, Copy)]
 pub struct WitnessArgsReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::Debug for WitnessArgsReader<'r> {
+impl<'r> ::std::fmt::LowerHex for WitnessArgsReader<'r> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         use molecule::faster_hex::hex_string;
-        write!(
-            f,
-            "{}(0x{})",
-            Self::NAME,
-            hex_string(self.as_slice()).unwrap()
-        )
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for WitnessArgsReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
 impl<'r> ::std::fmt::Display for WitnessArgsReader<'r> {
@@ -8514,31 +9945,31 @@ impl<'r> molecule::prelude::Reader<'r> for WitnessArgsReader<'r> {
         use molecule::verification_error as ve;
         let slice_len = slice.len();
         if slice_len < molecule::NUMBER_SIZE {
-            ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len)?;
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
         }
         let total_size = molecule::unpack_number(slice) as usize;
         if slice_len != total_size {
-            ve!(Self, TotalSizeNotMatch, total_size, slice_len)?;
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
         }
         if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
             return Ok(());
         }
         if slice_len < molecule::NUMBER_SIZE * 2 {
-            ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len)?;
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
         }
         let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
         if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            ve!(Self, OffsetsNotMatch)?;
+            return ve!(Self, OffsetsNotMatch);
         }
         let field_count = offset_first / 4 - 1;
         if field_count < Self::FIELD_COUNT {
-            ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count)?;
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
         } else if !compatible && field_count > Self::FIELD_COUNT {
-            ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count)?;
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
         };
         let header_size = molecule::NUMBER_SIZE * (field_count + 1);
         if slice_len < header_size {
-            ve!(Self, HeaderIsBroken, header_size, slice_len)?;
+            return ve!(Self, HeaderIsBroken, header_size, slice_len);
         }
         let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
         let mut offsets: Vec<usize> = ptr[..field_count]
@@ -8547,7 +9978,7 @@ impl<'r> molecule::prelude::Reader<'r> for WitnessArgsReader<'r> {
             .collect();
         offsets.push(total_size);
         if offsets.windows(2).any(|i| i[0] > i[1]) {
-            ve!(Self, OffsetsNotMatch)?;
+            return ve!(Self, OffsetsNotMatch);
         }
         BytesOptReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         BytesOptReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
@@ -8608,5 +10039,660 @@ impl molecule::prelude::Builder for WitnessArgsBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         WitnessArgs::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct CellbaseExtWitness(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for CellbaseExtWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for CellbaseExtWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for CellbaseExtWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "lock", self.lock())?;
+        write!(f, ", {}: {}", "message", self.message())?;
+        write!(f, ", {}: {}", "extension", self.extension())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for CellbaseExtWitness {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            77, 0, 0, 0, 16, 0, 0, 0, 69, 0, 0, 0, 73, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0,
+            0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        CellbaseExtWitness::new_unchecked(v.into())
+    }
+}
+impl CellbaseExtWitness {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn lock(&self) -> Script {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[0][..]) as usize;
+        let end = molecule::unpack_number(&offsets[1][..]) as usize;
+        Script::new_unchecked(self.0.slice(start, end))
+    }
+    pub fn message(&self) -> Bytes {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[1][..]) as usize;
+        let end = molecule::unpack_number(&offsets[2][..]) as usize;
+        Bytes::new_unchecked(self.0.slice(start, end))
+    }
+    pub fn extension(&self) -> Bytes {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[2][..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&offsets[3][..]) as usize;
+            Bytes::new_unchecked(self.0.slice(start, end))
+        } else {
+            Bytes::new_unchecked(self.0.slice_from(start))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> CellbaseExtWitnessReader<'r> {
+        CellbaseExtWitnessReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for CellbaseExtWitness {
+    type Builder = CellbaseExtWitnessBuilder;
+    const NAME: &'static str = "CellbaseExtWitness";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        CellbaseExtWitness(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        CellbaseExtWitnessReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        CellbaseExtWitnessReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .lock(self.lock())
+            .message(self.message())
+            .extension(self.extension())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct CellbaseExtWitnessReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for CellbaseExtWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for CellbaseExtWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for CellbaseExtWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "lock", self.lock())?;
+        write!(f, ", {}: {}", "message", self.message())?;
+        write!(f, ", {}: {}", "extension", self.extension())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> CellbaseExtWitnessReader<'r> {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn lock(&self) -> ScriptReader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[0][..]) as usize;
+        let end = molecule::unpack_number(&offsets[1][..]) as usize;
+        ScriptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn message(&self) -> BytesReader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[1][..]) as usize;
+        let end = molecule::unpack_number(&offsets[2][..]) as usize;
+        BytesReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn extension(&self) -> BytesReader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[2][..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&offsets[3][..]) as usize;
+            BytesReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            BytesReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for CellbaseExtWitnessReader<'r> {
+    type Entity = CellbaseExtWitness;
+    const NAME: &'static str = "CellbaseExtWitnessReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        CellbaseExtWitnessReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        let field_count = offset_first / 4 - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
+        if slice_len < header_size {
+            return ve!(Self, HeaderIsBroken, header_size, slice_len);
+        }
+        let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
+        let mut offsets: Vec<usize> = ptr[..field_count]
+            .iter()
+            .map(|x| molecule::unpack_number(&x[..]) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        ScriptReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        BytesReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        BytesReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct CellbaseExtWitnessBuilder {
+    pub(crate) lock: Script,
+    pub(crate) message: Bytes,
+    pub(crate) extension: Bytes,
+}
+impl CellbaseExtWitnessBuilder {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn lock(mut self, v: Script) -> Self {
+        self.lock = v;
+        self
+    }
+    pub fn message(mut self, v: Bytes) -> Self {
+        self.message = v;
+        self
+    }
+    pub fn extension(mut self, v: Bytes) -> Self {
+        self.extension = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for CellbaseExtWitnessBuilder {
+    type Entity = CellbaseExtWitness;
+    const NAME: &'static str = "CellbaseExtWitnessBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.lock.as_slice().len()
+            + self.message.as_slice().len()
+            + self.extension.as_slice().len()
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.lock.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.message.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.extension.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.lock.as_slice())?;
+        writer.write_all(self.message.as_slice())?;
+        writer.write_all(self.extension.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        CellbaseExtWitness::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct POAWitness(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for POAWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for POAWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for POAWitness {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "signature", self.signature())?;
+        write!(
+            f,
+            ", {}: {}",
+            "transactions_count",
+            self.transactions_count()
+        )?;
+        write!(
+            f,
+            ", {}: {}",
+            "raw_transactions_root",
+            self.raw_transactions_root()
+        )?;
+        write!(
+            f,
+            ", {}: {}",
+            "witnesses_root_proof",
+            self.witnesses_root_proof()
+        )?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for POAWitness {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            125, 0, 0, 0, 20, 0, 0, 0, 85, 0, 0, 0, 89, 0, 0, 0, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        POAWitness::new_unchecked(v.into())
+    }
+}
+impl POAWitness {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn signature(&self) -> Byte65 {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[0][..]) as usize;
+        let end = molecule::unpack_number(&offsets[1][..]) as usize;
+        Byte65::new_unchecked(self.0.slice(start, end))
+    }
+    pub fn transactions_count(&self) -> Uint32 {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[1][..]) as usize;
+        let end = molecule::unpack_number(&offsets[2][..]) as usize;
+        Uint32::new_unchecked(self.0.slice(start, end))
+    }
+    pub fn raw_transactions_root(&self) -> Byte32 {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[2][..]) as usize;
+        let end = molecule::unpack_number(&offsets[3][..]) as usize;
+        Byte32::new_unchecked(self.0.slice(start, end))
+    }
+    pub fn witnesses_root_proof(&self) -> Byte32Vec {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[3][..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&offsets[4][..]) as usize;
+            Byte32Vec::new_unchecked(self.0.slice(start, end))
+        } else {
+            Byte32Vec::new_unchecked(self.0.slice_from(start))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> POAWitnessReader<'r> {
+        POAWitnessReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for POAWitness {
+    type Builder = POAWitnessBuilder;
+    const NAME: &'static str = "POAWitness";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        POAWitness(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        POAWitnessReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        POAWitnessReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .signature(self.signature())
+            .transactions_count(self.transactions_count())
+            .raw_transactions_root(self.raw_transactions_root())
+            .witnesses_root_proof(self.witnesses_root_proof())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct POAWitnessReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for POAWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for POAWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for POAWitnessReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "signature", self.signature())?;
+        write!(
+            f,
+            ", {}: {}",
+            "transactions_count",
+            self.transactions_count()
+        )?;
+        write!(
+            f,
+            ", {}: {}",
+            "raw_transactions_root",
+            self.raw_transactions_root()
+        )?;
+        write!(
+            f,
+            ", {}: {}",
+            "witnesses_root_proof",
+            self.witnesses_root_proof()
+        )?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> POAWitnessReader<'r> {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn signature(&self) -> Byte65Reader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[0][..]) as usize;
+        let end = molecule::unpack_number(&offsets[1][..]) as usize;
+        Byte65Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn transactions_count(&self) -> Uint32Reader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[1][..]) as usize;
+        let end = molecule::unpack_number(&offsets[2][..]) as usize;
+        Uint32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn raw_transactions_root(&self) -> Byte32Reader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[2][..]) as usize;
+        let end = molecule::unpack_number(&offsets[3][..]) as usize;
+        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn witnesses_root_proof(&self) -> Byte32VecReader<'r> {
+        let offsets = self.field_offsets();
+        let start = molecule::unpack_number(&offsets[3][..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&offsets[4][..]) as usize;
+            Byte32VecReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Byte32VecReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for POAWitnessReader<'r> {
+    type Entity = POAWitness;
+    const NAME: &'static str = "POAWitnessReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        POAWitnessReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        let field_count = offset_first / 4 - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
+        if slice_len < header_size {
+            return ve!(Self, HeaderIsBroken, header_size, slice_len);
+        }
+        let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
+        let mut offsets: Vec<usize> = ptr[..field_count]
+            .iter()
+            .map(|x| molecule::unpack_number(&x[..]) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Byte65Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Uint32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Byte32Reader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Byte32VecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct POAWitnessBuilder {
+    pub(crate) signature: Byte65,
+    pub(crate) transactions_count: Uint32,
+    pub(crate) raw_transactions_root: Byte32,
+    pub(crate) witnesses_root_proof: Byte32Vec,
+}
+impl POAWitnessBuilder {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn signature(mut self, v: Byte65) -> Self {
+        self.signature = v;
+        self
+    }
+    pub fn transactions_count(mut self, v: Uint32) -> Self {
+        self.transactions_count = v;
+        self
+    }
+    pub fn raw_transactions_root(mut self, v: Byte32) -> Self {
+        self.raw_transactions_root = v;
+        self
+    }
+    pub fn witnesses_root_proof(mut self, v: Byte32Vec) -> Self {
+        self.witnesses_root_proof = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for POAWitnessBuilder {
+    type Entity = POAWitness;
+    const NAME: &'static str = "POAWitnessBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.signature.as_slice().len()
+            + self.transactions_count.as_slice().len()
+            + self.raw_transactions_root.as_slice().len()
+            + self.witnesses_root_proof.as_slice().len()
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.signature.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.transactions_count.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.raw_transactions_root.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.witnesses_root_proof.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.signature.as_slice())?;
+        writer.write_all(self.transactions_count.as_slice())?;
+        writer.write_all(self.raw_transactions_root.as_slice())?;
+        writer.write_all(self.witnesses_root_proof.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        POAWitness::new_unchecked(inner.into())
     }
 }

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -10382,6 +10382,734 @@ impl<'r> SyncMessageUnionReader<'r> {
     }
 }
 #[derive(Clone)]
+pub struct SetFilter(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for SetFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for SetFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for SetFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for SetFilter {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        SetFilter::new_unchecked(v.into())
+    }
+}
+impl SetFilter {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn as_reader<'r>(&'r self) -> SetFilterReader<'r> {
+        SetFilterReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for SetFilter {
+    type Builder = SetFilterBuilder;
+    const NAME: &'static str = "SetFilter";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        SetFilter(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SetFilterReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SetFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+    }
+}
+#[derive(Clone, Copy)]
+pub struct SetFilterReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for SetFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for SetFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for SetFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> SetFilterReader<'r> {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for SetFilterReader<'r> {
+    type Entity = SetFilter;
+    const NAME: &'static str = "SetFilterReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        SetFilterReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len > molecule::NUMBER_SIZE && !compatible {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct SetFilterBuilder {}
+impl SetFilterBuilder {
+    pub const FIELD_COUNT: usize = 0;
+}
+impl molecule::prelude::Builder for SetFilterBuilder {
+    type Entity = SetFilter;
+    const NAME: &'static str = "SetFilterBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(&molecule::pack_number(
+            molecule::NUMBER_SIZE as molecule::Number,
+        ))?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        SetFilter::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct AddFilter(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for AddFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for AddFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for AddFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for AddFilter {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        AddFilter::new_unchecked(v.into())
+    }
+}
+impl AddFilter {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn as_reader<'r>(&'r self) -> AddFilterReader<'r> {
+        AddFilterReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for AddFilter {
+    type Builder = AddFilterBuilder;
+    const NAME: &'static str = "AddFilter";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        AddFilter(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        AddFilterReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        AddFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+    }
+}
+#[derive(Clone, Copy)]
+pub struct AddFilterReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for AddFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for AddFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for AddFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> AddFilterReader<'r> {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for AddFilterReader<'r> {
+    type Entity = AddFilter;
+    const NAME: &'static str = "AddFilterReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        AddFilterReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len > molecule::NUMBER_SIZE && !compatible {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct AddFilterBuilder {}
+impl AddFilterBuilder {
+    pub const FIELD_COUNT: usize = 0;
+}
+impl molecule::prelude::Builder for AddFilterBuilder {
+    type Entity = AddFilter;
+    const NAME: &'static str = "AddFilterBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(&molecule::pack_number(
+            molecule::NUMBER_SIZE as molecule::Number,
+        ))?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        AddFilter::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct ClearFilter(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for ClearFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for ClearFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for ClearFilter {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for ClearFilter {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        ClearFilter::new_unchecked(v.into())
+    }
+}
+impl ClearFilter {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn as_reader<'r>(&'r self) -> ClearFilterReader<'r> {
+        ClearFilterReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for ClearFilter {
+    type Builder = ClearFilterBuilder;
+    const NAME: &'static str = "ClearFilter";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        ClearFilter(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        ClearFilterReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        ClearFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+    }
+}
+#[derive(Clone, Copy)]
+pub struct ClearFilterReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for ClearFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for ClearFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for ClearFilterReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> ClearFilterReader<'r> {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for ClearFilterReader<'r> {
+    type Entity = ClearFilter;
+    const NAME: &'static str = "ClearFilterReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        ClearFilterReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len > molecule::NUMBER_SIZE && !compatible {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct ClearFilterBuilder {}
+impl ClearFilterBuilder {
+    pub const FIELD_COUNT: usize = 0;
+}
+impl molecule::prelude::Builder for ClearFilterBuilder {
+    type Entity = ClearFilter;
+    const NAME: &'static str = "ClearFilterBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(&molecule::pack_number(
+            molecule::NUMBER_SIZE as molecule::Number,
+        ))?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        ClearFilter::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct FilteredBlock(molecule::bytes::Bytes);
+impl ::std::fmt::LowerHex for FilteredBlock {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl ::std::fmt::Debug for FilteredBlock {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::std::fmt::Display for FilteredBlock {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::std::default::Default for FilteredBlock {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        FilteredBlock::new_unchecked(v.into())
+    }
+}
+impl FilteredBlock {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn as_reader<'r>(&'r self) -> FilteredBlockReader<'r> {
+        FilteredBlockReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for FilteredBlock {
+    type Builder = FilteredBlockBuilder;
+    const NAME: &'static str = "FilteredBlock";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        FilteredBlock(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        FilteredBlockReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        FilteredBlockReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::std::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+    }
+}
+#[derive(Clone, Copy)]
+pub struct FilteredBlockReader<'r>(&'r [u8]);
+impl<'r> ::std::fmt::LowerHex for FilteredBlockReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use molecule::faster_hex::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()).unwrap())
+    }
+}
+impl<'r> ::std::fmt::Debug for FilteredBlockReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::std::fmt::Display for FilteredBlockReader<'r> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> FilteredBlockReader<'r> {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn field_offsets(&self) -> &[[u8; 4]] {
+        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for FilteredBlockReader<'r> {
+    type Entity = FilteredBlock;
+    const NAME: &'static str = "FilteredBlockReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        FilteredBlockReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len > molecule::NUMBER_SIZE && !compatible {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct FilteredBlockBuilder {}
+impl FilteredBlockBuilder {
+    pub const FIELD_COUNT: usize = 0;
+}
+impl molecule::prelude::Builder for FilteredBlockBuilder {
+    type Entity = FilteredBlock;
+    const NAME: &'static str = "FilteredBlockBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE
+    }
+    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        writer.write_all(&molecule::pack_number(
+            molecule::NUMBER_SIZE as molecule::Number,
+        ))?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        FilteredBlock::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct GetHeaders(molecule::bytes::Bytes);
 impl ::std::fmt::LowerHex for GetHeaders {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -11401,1033 +12129,6 @@ impl molecule::prelude::Builder for SendBlockBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         SendBlock::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct SetFilter(molecule::bytes::Bytes);
-impl ::std::fmt::LowerHex for SetFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl ::std::fmt::Debug for SetFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::std::fmt::Display for SetFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "hash_seed", self.hash_seed())?;
-        write!(f, ", {}: {}", "filter", self.filter())?;
-        write!(f, ", {}: {}", "num_hashes", self.num_hashes())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl ::std::default::Default for SetFilter {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![
-            25, 0, 0, 0, 16, 0, 0, 0, 20, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ];
-        SetFilter::new_unchecked(v.into())
-    }
-}
-impl SetFilter {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn hash_seed(&self) -> Uint32 {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        let end = molecule::unpack_number(&offsets[1][..]) as usize;
-        Uint32::new_unchecked(self.0.slice(start, end))
-    }
-    pub fn filter(&self) -> Bytes {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[1][..]) as usize;
-        let end = molecule::unpack_number(&offsets[2][..]) as usize;
-        Bytes::new_unchecked(self.0.slice(start, end))
-    }
-    pub fn num_hashes(&self) -> Byte {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[2][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[3][..]) as usize;
-            Byte::new_unchecked(self.0.slice(start, end))
-        } else {
-            Byte::new_unchecked(self.0.slice_from(start))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> SetFilterReader<'r> {
-        SetFilterReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for SetFilter {
-    type Builder = SetFilterBuilder;
-    const NAME: &'static str = "SetFilter";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        SetFilter(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SetFilterReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SetFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder()
-            .hash_seed(self.hash_seed())
-            .filter(self.filter())
-            .num_hashes(self.num_hashes())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct SetFilterReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::LowerHex for SetFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl<'r> ::std::fmt::Debug for SetFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::std::fmt::Display for SetFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "hash_seed", self.hash_seed())?;
-        write!(f, ", {}: {}", "filter", self.filter())?;
-        write!(f, ", {}: {}", "num_hashes", self.num_hashes())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl<'r> SetFilterReader<'r> {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn hash_seed(&self) -> Uint32Reader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        let end = molecule::unpack_number(&offsets[1][..]) as usize;
-        Uint32Reader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn filter(&self) -> BytesReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[1][..]) as usize;
-        let end = molecule::unpack_number(&offsets[2][..]) as usize;
-        BytesReader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn num_hashes(&self) -> ByteReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[2][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[3][..]) as usize;
-            ByteReader::new_unchecked(&self.as_slice()[start..end])
-        } else {
-            ByteReader::new_unchecked(&self.as_slice()[start..])
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for SetFilterReader<'r> {
-    type Entity = SetFilter;
-    const NAME: &'static str = "SetFilterReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        SetFilterReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-            return Ok(());
-        }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        let field_count = offset_first / 4 - 1;
-        if field_count < Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        } else if !compatible && field_count > Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        };
-        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
-        if slice_len < header_size {
-            return ve!(Self, HeaderIsBroken, header_size, slice_len);
-        }
-        let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
-        let mut offsets: Vec<usize> = ptr[..field_count]
-            .iter()
-            .map(|x| molecule::unpack_number(&x[..]) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        Uint32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        BytesReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        ByteReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct SetFilterBuilder {
-    pub(crate) hash_seed: Uint32,
-    pub(crate) filter: Bytes,
-    pub(crate) num_hashes: Byte,
-}
-impl SetFilterBuilder {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn hash_seed(mut self, v: Uint32) -> Self {
-        self.hash_seed = v;
-        self
-    }
-    pub fn filter(mut self, v: Bytes) -> Self {
-        self.filter = v;
-        self
-    }
-    pub fn num_hashes(mut self, v: Byte) -> Self {
-        self.num_hashes = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for SetFilterBuilder {
-    type Entity = SetFilter;
-    const NAME: &'static str = "SetFilterBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
-            + self.hash_seed.as_slice().len()
-            + self.filter.as_slice().len()
-            + self.num_hashes.as_slice().len()
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-        offsets.push(total_size);
-        total_size += self.hash_seed.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.filter.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.num_hashes.as_slice().len();
-        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-        for offset in offsets.into_iter() {
-            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-        }
-        writer.write_all(self.hash_seed.as_slice())?;
-        writer.write_all(self.filter.as_slice())?;
-        writer.write_all(self.num_hashes.as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        SetFilter::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct AddFilter(molecule::bytes::Bytes);
-impl ::std::fmt::LowerHex for AddFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl ::std::fmt::Debug for AddFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::std::fmt::Display for AddFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "filter", self.filter())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl ::std::default::Default for AddFilter {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![12, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0];
-        AddFilter::new_unchecked(v.into())
-    }
-}
-impl AddFilter {
-    pub const FIELD_COUNT: usize = 1;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn filter(&self) -> Bytes {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[1][..]) as usize;
-            Bytes::new_unchecked(self.0.slice(start, end))
-        } else {
-            Bytes::new_unchecked(self.0.slice_from(start))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> AddFilterReader<'r> {
-        AddFilterReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for AddFilter {
-    type Builder = AddFilterBuilder;
-    const NAME: &'static str = "AddFilter";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        AddFilter(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        AddFilterReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        AddFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().filter(self.filter())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct AddFilterReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::LowerHex for AddFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl<'r> ::std::fmt::Debug for AddFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::std::fmt::Display for AddFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "filter", self.filter())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl<'r> AddFilterReader<'r> {
-    pub const FIELD_COUNT: usize = 1;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn filter(&self) -> BytesReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[1][..]) as usize;
-            BytesReader::new_unchecked(&self.as_slice()[start..end])
-        } else {
-            BytesReader::new_unchecked(&self.as_slice()[start..])
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for AddFilterReader<'r> {
-    type Entity = AddFilter;
-    const NAME: &'static str = "AddFilterReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        AddFilterReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-            return Ok(());
-        }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        let field_count = offset_first / 4 - 1;
-        if field_count < Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        } else if !compatible && field_count > Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        };
-        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
-        if slice_len < header_size {
-            return ve!(Self, HeaderIsBroken, header_size, slice_len);
-        }
-        let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
-        let mut offsets: Vec<usize> = ptr[..field_count]
-            .iter()
-            .map(|x| molecule::unpack_number(&x[..]) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        BytesReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct AddFilterBuilder {
-    pub(crate) filter: Bytes,
-}
-impl AddFilterBuilder {
-    pub const FIELD_COUNT: usize = 1;
-    pub fn filter(mut self, v: Bytes) -> Self {
-        self.filter = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for AddFilterBuilder {
-    type Entity = AddFilter;
-    const NAME: &'static str = "AddFilterBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1) + self.filter.as_slice().len()
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-        offsets.push(total_size);
-        total_size += self.filter.as_slice().len();
-        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-        for offset in offsets.into_iter() {
-            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-        }
-        writer.write_all(self.filter.as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        AddFilter::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct ClearFilter(molecule::bytes::Bytes);
-impl ::std::fmt::LowerHex for ClearFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl ::std::fmt::Debug for ClearFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::std::fmt::Display for ClearFilter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ".. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl ::std::default::Default for ClearFilter {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![4, 0, 0, 0];
-        ClearFilter::new_unchecked(v.into())
-    }
-}
-impl ClearFilter {
-    pub const FIELD_COUNT: usize = 0;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn as_reader<'r>(&'r self) -> ClearFilterReader<'r> {
-        ClearFilterReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for ClearFilter {
-    type Builder = ClearFilterBuilder;
-    const NAME: &'static str = "ClearFilter";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        ClearFilter(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        ClearFilterReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        ClearFilterReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder()
-    }
-}
-#[derive(Clone, Copy)]
-pub struct ClearFilterReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::LowerHex for ClearFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl<'r> ::std::fmt::Debug for ClearFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::std::fmt::Display for ClearFilterReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ".. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl<'r> ClearFilterReader<'r> {
-    pub const FIELD_COUNT: usize = 0;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for ClearFilterReader<'r> {
-    type Entity = ClearFilter;
-    const NAME: &'static str = "ClearFilterReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        ClearFilterReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len > molecule::NUMBER_SIZE && !compatible {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
-        }
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct ClearFilterBuilder {}
-impl ClearFilterBuilder {
-    pub const FIELD_COUNT: usize = 0;
-}
-impl molecule::prelude::Builder for ClearFilterBuilder {
-    type Entity = ClearFilter;
-    const NAME: &'static str = "ClearFilterBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        writer.write_all(&molecule::pack_number(
-            molecule::NUMBER_SIZE as molecule::Number,
-        ))?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        ClearFilter::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct FilteredBlock(molecule::bytes::Bytes);
-impl ::std::fmt::LowerHex for FilteredBlock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl ::std::fmt::Debug for FilteredBlock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::std::fmt::Display for FilteredBlock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "header", self.header())?;
-        write!(f, ", {}: {}", "transactions", self.transactions())?;
-        write!(f, ", {}: {}", "proof", self.proof())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl ::std::default::Default for FilteredBlock {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![
-            248, 0, 0, 0, 16, 0, 0, 0, 224, 0, 0, 0, 228, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 20, 0,
-            0, 0, 12, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ];
-        FilteredBlock::new_unchecked(v.into())
-    }
-}
-impl FilteredBlock {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn header(&self) -> Header {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        let end = molecule::unpack_number(&offsets[1][..]) as usize;
-        Header::new_unchecked(self.0.slice(start, end))
-    }
-    pub fn transactions(&self) -> TransactionVec {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[1][..]) as usize;
-        let end = molecule::unpack_number(&offsets[2][..]) as usize;
-        TransactionVec::new_unchecked(self.0.slice(start, end))
-    }
-    pub fn proof(&self) -> MerkleProof {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[2][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[3][..]) as usize;
-            MerkleProof::new_unchecked(self.0.slice(start, end))
-        } else {
-            MerkleProof::new_unchecked(self.0.slice_from(start))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> FilteredBlockReader<'r> {
-        FilteredBlockReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for FilteredBlock {
-    type Builder = FilteredBlockBuilder;
-    const NAME: &'static str = "FilteredBlock";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        FilteredBlock(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        FilteredBlockReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        FilteredBlockReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::std::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder()
-            .header(self.header())
-            .transactions(self.transactions())
-            .proof(self.proof())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct FilteredBlockReader<'r>(&'r [u8]);
-impl<'r> ::std::fmt::LowerHex for FilteredBlockReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use molecule::faster_hex::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()).unwrap())
-    }
-}
-impl<'r> ::std::fmt::Debug for FilteredBlockReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::std::fmt::Display for FilteredBlockReader<'r> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "header", self.header())?;
-        write!(f, ", {}: {}", "transactions", self.transactions())?;
-        write!(f, ", {}: {}", "proof", self.proof())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl<'r> FilteredBlockReader<'r> {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn field_offsets(&self) -> &[[u8; 4]] {
-        molecule::unpack_number_vec(&self.as_slice()[molecule::NUMBER_SIZE..])
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn header(&self) -> HeaderReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[0][..]) as usize;
-        let end = molecule::unpack_number(&offsets[1][..]) as usize;
-        HeaderReader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn transactions(&self) -> TransactionVecReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[1][..]) as usize;
-        let end = molecule::unpack_number(&offsets[2][..]) as usize;
-        TransactionVecReader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn proof(&self) -> MerkleProofReader<'r> {
-        let offsets = self.field_offsets();
-        let start = molecule::unpack_number(&offsets[2][..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&offsets[3][..]) as usize;
-            MerkleProofReader::new_unchecked(&self.as_slice()[start..end])
-        } else {
-            MerkleProofReader::new_unchecked(&self.as_slice()[start..])
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for FilteredBlockReader<'r> {
-    type Entity = FilteredBlock;
-    const NAME: &'static str = "FilteredBlockReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        FilteredBlockReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-            return Ok(());
-        }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        let field_count = offset_first / 4 - 1;
-        if field_count < Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        } else if !compatible && field_count > Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        };
-        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
-        if slice_len < header_size {
-            return ve!(Self, HeaderIsBroken, header_size, slice_len);
-        }
-        let ptr = molecule::unpack_number_vec(&slice[molecule::NUMBER_SIZE..]);
-        let mut offsets: Vec<usize> = ptr[..field_count]
-            .iter()
-            .map(|x| molecule::unpack_number(&x[..]) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        HeaderReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        TransactionVecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        MerkleProofReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct FilteredBlockBuilder {
-    pub(crate) header: Header,
-    pub(crate) transactions: TransactionVec,
-    pub(crate) proof: MerkleProof,
-}
-impl FilteredBlockBuilder {
-    pub const FIELD_COUNT: usize = 3;
-    pub fn header(mut self, v: Header) -> Self {
-        self.header = v;
-        self
-    }
-    pub fn transactions(mut self, v: TransactionVec) -> Self {
-        self.transactions = v;
-        self
-    }
-    pub fn proof(mut self, v: MerkleProof) -> Self {
-        self.proof = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for FilteredBlockBuilder {
-    type Entity = FilteredBlock;
-    const NAME: &'static str = "FilteredBlockBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
-            + self.header.as_slice().len()
-            + self.transactions.as_slice().len()
-            + self.proof.as_slice().len()
-    }
-    fn write<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-        offsets.push(total_size);
-        total_size += self.header.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.transactions.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.proof.as_slice().len();
-        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-        for offset in offsets.into_iter() {
-            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-        }
-        writer.write_all(self.header.as_slice())?;
-        writer.write_all(self.transactions.as_slice())?;
-        writer.write_all(self.proof.as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        FilteredBlock::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/util/types/src/utilities/merkle_tree.rs
+++ b/util/types/src/utilities/merkle_tree.rs
@@ -1,5 +1,5 @@
 use ckb_hash::new_blake2b;
-use merkle_cbt::{merkle_tree::Merge, CBMT as ExCBMT};
+use merkle_cbt::{merkle_tree::Merge, MerkleProof as ExMerkleProof, CBMT as ExCBMT};
 
 use crate::{packed::Byte32, prelude::*};
 
@@ -19,6 +19,7 @@ impl Merge for MergeByte32 {
 }
 
 pub type CBMT = ExCBMT<Byte32, MergeByte32>;
+pub type MerkleProof = ExMerkleProof<Byte32, MergeByte32>;
 
 pub fn merkle_root(leaves: &[Byte32]) -> Byte32 {
     CBMT::build_merkle_root(leaves)

--- a/util/types/src/utilities/mod.rs
+++ b/util/types/src/utilities/mod.rs
@@ -4,4 +4,4 @@ mod merkle_tree;
 pub use difficulty::{
     compact_to_difficulty, compact_to_target, difficulty_to_compact, target_to_compact, DIFF_TWO,
 };
-pub use merkle_tree::{merkle_root, MergeByte32, CBMT};
+pub use merkle_tree::{merkle_root, MergeByte32, MerkleProof, CBMT};

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -3,7 +3,12 @@ use crate::{BlockErrorKind, NumberError, PowError, TimestampError, ALLOWED_FUTUR
 use ckb_error::assert_error_eq;
 use ckb_pow::PowEngine;
 use ckb_test_chain_utils::MockMedianTime;
-use ckb_types::{constants::BLOCK_VERSION, core::HeaderBuilder, packed::Header, prelude::*};
+use ckb_types::{
+    constants::BLOCK_VERSION,
+    core::{HeaderBuilder, HeaderContext},
+    packed::Header,
+    prelude::*,
+};
 use faketime::unix_time_as_millis;
 
 fn mock_median_time_context() -> MockMedianTime {
@@ -104,7 +109,7 @@ fn test_number() {
 struct FakePowEngine;
 
 impl PowEngine for FakePowEngine {
-    fn verify(&self, _header: &Header) -> bool {
+    fn verify(&self, _header_ctx: &HeaderContext) -> bool {
         false
     }
 }
@@ -112,8 +117,9 @@ impl PowEngine for FakePowEngine {
 #[test]
 fn test_pow_verifier() {
     let header = HeaderBuilder::default().build();
+    let header_ctx = HeaderContext::new(header);
     let fake_pow_engine: &dyn PowEngine = &FakePowEngine;
-    let verifier = PowVerifier::new(&header, fake_pow_engine);
+    let verifier = PowVerifier::new(&header_ctx, fake_pow_engine);
 
     assert_error_eq!(verifier.verify().unwrap_err(), PowError::InvalidNonce);
 }

--- a/verification/src/tests/two_phase_commit_verifier.rs
+++ b/verification/src/tests/two_phase_commit_verifier.rs
@@ -12,8 +12,8 @@ use ckb_test_chain_utils::always_success_cell;
 use ckb_types::{
     bytes::Bytes,
     core::{
-        capacity_bytes, BlockBuilder, BlockNumber, BlockView, Capacity, HeaderBuilder, HeaderView,
-        TransactionBuilder, TransactionView, UncleBlockView,
+        capacity_bytes, BlockBuilder, BlockNumber, BlockView, Capacity, HeaderBuilder,
+        HeaderContextType, HeaderView, TransactionBuilder, TransactionView, UncleBlockView,
     },
     packed::{Byte32, CellDep, CellInput, CellOutputBuilder, OutPoint, ProposalShortId, Script},
     prelude::*,
@@ -102,7 +102,11 @@ fn setup_env() -> (ChainController, Shared, Byte32, Script, OutPoint) {
     let (always_success_cell, always_success_cell_data, always_success_script) =
         always_success_cell();
     let tx = TransactionBuilder::default()
-        .witness(always_success_script.clone().into_witness())
+        .witness(
+            always_success_script
+                .clone()
+                .into_witness(HeaderContextType::NoneContext),
+        )
         .input(CellInput::new(OutPoint::null(), 0))
         .output(always_success_cell.clone())
         .outputs(vec![

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -11,8 +11,8 @@ use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_types::{
     core::{
-        BlockBuilder, BlockNumber, BlockView, EpochExt, HeaderView, TransactionBuilder,
-        TransactionView, UncleBlockView,
+        BlockBuilder, BlockNumber, BlockView, EpochExt, HeaderContextType, HeaderView,
+        TransactionBuilder, TransactionView, UncleBlockView,
     },
     packed::{Byte32, CellInput, ProposalShortId, Script, UncleBlockVec},
     prelude::*,
@@ -51,7 +51,7 @@ fn start_chain(consensus: Option<Consensus>) -> (ChainController, Shared) {
 
 fn create_cellbase(number: BlockNumber) -> TransactionView {
     TransactionBuilder::default()
-        .witness(Script::default().into_witness())
+        .witness(Script::default().into_witness(HeaderContextType::NoneContext))
         .input(CellInput::new_cellbase_input(number))
         .output(Default::default())
         .output_data(Default::default())


### PR DESCRIPTION
Mostly changes are generated by `moleculec`.

The core idea is to introduce a `HeaderContext` used in the `POWVerifier` context, to allow us to put a signature.

The `HeaderContextType` has two kinds:
* `NoneContext` - the `HeaderContext` only contains header itself
* `Cellbase` - the `HeaderContext` need cellbase tx as it's context

The core logic of poa https://github.com/nervosnetwork/ckb/pull/1855/files#diff-411cac0ad5e86ba40dbe50576538c9d7R1

TODO:
- [ ] more test(sync, relay poa blocks)
- [ ] miner support mine POA block.
