### PR TITLE
fix: remove duplicate p2p phase in discovery protocol

### DIFF
--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -58,7 +58,7 @@ impl PeerStore {
             self.addr_manager.add(AddrInfo::new(
                 peer_id.to_owned(),
                 addr.extract_ip_addr()?,
-                addr,
+                addr.exclude_p2p(),
                 now_ms,
                 score,
             ));

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -113,6 +113,10 @@ impl AddrInfo {
         // reset attempts
         self.attempts_count = 0;
     }
+
+    pub fn multiaddr(&self) -> Result<Multiaddr, Error> {
+        self.addr.attach_p2p(&self.peer_id)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]


### PR DESCRIPTION
* Consider space-efficient, we do not store p2p phase of multiaddr in peer store.
* Reattach the p2p phase when we send multiaddr to other nodes.

---
Closes https://github.com/nervosnetwork/ckb/issues/1872