### PR TITLE
chore: upgrade p2p/tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "snap",
  "tempfile",
  "tentacle",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-util",
 ]
 
@@ -3959,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fe0d7d314219019230d3a95ba6e5753a969936d9ac6428ed3dd136bb41680a"
+checksum = "2f7cab1d0b16fd44c8981b075625b8a68d838e0181f43b878dbf7f8eea5b2bf9"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -3971,7 +3971,7 @@ dependencies = [
  "molecule",
  "tentacle-multiaddr",
  "tentacle-secio",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-util",
  "tokio-yamux",
  "winapi 0.3.8",
@@ -3992,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476977fd1e39f88147f1dd70cd60619acf45b673e85aa4013d845add776c4a27"
+checksum = "2e314fcedaa2dfe7b0dc3d4894a21fa3e60b0fe7b4e9e506b1538974ab9ee02f"
 dependencies = [
  "bs58",
  "bytes 0.5.4",
@@ -4006,7 +4006,7 @@ dependencies = [
  "rand 0.7.0",
  "ring",
  "secp256k1 0.17.2",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-util",
  "unsigned-varint",
 ]
@@ -4134,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes 0.5.4",
  "futures-core",
@@ -4329,28 +4329,28 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes 0.5.4",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.18",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "tokio-yamux"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da58ec1e052364504833f6880a1c936f6e7ccbb6f99b95e2cbc6590ed1808fa"
+checksum = "fadb4597f69de066b89607edb8810ee52d54342702629fc78aece5663f2b8f29"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "log 0.4.8",
- "tokio 0.2.18",
+ "tokio 0.2.20",
  "tokio-util",
 ]
 

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -5,8 +5,8 @@ use ckb_chain::chain::ChainService;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_logger::info_target;
 use ckb_network::{
-    CKBProtocol, NetworkService, NetworkState, MAX_FRAME_LENGTH_ALERT, MAX_FRAME_LENGTH_RELAY,
-    MAX_FRAME_LENGTH_SYNC, MAX_FRAME_LENGTH_TIME,
+    BlockingFlag, CKBProtocol, NetworkService, NetworkState, MAX_FRAME_LENGTH_ALERT,
+    MAX_FRAME_LENGTH_RELAY, MAX_FRAME_LENGTH_SYNC, MAX_FRAME_LENGTH_TIME,
 };
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_resource::Resource;
@@ -82,6 +82,14 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let alert_notifier = Arc::clone(alert_relayer.notifier());
     let alert_verifier = Arc::clone(alert_relayer.verifier());
 
+    let mut no_blocking_flag = BlockingFlag::default();
+    no_blocking_flag.disable_all();
+
+    let mut blocking_recv_flag = BlockingFlag::default();
+    blocking_recv_flag.disable_connected();
+    blocking_recv_flag.disable_disconnected();
+    blocking_recv_flag.disable_notify();
+
     let synchronizer_clone = synchronizer.clone();
     let protocols = vec![
         CKBProtocol::new(
@@ -91,6 +99,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             MAX_FRAME_LENGTH_SYNC,
             move || Box::new(synchronizer_clone.clone()),
             Arc::clone(&network_state),
+            blocking_recv_flag,
         ),
         CKBProtocol::new(
             "rel".to_string(),
@@ -99,6 +108,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             MAX_FRAME_LENGTH_RELAY,
             move || Box::new(relayer.clone()),
             Arc::clone(&network_state),
+            blocking_recv_flag,
         ),
         CKBProtocol::new(
             "tim".to_string(),
@@ -107,6 +117,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             MAX_FRAME_LENGTH_TIME,
             move || Box::new(net_timer.clone()),
             Arc::clone(&network_state),
+            no_blocking_flag,
         ),
         CKBProtocol::new(
             "alt".to_string(),
@@ -115,6 +126,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             MAX_FRAME_LENGTH_ALERT,
             move || Box::new(alert_relayer.clone()),
             Arc::clone(&network_state),
+            no_blocking_flag,
         ),
     ];
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -12,10 +12,10 @@ ckb-util = { path = "../util" }
 ckb-stop-handler = { path = "../util/stop-handler" }
 ckb-logger = { path = "../util/logger" }
 tokio = { version = "0.2.11", features = ["time", "io-util", "tcp", "dns", "rt-threaded", "blocking", "stream"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 futures = "0.3"
 crossbeam-channel = "0.3"
-p2p = { version="0.3.0-alpha.3", package="tentacle", features = ["molc"] }
+p2p = { version="0.3.0-alpha.4", package="tentacle", features = ["molc"] }
 faketime = "0.2.0"
 lazy_static = "1.3.0"
 bs58 = "0.3.0"

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -26,10 +26,11 @@ pub use crate::{
 pub use p2p::{
     bytes, multiaddr,
     secio::{PeerId, PublicKey},
-    service::{ServiceControl, SessionType, TargetSession},
+    service::{BlockingFlag, ServiceControl, SessionType, TargetSession},
     traits::ServiceProtocol,
     ProtocolId,
 };
+pub use tokio;
 
 // Max message frame length for sync protocol: 2MB
 //   NOTE: update this value when block size limit changed

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -37,8 +37,8 @@ use p2p::{
     multiaddr::{self, Multiaddr},
     secio::{self, PeerId},
     service::{
-        ProtocolEvent, ProtocolHandle, Service, ServiceError, ServiceEvent, TargetProtocol,
-        TargetSession,
+        BlockingFlag, ProtocolEvent, ProtocolHandle, Service, ServiceError, ServiceEvent,
+        TargetProtocol, TargetSession,
     },
     traits::ServiceHandle,
     utils::extract_peer_id,
@@ -848,6 +848,9 @@ impl NetworkService {
     ) -> NetworkService {
         let config = &network_state.config;
 
+        let mut no_blocking_flag = BlockingFlag::default();
+        no_blocking_flag.disable_all();
+
         // == Build special protocols
 
         // TODO: how to deny banned node to open those protocols?
@@ -873,6 +876,7 @@ impl NetworkService {
                     ping_sender,
                 )))
             })
+            .flag(no_blocking_flag)
             .build();
 
         // Discovery protocol
@@ -893,6 +897,7 @@ impl NetworkService {
                     config.discovery_local_address,
                 )))
             })
+            .flag(no_blocking_flag)
             .build();
 
         // Identify protocol
@@ -911,6 +916,7 @@ impl NetworkService {
             .service_handle(move || {
                 ProtocolHandle::Both(Box::new(IdentifyProtocol::new(identify_callback)))
             })
+            .flag(no_blocking_flag)
             .build();
 
         // Feeler protocol
@@ -929,6 +935,7 @@ impl NetworkService {
                 let network_state = Arc::clone(&network_state);
                 move || ProtocolHandle::Both(Box::new(Feeler::new(Arc::clone(&network_state))))
             })
+            .flag(no_blocking_flag)
             .build();
 
         let disconnect_message_meta = MetaBuilder::default()
@@ -942,6 +949,7 @@ impl NetworkService {
                 )
             })
             .service_handle(move || ProtocolHandle::Both(Box::new(DisconnectMessageProtocol)))
+            .flag(no_blocking_flag)
             .build();
 
         // == Build p2p service struct

--- a/network/src/protocols/discovery/protocol.rs
+++ b/network/src/protocols/discovery/protocol.rs
@@ -45,11 +45,10 @@ impl Decoder for DiscoveryCodec {
     }
 }
 
-impl Encoder for DiscoveryCodec {
-    type Item = DiscoveryMessage;
+impl Encoder<DiscoveryMessage> for DiscoveryCodec {
     type Error = io::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: DiscoveryMessage, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.inner.encode(item.encode(), dst)
     }
 }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -25,7 +25,9 @@ use crate::types::{ActiveChain, SyncShared};
 use crate::{Status, StatusCode, BAD_MESSAGE_BAN_TIME};
 use ckb_chain::chain::ChainController;
 use ckb_logger::{debug_target, error_target, info_target, metric, trace_target, warn_target};
-use ckb_network::{bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession};
+use ckb_network::{
+    bytes::Bytes, tokio, CKBProtocolContext, CKBProtocolHandler, PeerIndex, TargetSession,
+};
 use ckb_tx_pool::FeeRate;
 use ckb_types::core::BlockView;
 use ckb_types::{
@@ -704,7 +706,9 @@ impl CKBProtocolHandler for Relayer {
         let start_time = Instant::now();
         trace_target!(crate::LOG_TARGET_RELAY, "start notify token={}", token);
         match token {
-            TX_PROPOSAL_TOKEN => self.prune_tx_proposal_request(nc.as_ref()),
+            TX_PROPOSAL_TOKEN => {
+                tokio::task::block_in_place(|| self.prune_tx_proposal_request(nc.as_ref()))
+            }
             ASK_FOR_TXS_TOKEN => self.ask_for_txs(nc.as_ref()),
             TX_HASHES_TOKEN => self.send_bulk_of_tx_hashes(nc.as_ref()),
             _ => unreachable!(),

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -122,6 +122,7 @@ impl Net {
                     1024 * 1024,
                     move || Box::new(DummyProtocolHandler { tx: tx.clone() }),
                     Arc::clone(&network_state),
+                    Default::default(),
                 )
             })
             .collect();


### PR DESCRIPTION
1. Upgrade p2p, use new `BlockingFlag` to optimize performance
2. Upgrade tokio, allow recursive call `block_in_place`

p2p release note:
```
Bug Fix

    Fix session proto open/close by user part(#220)

Features

    Replace unsplit with assignment(#225)
    Upgrade tokio util(#224)
    Avoids unnecessary session id checking(#223)
    Check all underscore(#228)
    Use flag to control how to use block_in_place(#226)
    More test(#227/#220)
```

tokio release note:
```
Fix
    rt: support block_in_place in more contexts
    stream: no panic in merge() and chain() when using size_hint()
    task: include visibility modifier when defining a task-local
    sync: broadcast closing the channel no longer requires capacity 

Added
    rt: runtime::Handle::block_on
```