### PR TITLE
feat: add rpc subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,11 +818,13 @@ dependencies = [
  "ckb-types 0.26.2-pre",
  "ckb-util 0.26.2-pre",
  "ckb-verification 0.26.2-pre",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "faketime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-tcp-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -875,11 +877,7 @@ dependencies = [
  "ckb-db 0.26.2-pre",
  "ckb-error 0.26.2-pre",
  "ckb-logger 0.26.2-pre",
-<<<<<<< HEAD
  "ckb-notify 0.26.2-pre",
-=======
- "ckb-notify 0.26.1-pre",
->>>>>>> chore: rebase with develop
  "ckb-proposal-table 0.26.2-pre",
  "ckb-snapshot 0.26.2-pre",
  "ckb-store 0.26.2-pre",
@@ -1942,6 +1940,17 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "14.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4253,6 +4262,7 @@ dependencies = [
 "checksum jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
 "checksum jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 "checksum jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2d83d348120edee487c560b7cdd2565055d61cda053aa0d0ef0f8b6a18429048"
+"checksum jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3453625f0f0f5cd6d6776d389d73b7d70fcc98620b7cbb1cbbb1f6a36e95f39a"
 "checksum jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95b7635e618a0edbbe0d2a2bbbc69874277c49383fcf6c3c0414491cfb517d22"
 "checksum jsonrpc-tcp-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05fa699852b9ab69fc4863092813fbb01ea3bcf2bbfb31551873fe3ba5dfc519"
 "checksum jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b34faa167c3ac9705aeecb986c0da6056529f348425dbe0441db60a2c4cc41d1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,11 @@ dependencies = [
  "ckb-db 0.26.2-pre",
  "ckb-error 0.26.2-pre",
  "ckb-logger 0.26.2-pre",
+<<<<<<< HEAD
  "ckb-notify 0.26.2-pre",
+=======
+ "ckb-notify 0.26.1-pre",
+>>>>>>> chore: rebase with develop
  "ckb-proposal-table 0.26.2-pre",
  "ckb-snapshot 0.26.2-pre",
  "ckb-store 0.26.2-pre",

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -137,10 +137,10 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         .enable_experiment(shared.clone())
         .enable_integration_test(shared.clone(), network_controller.clone(), chain_controller)
         .enable_alert(alert_verifier, alert_notifier, network_controller)
-        .enable_indexer(&args.config.indexer, shared);
+        .enable_indexer(&args.config.indexer, shared.clone());
     let io_handler = builder.build();
 
-    let rpc_server = RpcServer::new(args.config.rpc, io_handler);
+    let rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
 
     wait_for_exit(exit_condvar);
 

--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -126,6 +126,8 @@ def main():
     print("Allowing arbitrary machines to access the JSON-RPC port (using the `rpc.listen_address` configuration option) is **dangerous and strongly discouraged**. Please strictly limit the access to only trusted machines.")
     newline(1)
     print("CKB JSON-RPC only supports HTTP now. If you need SSL, please setup a proxy via Nginx or other HTTP servers.")
+    newline(1)
+    print("Subscriptions require a full duplex connection. CKB offers such connections in the form of tcp (enable with `rpc.tcp_listen_address` configuration option) and websockets (enable with `rpc.ws_listen_address`).")
     newline(2)
 
     print_toc(cases)

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -91,8 +91,8 @@ listen_address = "127.0.0.1:8114" # {{
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760
 
-# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Indexer", "Experiment"]
-modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Experiment"] # {{
+# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Indexer", "Experiment"]
+modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment"] # {{
 # integration => modules = ["Net", "Pool", "Miner", "Chain", "Experiment", "Stats", "Indexer", "IntegrationTest"]
 # }}
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -23,6 +23,8 @@ jsonrpc-http-server = "14.0"
 jsonrpc-tcp-server = "14.0"
 jsonrpc-ws-server = "14.0"
 jsonrpc-server-utils = "14.0"
+jsonrpc-pubsub = "14.0"
+crossbeam-channel = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num_cpus = "1.10"

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2132,7 +2132,7 @@ http://localhost:8114
 
 ### `subscribe`
 
-Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {"jsonrpc":"2.0","method":"subscribe","params":{"result":"...block header JSON-formatted string...","subscription":42}}
+Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {"jsonrpc":"2.0","method":"subscribe","params":{"result":"...block header JSON-formatted string...","subscription":"0x2a"}}
 
 #### Parameters
 
@@ -2161,7 +2161,7 @@ http://localhost:8114
 {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": 42
+    "result": "0x2a"
 }
 ```
 
@@ -2184,7 +2184,7 @@ echo '{
     "jsonrpc": "2.0",
     "method": "unsubscribe",
     "params": [
-        42
+        "0x2a"
     ]
 }' \
 | tr -d '\n' \

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -8,6 +8,8 @@ Allowing arbitrary machines to access the JSON-RPC port (using the `rpc.listen_a
 
 CKB JSON-RPC only supports HTTP now. If you need SSL, please setup a proxy via Nginx or other HTTP servers.
 
+Subscriptions require a full duplex connection. CKB offers such connections in the form of tcp (enable with `rpc.tcp_listen_address` configuration option) and websockets (enable with `rpc.ws_listen_address`).
+
 
 *   [`Chain`](#chain)
     *   [`get_tip_block_number`](#get_tip_block_number)
@@ -50,6 +52,9 @@ CKB JSON-RPC only supports HTTP now. If you need SSL, please setup a proxy via N
 *   [`Stats`](#stats)
     *   [`get_blockchain_info`](#get_blockchain_info)
     *   [`get_peers_state`](#get_peers_state)
+*   [`Subscription`](#subscription)
+    *   [`subscribe`](#subscribe)
+    *   [`unsubscribe`](#unsubscribe)
 
 ## Chain
 
@@ -2120,5 +2125,77 @@ http://localhost:8114
             "peer": "0x1"
         }
     ]
+}
+```
+
+## Subscription
+
+### `subscribe`
+
+Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {"jsonrpc":"2.0","method":"subscribe","params":{"result":"...block header JSON-formatted string...","subscription":42}}
+
+#### Parameters
+
+    topic - Subscription topic (enum: new_tip_header | new_tip_block)
+#### Returns
+
+    id - Subscription id
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "subscribe",
+    "params": [
+        "new_tip_header"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": 42
+}
+```
+
+### `unsubscribe`
+
+unsubscribe from a subscribed topic
+
+#### Parameters
+
+    id - Subscription id
+#### Returns
+
+    result - Unsubscribe result
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "unsubscribe",
+    "params": [
+        42
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": true
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -1490,5 +1490,45 @@
                 "block": "new block"
             }
         ]
+    },
+    {
+        "description": "Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {\"jsonrpc\":\"2.0\",\"method\":\"subscribe\",\"params\":{\"result\":\"...block header JSON-formatted string...\",\"subscription\":42}}",
+        "method": "subscribe",
+        "module": "subscription",
+        "params": [
+            "new_tip_header"
+        ],
+        "result": 42,
+        "types": [
+            {
+                "topic": "Subscription topic (enum: new_tip_header | new_tip_block)"
+            }
+        ],
+        "returns": [
+            {
+                "id": "Subscription id"
+            }
+        ],
+        "skip": true
+    },
+    {
+        "description": "unsubscribe from a subscribed topic",
+        "method": "unsubscribe",
+        "module": "subscription",
+        "params": [
+            42
+        ],
+        "result": true,
+        "types": [
+            {
+                "id": "Subscription id"
+            }
+        ],
+        "returns": [
+            {
+                "result": "Unsubscribe result"
+            }
+        ],
+        "skip": true
     }
 ]

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -1492,13 +1492,13 @@
         ]
     },
     {
-        "description": "Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {\"jsonrpc\":\"2.0\",\"method\":\"subscribe\",\"params\":{\"result\":\"...block header JSON-formatted string...\",\"subscription\":42}}",
+        "description": "Subscribe to a topic, if successful it returns the subscription id. For each event that matches the subscription a notification with relevant data (JSON-formatted string) is send together with the subscription id. Example: {\"jsonrpc\":\"2.0\",\"method\":\"subscribe\",\"params\":{\"result\":\"...block header JSON-formatted string...\",\"subscription\":\"0x2a\"}}",
         "method": "subscribe",
         "module": "subscription",
         "params": [
             "new_tip_header"
         ],
-        "result": 42,
+        "result": "0x2a",
         "types": [
             {
                 "topic": "Subscription topic (enum: new_tip_header | new_tip_block)"
@@ -1516,7 +1516,7 @@
         "method": "unsubscribe",
         "module": "subscription",
         "params": [
-            42
+            "0x2a"
         ],
         "result": true,
         "types": [

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -11,6 +11,7 @@ pub enum Module {
     Indexer,
     IntegrationTest,
     Alert,
+    Subscription,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -48,6 +49,10 @@ impl Config {
 
     pub fn stats_enable(&self) -> bool {
         self.modules.contains(&Module::Stats)
+    }
+
+    pub fn subscription_enable(&self) -> bool {
+        self.modules.contains(&Module::Subscription)
     }
 
     pub fn indexer_enable(&self) -> bool {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -10,3 +10,5 @@ mod test;
 pub use crate::config::{Config, Module};
 pub use crate::server::RpcServer;
 pub use crate::service_builder::ServiceBuilder;
+
+pub type IoHandler = jsonrpc_pubsub::PubSubHandler<Option<crate::module::SubscriptionSession>>;

--- a/rpc/src/module/mod.rs
+++ b/rpc/src/module/mod.rs
@@ -6,6 +6,7 @@ mod miner;
 mod net;
 mod pool;
 mod stats;
+mod subscription;
 mod test;
 
 pub(crate) use self::alert::{AlertRpc, AlertRpcImpl};
@@ -16,4 +17,5 @@ pub(crate) use self::miner::{MinerRpc, MinerRpcImpl};
 pub(crate) use self::net::{NetworkRpc, NetworkRpcImpl};
 pub(crate) use self::pool::{PoolRpc, PoolRpcImpl};
 pub(crate) use self::stats::{StatsRpc, StatsRpcImpl};
+pub(crate) use self::subscription::{SubscriptionRpc, SubscriptionRpcImpl, SubscriptionSession};
 pub(crate) use self::test::{IntegrationTestRpc, IntegrationTestRpcImpl};

--- a/rpc/src/module/subscription.rs
+++ b/rpc/src/module/subscription.rs
@@ -1,0 +1,170 @@
+use ckb_logger::error;
+use ckb_notify::NotifyController;
+use crossbeam_channel::select;
+use jsonrpc_core::{futures::Future, Metadata, Result};
+use jsonrpc_derive::rpc;
+use jsonrpc_pubsub::{
+    typed::{Sink, Subscriber},
+    PubSubMetadata, Session, SubscriptionId,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    RwLock,
+};
+use std::thread;
+
+#[derive(Clone, Debug)]
+pub struct SubscriptionSession {
+    pub(crate) subscription_ids: Arc<RwLock<HashSet<SubscriptionId>>>,
+    pub(crate) session: Arc<Session>,
+}
+
+impl SubscriptionSession {
+    pub fn new(session: Session) -> Self {
+        Self {
+            subscription_ids: Arc::new(RwLock::new(HashSet::new())),
+            session: Arc::new(session),
+        }
+    }
+}
+
+impl Metadata for SubscriptionSession {}
+
+impl PubSubMetadata for SubscriptionSession {
+    fn session(&self) -> Option<Arc<Session>> {
+        Some(Arc::clone(&self.session))
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Topic {
+    NewTipHeader,
+    NewTipBlock,
+}
+
+#[allow(clippy::needless_return)]
+#[rpc(server)]
+pub trait SubscriptionRpc {
+    type Metadata;
+
+    #[pubsub(subscription = "subscribe", subscribe, name = "subscribe")]
+    fn subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<String>, topic: Topic);
+
+    #[pubsub(subscription = "subscribe", unsubscribe, name = "unsubscribe")]
+    fn unsubscribe(&self, meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool>;
+}
+
+type Subscribers = HashMap<SubscriptionId, Sink<String>>;
+
+#[derive(Default)]
+pub struct SubscriptionRpcImpl {
+    pub(crate) id_generator: AtomicUsize,
+    pub(crate) subscribers: Arc<RwLock<HashMap<Topic, Subscribers>>>,
+}
+
+impl SubscriptionRpc for SubscriptionRpcImpl {
+    type Metadata = Option<SubscriptionSession>;
+
+    fn subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<String>, topic: Topic) {
+        if let Some(session) = meta {
+            let id =
+                SubscriptionId::Number(self.id_generator.fetch_add(1, Ordering::SeqCst) as u64);
+            if let Ok(sink) = subscriber.assign_id(id.clone()) {
+                let mut subscribers = self
+                    .subscribers
+                    .write()
+                    .expect("acquiring subscribers write lock");
+                subscribers
+                    .entry(topic)
+                    .or_default()
+                    .insert(id.clone(), sink);
+
+                session
+                    .subscription_ids
+                    .write()
+                    .expect("acquiring subscription_ids write lock")
+                    .insert(id);
+            }
+        }
+    }
+
+    fn unsubscribe(&self, meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
+        let mut subscribers = self
+            .subscribers
+            .write()
+            .expect("acquiring subscribers write lock");
+        match meta {
+            // unsubscribe handler method is explicitly called.
+            Some(Some(session)) => {
+                if session
+                    .subscription_ids
+                    .write()
+                    .expect("acquiring subscription_ids write lock")
+                    .remove(&id)
+                {
+                    Ok(subscribers.values_mut().any(|s| s.remove(&id).is_some()))
+                } else {
+                    Ok(false)
+                }
+            }
+            // closed or dropped connection
+            _ => {
+                subscribers.values_mut().for_each(|s| {
+                    s.remove(&id);
+                });
+                Ok(true)
+            }
+        }
+    }
+}
+
+impl SubscriptionRpcImpl {
+    pub fn new<S: ToString>(notify_controller: NotifyController, thread_name: Option<S>) -> Self {
+        let new_block_receiver =
+            notify_controller.subscribe_new_block(thread_name.as_ref().unwrap().to_string());
+
+        let subscription_rpc_impl = SubscriptionRpcImpl::default();
+        let subscribers = Arc::clone(&subscription_rpc_impl.subscribers);
+
+        let mut thread_builder = thread::Builder::new();
+        if let Some(name) = thread_name {
+            thread_builder = thread_builder.name(name.to_string());
+        }
+        thread_builder
+            .spawn(move || loop {
+                select! {
+                    recv(new_block_receiver) -> msg => match msg {
+                        Ok(block) => {
+                            let subscribers = subscribers.read().expect("acquiring subscribers read lock");
+                            if let Some(new_tip_header_subscribers) = subscribers.get(&Topic::NewTipHeader) {
+                                let header: ckb_jsonrpc_types::HeaderView  = block.header().into();
+                                let json_string = Ok(serde_json::to_string(&header).expect("serialization should be ok"));
+                                for sink in new_tip_header_subscribers.values() {
+                                    let _ = sink.notify(json_string.clone()).wait();
+                                }
+                            }
+                            if let Some(new_tip_block_subscribers) = subscribers.get(&Topic::NewTipBlock) {
+                                let block: ckb_jsonrpc_types::BlockView  = block.into();
+                                let json_string = Ok(serde_json::to_string(&block).expect("serialization should be ok"));
+                                for sink in new_tip_block_subscribers.values() {
+                                    let _ = sink.notify(json_string.clone()).wait();
+                                }
+                            }
+                        },
+                        _ => {
+                            error!("new_block_receiver closed");
+                            break;
+                        },
+                    }
+                }
+            })
+            .expect("Start SubscriptionRpc thread failed");
+
+        subscription_rpc_impl
+    }
+}

--- a/rpc/src/module/subscription.rs
+++ b/rpc/src/module/subscription.rs
@@ -72,8 +72,10 @@ impl SubscriptionRpc for SubscriptionRpcImpl {
 
     fn subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<String>, topic: Topic) {
         if let Some(session) = meta {
-            let id =
-                SubscriptionId::String(format!("{:#x}", self.id_generator.fetch_add(1, Ordering::SeqCst)));
+            let id = SubscriptionId::String(format!(
+                "{:#x}",
+                self.id_generator.fetch_add(1, Ordering::SeqCst)
+            ));
             if let Ok(sink) = subscriber.assign_id(id.clone()) {
                 let mut subscribers = self
                     .subscribers

--- a/rpc/src/module/subscription.rs
+++ b/rpc/src/module/subscription.rs
@@ -73,7 +73,7 @@ impl SubscriptionRpc for SubscriptionRpcImpl {
     fn subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<String>, topic: Topic) {
         if let Some(session) = meta {
             let id =
-                SubscriptionId::Number(self.id_generator.fetch_add(1, Ordering::SeqCst) as u64);
+                SubscriptionId::String(format!("{:#x}", self.id_generator.fetch_add(1, Ordering::SeqCst)));
             if let Ok(sink) = subscriber.assign_id(id.clone()) {
                 let mut subscribers = self
                     .subscribers

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -4,6 +4,7 @@ use crate::module::{
     IndexerRpcImpl, IntegrationTestRpc, IntegrationTestRpcImpl, MinerRpc, MinerRpcImpl, NetworkRpc,
     NetworkRpcImpl, PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl,
 };
+use crate::IoHandler;
 use ckb_chain::chain::ChainController;
 use ckb_indexer::{DefaultIndexerStore, IndexerConfig};
 use ckb_network::NetworkController;
@@ -13,7 +14,6 @@ use ckb_sync::SyncSharedState;
 use ckb_sync::Synchronizer;
 use ckb_tx_pool::FeeRate;
 use ckb_util::Mutex;
-use jsonrpc_core::IoHandler;
 use std::sync::Arc;
 
 pub struct ServiceBuilder<'a> {
@@ -25,7 +25,7 @@ impl<'a> ServiceBuilder<'a> {
     pub fn new(config: &'a Config) -> Self {
         Self {
             config,
-            io_handler: IoHandler::new(),
+            io_handler: IoHandler::default(),
         }
     }
     pub fn enable_chain(mut self, shared: Shared) -> Self {

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -399,12 +399,8 @@ fn params_of(shared: &Shared, method: &str) -> Value {
         "get_tip_block_number"
         | "get_tip_header"
         | "get_current_epoch"
-        | "local_node_info"
-        | "get_peers"
-        | "get_banned_addresses"
         | "get_blockchain_info"
         | "tx_pool_info"
-        | "get_peers_state"
         | "get_lock_hash_index_states" => vec![],
         "get_epoch_by_number" => vec![json!("0x0")],
         "get_block_hash" | "get_block_by_number" | "get_header_by_number" => {
@@ -439,8 +435,6 @@ fn params_of(shared: &Shared, method: &str) -> Value {
             vec![json!(json_script)]
         }
         "estimate_fee_rate" => vec![json!("0xa")],
-        "calculate_dao_maximum_withdraw" => vec![json!(always_success_out_point), json!(tip_hash)],
-        "get_block_template" => vec![json!(null), json!(null), json!(null)],
         "submit_block" => {
             let json_block: JsonBlock = tip.data().into();
             vec![json!("example"), json!(json_block)]
@@ -514,11 +508,13 @@ fn test_rpc() {
                 .as_str()
                 .unwrap()
                 .to_string();
-            actual.push((
-                method.clone(),
-                case.get("params").expect("get params").clone(),
-            ));
-            expected.push((method.clone(), params_of(&shared, &method)));
+            let params = case.get("params").expect("get params");
+            actual.push((method.clone(), params.clone()));
+            if case.get("skip").unwrap_or(&json!(false)).as_bool().unwrap() {
+                expected.push((method.clone(), params.clone()));
+            } else {
+                expected.push((method.clone(), params_of(&shared, &method)));
+            }
         });
         if actual != expected {
             print_document(Some(&expected), None);


### PR DESCRIPTION
resolve #1867 

tcp rpc subscription example:
```
telnet localhost 18114
> {"id": 2, "jsonrpc": "2.0", "method": "subscribe", "params": ["new_tip_header"]}
< {"jsonrpc":"2.0","result":0,"id":2}
< {"jsonrpc":"2.0","method":"subscribe","params":{"result":"...block header json...","subscription":0}}
< {"jsonrpc":"2.0","method":"subscribe","params":{"result":"...block header json...","subscription":0}}
< ...
> {"id": 2, "jsonrpc": "2.0", "method": "unsubscribe", "params": [0]}
< {"jsonrpc":"2.0","result":true,"id":2}
```

websocket rpc subscription example:
```
let socket = new WebSocket("ws://localhost:28114")

socket.onmessage = function(event) {
  console.log(`Data received from server: ${event.data}`);
}

socket.send(`{"id": 2, "jsonrpc": "2.0", "method": "subscribe", "params": ["new_tip_header"]}`)

socket.send(`{"id": 2, "jsonrpc": "2.0", "method": "unsubscribe", "params": [0]}`)
```