### PR TITLE
feat: add RPC truncate

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -242,14 +242,7 @@ impl ChainService {
 
         self.shared.store_snapshot(Arc::clone(&new_snapshot));
 
-        if let Err(e) = self.shared.tx_pool_controller().update_tx_pool_for_reorg(
-            fork.detached_blocks().clone(),
-            fork.attached_blocks().clone(),
-            fork.detached_proposal_id().clone(),
-            new_snapshot,
-        ) {
-            error!("notify update_tx_pool_for_reorg error {}", e);
-        }
+        // NOTE: Dont update tx-pool when truncate
 
         Ok(())
     }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -390,6 +390,7 @@ fn all_specs() -> SpecMap {
         Box::new(AvoidDuplicatedProposalsWithUncles),
         Box::new(TemplateTxSelect),
         Box::new(BlockSyncRelayerCollaboration),
+        Box::new(RpcTruncate),
     ];
     specs.into_iter().map(|spec| (spec.name(), spec)).collect()
 }

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -227,6 +227,12 @@ impl RpcClient {
             .map(|x| x.pack())
     }
 
+    pub fn truncate(&self, target_tip_hash: Byte32) {
+        self.inner()
+            .truncate(target_tip_hash.unpack())
+            .expect("rpc call truncate")
+    }
+
     pub fn get_live_cells_by_lock_hash(
         &self,
         lock_hash: Byte32,
@@ -364,6 +370,7 @@ jsonrpc!(pub struct Inner {
     pub fn add_node(&self, peer_id: String, address: String) -> ();
     pub fn remove_node(&self, peer_id: String) -> ();
     pub fn process_block_without_verify(&self, _data: Block) -> Option<H256>;
+    pub fn truncate(&self, target_tip_hash: H256) -> ();
 
     pub fn get_live_cells_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<LiveCell>;
     pub fn get_transactions_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<CellTransaction>;

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -5,6 +5,7 @@ mod indexer;
 mod mining;
 mod p2p;
 mod relay;
+mod rpc;
 mod sync;
 mod tx_pool;
 
@@ -15,6 +16,7 @@ pub use indexer::*;
 pub use mining::*;
 pub use p2p::*;
 pub use relay::*;
+pub use rpc::*;
 pub use sync::*;
 pub use tx_pool::*;
 

--- a/test/src/specs/rpc/mod.rs
+++ b/test/src/specs/rpc/mod.rs
@@ -1,0 +1,3 @@
+mod truncate;
+
+pub use truncate::*;

--- a/test/src/specs/rpc/truncate.rs
+++ b/test/src/specs/rpc/truncate.rs
@@ -1,0 +1,81 @@
+use crate::{Net, Spec};
+
+pub struct RpcTruncate;
+
+impl Spec for RpcTruncate {
+    crate::name!("rpc_truncate");
+
+    // After truncating, the chain will be rollback to the target block, and tx-pool be cleared.
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        node.generate_blocks(12);
+        let to_truncate = node.get_block_by_number(node.get_tip_block_number()).hash();
+        let tx1 = {
+            let tx1 = node.new_transaction_spend_tip_cellbase();
+            node.submit_transaction(&tx1);
+            tx1
+        };
+        node.generate_blocks(3);
+        let _tx2 = {
+            let tx2 = node.new_transaction_spend_tip_cellbase();
+            node.submit_transaction(&tx2);
+            tx2
+        };
+
+        // tx1 is already committed on chain, tx2 is still in tx-pool.
+
+        let cell1 = node
+            .rpc_client()
+            .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
+        assert_eq!(cell1.status, "unknown", "cell1 was spent within tx1");
+
+        let tx_pool_info = node.rpc_client().tx_pool_info();
+        assert!(tx_pool_info.total_tx_size.value() > 0, "tx-pool holds tx2");
+
+        // Truncate from `to_truncate`
+
+        let old_tip_block = node.get_tip_block();
+        node.rpc_client().truncate(to_truncate.clone());
+
+        // After truncating, tx1 has been rollback, so cell1 become alive.
+
+        assert_eq!(node.get_tip_block().hash(), to_truncate);
+        assert!(
+            node.rpc_client().get_header(old_tip_block.hash()).is_none(),
+            "old_tip_block should be truncated",
+        );
+        assert!(
+            node.rpc_client()
+                .get_block_by_number(old_tip_block.number())
+                .is_none(),
+            "old_tip_block should be truncated",
+        );
+
+        let cell1 = node
+            .rpc_client()
+            .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
+        assert_eq!(cell1.status, "live", "cell1 is alive after roll-backing");
+
+        let tx_pool_info = node.rpc_client().tx_pool_info();
+        assert!(
+            tx_pool_info.total_tx_size.value() == 0,
+            "tx-pool was cleared"
+        );
+        assert!(tx_pool_info.orphan.value() == 0, "tx-pool was cleared");
+        assert!(tx_pool_info.pending.value() == 0, "tx-pool was cleared");
+        assert!(tx_pool_info.proposed.value() == 0, "tx-pool was cleared");
+        assert!(
+            tx_pool_info.total_tx_cycles.value() == 0,
+            "tx-pool was cleared"
+        );
+
+        // The chain can generate new blocks
+        node.generate_blocks(3);
+        node.submit_transaction(&tx1);
+        node.generate_blocks(3);
+        let cell1 = node
+            .rpc_client()
+            .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
+        assert_eq!(cell1.status, "unknown", "cell1 was spent within tx1");
+    }
+}

--- a/test/src/specs/rpc/truncate.rs
+++ b/test/src/specs/rpc/truncate.rs
@@ -57,17 +57,15 @@ impl Spec for RpcTruncate {
         assert_eq!(cell1.status, "live", "cell1 is alive after roll-backing");
 
         let tx_pool_info = node.rpc_client().tx_pool_info();
-        assert!(
-            tx_pool_info.total_tx_size.value() == 0,
+        assert_eq!(tx_pool_info.orphan.value(), 0, "tx-pool was cleared");
+        assert_eq!(tx_pool_info.pending.value(), 0, "tx-pool was cleared");
+        assert_eq!(tx_pool_info.proposed.value(), 0, "tx-pool was cleared");
+        assert_eq!(
+            tx_pool_info.total_tx_cycles.value(),
+            0,
             "tx-pool was cleared"
         );
-        assert!(tx_pool_info.orphan.value() == 0, "tx-pool was cleared");
-        assert!(tx_pool_info.pending.value() == 0, "tx-pool was cleared");
-        assert!(tx_pool_info.proposed.value() == 0, "tx-pool was cleared");
-        assert!(
-            tx_pool_info.total_tx_cycles.value() == 0,
-            "tx-pool was cleared"
-        );
+        assert_eq!(tx_pool_info.total_tx_size.value(), 0, "tx-pool was cleared");
 
         // The chain can generate new blocks
         node.generate_blocks(3);

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -29,7 +29,6 @@ use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::collections::HashSet;
 use std::collections::{HashMap, VecDeque};
-use std::ops::DerefMut;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicU64, Arc};
 use std::{cmp, iter};
@@ -498,9 +497,7 @@ impl TxPoolService {
         let config = tx_pool.config;
         let snapshot = Arc::clone(&tx_pool.snapshot);
         let last_txs_updated_at = Arc::new(AtomicU64::new(0));
-        let mut new_pool = TxPool::new(config, snapshot, last_txs_updated_at);
-        let old_pool = tx_pool.deref_mut();
-        ::std::mem::swap(old_pool, &mut new_pool);
+        *tx_pool = TxPool::new(config, snapshot, last_txs_updated_at);
     }
 }
 

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -29,8 +29,9 @@ use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::collections::HashSet;
 use std::collections::{HashMap, VecDeque};
+use std::ops::DerefMut;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, Arc};
 use std::{cmp, iter};
 use tokio::task::block_in_place;
 
@@ -490,6 +491,16 @@ impl TxPoolService {
                 guard.insert(k, v);
             }
         });
+    }
+
+    pub(crate) async fn clear_pool(&self) {
+        let mut tx_pool = self.tx_pool.write().await;
+        let config = tx_pool.config;
+        let snapshot = Arc::clone(&tx_pool.snapshot);
+        let last_txs_updated_at = Arc::new(AtomicU64::new(0));
+        let mut new_pool = TxPool::new(config, snapshot, last_txs_updated_at);
+        let old_pool = tx_pool.deref_mut();
+        ::std::mem::swap(old_pool, &mut new_pool);
     }
 }
 


### PR DESCRIPTION
For convenient to reproduce a specified environment when test, this PR adds RPC `truncate(target_tip_hash)` to roll-back the blockchain downto the target block. It trigger the below behaviours:

  * Roll-back the blockchain status, like cellset and transactions, downto the height corresponding to `target_tip_hash`. In short, reset the tip to the target block.
  * Delete the truncated blocks from database.
  * Clear the tx-pool, which may hold dirty transactions/proposals.