### PR TITLE
refactory: repair using of snapshot

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -373,8 +373,6 @@ impl ChainService {
                 new_proposals,
             );
 
-            self.shared.store_snapshot(Arc::clone(&new_snapshot));
-
             if let Err(e) = self.shared.tx_pool_controller().update_tx_pool_for_reorg(
                 fork.detached_blocks().clone(),
                 fork.attached_blocks().clone(),
@@ -400,6 +398,7 @@ impl ChainService {
                 self.print_chain(10);
             }
         } else {
+            self.shared.refresh_snapshot(shared_snapshot);
             info!(
                 "uncle: {}, hash: {:#x}, epoch: {:#}, total_diff: {:#x}, txs: {}",
                 block.header().number(),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -373,6 +373,8 @@ impl ChainService {
                 new_proposals,
             );
 
+            self.shared.store_snapshot(Arc::clone(&new_snapshot));
+
             if let Err(e) = self.shared.tx_pool_controller().update_tx_pool_for_reorg(
                 fork.detached_blocks().clone(),
                 fork.attached_blocks().clone(),
@@ -398,7 +400,7 @@ impl ChainService {
                 self.print_chain(10);
             }
         } else {
-            self.shared.refresh_snapshot(shared_snapshot);
+            self.shared.refresh_snapshot();
             info!(
                 "uncle: {}, hash: {:#x}, epoch: {:#}, total_diff: {:#x}, txs: {}",
                 block.header().number(),

--- a/chain/src/tests/mod.rs
+++ b/chain/src/tests/mod.rs
@@ -3,4 +3,5 @@ mod block_assembler;
 mod delay_verify;
 mod find_fork;
 mod reward;
+mod uncle;
 mod util;

--- a/chain/src/tests/uncle.rs
+++ b/chain/src/tests/uncle.rs
@@ -35,7 +35,11 @@ fn test_get_block_body_after_inserting() {
         chain_service
             .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
             .unwrap();
-        let len = shared.snapshot().get_block_body(&blk.hash()).len();
+        let snapshot = shared.snapshot();
+        assert!(snapshot.get_block_header(&blk.hash()).is_some());
+        assert!(snapshot.get_block_uncles(&blk.hash()).is_some());
+        assert!(snapshot.get_block_proposal_txs_ids(&blk.hash()).is_some());
+        let len = snapshot.get_block_body(&blk.hash()).len();
         assert_eq!(len, 1, "[fork2] snapshot.get_block_body({})", blk.hash(),);
     }
 }

--- a/chain/src/tests/uncle.rs
+++ b/chain/src/tests/uncle.rs
@@ -1,0 +1,41 @@
+use crate::tests::util::{MockChain, MockStore};
+use crate::{chain::ChainService, switch::Switch};
+use ckb_chain_spec::consensus::Consensus;
+use ckb_shared::shared::SharedBuilder;
+use ckb_store::ChainStore;
+use std::sync::Arc;
+
+#[test]
+fn test_get_block_body_after_inserting() {
+    let builder = SharedBuilder::default();
+    let (shared, table) = builder.consensus(Consensus::default()).build().unwrap();
+    let mut chain_service = ChainService::new(shared.clone(), table);
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
+
+    let parent = genesis;
+    let mock_store = MockStore::new(&parent, shared.store());
+    let mut fork1 = MockChain::new(parent.clone(), shared.consensus());
+    let mut fork2 = MockChain::new(parent, shared.consensus());
+    for _ in 0..4 {
+        fork1.gen_empty_block_with_diff(100u64, &mock_store);
+        fork2.gen_empty_block_with_diff(90u64, &mock_store);
+    }
+
+    for blk in fork1.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+        let len = shared.snapshot().get_block_body(&blk.hash()).len();
+        assert_eq!(len, 1, "[fork1] snapshot.get_block_body({})", blk.hash(),);
+    }
+    for blk in fork2.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+        let len = shared.snapshot().get_block_body(&blk.hash()).len();
+        assert_eq!(len, 1, "[fork2] snapshot.get_block_body({})", blk.hash(),);
+    }
+}

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -12,7 +12,7 @@ use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_resource::Resource;
 use ckb_rpc::{RpcServer, ServiceBuilder};
 use ckb_shared::shared::{Shared, SharedBuilder};
-use ckb_sync::{NetTimeProtocol, NetworkProtocol, Relayer, SyncSharedState, Synchronizer};
+use ckb_sync::{NetTimeProtocol, NetworkProtocol, Relayer, SyncShared, Synchronizer};
 use ckb_types::prelude::*;
 use ckb_util::{Condvar, Mutex};
 use ckb_verification::{GenesisVerifier, Verifier};
@@ -51,15 +51,15 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         shared.genesis_hash()
     );
 
-    let sync_shared_state = Arc::new(SyncSharedState::new(shared.clone()));
+    let sync_shared = Arc::new(SyncShared::new(shared.clone()));
     let network_state = Arc::new(
         NetworkState::from_config(args.config.network).expect("Init network state failed"),
     );
-    let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared_state));
+    let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
 
     let relayer = Relayer::new(
         chain_controller.clone(),
-        Arc::clone(&sync_shared_state),
+        Arc::clone(&sync_shared),
         args.config.tx_pool.min_fee_rate,
         args.config.tx_pool.max_tx_verify_cycles,
     );
@@ -127,7 +127,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         .enable_chain(shared.clone())
         .enable_pool(
             shared.clone(),
-            sync_shared_state,
+            sync_shared,
             args.config.tx_pool.min_fee_rate,
             args.config.rpc.reject_ill_transactions,
         )

--- a/db/src/snapshot.rs
+++ b/db/src/snapshot.rs
@@ -32,8 +32,7 @@ impl RocksDBSnapshot {
 
     pub fn get_pinned(&self, col: Col, key: &[u8]) -> Result<Option<DBPinnableSlice>> {
         let cf = cf_handle(&self.db, col)?;
-        self.db
-            .get_pinned_cf_full(Some(cf), &key, None)
+        self.get_pinned_cf_full(Some(cf), &key, None)
             .map_err(internal_error)
     }
 }

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -5,7 +5,7 @@ use ckb_logger::error;
 use ckb_network::PeerIndex;
 use ckb_script::IllTransactionChecker;
 use ckb_shared::shared::Shared;
-use ckb_sync::SyncSharedState;
+use ckb_sync::SyncShared;
 use ckb_tx_pool::{error::SubmitTxError, FeeRate};
 use ckb_types::{core, packed, prelude::*, H256};
 use ckb_verification::{Since, SinceMetric};
@@ -38,7 +38,7 @@ pub trait PoolRpc {
 }
 
 pub(crate) struct PoolRpcImpl {
-    sync_shared_state: Arc<SyncSharedState>,
+    sync_shared: Arc<SyncShared>,
     shared: Shared,
     min_fee_rate: FeeRate,
     reject_ill_transactions: bool,
@@ -47,12 +47,12 @@ pub(crate) struct PoolRpcImpl {
 impl PoolRpcImpl {
     pub fn new(
         shared: Shared,
-        sync_shared_state: Arc<SyncSharedState>,
+        sync_shared: Arc<SyncShared>,
         min_fee_rate: FeeRate,
         reject_ill_transactions: bool,
     ) -> PoolRpcImpl {
         PoolRpcImpl {
-            sync_shared_state,
+            sync_shared,
             shared,
             min_fee_rate,
             reject_ill_transactions,
@@ -97,7 +97,7 @@ impl PoolRpc for PoolRpcImpl {
                 // workaround: we are using `PeerIndex(usize::max)` to indicate that tx hash source is itself.
                 let peer_index = PeerIndex::new(usize::max_value());
                 let hash = tx.hash();
-                self.sync_shared_state
+                self.sync_shared
                     .state()
                     .tx_hashes()
                     .entry(peer_index)

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -37,7 +37,7 @@ impl StatsRpc for StatsRpcImpl {
         let is_initial_block_download = self
             .synchronizer
             .shared
-            .snapshot()
+            .active_chain()
             .is_initial_block_download();
         let alerts: Vec<AlertMessage> = {
             let now = faketime::unix_time_as_millis();

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -10,7 +10,7 @@ use ckb_indexer::{DefaultIndexerStore, IndexerConfig};
 use ckb_network::NetworkController;
 use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
 use ckb_shared::shared::Shared;
-use ckb_sync::SyncSharedState;
+use ckb_sync::SyncShared;
 use ckb_sync::Synchronizer;
 use ckb_tx_pool::FeeRate;
 use ckb_util::Mutex;
@@ -41,17 +41,13 @@ impl<'a> ServiceBuilder<'a> {
     pub fn enable_pool(
         mut self,
         shared: Shared,
-        sync_shared_state: Arc<SyncSharedState>,
+        sync_shared: Arc<SyncShared>,
         min_fee_rate: FeeRate,
         reject_ill_transactions: bool,
     ) -> Self {
-        let rpc_method = PoolRpcImpl::new(
-            shared,
-            sync_shared_state,
-            min_fee_rate,
-            reject_ill_transactions,
-        )
-        .to_delegate();
+        let rpc_method =
+            PoolRpcImpl::new(shared, sync_shared, min_fee_rate, reject_ill_transactions)
+                .to_delegate();
         if self.config.pool_enable() {
             self.io_handler.extend_with(rpc_method);
         } else {

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -19,7 +19,7 @@ use ckb_shared::{
     Snapshot,
 };
 use ckb_store::ChainStore;
-use ckb_sync::{SyncSharedState, Synchronizer};
+use ckb_sync::{SyncShared, Synchronizer};
 use ckb_test_chain_utils::{always_success_cell, always_success_cellbase};
 use ckb_tx_pool::FeeRate;
 use ckb_types::{
@@ -211,8 +211,8 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         .start::<&str>(Default::default(), None)
         .expect("Start network service failed")
     };
-    let sync_shared_state = Arc::new(SyncSharedState::new(shared.clone()));
-    let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared_state));
+    let sync_shared = Arc::new(SyncShared::new(shared.clone()));
+    let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
     let indexer_store = {
         let mut indexer_config = IndexerConfig::default();
         indexer_config.db.path = dir.join("indexer");
@@ -257,7 +257,7 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         .to_delegate(),
     );
     io.extend_with(
-        PoolRpcImpl::new(shared.clone(), sync_shared_state, FeeRate::zero(), true).to_delegate(),
+        PoolRpcImpl::new(shared.clone(), sync_shared, FeeRate::zero(), true).to_delegate(),
     );
     io.extend_with(
         NetworkRpcImpl {

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -203,6 +203,11 @@ impl Shared {
         self.snapshot_mgr.store(snapshot)
     }
 
+    pub fn refresh_snapshot(&self, old_snapshot: Arc<Snapshot>) {
+        let new = old_snapshot.refresh(self.store.get_snapshot());
+        self.store_snapshot(Arc::new(new));
+    }
+
     pub fn new_snapshot(
         &self,
         tip_header: HeaderView,
@@ -211,7 +216,7 @@ impl Shared {
         cell_set: HamtMap<Byte32, TransactionMeta>,
         proposals: ProposalView,
     ) -> Arc<Snapshot> {
-        Arc::new(Snapshot::new(
+        let new_snapshot = Snapshot::new(
             tip_header,
             total_difficulty,
             epoch_ext,
@@ -219,7 +224,8 @@ impl Shared {
             cell_set,
             proposals,
             Arc::clone(&self.consensus),
-        ))
+        );
+        self.store_snapshot(Arc::new(new_snapshot));
     }
 
     pub fn consensus(&self) -> &Consensus {

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -203,8 +203,8 @@ impl Shared {
         self.snapshot_mgr.store(snapshot)
     }
 
-    pub fn refresh_snapshot(&self, old_snapshot: Arc<Snapshot>) {
-        let new = old_snapshot.refresh(self.store.get_snapshot());
+    pub fn refresh_snapshot(&self) {
+        let new = self.snapshot().refresh(self.store.get_snapshot());
         self.store_snapshot(Arc::new(new));
     }
 
@@ -216,7 +216,7 @@ impl Shared {
         cell_set: HamtMap<Byte32, TransactionMeta>,
         proposals: ProposalView,
     ) -> Arc<Snapshot> {
-        let new_snapshot = Snapshot::new(
+        Arc::new(Snapshot::new(
             tip_header,
             total_difficulty,
             epoch_ext,
@@ -224,8 +224,7 @@ impl Shared {
             cell_set,
             proposals,
             Arc::clone(&self.consensus),
-        );
-        self.store_snapshot(Arc::new(new_snapshot));
+        ))
     }
 
     pub fn consensus(&self) -> &Consensus {

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::net_time_checker::NetTimeProtocol;
 pub use crate::relayer::Relayer;
 pub use crate::status::{Status, StatusCode};
 pub use crate::synchronizer::Synchronizer;
-pub use crate::types::SyncSharedState;
+pub use crate::types::SyncShared;
 use std::time::Duration;
 
 pub const MAX_HEADERS_LEN: usize = 2_000;

--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -14,17 +14,18 @@ impl<'a> BlockProposalProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.relayer.shared().snapshot();
+        let shared = self.relayer.shared();
+        let sync_state = shared.state();
         {
             let block_proposals = self.message;
-            let limit = snapshot.consensus().max_block_proposals_limit()
-                * (snapshot.consensus().max_uncles_num() as u64);
+            let limit = shared.consensus().max_block_proposals_limit()
+                * (shared.consensus().max_uncles_num() as u64);
             if (block_proposals.transactions().len() as u64) > limit {
                 return StatusCode::ProtocolMessageIsMalformed.with_context(format!(
                     "Transactions count({}) > consensus max_block_proposals_limit({}) * max_uncles_num({})",
                     block_proposals.transactions().len(),
-                    snapshot.consensus().max_block_proposals_limit(),
-                    snapshot.consensus().max_uncles_num(),
+                    shared.consensus().max_block_proposals_limit(),
+                    shared.consensus().max_uncles_num(),
                 ));
             }
         }
@@ -34,7 +35,7 @@ impl<'a> BlockProposalProcess<'a> {
             .transactions()
             .iter()
             .map(|x| x.to_entity().into_view())
-            .filter(|tx| !snapshot.state().already_known_tx(&tx.hash()))
+            .filter(|tx| !sync_state.already_known_tx(&tx.hash()))
             .collect();
 
         if unknown_txs.is_empty() {
@@ -45,11 +46,11 @@ impl<'a> BlockProposalProcess<'a> {
             .iter()
             .map(|tx| packed::ProposalShortId::from_tx_hash(&tx.hash()))
             .collect();
-        let removes = snapshot.state().remove_inflight_proposals(&proposals);
+        let removes = sync_state.remove_inflight_proposals(&proposals);
         let mut asked_txs = Vec::new();
         for (previously_in, tx) in removes.into_iter().zip(unknown_txs) {
             if previously_in {
-                snapshot.state().mark_as_known_tx(tx.hash());
+                sync_state.mark_as_known_tx(tx.hash());
                 asked_txs.push(tx);
             }
         }

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -111,7 +111,7 @@ impl<'a> BlockTransactionsProcess<'a> {
                     ReconstructionResult::Block(block) => {
                         pending.remove();
                         self.relayer
-                            .accept_block(&snapshot, self.nc.as_ref(), self.peer, block);
+                            .accept_block(self.nc.as_ref(), self.peer, block);
                         return Status::ok();
                     }
                     ReconstructionResult::Missing(transactions, uncles) => {

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -42,7 +42,8 @@ impl<'a> BlockTransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.relayer.shared().snapshot();
+        let shared = self.relayer.shared();
+        let active_chain = shared.active_chain();
         let block_transactions = self.message.to_entity();
         let block_hash = block_transactions.block_hash();
         let received_transactions: Vec<core::TransactionView> = block_transactions
@@ -60,7 +61,7 @@ impl<'a> BlockTransactionsProcess<'a> {
         let missing_uncles: Vec<u32>;
         let mut collision = false;
 
-        if let Entry::Occupied(mut pending) = snapshot
+        if let Entry::Occupied(mut pending) = shared
             .state()
             .pending_compact_blocks()
             .entry(block_hash.clone())
@@ -86,7 +87,7 @@ impl<'a> BlockTransactionsProcess<'a> {
                 ));
 
                 let ret = self.relayer.reconstruct_block(
-                    &snapshot,
+                    &active_chain,
                     compact_block,
                     received_transactions,
                     &expected_uncle_indexes,

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -192,7 +192,7 @@ impl<'a> CompactBlockProcess<'a> {
                 ReconstructionResult::Block(block) => {
                     pending_compact_blocks.remove(&block_hash);
                     self.relayer
-                        .accept_block(&snapshot, self.nc.as_ref(), self.peer, block);
+                        .accept_block(self.nc.as_ref(), self.peer, block);
                     return Status::ok();
                 }
                 ReconstructionResult::Missing(transactions, uncles) => {
@@ -222,7 +222,8 @@ impl<'a> CompactBlockProcess<'a> {
                     (missing_transactions.clone(), missing_uncles.clone()),
                 );
         }
-
+        // refresh snapshot
+        let snapshot = self.relayer.shared.snapshot();
         if !snapshot
             .state()
             .write_inflight_blocks()

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -28,11 +28,11 @@ impl<'a> GetBlockProposalProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.relayer.shared.snapshot();
+        let shared = self.relayer.shared();
         {
             let get_block_proposal = self.message;
-            let limit = snapshot.consensus().max_block_proposals_limit()
-                * (snapshot.consensus().max_uncles_num() as u64);
+            let limit = shared.consensus().max_block_proposals_limit()
+                * (shared.consensus().max_uncles_num() as u64);
             if (get_block_proposal.proposals().len() as u64) > limit {
                 return StatusCode::ProtocolMessageIsMalformed.with_context(format!(
                     "GetBlockProposal proposals count({}) > consensus max_block_proposals_limit({})",

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -2,6 +2,7 @@ use crate::relayer::{Relayer, MAX_RELAY_TXS_NUM_PER_BATCH};
 use crate::{Status, StatusCode};
 use ckb_logger::debug_target;
 use ckb_network::{CKBProtocolContext, PeerIndex};
+use ckb_store::ChainStore;
 use ckb_types::{packed, prelude::*};
 use std::sync::Arc;
 
@@ -28,7 +29,7 @@ impl<'a> GetBlockTransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.relayer.shared.snapshot();
+        let shared = self.relayer.shared();
         {
             let get_block_transactions = self.message;
             if get_block_transactions.indexes().len() > MAX_RELAY_TXS_NUM_PER_BATCH {
@@ -38,12 +39,11 @@ impl<'a> GetBlockTransactionsProcess<'a> {
                     MAX_RELAY_TXS_NUM_PER_BATCH,
                 ));
             }
-            if get_block_transactions.uncle_indexes().len() > snapshot.consensus().max_uncles_num()
-            {
+            if get_block_transactions.uncle_indexes().len() > shared.consensus().max_uncles_num() {
                 return StatusCode::ProtocolMessageIsMalformed.with_context(format!(
                     "UncleIndexes count({}) > consensus max_uncles_num({})",
                     get_block_transactions.uncle_indexes().len(),
-                    snapshot.consensus().max_uncles_num(),
+                    shared.consensus().max_uncles_num(),
                 ));
             }
         }
@@ -55,7 +55,7 @@ impl<'a> GetBlockTransactionsProcess<'a> {
             block_hash
         );
 
-        if let Some(block) = snapshot.get_block(&block_hash) {
+        if let Some(block) = shared.store().get_block(&block_hash) {
             let transactions = self
                 .message
                 .indexes()

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -21,7 +21,7 @@ use self::get_transactions_process::GetTransactionsProcess;
 use self::transaction_hashes_process::TransactionHashesProcess;
 use self::transactions_process::TransactionsProcess;
 use crate::block_status::BlockStatus;
-use crate::types::{SyncSharedState, SyncSnapshot};
+use crate::types::{ActiveChain, SyncShared};
 use crate::{Status, StatusCode, BAD_MESSAGE_BAN_TIME};
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug_target, error_target, info_target, metric, trace_target, warn_target};
@@ -57,7 +57,7 @@ pub enum ReconstructionResult {
 #[derive(Clone)]
 pub struct Relayer {
     chain: ChainController,
-    pub(crate) shared: Arc<SyncSharedState>,
+    pub(crate) shared: Arc<SyncShared>,
     pub(crate) min_fee_rate: FeeRate,
     pub(crate) max_tx_verify_cycles: Cycle,
 }
@@ -65,7 +65,7 @@ pub struct Relayer {
 impl Relayer {
     pub fn new(
         chain: ChainController,
-        shared: Arc<SyncSharedState>,
+        shared: Arc<SyncShared>,
         min_fee_rate: FeeRate,
         max_tx_verify_cycles: Cycle,
     ) -> Self {
@@ -77,7 +77,7 @@ impl Relayer {
         }
     }
 
-    pub fn shared(&self) -> &Arc<SyncSharedState> {
+    pub fn shared(&self) -> &Arc<SyncShared> {
         &self.shared
     }
 
@@ -228,7 +228,7 @@ impl Relayer {
     ) {
         if self
             .shared()
-            .snapshot()
+            .active_chain()
             .contains_block_status(&block.hash(), BlockStatus::BLOCK_STORED)
         {
             return;
@@ -247,10 +247,7 @@ impl Relayer {
                 unix_time_as_millis()
             );
             let block_hash = boxed.hash();
-            self.shared()
-                .snapshot()
-                .state()
-                .remove_header_view(&block_hash);
+            self.shared().state().remove_header_view(&block_hash);
             let cb = packed::CompactBlock::build_from_block(&boxed, &HashSet::new());
             let message = packed::RelayMessage::new_builder().set(cb).build();
             let data = message.as_slice().into();
@@ -282,7 +279,7 @@ impl Relayer {
     // and that nodes must not be penalized for such collisions, wherever they appear.
     pub fn reconstruct_block(
         &self,
-        snapshot: &SyncSnapshot,
+        active_chain: &ActiveChain,
         compact_block: &packed::CompactBlock,
         received_transactions: Vec<core::TransactionView>,
         uncles_index: &[u32],
@@ -363,11 +360,11 @@ impl Relayer {
                 position += 1;
                 continue;
             };
-            let status = snapshot.get_block_status(&uncle_hash);
+            let status = active_chain.get_block_status(&uncle_hash);
             match status {
                 BlockStatus::UNKNOWN | BlockStatus::HEADER_VALID => missing_uncles.push(i),
                 BlockStatus::BLOCK_STORED | BlockStatus::BLOCK_VALID => {
-                    if let Some(uncle) = snapshot.get_block(&uncle_hash) {
+                    if let Some(uncle) = active_chain.get_block(&uncle_hash) {
                         uncles.push(uncle.as_uncle().data());
                     } else {
                         debug_target!(
@@ -608,7 +605,7 @@ impl CKBProtocolHandler for Relayer {
         data: Bytes,
     ) {
         // If self is in the IBD state, don't process any relayer message.
-        if self.shared.snapshot().is_initial_block_download() {
+        if self.shared.active_chain().is_initial_block_download() {
             return;
         }
 
@@ -692,7 +689,7 @@ impl CKBProtocolHandler for Relayer {
 
     fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {
         // If self is in the IBD state, don't trigger any relayer notify.
-        if self.shared.snapshot().is_initial_block_download() {
+        if self.shared.active_chain().is_initial_block_download() {
             return;
         }
 

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -2,6 +2,7 @@ use crate::relayer::block_transactions_process::BlockTransactionsProcess;
 use crate::relayer::tests::helper::{build_chain, MockProtocalContext};
 use crate::{Status, StatusCode};
 use ckb_network::PeerIndex;
+use ckb_store::ChainStore;
 use ckb_tx_pool::{PlugTarget, TxEntry};
 use ckb_types::prelude::*;
 use ckb_types::{
@@ -218,8 +219,12 @@ fn test_invalid_transaction_root() {
 fn test_collision_and_send_missing_indexes() {
     let (relayer, _) = build_chain(5);
 
-    let snapshot = relayer.shared.snapshot();
-    let last_block = snapshot.get_block(&snapshot.tip_hash()).unwrap();
+    let active_chain = relayer.shared.active_chain();
+    let last_block = relayer
+        .shared
+        .store()
+        .get_block(&active_chain.tip_hash())
+        .unwrap();
     let last_cellbase = last_block.transactions().first().cloned().unwrap();
 
     let peer_index: PeerIndex = 100.into();

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -484,6 +484,7 @@ fn test_accept_block() {
         db_txn.commit().unwrap();
     }
 
+    relayer.shared().shared().refresh_snapshot();
     let mut prefilled_transactions_indexes = HashSet::new();
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -1,4 +1,4 @@
-use crate::{Relayer, SyncSharedState};
+use crate::{Relayer, SyncShared};
 use ckb_chain::{chain::ChainService, switch::Switch};
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_network::{
@@ -153,11 +153,11 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
             .expect("processing block should be ok");
     }
 
-    let sync_shared_state = Arc::new(SyncSharedState::new(shared));
+    let sync_shared = Arc::new(SyncShared::new(shared));
     (
         Relayer::new(
             chain_controller,
-            sync_shared_state,
+            sync_shared,
             FeeRate::zero(),
             std::u64::MAX,
         ),

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -25,7 +25,7 @@ fn test_missing_txs() {
         let compact = compact_block_builder.short_ids(short_ids.pack()).build();
         assert_eq!(
             relayer.reconstruct_block(
-                &relayer.shared().snapshot(),
+                &relayer.shared().active_chain(),
                 &compact,
                 transactions,
                 &[],
@@ -50,7 +50,7 @@ fn test_missing_txs() {
         let compact = compact_block_builder.short_ids(short_ids.pack()).build();
         assert_eq!(
             relayer.reconstruct_block(
-                &relayer.shared().snapshot(),
+                &relayer.shared().active_chain(),
                 &compact,
                 transactions,
                 &[],
@@ -119,7 +119,7 @@ fn test_reconstruct_transactions_and_uncles() {
     relayer.shared().shared().refresh_snapshot();
 
     let ret = relayer.reconstruct_block(
-        &relayer.shared().snapshot(),
+        &relayer.shared().active_chain(),
         &compact,
         short_transactions,
         &[],
@@ -155,7 +155,7 @@ fn test_reconstruct_invalid_uncles() {
     relayer.shared().shared().refresh_snapshot();
 
     assert_eq!(
-        relayer.reconstruct_block(&relayer.shared().snapshot(), &compact, vec![], &[], &[]),
+        relayer.reconstruct_block(&relayer.shared().active_chain(), &compact, vec![], &[], &[]),
         ReconstructionResult::Error(StatusCode::CompactBlockHasInvalidUncle.into()),
     );
 }

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -116,6 +116,7 @@ fn test_reconstruct_transactions_and_uncles() {
         db_txn.insert_block_ext(&uncle_hash, &ext.unpack()).unwrap();
         db_txn.commit().unwrap();
     }
+    relayer.shared().shared().refresh_snapshot();
 
     let ret = relayer.reconstruct_block(
         &relayer.shared().snapshot(),
@@ -151,6 +152,7 @@ fn test_reconstruct_invalid_uncles() {
         db_txn.insert_block_ext(&uncle_hash, &ext.unpack()).unwrap();
         db_txn.commit().unwrap();
     }
+    relayer.shared().shared().refresh_snapshot();
 
     assert_eq!(
         relayer.reconstruct_block(&relayer.shared().snapshot(), &compact, vec![], &[], &[]),

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -32,8 +32,8 @@ impl<'a> BlockProcess<'a> {
             block.number(),
             block.hash(),
         );
-        let snapshot = self.synchronizer.shared().snapshot();
-        let state = self.synchronizer.shared().state();
+        let shared = self.synchronizer.shared();
+        let state = shared.state();
 
         if state.new_block_received(&block) {
             if let Err(err) = self
@@ -47,7 +47,10 @@ impl<'a> BlockProcess<'a> {
                     err,
                 ));
             }
-        } else if snapshot.contains_block_status(&block.hash(), BlockStatus::BLOCK_STORED) {
+        } else if shared
+            .active_chain()
+            .contains_block_status(&block.hash(), BlockStatus::BLOCK_STORED)
+        {
             state
                 .peers()
                 .set_last_common_header(self.peer, block.header());

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -36,9 +36,9 @@ impl<'a> BlockProcess<'a> {
         let state = self.synchronizer.shared().state();
 
         if state.new_block_received(&block) {
-            if let Err(err) =
-                self.synchronizer
-                    .process_new_block(&snapshot, self.peer, block.clone())
+            if let Err(err) = self
+                .synchronizer
+                .process_new_block(self.peer, block.clone())
             {
                 state.insert_block_status(block.hash(), BlockStatus::BLOCK_INVALID);
                 return StatusCode::BlockIsInvalid.with_context(format!(

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -37,13 +37,13 @@ impl<'a> GetBlocksProcess<'a> {
                 MAX_HEADERS_LEN,
             ));
         }
-        let snapshot = self.synchronizer.shared.snapshot();
+        let active_chain = self.synchronizer.shared.active_chain();
 
         for block_hash in block_hashes.iter().take(MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             debug!("get_blocks {} from peer {:?}", block_hash, self.peer);
             let block_hash = block_hash.to_entity();
 
-            if !snapshot.contains_block_status(&block_hash, BlockStatus::BLOCK_VALID) {
+            if !active_chain.contains_block_status(&block_hash, BlockStatus::BLOCK_VALID) {
                 debug!(
                     "ignoring get_block {} request from peer={} for unverified",
                     block_hash, self.peer
@@ -59,7 +59,7 @@ impl<'a> GetBlocksProcess<'a> {
                 break;
             }
 
-            if let Some(block) = snapshot.get_block(&block_hash) {
+            if let Some(block) = active_chain.get_block(&block_hash) {
                 debug!(
                     "respond_block {} {} to peer {:?}",
                     block.number(),

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -31,8 +31,8 @@ impl<'a> GetHeadersProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.synchronizer.shared.snapshot();
-        if snapshot.is_initial_block_download() {
+        let active_chain = self.synchronizer.shared.active_chain();
+        if active_chain.is_initial_block_download() {
             info!(
                 "Ignoring getheaders from peer={} because node is in initial block download",
                 self.peer
@@ -57,17 +57,17 @@ impl<'a> GetHeadersProcess<'a> {
         }
 
         if let Some(block_number) =
-            snapshot.locate_latest_common_block(&hash_stop, &block_locator_hashes[..])
+            active_chain.locate_latest_common_block(&hash_stop, &block_locator_hashes[..])
         {
             debug!(
                 "headers latest_common={} tip={} begin",
                 block_number,
-                snapshot.tip_header().number(),
+                active_chain.tip_header().number(),
             );
 
             self.synchronizer.peers().getheaders_received(self.peer);
             let headers: Vec<core::HeaderView> =
-                snapshot.get_locator_response(block_number, &hash_stop);
+                active_chain.get_locator_response(block_number, &hash_stop);
             // response headers
 
             debug!("headers len={}", headers.len());

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -11,7 +11,7 @@ use std::thread;
 use std::time::Duration;
 
 mod inflight_blocks;
-mod sync_shared_state;
+mod sync_shared;
 #[cfg(not(disable_faketime))]
 mod synchronizer;
 mod util;

--- a/sync/src/tests/sync_shared.rs
+++ b/sync/src/tests/sync_shared.rs
@@ -1,6 +1,6 @@
 use crate::block_status::BlockStatus;
 use crate::tests::util::{build_chain, inherit_block};
-use crate::SyncSharedState;
+use crate::SyncShared;
 use ckb_chain::chain::ChainService;
 use ckb_network::PeerIndex;
 use ckb_shared::shared::SharedBuilder;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 fn test_insert_new_block() {
     let (shared, chain) = build_chain(2);
     let new_block = {
-        let tip_hash = shared.snapshot().tip_header().hash();
+        let tip_hash = shared.active_chain().tip_header().hash();
         let next_block = inherit_block(shared.shared(), &tip_hash).build();
         Arc::new(next_block)
     };
@@ -37,11 +37,11 @@ fn test_insert_new_block() {
 fn test_insert_invalid_block() {
     let (shared, chain) = build_chain(2);
     let invalid_block = {
-        let snapshot = shared.snapshot();
-        let tip_number = snapshot.tip_number();
-        let tip_hash = snapshot.tip_hash();
+        let active_chain = shared.active_chain();
+        let tip_number = active_chain.tip_number();
+        let tip_hash = active_chain.tip_hash();
         let invalid_cellbase =
-            always_success_cellbase(tip_number, Capacity::zero(), snapshot.consensus());
+            always_success_cellbase(tip_number, Capacity::zero(), shared.consensus());
         let next_block = inherit_block(shared.shared(), &tip_hash)
             .transaction(invalid_cellbase)
             .build();
@@ -65,16 +65,16 @@ fn test_insert_parent_unknown_block() {
             let chain_service = ChainService::new(shared.clone(), table);
             chain_service.start::<&str>(None)
         };
-        (SyncSharedState::new(shared), chain_controller)
+        (SyncShared::new(shared), chain_controller)
     };
 
     let block = shared1
-        .snapshot()
-        .get_block(&shared1.snapshot().tip_header().hash())
+        .store()
+        .get_block(&shared1.active_chain().tip_header().hash())
         .unwrap();
     let parent = {
         let parent = shared1
-            .snapshot()
+            .store()
             .get_block(&block.header().parent_hash())
             .unwrap();
         Arc::new(parent)
@@ -106,11 +106,11 @@ fn test_insert_parent_unknown_block() {
         false,
     );
     assert_eq!(
-        shared.snapshot().get_block_status(&valid_hash),
+        shared.active_chain().get_block_status(&valid_hash),
         BlockStatus::BLOCK_RECEIVED
     );
     assert_eq!(
-        shared.snapshot().get_block_status(&invalid_hash),
+        shared.active_chain().get_block_status(&invalid_hash),
         BlockStatus::BLOCK_RECEIVED
     );
 
@@ -122,15 +122,15 @@ fn test_insert_parent_unknown_block() {
         true,
     );
     assert_eq!(
-        shared.snapshot().get_block_status(&valid_hash),
+        shared.active_chain().get_block_status(&valid_hash),
         BlockStatus::BLOCK_VALID
     );
     assert_eq!(
-        shared.snapshot().get_block_status(&invalid_hash),
+        shared.active_chain().get_block_status(&invalid_hash),
         BlockStatus::BLOCK_INVALID
     );
     assert_eq!(
-        shared.snapshot().get_block_status(&parent_hash),
+        shared.active_chain().get_block_status(&parent_hash),
         BlockStatus::BLOCK_VALID
     );
 }
@@ -152,9 +152,9 @@ fn test_switch_invalid_fork() {
     // Insert the invalid fork. The fork blocks would not been verified until the fork switches as
     // the main chain. So`insert_new_block` is ok even for invalid block. And `block_status_map`
     // would mark the fork blocks as `BLOCK_STORED`
-    let mut parent_hash = shared.snapshot().store().get_block_hash(1).unwrap();
+    let mut parent_hash = shared.store().get_block_hash(1).unwrap();
     let mut invalid_fork = Vec::new();
-    for _ in 2..shared.snapshot().tip_number() {
+    for _ in 2..shared.active_chain().tip_number() {
         let block = make_invalid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
@@ -168,7 +168,9 @@ fn test_switch_invalid_fork() {
     }
     for block in invalid_fork.iter() {
         assert_eq!(
-            shared.snapshot().get_block_status(&block.header().hash()),
+            shared
+                .active_chain()
+                .get_block_status(&block.header().hash()),
             BlockStatus::BLOCK_STORED,
         );
     }
@@ -195,7 +197,7 @@ fn test_switch_invalid_fork() {
     //    }
     for block in invalid_fork.iter() {
         assert!(!shared
-            .snapshot()
+            .active_chain()
             .contains_block_status(&block.header().hash(), BlockStatus::BLOCK_VALID));
     }
 }
@@ -217,17 +219,13 @@ fn test_switch_valid_fork() {
     // Insert the valid fork. The fork blocks would not been verified until the fork switches as
     // the main chain. And `block_status_map` would mark the fork blocks as `BLOCK_STORED`
     let block_number = 1;
-    let mut parent_hash = shared
-        .snapshot()
-        .store()
-        .get_block_hash(block_number)
-        .unwrap();
+    let mut parent_hash = shared.store().get_block_hash(block_number).unwrap();
     for number in 0..=block_number {
-        let block_hash = shared.snapshot().store().get_block_hash(number).unwrap();
-        shared.snapshot().store().get_block(&block_hash).unwrap();
+        let block_hash = shared.store().get_block_hash(number).unwrap();
+        shared.store().get_block(&block_hash).unwrap();
     }
     let mut valid_fork = Vec::new();
-    for _ in 2..shared.snapshot().tip_number() {
+    for _ in 2..shared.active_chain().tip_number() {
         let block = make_valid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
@@ -241,12 +239,14 @@ fn test_switch_valid_fork() {
     }
     for block in valid_fork.iter() {
         assert_eq!(
-            shared.snapshot().get_block_status(&block.header().hash()),
+            shared
+                .active_chain()
+                .get_block_status(&block.header().hash()),
             BlockStatus::BLOCK_STORED,
         );
     }
 
-    let tip_number = shared.snapshot().tip_number();
+    let tip_number = shared.active_chain().tip_number();
     // Make the fork switch as the main chain.
     for _ in tip_number..tip_number + 2 {
         let block = inherit_block(shared.shared(), &parent_hash.clone()).build();
@@ -262,7 +262,9 @@ fn test_switch_valid_fork() {
     }
     for block in valid_fork.iter() {
         assert_eq!(
-            shared.snapshot().get_block_status(&block.header().hash()),
+            shared
+                .active_chain()
+                .get_block_status(&block.header().hash()),
             BlockStatus::BLOCK_VALID,
         );
     }

--- a/sync/src/tests/sync_shared_state.rs
+++ b/sync/src/tests/sync_shared_state.rs
@@ -21,14 +21,12 @@ fn test_insert_new_block() {
 
     assert_eq!(
         shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
             .expect("insert valid block"),
         true,
     );
     assert_eq!(
         shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
             .expect("insert duplicated valid block"),
         false,
@@ -51,7 +49,6 @@ fn test_insert_invalid_block() {
     };
 
     assert!(shared
-        .snapshot()
         .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_block))
         .is_err(),);
 }
@@ -98,14 +95,12 @@ fn test_insert_parent_unknown_block() {
 
     assert_eq!(
         shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&valid_orphan))
             .expect("insert orphan block"),
         false,
     );
     assert_eq!(
         shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_orphan))
             .expect("insert orphan block"),
         false,
@@ -122,7 +117,6 @@ fn test_insert_parent_unknown_block() {
     // After inserting parent of an orphan block
     assert_eq!(
         shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(2), Arc::clone(&parent))
             .expect("insert parent of orphan block"),
         true,
@@ -164,7 +158,6 @@ fn test_switch_invalid_fork() {
         let block = make_invalid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
-                .snapshot()
                 .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
                 .expect("insert fork"),
             true,
@@ -184,7 +177,6 @@ fn test_switch_invalid_fork() {
     loop {
         let block = inherit_block(shared.shared(), &parent_hash.clone()).build();
         if shared
-            .snapshot()
             .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
             .is_err()
         {
@@ -239,7 +231,6 @@ fn test_switch_valid_fork() {
         let block = make_valid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
-                .snapshot()
                 .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
                 .expect("insert fork"),
             true,
@@ -261,7 +252,6 @@ fn test_switch_valid_fork() {
         let block = inherit_block(shared.shared(), &parent_hash.clone()).build();
         assert_eq!(
             shared
-                .snapshot()
                 .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
                 .expect("insert fork"),
             true,

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -3,7 +3,7 @@ use crate::synchronizer::{
     TIMEOUT_EVICTION_TOKEN,
 };
 use crate::tests::TestNode;
-use crate::{NetworkProtocol, SyncSharedState, Synchronizer};
+use crate::{NetworkProtocol, SyncShared, Synchronizer};
 use ckb_chain::{chain::ChainService, switch::Switch};
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_dao::DaoCalculator;
@@ -165,8 +165,8 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
             .expect("process block should be OK");
     }
 
-    let sync_shared_state = Arc::new(SyncSharedState::new(shared.clone()));
-    let synchronizer = Synchronizer::new(chain_controller, sync_shared_state);
+    let sync_shared = Arc::new(SyncShared::new(shared.clone()));
+    let synchronizer = Synchronizer::new(chain_controller, sync_shared);
     let mut node = TestNode::default();
     let protocol = Arc::new(RwLock::new(synchronizer)) as Arc<_>;
     node.add_protocol(

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -1,4 +1,4 @@
-use crate::SyncSharedState;
+use crate::SyncShared;
 use ckb_chain::{
     chain::{ChainController, ChainService},
     switch::Switch,
@@ -19,7 +19,7 @@ use ckb_types::{
 use std::collections::HashSet;
 use std::sync::Arc;
 
-pub fn build_chain(tip: BlockNumber) -> (SyncSharedState, ChainController) {
+pub fn build_chain(tip: BlockNumber) -> (SyncShared, ChainController) {
     let (shared, table) = SharedBuilder::default()
         .consensus(always_success_consensus())
         .build()
@@ -29,8 +29,8 @@ pub fn build_chain(tip: BlockNumber) -> (SyncSharedState, ChainController) {
         chain_service.start::<&str>(None)
     };
     generate_blocks(&shared, &chain_controller, tip);
-    let sync_shared_state = SyncSharedState::new(shared);
-    (sync_shared_state, chain_controller)
+    let sync_shared = SyncShared::new(shared);
+    (sync_shared, chain_controller)
 }
 
 pub fn generate_blocks(

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -9,7 +9,7 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_logger::{debug, debug_target, error};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_shared::{shared::Shared, Snapshot};
-use ckb_store::ChainStore;
+use ckb_store::{ChainDB, ChainStore};
 use ckb_types::{
     core::{self, BlockNumber, EpochExt},
     packed::{self, Byte32},
@@ -561,50 +561,13 @@ type PendingCompactBlockMap = HashMap<
 >;
 
 #[derive(Clone)]
-pub struct SyncSharedState {
+pub struct SyncShared {
     shared: Shared,
     state: Arc<SyncState>,
 }
 
-#[derive(Clone)]
-pub struct SyncSnapshot {
-    store: Arc<Snapshot>,
-    state: Arc<SyncState>,
-}
-
-pub struct SyncState {
-    n_sync_started: AtomicUsize,
-    n_protected_outbound_peers: AtomicUsize,
-    ibd_finished: AtomicBool,
-
-    /* Status irrelevant to peers */
-    shared_best_header: RwLock<HeaderView>,
-    header_map: RwLock<HashMap<Byte32, HeaderView>>,
-    block_status_map: Mutex<HashMap<Byte32, BlockStatus>>,
-    tx_filter: Mutex<Filter<Byte32>>,
-
-    /* Status relevant to peers */
-    peers: Peers,
-    misbehavior: RwLock<HashMap<PeerIndex, u32>>,
-    known_txs: Mutex<KnownFilter>,
-
-    /* Cached items which we had received but not completely process */
-    pending_get_block_proposals: Mutex<HashMap<packed::ProposalShortId, HashSet<PeerIndex>>>,
-    pending_get_headers: RwLock<LruCache<(PeerIndex, Byte32), Instant>>,
-    pending_compact_blocks: Mutex<PendingCompactBlockMap>,
-    orphan_block_pool: OrphanBlockPool,
-
-    /* In-flight items for which we request to peers, but not got the responses yet */
-    inflight_proposals: Mutex<HashSet<packed::ProposalShortId>>,
-    inflight_transactions: Mutex<LruCache<Byte32, Instant>>,
-    inflight_blocks: RwLock<InflightBlocks>,
-
-    /* cached for sending bulk */
-    tx_hashes: Mutex<HashMap<PeerIndex, LinkedHashSet<Byte32>>>,
-}
-
-impl SyncSharedState {
-    pub fn new(shared: Shared) -> SyncSharedState {
+impl SyncShared {
+    pub fn new(shared: Shared) -> SyncShared {
         let (total_difficulty, header) = {
             let snapshot = shared.snapshot();
             (
@@ -635,7 +598,7 @@ impl SyncSharedState {
             tx_hashes: Mutex::new(HashMap::default()),
         };
 
-        SyncSharedState {
+        SyncShared {
             shared,
             state: Arc::new(state),
         }
@@ -645,15 +608,20 @@ impl SyncSharedState {
         &self.shared
     }
 
-    pub fn state(&self) -> &SyncState {
-        &self.state
-    }
-
-    pub fn snapshot(&self) -> SyncSnapshot {
-        SyncSnapshot {
-            store: Arc::clone(&self.shared.snapshot()),
+    pub fn active_chain(&self) -> ActiveChain {
+        ActiveChain {
+            shared: self.clone(),
+            snapshot: Arc::clone(&self.shared.snapshot()),
             state: Arc::clone(&self.state),
         }
+    }
+
+    pub fn store(&self) -> &ChainDB {
+        self.shared.store()
+    }
+
+    pub fn state(&self) -> &SyncState {
+        &self.state
     }
 
     pub fn consensus(&self) -> &Consensus {
@@ -667,7 +635,7 @@ impl SyncSharedState {
         block: Arc<core::BlockView>,
     ) -> Result<bool, FailureError> {
         // Insert the given block into orphan_block_pool if its parent is not found
-        if !self.snapshot().known_parent(&block) {
+        if !self.is_parent_stored(&block) {
             debug!(
                 "insert new orphan block {} {}",
                 block.header().number(),
@@ -690,7 +658,7 @@ impl SyncSharedState {
         for block in descendants {
             // If we can not find the block's parent in database, that means it was failed to accept
             // its parent, so we treat it as an invalid block as well.
-            if !self.snapshot().known_parent(&block) {
+            if !self.is_parent_stored(&block) {
                 debug!(
                     "parent-unknown orphan block, block: {}, {}, parent: {}",
                     block.header().number(),
@@ -739,6 +707,108 @@ impl SyncSharedState {
 
         Ok(ret?)
     }
+
+    // Update the header_map
+    // Update the block_status_map
+    // Update the shared_best_header if need
+    // Update the peer's best_known_header
+    pub fn insert_valid_header(&self, peer: PeerIndex, header: &core::HeaderView) {
+        let parent_view = self
+            .get_header_view(&header.data().raw().parent_hash())
+            .expect("parent should be verified");
+        let mut header_view = {
+            let total_difficulty = parent_view.total_difficulty() + header.difficulty();
+            HeaderView::new(header.clone(), total_difficulty)
+        };
+
+        header_view.build_skip(|hash| self.get_header_view(hash));
+        self.state
+            .header_map
+            .write()
+            .insert(header.hash(), header_view.clone());
+        self.state
+            .insert_block_status(header.hash(), BlockStatus::HEADER_VALID);
+
+        // NOTE: Must update best headers(peers/global) after update header_map, otherwise will have
+        //   multiple threads inconsistent bug.
+
+        // Update shared_best_header if the arrived header has greater difficulty
+        let shared_best_header = self.state().shared_best_header();
+        if header_view.is_better_than(&shared_best_header.total_difficulty()) {
+            self.state.set_shared_best_header(header_view.clone());
+        }
+        self.state.peers().new_header_received(peer, &header_view);
+    }
+
+    pub fn get_header_view(&self, hash: &Byte32) -> Option<HeaderView> {
+        let store = self.store();
+        self.state.header_map.read().get(hash).cloned().or_else(|| {
+            store.get_block_header(hash).and_then(|header| {
+                store
+                    .get_block_ext(&hash)
+                    .map(|block_ext| HeaderView::new(header, block_ext.total_difficulty))
+            })
+        })
+    }
+
+    pub fn get_header(&self, hash: &Byte32) -> Option<core::HeaderView> {
+        self.state
+            .header_map
+            .read()
+            .get(hash)
+            .map(HeaderView::inner)
+            .cloned()
+            .or_else(|| self.store().get_block_header(hash))
+    }
+
+    pub fn is_parent_stored(&self, block: &core::BlockView) -> bool {
+        self.store()
+            .get_block_header(&block.data().header().raw().parent_hash())
+            .is_some()
+    }
+
+    pub fn get_epoch_ext(&self, hash: &Byte32) -> Option<EpochExt> {
+        self.store().get_block_epoch(&hash)
+    }
+
+    pub(crate) fn new_header_resolver<'a>(
+        &'a self,
+        header: &'a core::HeaderView,
+        parent: core::HeaderView,
+    ) -> HeaderResolverWrapper<'a> {
+        HeaderResolverWrapper::build(header, Some(parent))
+    }
+}
+
+pub struct SyncState {
+    n_sync_started: AtomicUsize,
+    n_protected_outbound_peers: AtomicUsize,
+    ibd_finished: AtomicBool,
+
+    /* Status irrelevant to peers */
+    shared_best_header: RwLock<HeaderView>,
+    header_map: RwLock<HashMap<Byte32, HeaderView>>,
+    block_status_map: Mutex<HashMap<Byte32, BlockStatus>>,
+    tx_filter: Mutex<Filter<Byte32>>,
+
+    /* Status relevant to peers */
+    peers: Peers,
+    misbehavior: RwLock<HashMap<PeerIndex, u32>>,
+    known_txs: Mutex<KnownFilter>,
+
+    /* Cached items which we had received but not completely process */
+    pending_get_block_proposals: Mutex<HashMap<packed::ProposalShortId, HashSet<PeerIndex>>>,
+    pending_get_headers: RwLock<LruCache<(PeerIndex, Byte32), Instant>>,
+    pending_compact_blocks: Mutex<PendingCompactBlockMap>,
+    orphan_block_pool: OrphanBlockPool,
+
+    /* In-flight items for which we request to peers, but not got the responses yet */
+    inflight_proposals: Mutex<HashSet<packed::ProposalShortId>>,
+    inflight_transactions: Mutex<LruCache<Byte32, Instant>>,
+    inflight_blocks: RwLock<InflightBlocks>,
+
+    /* cached for sending bulk */
+    tx_hashes: Mutex<HashMap<PeerIndex, LinkedHashSet<Byte32>>>,
 }
 
 impl SyncState {
@@ -918,41 +988,57 @@ impl SyncState {
     }
 }
 
-impl SyncSnapshot {
-    pub fn state(&self) -> &SyncState {
-        &self.state
+/** ActiveChain captures a point-in-time view of indexed chain of blocks. */
+#[derive(Clone)]
+pub struct ActiveChain {
+    shared: SyncShared,
+    snapshot: Arc<Snapshot>,
+    state: Arc<SyncState>,
+}
+
+impl ActiveChain {
+    fn store(&self) -> &ChainDB {
+        self.shared.store()
     }
 
-    pub fn get_block(&self, hash: &packed::Byte32) -> Option<core::BlockView> {
-        self.store.get_block(hash)
+    fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    pub fn get_block_hash(&self, number: BlockNumber) -> Option<packed::Byte32> {
+        self.snapshot().get_block_hash(number)
+    }
+
+    pub fn get_block(&self, h: &packed::Byte32) -> Option<core::BlockView> {
+        self.store().get_block(h)
+    }
+
+    pub fn get_block_header(&self, h: &packed::Byte32) -> Option<core::HeaderView> {
+        self.store().get_block_header(h)
+    }
+
+    pub fn shared(&self) -> &SyncShared {
+        &self.shared
     }
 
     pub fn total_difficulty(&self) -> &U256 {
-        self.store.total_difficulty()
-    }
-
-    pub fn store(&self) -> &Snapshot {
-        &self.store
+        self.snapshot.total_difficulty()
     }
 
     pub fn tip_header(&self) -> core::HeaderView {
-        self.store.tip_header().clone()
+        self.snapshot.tip_header().clone()
     }
 
     pub fn tip_hash(&self) -> Byte32 {
-        self.store.tip_hash()
+        self.snapshot.tip_hash()
     }
 
     pub fn tip_number(&self) -> BlockNumber {
-        self.store.tip_number()
+        self.snapshot.tip_number()
     }
 
     pub fn epoch_ext(&self) -> core::EpochExt {
-        self.store.epoch_ext().clone()
-    }
-
-    pub fn consensus(&self) -> &Consensus {
-        self.store.consensus()
+        self.snapshot.epoch_ext().clone()
     }
 
     pub fn is_initial_block_download(&self) -> bool {
@@ -968,72 +1054,18 @@ impl SyncSnapshot {
         }
     }
 
-    // Update the header_map
-    // Update the block_status_map
-    // Update the shared_best_header if need
-    // Update the peer's best_known_header
-    pub fn insert_valid_header(&self, peer: PeerIndex, header: &core::HeaderView) {
-        let parent_view = self
-            .get_header_view(&header.data().raw().parent_hash())
-            .expect("parent should be verified");
-        let mut header_view = {
-            let total_difficulty = parent_view.total_difficulty() + header.difficulty();
-            HeaderView::new(header.clone(), total_difficulty)
-        };
-
-        header_view.build_skip(|hash| self.get_header_view(hash));
-        self.state
-            .header_map
-            .write()
-            .insert(header.hash(), header_view.clone());
-        self.state
-            .insert_block_status(header.hash(), BlockStatus::HEADER_VALID);
-
-        // NOTE: Must update best headers(peers/global) after update header_map, otherwise will have
-        //   multiple threads inconsistent bug.
-
-        // Update shared_best_header if the arrived header has greater difficulty
-        let shared_best_header = self.state().shared_best_header();
-        if header_view.is_better_than(&shared_best_header.total_difficulty()) {
-            self.state.set_shared_best_header(header_view.clone());
-        }
-        self.state.peers().new_header_received(peer, &header_view);
-    }
-
-    pub fn get_header_view(&self, hash: &Byte32) -> Option<HeaderView> {
-        self.state.header_map.read().get(hash).cloned().or_else(|| {
-            self.store.get_block_header(hash).and_then(|header| {
-                self.store
-                    .get_block_ext(&hash)
-                    .map(|block_ext| HeaderView::new(header, block_ext.total_difficulty))
-            })
-        })
-    }
-
-    pub fn get_header(&self, hash: &Byte32) -> Option<core::HeaderView> {
-        self.state
-            .header_map
-            .read()
-            .get(hash)
-            .map(HeaderView::inner)
-            .cloned()
-            .or_else(|| self.store.get_block_header(hash))
-    }
-
-    pub fn get_epoch_ext(&self, hash: &Byte32) -> Option<EpochExt> {
-        self.store.get_block_epoch(&hash)
-    }
-
     pub fn get_ancestor(&self, base: &Byte32, number: BlockNumber) -> Option<core::HeaderView> {
         // shortcut to return a ancestor block
-        if self.store().is_main_chain(&base) {
-            return self
-                .store()
-                .get_block_hash(number)
-                .and_then(|hash| self.get_header_view(&hash).map(HeaderView::into_inner));
+        if self.snapshot.is_main_chain(&base) {
+            return self.snapshot.get_block_hash(number).and_then(|hash| {
+                self.shared
+                    .get_header_view(&hash)
+                    .map(HeaderView::into_inner)
+            });
         }
-        self.get_header_view(base)?
-            .get_ancestor(number, |hash| self.get_header_view(hash))
+        self.shared
+            .get_header_view(base)?
+            .get_ancestor(number, |hash| self.shared.get_header_view(hash))
     }
 
     pub fn get_locator(&self, start: &core::HeaderView) -> Vec<Byte32> {
@@ -1065,7 +1097,7 @@ impl SyncSnapshot {
             if index < step {
                 // always include genesis hash
                 if index != 0 {
-                    locator.push(self.consensus().genesis_hash());
+                    locator.push(self.shared.consensus().genesis_hash());
                 }
                 break;
             }
@@ -1091,7 +1123,7 @@ impl SyncSnapshot {
             return Some(m_right);
         }
 
-        let mut m_left = self.get_header(&last_common_header.hash())?;
+        let mut m_left = self.shared.get_header(&last_common_header.hash())?;
         debug_assert!(m_right.number() == m_left.number());
 
         while m_left != m_right {
@@ -1111,7 +1143,7 @@ impl SyncSnapshot {
         }
 
         let locator_hash = locator.last().expect("empty checked");
-        if locator_hash != &self.consensus().genesis_hash() {
+        if locator_hash != &self.shared.consensus().genesis_hash() {
             return None;
         }
 
@@ -1119,7 +1151,7 @@ impl SyncSnapshot {
         let (index, latest_common) = locator
             .iter()
             .enumerate()
-            .map(|(index, hash)| (index, self.store.get_block_number(hash)))
+            .map(|(index, hash)| (index, self.snapshot.get_block_number(hash)))
             .find(|(_index, number)| number.is_some())
             .expect("locator last checked");
 
@@ -1129,16 +1161,16 @@ impl SyncSnapshot {
 
         if let Some(header) = locator
             .get(index - 1)
-            .and_then(|hash| self.store.get_block_header(hash))
+            .and_then(|hash| self.shared.store().get_block_header(hash))
         {
             let mut block_hash = header.data().raw().parent_hash();
             loop {
-                let block_header = match self.store.get_block_header(&block_hash) {
+                let block_header = match self.shared.store().get_block_header(&block_hash) {
                     None => break latest_common,
                     Some(block_header) => block_header,
                 };
 
-                if let Some(block_number) = self.store.get_block_number(&block_hash) {
+                if let Some(block_number) = self.snapshot.get_block_number(&block_hash) {
                     return Some(block_number);
                 }
 
@@ -1160,9 +1192,9 @@ impl SyncSnapshot {
             tip_number + 1,
         );
         (block_number + 1..max_height)
-            .filter_map(|block_number| self.store.get_block_hash(block_number))
+            .filter_map(|block_number| self.snapshot.get_block_hash(block_number))
             .take_while(|block_hash| block_hash != hash_stop)
-            .filter_map(|block_hash| self.store.get_block_header(&block_hash))
+            .filter_map(|block_hash| self.shared.store().get_block_header(&block_hash))
             .collect()
     }
 
@@ -1219,7 +1251,7 @@ impl SyncSnapshot {
             Some(status) => status,
             None => {
                 let verified = self
-                    .store
+                    .snapshot
                     .get_block_ext(block_hash)
                     .map(|block_ext| block_ext.verified);
                 match verified {
@@ -1245,20 +1277,6 @@ impl SyncSnapshot {
 
     pub fn unknown_block_status(&self, block_hash: &Byte32) -> bool {
         self.get_block_status(block_hash) == BlockStatus::UNKNOWN
-    }
-
-    pub fn known_parent(&self, block: &core::BlockView) -> bool {
-        self.store
-            .get_block_header(&block.data().header().raw().parent_hash())
-            .is_some()
-    }
-
-    pub(crate) fn new_header_resolver<'a>(
-        &'a self,
-        header: &'a core::HeaderView,
-        parent: core::HeaderView,
-    ) -> HeaderResolverWrapper<'a> {
-        HeaderResolverWrapper::build(header, Some(parent))
     }
 }
 

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -42,6 +42,13 @@ impl SnapshotMgr {
     }
 }
 
+// A snapshot captures a point-in-time view of the DB at the time it's created
+//
+//                   yes —— new snapshot
+//                   /                    \
+//    tip —— change?                        SnapshotMgr swap
+//                  \                      /
+//                   no —— refresh snapshot
 pub struct Snapshot {
     tip_header: HeaderView,
     total_difficulty: U256,
@@ -53,6 +60,7 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    // New snapshot created after tip change
     pub fn new(
         tip_header: HeaderView,
         total_difficulty: U256,
@@ -73,6 +81,9 @@ impl Snapshot {
         }
     }
 
+    // Refreshing on block commit is necessary operation, even tip remains unchanged.
+    // when node relayed compact block,if some uncles were not available from receiver's local sources,
+    // in GetBlockTransactions/BlockTransactions roundtrip, node will need access block data of uncles.
     pub fn refresh(&self, store: StoreSnapshot) -> Snapshot {
         Snapshot {
             store,

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -73,6 +73,18 @@ impl Snapshot {
         }
     }
 
+    pub fn refresh(&self, store: StoreSnapshot) -> Snapshot {
+        Snapshot {
+            store,
+            tip_header: self.tip_header.clone(),
+            total_difficulty: self.total_difficulty.clone(),
+            epoch_ext: self.epoch_ext.clone(),
+            cell_set: self.cell_set.clone(),
+            proposals: self.proposals.clone(),
+            consensus: Arc::clone(&self.consensus),
+        }
+    }
+
     pub fn tip_header(&self) -> &HeaderView {
         &self.tip_header
     }


### PR DESCRIPTION
## Fixes

  - snapshot not refresh after insert block
  - snapshot `get_pinned` isolation

## Refactory
Reimplement `sync-snapshot`, rename to `active-chain`,  prevent misuse of snapshot.
chain data are immutable, we don't need snapshot freeze it.
also, access chain data from snapshot in network-handler may inconsistent with memory state, cause network process are asynchronize, it hard to keep snapshot sync with memory state.


## Bench
 https://github.com/nervosnetwork/ckb-bench/issues/7
