### PR TITLE
fix: fetch_random_addrs should be able to return peers addrs

### DIFF
--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -159,11 +159,13 @@ impl PeerStore {
         let now_ms = faketime::unix_time_as_millis();
         let addr_expired_ms = now_ms - ADDR_TIMEOUT_MS;
         let ban_list = self.ban_list.borrow();
+        let peers = self.peers.borrow();
         // get success connected addrs.
         self.addr_manager
             .fetch_random(count, |peer_addr: &AddrInfo| {
                 !ban_list.is_addr_banned(&peer_addr.addr)
-                    && peer_addr.had_connected(addr_expired_ms)
+                    && (peers.contains_key(&peer_addr.peer_id)
+                        || peer_addr.had_connected(addr_expired_ms))
             })
     }
 


### PR DESCRIPTION
The old code use `last_connected_at_ms > expired_ms` to detect a recently connected address, but the condition is wrong if a peer keeps connected for a long time(`ADDR_TIMEOUT_MS = 7days`), because when the peer is connected, a feeler protocol will not refresh the address's `last_connected_at_ms`.

This PR fixes the condition of `fetch_random_addrs`. this function should return address that belongs to currently connected peers. When a peer disconnected, the feeler protocol will be able to refresh the address's `last_connected_at_ms`.