### PR TITLE
chore: ignore spin warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ clippy: setup-ckb-test ## Run linter to examine Rust source codes.
 
 .PHONY: security-audit
 security-audit: ## Use cargo-audit to audit Cargo.lock for crates with security vulnerabilities.
-	cargo audit
+	# https://rustsec.org/advisories/RUSTSEC-2019-0031: spin is no longer actively maintained, it's not a problem
+	cargo audit --ignore RUSTSEC-2019-0031 --deny-warnings
 	# expecting to see "Success No vulnerable packages found"
 
 .PHONY: bench-test


### PR DESCRIPTION
`spin` is a stable synchronization primitive implementation, not updating for 5 months is not a security issue, just ignore this warning