### PR TITLE
feat: Use scoop to replace chocolatey for more stable CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
  "ckb-store 0.26.1-pre",
  "ckb-test-chain-utils 0.26.1-pre",
  "ckb-types 0.26.1-pre",
- "ckb-vm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,13 +1060,13 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3994,8 +3994,8 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum ckb-system-scripts 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "261dd95a93c09ea24397c85b4fbca061e1da2d6573189749aeb99fe840aaf0c9"
-"checksum ckb-vm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a645990a41708a9a55ea8a90c42c98d20ce9b2d2dd457f51fce33bca8854474"
-"checksum ckb-vm-definitions 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bd01bf493cff1315fd73a3be4a3ec135afe04503b81ebc1b531fcb061b42de6c"
+"checksum ckb-vm 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "684aca846d958bc5c2196b10839b69ec573cc693b14dc701986adda123ffbef0"
+"checksum ckb-vm-definitions 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4a65696efd8974a3c785619f2bfc4c40f2cf318ac184c30aa72d0f539a4a4f"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"

--- a/devtools/azure/windows-dependencies.yml
+++ b/devtools/azure/windows-dependencies.yml
@@ -1,14 +1,18 @@
 parameters:
   rustup_toolchain: ''
 steps:
+- powershell: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+  displayName: Install scoop
 - script: |
-    choco install -y llvm
-    set "PATH=%PATH%;C:\Program Files\LLVM\bin"
-    echo "##vso[task.setvariable variable=PATH;]%PATH%;C:\Program Files\LLVM\bin"
+    set PATH=%PATH%;%USERPROFILE%\scoop\shims
+    echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\scoop\shims"
+    scoop help
+  displayName: Add scoop to path
+- script: scoop install llvm
   displayName: Install LLVM
-- script: choco install -y msys2
+- script: scoop install msys2
   displayName: Install msys2
-- script: choco install --allow-empty-checksums -y yasm
+- script: scoop install yasm
   displayName: Install yasm
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -17,7 +17,7 @@ ckb-script-data-loader = { path = "data-loader" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.18.1", default-features = false }
+ckb-vm = { version = "0.18.2", default-features = false }
 faster-hex = "0.4"
 ckb-logger = { path = "../util/logger", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
See [here](https://github.com/nervosnetwork/ckb-vm/releases/tag/0.18.2) for CKB VM changes.