### PR TITLE
feat: Bump CKB VM to fix a performance regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d3ba078ad0a856b82a9e0c62f7ca564df027898bb2e6e367a26455f114fa67"
+checksum = "d7a75c9a092719293a09da2e233fd7802fe909fa2b88a9256034f1e486a6bc7c"
 dependencies = [
  "byteorder",
  "bytes 0.5.4",
@@ -1140,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfc1ed5a58a3015b236fda0956e0fe060823d072267b6d7bd68b3ccd0b290e1"
+checksum = "3ce774f97919ed2458881e02ddf431ae82bc6203fbae8d75563b4499126c0ad2"
 
 [[package]]
 name = "clap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "ckb-occupied-capacity",
  "enum-display-derive",
  "failure",
+ "quote 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,6 @@ dependencies = [
  "ckb-occupied-capacity",
  "enum-display-derive",
  "failure",
- "quote 1.0.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ cov: ## Run code coverage.
 
 .PHONY: wasm-build-test
 wasm-build-test: ## Build core packages for wasm target
+	cp -f Cargo.lock test/Cargo.lock
 	cd wasm-build-test && cargo build --target=wasm32-unknown-unknown
 
 .PHONY: setup-ckb-test

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ cov: ## Run code coverage.
 
 .PHONY: wasm-build-test
 wasm-build-test: ## Build core packages for wasm target
-	cp -f Cargo.lock test/Cargo.lock
 	cd wasm-build-test && cargo build --target=wasm32-unknown-unknown
 
 .PHONY: setup-ckb-test

--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -131,7 +131,7 @@ function check_dependencies_for() {
             fi
             if [ "${depcnt}" -eq 0 ]; then
                 case "${dependency}" in
-                    phf)
+                    phf|quote)
                         # We cann't handle these crates.
                         printf "Warn: [%s::%s] in <%s>\n" \
                             "${deptype}" "${dependency}" "${pkgroot}"

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -11,3 +11,5 @@ edition = "2018"
 failure = "0.1.5"
 ckb-occupied-capacity = { path = "../util/occupied-capacity" }
 enum-display-derive = "0.1.0"
+# See https://users.rust-lang.org/t/failure-derive-compilation-error/39062 for more details
+quote = "=1.0.2"

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -11,5 +11,3 @@ edition = "2018"
 failure = "0.1.5"
 ckb-occupied-capacity = { path = "../util/occupied-capacity" }
 enum-display-derive = "0.1.0"
-# See https://users.rust-lang.org/t/failure-derive-compilation-error/39062 for more details
-quote = "=1.0.2"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -18,7 +18,7 @@ ckb-script-data-loader = { path = "data-loader" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types"}
 ckb-hash = {path = "../util/hash"}
-ckb-vm = { version = "0.19.0", default-features = false }
+ckb-vm = { version = "0.19.1", default-features = false }
 faster-hex = "0.4"
 ckb-logger = { path = "../util/logger", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ ckb-error = { path = "../error" }
 failure = "0.1.5"
 ckb-chain-spec = { path = "../spec" }
 goblin = "0.1.3"
-ckb-vm-definitions = "0.19.0"
+ckb-vm-definitions = "0.19.1"
 
 [dev-dependencies]
 proptest = "0.9"


### PR DESCRIPTION
See the release notes for CKB VM 0.19.1 for more details:
https://github.com/nervosnetwork/ckb-vm/releases/tag/0.19.1