### PR TITLE
perf: improve get_ancestor efficiency

### DIFF
--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -2,7 +2,7 @@ use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::types::{ActiveChain, HeaderView, IBDState};
 use crate::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
-use ckb_logger::{debug, trace, metric};
+use ckb_logger::{debug, metric, trace};
 use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
 use faketime::unix_time_as_millis;

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -2,10 +2,10 @@ use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::types::{ActiveChain, HeaderView, IBDState};
 use crate::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
-use ckb_logger::{debug, metric, trace};
+use ckb_logger::{debug, trace};
 use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
-use faketime::unix_time_as_millis;
+use std::cmp::min;
 
 pub struct BlockFetcher {
     synchronizer: Synchronizer,
@@ -125,50 +125,51 @@ impl BlockFetcher {
 
         debug_assert!(best_known_header.number() > fixed_last_common_header.number());
 
-        let mut index_height = fixed_last_common_header.number();
-        let mut fetch = Vec::with_capacity(MAX_BLOCKS_IN_TRANSIT_PER_PEER);
+        let mut inflight = self.synchronizer.shared().state().write_inflight_blocks();
+        let count =
+            MAX_BLOCKS_IN_TRANSIT_PER_PEER.saturating_sub(inflight.peer_inflight_count(self.peer));
+        let mut fetch = Vec::with_capacity(count);
+        let mut start = fixed_last_common_header.number() + 1;
 
-        let timestamp = unix_time_as_millis();
-        let mut steps = 0;
-        {
-            let mut inflight = self.synchronizer.shared().state().write_inflight_blocks();
-            let count = MAX_BLOCKS_IN_TRANSIT_PER_PEER
-                .saturating_sub(inflight.peer_inflight_count(self.peer));
+        // Judge whether we should fetch the target block, neither stored nor in-flighted
+        let mut should_fetch = |block_hash| {
+            // NOTE: Filtering `BLOCK_STORED` but not `BLOCK_RECEIVED`, is for avoiding
+            // stopping synchronization even when orphan_pool maintains dirty items by bugs.
+            let stored = self
+                .active_chain
+                .contains_block_status(&block_hash, BlockStatus::BLOCK_STORED);
+            !stored && inflight.insert(self.peer, block_hash)
+        };
 
-            while fetch.len() < count {
-                index_height += 1;
-                if index_height > best_known_header.number() {
-                    break;
+        while fetch.len() < count && start <= best_known_header.number() {
+            let span = min(
+                best_known_header.number() - start + 1,
+                (count - fetch.len()) as u64,
+            );
+
+            // Iterate in range `[start, start+span)` and consider as the next to-fetch candidates.
+            let mut header = self
+                .active_chain
+                .get_ancestor(&best_known_header.hash(), start + span - 1)?;
+            for _ in 0..span {
+                let parent_hash = header.parent_hash();
+                if should_fetch(header.hash()) {
+                    fetch.push(header)
                 }
 
-                steps += 1;
-                let to_fetch = self
-                    .active_chain
-                    .get_ancestor(&best_known_header.hash(), index_height)?;
-
-                // NOTE: Filtering `BLOCK_STORED` but not `BLOCK_RECEIVED`, is for avoiding
-                // stopping synchronization even when orphan_pool maintains dirty items by bugs.
-                if self
-                    .active_chain
-                    .contains_block_status(&to_fetch.hash(), BlockStatus::BLOCK_STORED)
-                {
-                    continue;
-                }
-
-                if inflight.insert(self.peer, to_fetch.hash()) {
-                    trace!(
-                        "[Synchronizer] inflight insert {:?}------------{}",
-                        to_fetch.number(),
-                        to_fetch.hash(),
-                    );
-                    fetch.push(to_fetch.hash());
-                }
+                header = self
+                    .synchronizer
+                    .shared
+                    .get_header_view(&parent_hash)?
+                    .into_inner();
             }
+
+            // Move `start` forward
+            start += span as u64;
         }
-        metric!({
-            "topic": "fetch_blocks",
-            "fields": { "elapsed": unix_time_as_millis().saturating_sub(timestamp), "steps": steps }
-        });
-        Some(fetch)
+
+        // The headers in `fetch` may be unordered. Sort them by number.
+        fetch.sort_by_key(|header| header.number());
+        Some(fetch.iter().map(core::HeaderView::hash).collect())
     }
 }

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1129,7 +1129,7 @@ impl ActiveChain {
                 if current.number() <= tip_number && self.snapshot().is_main_chain(&current.hash())
                 {
                     self.get_block_hash(number)
-                        .and_then(|hash| self.get_header_view(&hash))
+                        .and_then(|hash| self.shared.get_header_view(&hash))
                 } else {
                     None
                 }


### PR DESCRIPTION
This PR introduces 2 optimizations related to `get_ancestor`

#### 1. `BlockFetcher::fetch` save times of involving `get_ancestor` with the help of tracing parents

  https://github.com/nervosnetwork/ckb/pull/1959/files#diff-86d69964b227ca1248fadb84da967a96

* [Original]  `BlockFetcher::fetch` would involve `get_ancestor` multiple times for continuous headers.
For example, assume `block-chain-tip = 100, header-chain-tip=999`, `get_ancestor` would be involved at least 16(`MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16`) times:
    - `get_ancestor(101)`
    - `get_ancestor(102)`
    - ...
    - `get_ancestor(115)`

* [Now] While we can save 15 times of involving `get_ancestor` with the help of tracing parents:

    - `get_ancestor(115)`
    - get `headers[100...114]` by tracing parents

#### 2. `get_ancestor` shortcuts scanning for main-chain headers.

  https://github.com/nervosnetwork/ckb/pull/1959/files#diff-9912cd1cc8b513bd52d8bfe461cadfd0

* [Original] `get_ancestor` locate the header of the target number via skip-scanning. While the scan may get block-headers from storage frequently, which may make `get_ancestor` become a heavy operation.

* [Now] This PR introduces a shortcut: If we already skip into the main-chain scope, then we can use `store.get_header_by_number` to locate the target header directly.