### PR TITLE
feat: avoid explosion of disordering blocks based on BLOCK_DOWNLOAD_WINDOW

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -65,6 +65,11 @@ pub const MAX_LOCATOR_SIZE: usize = 101;
 
 pub const BLOCK_DOWNLOAD_TIMEOUT: u64 = 30 * 1000; // 30s
 
+// Size of the "block download window": how far ahead of our current height do we fetch?
+// Larger windows tolerate larger download speed differences between peers, but increase the
+// potential degree of disordering of blocks.
+pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024 * 8; // 1024 * default_outbound_peers
+
 pub const RETRY_ASK_TX_TIMEOUT_INCREASE: Duration = Duration::from_secs(30);
 
 // ban time


### PR DESCRIPTION
The "sync" protocol downloads different blocks from multiple peers. In the case of different download speeds between peers, that will cause some disordering blocks backlog in `orphan_pool`.

To avoid the explosion of disordering blocks, we limit the download speed based on `BLOCK_DOWNLOAD_WINDOW`:

  ```
  // Size of the "block download window": how far ahead of our current height do we fetch?
  // Larger windows tolerate larger download speed differences between peers, but increase the
  // potential degree of disordering of blocks.
  pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024 * 8; // 1024 * default_outbound_peers
  ```

----

`BLOCK_DOWNLOAD_WINDOW` should be good enough to limit the disordering blocks but meanwhile, tolerate download speed differences between peers. I am not sure whether `1024 * 8` is good enough, but it is a safe value in my opinion.