### PR TITLE
test: add a unit test about getting uncle block body

### DIFF
--- a/chain/src/tests/mod.rs
+++ b/chain/src/tests/mod.rs
@@ -3,4 +3,5 @@ mod block_assembler;
 mod delay_verify;
 mod find_fork;
 mod reward;
+mod uncle;
 mod util;

--- a/chain/src/tests/uncle.rs
+++ b/chain/src/tests/uncle.rs
@@ -1,0 +1,41 @@
+use crate::tests::util::{MockChain, MockStore};
+use crate::{chain::ChainService, switch::Switch};
+use ckb_chain_spec::consensus::Consensus;
+use ckb_shared::shared::SharedBuilder;
+use ckb_store::ChainStore;
+use std::sync::Arc;
+
+#[test]
+fn test_get_block_body_after_inserting() {
+    let builder = SharedBuilder::default();
+    let (shared, table) = builder.consensus(Consensus::default()).build().unwrap();
+    let mut chain_service = ChainService::new(shared.clone(), table);
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
+
+    let parent = genesis;
+    let mock_store = MockStore::new(&parent, shared.store());
+    let mut fork1 = MockChain::new(parent.clone(), shared.consensus());
+    let mut fork2 = MockChain::new(parent, shared.consensus());
+    for _ in 0..4 {
+        fork1.gen_empty_block_with_diff(100u64, &mock_store);
+        fork2.gen_empty_block_with_diff(90u64, &mock_store);
+    }
+
+    for blk in fork1.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+        let len = shared.snapshot().get_block_body(&blk.hash()).len();
+        assert_eq!(len, 1, "[fork1] snapshot.get_block_body({})", blk.hash(),);
+    }
+    for blk in fork2.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+        let len = shared.snapshot().get_block_body(&blk.hash()).len();
+        assert_eq!(len, 1, "[fork2] snapshot.get_block_body({})", blk.hash(),);
+    }
+}


### PR DESCRIPTION
This PR just provides a test case to produce the problem: Getting the body of an uncle block, which has been inserted at once, will return empty.

A possible reason is that we don't restore the new snapshot after the uncle blocks inserting [code](https://github.com/nervosnetwork/ckb/blob/1447929d4516e972e6f6bb7c16f31bbd33ccc2c8/chain/src/chain.rs#L369).

@zhangsoledad Please help review&debug it.