### PR TITLE
feat: prof command support specify execution path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_plain",
+ "tempfile",
  "toml",
 ]
 

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -32,6 +32,7 @@ ckb-build-info = { path = "../util/build-info" }
 ckb-memory-tracker = { path = "../util/memory-tracker" }
 ckb-verification = { path = "../verification" }
 base64 = "0.10.1"
+tempfile = "3.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -28,6 +28,7 @@ pub struct RunArgs {
 pub struct ProfArgs {
     pub config: Box<CKBAppConfig>,
     pub consensus: Consensus,
+    pub tmp_target: PathBuf,
     pub from: u64,
     pub to: u64,
 }

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -41,6 +41,7 @@ pub const ARG_NETWORK: &str = "network";
 pub const ARG_NETWORK_PEER_STORE: &str = "network-peer-store";
 pub const ARG_NETWORK_SECRET_KEY: &str = "network-secret-key";
 pub const ARG_LOGS: &str = "logs";
+pub const ARG_TMP_TARGET: &str = "tmp-target";
 
 const GROUP_BA: &str = "ba";
 
@@ -174,20 +175,23 @@ pub(crate) fn stats() -> App<'static, 'static> {
 fn prof() -> App<'static, 'static> {
     SubCommand::with_name(CMD_PROF)
         .about(
-            "Profiles ckb node\n\
+            "Profiles ckb process block\n\
              Example: Process 1..500 blocks then output flagme graph\n\
-             cargo flamegraph --bin ckb -- -C <dir> prof 1 500",
+             cargo flamegraph --bin ckb -- -C <dir> prof <TMP> 1 500",
         )
+        .arg(Arg::with_name(ARG_TMP_TARGET).required(true).index(1).help(
+            "Specifies a target path, prof command make a temporary directory inside of target and the directory will be automatically deleted when finished",
+        ))
         .arg(
             Arg::with_name(ARG_FROM)
                 .required(true)
-                .index(1)
+                .index(2)
                 .help("Specifies from block number."),
         )
         .arg(
             Arg::with_name(ARG_TO)
                 .required(true)
-                .index(2)
+                .index(3)
                 .help("Specifies to block number."),
         )
 }

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -129,12 +129,14 @@ impl Setup {
     pub fn prof<'m>(self, matches: &ArgMatches<'m>) -> Result<ProfArgs, ExitCode> {
         let consensus = self.consensus()?;
         let config = self.config.into_ckb()?;
+        let tmp_target = value_t!(matches, cli::ARG_TMP_TARGET, PathBuf)?;
         let from = value_t!(matches, cli::ARG_FROM, u64)?;
         let to = value_t!(matches, cli::ARG_TO, u64)?;
 
         Ok(ProfArgs {
             config,
             consensus,
+            tmp_target,
             from,
             to,
         })


### PR DESCRIPTION
## Proposed Changes
Previously, the prof command can not configure the execution path. it hard coding in system temporary folder. 

But the system temporary folder usually has some limit, such as Linux putting a limit on `/tmp` size if it is mounted as `tmpfs` is to prevent a DOS attack. although the settings can be changed, I'm afraid it's not worth to do so. 

So, this PR proposal appends a new arg to prof command to support specify execution path.