### PR TITLE
chore: export OutputsValidator

### DIFF
--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -1,6 +1,6 @@
 use crate::error::RPCError;
 use ckb_chain_spec::consensus::Consensus;
-use ckb_jsonrpc_types::{Transaction, TxPoolInfo};
+use ckb_jsonrpc_types::{OutputsValidator, Transaction, TxPoolInfo};
 use ckb_logger::error;
 use ckb_network::PeerIndex;
 use ckb_script::IllTransactionChecker;
@@ -11,16 +11,8 @@ use ckb_types::{core, packed, prelude::*, H256};
 use ckb_verification::{Since, SinceMetric};
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::sync::Arc;
-
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum OutputsValidator {
-    Default,
-    Passthrough,
-}
 
 #[rpc(server)]
 pub trait PoolRpc {

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::indexer::{
     CellTransaction, LiveCell, LockHashCapacity, LockHashIndexState, TransactionPoint,
 };
 pub use self::net::{BannedAddr, Node, NodeAddress};
-pub use self::pool::TxPoolInfo;
+pub use self::pool::{OutputsValidator, TxPoolInfo};
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::sync::PeerState;
 pub use self::uints::{Uint128, Uint32, Uint64};

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -11,3 +11,10 @@ pub struct TxPoolInfo {
     pub min_fee_rate: Uint64,
     pub last_txs_updated_at: Timestamp,
 }
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputsValidator {
+    Default,
+    Passthrough,
+}


### PR DESCRIPTION
### The Issue
- `OutputsValidator` is in `ckb_rpc::module::pool`.
- `OutputsValidator` is `public` but `ckb_rpc::module::pool` is private.
- `OutputsValidator` is not re-exported.
- So, no one can use `OutputsValidator`.

### Changes
- Move `OutputsValidator` to `ckb-jsonrpc-types`
- Export `OutputsValidator`