### PR TITLE
feat(rpc): Re-organize RPC errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "ckb-util",
  "ckb-verification",
  "crossbeam-channel",
+ "failure",
  "faketime",
  "futures 0.1.29",
  "jsonrpc-core",

--- a/error/src/internal.rs
+++ b/error/src/internal.rs
@@ -30,6 +30,9 @@ pub enum InternalErrorKind {
 
     /// Unknown system error
     System,
+
+    /// The feature is disabled or is conflicted with the configuration
+    Config,
 }
 
 impl fmt::Display for InternalError {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -66,7 +66,7 @@ impl Error {
         self.cause().and_then(|cause| cause.downcast_ref::<T>())
     }
 
-    pub fn as_fail_ref(&self) -> &dyn Fail {
+    pub fn unwrap_cause_or_self(&self) -> &dyn Fail {
         self.cause().unwrap_or(self)
     }
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -65,4 +65,8 @@ impl Error {
     pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
         self.cause().and_then(|cause| cause.downcast_ref::<T>())
     }
+
+    pub fn as_fail_ref(&self) -> &dyn Fail {
+        self.cause().unwrap_or(self)
+    }
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -43,6 +43,7 @@ ckb-reward-calculator = { path = "../util/reward-calculator" }
 ckb-tx-pool = { path = "../tx-pool" }
 ckb-script = { path = "../script" }
 ckb-memory-tracker = { path = "../util/memory-tracker" }
+failure = "0.1.5"
 
 [dev-dependencies]
 reqwest = "0.9.16"

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,16 +1,52 @@
-use jsonrpc_core::{Error, ErrorCode};
+use jsonrpc_core::{Error, ErrorCode, Value};
+use std::fmt::{Debug, Display};
 
+// * -1 ~ -999 General errors
+// * -1000 ~ -2999 Module specific errors
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RPCError {
+    // ,-- General application errors
     Invalid = -3,
+    RPCModuleIsDisabled = -4,
+    // ,-- P2P errors
+    P2PFailedToBroadcast = -101,
+    // ,-- Alert module
+    AlertFailedToVerifySignatures = -1000,
 }
 
 impl RPCError {
-    pub fn custom(err: RPCError, message: String) -> Error {
+    pub fn invalid_params<T: Display>(message: T) -> Error {
         Error {
-            code: ErrorCode::ServerError(err as i64),
-            message,
+            code: ErrorCode::InvalidParams,
+            message: format!("InvalidParams: {}", message),
             data: None,
         }
+    }
+
+    pub fn custom<T: Display>(error_code: RPCError, message: T) -> Error {
+        Error {
+            code: ErrorCode::ServerError(error_code as i64),
+            message: format!("{:?}: {}", error_code, message),
+            data: None,
+        }
+    }
+
+    pub fn custom_with_error<T: Display + Debug>(error_code: RPCError, err: T) -> Error {
+        Error {
+            code: ErrorCode::ServerError(error_code as i64),
+            message: format!("{:?}: {}", error_code, err),
+            data: Some(Value::String(format!("{:?}", err))),
+        }
+    }
+
+    pub fn rpc_module_is_disabled(module: &str) -> Error {
+        Self::custom(
+            RPCError::RPCModuleIsDisabled,
+            format!(
+                "This RPC method is in the module `{module}`. \
+                 Please modify `rpc.modules`{miner_info} in ckb.toml and restart the ckb node to enable it.",
+                 module = module, miner_info = if module == "Miner" {" and `block_assembler`"} else {""}
+            )
+        )
     }
 }

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -122,6 +122,13 @@ impl RPCError {
         }
     }
 
+    pub fn from_failure_error(err: failure::Error) -> Error {
+        match err.downcast::<CKBError>() {
+            Ok(ckb_error) => Self::from_ckb_error(ckb_error),
+            Err(err) => Self::ckb_internal_error(err),
+        }
+    }
+
     pub fn ckb_internal_error<T: Display + Debug>(err: T) -> Error {
         Self::custom_with_error(RPCError::CKBInternalError, err)
     }

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -75,11 +75,12 @@ impl RPCError {
     pub fn from_ckb_error(err: CKBError) -> Error {
         use ckb_error::ErrorKind::*;
         match err.kind() {
-            Dao => Self::custom_with_error(RPCError::DaoError, err.as_fail_ref()),
+            Dao => Self::custom_with_error(RPCError::DaoError, err.unwrap_cause_or_self()),
             OutPoint => Self::custom_with_error(RPCError::TransactionFailedToResolve, err),
-            Transaction => {
-                Self::custom_with_error(RPCError::TransactionFailedToVerify, err.as_fail_ref())
-            }
+            Transaction => Self::custom_with_error(
+                RPCError::TransactionFailedToVerify,
+                err.unwrap_cause_or_self(),
+            ),
             SubmitTransaction => {
                 let submit_tx_err = match err.downcast_ref::<SubmitTxError>() {
                     Some(err) => err,

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,4 +1,5 @@
-use ckb_error::Error as CKBError;
+use ckb_error::{Error as CKBError, InternalError, InternalErrorKind};
+use ckb_tx_pool::error::SubmitTxError;
 use jsonrpc_core::{Error, ErrorCode, Value};
 use std::fmt::{Debug, Display};
 
@@ -12,9 +13,12 @@ pub enum RPCError {
     Invalid = -3,
     RPCModuleIsDisabled = -4,
     DaoError = -5,
+    IntegerOverflow = -6,
+    ConfigError = -7,
     // ,-- P2P errors
     P2PFailedToBroadcast = -101,
     // ,-- Store errors
+    DatabaseError = -200,
     ChainIndexIsInconsistent = -201,
     DatabaseIsCorrupt = -202,
     // ,-- Transaction errors
@@ -22,6 +26,13 @@ pub enum RPCError {
     TransactionFailedToVerify = -302,
     // ,-- Alert module
     AlertFailedToVerifySignatures = -1000,
+    // ,-- Pool module
+    PoolRejectedTransactionByOutputsValidator = -1102,
+    PoolRejectedTransactionByIllTransactionChecker = -1103,
+    PoolRejectedTransactionByMinFeeRate = -1104,
+    PoolRejectedTransactionByMaxAncestorsCountLimit = -1105,
+    PoolIsFull = -1106,
+    PoolRejectedDuplicatedTransaction = -1107,
 }
 
 impl RPCError {
@@ -41,6 +52,18 @@ impl RPCError {
         }
     }
 
+    pub fn custom_with_data<T: Display, F: Debug>(
+        error_code: RPCError,
+        message: T,
+        data: F,
+    ) -> Error {
+        Error {
+            code: ErrorCode::ServerError(error_code as i64),
+            message: format!("{:?}: {}", error_code, message),
+            data: Some(Value::String(format!("{:?}", data))),
+        }
+    }
+
     pub fn custom_with_error<T: Display + Debug>(error_code: RPCError, err: T) -> Error {
         Error {
             code: ErrorCode::ServerError(error_code as i64),
@@ -53,6 +76,45 @@ impl RPCError {
         use ckb_error::ErrorKind::*;
         match err.kind() {
             Dao => Self::custom_with_error(RPCError::DaoError, err),
+            OutPoint => Self::custom_with_error(RPCError::TransactionFailedToResolve, err),
+            Transaction => Self::custom_with_error(RPCError::TransactionFailedToVerify, err),
+            SubmitTransaction => {
+                let submit_tx_err = match err.downcast_ref::<SubmitTxError>() {
+                    Some(err) => err,
+                    None => return Self::ckb_internal_error(err),
+                };
+
+                let kind = match *submit_tx_err {
+                    SubmitTxError::LowFeeRate(_, _) => {
+                        RPCError::PoolRejectedTransactionByMinFeeRate
+                    }
+                    SubmitTxError::ExceededMaximumAncestorsCount => {
+                        RPCError::PoolRejectedTransactionByMaxAncestorsCountLimit
+                    }
+                };
+
+                RPCError::custom_with_error(kind, err)
+            }
+            Internal => {
+                let internal_err = match err.downcast_ref::<InternalError>() {
+                    Some(err) => err,
+                    None => return Self::ckb_internal_error(err),
+                };
+
+                let kind = match internal_err.kind() {
+                    InternalErrorKind::CapacityOverflow => RPCError::IntegerOverflow,
+                    InternalErrorKind::TransactionPoolFull => RPCError::PoolIsFull,
+                    InternalErrorKind::PoolTransactionDuplicated => {
+                        RPCError::PoolRejectedDuplicatedTransaction
+                    }
+                    InternalErrorKind::DataCorrupted => RPCError::DatabaseIsCorrupt,
+                    InternalErrorKind::Database => RPCError::DatabaseError,
+                    InternalErrorKind::Config => RPCError::ConfigError,
+                    _ => RPCError::CKBInternalError,
+                };
+
+                RPCError::custom_with_error(kind, err)
+            }
             _ => Self::custom_with_error(RPCError::CKBInternalError, err),
         }
     }
@@ -70,5 +132,54 @@ impl RPCError {
                  module = module, miner_info = if module == "Miner" {" and `block_assembler`"} else {""}
             )
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ckb_dao_utils::DaoError;
+    use ckb_types::{core::error::OutPointError, packed::Byte32};
+
+    #[test]
+    fn test_dao_error_from_ckb_error() {
+        let err: CKBError = DaoError::InvalidHeader.into();
+        assert_eq!(
+            "DaoError: Dao(InvalidHeader)",
+            RPCError::from_ckb_error(err).message
+        );
+    }
+
+    #[test]
+    fn test_submit_tx_error_from_ckb_error() {
+        let err: CKBError = SubmitTxError::LowFeeRate(100, 50).into();
+        assert_eq!(
+            "PoolRejectedTransactionByMinFeeRate: SubmitTransaction(Transaction fee rate must >= 100 shannons/KB, got: 50)",
+            RPCError::from_ckb_error(err).message
+        );
+
+        let err: CKBError = SubmitTxError::ExceededMaximumAncestorsCount.into();
+        assert_eq!(
+            "PoolRejectedTransactionByMaxAncestorsCountLimit: SubmitTransaction(Transaction exceeded maximum ancestors count limit, try send it later)",
+            RPCError::from_ckb_error(err).message
+        );
+    }
+
+    #[test]
+    fn test_internal_error_from_ckb_error() {
+        let err: CKBError = InternalErrorKind::TransactionPoolFull.into();
+        assert_eq!(
+            "PoolIsFull: Internal(TransactionPoolFull)",
+            RPCError::from_ckb_error(err).message
+        );
+    }
+
+    #[test]
+    fn test_out_point_error_from_ckb_error() {
+        let err: CKBError = OutPointError::InvalidHeader(Byte32::new([0; 32])).into();
+        assert_eq!(
+            "TransactionFailedToResolve: OutPoint(InvalidHeader(Byte32(0x0000000000000000000000000000000000000000000000000000000000000000)))",
+            RPCError::from_ckb_error(err).message
+        );
     }
 }

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -6,10 +6,14 @@ use std::fmt::{Debug, Display};
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RPCError {
     // ,-- General application errors
+    CKBInternalError = -1,
     Invalid = -3,
     RPCModuleIsDisabled = -4,
     // ,-- P2P errors
     P2PFailedToBroadcast = -101,
+    // ,-- Store errors
+    ChainIndexIsInconsistent = -201,
+    DatabaseIsCorrupt = -202,
     // ,-- Alert module
     AlertFailedToVerifySignatures = -1000,
 }
@@ -37,6 +41,10 @@ impl RPCError {
             message: format!("{:?}: {}", error_code, err),
             data: Some(Value::String(format!("{:?}", err))),
         }
+    }
+
+    pub fn ckb_internal_error<T: Display + Debug>(err: T) -> Error {
+        Self::custom_with_error(RPCError::CKBInternalError, err)
     }
 
     pub fn rpc_module_is_disabled(module: &str) -> Error {

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -64,13 +64,13 @@ impl ExperimentRpc for ExperimentRpcImpl {
         let calculator = DaoCalculator::new(consensus, snapshot);
         match calculator.maximum_withdraw(&out_point.into(), &hash.pack()) {
             Ok(capacity) => Ok(capacity.into()),
-            Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:#}", err))),
+            Err(err) => Err(RPCError::from_ckb_error(err)),
         }
     }
 
     fn estimate_fee_rate(&self, _expect_confirm_blocks: Uint64) -> Result<EstimateResult> {
         Err(RPCError::custom(
-            RPCError::Invalid,
+            RPCError::Deprecated,
             "estimate_fee_rate have been deprecated due to it has availability and performance issue"
         ))
     }
@@ -121,10 +121,16 @@ impl<'a> DryRunner<'a> {
                     Ok(cycles) => Ok(DryRunResult {
                         cycles: cycles.into(),
                     }),
-                    Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
+                    Err(err) => Err(RPCError::custom_with_error(
+                        RPCError::TransactionFailedToVerify,
+                        err,
+                    )),
                 }
             }
-            Err(err) => Err(RPCError::custom(RPCError::Invalid, format!("{:?}", err))),
+            Err(err) => Err(RPCError::custom_with_error(
+                RPCError::TransactionFailedToResolve,
+                err,
+            )),
         }
     }
 }

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -72,7 +72,6 @@ impl ExperimentRpc for ExperimentRpcImpl {
         Err(RPCError::custom(
             RPCError::Invalid,
             "estimate_fee_rate have been deprecated due to it has availability and performance issue"
-                .into(),
         ))
     }
 }

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -54,17 +54,16 @@ impl MinerRpc for MinerRpcImpl {
 
         let tx_pool = self.shared.tx_pool_controller();
 
-        let get_block_template =
-            tx_pool.get_block_template(bytes_limit, proposals_limit, max_version.map(Into::into));
-        if let Err(e) = get_block_template {
-            error!("send get_block_template request error {}", e);
-            return Err(Error::internal_error());
-        };
-
-        get_block_template.unwrap().map_err(|err| {
-            error!("get_block_template result error {}", err);
-            Error::internal_error()
-        })
+        tx_pool
+            .get_block_template(bytes_limit, proposals_limit, max_version.map(Into::into))
+            .map_err(|err| {
+                error!("send get_block_template request error {}", err);
+                RPCError::ckb_internal_error(err)
+            })?
+            .map_err(|err| {
+                error!("get_block_template result error {}", err);
+                RPCError::ckb_internal_error(err)
+            })
     }
 
     fn submit_block(&self, work_id: String, data: Block) -> Result<H256> {

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -62,7 +62,7 @@ impl MinerRpc for MinerRpcImpl {
             })?
             .map_err(|err| {
                 error!("get_block_template result error {}", err);
-                RPCError::ckb_internal_error(err)
+                RPCError::from_failure_error(err)
             })
     }
 
@@ -113,10 +113,10 @@ impl MinerRpc for MinerRpcImpl {
     }
 }
 
-fn handle_submit_error<E: Debug + ToString>(work_id: &str, err: &E) -> Error {
+fn handle_submit_error<E: std::fmt::Display + Debug>(work_id: &str, err: &E) -> Error {
     error!("[{}] submit_block error: {:?}", work_id, err);
     capture_submit_error(err);
-    RPCError::custom(RPCError::Invalid, err.to_string())
+    RPCError::custom_with_error(RPCError::Invalid, err)
 }
 
 fn capture_submit_error<D: Debug>(err: &D) {

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -116,7 +116,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
         {
             error!("Broadcast transaction failed: {:?}", err);
-            Err(RPCError::custom(RPCError::Invalid, err.to_string()))
+            Err(RPCError::ckb_internal_error(err))
         } else {
             Ok(hash.unpack())
         }

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -116,7 +116,10 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
         {
             error!("Broadcast transaction failed: {:?}", err);
-            Err(RPCError::ckb_internal_error(err))
+            Err(RPCError::custom_with_error(
+                RPCError::P2PFailedToBroadcast,
+                err,
+            ))
         } else {
             Ok(hash.unpack())
         }

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -183,22 +183,13 @@ impl<'a> ServiceBuilder<'a> {
     {
         use crate::error::RPCError;
 
-        let error = |method: &str| {
-            RPCError::custom(
-                RPCError::Invalid,
-                format!(
-                    "You need to enable `{module}` module to invoke `{method}` rpc, \
-                        please modify `rpc.modules` {miner_info} of configuration file ckb.toml and restart the ckb node",
-                    method = method, module = module, miner_info = if module == "Miner" {"and `block_assembler`"} else {""}
-                ))
-        };
         rpc_method
             .into_iter()
             .map(|(method, _)| method)
             .for_each(|method| {
-                let error = error(&method);
+                let error = Err(RPCError::rpc_module_is_disabled(module));
                 self.io_handler
-                    .add_method(&method, move |_param| Err(error.clone()))
+                    .add_method(&method, move |_param| error.clone())
             });
     }
 

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -44,7 +44,7 @@ impl ValidSince {
 
         // Failed to send transaction since SinceImmaturity
         for _ in 1..relative {
-            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
+            assert_send_transaction_fail(node, &transaction, "TransactionFailedToVerify: Immature");
             node.generate_block();
         }
 
@@ -69,7 +69,7 @@ impl ValidSince {
         // Failed to send transaction since SinceImmaturity
         let tip_number = node.rpc_client().get_tip_block_number();
         for _ in tip_number + 1..absolute {
-            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
+            assert_send_transaction_fail(node, &transaction, "TransactionFailedToVerify: Immature");
             node.generate_block();
         }
 
@@ -113,7 +113,7 @@ impl ValidSince {
         {
             let since = since_from_relative_timestamp(median_time_seconds + 1);
             let transaction = node.new_transaction_with_since(cellbase.hash(), since);
-            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
+            assert_send_transaction_fail(node, &transaction, "TransactionFailedToVerify: Immature");
         }
         {
             let since = since_from_relative_timestamp(median_time_seconds - 1);
@@ -155,7 +155,7 @@ impl ValidSince {
         {
             let since = since_from_absolute_timestamp(median_time_seconds + 1);
             let transaction = node.new_transaction_with_since(cellbase.hash(), since);
-            assert_send_transaction_fail(node, &transaction, "Transaction: Immature");
+            assert_send_transaction_fail(node, &transaction, "TransactionFailedToVerify: Immature");
         }
         {
             let since = since_from_absolute_timestamp(median_time_seconds - 1);
@@ -182,7 +182,7 @@ impl ValidSince {
 
         (0..relative_blocks - DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|i| {
             info!("Tx is Immature in block N + {}", i);
-            assert_send_transaction_fail(node, &tx, "Transaction: Immature");
+            assert_send_transaction_fail(node, &tx, "TransactionFailedToVerify: Immature");
             node.generate_block();
         });
 

--- a/tx-pool/src/error.rs
+++ b/tx-pool/src/error.rs
@@ -5,9 +5,12 @@ use tokio::sync::mpsc::error::TrySendError as TokioTrySendError;
 #[derive(Debug, PartialEq, Clone, Eq, Fail)]
 pub enum SubmitTxError {
     /// The fee rate of transaction is lower than min fee rate
-    #[fail(display = "LowFeeRate")]
-    LowFeeRate(u64),
-    #[fail(display = "ExceededMaximumAncestorsCount")]
+    #[fail(
+        display = "Transaction fee rate must >= {} shannons/KB, got: {}",
+        _0, _1
+    )]
+    LowFeeRate(u64, u64),
+    #[fail(display = "Transaction exceeded maximum ancestors count limit, try send it later")]
     ExceededMaximumAncestorsCount,
 }
 

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -401,7 +401,7 @@ impl TxPoolService {
             let min_fee = tx_pool.config.min_fee_rate.fee(tx_size);
             // reject txs which fee lower than min fee rate
             if fee < min_fee {
-                return Err(SubmitTxError::LowFeeRate(min_fee.as_u64()).into());
+                return Err(SubmitTxError::LowFeeRate(min_fee.as_u64(), fee.as_u64()).into());
             }
 
             let related_dep_out_points = rtx.related_dep_out_points();

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -260,7 +260,7 @@ impl TxPoolService {
         max_version: Option<Version>,
     ) -> Result<BlockTemplate, FailureError> {
         if self.block_assembler.is_none() {
-            Err(InternalErrorKind::System
+            Err(InternalErrorKind::Config
                 .reason("BlockAssembler disabled")
                 .into())
         } else {

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -1,5 +1,6 @@
 use crate::{Timestamp, Uint64};
 use serde::{Deserialize, Serialize};
+use serde_json;
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct TxPoolInfo {
@@ -17,4 +18,22 @@ pub struct TxPoolInfo {
 pub enum OutputsValidator {
     Default,
     Passthrough,
+}
+
+impl OutputsValidator {
+    pub fn json_display(&self) -> String {
+        let v = serde_json::to_value(self).expect("OutputsValidator to JSON should never fail");
+        v.as_str().unwrap_or_default().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_outputs_validator_json_display() {
+        assert_eq!("default", OutputsValidator::Default.json_display());
+        assert_eq!("passthrough", OutputsValidator::Passthrough.json_display());
+    }
 }


### PR DESCRIPTION
This PR reworks on the RPC errors:

* Use JSONRPC error code to differentiate different errors. Also prefix the error code in the message to be search engine friendly.
* Make error message simple and easy to understand. The dump of the error is added as the data instead.
* Avoid reusing the same error message for different reasons.

## Breaking Changes

* The error object `date` field is always absent before, now it can be a string which contains the detailed error information.
* The `code` in error object is always -3 for all the CKB internal errors, now it can have different values to differentiate different errors. Check the file `rpc/src/error.rs`.
* The error messages have been updated to improve readability.

## JSON-RPC Errors

See [JSON-RPC spec](https://www.jsonrpc.org/specification#error_object).

## General Errors

┌ `CKBInternalError (-1)`

Errors in this category are considered to never happen or only happen when the system resources are exhausted.

┌ `RPCModuleIsDisabled (-4)`

Not all RPC modules are enabled by default. Please edit `rpc.modules` in the configuration file `ckb.toml`.

## Alert

### `send_alert`

┌  `AlertFailedToVerifySignatures (-1000)`

Some signatures are invalid.


┌ `P2PFailedToBroadcast (-101)`

Alert is saved locally but has failed to broadcast to the P2P network.


┌ `InvalidParams (-32602)`

* Expected `params[0].notice_until` in the future.

## Chain

### `get_block_by_number`

┌ `ChainIndexIsInconsistent (-201)`

The index is inconsistent. It says a block hash is in the main chain, but cannot read it from database.

┌ `DatabaseIsCorrupt (-202)`

The data read from database is dirty. Please report it as a bug.

### `get_header_by_number`

┌ `ChainIndexIsInconsistent (-201)`

The index is inconsistent. It says a block hash is in the main chain, but cannot read it from database.


### `get_cells_by_lock_hash`

┌ `InvalidParams (-32602)`

* Expected `from <= to` in `params[0]`.
* Expected `to - from <= 100`.

┌ `ChainIndexIsInconsistent (-201)`

The index is inconsistent. It says a block hash is in the main chain, but cannot read it from database.


## Experiment

### `dry_run_transaction`

┌ `TransactionFailedToResolve (-301)`

Failed to resolve the referenced cells and headers used in the transaction, as inputs or dependencies.

┌ `TransactionFailedToVerify (-302)`

Failed to verify the transaction.

### `calculate_dao_maximum_withdraw`

┌ `DAOError (-5)`

The given out point is not a valid cell for DAO computation.

┌ `CKBInternalError (-1)`

Mathematics overflow.

## Network

### `set_ban`

┌ `InvalidParams (-32602)`

* Expected `params[0]` to be a valid IP address.
* Expected `params[1]` to be in the list [insert, delete].

## Pool

### `send_transaction`

┌ `PoolRejectedTransactionByOutputsValidator (-1102)`

The transaction is rejected by the validator specified by `params[1]`. If you really want to send transactions with advanced scripts, please set `params[1]` to "passthrough".

┌ `PoolRejectedTransactionByIllTransactionChecker (-1103)`

Pool rejects some transactions which seem contain invalid VM instructions. See the issue link in the error message for details.

┌ `PoolRejectedTransactionByMinFeeRate (-1104)`

The transaction fee rate must >= `tx_pool.min_fee_rate` in `ckb.toml`.

┌ `PoolRejectedTransactionByMaxAncestorsCountLimit (-1105)`

The ancestors count must <= `tx_pool.max_ancestors_count` in `ckb.toml`.

┌ `PoolIsFull (-1106)`

Pool is full.

┌ `PoolRejectedDuplicatedTransaction (-1107)`

The transaction is already in the pool.

┌ TransactionFailedToResolve (-301)

Failed to resolve the referenced cells and headers used in the transaction, as inputs or dependencies.

┌ TransactionFailedToVerify (-302)

Failed to verify the transaction.