### PR TITLE
feat: use same allocator for all

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ members = [
 overflow-checks = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
-jemallocator = { version = "0.3.0" }
+jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [features]
 default = []


### PR DESCRIPTION
#### Notice

**This PR can be reviewed but it requires test before merge.**

#### Issue

Currently, ckb has two allocators:

- When we compile the latest version CKB on Linux, the code written by Rust will use Jemalloc.
 
 https://github.com/nervosnetwork/ckb/blob/dad394ea3f50f518a40e5a8a457dfb6811ba245a/Cargo.toml#L72-L73
 
 https://github.com/nervosnetwork/ckb/blob/dad394ea3f50f518a40e5a8a457dfb6811ba245a/src/main.rs#L4-L6

- But the code written by C will use system allocator, since [the `jemalloc` will compiled with `--with-jemalloc-prefix=_rjem_`](https://github.com/gnzlbg/jemallocator/blob/c27a859e98e3cb790dc269773d9da71a1e918458/jemalloc-sys/README.md#cargo-features), 

  >* `unprefixed_malloc_on_supported_platforms`: when disabled, configure
  >  `jemalloc` with `--with-jemalloc-prefix=_rjem_`. Enabling this causes symbols
  >  like `malloc` to be emitted without a prefix, overriding the ones defined by
  >  libc. This usually causes C and C++ code linked in the same program to use
  >  `jemalloc` as well. On some platforms prefixes are always used because
  >  unprefixing is known to cause segfaults due to allocator mismatches.

#### Solution

We can enable feature `unprefixed_malloc_on_supported_platforms` to let symbols like `malloc` to be emitted without a prefix, overriding the ones defined by libc.