### PR TITLE
chore: remove unnecessary closure from CKBProtocol

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -90,14 +90,13 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     blocking_recv_flag.disable_disconnected();
     blocking_recv_flag.disable_notify();
 
-    let synchronizer_clone = synchronizer.clone();
     let protocols = vec![
         CKBProtocol::new(
             "syn".to_string(),
             NetworkProtocol::SYNC.into(),
             &["1".to_string()][..],
             MAX_FRAME_LENGTH_SYNC,
-            move || Box::new(synchronizer_clone.clone()),
+            Box::new(synchronizer.clone()),
             Arc::clone(&network_state),
             blocking_recv_flag,
         ),
@@ -106,7 +105,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             NetworkProtocol::RELAY.into(),
             &["1".to_string()][..],
             MAX_FRAME_LENGTH_RELAY,
-            move || Box::new(relayer.clone()),
+            Box::new(relayer),
             Arc::clone(&network_state),
             blocking_recv_flag,
         ),
@@ -115,7 +114,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             NetworkProtocol::TIME.into(),
             &["1".to_string()][..],
             MAX_FRAME_LENGTH_TIME,
-            move || Box::new(net_timer.clone()),
+            Box::new(net_timer),
             Arc::clone(&network_state),
             no_blocking_flag,
         ),
@@ -124,7 +123,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
             NetworkProtocol::ALERT.into(),
             &["1".to_string()][..],
             MAX_FRAME_LENGTH_ALERT,
-            move || Box::new(alert_relayer.clone()),
+            Box::new(alert_relayer),
             Arc::clone(&network_state),
             no_blocking_flag,
         ),

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -104,18 +104,18 @@ pub struct CKBProtocol {
     // supported version, used to check protocol version
     supported_versions: Vec<ProtocolVersion>,
     max_frame_length: usize,
-    handler: Box<dyn Fn() -> Box<dyn CKBProtocolHandler + Send + 'static> + Send + 'static>,
+    handler: Box<dyn CKBProtocolHandler + Send + 'static>,
     network_state: Arc<NetworkState>,
     flag: BlockingFlag,
 }
 
 impl CKBProtocol {
-    pub fn new<F: Fn() -> Box<dyn CKBProtocolHandler + Send + 'static> + Send + 'static>(
+    pub fn new(
         protocol_name: String,
         id: ProtocolId,
         versions: &[ProtocolVersion],
         max_frame_length: usize,
-        handler: F,
+        handler: Box<dyn CKBProtocolHandler + Send + 'static>,
         network_state: Arc<NetworkState>,
         flag: BlockingFlag,
     ) -> Self {
@@ -123,7 +123,7 @@ impl CKBProtocol {
             id,
             max_frame_length,
             network_state,
-            handler: Box::new(handler),
+            handler,
             protocol_name: format!("/ckb/{}", protocol_name),
             supported_versions: {
                 let mut versions: Vec<_> = versions.to_vec();
@@ -170,7 +170,7 @@ impl CKBProtocol {
                 ProtocolHandle::Both(Box::new(CKBHandler {
                     proto_id: self.id,
                     network_state: Arc::clone(&self.network_state),
-                    handler: (self.handler)(),
+                    handler: self.handler,
                 }))
             })
             .before_send(compress)

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -104,7 +104,7 @@ pub struct CKBProtocol {
     // supported version, used to check protocol version
     supported_versions: Vec<ProtocolVersion>,
     max_frame_length: usize,
-    handler: Box<dyn CKBProtocolHandler + Send + 'static>,
+    handler: Box<dyn CKBProtocolHandler>,
     network_state: Arc<NetworkState>,
     flag: BlockingFlag,
 }
@@ -115,7 +115,7 @@ impl CKBProtocol {
         id: ProtocolId,
         versions: &[ProtocolVersion],
         max_frame_length: usize,
-        handler: Box<dyn CKBProtocolHandler + Send + 'static>,
+        handler: Box<dyn CKBProtocolHandler>,
         network_state: Arc<NetworkState>,
         flag: BlockingFlag,
     ) -> Self {

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -114,7 +114,6 @@ impl Net {
             .iter()
             .cloned()
             .map(|tp| {
-                let tx = tx.clone();
                 CKBProtocol::new(
                     tp.protocol_name,
                     tp.id,

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -120,7 +120,7 @@ impl Net {
                     tp.id,
                     &tp.supported_versions,
                     1024 * 1024,
-                    move || Box::new(DummyProtocolHandler { tx: tx.clone() }),
+                    Box::new(DummyProtocolHandler { tx: tx.clone() }),
                     Arc::clone(&network_state),
                     Default::default(),
                 )


### PR DESCRIPTION
this PR removed the unnecessary closure and trait bounds from the `handler` field of `CKBProtocol`