### PR TITLE
chore: send failed integration test to sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ tags
 
 # tmp files
 *.pyc
+/test/integration.log
+/test/integration.failure
 
 # generated files
 cobertura.xml

--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,19 @@ submodule-init:
 .PHONY: integration
 integration: submodule-init setup-ckb-test ## Run integration tests in "test" dir.
 	cargo build --features deadlock_detection
-	cd test && RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
+	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-windows
 integration-windows: submodule-init
 	cp -f Cargo.lock test/Cargo.lock
 	cargo build --features deadlock_detection
 	mv target test/
-	cd test && cargo run -- --bin target/debug/ckb ${CKB_TEST_ARGS}
+	cd test && RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -- --bin target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-release
 integration-release: submodule-init setup-ckb-test
 	cargo build --release --features deadlock_detection
-	cd test && cargo run --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
+	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
 
 ##@ Document
 .PHONY: doc

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+
+set -e
+set -u
+[ -n "${DEBUG:-}" ] && set -x || true
+
+cd "$DIR"
+
+set +e
+
+export CKB_INTEGRATION_FAILURE_FILE="$(pwd)/integration.failure"
+echo "Unknown integration error" > "$CKB_INTEGRATION_FAILURE_FILE"
+cargo run "$@" 2>&1 | tee integration.log
+EXIT_CODE="${PIPESTATUS[0]}"
+set -e
+
+if [ "$EXIT_CODE" != 0 ]; then
+  if ! command -v sentry-cli &> /dev/null; then
+    curl -sL https://sentry.io/get-cli/ | bash
+  fi
+  export SENTRY_DSN="https://15373165fbf2439b99ba46684dfbcb12@sentry.nervos.org/7"
+  CKB_BIN="../target/debug/ckb"
+
+  while [[ "$#" > 1 ]]; do
+    case "$1" in
+      --bin)
+        CKB_BIN="$2"
+        break
+        ;;
+      *)
+        ;;
+    esac
+    shift
+  done
+
+  CKB_RELEASE="$("$CKB_BIN" --version)"
+  cat "$CKB_INTEGRATION_FAILURE_FILE" | xargs -t -L 1 -I '%' sentry-cli send-event -m '%' -r "$CKB_RELEASE" --logfile integration.log
+
+  exit "$EXIT_CODE"
+fi

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 fn main() {
     env::set_var("RUST_BACKTRACE", "full");
     let _ = {
-        let filter = ::std::env::var("CKB_LOG").unwrap_or_else(|_| "info".to_string());
+        let filter = env::var("CKB_LOG").unwrap_or_else(|_| "info".to_string());
         env_logger::builder().parse_filters(&filter).try_init()
     };
 
@@ -156,7 +156,7 @@ fn main() {
     }
 
     if !spec_errors.is_empty() {
-        error!("ckb-failed on spec {}", error_spec_names.join(", "));
+        error!("ckb-test failed on spec {}", error_spec_names.join(", "));
         log_failed_specs(&error_spec_names)
             .unwrap_or_else(|err| error!("Failed to write integration failure reason: {}", err));
         info!("You can rerun remaining specs using following command:");
@@ -252,7 +252,7 @@ fn filter_specs(mut all_specs: SpecMap, spec_names_to_run: Vec<&str>) -> Vec<Spe
 }
 
 fn current_dir() -> PathBuf {
-    ::std::env::current_dir()
+    env::current_dir()
         .expect("can't get current_dir")
         .join("vendor")
 }


### PR DESCRIPTION
Collecting the failed specs so we can known which specs fail most and should be disabled until fixed.

#2bm04k[closed]