### PR TITLE
feat: return filename of jemalloc_profiling_dump

### DIFF
--- a/rpc/src/module/debug.rs
+++ b/rpc/src/module/debug.rs
@@ -1,5 +1,5 @@
 use ckb_logger::configure_logger_filter;
-use jsonrpc_core::{Error, ErrorCode::InternalError, Result};
+use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use std::time;
 
@@ -20,14 +20,8 @@ impl DebugRpc for DebugRpcImpl {
             .unwrap()
             .as_secs();
         let filename = format!("ckb-jeprof.{}.heap", timestamp);
-        match ckb_memory_tracker::jemalloc_profiling_dump(&filename) {
-            Ok(()) => Ok(filename),
-            Err(err) => Err(Error {
-                code: InternalError,
-                message: err,
-                data: None,
-            }),
-        }
+        ckb_memory_tracker::jemalloc_profiling_dump(filename.clone());
+        Ok(filename)
     }
 
     fn set_logger_filter(&self, filter: String) -> Result<()> {

--- a/rpc/src/module/debug.rs
+++ b/rpc/src/module/debug.rs
@@ -1,12 +1,12 @@
 use ckb_logger::configure_logger_filter;
-use jsonrpc_core::Result;
+use jsonrpc_core::{Error, ErrorCode::InternalError, Result};
 use jsonrpc_derive::rpc;
 use std::time;
 
 #[rpc(server)]
 pub trait DebugRpc {
     #[rpc(name = "jemalloc_profiling_dump")]
-    fn jemalloc_profiling_dump(&self) -> Result<()>;
+    fn jemalloc_profiling_dump(&self) -> Result<String>;
     #[rpc(name = "set_logger_filter")]
     fn set_logger_filter(&self, filter: String) -> Result<()>;
 }
@@ -14,14 +14,20 @@ pub trait DebugRpc {
 pub(crate) struct DebugRpcImpl {}
 
 impl DebugRpc for DebugRpcImpl {
-    fn jemalloc_profiling_dump(&self) -> Result<()> {
+    fn jemalloc_profiling_dump(&self) -> Result<String> {
         let timestamp = time::SystemTime::now()
             .duration_since(time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let filename = format!("ckb-jeprof.{}.heap\0", timestamp);
-        ckb_memory_tracker::jemalloc_profiling_dump(filename);
-        Ok(())
+        let filename = format!("ckb-jeprof.{}.heap", timestamp);
+        match ckb_memory_tracker::jemalloc_profiling_dump(&filename) {
+            Ok(()) => Ok(filename),
+            Err(err) => Err(Error {
+                code: InternalError,
+                message: err,
+                data: None,
+            }),
+        }
     }
 
     fn set_logger_filter(&self, filter: String) -> Result<()> {

--- a/rpc/src/module/debug.rs
+++ b/rpc/src/module/debug.rs
@@ -20,7 +20,7 @@ impl DebugRpc for DebugRpcImpl {
             .unwrap()
             .as_secs();
         let filename = format!("ckb-jeprof.{}.heap", timestamp);
-        match ckb_memory_tracker::jemalloc_profiling_dump(filename.clone()) {
+        match ckb_memory_tracker::jemalloc_profiling_dump(&filename) {
             Ok(()) => Ok(filename),
             Err(err) => Err(Error {
                 code: InternalError,

--- a/rpc/src/module/debug.rs
+++ b/rpc/src/module/debug.rs
@@ -1,5 +1,5 @@
 use ckb_logger::configure_logger_filter;
-use jsonrpc_core::Result;
+use jsonrpc_core::{Error, ErrorCode::InternalError, Result};
 use jsonrpc_derive::rpc;
 use std::time;
 
@@ -20,8 +20,14 @@ impl DebugRpc for DebugRpcImpl {
             .unwrap()
             .as_secs();
         let filename = format!("ckb-jeprof.{}.heap", timestamp);
-        ckb_memory_tracker::jemalloc_profiling_dump(filename.clone());
-        Ok(filename)
+        match ckb_memory_tracker::jemalloc_profiling_dump(filename.clone()) {
+            Ok(()) => Ok(filename),
+            Err(err) => Err(Error {
+                code: InternalError,
+                message: err,
+                data: None,
+            }),
+        }
     }
 
     fn set_logger_filter(&self, filter: String) -> Result<()> {

--- a/util/memory-tracker/src/jemalloc.rs
+++ b/util/memory-tracker/src/jemalloc.rs
@@ -1,7 +1,9 @@
 use ckb_logger::info;
 use std::{ffi, mem, ptr};
+use ckb_logger::warn;
 
-pub fn jemalloc_profiling_dump(mut filename: String) {
+pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {
+    let mut filename0 = format!("{}\0", filename);
     let opt_name = "prof.dump";
     let opt_c_name = ffi::CString::new(opt_name).unwrap();
     info!("jemalloc profiling dump: {}", filename);
@@ -10,8 +12,10 @@ pub fn jemalloc_profiling_dump(mut filename: String) {
             opt_c_name.as_ptr(),
             ptr::null_mut(),
             ptr::null_mut(),
-            &mut filename as *mut _ as *mut _,
+            &mut filename0 as *mut _ as *mut _,
             mem::size_of::<*mut ffi::c_void>(),
         );
     }
+
+    Ok(())
 }

--- a/util/memory-tracker/src/jemalloc.rs
+++ b/util/memory-tracker/src/jemalloc.rs
@@ -1,5 +1,4 @@
 use ckb_logger::info;
-use ckb_logger::warn;
 use std::{ffi, mem, ptr};
 
 pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {

--- a/util/memory-tracker/src/jemalloc.rs
+++ b/util/memory-tracker/src/jemalloc.rs
@@ -1,6 +1,6 @@
 use ckb_logger::info;
-use std::{ffi, mem, ptr};
 use ckb_logger::warn;
+use std::{ffi, mem, ptr};
 
 pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {
     let mut filename0 = format!("{}\0", filename);

--- a/util/memory-tracker/src/lib.rs
+++ b/util/memory-tracker/src/lib.rs
@@ -10,7 +10,7 @@ mod jemalloc;
     feature = "profiling"
 )))]
 mod jemalloc {
-    pub fn jemalloc_profiling_dump(_: String) -> Result<(), String> {
+    pub fn jemalloc_profiling_dump(_: &str) -> Result<(), String> {
         Err("jemalloc profiling dump: unsupported".to_string())
     }
 }

--- a/util/memory-tracker/src/lib.rs
+++ b/util/memory-tracker/src/lib.rs
@@ -10,10 +10,8 @@ mod jemalloc;
     feature = "profiling"
 )))]
 mod jemalloc {
-    use ckb_logger::warn;
-
-    pub fn jemalloc_profiling_dump(_: String) {
-        warn!("jemalloc profiling dump: unsupported");
+    pub fn jemalloc_profiling_dump(_: String) -> Result<(), String> {
+        Err("jemalloc profiling dump: unsupported".to_string())
     }
 }
 


### PR DESCRIPTION
RPC `jemalloc_profiling_dump` will generate the target heap file with a timestamp to the working directory. Returning the target filename will be convenient for the command-sender to know which heap file is the current one.

Examples of the proposed responses of RPC `jemalloc_profiling_dump`:

* Success : `{"jsonrpc":"2.0","result":"ckb-jeprof.1587964630.heap","id":2}`
* ~~Fail: `{"jsonrpc":"2.0","error":{"code":-32603,"message":"jemalloc profiling dump: unsupported"},"id":2}`~~ // It never return errors at the current implementation.