### PR TITLE
fix: Delete insert judgment with side effects

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -237,10 +237,12 @@ impl<'a> CompactBlockProcess<'a> {
                     (missing_transactions.clone(), missing_uncles.clone()),
                 );
         }
-        if !shared
+        if shared
             .state()
-            .write_inflight_blocks()
-            .insert(self.peer, block_hash.clone())
+            .read_inflight_blocks()
+            .inflight_state_by_block(&block_hash)
+            .map(|state| state.peers.len() > 1)
+            .unwrap_or_default()
         {
             debug_target!(
                 crate::LOG_TARGET_RELAY,


### PR DESCRIPTION
inflight holds the `getblocks` request that has been sent. If inserted here, it means that the request bit is occupied, and here should not use insert