### PR TITLE
[backport] #2063 fix: should use an empty peer store when failed to load data from file

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -105,7 +105,9 @@ impl NetworkState {
             .chain(config.public_addresses.iter())
             .map(|addr| (addr.to_owned(), std::u8::MAX))
             .collect();
-        let peer_store = Mutex::new(PeerStore::load_from_dir(config.peer_store_path())?);
+        let peer_store = Mutex::new(PeerStore::load_from_dir_or_default(
+            config.peer_store_path(),
+        ));
         let bootnodes = config.bootnodes()?;
 
         let whitelist_peers = config


### PR DESCRIPTION
Backport #2063 

Closes #2065