### PR TITLE
feat: uses feature flags to enable deadlock detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ overflow-checks = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 jemallocator = { version = "0.3.0" }
+
+[features]
+default = []
+deadlock_detection = ["ckb-bin/deadlock_detection"]

--- a/Makefile
+++ b/Makefile
@@ -34,19 +34,19 @@ submodule-init:
 
 .PHONY: integration
 integration: submodule-init setup-ckb-test ## Run integration tests in "test" dir.
-	cargo build
+	cargo build --features deadlock_detection
 	cd test && RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-windows
 integration-windows: submodule-init
 	cp -f Cargo.lock test/Cargo.lock
-	cargo build
+	cargo build --features deadlock_detection
 	mv target test/
 	cd test && cargo run -- --bin target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-release
 integration-release: submodule-init setup-ckb-test
-	cargo build --release
+	cargo build --release --features deadlock_detection
 	cd test && cargo run --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
 
 ##@ Document

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -31,3 +31,7 @@ ckb-instrument = { path = "../util/instrument", features = ["progress_bar"] }
 ckb-build-info = { path = "../util/build-info" }
 ckb-verification = { path = "../verification" }
 base64 = "0.10.1"
+
+
+[features]
+deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/helper.rs
+++ b/ckb-bin/src/helper.rs
@@ -1,9 +1,6 @@
-use ckb_logger::warn;
-use ckb_util::{parking_lot::deadlock, Condvar, Mutex};
+use ckb_util::{Condvar, Mutex};
 use std::io::{stdin, stdout, Write};
 use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 
 pub fn wait_for_exit(exit: Arc<(Mutex<()>, Condvar)>) {
     // Handle possible exits
@@ -17,7 +14,16 @@ pub fn wait_for_exit(exit: Arc<(Mutex<()>, Condvar)>) {
     exit.1.wait(&mut l);
 }
 
+#[cfg(not(feature = "deadlock_detection"))]
+pub fn deadlock_detection() {}
+
+#[cfg(feature = "deadlock_detection")]
 pub fn deadlock_detection() {
+    use ckb_logger::{info, warn};
+    use ckb_util::parking_lot::deadlock;
+    use std::{thread, time::Duration};
+
+    info!("deadlock_detection enable");
     thread::spawn(move || loop {
         thread::sleep(Duration::from_secs(10));
         let deadlocks = deadlock::check_deadlock();

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,8 +6,12 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dependencies]
-parking_lot = {version = "=0.7.1", features = ["deadlock_detection"]}
+parking_lot = "=0.7.1"
 linked-hash-map = { git = "https://github.com/nervosnetwork/linked-hash-map", rev = "df27f21" }
 
 [dev-dependencies]
 ckb-fixed-hash = { path = "fixed-hash" }
+
+
+[features]
+deadlock_detection = ["parking_lot/deadlock_detection"]


### PR DESCRIPTION
we should disable deadlock detection by default.  
use the `deadlock_detection` feature flag enable  deadlock detection.