### PR TITLE
feat(rpc): Improve error messages from send transaction RPC

### DIFF
--- a/util/occupied-capacity/core/src/units.rs
+++ b/util/occupied-capacity/core/src/units.rs
@@ -135,6 +135,12 @@ impl ::std::str::FromStr for Capacity {
 
 impl ::std::fmt::Display for Capacity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
+    }
+}
+
+impl ::std::fmt::LowerHex for Capacity {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -56,10 +56,6 @@ pub enum TransactionError {
     #[fail(display = "OutputsDataLengthMismatch")]
     OutputsDataLengthMismatch,
 
-    /// ANY([o.data_hash != d.data_hash() for (o, d) in ZIP(outputs, outputs_data)])
-    #[fail(display = "OutputDataHashMismatch")]
-    OutputDataHashMismatch,
-
     /// The format of `transaction.since` is invalid
     #[fail(display = "InvalidSince")]
     InvalidSince,
@@ -278,8 +274,7 @@ impl TransactionError {
             | TransactionError::InsufficientCellCapacity { .. }
             | TransactionError::InvalidSince
             | TransactionError::ExceededMaximumBlockBytes
-            | TransactionError::OutputsDataLengthMismatch
-            | TransactionError::OutputDataHashMismatch => true,
+            | TransactionError::OutputsDataLengthMismatch => true,
 
             TransactionError::Immature
             | TransactionError::CellbaseImmaturity { .. }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -63,8 +63,11 @@ pub enum TransactionError {
     },
 
     /// The format of `transaction.since` is invalid
-    #[fail(display = "InvalidSince")]
-    InvalidSince,
+    #[fail(
+        display = "InvalidSince: the field since in input {} is invalid",
+        index
+    )]
+    InvalidSince { index: usize },
 
     /// The transaction is not mature which is required by `transaction.since`
     #[fail(display = "Immature")]
@@ -278,7 +281,7 @@ impl TransactionError {
             | TransactionError::DuplicateHeaderDeps { .. }
             | TransactionError::Empty { .. }
             | TransactionError::InsufficientCellCapacity { .. }
-            | TransactionError::InvalidSince
+            | TransactionError::InvalidSince { .. }
             | TransactionError::ExceededMaximumBlockBytes
             | TransactionError::OutputsDataLengthMismatch { .. } => true,
 

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -70,8 +70,11 @@ pub enum TransactionError {
     InvalidSince { index: usize },
 
     /// The transaction is not mature which is required by `transaction.since`
-    #[fail(display = "Immature")]
-    Immature,
+    #[fail(
+        display = "Immature: the transaction is not mature because of the field since in input {}",
+        index
+    )]
+    Immature { index: usize },
 
     /// The transaction is not mature which is required by cellbase maturity rule
     #[fail(display = "CellbaseImmaturity({}[{}])", source, index)]
@@ -285,7 +288,7 @@ impl TransactionError {
             | TransactionError::ExceededMaximumBlockBytes
             | TransactionError::OutputsDataLengthMismatch { .. } => true,
 
-            TransactionError::Immature
+            TransactionError::Immature { .. }
             | TransactionError::CellbaseImmaturity { .. }
             | TransactionError::MismatchedVersion => false,
         }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -53,8 +53,14 @@ pub enum TransactionError {
     DuplicateHeaderDeps { hash: Byte32 },
 
     /// outputs.len() != outputs_data.len()
-    #[fail(display = "OutputsDataLengthMismatch")]
-    OutputsDataLengthMismatch,
+    #[fail(
+        display = "OutputsDataLengthMismatch: expected outputs data length ({}) = outputs length ({})",
+        outputs_data_len, outputs_len
+    )]
+    OutputsDataLengthMismatch {
+        outputs_len: usize,
+        outputs_data_len: usize,
+    },
 
     /// The format of `transaction.since` is invalid
     #[fail(display = "InvalidSince")]
@@ -274,7 +280,7 @@ impl TransactionError {
             | TransactionError::InsufficientCellCapacity { .. }
             | TransactionError::InvalidSince
             | TransactionError::ExceededMaximumBlockBytes
-            | TransactionError::OutputsDataLengthMismatch => true,
+            | TransactionError::OutputsDataLengthMismatch { .. } => true,
 
             TransactionError::Immature
             | TransactionError::CellbaseImmaturity { .. }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -64,14 +64,14 @@ pub enum TransactionError {
 
     /// The format of `transaction.since` is invalid
     #[fail(
-        display = "InvalidSince: the field since in input {} is invalid",
+        display = "InvalidSince(Inputs[{}]): the field since is invalid",
         index
     )]
     InvalidSince { index: usize },
 
     /// The transaction is not mature which is required by `transaction.since`
     #[fail(
-        display = "Immature: the transaction is not mature because of the field since in input {}",
+        display = "Immature(Inputs[{}]): the transaction is immature because of the since requirement",
         index
     )]
     Immature { index: usize },
@@ -88,8 +88,11 @@ pub enum TransactionError {
     MismatchedVersion { expected: Version, actual: Version },
 
     /// The transaction size is too large
-    #[fail(display = "ExceededMaximumBlockBytes")]
-    ExceededMaximumBlockBytes,
+    #[fail(
+        display = "ExceededMaximumBlockBytes: expected transaction serialized size ({}) < block size limit ({})",
+        actual, limit
+    )]
+    ExceededMaximumBlockBytes { limit: u64, actual: u64 },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Display)]
@@ -285,7 +288,7 @@ impl TransactionError {
             | TransactionError::Empty { .. }
             | TransactionError::InsufficientCellCapacity { .. }
             | TransactionError::InvalidSince { .. }
-            | TransactionError::ExceededMaximumBlockBytes
+            | TransactionError::ExceededMaximumBlockBytes { .. }
             | TransactionError::OutputsDataLengthMismatch { .. } => true,
 
             TransactionError::Immature { .. }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -28,8 +28,14 @@ pub enum TransactionError {
     },
 
     /// SUM([o.capacity for o in outputs]) > SUM([i.capacity for i in inputs])
-    #[fail(display = "OutputsSumOverflow")]
-    OutputsSumOverflow,
+    #[fail(
+        display = "OutputsSumOverflow: expected outputs capacity ({:#x}) <= inputs capacity ({:#x})",
+        outputs_sum, inputs_sum
+    )]
+    OutputsSumOverflow {
+        inputs_sum: Capacity,
+        outputs_sum: Capacity,
+    },
 
     /// inputs.is_empty() || outputs.is_empty()
     #[fail(display = "Empty({})", source)]
@@ -258,7 +264,7 @@ pub enum EpochError {
 impl TransactionError {
     pub fn is_malformed_tx(&self) -> bool {
         match self {
-            TransactionError::OutputsSumOverflow
+            TransactionError::OutputsSumOverflow { .. }
             | TransactionError::DuplicateDeps
             | TransactionError::Empty { .. }
             | TransactionError::InsufficientCellCapacity { .. }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -1,6 +1,6 @@
 use ckb_error::Error;
 use ckb_types::{
-    core::Capacity,
+    core::{Capacity, Version},
     packed::{Byte32, OutPoint},
 };
 use failure::{Backtrace, Context, Fail};
@@ -84,8 +84,8 @@ pub enum TransactionError {
     },
 
     /// The transaction version is mismatched with the system can hold
-    #[fail(display = "MismatchedVersion")]
-    MismatchedVersion,
+    #[fail(display = "MismatchedVersion: expected {}, got {}", expected, actual)]
+    MismatchedVersion { expected: Version, actual: Version },
 
     /// The transaction size is too large
     #[fail(display = "ExceededMaximumBlockBytes")]
@@ -290,7 +290,7 @@ impl TransactionError {
 
             TransactionError::Immature { .. }
             | TransactionError::CellbaseImmaturity { .. }
-            | TransactionError::MismatchedVersion => false,
+            | TransactionError::MismatchedVersion { .. } => false,
         }
     }
 }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -32,8 +32,8 @@ pub enum TransactionError {
     OutputsSumOverflow,
 
     /// inputs.is_empty() || outputs.is_empty()
-    #[fail(display = "Empty")]
-    Empty,
+    #[fail(display = "Empty({})", source)]
+    Empty { source: TransactionErrorSource },
 
     /// Duplicated dep-out-points within the same one transaction
     #[fail(display = "DuplicateDeps")]
@@ -260,7 +260,7 @@ impl TransactionError {
         match self {
             TransactionError::OutputsSumOverflow
             | TransactionError::DuplicateDeps
-            | TransactionError::Empty
+            | TransactionError::Empty { .. }
             | TransactionError::InsufficientCellCapacity { .. }
             | TransactionError::InvalidSince
             | TransactionError::ExceededMaximumBlockBytes

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -339,7 +339,10 @@ pub fn test_capacity_invalid() {
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::OutputsSumOverflow,
+        TransactionError::OutputsSumOverflow {
+            inputs_sum: capacity_bytes!(149),
+            outputs_sum: capacity_bytes!(150),
+        },
     );
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -2,6 +2,7 @@ use super::super::transaction_verifier::{
     CapacityVerifier, DuplicateDepsVerifier, EmptyVerifier, MaturityVerifier, OutputsDataVerifier,
     Since, SinceVerifier, SizeVerifier, VersionVerifier,
 };
+use crate::error::TransactionErrorSource;
 use crate::TransactionError;
 use ckb_chain_spec::{build_genesis_type_id_script, OUTPUT_INDEX_DAO};
 use ckb_error::{assert_error_eq, Error};
@@ -148,7 +149,10 @@ pub fn test_inputs_cellbase_maturity() {
         if current < threshold {
             assert_error_eq!(
                 verifier.verify().unwrap_err(),
-                TransactionError::CellbaseImmaturity,
+                TransactionError::CellbaseImmaturity {
+                    source: TransactionErrorSource::Inputs,
+                    index: 0
+                },
                 "base_epoch = {}, current_epoch = {}, cellbase_maturity = {}",
                 base_epoch,
                 current_epoch,
@@ -251,7 +255,10 @@ pub fn test_deps_cellbase_maturity() {
         if current < threshold {
             assert_error_eq!(
                 verifier.verify().unwrap_err(),
-                TransactionError::CellbaseImmaturity,
+                TransactionError::CellbaseImmaturity {
+                    source: TransactionErrorSource::CellDeps,
+                    index: 0
+                },
                 "base_epoch = {}, current_epoch = {}, cellbase_maturity = {}",
                 base_epoch,
                 current_epoch,

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -15,7 +15,7 @@ use ckb_types::{
         capacity_bytes,
         cell::{CellMetaBuilder, ResolvedTransaction},
         BlockNumber, Capacity, EpochNumber, EpochNumberWithFraction, TransactionBuilder,
-        TransactionInfo, TransactionView, Version,
+        TransactionInfo, TransactionView,
     },
     h256,
     packed::{CellDep, CellInput, CellOutput, OutPoint},
@@ -57,7 +57,6 @@ pub fn test_version() {
 pub fn test_exceeded_maximum_block_bytes() {
     let data: Bytes = vec![1; 500].into();
     let transaction = TransactionBuilder::default()
-        .version((Version::default() + 1).pack())
         .output(
             CellOutput::new_builder()
                 .capacity(capacity_bytes!(50).pack())
@@ -69,7 +68,10 @@ pub fn test_exceeded_maximum_block_bytes() {
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::ExceededMaximumBlockBytes,
+        TransactionError::ExceededMaximumBlockBytes {
+            actual: 661,
+            limit: 100
+        },
     );
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -468,7 +468,7 @@ fn test_invalid_since_verify() {
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
-        TransactionError::InvalidSince,
+        TransactionError::InvalidSince { index: 0 },
     );
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -94,7 +94,12 @@ pub fn test_capacity_outofbound() {
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::InsufficientCellCapacity,
+        TransactionError::InsufficientCellCapacity {
+            source: TransactionErrorSource::Outputs,
+            index: 0,
+            capacity: capacity_bytes!(50),
+            occupied_capacity: capacity_bytes!(92),
+        }
     );
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -46,7 +46,10 @@ pub fn test_version() {
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::MismatchedVersion,
+        TransactionError::MismatchedVersion {
+            expected: 0,
+            actual: 1
+        },
     );
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -29,7 +29,12 @@ pub fn test_empty() {
     let transaction = TransactionBuilder::default().build();
     let verifier = EmptyVerifier::new(&transaction);
 
-    assert_error_eq!(verifier.verify().unwrap_err(), TransactionError::Empty);
+    assert_error_eq!(
+        verifier.verify().unwrap_err(),
+        TransactionError::Empty {
+            source: TransactionErrorSource::Inputs,
+        }
+    );
 }
 
 #[test]

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -661,7 +661,10 @@ pub fn test_outputs_data_length_mismatch() {
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::OutputsDataLengthMismatch,
+        TransactionError::OutputsDataLengthMismatch {
+            outputs_len: 1,
+            outputs_data_len: 0
+        },
     );
 
     let transaction = TransactionBuilder::default()

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -504,7 +504,7 @@ fn test_fraction_epoch_since_verify() {
         parent_hash.as_ref().to_owned(),
     )
     .verify();
-    assert_error_eq!(result.unwrap_err(), TransactionError::Immature);
+    assert_error_eq!(result.unwrap_err(), TransactionError::Immature { index: 0 });
 
     let result = SinceVerifier::new(
         &rtx,
@@ -529,7 +529,7 @@ pub fn test_absolute_block_number_lock() {
 
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
-        TransactionError::Immature,
+        TransactionError::Immature { index: 0 },
     );
     // spent after 10 height
     assert!(verify_since(&rtx, &median_time_context, 10, 1).is_ok());
@@ -547,7 +547,7 @@ pub fn test_absolute_epoch_number_lock() {
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
-        TransactionError::Immature,
+        TransactionError::Immature { index: 0 },
     );
     // spent after 10 epoch
     assert!(verify_since(&rtx, &median_time_context, 100, 10).is_ok());
@@ -565,7 +565,7 @@ pub fn test_relative_timestamp_lock() {
     let median_time_context = MockMedianTime::new(vec![0; 11]);
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
-        TransactionError::Immature,
+        TransactionError::Immature { index: 0 },
     );
 
     // spent after 1024 seconds
@@ -588,7 +588,7 @@ pub fn test_relative_epoch() {
 
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
-        TransactionError::Immature,
+        TransactionError::Immature { index: 0 },
     );
 
     assert!(verify_since(&rtx, &median_time_context, 4, 2).is_ok());
@@ -617,7 +617,7 @@ pub fn test_since_both() {
 
     assert_error_eq!(
         verify_since(&rtx, &median_time_context, 4, 1).unwrap_err(),
-        TransactionError::Immature,
+        TransactionError::Immature { index: 0 },
     );
     // spent after 1024 seconds and 10 blocks
     // fake median time: 1124
@@ -647,7 +647,7 @@ fn test_since_overflow() {
         let median_time_context = MockMedianTime::new(vec![0; 11]);
         assert_error_eq!(
             verify_since(&rtx, &median_time_context, 5, 1).unwrap_err(),
-            TransactionError::Immature,
+            TransactionError::Immature { index: 0 },
         );
     }
 }

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -347,18 +347,36 @@ pub fn test_capacity_invalid() {
 }
 
 #[test]
-pub fn test_duplicate_deps() {
+pub fn test_duplicate_cell_deps() {
     let out_point = OutPoint::new(h256!("0x1").pack(), 0);
     let cell_dep = CellDep::new_builder().out_point(out_point).build();
     let transaction = TransactionBuilder::default()
-        .cell_deps(vec![cell_dep.clone(), cell_dep])
+        .cell_deps(vec![cell_dep.clone(), cell_dep.clone()])
         .build();
 
     let verifier = DuplicateDepsVerifier::new(&transaction);
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
-        TransactionError::DuplicateDeps,
+        TransactionError::DuplicateCellDeps {
+            out_point: cell_dep.out_point()
+        },
+    );
+}
+
+#[test]
+pub fn test_duplicate_header_deps() {
+    let transaction = TransactionBuilder::default()
+        .header_deps(vec![h256!("0x1").pack(), h256!("0x1").pack()])
+        .build();
+
+    let verifier = DuplicateDepsVerifier::new(&transaction);
+
+    assert_error_eq!(
+        verifier.verify().unwrap_err(),
+        TransactionError::DuplicateHeaderDeps {
+            hash: h256!("0x1").pack()
+        },
     );
 }
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -171,7 +171,11 @@ impl<'a> VersionVerifier<'a> {
 
     pub fn verify(&self) -> Result<(), Error> {
         if self.transaction.version() != self.tx_version {
-            return Err((TransactionError::MismatchedVersion).into());
+            return Err((TransactionError::MismatchedVersion {
+                expected: self.tx_version,
+                actual: self.transaction.version(),
+            })
+            .into());
         }
         Ok(())
     }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -199,7 +199,11 @@ impl<'a> SizeVerifier<'a> {
         if size <= self.block_bytes_limit {
             Ok(())
         } else {
-            Err(TransactionError::ExceededMaximumBlockBytes.into())
+            Err(TransactionError::ExceededMaximumBlockBytes {
+                actual: size,
+                limit: self.block_bytes_limit,
+            }
+            .into())
         }
     }
 }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -519,18 +519,18 @@ where
             match since.extract_metric() {
                 Some(SinceMetric::BlockNumber(block_number)) => {
                     if self.block_number < block_number {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 Some(SinceMetric::EpochNumberWithFraction(epoch_number_with_fraction)) => {
                     if self.epoch_number_with_fraction < epoch_number_with_fraction {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 Some(SinceMetric::Timestamp(timestamp)) => {
                     let tip_timestamp = self.block_median_time(&self.parent_hash);
                     if tip_timestamp < timestamp {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 None => {
@@ -550,12 +550,12 @@ where
         if since.is_relative() {
             let info = match cell_meta.transaction_info {
                 Some(ref transaction_info) => Ok(transaction_info),
-                None => Err(TransactionError::Immature),
+                None => Err(TransactionError::Immature { index }),
             }?;
             match since.extract_metric() {
                 Some(SinceMetric::BlockNumber(block_number)) => {
                     if self.block_number < info.block_number + block_number {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 Some(SinceMetric::EpochNumberWithFraction(epoch_number_with_fraction)) => {
@@ -563,7 +563,7 @@ where
                     let b =
                         info.block_epoch.to_rational() + epoch_number_with_fraction.to_rational();
                     if a < b {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 Some(SinceMetric::Timestamp(timestamp)) => {
@@ -574,7 +574,7 @@ where
                     let cell_median_timestamp = self.parent_median_time(&info.block_hash);
                     let current_median_time = self.block_median_time(&self.parent_hash);
                     if current_median_time < cell_median_timestamp + timestamp {
-                        return Err((TransactionError::Immature).into());
+                        return Err((TransactionError::Immature { index }).into());
                     }
                 }
                 None => {

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -616,8 +616,14 @@ impl<'a> OutputsDataVerifier<'a> {
     }
 
     pub fn verify(&self) -> Result<(), TransactionError> {
-        if self.transaction.outputs().len() != self.transaction.outputs_data().len() {
-            return Err(TransactionError::OutputsDataLengthMismatch);
+        let outputs_len = self.transaction.outputs().len();
+        let outputs_data_len = self.transaction.outputs_data().len();
+
+        if outputs_len != outputs_data_len {
+            return Err(TransactionError::OutputsDataLengthMismatch {
+                outputs_len,
+                outputs_data_len,
+            });
         }
         Ok(())
     }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -229,10 +229,16 @@ impl<'a> EmptyVerifier<'a> {
     }
 
     pub fn verify(&self) -> Result<(), Error> {
-        if self.transaction.inputs().is_empty()
-            || (self.transaction.outputs().is_empty() && !self.transaction.is_cellbase())
-        {
-            Err(TransactionError::Empty.into())
+        if self.transaction.inputs().is_empty() {
+            Err(TransactionError::Empty {
+                source: TransactionErrorSource::Inputs,
+            }
+            .into())
+        } else if self.transaction.outputs().is_empty() && !self.transaction.is_cellbase() {
+            Err(TransactionError::Empty {
+                source: TransactionErrorSource::Outputs,
+            }
+            .into())
         } else {
             Ok(())
         }

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -360,11 +360,15 @@ impl<'a> CapacityVerifier<'a> {
         // cellbase's outputs are verified by RewardVerifier
         // DAO withdraw transaction is verified via the type script of DAO cells
         if !(self.resolved_transaction.is_cellbase() || self.valid_dao_withdraw_transaction()) {
-            let inputs_total = self.resolved_transaction.inputs_capacity()?;
-            let outputs_total = self.resolved_transaction.outputs_capacity()?;
+            let inputs_sum = self.resolved_transaction.inputs_capacity()?;
+            let outputs_sum = self.resolved_transaction.outputs_capacity()?;
 
-            if inputs_total < outputs_total {
-                return Err((TransactionError::OutputsSumOverflow).into());
+            if inputs_sum < outputs_sum {
+                return Err((TransactionError::OutputsSumOverflow {
+                    inputs_sum,
+                    outputs_sum,
+                })
+                .into());
             }
         }
 


### PR DESCRIPTION
This PR adds extra information in transaction verification errors, such as:

* Which `input`, `cell_dep`, `header_dep` or `output` causes the error
* If there's a limit, what's the value of the limit.

There're also ambiguous error messages. For example, the pool has its own cycles limit on a single transaction, which is configurable in the config file. The block also as a limit on all the transactions in the block. Apparently, for a single transaction, the cycles should not exceed the block limit. This PR also avoids using the same error for different reasons.