### PR TITLE
feat: replace rocksdb wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.3"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
+checksum = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
 dependencies = [
  "memchr",
 ]
@@ -488,8 +488,8 @@ version = "0.30.1-pre"
 dependencies = [
  "ckb-error",
  "ckb-logger",
+ "ckb-rocksdb",
  "libc",
- "rocksdb",
  "serde",
  "tempfile",
 ]
@@ -624,6 +624,17 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ckb-librocksdb-sys"
+version = "6.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab170e26569d712ab6a52561d36239ea240ce58f6a601ecb3a518b485156cdde"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
 ]
 
 [[package]]
@@ -833,6 +844,16 @@ dependencies = [
  "ckb-occupied-capacity",
  "ckb-store",
  "ckb-types",
+]
+
+[[package]]
+name = "ckb-rocksdb"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe6167dec272389e8f02015ab47a6b6b91a06eb870af61598423fb0ee12a386"
+dependencies = [
+ "ckb-librocksdb-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1800,9 +1821,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
@@ -2135,16 +2156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 
 [[package]]
-name = "librocksdb-sys"
-version = "6.4.6"
-source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=a8dd2ad#a8dd2adace8224da52318f89d5db4a8063332d86"
-dependencies = [
- "cc",
- "glob",
- "libc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.1"
 source = "git+https://github.com/nervosnetwork/linked-hash-map?rev=df27f21#df27f2194df66d3c652b0fb661da707cc167c9d1"
@@ -2209,9 +2220,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 dependencies = [
  "libc",
 ]
@@ -3105,15 +3116,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.1.7"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
+checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 dependencies = [
- "aho-corasick 0.7.3",
+ "aho-corasick 0.7.9",
  "memchr",
  "regex-syntax",
  "thread_local",
- "utf8-ranges",
 ]
 
 [[package]]
@@ -3127,12 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.6"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
-dependencies = [
- "ucd-util",
-]
+checksum = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 
 [[package]]
 name = "remove_dir_all"
@@ -3202,15 +3209,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.7",
-]
-
-[[package]]
-name = "rocksdb"
-version = "0.12.2"
-source = "git+https://github.com/nervosnetwork/rust-rocksdb?rev=a8dd2ad#a8dd2adace8224da52318f89d5db4a8063332d86"
-dependencies = [
- "libc",
- "librocksdb-sys",
 ]
 
 [[package]]
@@ -3712,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
@@ -3995,12 +3993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
-
-[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,12 +4110,6 @@ dependencies = [
  "serde",
  "url 1.7.2",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 
 [[package]]
 name = "uuid"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -11,7 +11,4 @@ ckb-logger = { path = "../util/logger" }
 tempfile = "3.0"
 ckb-error = { path = "../error" }
 libc = "0.2"
-
-[dependencies.rocksdb]
-git = "https://github.com/nervosnetwork/rust-rocksdb"
-rev = "a8dd2ad"
+rocksdb = { package = "ckb-rocksdb", version = "=0.12.3", features = ["snappy"] }


### PR DESCRIPTION
## Issue
Cargo fetch the git repository is unbearably slow

## Proposed Changes
Replace it with published crate.
explicitly `features = ["snappy"]` for backward compatibility.