### PR TITLE
feat: enhanced locator

### DIFF
--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -42,6 +42,8 @@ const GET_HEADERS_TIMEOUT: Duration = Duration::from_secs(15);
 const TX_FILTER_SIZE: usize = 50000;
 const TX_ASKED_SIZE: usize = TX_FILTER_SIZE;
 const ORPHAN_BLOCK_SIZE: usize = 1024;
+// 2 ** 13 < 6 * 1800 < 2 ** 14
+const ONE_DAY_BLOCK_NUMBER: u64 = 8192;
 
 // State used to enforce CHAIN_SYNC_TIMEOUT
 // Only in effect for connections that are outbound, non-manual,
@@ -983,6 +985,14 @@ impl SyncSnapshot {
             }
 
             if index < step {
+                // Insert some low-height blocks in the locator
+                // to quickly start parallel ibd block downloads
+                // and it should not be too much
+                if locator.len() < 31 && index > ONE_DAY_BLOCK_NUMBER {
+                    index >>= 1;
+                    base = header_hash;
+                    continue;
+                }
                 // always include genesis hash
                 if index != 0 {
                     locator.push(self.consensus().genesis_hash());


### PR DESCRIPTION
After allowing ibd multi-node download, the premise of enabling multi-node download is to update the best-known header of the corresponding node as soon as possible.

However, as the chain height continues to increase, the exponentially descending abstraction header of the locator will cause the minimum height header in the locator to become higher and higher, that is, it will take longer and longer to enable ibd multi-node download.

So, slightly improve the step insertion method of the locator so that the minimum height within it is as low as possible