### PR TITLE
fix: orphan_block_pool should record block origin

### DIFF
--- a/sync/src/orphan_block_pool.rs
+++ b/sync/src/orphan_block_pool.rs
@@ -1,14 +1,16 @@
+use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
 use ckb_util::RwLock;
 use std::collections::{HashMap, VecDeque};
 
 pub type ParentHash = packed::Byte32;
+pub type OrphanBlock = (PeerIndex, core::BlockView);
 
 // NOTE: Never use `LruCache` as container. We have to ensure synchronizing between
 // orphan_block_pool and block_status_map, but `LruCache` would prune old items implicitly.
 #[derive(Default)]
 pub struct OrphanBlockPool {
-    blocks: RwLock<HashMap<ParentHash, HashMap<packed::Byte32, core::BlockView>>>,
+    blocks: RwLock<HashMap<ParentHash, HashMap<packed::Byte32, OrphanBlock>>>,
     parents: RwLock<HashMap<packed::Byte32, ParentHash>>,
 }
 
@@ -24,23 +26,23 @@ impl OrphanBlockPool {
     }
 
     /// Insert orphaned block, for which we have already requested its parent block
-    pub fn insert(&self, block: core::BlockView) {
+    pub fn insert(&self, peer: PeerIndex, block: core::BlockView) {
         let hash = block.header().hash();
         let parent_hash = block.data().header().raw().parent_hash();
         self.blocks
             .write()
             .entry(parent_hash.clone())
             .or_insert_with(HashMap::default)
-            .insert(hash.clone(), block);
+            .insert(hash.clone(), (peer, block));
         self.parents.write().insert(hash, parent_hash);
     }
 
-    pub fn remove_blocks_by_parent(&self, hash: &packed::Byte32) -> Vec<core::BlockView> {
+    pub fn remove_blocks_by_parent(&self, hash: &packed::Byte32) -> Vec<OrphanBlock> {
         let mut guard = self.blocks.write();
         let mut queue: VecDeque<packed::Byte32> = VecDeque::new();
         queue.push_back(hash.to_owned());
 
-        let mut removed: Vec<core::BlockView> = Vec::new();
+        let mut removed: Vec<OrphanBlock> = Vec::new();
         while let Some(parent_hash) = queue.pop_front() {
             if let Some(orphaned) = guard.remove(&parent_hash) {
                 let (hashes, blocks): (Vec<_>, Vec<_>) = orphaned.into_iter().unzip();
@@ -56,23 +58,18 @@ impl OrphanBlockPool {
     }
 
     pub fn get_block(&self, hash: &packed::Byte32) -> Option<core::BlockView> {
-        self.parents
-            .write()
-            .get(hash)
-            .map(|parent_hash| {
-                self.blocks
-                    .write()
-                    .get(parent_hash)
-                    .map(|value| value.get(hash).cloned())
-                    .unwrap_or(None)
-            })
-            .unwrap_or(None)
+        self.parents.write().get(hash).and_then(|parent_hash| {
+            self.blocks
+                .write()
+                .get(parent_hash)
+                .and_then(|value| value.get(hash).map(|v| v.1.clone()))
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::OrphanBlockPool;
+    use super::{OrphanBlockPool, PeerIndex};
     use ckb_chain_spec::consensus::ConsensusBuilder;
     use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
     use ckb_types::prelude::*;
@@ -99,12 +96,13 @@ mod tests {
         for _ in 1..block_number {
             let new_block = gen_block(&parent);
             blocks.push(new_block.clone());
-            pool.insert(new_block.clone());
+            pool.insert(PeerIndex::new(0usize), new_block.clone());
             parent = new_block.header();
         }
 
         let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
-        let orphan: HashSet<BlockView> = HashSet::from_iter(orphan.into_iter());
+        let orphan: HashSet<BlockView> =
+            HashSet::from_iter(orphan.into_iter().map(|(_, block)| block));
         let block: HashSet<BlockView> = HashSet::from_iter(blocks.into_iter());
         assert_eq!(orphan, block)
     }


### PR DESCRIPTION
## Issue
Currently, `last_common_header` may be incorrectly updated when inserting block from the orphan pool.
https://github.com/nervosnetwork/ckb/blob/0911bdce06aff45df4162dec10c577ff26a9fa63/sync/src/types.rs#L738-L753

## Proposed Changes
Record block origin in the orphan pool.

