### PR TITLE
feat: collect metrics by a independent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-metrics"
+version = "0.28.1-pre"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "serde_json",
+]
+
+[[package]]
 name = "ckb-miner"
 version = "0.28.1-pre"
 dependencies = [
@@ -977,6 +986,7 @@ dependencies = [
  "ckb-dao-utils",
  "ckb-error",
  "ckb-logger",
+ "ckb-metrics",
  "ckb-network",
  "ckb-shared",
  "ckb-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "ckb-indexer",
  "ckb-jsonrpc-types",
  "ckb-logger",
+ "ckb-metrics",
  "ckb-miner",
  "ckb-network",
  "ckb-network-alert",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "protocols/ping",
     "protocols/identify",
     "protocols/discovery",
+    "util/metrics",
 ]
 
 [profile.release]

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -25,6 +25,7 @@ sentry = "0.16.0"
 futures = "0.1"
 ckb-error = {path = "../error"}
 ckb-tx-pool = { path = "../tx-pool" }
+ckb-metrics = { path = "../util/metrics" }
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -25,6 +25,7 @@ use crate::types::{SyncSharedState, SyncSnapshot};
 use crate::{Status, StatusCode, BAD_MESSAGE_BAN_TIME};
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug_target, error_target, info_target, trace_target};
+use ckb_metrics::metric;
 use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
 use ckb_tx_pool::FeeRate;
 use ckb_types::core::BlockView;
@@ -134,6 +135,7 @@ impl Relayer {
         let item_name = message.item_name();
         let status = self.try_process(Arc::clone(&nc), peer, message);
         if let Some(ban_time) = status.should_ban() {
+            metric(&status.class(), status.context());
             error_target!(
                 crate::LOG_TARGET_RELAY,
                 "receive {} from {}, ban {:?} for {}",
@@ -144,6 +146,7 @@ impl Relayer {
             );
             nc.ban_peer(peer, ban_time, status.to_string());
         } else if !status.is_ok() {
+            metric(&status.class(), status.context());
             debug_target!(
                 crate::LOG_TARGET_RELAY,
                 "receive {} from {}, {}",

--- a/sync/src/status.rs
+++ b/sync/src/status.rs
@@ -148,6 +148,17 @@ impl Status {
             _ => Some(BAD_MESSAGE_BAN_TIME),
         }
     }
+
+    pub fn class(&self) -> String {
+        format!("{:?}", self.code)
+    }
+
+    pub fn context(&self) -> &str {
+        self.context
+            .as_ref()
+            .map(|context| context.as_str())
+            .unwrap_or("")
+    }
 }
 
 impl PartialEq for Status {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug, error, info, trace};
+use ckb_metrics::metric;
 use ckb_network::{CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_types::{core, packed, prelude::*};
 use failure::Error as FailureError;
@@ -91,12 +92,14 @@ impl Synchronizer {
         let item_name = message.item_name();
         let status = self.try_process(nc, peer, message);
         if let Some(ban_time) = status.should_ban() {
+            metric(&status.class(), status.context());
             error!(
                 "receive {} from {}, ban {:?} for {}",
                 item_name, peer, ban_time, status
             );
             nc.ban_peer(peer, ban_time, status.to_string());
         } else if !status.is_ok() {
+            metric(&status.class(), status.context());
             debug!("receive {} from {}, {}", item_name, peer, status);
         }
     }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -27,6 +27,7 @@ ckb-build-info = { path = "../build-info" }
 ckb-indexer = { path = "../../indexer" }
 ckb-tx-pool = { path = "../../tx-pool" }
 ckb-notify = { path = "../../notify" }
+ckb-metrics = { path = "../metrics" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -35,6 +35,9 @@ pub enum AppConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CKBAppConfig {
     pub data_dir: PathBuf,
+    #[serde(default)]
+    pub enable_metrics_collection: bool,
+
     pub logger: LogConfig,
     pub sentry: SentryConfig,
     pub chain: ChainConfig,

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -88,6 +88,13 @@ impl Setup {
             None
         };
 
+        if let AppConfig::CKB(ref config) = self.config {
+            if config.enable_metrics_collection {
+                let path = config.data_dir.join("logs").join("metrics.log");
+                ckb_metrics::init(path);
+            }
+        }
+
         Ok(SetupGuard {
             logger_guard,
             sentry_guard,

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ckb-metrics"
+version = "0.28.1-pre"
+license = "MIT"
+authors = ["Nervos <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+serde_json = "1.0"
+chrono = "0.4"
+crossbeam-channel = "0.3"

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -1,0 +1,54 @@
+use chrono::prelude::{DateTime, Local};
+use crossbeam_channel::{bounded, Sender};
+use serde_json::json;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::thread;
+
+static mut SENDER: Option<Sender<String>> = None;
+
+pub fn metric(class: &str, context: &str) {
+    let dt: DateTime<Local> = Local::now();
+    let timestamp = dt.format("%Y-%m-%d %H:%M:%S%.3f %Z").to_string();
+    let json = json!({
+        "ts": timestamp,
+        "class": class,
+        "context": context,
+    })
+    .to_string();
+
+    // Send metrics in json to the writer thread via global channel
+    unsafe {
+        if let Some(ref sender) = SENDER {
+            let _ = sender.send(json);
+        }
+    }
+}
+
+pub fn init(filepath: PathBuf) {
+    let (sender, receiver) = bounded::<String>(1024);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&filepath)
+        .unwrap_or_else(|_| {
+            panic!(
+                "Cannot write to metrics file given: {:?}",
+                filepath.as_os_str()
+            )
+        });
+    let _ = thread::Builder::new()
+        .name("MetricWriter".to_owned())
+        .spawn(move || {
+            while let Ok(metric) = receiver.recv() {
+                let _ = file.write_all(metric.as_bytes());
+                let _ = file.write_all(b"\n");
+            }
+        });
+
+    // Initialize the global channel
+    unsafe {
+        SENDER = Some(sender);
+    }
+}


### PR DESCRIPTION
Add a new global configuration item `enable_metrics_collection`, which default is `false`. When set to `true`, CKB will write the metrics, which specifies via function `metric`, into `<BASEDIR>/data/logs/metrics.log`.

Here are some sync/relay metrics examples:

```json
{"class":"Ignored","context":"","ts":"2020-02-11 05:04:04.365 +08:00"}
{"class":"CompactBlockAlreadyStored","context":"Byte32(0x61c32e24502c8e1d754f984859cf9883d9302b2c3446bfc329309b7eaab8964f)","ts":"2020-02-11 07:36:20.674 +08:00"}
{"class":"CompactBlockRequiresFreshTransactions","context":"Byte32(0x57b4d8869b0c7a584e53c90ca5d8c33ed0ad69b29493178b328182488c11e1d4)","ts":"2020-02-11 07:35:40.285 +08:00"}
{"class":"BlocksInFlightReachLimit","context":"Byte32(0x57b4d8869b0c7a584e53c90ca5d8c33ed0ad69b29493178b328182488c11e1d4)","ts":"2020-02-11 07:35:40.410 +08:00"}
```

--------

NOTE: This PR adds 2 UB, [`metric `](https://github.com/keroro520/ckb/blob/metrics-in-single-crate/util/metrics/src/lib.rs#L22-L26) and [`init`](https://github.com/keroro520/ckb/blob/metrics-in-single-crate/util/metrics/src/lib.rs#L51-L53). I am not sure that's a good idea. Please let me know if you have other suggestions.