### PR TITLE
feat: null outputs_validator means passthrough.

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2011,7 +2011,7 @@ Send new transaction into transaction pool.
 #### Parameters
 
     transaction - The transaction object, struct reference: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Transaction
-    outputs_validator - Validates the transaction outputs before entering the tx-pool, an optional string parameter (enum: default | passthrough ), null means using default validator, passthrough means skipping outputs validation
+    outputs_validator - Validates the transaction outputs before entering the tx-pool, an optional string parameter (enum: default | passthrough ), null means passthrough. The deafult validator requires each output use the standard lock and type scripts, passthrough means skipping the validation.
 
 #### Examples
 

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -654,7 +654,7 @@
                 "transaction": "The transaction object, struct reference: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Transaction"
             },
             {
-                "outputs_validator": "Validates the transaction outputs before entering the tx-pool, an optional string parameter (enum: default | passthrough ), null means using default validator, passthrough means skipping outputs validation"
+                "outputs_validator": "Validates the transaction outputs before entering the tx-pool, an optional string parameter (enum: default | passthrough ), null means passthrough. The deafult validator requires each output use the standard lock and type scripts, passthrough means skipping the validation."
             }
         ]
     },

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -70,10 +70,10 @@ impl PoolRpc for PoolRpcImpl {
         let tx: core::TransactionView = tx.into_view();
 
         if let Err(e) = match outputs_validator {
-            Some(OutputsValidator::Default) | None => {
+            Some(OutputsValidator::Default) => {
                 DefaultOutputsValidator::new(self.shared.consensus()).validate(&tx)
             }
-            Some(OutputsValidator::Passthrough) => Ok(()),
+            Some(OutputsValidator::Passthrough) | None => Ok(()),
         } {
             return Err(RPCError::custom(RPCError::Invalid, e));
         }


### PR DESCRIPTION
Make it backward compatible with the previous version. We should upgrade SDK
to support this flag by default when version is 0.28.0 or above, instead of
introducing the breaking change directly in the RPC.