### PR TITLE
refactor: use a new method to detect headers sync timeout

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -46,10 +46,18 @@ pub(crate) const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
 
-//  Timeout = base + per_header * (expected number of headers)
-pub const HEADERS_DOWNLOAD_TIMEOUT_BASE: u64 = 6 * 60 * 1000; // 6 minutes
-pub const HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER: u64 = 1; // 1ms/header
-pub const POW_SPACE: u64 = 10_000; // 10s
+// Inspect the headers downloading every 2 minutes
+pub const HEADERS_DOWNLOAD_INSPECT_WINDOW: u64 = 2 * 60 * 1000;
+// Global Average Speed
+//      Expect 300 KiB/second
+//          = 1600 headers/second (300*1024/192)
+//          = 96000 headers/minute (1600*60)
+//          = 11.11 days-in-blockchain/minute-in-reality (96000*10/60/60/24)
+//      => Sync 1 year headers in blockchain will be in 32.85 minutes (365/11.11) in reality
+pub const HEADERS_DOWNLOAD_HEADERS_PER_SECOND: u64 = 1600;
+// Acceptable Lowest Instantaneous Speed: 75.0 KiB/second (300/4)
+pub const HEADERS_DOWNLOAD_TOLERABLE_BIAS_FOR_SINGLE_SAMPLE: u64 = 4;
+pub const POW_INTERVAL: u64 = 10;
 
 // Protect at least this many outbound peers from disconnection due to slow
 // behind headers chain.

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -145,15 +145,15 @@ impl<'a> HeadersProcess<'a> {
         }
 
         if headers.is_empty() {
-            // Reset headers sync timeout
-            self.synchronizer
-                .peers()
-                .state
-                .write()
-                .get_mut(&self.peer)
-                .expect("Peer must exists")
-                .headers_sync_timeout = None;
             debug!("HeadersProcess is_empty (synchronized)");
+            let ibd = self.active_chain.is_initial_block_download();
+            if !ibd {
+                if let Some(ref mut peer_state) =
+                    self.synchronizer.peers().state.write().get_mut(&self.peer)
+                {
+                    peer_state.stop_headers_sync();
+                }
+            }
             return Status::ok();
         }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -12,11 +12,10 @@ use self::get_headers_process::GetHeadersProcess;
 use self::headers_process::HeadersProcess;
 use self::in_ibd_process::InIBDProcess;
 use crate::block_status::BlockStatus;
-use crate::types::{HeaderView, IBDState, PeerFlags, Peers, SyncShared};
+use crate::types::{HeaderView, HeadersSyncController, IBDState, PeerFlags, Peers, SyncShared};
 use crate::{
     Status, StatusCode, BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
-    HEADERS_DOWNLOAD_TIMEOUT_BASE, HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER, MAX_HEADERS_LEN,
-    MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, POW_SPACE,
+    MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT,
 };
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug, error, info, metric, trace, warn};
@@ -27,7 +26,6 @@ use ckb_network::{
 use ckb_types::{core, packed, prelude::*};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
-use std::cmp::min;
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -175,13 +173,21 @@ impl Synchronizer {
         self.shared().state().peers()
     }
 
-    pub fn predict_headers_sync_time(&self, header: &core::HeaderView) -> u64 {
-        let now = unix_time_as_millis();
-        let expected_headers = min(
-            MAX_HEADERS_LEN as u64,
-            now.saturating_sub(header.timestamp()) / POW_SPACE,
-        );
-        now + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * expected_headers
+    fn better_tip_header(&self) -> core::HeaderView {
+        let (header, total_difficulty) = {
+            let active_chain = self.shared.active_chain();
+            (
+                active_chain.tip_header(),
+                active_chain.total_difficulty().to_owned(),
+            )
+        };
+        let best_known = self.shared.state().shared_best_header();
+        // is_better_chain
+        if total_difficulty > *best_known.total_difficulty() {
+            header
+        } else {
+            best_known.into_inner()
+        }
     }
 
     //TODO: process block which we don't request
@@ -253,21 +259,21 @@ impl Synchronizer {
     pub fn eviction(&self, nc: &dyn CKBProtocolContext) {
         let mut peer_states = self.peers().state.write();
         let active_chain = self.shared.active_chain();
-        let is_initial_header_sync = self.shared.state().is_initial_header_sync();
         let mut eviction = Vec::new();
+        let better_tip_header = self.better_tip_header();
         for (peer, state) in peer_states.iter_mut() {
             let now = unix_time_as_millis();
 
-            // headers_sync_timeout
-            if let Some(timeout) = state.headers_sync_timeout {
-                if is_initial_header_sync {
-                    if now > timeout && !state.disconnect {
+            if let Some(ref mut controller) = state.headers_sync_controller {
+                let better_tip_ts = better_tip_header.timestamp();
+                if let Some(is_timeout) = controller.is_timeout(better_tip_ts, now) {
+                    if is_timeout && !state.disconnect {
                         eviction.push(*peer);
                         state.disconnect = true;
                         continue;
                     }
                 } else {
-                    state.headers_sync_timeout = None
+                    active_chain.send_getheaders_to_peer(nc, *peer, &better_tip_header);
                 }
             }
 
@@ -356,21 +362,7 @@ impl Synchronizer {
             return;
         }
 
-        let tip = {
-            let (header, total_difficulty) = {
-                (
-                    active_chain.tip_header(),
-                    active_chain.total_difficulty().to_owned(),
-                )
-            };
-            let best_known = self.shared.state().shared_best_header();
-            // is_better_chain
-            if total_difficulty > *best_known.total_difficulty() {
-                header
-            } else {
-                best_known.into_inner()
-            }
-        };
+        let tip = self.better_tip_header();
 
         for peer in peers {
             // Only sync with 1 peer if we're in IBD
@@ -388,8 +380,7 @@ impl Synchronizer {
                 let mut state = self.peers().state.write();
                 if let Some(peer_state) = state.get_mut(&peer) {
                     if !peer_state.sync_started {
-                        let headers_sync_timeout = self.predict_headers_sync_time(&tip);
-                        peer_state.start_sync(headers_sync_timeout);
+                        peer_state.start_sync(HeadersSyncController::from_header(&tip));
                         self.shared()
                             .state()
                             .n_sync_started()
@@ -675,7 +666,10 @@ mod tests {
     use self::block_process::BlockProcess;
     use self::headers_process::HeadersProcess;
     use super::*;
-    use crate::{types::HeaderView, types::PeerState, SyncShared, MAX_TIP_AGE};
+    use crate::{
+        types::{HeaderView, HeadersSyncController, PeerState},
+        SyncShared, MAX_TIP_AGE,
+    };
     use ckb_chain::{chain::ChainService, switch::Switch};
     use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
     use ckb_dao::DaoCalculator;
@@ -1331,24 +1325,28 @@ mod tests {
         let peers = synchronizer.peers();
         // protect should not effect headers_timeout
         {
+            let timeout = HeadersSyncController::new(0, 0, 0, 0, false);
+            let not_timeout =
+                HeadersSyncController::new(MAX_TIP_AGE * 2, 0, MAX_TIP_AGE * 2, 0, false);
+
             let mut state = peers.state.write();
             let mut state_0 = PeerState::default();
             state_0.peer_flags.is_protect = true;
             state_0.peer_flags.is_outbound = true;
-            state_0.headers_sync_timeout = Some(0);
+            state_0.headers_sync_controller = Some(timeout);
 
             let mut state_1 = PeerState::default();
             state_1.peer_flags.is_outbound = true;
-            state_1.headers_sync_timeout = Some(0);
+            state_1.headers_sync_controller = Some(timeout);
 
             let mut state_2 = PeerState::default();
             state_2.peer_flags.is_whitelist = true;
             state_2.peer_flags.is_outbound = true;
-            state_2.headers_sync_timeout = Some(0);
+            state_2.headers_sync_controller = Some(timeout);
 
             let mut state_3 = PeerState::default();
             state_3.peer_flags.is_outbound = true;
-            state_3.headers_sync_timeout = Some(MAX_TIP_AGE * 2);
+            state_3.headers_sync_controller = Some(not_timeout);
 
             state.insert(0.into(), state_0);
             state.insert(1.into(), state_1);
@@ -1386,41 +1384,41 @@ mod tests {
         let network_context = mock_network_context(7);
         let peers = synchronizer.peers();
         //6 peers do not trigger header sync timeout
-        let headers_sync_timeout = MAX_TIP_AGE * 2;
+        let not_timeout = HeadersSyncController::new(MAX_TIP_AGE * 2, 0, MAX_TIP_AGE * 2, 0, false);
         let sync_protected_peer = 0.into();
         {
             let mut state = peers.state.write();
             let mut state_0 = PeerState::default();
             state_0.peer_flags.is_protect = true;
             state_0.peer_flags.is_outbound = true;
-            state_0.headers_sync_timeout = Some(headers_sync_timeout);
+            state_0.headers_sync_controller = Some(not_timeout);
 
             let mut state_1 = PeerState::default();
             state_1.peer_flags.is_protect = true;
             state_1.peer_flags.is_outbound = true;
-            state_1.headers_sync_timeout = Some(headers_sync_timeout);
+            state_1.headers_sync_controller = Some(not_timeout);
 
             let mut state_2 = PeerState::default();
             state_2.peer_flags.is_protect = true;
             state_2.peer_flags.is_outbound = true;
-            state_2.headers_sync_timeout = Some(headers_sync_timeout);
+            state_2.headers_sync_controller = Some(not_timeout);
 
             let mut state_3 = PeerState::default();
             state_3.peer_flags.is_outbound = true;
-            state_3.headers_sync_timeout = Some(headers_sync_timeout);
+            state_3.headers_sync_controller = Some(not_timeout);
 
             let mut state_4 = PeerState::default();
             state_4.peer_flags.is_outbound = true;
-            state_4.headers_sync_timeout = Some(headers_sync_timeout);
+            state_4.headers_sync_controller = Some(not_timeout);
 
             let mut state_5 = PeerState::default();
             state_5.peer_flags.is_outbound = true;
-            state_5.headers_sync_timeout = Some(headers_sync_timeout);
+            state_5.headers_sync_controller = Some(not_timeout);
 
             let mut state_6 = PeerState::default();
             state_6.peer_flags.is_whitelist = true;
             state_6.peer_flags.is_outbound = true;
-            state_6.headers_sync_timeout = Some(headers_sync_timeout);
+            state_6.headers_sync_controller = Some(not_timeout);
 
             state.insert(0.into(), state_0);
             state.insert(1.into(), state_1);
@@ -1441,7 +1439,7 @@ mod tests {
                 .write()
                 .get_mut(&sync_protected_peer)
                 .unwrap()
-                .start_sync(headers_sync_timeout);
+                .start_sync(not_timeout);
             synchronizer
                 .shared()
                 .state()


### PR DESCRIPTION
### Purpose

To avoid possible performance issues on headers synchronization.

---

### Possible Issues

#### The Timeout is Ambiguous

- [The first commit introduced the `headers_sync_timeout` treat `headers_sync_timeout` as a **total** timeout for all headers.](https://github.com/nervosnetwork/ckb/commit/b7db483cb519c37d15dfbd868d4621091c61d6a2#diff-af95c26bdbe8ee3013958651bd249995R143-R148)

- [But, the commit add a upper bound to `estimated_headers_count`, try to treat the timeout as a **partial** timeout, but didn't finish it.](https://github.com/nervosnetwork/ckb/commit/f14c8dc0fb5bd77e5935e818d2340f38c3802ab6#diff-67a34c19141a7c62f189385b4c2bacf7R181-R185)

#### The Timeout Could be Lacked

The timeout has upper bound, but the headers need to sync doesn't have a upper bound, it could be a fatal error in someday.

- Current timeout is `base_timeout + estimated_headers_count * timeout_per_header`: https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/lib.rs#L50-L53 https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/mod.rs#L128

- And, the `estimated_headers_count` has a upper bound: https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/mod.rs#L124-L127 https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/lib.rs#L24

So, if the timeout wasn't update after set, **the max timeout is 362 seconds for syncing all headers**.

  - There are only 3 conditions that will update the `headers_sync_timeout` in whole project:

    - [Receive an empty SendHeaders](https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/headers_process.rs#L147-L158
)
    - [The difference of current time and tip header timestamp smaller than](https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/mod.rs#L217-L225) [`MAX_TIP_AGE`](https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/types.rs#L966-L968) 

    - [Suspend syncing](https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/types.rs#L130-L135)

#### Timeout could be Disable by an Empty `SendHeaders`

https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/headers_process.rs#L147-L158

#### The Best Known Tip Header Wouldn't Update Again in IBD

At first time when do headers sync, we will know the current best header, but it will not update in IBD again. (I did a test for this: print the best known tip header, it was a same value during the IBD.)

So if IBD is too slow, the best known tip header will be drop behind real tip header too much.

---

### My Solution

- Not use `base_timeout`.
- Check both of **the global average speed** and **the instantaneous speed** for headers synchronization.
- Only check speeds after a fixed interval, to avoid a too small time range for checking speeds.
- Not reset headers sync timeout during IBD.
- Send `GetHeaders` if the best known tip header was drop behind the estimated real tip header too much.

---

### Additional Explanations

#### Why use Both Global Average Speed and Instantaneous Speed

- A fixed timeout isn't enough for all conditions.
  - If `estimated_headers_count` is too small , we shouldn't care about the timeout / speed;
  - If `estimated_headers_count` is big enough, we should check the timeout / speed again;
  - If only check the timeout for a `SendHeaders` message, not check how many headers in a `SendHeaders` message, the sync node can send only 1 header in each SendHeaders, then need `timeout * tip-number` milliseconds to sync to the tip.
- If we only check the global average speed, if the headers sync is fast at beginning, but it became slow or it was stopped after enough time, the global average speed will still keep elevated in a long period.
- If we only check the instantaneous speed, the effect of a unstable network will be increased.
  If a node send headers very fast in a long period, we should tolerate more bias for the instantaneous speed in a short period. 

#### What does `expected_headers_per_sec * inspect_window * POW_INTERVAL / 1000` Mean

The old code estimates a height number for now: https://github.com/nervosnetwork/ckb/blob/26e2599b90063fdde209039b2c6e8c69b9b96bb5/sync/src/synchronizer/mod.rs#L126

The current code use `time-in-blockchain` instead of it.

So, `let y = expected_headers_per_sec * x * POW_INTERVAL / 1000` means:
after `x` milliseconds in reality, the timestamp in tip header should be increase `y` milliseconds.

#### Preset Parameters

- Lowest Global Average Speed: `300 KiB/second`
  Sync 1 year headers in blockchain will be in 32.85 minutes in reality
- Lowest Instantaneous Speed: `75.0 KiB/second`