### PR TITLE
feat: add an option to control how many blocks the miner has to mine

### DIFF
--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -28,7 +28,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
 
     match app_matches.subcommand() {
         (cli::CMD_RUN, Some(matches)) => subcommand::run(setup.run(&matches)?, version),
-        (cli::CMD_MINER, _) => subcommand::miner(setup.miner()?),
+        (cli::CMD_MINER, Some(matches)) => subcommand::miner(setup.miner(&matches)?),
         (cli::CMD_PROF, Some(matches)) => subcommand::profile(setup.prof(&matches)?),
         (cli::CMD_EXPORT, Some(matches)) => subcommand::export(setup.export(&matches)?),
         (cli::CMD_IMPORT, Some(matches)) => subcommand::import(setup.import(&matches)?),

--- a/ckb-bin/src/subcommand/miner.rs
+++ b/ckb-bin/src/subcommand/miner.rs
@@ -8,7 +8,13 @@ pub fn miner(args: MinerArgs) -> Result<(), ExitCode> {
     let MinerConfig { client, workers } = args.config;
 
     let mut client = Client::new(new_work_tx, client);
-    let mut miner = Miner::new(args.pow_engine, client.clone(), new_work_rx, &workers);
+    let mut miner = Miner::new(
+        args.pow_engine,
+        client.clone(),
+        new_work_rx,
+        &workers,
+        args.limit,
+    );
 
     ckb_memory_tracker::track_current_process(args.memory_tracker.interval);
 

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -36,6 +36,7 @@ pub struct MinerArgs {
     pub config: MinerConfig,
     pub pow_engine: Arc<dyn PowEngine>,
     pub memory_tracker: MemoryTrackerConfig,
+    pub limit: u128,
 }
 
 pub struct StatsArgs {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -34,6 +34,7 @@ pub const ARG_BA_ADVANCED: &str = "ba-advanced";
 pub const ARG_FROM: &str = "from";
 pub const ARG_TO: &str = "to";
 pub const ARG_ALL: &str = "all";
+pub const ARG_LIMIT: &str = "limit";
 pub const ARG_DATABASE: &str = "database";
 pub const ARG_INDEXER: &str = "indexer";
 pub const ARG_NETWORK: &str = "network";
@@ -85,7 +86,18 @@ fn run() -> App<'static, 'static> {
 }
 
 fn miner() -> App<'static, 'static> {
-    SubCommand::with_name(CMD_MINER).about("Runs ckb miner")
+    SubCommand::with_name(CMD_MINER)
+        .about("Runs ckb miner")
+        .arg(
+            Arg::with_name(ARG_LIMIT)
+                .short("l")
+                .long(ARG_LIMIT)
+                .takes_value(true)
+                .help(
+                    "Exit after how many nonces found; \
+            0 means the miner will never exit. [default: 0]",
+                ),
+        )
 }
 
 fn reset_data() -> App<'static, 'static> {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -105,16 +105,24 @@ impl Setup {
         })
     }
 
-    pub fn miner(self) -> Result<MinerArgs, ExitCode> {
+    pub fn miner<'m>(self, matches: &ArgMatches<'m>) -> Result<MinerArgs, ExitCode> {
         let spec = self.chain_spec()?;
         let memory_tracker = self.config.memory_tracker().to_owned();
         let config = self.config.into_miner()?;
         let pow_engine = spec.pow_engine();
+        let limit = match value_t!(matches, cli::ARG_LIMIT, u128) {
+            Ok(l) => l,
+            Err(ref e) if e.kind == ErrorKind::ArgumentNotFound => 0,
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
 
         Ok(MinerArgs {
             pow_engine,
             config: config.miner,
             memory_tracker,
+            limit,
         })
     }
 


### PR DESCRIPTION
### Usage

```bash
ckb miner -C . --limit 10 # Exit after 10 nonces found
ckb miner -C . -l 5       # Exit after 5 nonces found
ckb miner -C .            # Run forever
ckb miner -C . --limit 0  # Run forever, too
```

Ref:
- [CKB-Cli Issue-256: Mining with CKB-Cli (for dev chain)](https://github.com/nervosnetwork/ckb-cli/issues/259)