### PR TITLE
feat: Optimize block download tasks with a simple task scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "snap",
  "tempfile",
  "tentacle",
- "tokio 0.2.17",
+ "tokio 0.2.18",
  "tokio-util",
 ]
 
@@ -3982,7 +3982,7 @@ dependencies = [
  "molecule 0.5.0",
  "tentacle-multiaddr",
  "tentacle-secio",
- "tokio 0.2.17",
+ "tokio 0.2.18",
  "tokio-util",
  "tokio-yamux",
  "winapi 0.3.8",
@@ -4017,7 +4017,7 @@ dependencies = [
  "rand 0.7.0",
  "ring",
  "secp256k1 0.17.2",
- "tokio 0.2.17",
+ "tokio 0.2.18",
  "tokio-util",
  "unsigned-varint",
 ]
@@ -4145,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fb9142eb6e9cc37f4f29144e62618440b149a138eee01a7bbe9b9226aaf17c"
+checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
 dependencies = [
  "bytes 0.5.4",
  "futures-core",
@@ -4349,7 +4349,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.17",
+ "tokio 0.2.18",
 ]
 
 [[package]]
@@ -4361,7 +4361,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "log 0.4.8",
- "tokio 0.2.17",
+ "tokio 0.2.18",
  "tokio-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
+ "crossbeam-channel",
  "failure",
  "faketime",
  "futures 0.3.4",

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -66,6 +66,9 @@ pub trait CKBProtocolContext: Send {
     fn send_paused(&self) -> bool;
     // Other methods
     fn protocol_id(&self) -> ProtocolId;
+    fn p2p_control(&self) -> Option<&ServiceControl> {
+        None
+    }
 }
 
 pub trait CKBProtocolHandler: Sync + Send {
@@ -398,6 +401,10 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
 
     fn send_paused(&self) -> bool {
         self.send_paused
+    }
+
+    fn p2p_control(&self) -> Option<&ServiceControl> {
+        Some(&self.p2p_control)
     }
 }
 

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -24,6 +24,7 @@ sentry = "0.16.0"
 futures = "0.3"
 ckb-error = {path = "../error"}
 ckb-tx-pool = { path = "../tx-pool" }
+crossbeam-channel = "0.3"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -26,9 +26,14 @@ pub const MAX_INVENTORY_LEN: usize = 50_000;
 pub const MAX_SCHEDULED_LEN: usize = 4 * 1024;
 pub const MAX_BLOCKS_TO_ANNOUNCE: usize = 8;
 pub const MAX_UNCONNECTING_HEADERS: usize = 10;
-pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
 pub const MAX_TIP_AGE: u64 = 24 * 60 * 60 * 1000;
 pub const STALE_RELAY_AGE_LIMIT: u64 = 30 * 24 * 60 * 60 * 1000;
+
+/* About Download Scheduler */
+pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
+pub const FIRST_LEVEL_MAX: usize = 32;
+pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
+pub const CHECK_POINT_WINDOW: u64 = (MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4) as u64;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -51,7 +51,6 @@ impl Into<ProtocolId> for NetworkProtocol {
 pub const HEADERS_DOWNLOAD_TIMEOUT_BASE: u64 = 6 * 60 * 1000; // 6 minutes
 pub const HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER: u64 = 1; // 1ms/header
 pub const POW_SPACE: u64 = 10_000; // 10s
-pub const MAX_PEERS_PER_BLOCK: usize = 2;
 
 // Protect at least this many outbound peers from disconnection due to slow
 // behind headers chain.

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -61,6 +61,14 @@ impl<'a> BlockTransactionsProcess<'a> {
         let missing_uncles: Vec<u32>;
         let mut collision = false;
 
+        {
+            self.relayer
+                .shared
+                .state()
+                .write_inflight_blocks()
+                .remove_compact(self.peer, &block_hash);
+        }
+
         if let Entry::Occupied(mut pending) = shared
             .state()
             .pending_compact_blocks()
@@ -135,18 +143,24 @@ impl<'a> BlockTransactionsProcess<'a> {
 
                 assert!(!missing_transactions.is_empty() || !missing_uncles.is_empty());
 
-                let content = packed::GetBlockTransactions::new_builder()
-                    .block_hash(block_hash.clone())
-                    .indexes(missing_transactions.pack())
-                    .uncle_indexes(missing_uncles.pack())
-                    .build();
-                let message = packed::RelayMessage::new_builder().set(content).build();
+                if shared
+                    .state()
+                    .write_inflight_blocks()
+                    .compact_reconstruct(self.peer, block_hash.clone())
+                {
+                    let content = packed::GetBlockTransactions::new_builder()
+                        .block_hash(block_hash.clone())
+                        .indexes(missing_transactions.pack())
+                        .uncle_indexes(missing_uncles.pack())
+                        .build();
+                    let message = packed::RelayMessage::new_builder().set(content).build();
 
-                if let Err(err) = self.nc.send_message_to(self.peer, message.as_bytes()) {
-                    return StatusCode::Network
-                        .with_context(format!("Send GetBlockTransactions error: {:?}", err,));
+                    if let Err(err) = self.nc.send_message_to(self.peer, message.as_bytes()) {
+                        return StatusCode::Network
+                            .with_context(format!("Send GetBlockTransactions error: {:?}", err,));
+                    }
+                    crate::relayer::log_sent_metric(message.to_enum().item_name());
                 }
-                crate::relayer::log_sent_metric(message.to_enum().item_name());
 
                 mem::replace(expected_transaction_indexes, missing_transactions);
                 mem::replace(expected_uncle_indexes, missing_uncles);

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -122,12 +122,12 @@ impl<'a> CompactBlockProcess<'a> {
 
         let parent = parent.unwrap();
 
-        if let Some(flight) = shared
+        if let Some(peers) = shared
             .state()
             .read_inflight_blocks()
-            .inflight_state_by_block(&block_hash)
+            .inflight_compact_by_block(&block_hash)
         {
-            if flight.peers.contains(&self.peer) {
+            if peers.contains(&self.peer) {
                 debug_target!(
                     crate::LOG_TARGET_RELAY,
                     "discard already in-flight compact block {}",
@@ -240,7 +240,7 @@ impl<'a> CompactBlockProcess<'a> {
         if !shared
             .state()
             .write_inflight_blocks()
-            .insert(self.peer, block_hash.clone())
+            .compact_reconstruct(self.peer, block_hash.clone())
         {
             debug_target!(
                 crate::LOG_TARGET_RELAY,

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -2,7 +2,6 @@ use crate::block_status::BlockStatus;
 use crate::relayer::compact_block_process::CompactBlockProcess;
 use crate::relayer::tests::helper::{build_chain, new_header_builder, MockProtocalContext};
 use crate::types::InflightBlocks;
-use crate::MAX_PEERS_PER_BLOCK;
 use crate::{NetworkProtocol, Status, StatusCode};
 use ckb_network::PeerIndex;
 use ckb_store::ChainStore;
@@ -201,7 +200,7 @@ fn test_already_in_flight() {
 
     // Already in flight
     let mut in_flight_blocks = InflightBlocks::default();
-    in_flight_blocks.insert(peer_index, block.header().hash());
+    in_flight_blocks.compact_reconstruct(peer_index, block.header().hash());
     *relayer.shared.state().write_inflight_blocks() = in_flight_blocks;
 
     let compact_block_process = CompactBlockProcess::new(
@@ -349,8 +348,8 @@ fn test_inflight_blocks_reach_limit() {
     // in_flight_blocks is full
     {
         let mut in_flight_blocks = InflightBlocks::default();
-        for i in 0..=MAX_PEERS_PER_BLOCK {
-            in_flight_blocks.insert(i.into(), block.header().hash());
+        for i in 0..=2 {
+            in_flight_blocks.compact_reconstruct(i.into(), block.header().hash());
         }
         *relayer.shared.state().write_inflight_blocks() = in_flight_blocks;
     }

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -1,6 +1,6 @@
 use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
-use crate::{Status, StatusCode, MAX_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
+use crate::{Status, StatusCode, INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
 use ckb_logger::debug;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{packed, prelude::*};
@@ -29,7 +29,7 @@ impl<'a> GetBlocksProcess<'a> {
 
     pub fn execute(self) -> Status {
         let block_hashes = self.message.block_hashes();
-        // use MAX_HEADERS_LEN as limit, we may increase the value of MAX_BLOCKS_IN_TRANSIT_PER_PEER in the future
+        // use MAX_HEADERS_LEN as limit, we may increase the value of INIT_BLOCKS_IN_TRANSIT_PER_PEER in the future
         if block_hashes.len() > MAX_HEADERS_LEN {
             return StatusCode::ProtocolMessageIsMalformed.with_context(format!(
                 "BlockHashes count({}) > MAX_HEADERS_LEN({})",
@@ -39,7 +39,7 @@ impl<'a> GetBlocksProcess<'a> {
         }
         let active_chain = self.synchronizer.shared.active_chain();
 
-        for block_hash in block_hashes.iter().take(MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        for block_hash in block_hashes.iter().take(INIT_BLOCKS_IN_TRANSIT_PER_PEER) {
             debug!("get_blocks {} from peer {:?}", block_hash, self.peer);
             let block_hash = block_hash.to_entity();
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -20,12 +20,14 @@ use crate::{
 };
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug, error, info, metric, trace, warn};
-use ckb_network::{bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
+use ckb_network::{
+    bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex, ServiceControl,
+};
 use ckb_types::{core, packed, prelude::*};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::cmp::min;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -39,15 +41,74 @@ const SYNC_NOTIFY_INTERVAL: Duration = Duration::from_millis(200);
 const IBD_BLOCK_FETCH_INTERVAL: Duration = Duration::from_millis(40);
 const NOT_IBD_BLOCK_FETCH_INTERVAL: Duration = Duration::from_millis(200);
 
+enum FetchCMD {
+    Fetch(Vec<PeerIndex>),
+    Shutdown,
+}
+
+struct BlockFetchCMD {
+    can_fetch_block: Arc<AtomicBool>,
+    sync: Synchronizer,
+    p2p_control: ServiceControl,
+    recv: crossbeam_channel::Receiver<FetchCMD>,
+}
+
+impl BlockFetchCMD {
+    fn run(&self) {
+        while let Ok(cmd) = self.recv.recv() {
+            match cmd {
+                FetchCMD::Fetch(peers) => {
+                    self.can_fetch_block.store(false, Ordering::Release);
+                    for peer in peers {
+                        if let Some(fetch) =
+                            BlockFetcher::new(&self.sync, peer, IBDState::In).fetch()
+                        {
+                            for item in fetch {
+                                BlockFetchCMD::send_getblocks(item, &self.p2p_control, peer);
+                            }
+                        }
+                    }
+                    self.can_fetch_block.store(true, Ordering::Release)
+                }
+                FetchCMD::Shutdown => break,
+            }
+        }
+    }
+
+    fn send_getblocks(v_fetch: Vec<packed::Byte32>, nc: &ServiceControl, peer: PeerIndex) {
+        let content = packed::GetBlocks::new_builder()
+            .block_hashes(v_fetch.clone().pack())
+            .build();
+        let message = packed::SyncMessage::new_builder().set(content).build();
+
+        debug!("send_getblocks len={:?} to peer={}", v_fetch.len(), peer);
+        if let Err(err) = nc.send_message_to(
+            peer,
+            crate::NetworkProtocol::SYNC.into(),
+            message.as_bytes(),
+        ) {
+            debug!("synchronizer send GetBlocks error: {:?}", err);
+        }
+        crate::synchronizer::log_sent_metric(message.to_enum().item_name());
+    }
+}
+
 #[derive(Clone)]
 pub struct Synchronizer {
     chain: ChainController,
     pub shared: Arc<SyncShared>,
+    can_fetch_block: Arc<AtomicBool>,
+    fetch_channel: Option<crossbeam_channel::Sender<FetchCMD>>,
 }
 
 impl Synchronizer {
     pub fn new(chain: ChainController, shared: Arc<SyncShared>) -> Synchronizer {
-        Synchronizer { chain, shared }
+        Synchronizer {
+            chain,
+            shared,
+            can_fetch_block: Arc::new(AtomicBool::new(true)),
+            fetch_channel: None,
+        }
     }
 
     pub fn shared(&self) -> &Arc<SyncShared> {
@@ -163,8 +224,8 @@ impl Synchronizer {
         &self,
         peer: PeerIndex,
         ibd: IBDState,
-    ) -> Option<Vec<packed::Byte32>> {
-        BlockFetcher::new(self.clone(), peer, ibd).fetch()
+    ) -> Option<Vec<Vec<packed::Byte32>>> {
+        BlockFetcher::new(&self, peer, ibd).fetch()
     }
 
     fn on_connected(&self, nc: &dyn CKBProtocolContext, peer: PeerIndex) {
@@ -357,33 +418,111 @@ impl Synchronizer {
         }
     }
 
-    fn find_blocks_to_fetch(&self, nc: &dyn CKBProtocolContext, ibd: IBDState) {
+    fn find_blocks_to_fetch(&mut self, nc: &dyn CKBProtocolContext, ibd: IBDState) {
+        let tip = self.shared.active_chain().tip_number();
+
+        let disconnect_list = {
+            let mut list = self.shared().state().write_inflight_blocks().prune(tip);
+            if let IBDState::In = ibd {
+                // best known < tip and in IBD state, these node can be disconnect
+                list.extend(
+                    self.shared
+                        .state()
+                        .peers()
+                        .get_best_known_less_than_tip(tip),
+                )
+            };
+            list
+        };
+
+        for peer in disconnect_list.iter() {
+            if self
+                .peers()
+                .get_flag(*peer)
+                .map(|flag| flag.is_whitelist || flag.is_protect)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if let Err(err) = nc.disconnect(*peer, "sync disconnect") {
+                debug!("synchronizer disconnect error: {:?}", err);
+            }
+        }
+
+        if !self.can_fetch_block.load(Ordering::Acquire) {
+            return;
+        }
+
         let peers: Vec<PeerIndex> = {
-            self.peers()
+            let state = &self
+                .shared
+                .state()
+                .read_inflight_blocks()
+                .download_schedulers;
+            let mut peers: Vec<PeerIndex> = self
+                .peers()
                 .state
                 .read()
                 .iter()
-                .filter(|(_, state)| match ibd {
-                    IBDState::In => {
-                        state.peer_flags.is_outbound
-                            || state.peer_flags.is_whitelist
-                            || state.peer_flags.is_protect
+                .filter(|(id, state)| {
+                    if disconnect_list.contains(id) {
+                        return false;
+                    };
+                    match ibd {
+                        IBDState::In => {
+                            state.peer_flags.is_outbound
+                                || state.peer_flags.is_whitelist
+                                || state.peer_flags.is_protect
+                        }
+                        IBDState::Out => state.sync_started,
                     }
-                    IBDState::Out => state.sync_started,
                 })
                 .map(|(peer_id, _)| peer_id)
                 .cloned()
-                .collect()
+                .collect();
+            peers.sort_by_key(|id| {
+                state
+                    .get(id)
+                    .map(|d| d.task_count())
+                    .unwrap_or(crate::MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+            });
+            peers
         };
 
         trace!("poll find_blocks_to_fetch select peers");
-        {
-            self.shared().state().write_inflight_blocks().prune();
-        }
-        for peer in peers {
-            if let Some(fetch) = self.get_blocks_to_fetch(peer, ibd) {
-                if !fetch.is_empty() {
-                    self.send_getblocks(fetch, nc, peer);
+        // fetch use a lot of cpu time, especially in ibd state
+        match nc.p2p_control() {
+            Some(raw) if ibd.into() => match self.fetch_channel {
+                Some(ref send) => send.send(FetchCMD::Fetch(peers)).unwrap(),
+                None => {
+                    let p2p_control = raw.clone();
+                    let sync = self.clone();
+                    let can_fetch_block = Arc::clone(&self.can_fetch_block);
+                    let (sender, recv) = crossbeam_channel::bounded(2);
+                    sender.send(FetchCMD::Fetch(peers)).unwrap();
+                    self.fetch_channel = Some(sender);
+                    ::std::thread::spawn(move || {
+                        BlockFetchCMD {
+                            sync,
+                            p2p_control,
+                            recv,
+                            can_fetch_block,
+                        }
+                        .run();
+                    });
+                }
+            },
+            _ => {
+                if let Some(sender) = self.fetch_channel.take() {
+                    sender.send(FetchCMD::Shutdown).unwrap();
+                }
+
+                for peer in peers {
+                    if let Some(fetch) = self.get_blocks_to_fetch(peer, ibd) {
+                        for item in fetch {
+                            self.send_getblocks(item, nc, peer);
+                        }
+                    }
                 }
             }
         }
@@ -1149,16 +1288,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            blocks_to_fetch.first().unwrap(),
+            blocks_to_fetch[0].first().unwrap(),
             &shared2.store().get_block_hash(193).unwrap()
         );
         assert_eq!(
-            blocks_to_fetch.last().unwrap(),
+            blocks_to_fetch[0].last().unwrap(),
             &shared2.store().get_block_hash(200).unwrap()
         );
 
         let mut fetched_blocks = Vec::new();
-        for block_hash in &blocks_to_fetch {
+        for block_hash in &blocks_to_fetch[0] {
             fetched_blocks.push(shared2.store().get_block(block_hash).unwrap());
         }
 
@@ -1176,7 +1315,7 @@ mod tests {
                 .get_last_common_header(peer1)
                 .unwrap()
                 .hash(),
-            blocks_to_fetch.last().unwrap()
+            blocks_to_fetch[0].last().unwrap()
         );
     }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -483,9 +483,9 @@ impl Synchronizer {
             peers.sort_by_key(|id| {
                 state
                     .get(id)
-                    .map(|d| d.task_count())
-                    .unwrap_or(crate::MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+                    .map_or(crate::INIT_BLOCKS_IN_TRANSIT_PER_PEER, |d| d.task_count())
             });
+            peers.reverse();
             peers
         };
 

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -9,25 +9,21 @@ use std::iter::FromIterator;
 fn inflight_blocks_count() {
     let mut inflight_blocks = InflightBlocks::default();
 
-    // allow 2 peer for one block
-    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.insert(2.into(), h256!("0x1").pack()));
-    assert!(!inflight_blocks.insert(3.into(), h256!("0x1").pack()));
+    // don't allow 2 peer for one block
+    assert!(inflight_blocks.insert(2.into(), h256!("0x1").pack(), 1));
+    assert!(!inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
 
     // peer 1 inflight
-    assert!(!inflight_blocks.insert(1.into(), h256!("0x1").pack()));
+    assert!(!inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
 
-    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack()));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack(), 2));
 
     assert_eq!(inflight_blocks.total_inflight_count(), 2); // 0x1 0x2
-    assert_eq!(inflight_blocks.peer_inflight_count(1.into()), 2);
+    assert_eq!(inflight_blocks.peer_inflight_count(1.into()), 1);
     assert_eq!(inflight_blocks.peer_inflight_count(2.into()), 1); // one block inflight
     assert_eq!(
         inflight_blocks.inflight_block_by_peer(1.into()).cloned(),
-        Some(HashSet::from_iter(vec![
-            h256!("0x1").pack(),
-            h256!("0x2").pack()
-        ]))
+        Some(HashSet::from_iter(vec![h256!("0x2").pack()]))
     );
 
     // receive block 0x1
@@ -48,29 +44,29 @@ fn inflight_blocks_count() {
 fn inflight_blocks_state() {
     let mut inflight_blocks = InflightBlocks::default();
 
-    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.insert(2.into(), h256!("0x1").pack()));
-    assert!(!inflight_blocks.insert(3.into(), h256!("0x1").pack()));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
+    assert!(!inflight_blocks.insert(2.into(), h256!("0x1").pack(), 1));
+    assert!(!inflight_blocks.insert(3.into(), h256!("0x1").pack(), 1));
 
     // peer 1 inflight
-    assert!(!inflight_blocks.insert(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack()));
+    assert!(!inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack(), 2));
 
-    assert!(inflight_blocks.insert(3.into(), h256!("0x3").pack()));
+    assert!(inflight_blocks.insert(3.into(), h256!("0x3").pack(), 3));
 
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x1").pack())
             .cloned()
-            .map(|state| { state.peers }),
-        Some(HashSet::from_iter(vec![1.into(), 2.into()]))
+            .map(|state| { state.peer }),
+        Some(1.into())
     );
 
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x3").pack())
-            .map(|state| state.peers.iter().collect()),
-        Some(vec![&(3.into())])
+            .map(|state| state.peer),
+        Some(3.into())
     );
 
     // peer 1 disconnect
@@ -80,15 +76,15 @@ fn inflight_blocks_state() {
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x1").pack())
-            .map(|state| state.peers.iter().collect()),
-        Some(vec![&(2.into())])
+            .map(|state| state.peer),
+        None
     );
 
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x3").pack())
-            .map(|state| state.peers.iter().collect()),
-        Some(vec![&(3.into())])
+            .map(|state| state.peer),
+        Some(3.into())
     );
 }
 
@@ -99,42 +95,102 @@ fn inflight_blocks_timeout() {
     faketime::enable(&faketime_file);
     let mut inflight_blocks = InflightBlocks::default();
 
-    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack()));
-    assert!(inflight_blocks.insert(2.into(), h256!("0x2").pack()));
-    assert!(inflight_blocks.insert(1.into(), h256!("0x3").pack()));
-    assert!(inflight_blocks.insert(2.into(), h256!("0x3").pack()));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x2").pack(), 2));
+    assert!(inflight_blocks.insert(2.into(), h256!("0x3").pack(), 3));
+    assert!(!inflight_blocks.insert(1.into(), h256!("0x3").pack(), 3));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x4").pack(), 4));
+    assert!(inflight_blocks.insert(2.into(), h256!("0x5").pack(), 5));
+    assert!(!inflight_blocks.insert(2.into(), h256!("0x5").pack(), 5));
 
     faketime::write_millis(&faketime_file, BLOCK_DOWNLOAD_TIMEOUT + 1).expect("write millis");
 
-    assert!(!inflight_blocks.insert(3.into(), h256!("0x3").pack()));
-    assert!(!inflight_blocks.insert(3.into(), h256!("0x2").pack()));
-    assert!(inflight_blocks.insert(4.into(), h256!("0x4").pack()));
-    assert!(inflight_blocks.insert(1.into(), h256!("0x4").pack()));
+    assert!(!inflight_blocks.insert(3.into(), h256!("0x3").pack(), 3));
+    assert!(!inflight_blocks.insert(3.into(), h256!("0x2").pack(), 2));
+    assert!(inflight_blocks.insert(4.into(), h256!("0x6").pack(), 6));
+    assert!(inflight_blocks.insert(1.into(), h256!("0x7").pack(), 7));
 
-    inflight_blocks.prune();
-    assert!(inflight_blocks.insert(3.into(), h256!("0x2").pack()));
-    assert!(inflight_blocks.insert(3.into(), h256!("0x3").pack()));
+    let peers = inflight_blocks.prune(0);
+    assert_eq!(peers, HashSet::from_iter(vec![1.into(), 2.into()]));
+    assert!(inflight_blocks.insert(3.into(), h256!("0x2").pack(), 2));
+    assert!(inflight_blocks.insert(3.into(), h256!("0x3").pack(), 3));
 
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x3").pack())
-            .map(|state| state.peers.iter().collect()),
-        Some(vec![&(3.into())])
+            .map(|state| state.peer),
+        Some(3.into())
     );
 
     assert_eq!(
         inflight_blocks
             .inflight_state_by_block(&h256!("0x2").pack())
-            .map(|state| state.peers.iter().collect()),
-        Some(vec![&(3.into())])
+            .map(|state| state.peer),
+        Some(3.into())
     );
 
     assert_eq!(
         inflight_blocks
-            .inflight_state_by_block(&h256!("0x4").pack())
+            .inflight_state_by_block(&h256!("0x6").pack())
             .cloned()
-            .map(|state| { state.peers }),
-        Some(HashSet::from_iter(vec![1.into(), 4.into()]))
+            .map(|state| state.peer),
+        Some(4.into())
     );
+}
+
+#[cfg(not(disable_faketime))]
+#[test]
+fn inflight_trace_number_state() {
+    let faketime_file = faketime::millis_tempfile(0).expect("create faketime file");
+    faketime::enable(&faketime_file);
+
+    let mut inflight_blocks = InflightBlocks::default();
+
+    assert!(inflight_blocks.insert(1.into(), h256!("0x1").pack(), 1));
+    assert!(inflight_blocks.insert(2.into(), h256!("0x2").pack(), 2));
+    assert!(inflight_blocks.insert(3.into(), h256!("0x3").pack(), 3));
+    assert!(inflight_blocks.insert(4.into(), h256!("0x33").pack(), 3));
+    assert!(inflight_blocks.insert(5.into(), h256!("0x4").pack(), 4));
+    assert!(inflight_blocks.insert(6.into(), h256!("0x5").pack(), 5));
+    assert!(inflight_blocks.insert(7.into(), h256!("0x55").pack(), 5));
+
+    let list = inflight_blocks.prune(2);
+    assert!(list.is_empty());
+
+    let (next_number, (blocks, time)) = inflight_blocks.trace_number.iter().next().unwrap();
+
+    assert_eq!(next_number, &3);
+    assert_eq!(
+        blocks,
+        &HashSet::from_iter(vec![h256!("0x3").pack(), h256!("0x33").pack()])
+    );
+    assert!(time.is_none());
+
+    // When an orphan block is inserted
+    {
+        if let Some((_, time)) = inflight_blocks.trace_number.get_mut(&3) {
+            *time = Some(faketime::unix_time_as_millis())
+        }
+    }
+
+    faketime::write_millis(&faketime_file, 2000).expect("write millis");
+
+    let list = inflight_blocks.prune(2);
+    assert!(list.is_empty());
+
+    let (next_number, (blocks, time)) = inflight_blocks.trace_number.iter().next().unwrap();
+
+    assert_eq!(next_number, &4);
+    assert_eq!(blocks, &HashSet::from_iter(vec![h256!("0x4").pack()]));
+    assert!(time.is_none());
+
+    assert!(inflight_blocks
+        .inflight_state_by_block(&h256!("0x3").pack())
+        .is_none());
+    assert!(inflight_blocks
+        .inflight_state_by_block(&h256!("0x33").pack())
+        .is_none());
+
+    assert_eq!(inflight_blocks.peer_can_fetch_count(3.into()), 8);
+    assert_eq!(inflight_blocks.peer_can_fetch_count(4.into()), 8);
 }


### PR DESCRIPTION
This implementation aims to optimize the task scheduling of the download block. 

It contains a simple task counter to allocate the number of tasks for each node, record and filter the relatively good nodes for download.

After about a week of testing and continuous adjustments, the current PR data is relatively satisfactory, but the possibility of continued adjustments in the future is not ruled out

This PR changes a number of things, including but not limited：
1. Raise the maximum inflight block limit per node to 32-128, but the default is 16, and dynamically adjust this data
2. Remove redundant designs where the same block can be requested from two nodes
3. ~When inserting a orphan block, the countdown for 1 second at the tip + 1 corresponding to `trace_number`, if still not completed, clear the task and send it to another node for download (exponentially decreasing the task limit of the corresponding node)~
4. Split the `getBlockTransaction` task from the `getBlocks` task, keeping the design that getBlockTransaction can request from 2 nodes
5. Clearing out nodes that are peer_best_known < tip in IBD time
6. Separating the `block fetch` process
7. Clearing nodes that do not respond to `getblock` requests for 30 seconds
8. mark timeout on  all `< tip +1` block request if request window > tip + 512
9. Reduce the consumption of checking the maximum timeout time, from check all inflight to check all Less than tip + 20

Test machine configuration: 
2 core 8G RAM 
IP Location on Hong Kong
```
$ cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq -c
2  Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
```

before:

| net state | outbound | average speed | CPU occupancy | Bandwidth consumption
| - | - | - | - | - |
| relatively good | 8 peer | 102-120 block/s | average 70.49%, max 92.77% | average 4 Mbps, max 7.12 Mbps
| relatively poor | 8 peer | 93-100 block/s | average 49.99%, max 74.37% | average 4 Mbps, max 7.12 Mbps

after:

| net state | outbound | average speed | CPU occupancy | Bandwidth consumption
| - | - | - | - | - |
| relatively good | 8 peer | 219-240 block/s | average 78.34%, max 93.17% | average 2Mbps, max 5.52 Mbps
| relatively poor | 8 peer | 200-220 block/s | average 70.06%, max 85.83% | average 3 Mbps, max 19.55 Mbps
