### PR TITLE
fix: fix bug on last common marked

### DIFF
--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -22,11 +22,18 @@ use std::sync::Arc;
 #[test]
 fn test_in_block_status_map() {
     let (relayer, _) = build_chain(5);
-
+    let header = {
+        let shared = relayer.shared.shared();
+        let parent = shared
+            .store()
+            .get_block_hash(4)
+            .and_then(|block_hash| shared.store().get_block(&block_hash))
+            .unwrap();
+        new_header_builder(&relayer.shared.shared(), &parent.header()).build()
+    };
     let block = BlockBuilder::default()
-        .number(5.pack())
-        .timestamp(unix_time_as_millis().pack())
         .transaction(TransactionBuilder::default().build())
+        .header(header)
         .build();
 
     let mut prefilled_transactions_indexes = HashSet::new();

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -37,16 +37,22 @@ impl BlockFetcher {
     }
 
     pub fn last_common_header(&self, best: &HeaderView) -> Option<core::HeaderView> {
+        let tip_header = self.active_chain.tip_header();
         let last_common_header = {
             if let Some(header) = self.synchronizer.peers().get_last_common_header(self.peer) {
-                Some(header)
+                // may reorganized, then it can't be used
+                if header.number() > tip_header.number() {
+                    Some(tip_header)
+                } else {
+                    Some(header)
+                }
             // Bootstrap quickly by guessing a parent of our best tip is the forking point.
             // Guessing wrong in either direction is not a problem.
-            } else if best.number() < self.active_chain.tip_header().number() {
+            } else if best.number() < tip_header.number() {
                 let last_common_hash = self.active_chain.get_block_hash(best.number())?;
                 self.active_chain.get_block_header(&last_common_hash)
             } else {
-                Some(self.active_chain.tip_header())
+                Some(tip_header)
             }
         }?;
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -136,6 +136,11 @@ impl Synchronizer {
         // stopping synchronization even when orphan_pool maintains dirty items by bugs.
         if status.contains(BlockStatus::BLOCK_STORED) {
             debug!("block {} already stored", block_hash);
+            // update last common header
+            self.shared
+                .state()
+                .peers()
+                .set_last_common_header(peer, block.header());
             Ok(false)
         } else if status.contains(BlockStatus::HEADER_VALID) {
             self.shared


### PR DESCRIPTION
Fix the stuttering problem of multi-node download on ibd concurrent download and no-ibd concurrent download.

If the `last common` tag is incorrect, it will cause the `index_height` and `tip` to be too far apart, which will cause `get_ancestor` and `contains_block_status` to be penetrated to RocksDB. When the gap exceeds 500k, it means that each time you look for the `can fetch` block, it will take up to Millions of cache breakdowns, this problem will increase rapidly with the number of synchronizable nodes and chain height, which will lead to pauses.

https://github.com/nervosnetwork/ckb/blob/e76cbe076586d362ce7f676635caf1e84f1cc9d4/sync/src/synchronizer/block_fetcher.rs#L40-L52

https://github.com/nervosnetwork/ckb/blob/e76cbe076586d362ce7f676635caf1e84f1cc9d4/sync/src/synchronizer/block_fetcher.rs#L121-L137

Currently, our strategy for downloading blocks is to request a block from two nodes at the same time. However, we only recorded the last common update information of one node. This is incorrect. At the same time, the same problem occurs in the compact block

The problem here will cause the local sync protocol to fall into the pseudo-death stage, unable to send or receive any messages