### PR TITLE
fix: remove unsupport configurations in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,10 @@ members = [
 [profile.release]
 overflow-checks = true
 
-[target.'cfg(all(not(target_env = "msvc"), not(target_os="macos"), not(feature = "profiling")))'.dependencies]
+[target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_platforms"] }
-[target.'cfg(all(not(target_env = "msvc"), not(target_os="macos"), feature = "profiling"))'.dependencies]
-jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
 
 [features]
 default = []
 deadlock_detection = ["ckb-bin/deadlock_detection"]
-profiling = []
+profiling = ["jemallocator/profiling", "ckb-bin/profiling"]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -36,3 +36,4 @@ tempfile = "3.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]
+profiling = ["ckb-memory-tracker/profiling"]

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -21,3 +21,7 @@ heim = "0.0.10"
 futures = "0.3.1"
 jemalloc-ctl = "0.3.3"
 jemalloc-sys = "0.3.2"
+
+[features]
+default = []
+profiling = []

--- a/util/memory-tracker/src/jemalloc-mock.rs
+++ b/util/memory-tracker/src/jemalloc-mock.rs
@@ -1,5 +1,0 @@
-use ckb_logger::warn;
-
-pub fn jemalloc_profiling_dump(_: String) {
-    warn!("jemalloc profiling dump: unsupported");
-}

--- a/util/memory-tracker/src/jemalloc.rs
+++ b/util/memory-tracker/src/jemalloc.rs
@@ -1,8 +1,10 @@
+use ckb_logger::info;
 use std::{ffi, mem, ptr};
 
 pub fn jemalloc_profiling_dump(mut filename: String) {
     let opt_name = "prof.dump";
     let opt_c_name = ffi::CString::new(opt_name).unwrap();
+    info!("jemalloc profiling dump: {}", filename);
     unsafe {
         jemalloc_sys::mallctl(
             opt_c_name.as_ptr(),

--- a/util/memory-tracker/src/lib.rs
+++ b/util/memory-tracker/src/lib.rs
@@ -1,22 +1,34 @@
 mod config;
-#[cfg_attr(
-    all(not(target_env = "msvc"), not(target_os = "macos")),
-    path = "jemalloc.rs"
-)]
-#[cfg_attr(
-    not(all(not(target_env = "msvc"), not(target_os = "macos"))),
-    path = "jemalloc-mock.rs"
-)]
+
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    feature = "profiling"
+))]
 mod jemalloc;
-#[cfg_attr(
-    all(not(target_env = "msvc"), not(target_os = "macos")),
-    path = "process.rs"
-)]
-#[cfg_attr(
-    not(all(not(target_env = "msvc"), not(target_os = "macos"))),
-    path = "process-mock.rs"
-)]
+#[cfg(not(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    feature = "profiling"
+)))]
+mod jemalloc {
+    use ckb_logger::warn;
+
+    pub fn jemalloc_profiling_dump(_: String) {
+        warn!("jemalloc profiling dump: unsupported");
+    }
+}
+
+#[cfg(all(not(target_env = "msvc"), not(target_os = "macos")))]
 mod process;
+#[cfg(not(all(not(target_env = "msvc"), not(target_os = "macos"))))]
+mod process {
+    use ckb_logger::info;
+
+    pub fn track_current_process(_: u64) {
+        info!("track current process: unsupported");
+    }
+}
 
 pub use config::Config;
 pub use jemalloc::jemalloc_profiling_dump;

--- a/util/memory-tracker/src/process-mock.rs
+++ b/util/memory-tracker/src/process-mock.rs
@@ -1,5 +1,0 @@
-use ckb_logger::info;
-
-pub fn track_current_process(_: u64) {
-    info!("track current process: unsupported");
-}


### PR DESCRIPTION
### The Issue

Here is a potential issue which was introduced by #1940.

- Since our `rust-toolchain` is still be `1.41.0`, there will be no errors or warnings when we build the project. (This is why #1940 was merged)

  https://github.com/nervosnetwork/ckb/blob/22829ae85db1643480bd810150f9619250aac92e/rust-toolchain#L1

 - But if you update the `rust-toolchain` to `1.42.0`, when you build the whole project (just execute `make prod`), you will get two warnings:

    > warning: ckb/Cargo.toml: Found `feature = ...` in `target.'cfg(...)'.dependencies`. This key is not supported for selecting dependencies and will not work as expected. Use the [features] section instead: https://doc.rust-lang.org/cargo/reference/features.html
    > warning: ckb/Cargo.toml: Found `feature = ...` in `target.'cfg(...)'.dependencies`. This key is not supported for selecting dependencies and will not work as expected. Use the [features] section instead: https://doc.rust-lang.org/cargo/reference/features.html

~~Although I haven't found any evidences now, I still strongly suspect that it was related to our recent memory leak.~~
**After a lot of tests, I think this issue was not related to our recent memory leak.** But it's still a bug.

### My Solution

I read a lot of issues about cargo in few weeks, I didn't find any official / standard solution to fix it, and I thought they wouldn't fix it in few months. (`build.rs` can't fix it, too)

So, I use a complex and dirty way to fix it, just review the code, please.

#### How can I prove my modification was valid?

- Please check [this example](https://github.com/yangby-cryptape/rust-features-trials/tree/99455ef/features/example-1), I have run it under Debian Buster and Windows 10.

- I have build various kinds of CKB with different features and check a lot logs of them under Debian Buster.

### A Very Important Note

**If any features of a rust bindings (to c library) crate was changed, please do `cargo clean` before build the project.**

Some C libraries wouldn't re-compile by cargo after features changed, for example, `jemalloc-sys`.