### PR TITLE
chore: auto init ckb dir in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ data/
 specs/
 docs/
 docker/
+!docker/docker-entrypoint.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${1:-}" = "run" ] && ! [ -f ckb.toml ]; then
+  /bin/ckb init --chain "$CKB_CHAIN"
+fi
+
+exec /bin/ckb "$@"

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -19,13 +19,13 @@ COPY --from=ckb-docker-builder \
      /usr/lib/x86_64-linux-gnu/libssl.so.* \
      /usr/lib/x86_64-linux-gnu/libcrypto.so.* \
      /usr/lib/x86_64-linux-gnu/
-COPY --from=ckb-docker-builder /ckb/target/release/ckb /bin/ckb
-RUN /bin/ckb init --chain dev --force \
- && chown -R ckb:ckb /var/lib/ckb \
+COPY --from=ckb-docker-builder /ckb/target/release/ckb /ckb/docker/docker-entrypoint.sh /bin/
+RUN chown -R ckb:ckb /var/lib/ckb \
  && chmod 755 /var/lib/ckb
 
 USER ckb
+ENV CKB_CHAIN=mainnet
 
 EXPOSE 8114 8115
 VOLUME ["/var/lib/ckb"]
-ENTRYPOINT ["/bin/ckb"]
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]

--- a/docs/run-ckb-with-docker.md
+++ b/docs/run-ckb-with-docker.md
@@ -6,6 +6,14 @@ Start latest CKB release with default configuration:
 docker run --rm -it nervos/ckb:latest run
 ```
 
+Starting from v0.26.1, the docker container connects to mainnet by default,
+which can be overrode by the environment variable `CKB_CHAIN`, for example
+
+
+```bash
+docker run -e CKB_CHAIN=testnet --rm -it nervos/ckb:latest run
+```
+
 See other
 [tags](https://hub.docker.com/r/nervos/ckb/tags)
 listed in DockerHub.


### PR DESCRIPTION
This PR changes the behavior of the docker image.

Before the configuration are generated when building the image.

After the changes, the docker image uses a shell script as the entrypoint instead. The shell script will auto init the ckb directory when no config files are found. The environment variable `CKB_CHAIN` can control which chain spec to init.