### PR TITLE
feat: monitor rocksdb memory usages in logs (optional; default: disable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
 name = "ckb-memory-tracker"
 version = "0.33.0-pre"
 dependencies = [
+ "ckb-db",
  "ckb-logger",
  "futures 0.3.4",
  "heim",

--- a/ckb-bin/src/subcommand/miner.rs
+++ b/ckb-bin/src/subcommand/miner.rs
@@ -16,7 +16,7 @@ pub fn miner(args: MinerArgs) -> Result<(), ExitCode> {
         args.limit,
     );
 
-    ckb_memory_tracker::track_current_process(args.memory_tracker.interval);
+    ckb_memory_tracker::track_current_process_simple(args.memory_tracker.interval);
 
     thread::Builder::new()
         .name("client".to_string())

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -48,7 +48,10 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         &shared.store().cell_provider(),
     );
 
-    ckb_memory_tracker::track_current_process(args.config.memory_tracker.interval);
+    ckb_memory_tracker::track_current_process(
+        args.config.memory_tracker.interval,
+        Some(shared.store().db().inner()),
+    );
 
     let chain_service = ChainService::new(shared.clone(), table);
     let chain_controller = chain_service.start(Some("ChainService"));

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -4,7 +4,7 @@ use crate::transaction::RocksDBTransaction;
 use crate::{internal_error, Col, Result};
 use ckb_app_config::DBConfig;
 use ckb_logger::{info, warn};
-use rocksdb::ops::{GetColumnFamilys, GetPinnedCF, GetPropertyCF, IterateCF, OpenCF, SetOptions};
+use rocksdb::ops::{GetColumnFamilys, GetPinnedCF, IterateCF, OpenCF, SetOptions};
 use rocksdb::{
     ffi, ColumnFamily, DBPinnableSlice, IteratorMode, OptimisticTransactionDB,
     OptimisticTransactionOptions, Options, WriteOptions,
@@ -139,18 +139,8 @@ impl RocksDB {
         }
     }
 
-    pub fn property_value(&self, col: Col, name: &str) -> Result<Option<String>> {
-        let cf = cf_handle(&self.inner, col)?;
-        self.inner
-            .property_value_cf(cf, name)
-            .map_err(internal_error)
-    }
-
-    pub fn property_int_value(&self, col: Col, name: &str) -> Result<Option<u64>> {
-        let cf = cf_handle(&self.inner, col)?;
-        self.inner
-            .property_int_value_cf(cf, name)
-            .map_err(internal_error)
+    pub fn inner(&self) -> Arc<OptimisticTransactionDB> {
+        Arc::clone(&self.inner)
     }
 }
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -18,7 +18,9 @@ pub use crate::iter::DBIterator;
 pub use crate::migration::{DefaultMigration, Migration, Migrations};
 pub use crate::snapshot::RocksDBSnapshot;
 pub use crate::transaction::{RocksDBTransaction, RocksDBTransactionSnapshot};
-pub use rocksdb::{DBPinnableSlice, DBVector, Direction, Error as DBError, IteratorMode};
+pub use rocksdb::{
+    self as internal, DBPinnableSlice, DBVector, Direction, Error as DBError, IteratorMode,
+};
 
 pub type Col = &'static str;
 pub type Result<T> = result::Result<T, Error>;

--- a/docs/ckb-debugging.md
+++ b/docs/ckb-debugging.md
@@ -22,7 +22,7 @@ interval = 600
 - Compile `ckb` with feature `profiling`.
 
   ```sh
-  make build-for-profiling`
+  make build-for-profiling
   ```
 
   After compiling, a script named `jeprof` will be generated in `target` direcotry.
@@ -60,3 +60,4 @@ interval = 600
 
 - [JEMALLOC: Use Case: Leak Checking](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Leak-Checking)
 - [JEMALLOC: Use Case: Heap Profiling](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling)
+- [RocksDB: Memory usage in RocksDB](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -47,12 +47,8 @@ impl ChainDB {
         }
     }
 
-    pub fn property_value(&self, col: Col, name: &str) -> Result<Option<String>, Error> {
-        self.db.property_value(col, name)
-    }
-
-    pub fn property_int_value(&self, col: Col, name: &str) -> Result<Option<u64>, Error> {
-        self.db.property_int_value(col, name)
+    pub fn db(&self) -> &RocksDB {
+        &self.db
     }
 
     pub fn begin_transaction(&self) -> StoreTransaction {

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 ckb-logger = { path = "../logger" }
+ckb-db = { path = "../../db" }
 
 # TODO Why don't disable this crate by "target.*" in the crates which are dependent on this crate?
 #

--- a/util/memory-tracker/src/lib.rs
+++ b/util/memory-tracker/src/lib.rs
@@ -21,12 +21,24 @@ mod jemalloc {
 mod process;
 #[cfg(not(all(not(target_env = "msvc"), not(target_os = "macos"))))]
 mod process {
+    use std::sync;
+
+    use crate::rocksdb::TrackRocksDBMemory;
     use ckb_logger::info;
 
-    pub fn track_current_process(_: u64) {
+    pub fn track_current_process<Tracker: 'static + TrackRocksDBMemory + Sync + Send>(
+        _: u64,
+        _: Option<sync::Arc<Tracker>>,
+    ) {
         info!("track current process: unsupported");
     }
 }
+pub mod rocksdb;
+pub mod utils;
 
 pub use jemalloc::jemalloc_profiling_dump;
 pub use process::track_current_process;
+
+pub fn track_current_process_simple(interval: u64) {
+    track_current_process::<rocksdb::DummyRocksDB>(interval, None);
+}

--- a/util/memory-tracker/src/rocksdb.rs
+++ b/util/memory-tracker/src/rocksdb.rs
@@ -1,0 +1,66 @@
+use ckb_db::internal::ops::{GetColumnFamilys, GetProperty, GetPropertyCF};
+use ckb_logger::trace;
+
+use crate::utils::{sum_int_values, PropertyValue};
+
+// Ref: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+pub struct RocksDBMemoryStatistics {
+    pub total_memory: PropertyValue<u64>,
+    pub block_cache_usage: PropertyValue<u64>,
+    pub estimate_table_readers_mem: PropertyValue<u64>,
+    pub cur_size_all_mem_tables: PropertyValue<u64>,
+    pub block_cache_pinned_usage: PropertyValue<u64>,
+    pub block_cache_capacity: PropertyValue<u64>,
+}
+
+pub trait TrackRocksDBMemory {
+    fn gather_memory_stats(&self) -> RocksDBMemoryStatistics {
+        let block_cache_usage = self.gather_int_values("rocksdb.block-cache-usage");
+        let estimate_table_readers_mem =
+            self.gather_int_values("rocksdb.estimate-table-readers-mem");
+        let cur_size_all_mem_tables = self.gather_int_values("rocksdb.cur-size-all-mem-tables");
+        let block_cache_pinned_usage = self.gather_int_values("rocksdb.block-cache-pinned-usage");
+        let total_memory = sum_int_values(&[
+            block_cache_usage.clone(),
+            estimate_table_readers_mem.clone(),
+            cur_size_all_mem_tables.clone(),
+            block_cache_pinned_usage.clone(),
+        ]);
+        let block_cache_capacity = self.gather_int_values("rocksdb.block-cache-capacity");
+        RocksDBMemoryStatistics {
+            total_memory,
+            block_cache_usage,
+            estimate_table_readers_mem,
+            cur_size_all_mem_tables,
+            block_cache_pinned_usage,
+            block_cache_capacity,
+        }
+    }
+    fn gather_int_values(&self, key: &str) -> PropertyValue<u64>;
+}
+
+pub struct DummyRocksDB;
+
+impl TrackRocksDBMemory for DummyRocksDB {
+    fn gather_int_values(&self, _: &str) -> PropertyValue<u64> {
+        PropertyValue::Null
+    }
+}
+
+impl<RocksDB> TrackRocksDBMemory for RocksDB
+where
+    RocksDB: GetColumnFamilys + GetProperty + GetPropertyCF,
+{
+    fn gather_int_values(&self, key: &str) -> PropertyValue<u64> {
+        let mut values = Vec::new();
+        for (cf_name, cf) in self.get_cfs() {
+            let value_col = self
+                .property_int_value_cf(cf, key)
+                .map_err(|err| format!("{}", err))
+                .into();
+            trace!("{}({}): {}", key, cf_name, value_col);
+            values.push(value_col);
+        }
+        sum_int_values(&values)
+    }
+}

--- a/util/memory-tracker/src/utils.rs
+++ b/util/memory-tracker/src/utils.rs
@@ -1,0 +1,81 @@
+use std::fmt;
+
+pub enum HumanReadableSize {
+    Bytes(u64),
+    KiBytes(f64),
+    MiBytes(f64),
+    GiBytes(f64),
+}
+
+impl fmt::Display for HumanReadableSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Bytes(v) => write!(f, "{} Bytes", v),
+            Self::KiBytes(v) => write!(f, "{:.2} KiB", v),
+            Self::MiBytes(v) => write!(f, "{:.2} MiB", v),
+            Self::GiBytes(v) => write!(f, "{:.2} GiB", v),
+        }
+    }
+}
+
+impl From<u64> for HumanReadableSize {
+    fn from(v: u64) -> Self {
+        match v {
+            _ if v < 1024 => Self::Bytes(v),
+            _ if v < 1024 * 1024 => Self::KiBytes((v as f64) / 1024.0),
+            _ if v < 1024 * 1024 * 1024 => Self::MiBytes((v as f64) / 1024.0 / 1024.0),
+            _ => Self::GiBytes((v as f64) / 1024.0 / 1024.0 / 1024.0),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PropertyValue<T> {
+    Value(T),
+    Null,
+    Error(String),
+}
+
+impl fmt::Display for PropertyValue<u64> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Value(v) => write!(f, "{}", HumanReadableSize::from(*v)),
+            Self::Null => write!(f, "null"),
+            Self::Error(_) => write!(f, "err"),
+        }
+    }
+}
+
+impl<T> From<Result<Option<T>, String>> for PropertyValue<T> {
+    fn from(res: Result<Option<T>, String>) -> Self {
+        match res {
+            Ok(Some(v)) => Self::Value(v),
+            Ok(None) => Self::Null,
+            Err(e) => Self::Error(e),
+        }
+    }
+}
+
+pub fn sum_int_values(values: &[PropertyValue<u64>]) -> PropertyValue<u64> {
+    let mut total = 0;
+    let mut errors = 0;
+    let mut nulls = 0;
+    for value in values {
+        match value {
+            PropertyValue::Value(v) => {
+                total += v;
+            }
+            PropertyValue::Null => {
+                nulls += 1;
+            }
+            PropertyValue::Error(_) => {
+                errors += 1;
+            }
+        }
+    }
+    if errors > 0 || nulls > 0 {
+        PropertyValue::Error(format!("{} errors, {} nulls", errors, nulls))
+    } else {
+        PropertyValue::Value(total)
+    }
+}


### PR DESCRIPTION
[Set `memory_tracker.interval` to be a non-zero number in the configuration file](https://github.com/nervosnetwork/ckb/blob/22829ae/docs/ckb-debugging.md#tracking-memory-usage-in-logs) and restart CKB, then we can monitor RocksDB memory usages in logs, without re-compile the binary.

Ref: [RocksDB: Memory usage in RocksDB](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)