### PR TITLE
fix: wait for RPC server to cleanup on shutdown

### DIFF
--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -10,10 +10,31 @@ use jsonrpc_tcp_server;
 use jsonrpc_ws_server;
 use std::net::ToSocketAddrs;
 
+// Wrapper for HTTP and WS servers that makes sure they are properly shut down.
+pub(crate) mod waiting {
+    pub struct HttpServer(pub jsonrpc_http_server::Server);
+    impl HttpServer {
+        pub fn close(self) {
+            self.0.close_handle().close();
+            self.0.wait();
+        }
+    }
+
+    pub struct WsServer(pub Option<jsonrpc_ws_server::Server>);
+    impl WsServer {
+        pub fn close(mut self) {
+            if let Some(server) = self.0.take() {
+                server.close_handle().close();
+                let _ = server.wait();
+            }
+        }
+    }
+}
+
 pub struct RpcServer {
-    pub(crate) http: jsonrpc_http_server::Server,
+    pub(crate) http: waiting::HttpServer,
     pub(crate) tcp: Option<jsonrpc_tcp_server::Server>,
-    pub(crate) ws: Option<jsonrpc_ws_server::Server>,
+    pub(crate) ws: waiting::WsServer,
 }
 
 impl RpcServer {
@@ -91,16 +112,18 @@ impl RpcServer {
             .expect("Start Jsonrpc WebSocket service")
         });
 
-        RpcServer { http, tcp, ws }
+        RpcServer {
+            tcp,
+            http: waiting::HttpServer(http),
+            ws: waiting::WsServer(ws),
+        }
     }
 
     pub fn close(self) {
         self.http.close();
+        self.ws.close();
         if let Some(tcp) = self.tcp {
             tcp.close();
-        }
-        if let Some(ws) = self.ws {
-            ws.close();
         }
     }
 }

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -303,9 +303,9 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         .start_http(&"127.0.0.1:0".parse().unwrap())
         .expect("JsonRpc initialize");
     let rpc_server = RpcServer {
-        http,
+        http: crate::server::waiting::HttpServer(http),
         tcp: None,
-        ws: None,
+        ws: crate::server::waiting::WsServer(None),
     };
 
     (shared, chain_controller, rpc_server)
@@ -500,8 +500,8 @@ fn test_rpc() {
     let client = reqwest::Client::new();
     let uri = format!(
         "http://{}:{}/",
-        server.http.address().ip(),
-        server.http.address().port()
+        server.http.0.address().ip(),
+        server.http.0.address().port()
     );
 
     // Assert the params of jsonrpc requests


### PR DESCRIPTION
RPC servers currently don't wait for threads to cleanup, leading rpc-test to segfaults.
Should be reverted once upstream fix is released.
