### PR TITLE
fix: fix a typo of a thread name

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1078,7 +1078,7 @@ impl NetworkService {
                     .core_threads(num_threads)
                     .enable_all()
                     .threaded_scheduler()
-                    .thread_name("NetworkRuntime-")
+                    .thread_name("NetworkRuntime")
                     .build()
                     .expect("Network tokio runtime init failed");
                 let handle = runtime.spawn(async move {


### PR DESCRIPTION
After bump `tokio` from `0.1` to `0.2`, [`name_prefix(..)`] was removed, and it was replace by [`thread_name(..)`].

[`name_prefix(..)`]: https://docs.rs/tokio/0.1.22/tokio/runtime/struct.Builder.html#method.name_prefix
[`thread_name(..)`]: https://docs.rs/tokio/0.2.20/tokio/runtime/struct.Builder.html#method.thread_name