### PR TITLE
chore: Only use gow instead of msys2 in Windows CI

### DIFF
--- a/devtools/azure/windows-dependencies.yml
+++ b/devtools/azure/windows-dependencies.yml
@@ -10,8 +10,8 @@ steps:
   displayName: Add scoop to path
 - script: scoop install llvm
   displayName: Install LLVM
-- script: scoop install msys2
-  displayName: Install msys2
+- script: scoop install gow
+  displayName: Install gow
 - script: scoop install yasm
   displayName: Install yasm
 - script: |


### PR DESCRIPTION
We don't need the full msys2 to build, gow can help us save some
dependency installation time