### PR TITLE
feat: notify service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-notify"
+version = "0.26.1-pre"
+dependencies = [
+ "ckb-jsonrpc-types 0.26.1-pre",
+ "ckb-logger 0.26.1-pre",
+ "ckb-stop-handler 0.26.1-pre",
+ "ckb-types 0.26.1-pre",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-occupied-capacity"
 version = "0.26.2-pre"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,13 +701,11 @@ dependencies = [
 name = "ckb-notify"
 version = "0.26.1-pre"
 dependencies = [
- "ckb-jsonrpc-types 0.26.1-pre",
  "ckb-logger 0.26.1-pre",
  "ckb-stop-handler 0.26.1-pre",
  "ckb-types 0.26.1-pre",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "ckb-miner 0.26.2-pre",
  "ckb-network 0.26.2-pre",
  "ckb-network-alert 0.26.2-pre",
+ "ckb-notify 0.26.2-pre",
  "ckb-pow 0.26.2-pre",
  "ckb-resource 0.26.2-pre",
  "ckb-rpc 0.26.2-pre",
@@ -687,6 +688,7 @@ dependencies = [
  "ckb-logger 0.26.2-pre",
  "ckb-multisig 0.26.2-pre",
  "ckb-network 0.26.2-pre",
+ "ckb-notify 0.26.2-pre",
  "ckb-types 0.26.2-pre",
  "ckb-util 0.26.2-pre",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -699,11 +701,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-notify"
-version = "0.26.1-pre"
+version = "0.26.2-pre"
 dependencies = [
- "ckb-logger 0.26.1-pre",
- "ckb-stop-handler 0.26.1-pre",
- "ckb-types 0.26.1-pre",
+ "ckb-logger 0.26.2-pre",
+ "ckb-stop-handler 0.26.2-pre",
+ "ckb-types 0.26.2-pre",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -805,6 +807,7 @@ dependencies = [
  "ckb-logger 0.26.2-pre",
  "ckb-network 0.26.2-pre",
  "ckb-network-alert 0.26.2-pre",
+ "ckb-notify 0.26.2-pre",
  "ckb-reward-calculator 0.26.2-pre",
  "ckb-shared 0.26.2-pre",
  "ckb-store 0.26.2-pre",
@@ -872,6 +875,7 @@ dependencies = [
  "ckb-db 0.26.2-pre",
  "ckb-error 0.26.2-pre",
  "ckb-logger 0.26.2-pre",
+ "ckb-notify 0.26.2-pre",
  "ckb-proposal-table 0.26.2-pre",
  "ckb-snapshot 0.26.2-pre",
  "ckb-store 0.26.2-pre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ members = [
     "ckb-bin",
     "benches",
     "error",
+    "notify",
 ]
 
 [profile.release]

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -385,6 +385,10 @@ impl ChainService {
                     error!("notify new_uncle error {}", e);
                 }
             }
+            let block_ref: &BlockView = &block;
+            self.shared
+                .notify_controller()
+                .notify_new_block(block_ref.clone());
             if log_enabled!(ckb_logger::Level::Debug) {
                 self.print_chain(10);
             }

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -30,6 +30,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let (shared, table) = SharedBuilder::with_db_config(&args.config.db)
         .consensus(args.consensus)
         .tx_pool_config(args.config.tx_pool)
+        .notify_config(args.config.notify)
         .store_config(args.config.store)
         .block_assembler_config(block_assembler_config)
         .build()
@@ -64,10 +65,9 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     );
     let net_timer = NetTimeProtocol::default();
     let alert_signature_config = args.config.alert_signature.unwrap_or_default();
-    let alert_notifier_config = args.config.alert_notifier.unwrap_or_default();
     let alert_relayer = AlertRelayer::new(
         version.to_string(),
-        alert_notifier_config,
+        shared.notify_controller().clone(),
         alert_signature_config,
     );
 

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-notify"
-version = "0.26.1-pre"
+version = "0.26.2-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -8,10 +8,8 @@ license = "MIT"
 [dependencies]
 ckb-logger = { path = "../util/logger" }
 ckb-types = { path = "../util/types" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 ckb-stop-handler = { path = "../util/stop-handler" }
 crossbeam-channel = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [dev-dependencies]

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ckb-notify"
+version = "0.26.1-pre"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+license = "MIT"
+
+[dependencies]
+ckb-logger = { path = "../util/logger" }
+ckb-types = { path = "../util/types" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
+ckb-stop-handler = { path = "../util/stop-handler" }
+crossbeam-channel = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -6,7 +6,6 @@ use ckb_types::{
 };
 use crossbeam_channel::{bounded, select, Receiver, RecvError, Sender};
 use serde::{Deserialize, Serialize};
-use serde_json::to_string;
 use std::collections::HashMap;
 use std::process::Command;
 use std::thread;
@@ -112,12 +111,11 @@ impl NotifyService {
                 }
                 // notify script
                 if let Some(script) = self.config.new_block_notify_script.as_ref() {
-                    let block_json: ckb_jsonrpc_types::BlockView = block.into();
-                    let args = [to_string(&block_json).expect("serializing should be ok")];
+                    let args = [format!("{:#x}", block.hash())];
                     if let Err(err) = Command::new(script).args(&args).status() {
                         error!(
-                            "failed to run new_block_notify_script, script: {}, error: {}",
-                            script, err
+                            "failed to run new_block_notify_script: {} {}, error: {}",
+                            script, args[0], err
                         );
                     }
                 }
@@ -163,8 +161,8 @@ impl NotifyService {
                         .to_owned()];
                     if let Err(err) = Command::new(script).args(&args).status() {
                         error!(
-                            "failed to run network_alert_notify_script, script: {}, error: {}",
-                            script, err
+                            "failed to run network_alert_notify_script: {} {}, error: {}",
+                            script, args[0], err
                         );
                     }
                 }

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -6,6 +6,7 @@ use ckb_types::{
 };
 use crossbeam_channel::{bounded, select, Receiver, RecvError, Sender};
 use serde::{Deserialize, Serialize};
+use serde_json::to_string;
 use std::collections::HashMap;
 use std::process::Command;
 use std::thread;
@@ -112,8 +113,7 @@ impl NotifyService {
                 // notify script
                 if let Some(script) = self.config.new_block_notify_script.as_ref() {
                     let block_json: ckb_jsonrpc_types::BlockView = block.into();
-                    let args =
-                        [serde_json::to_string(&block_json).expect("serializing should be ok")];
+                    let args = [to_string(&block_json).expect("serializing should be ok")];
                     if let Err(err) = Command::new(script).args(&args).status() {
                         error!(
                             "failed to run new_block_notify_script script, error: {}",

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -116,8 +116,8 @@ impl NotifyService {
                     let args = [to_string(&block_json).expect("serializing should be ok")];
                     if let Err(err) = Command::new(script).args(&args).status() {
                         error!(
-                            "failed to run new_block_notify_script script, error: {}",
-                            err
+                            "failed to run new_block_notify_script, script: {}, error: {}",
+                            script, err
                         );
                     }
                 }
@@ -163,8 +163,8 @@ impl NotifyService {
                         .to_owned()];
                     if let Err(err) = Command::new(script).args(&args).status() {
                         error!(
-                            "failed to run network_alert_notify_script script, error: {}",
-                            err
+                            "failed to run network_alert_notify_script, script: {}, error: {}",
+                            script, err
                         );
                     }
                 }

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -1,0 +1,201 @@
+use ckb_logger::{debug, error, trace};
+use ckb_stop_handler::{SignalSender, StopHandler};
+use ckb_types::{
+    core::{service::Request, BlockView},
+    packed::Alert,
+};
+use crossbeam_channel::{bounded, select, Receiver, RecvError, Sender};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::process::Command;
+use std::thread;
+
+pub const SIGNAL_CHANNEL_SIZE: usize = 1;
+pub const REGISTER_CHANNEL_SIZE: usize = 2;
+pub const NOTIFY_CHANNEL_SIZE: usize = 128;
+
+pub type NotifyRegister<M> = Sender<Request<String, Receiver<M>>>;
+
+#[derive(Clone)]
+pub struct NotifyController {
+    stop: StopHandler<()>,
+    new_block_register: NotifyRegister<BlockView>,
+    new_block_notifier: Sender<BlockView>,
+    network_alert_register: NotifyRegister<Alert>,
+    network_alert_notifier: Sender<Alert>,
+}
+
+impl Drop for NotifyController {
+    fn drop(&mut self) {
+        self.stop.try_send();
+    }
+}
+
+pub struct NotifyService {
+    config: Config,
+    new_block_subscribers: HashMap<String, Sender<BlockView>>,
+    network_alert_subscribers: HashMap<String, Sender<Alert>>,
+}
+
+impl NotifyService {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            new_block_subscribers: HashMap::default(),
+            network_alert_subscribers: HashMap::default(),
+        }
+    }
+
+    // remove `allow` tag when https://github.com/crossbeam-rs/crossbeam/issues/404 is solved
+    #[allow(clippy::zero_ptr, clippy::drop_copy)]
+    pub fn start<S: ToString>(mut self, thread_name: Option<S>) -> NotifyController {
+        let (signal_sender, signal_receiver) = bounded::<()>(SIGNAL_CHANNEL_SIZE);
+        let (new_block_register, new_block_register_receiver) = bounded(REGISTER_CHANNEL_SIZE);
+        let (new_block_sender, new_block_receiver) = bounded::<BlockView>(NOTIFY_CHANNEL_SIZE);
+        let (network_alert_register, network_alert_register_receiver) =
+            bounded(REGISTER_CHANNEL_SIZE);
+        let (network_alert_sender, network_alert_receiver) = bounded::<Alert>(NOTIFY_CHANNEL_SIZE);
+
+        let mut thread_builder = thread::Builder::new();
+        if let Some(name) = thread_name {
+            thread_builder = thread_builder.name(name.to_string());
+        }
+        let join_handle = thread_builder
+            .spawn(move || loop {
+                select! {
+                    recv(signal_receiver) -> _ => {
+                        break;
+                    }
+                    recv(new_block_register_receiver) -> msg => self.handle_register_new_block(msg),
+                    recv(new_block_receiver) -> msg => self.handle_notify_new_block(msg),
+                    recv(network_alert_register_receiver) -> msg => self.handle_register_network_alert(msg),
+                    recv(network_alert_receiver) -> msg => self.handle_notify_network_alert(msg),
+                }
+            })
+            .expect("Start notify service failed");
+
+        NotifyController {
+            new_block_register,
+            new_block_notifier: new_block_sender,
+            network_alert_register,
+            network_alert_notifier: network_alert_sender,
+            stop: StopHandler::new(SignalSender::Crossbeam(signal_sender), join_handle),
+        }
+    }
+
+    fn handle_register_new_block(
+        &mut self,
+        msg: Result<Request<String, Receiver<BlockView>>, RecvError>,
+    ) {
+        match msg {
+            Ok(Request {
+                responder,
+                arguments: name,
+            }) => {
+                debug!("Register new_block {:?}", name);
+                let (sender, receiver) = bounded::<BlockView>(NOTIFY_CHANNEL_SIZE);
+                self.new_block_subscribers.insert(name, sender);
+                let _ = responder.send(receiver);
+            }
+            _ => debug!("Register new_block channel is closed"),
+        }
+    }
+
+    fn handle_notify_new_block(&mut self, msg: Result<BlockView, RecvError>) {
+        match msg {
+            Ok(block) => {
+                trace!("event new block {:?}", block);
+                // notify all subscribers
+                for subscriber in self.new_block_subscribers.values() {
+                    let _ = subscriber.send(block.clone());
+                }
+                // notify script
+                if let Some(script) = self.config.new_block_notify_script.as_ref() {
+                    let block_json: ckb_jsonrpc_types::BlockView = block.into();
+                    let args =
+                        [serde_json::to_string(&block_json).expect("serializing should be ok")];
+                    if let Err(err) = Command::new(script).args(&args).status() {
+                        error!(
+                            "failed to run new_block_notify_script script, error: {}",
+                            err
+                        );
+                    }
+                }
+            }
+            _ => debug!("new block channel is closed"),
+        }
+    }
+
+    fn handle_register_network_alert(
+        &mut self,
+        msg: Result<Request<String, Receiver<Alert>>, RecvError>,
+    ) {
+        match msg {
+            Ok(Request {
+                responder,
+                arguments: name,
+            }) => {
+                debug!("Register network_alert {:?}", name);
+                let (sender, receiver) = bounded::<Alert>(NOTIFY_CHANNEL_SIZE);
+                self.network_alert_subscribers.insert(name, sender);
+                let _ = responder.send(receiver);
+            }
+            _ => debug!("Register network_alert channel is closed"),
+        }
+    }
+
+    fn handle_notify_network_alert(&mut self, msg: Result<Alert, RecvError>) {
+        match msg {
+            Ok(alert) => {
+                trace!("event network alert {:?}", alert);
+                // notify all subscribers
+                for subscriber in self.network_alert_subscribers.values() {
+                    let _ = subscriber.send(alert.clone());
+                }
+                // notify script
+                if let Some(script) = self.config.network_alert_notify_script.as_ref() {
+                    let args = [alert
+                        .as_reader()
+                        .raw()
+                        .message()
+                        .as_utf8()
+                        .expect("alert message should be utf8")
+                        .to_owned()];
+                    if let Err(err) = Command::new(script).args(&args).status() {
+                        error!(
+                            "failed to run network_alert_notify_script script, error: {}",
+                            err
+                        );
+                    }
+                }
+            }
+            _ => debug!("network alert channel is closed"),
+        }
+    }
+}
+
+impl NotifyController {
+    pub fn subscribe_new_block<S: ToString>(&self, name: S) -> Receiver<BlockView> {
+        Request::call(&self.new_block_register, name.to_string())
+            .expect("Subscribe new block should be OK")
+    }
+
+    pub fn notify_new_block(&self, block: BlockView) {
+        let _ = self.new_block_notifier.send(block);
+    }
+
+    pub fn subscribe_network_alert<S: ToString>(&self, name: S) -> Receiver<Alert> {
+        Request::call(&self.network_alert_register, name.to_string())
+            .expect("Subscribe network alert should be OK")
+    }
+
+    pub fn notify_network_alert(&self, alert: Alert) {
+        let _ = self.network_alert_notifier.send(alert);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct Config {
+    pub new_block_notify_script: Option<String>,
+    pub network_alert_notify_script: Option<String>,
+}

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -125,7 +125,7 @@ cellbase_cache_size        = 30
 # batch_size = 200
 
 # [notifier]
-# # Execute command when the new tip block changes, first arg is block struct in json format string.
+# # Execute command when the new tip block changes, first arg is block hash.
 # new_block_notify_script = "your_new_block_notify_script.sh"
 # # Execute command when node received an network alert, first arg is alert message string.
 # network_alert_notify_script = "your_network_alert_notify_script.sh"

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -124,9 +124,11 @@ cellbase_cache_size        = 30
 # # The maximum number of blocks in a single indexing execution batch, default is 200
 # batch_size = 200
 
-# [alert_notifier]
-# # Script will be notified when node received an alert, first arg is alert message string.
-# notify_script = "echo"
+# [notifier]
+# # Execute command when the new tip block changes, first arg is block struct in json format string.
+# new_block_notify_script = "your_new_block_notify_script.sh"
+# # Execute command when node received an network alert, first arg is alert message string.
+# network_alert_notify_script = "your_network_alert_notify_script.sh"
 
 # Set the lock script to protect mined CKB.
 #

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 ckb-types = { path = "../util/types" }
 ckb-network = { path = "../network" }
+ckb-notify = { path = "../notify" }
 ckb-indexer = { path = "../indexer" }
 ckb-shared = { path = "../shared" }
 ckb-store = { path = "../store" }

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -63,7 +63,7 @@ impl AlertRpc for AlertRpcImpl {
                     error!("Broadcast alert failed: {:?}", err);
                 }
                 // set self node notifier
-                self.notifier.lock().add(Arc::new(alert));
+                self.notifier.lock().add(&alert);
                 Ok(())
             }
             Err(e) => Err(RPCError::custom(RPCError::Invalid, format!("{:#}", e))),

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -45,8 +45,8 @@ impl StatsRpc for StatsRpcImpl {
             notifier.clear_expired_alerts(now);
             notifier
                 .noticed_alerts()
-                .iter()
-                .map(|alert| AlertMessage::from(alert.as_ref().to_owned()))
+                .into_iter()
+                .map(Into::into)
                 .collect()
         };
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -20,3 +20,4 @@ ckb-error = { path = "../error" }
 ckb-snapshot = { path = "../util/snapshot" }
 ckb-tx-pool = { path = "../tx-pool" }
 ckb-verification = { path = "../verification" }
+ckb-notify = { path = "../notify" }

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -5,6 +5,7 @@ use ckb_chain_spec::SpecError;
 use ckb_db::{DBConfig, DefaultMigration, Migrations, RocksDB};
 use ckb_error::{Error, InternalErrorKind};
 use ckb_logger::info_target;
+use ckb_notify::{Config as NotifyConfig, NotifyController, NotifyService};
 use ckb_proposal_table::{ProposalTable, ProposalView};
 use ckb_store::ChainDB;
 use ckb_store::{ChainStore, StoreConfig, COLUMNS};
@@ -26,6 +27,7 @@ use std::sync::Arc;
 pub struct Shared {
     pub(crate) store: Arc<ChainDB>,
     pub(crate) tx_pool_controller: TxPoolController,
+    pub(crate) notify_controller: NotifyController,
     pub(crate) txs_verify_cache: PollLock<TxVerifyCache>,
     pub(crate) consensus: Arc<Consensus>,
     pub(crate) snapshot_mgr: Arc<SnapshotMgr>,
@@ -36,6 +38,7 @@ impl Shared {
         store: ChainDB,
         consensus: Consensus,
         tx_pool_config: TxPoolConfig,
+        notify_config: NotifyConfig,
         block_assembler_config: Option<BlockAssemblerConfig>,
     ) -> Result<(Self, ProposalTable), Error> {
         let (tip_header, epoch) = Self::init_store(&store, &consensus)?;
@@ -72,12 +75,15 @@ impl Shared {
 
         let tx_pool_controller = tx_pool_builder.start();
 
+        let notify_controller = NotifyService::new(notify_config).start(Some("NotifyService"));
+
         let shared = Shared {
             store,
             consensus,
             txs_verify_cache,
             snapshot_mgr,
             tx_pool_controller,
+            notify_controller,
         };
 
         Ok((shared, proposal_table))
@@ -185,6 +191,10 @@ impl Shared {
         self.txs_verify_cache.clone()
     }
 
+    pub fn notify_controller(&self) -> &NotifyController {
+        &self.notify_controller
+    }
+
     pub fn snapshot(&self) -> Guard<Arc<Snapshot>> {
         self.snapshot_mgr.load()
     }
@@ -231,6 +241,7 @@ pub struct SharedBuilder {
     tx_pool_config: Option<TxPoolConfig>,
     store_config: Option<StoreConfig>,
     block_assembler_config: Option<BlockAssemblerConfig>,
+    notify_config: Option<NotifyConfig>,
 }
 
 impl Default for SharedBuilder {
@@ -239,6 +250,7 @@ impl Default for SharedBuilder {
             db: RocksDB::open_tmp(COLUMNS),
             consensus: None,
             tx_pool_config: None,
+            notify_config: None,
             store_config: None,
             block_assembler_config: None,
         }
@@ -257,6 +269,7 @@ impl SharedBuilder {
             db,
             consensus: None,
             tx_pool_config: None,
+            notify_config: None,
             store_config: None,
             block_assembler_config: None,
         }
@@ -274,6 +287,11 @@ impl SharedBuilder {
         self
     }
 
+    pub fn notify_config(mut self, config: NotifyConfig) -> Self {
+        self.notify_config = Some(config);
+        self
+    }
+
     pub fn store_config(mut self, config: StoreConfig) -> Self {
         self.store_config = Some(config);
         self
@@ -287,12 +305,14 @@ impl SharedBuilder {
     pub fn build(self) -> Result<(Shared, ProposalTable), Error> {
         let consensus = self.consensus.unwrap_or_else(Consensus::default);
         let tx_pool_config = self.tx_pool_config.unwrap_or_else(Default::default);
+        let notify_config = self.notify_config.unwrap_or_else(Default::default);
         let store_config = self.store_config.unwrap_or_else(Default::default);
         let store = ChainDB::new(self.db, store_config);
         Shared::init(
             store,
             consensus,
             tx_pool_config,
+            notify_config,
             self.block_assembler_config,
         )
     }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -26,6 +26,7 @@ ckb-network-alert = { path = "../network-alert" }
 ckb-build-info = { path = "../build-info" }
 ckb-indexer = { path = "../../indexer" }
 ckb-tx-pool = { path = "../../tx-pool" }
+ckb-notify = { path = "../../notify" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -16,9 +16,8 @@ use ckb_indexer::IndexerConfig;
 use ckb_logger::Config as LogConfig;
 use ckb_miner::MinerConfig;
 use ckb_network::NetworkConfig;
-use ckb_network_alert::config::{
-    NotifierConfig as AlertNotifierConfig, SignatureConfig as AlertSignatureConfig,
-};
+use ckb_network_alert::config::SignatureConfig as AlertSignatureConfig;
+use ckb_notify::Config as NotifyConfig;
 use ckb_resource::Resource;
 use ckb_rpc::Config as RpcConfig;
 use ckb_store::StoreConfig;
@@ -51,7 +50,8 @@ pub struct CKBAppConfig {
     #[serde(default)]
     pub store: StoreConfig,
     pub alert_signature: Option<AlertSignatureConfig>,
-    pub alert_notifier: Option<AlertNotifierConfig>,
+    #[serde(default)]
+    pub notify: NotifyConfig,
 }
 
 // change the order of fields will break integration test, see module doc.

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -11,6 +11,7 @@ ckb-multisig = { path = "../multisig" }
 ckb-types = { path = "../types" }
 ckb-util = { path = ".." }
 ckb-network = { path = "../../network" }
+ckb-notify = { path = "../../notify"}
 ckb-jsonrpc-types = { path = "../jsonrpc-types" }
 ckb-logger = { path = "../logger"}
 faketime = "0.2.0"

--- a/util/network-alert/src/config.rs
+++ b/util/network-alert/src/config.rs
@@ -13,8 +13,3 @@ impl Default for SignatureConfig {
         toml::from_slice(&alert_config[..]).expect("alert system config")
     }
 }
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct NotifierConfig {
-    pub notify_script: Option<String>,
-}

--- a/util/network-alert/src/tests/test_notifier.rs
+++ b/util/network-alert/src/tests/test_notifier.rs
@@ -1,6 +1,6 @@
 use crate::notifier::Notifier;
+use ckb_notify::NotifyService;
 use ckb_types::{packed, prelude::*};
-use std::sync::Arc;
 
 fn build_alert(
     id: u32,
@@ -19,13 +19,18 @@ fn build_alert(
     packed::Alert::new_builder().raw(raw).build()
 }
 
+fn new_notifier(version: &str) -> Notifier {
+    let notify_controller = NotifyService::new(Default::default()).start(Some("test"));
+    Notifier::new(version.into(), notify_controller)
+}
+
 #[test]
 fn test_notice_alerts_by_version() {
-    let mut notifier = Notifier::new("0.9.0".into(), Default::default());
-    let alert1 = Arc::new(build_alert(1, 0, None, Some("0.10.0"), 0));
-    let alert2 = Arc::new(build_alert(2, 0, Some("0.10.0"), None, 0));
-    notifier.add(alert1);
-    notifier.add(alert2);
+    let mut notifier = new_notifier("0.9.0");
+    let alert1 = build_alert(1, 0, None, Some("0.10.0"), 0);
+    let alert2 = build_alert(2, 0, Some("0.10.0"), None, 0);
+    notifier.add(&alert1);
+    notifier.add(&alert2);
     assert_eq!(notifier.received_alerts().len(), 2);
     assert_eq!(notifier.noticed_alerts().len(), 1);
     assert_eq!(
@@ -36,12 +41,12 @@ fn test_notice_alerts_by_version() {
 
 #[test]
 fn test_received_alerts() {
-    let mut notifier = Notifier::new("0.1.0".into(), Default::default());
-    let alert1 = Arc::new(build_alert(1, 0, Some("0.1.0"), Some("0.2.0"), 0));
-    let dup_alert1 = Arc::new(build_alert(1, 0, None, None, 0));
-    notifier.add(Arc::clone(&alert1));
+    let mut notifier = new_notifier("0.1.0");
+    let alert1 = build_alert(1, 0, Some("0.1.0"), Some("0.2.0"), 0);
+    let dup_alert1 = build_alert(1, 0, None, None, 0);
+    notifier.add(&alert1);
     assert!(notifier.has_received(1));
-    notifier.add(dup_alert1);
+    notifier.add(&dup_alert1);
     assert_eq!(notifier.received_alerts().len(), 1);
     assert_eq!(
         notifier.received_alerts()[0].calc_alert_hash(),
@@ -51,12 +56,12 @@ fn test_received_alerts() {
 
 #[test]
 fn test_cancel_alert() {
-    let mut notifier = Notifier::new("0.1.0".into(), Default::default());
-    let alert1 = Arc::new(build_alert(1, 0, Some("0.1.0"), Some("0.2.0"), 0));
-    let cancel_alert1 = Arc::new(build_alert(2, 1, None, None, 0));
-    notifier.add(Arc::clone(&alert1));
+    let mut notifier = new_notifier("0.1.0");
+    let alert1 = build_alert(1, 0, Some("0.1.0"), Some("0.2.0"), 0);
+    let cancel_alert1 = build_alert(2, 1, None, None, 0);
+    notifier.add(&alert1);
     assert!(notifier.has_received(1));
-    notifier.add(Arc::clone(&cancel_alert1));
+    notifier.add(&cancel_alert1);
     assert!(notifier.has_received(1));
     assert!(notifier.has_received(2));
     assert_eq!(notifier.received_alerts().len(), 1);
@@ -69,12 +74,12 @@ fn test_cancel_alert() {
 
 #[test]
 fn test_clear_expired_alerts() {
-    let mut notifier = Notifier::new("0.1.0".into(), Default::default());
+    let mut notifier = new_notifier("0.1.0");
     let notice_until = 1_561_084_974_000;
     let before_expired_time = notice_until - 1000;
     let after_expired_time = notice_until + 1000;
-    let alert1 = Arc::new(build_alert(1, 0, None, None, notice_until));
-    notifier.add(Arc::clone(&alert1));
+    let alert1 = build_alert(1, 0, None, None, notice_until);
+    notifier.add(&alert1);
     notifier.clear_expired_alerts(before_expired_time);
     assert!(notifier.has_received(1));
     assert_eq!(notifier.received_alerts().len(), 1);


### PR DESCRIPTION
This PR resolve https://github.com/nervosnetwork/ckb/issues/1860 and refactor network alert script notification by adding a notify service, and it's required to implement https://github.com/nervosnetwork/ckb/issues/1867

**configuration  file breaking change**

```diff
-# [alert_notifier]
-# # Script will be notified when node received an alert, first arg is alert message string.
-# notify_script = "echo"
+# [notifier]
+# # Execute command when the new tip block changes, first arg is block struct in json format string.
+# new_block_notify_script = "your_new_block_notify_script.sh"
+# # Execute command when node received an network alert, first arg is alert message string.
+# network_alert_notify_script = "your_network_alert_notify_script.sh"
```