### PR TITLE
chore: fix clippy warn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ deploy:
 if: 'type != pull_request or head_branch != develop'
 
 matrix:
+  allow_failures:
+    - rust: stable
   include:
     # We don't run tests, linters and quck check in fork branch, since they will be covered in PR.
     - name: Tests on macOS
@@ -77,6 +79,20 @@ matrix:
         - make fmt
         - make clippy
         - git diff --exit-code Cargo.lock
+    - name: Latest Linters
+      if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, staging2, trying) OR repo != nervosnetwork/ckb)'
+      os: linux
+      rust: stable
+      cache: false
+      addons: { apt: { packages: [] } }
+      env:
+        - CLIPPY_OPTS="-D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from"
+      install:
+        - rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
+        - rustup component add clippy --toolchain stable-x86_64-unknown-linux-gnu
+      script:
+        - cargo +stable fmt --all -- --check
+        - cargo +stable clippy --all --all-targets --all-features -- ${CLIPPY_OPTS}
     - name: Quick Check
       if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, staging2, trying) OR repo != nervosnetwork/ckb)'
       os: linux

--- a/ckb-bin/src/subcommand/prof.rs
+++ b/ckb-bin/src/subcommand/prof.rs
@@ -5,7 +5,6 @@ use ckb_logger::info;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainStore;
 use std::sync::Arc;
-use tempfile;
 
 pub fn profile(args: ProfArgs) -> Result<(), ExitCode> {
     let (shared, _table) = SharedBuilder::with_db_config(&args.config.db)

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -164,7 +164,6 @@ mod tests {
     use crate::migration::{DefaultMigration, Migration, Migrations};
     use rocksdb::ops::Get;
     use std::collections::HashMap;
-    use tempfile;
 
     fn setup_db(prefix: &str, columns: u32) -> RocksDB {
         setup_db_with_check(prefix, columns).unwrap()

--- a/indexer/src/store.rs
+++ b/indexer/src/store.rs
@@ -723,7 +723,6 @@ mod tests {
         U256,
     };
     use std::sync::Arc;
-    use tempfile;
 
     fn setup(prefix: &str) -> (DefaultIndexerStore, ChainController, Shared) {
         let builder = SharedBuilder::default();

--- a/network/src/behaviour.rs
+++ b/network/src/behaviour.rs
@@ -15,13 +15,12 @@ pub enum Behaviour {
 
 impl Behaviour {
     pub fn score(self) -> Score {
-        #[allow(unreachable_patterns)]
+        #[cfg(test)]
         match self {
-            #[cfg(test)]
             Behaviour::TestGood => 10,
-            #[cfg(test)]
             Behaviour::TestBad => -10,
-            _ => 0,
         }
+        #[cfg(not(test))]
+        0
     }
 }

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -7,7 +7,6 @@ use p2p::{
     multiaddr::{Multiaddr, Protocol},
     secio,
 };
-use rand;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::fs;

--- a/network/src/protocols/discovery/substream.rs
+++ b/network/src/protocols/discovery/substream.rs
@@ -390,7 +390,7 @@ impl Substream {
                 .listens()
                 .iter()
                 .map(|address| multiaddr_to_socketaddr(address).unwrap().port())
-                .nth(0)
+                .next()
         } else {
             None
         };

--- a/network/src/protocols/ping.rs
+++ b/network/src/protocols/ping.rs
@@ -339,7 +339,7 @@ impl PingService {
 impl Stream for PingService {
     type Item = ();
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        use Event::*;
+        use Event::{Ping, Pong, Timeout, UnexpectedError};
 
         loop {
             match self.event_receiver.poll_next_unpin(cx) {

--- a/network/src/services/protocol_type_checker.rs
+++ b/network/src/services/protocol_type_checker.rs
@@ -34,7 +34,7 @@ enum ProtocolType {
 
 impl std::fmt::Display for ProtocolType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        use ProtocolType::*;
+        use ProtocolType::{Feeler, FullyOpen};
         match self {
             FullyOpen => write!(f, "fully-open")?,
             Feeler => write!(f, "feeler")?,
@@ -50,7 +50,7 @@ enum ProtocolTypeError {
 
 impl std::fmt::Display for ProtocolTypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        use ProtocolTypeError::*;
+        use ProtocolTypeError::Incomplete;
         match self {
             Incomplete => write!(f, "incomplete open protocols")?,
         }

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -2,12 +2,9 @@ use crate::config::Config;
 use crate::module::{SubscriptionRpc, SubscriptionRpcImpl, SubscriptionSession};
 use crate::IoHandler;
 use ckb_notify::NotifyController;
-use jsonrpc_http_server;
 use jsonrpc_pubsub::Session;
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
-use jsonrpc_tcp_server;
-use jsonrpc_ws_server;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 pub struct RpcServer {

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -41,7 +41,6 @@ use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use rand::{thread_rng, Rng};
-use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, json, to_string, Map, Value};
 use std::cell::RefCell;

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -726,8 +726,6 @@ mod tests {
         U256,
     };
     use ckb_util::Mutex;
-    #[cfg(not(disable_faketime))]
-    use faketime;
     use futures::future::Future;
     use std::{
         collections::{HashMap, HashSet},

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1244,7 +1244,7 @@ impl SyncState {
 
     pub fn take_tx_hashes(&self) -> HashMap<PeerIndex, LinkedHashSet<Byte32>> {
         let mut map = self.tx_hashes.lock();
-        mem::replace(&mut *map, HashMap::default())
+        mem::take(&mut *map)
     }
 
     pub fn is_initial_header_sync(&self) -> bool {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
 
     info!(
         "{} --bin {} --port {} {}",
-        canonicalize_path(env::args().nth(0).unwrap_or_else(|| "ckb-test".to_string())).display(),
+        canonicalize_path(env::args().next().unwrap_or_else(|| "ckb-test".to_string())).display(),
         canonicalize_path(binary).display(),
         start_port,
         rerun_specs.join(" "),

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -28,7 +28,9 @@ use ckb_tx_pool::FeeRate;
 #[macro_export]
 macro_rules! name {
     ($name:literal) => {
-        fn name(&self) -> &'static str { $name }
+        fn name(&self) -> &'static str {
+            $name
+        }
     };
 }
 

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -23,7 +23,6 @@ use ckb_types::{
     packed::{Byte32, ProposalShortId},
 };
 use ckb_verification::cache::{CacheEntry, TxVerifyCache};
-use crossbeam_channel;
 use failure::Error as FailureError;
 use futures::future::{self, Future};
 use futures::stream::Stream;

--- a/util/instrument/src/export.rs
+++ b/util/instrument/src/export.rs
@@ -3,7 +3,6 @@ use ckb_jsonrpc_types::BlockView as JsonBlock;
 use ckb_shared::shared::Shared;
 #[cfg(feature = "progress_bar")]
 use indicatif::{ProgressBar, ProgressStyle};
-use serde_json;
 use std::error::Error;
 use std::fs;
 use std::io;

--- a/util/instrument/src/import.rs
+++ b/util/instrument/src/import.rs
@@ -3,7 +3,6 @@ use ckb_jsonrpc_types::BlockView as JsonBlock;
 use ckb_types::core;
 #[cfg(feature = "progress_bar")]
 use indicatif::{ProgressBar, ProgressStyle};
-use serde_json;
 use std::error::Error;
 use std::fs;
 use std::io;

--- a/util/jsonrpc-types/src/bytes.rs
+++ b/util/jsonrpc-types/src/bytes.rs
@@ -110,7 +110,6 @@ mod test {
     use super::JsonBytes;
     use regex::Regex;
     use serde::{Deserialize, Serialize};
-    use serde_json;
 
     #[test]
     fn test_de_error() {

--- a/util/types/src/core/advanced_builders.rs
+++ b/util/types/src/core/advanced_builders.rs
@@ -110,16 +110,16 @@ macro_rules! def_setter_for_vector {
         }
         pub fn $func_extend<T>(mut self, v: T) -> Self
         where
-            T: ::std::iter::IntoIterator<Item = packed::$type>
+            T: ::std::iter::IntoIterator<Item = packed::$type>,
         {
             self.$field.extend(v);
             self
         }
         pub fn $func_set(mut self, v: Vec<packed::$type>) -> Self {
-            self.$field= v;
+            self.$field = v;
             self
         }
-    }
+    };
 }
 
 macro_rules! def_setter_for_view_vector {
@@ -130,16 +130,16 @@ macro_rules! def_setter_for_view_vector {
         }
         pub fn $func_extend<T>(mut self, v: T) -> Self
         where
-            T: ::std::iter::IntoIterator<Item = core::$type>
+            T: ::std::iter::IntoIterator<Item = core::$type>,
         {
             self.$field.extend(v);
             self
         }
         pub fn $func_set(mut self, v: Vec<core::$type>) -> Self {
-            self.$field= v;
+            self.$field = v;
             self
         }
-    }
+    };
 }
 
 impl TransactionBuilder {

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -119,7 +119,7 @@ macro_rules! define_simple_getter {
         pub fn $field(&self) -> packed::$type {
             self.$field.clone()
         }
-    }
+    };
 }
 
 macro_rules! define_vector_getter {
@@ -127,7 +127,7 @@ macro_rules! define_vector_getter {
         pub fn $field(&self) -> &[packed::$type] {
             &self.$field[..]
         }
-    }
+    };
 }
 
 impl TransactionView {
@@ -236,7 +236,7 @@ macro_rules! define_header_unpacked_inner_getter {
         pub fn $field(&self) -> $type {
             self.data().as_reader().raw().$field().unpack()
         }
-    }
+    };
 }
 
 macro_rules! define_header_packed_inner_getter {
@@ -244,7 +244,7 @@ macro_rules! define_header_packed_inner_getter {
         pub fn $field(&self) -> packed::$type {
             self.data().raw().$field()
         }
-    }
+    };
 }
 
 impl HeaderView {
@@ -289,7 +289,7 @@ macro_rules! define_uncle_unpacked_inner_getter {
         pub fn $field(&self) -> $type {
             self.data().as_reader().header().raw().$field().unpack()
         }
-    }
+    };
 }
 
 macro_rules! define_uncle_packed_inner_getter {
@@ -297,7 +297,7 @@ macro_rules! define_uncle_packed_inner_getter {
         pub fn $field(&self) -> packed::$type {
             self.data().header().raw().$field()
         }
-    }
+    };
 }
 
 impl UncleBlockView {
@@ -400,7 +400,7 @@ macro_rules! define_block_unpacked_inner_getter {
         pub fn $field(&self) -> $type {
             self.data().as_reader().header().raw().$field().unpack()
         }
-    }
+    };
 }
 
 macro_rules! define_block_packed_inner_getter {
@@ -408,7 +408,7 @@ macro_rules! define_block_packed_inner_getter {
         pub fn $field(&self) -> packed::$type {
             self.data().header().raw().$field()
         }
-    }
+    };
 }
 
 impl BlockView {

--- a/verification/src/tests/uncle_verifier.rs
+++ b/verification/src/tests/uncle_verifier.rs
@@ -17,7 +17,6 @@ use ckb_types::{
     packed::{Byte32, CellInput, ProposalShortId, Script, UncleBlockVec},
     prelude::*,
 };
-use faketime;
 use rand::random;
 use std::sync::Arc;
 


### PR DESCRIPTION
Within CI, using the latest `fmt` and `clippy`, but allow it fail