### PR TITLE
fix: return connected address in RPC `get_peers`

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1,7 +1,7 @@
 use crate::errors::Error;
 use crate::peer_registry::{ConnectionStatus, PeerRegistry};
 use crate::peer_store::{
-    types::{BannedAddr, MultiaddrExt},
+    types::{AddrInfo, BannedAddr, IpPort, MultiaddrExt},
     PeerStore,
 };
 use crate::protocols::{
@@ -1213,6 +1213,15 @@ impl NetworkController {
             .lock()
             .ban_list()
             .get_banned_addrs()
+    }
+
+    pub fn addr_info(&self, ip_port: &IpPort) -> Option<AddrInfo> {
+        self.network_state
+            .peer_store
+            .lock()
+            .addr_manager()
+            .get(ip_port)
+            .cloned()
     }
 
     pub fn ban(&self, address: IpNetwork, ban_until: u64, ban_reason: String) -> Result<(), Error> {

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1900,29 +1900,28 @@ http://localhost:8114
         {
             "addresses": [
                 {
-                    "address": "/ip4/192.168.0.3/tcp/8115",
-                    "score": "0x1"
+                    "address": "/ip6/::ffff:18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+                    "score": "0x64"
+                },
+                {
+                    "address": "/ip4/18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+                    "score": "0x64"
                 }
             ],
             "is_outbound": true,
-            "node_id": "QmaaaLB4uPyDpZwTQGhV63zuYrKm4reyN2tF1j2ain4oE7",
-            "version": "unknown"
+            "node_id": "QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+            "version": "0.31.0 (4231360 2020-04-20)"
         },
         {
             "addresses": [
                 {
-                    "address": "/ip4/192.168.0.4/tcp/8113",
-                    "score": "0xff"
+                    "address": "/ip4/174.80.182.60/tcp/52965/p2p/QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
+                    "score": "0x1"
                 }
             ],
             "is_outbound": false,
-            "node_id": "QmRuGcpVC3vE7aEoB6fhUdq9uzdHbyweCnn1sDBSjfmcbM",
-            "version": "unknown"
-        },
-        {
-            "addresses": [],
-            "node_id": "QmUddxwRqgTmT6tFujXbYPMLGLAE2Tciyv6uHGfdYFyDVa",
-            "version": "unknown"
+            "node_id": "QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
+            "version": "0.29.0 (a6733e6 2020-02-26)"
         }
     ]
 }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -343,29 +343,28 @@
             {
                 "addresses": [
                     {
-                        "address": "/ip4/192.168.0.3/tcp/8115",
-                        "score": "0x1"
+                        "score": "0x64",
+                        "address": "/ip6/::ffff:18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN"
+                    },
+                    {
+                        "address": "/ip4/18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+                        "score": "0x64"
                     }
                 ],
                 "is_outbound": true,
-                "node_id": "QmaaaLB4uPyDpZwTQGhV63zuYrKm4reyN2tF1j2ain4oE7",
-                "version": "unknown"
+                "node_id": "QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+                "version": "0.31.0 (4231360 2020-04-20)"
             },
             {
+                "version": "0.29.0 (a6733e6 2020-02-26)",
                 "addresses": [
                     {
-                        "address": "/ip4/192.168.0.4/tcp/8113",
-                        "score": "0xff"
+                        "address": "/ip4/174.80.182.60/tcp/52965/p2p/QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
+                        "score": "0x1"
                     }
                 ],
-                "is_outbound": false,
-                "node_id": "QmRuGcpVC3vE7aEoB6fhUdq9uzdHbyweCnn1sDBSjfmcbM",
-                "version": "unknown"
-            },
-            {
-                "addresses": [],
-                "node_id": "QmUddxwRqgTmT6tFujXbYPMLGLAE2Tciyv6uHGfdYFyDVa",
-                "version": "unknown"
+                "node_id": "QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
+                "is_outbound": false
             }
         ],
         "skip": true


### PR DESCRIPTION
The RPC `get_peers` miss the peer connected address. Hence it may be empty addresses returned for inbound peers. e.g.

```json
      {
         "addresses" : [],
         "version" : "0.29.0 (a6733e6 2020-02-26)",
         "node_id" : "QmPoPDhGPbNfAuDM1kmQFyY8cocC2SXipi6gYV6BmAj2w7",
         "is_outbound" : false
      }
```

This PR:

* Includes connected address in the returning addresses
* Uses the score recorded in `peer_store` as the returning peer score