### PR TITLE
chore: bump jsonrpc from 14.0.5 to 14.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
+checksum = "25525f6002338fb4debb5167a89a0b47f727a5a48418417545ad3429758b7fec"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.8",
@@ -2345,36 +2345,36 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d83d348120edee487c560b7cdd2565055d61cda053aa0d0ef0f8b6a18429048"
+checksum = "d52860f0549694aa4abb12766856f56952ab46d3fb9f0815131b2db3d9cc2f29"
 dependencies = [
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log 0.4.8",
  "net2",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "unicase 2.3.0",
 ]
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3453625f0f0f5cd6d6776d389d73b7d70fcc98620b7cbb1cbbb1f6a36e95f39a"
+checksum = "c4ca5e391d6c6a2261d4adca029f427fe63ea546ad6cef2957c654c08495ec16"
 dependencies = [
  "jsonrpc-core",
  "log 0.4.8",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "serde",
 ]
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b7635e618a0edbbe0d2a2bbbc69874277c49383fcf6c3c0414491cfb517d22"
+checksum = "1f06add502b48351e05dd95814835327fb115e4e9f834ca42fd522d3b769d4d2"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2388,27 +2388,27 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-tcp-server"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fa699852b9ab69fc4863092813fbb01ea3bcf2bbfb31551873fe3ba5dfc519"
+checksum = "4244677aaf41cfa2feb0ce2d7a041ec4c60cbc26b1e16d4ef3862fd8fb411c9f"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log 0.4.8",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "tokio-service",
 ]
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34faa167c3ac9705aeecb986c0da6056529f348425dbe0441db60a2c4cc41d1"
+checksum = "017a7dd5083d9ed62c5e1dd3e317975c33c3115dac5447f4480fe05a8c354754"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log 0.4.8",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "slab",
  "ws",
 ]
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard 1.0.0",
 ]
@@ -2938,9 +2938,19 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api 0.3.2",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.1",
 ]
 
 [[package]]
@@ -2954,7 +2964,7 @@ dependencies = [
  "petgraph",
  "rand 0.6.5",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.10",
  "thread-id",
  "winapi 0.3.8",
 ]
@@ -2970,7 +2980,21 @@ dependencies = [
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.10",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.3.0",
  "winapi 0.3.8",
 ]
 
@@ -3872,6 +3896,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 
 [[package]]
+name = "smallvec"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+
+[[package]]
 name = "snap"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,7 +4478,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 dependencies = [
- "smallvec",
+ "smallvec 0.6.10",
 ]
 
 [[package]]

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -148,14 +148,12 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         .enable_debug();
     let io_handler = builder.build();
 
-    let rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
+    let _rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
 
     wait_for_exit(exit_condvar);
 
     info_target!(crate::LOG_TARGET_MAIN, "Finishing work, please wait...");
 
-    rpc_server.close();
-    info_target!(crate::LOG_TARGET_MAIN, "Jsonrpc shutdown");
     Ok(())
 }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,13 +18,13 @@ ckb-chain = { path = "../chain" }
 ckb-logger = { path = "../util/logger"}
 ckb-network-alert = { path = "../util/network-alert" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
-jsonrpc-core = "14.0"
-jsonrpc-derive = "14.0"
-jsonrpc-http-server = "14.0"
-jsonrpc-tcp-server = "14.0"
-jsonrpc-ws-server = "14.0"
-jsonrpc-server-utils = "14.0"
-jsonrpc-pubsub = "14.0"
+jsonrpc-core = "~14.1"
+jsonrpc-derive = "14.0" # quote requirement conflict
+jsonrpc-http-server = "~14.1"
+jsonrpc-tcp-server = "~14.1"
+jsonrpc-ws-server = "~14.1"
+jsonrpc-server-utils = "~14.1"
+jsonrpc-pubsub = "~14.1"
 crossbeam-channel = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -8,12 +8,12 @@ use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
 use jsonrpc_tcp_server;
 use jsonrpc_ws_server;
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 pub struct RpcServer {
     pub(crate) http: jsonrpc_http_server::Server,
-    pub(crate) tcp: Option<jsonrpc_tcp_server::Server>,
-    pub(crate) ws: Option<jsonrpc_ws_server::Server>,
+    pub(crate) _tcp: Option<jsonrpc_tcp_server::Server>,
+    pub(crate) _ws: Option<jsonrpc_ws_server::Server>,
 }
 
 impl RpcServer {
@@ -40,7 +40,7 @@ impl RpcServer {
             )
             .expect("Start Jsonrpc HTTP service");
 
-        let tcp = config
+        let _tcp = config
             .tcp_listen_address
             .as_ref()
             .map(|tcp_listen_address| {
@@ -68,7 +68,7 @@ impl RpcServer {
                 .expect("Start Jsonrpc TCP service")
             });
 
-        let ws = config.ws_listen_address.as_ref().map(|ws_listen_address| {
+        let _ws = config.ws_listen_address.as_ref().map(|ws_listen_address| {
             let subscription_rpc_impl =
                 SubscriptionRpcImpl::new(notify_controller.clone(), Some("WsSubscription"));
             let mut handler = io_handler.clone();
@@ -91,16 +91,10 @@ impl RpcServer {
             .expect("Start Jsonrpc WebSocket service")
         });
 
-        RpcServer { http, tcp, ws }
+        RpcServer { http, _tcp, _ws }
     }
 
-    pub fn close(self) {
-        self.http.close();
-        if let Some(tcp) = self.tcp {
-            tcp.close();
-        }
-        if let Some(ws) = self.ws {
-            ws.close();
-        }
+    pub fn http_address(&self) -> &SocketAddr {
+        self.http.address()
     }
 }

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -303,9 +303,9 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         .start_http(&"127.0.0.1:0".parse().unwrap())
         .expect("JsonRpc initialize");
     let rpc_server = RpcServer {
-        http: crate::server::waiting::HttpServer(http),
+        http,
         tcp: None,
-        ws: crate::server::waiting::WsServer(None),
+        ws: None,
     };
 
     (shared, chain_controller, rpc_server)
@@ -500,8 +500,8 @@ fn test_rpc() {
     let client = reqwest::Client::new();
     let uri = format!(
         "http://{}:{}/",
-        server.http.0.address().ip(),
-        server.http.0.address().port()
+        server.http.address().ip(),
+        server.http.address().port()
     );
 
     // Assert the params of jsonrpc requests

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -304,8 +304,8 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         .expect("JsonRpc initialize");
     let rpc_server = RpcServer {
         http,
-        tcp: None,
-        ws: None,
+        _tcp: None,
+        _ws: None,
     };
 
     (shared, chain_controller, rpc_server)
@@ -500,8 +500,8 @@ fn test_rpc() {
     let client = reqwest::Client::new();
     let uri = format!(
         "http://{}:{}/",
-        server.http.address().ip(),
-        server.http.address().port()
+        server.http_address().ip(),
+        server.http_address().port()
     );
 
     // Assert the params of jsonrpc requests
@@ -554,6 +554,4 @@ fn test_rpc() {
             pretty_assert_eq!(actual, expected, "Assert results of jsonrpc",);
         }
     }
-
-    server.close();
 }


### PR DESCRIPTION
## Changes

### bump jsonrpc from 14.0.5 to 14.1.0

> Release notes
> * Wait for http server to close on Drop. 
> * Add "Accept:application/json" header for all requests. 
> * Client call with named params 

Additional commits viewable in <a href="https://github.com/paritytech/jsonrpc/compare/jsonrpc-http-server-v14.0.5...v14.1.0">compare view</a>

### revert PR#1996
As described in https://github.com/nervosnetwork/ckb/pull/1996, it can be revert.