### PR TITLE
Optimize scheduler

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -33,10 +33,16 @@ pub const STALE_RELAY_AGE_LIMIT: u64 = 30 * 24 * 60 * 60 * 1000;
 pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
 pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
 pub const CHECK_POINT_WINDOW: u64 = (MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4) as u64;
-pub const TIME_TRACE_SIZE: usize = MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4;
-pub const MEDIAN_INDEX: usize = TIME_TRACE_SIZE / 2;
-pub const NORMAL_INDEX: usize = TIME_TRACE_SIZE * 4 / 5;
-pub const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
+
+// Time recording window size, ibd period scheduler dynamically adjusts frequency
+// for acquisition/analysis generating dynamic time range
+pub(crate) const TIME_TRACE_SIZE: usize = MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4;
+// Fast Zone Boundaries for the Time Window
+pub(crate) const FAST_INDEX: usize = TIME_TRACE_SIZE / 3;
+// Normal Zone Boundaries for the Time Window
+pub(crate) const NORMAL_INDEX: usize = TIME_TRACE_SIZE * 4 / 5;
+// Low Zone Boundaries for the Time Window
+pub(crate) const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -31,9 +31,12 @@ pub const STALE_RELAY_AGE_LIMIT: u64 = 30 * 24 * 60 * 60 * 1000;
 
 /* About Download Scheduler */
 pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
-pub const FIRST_LEVEL_MAX: usize = 32;
 pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
 pub const CHECK_POINT_WINDOW: u64 = (MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4) as u64;
+pub const TIME_TRACE_SIZE: usize = MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4;
+pub const MEDIAN_INDEX: usize = TIME_TRACE_SIZE / 2;
+pub const NORMAL_INDEX: usize = TIME_TRACE_SIZE * 4 / 5;
+pub const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
 

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -166,7 +166,7 @@ impl<'a> BlockFetcher<'a> {
             }
 
             // Move `start` forward
-            start += span as u64;
+            start += span;
         }
 
         // The headers in `fetch` may be unordered. Sort them by number.

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -445,11 +445,12 @@ impl Synchronizer {
             .cloned()
             .collect();
         peers.sort_by_key(|id| {
-            state
-                .get(id)
-                .map_or(crate::INIT_BLOCKS_IN_TRANSIT_PER_PEER, |d| d.task_count())
+            ::std::cmp::Reverse(
+                state
+                    .get(id)
+                    .map_or(crate::INIT_BLOCKS_IN_TRANSIT_PER_PEER, |d| d.task_count()),
+            )
         });
-        peers.reverse();
         peers
     }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -492,7 +492,7 @@ impl Synchronizer {
                 Some(ref sender) => {
                     if !sender.is_full() {
                         let peers = self.get_peers_to_fetch(ibd, &disconnect_list);
-                        let _ = sender.try_send(FetchCMD::Fetch(peers));
+                        let _ignore = sender.try_send(FetchCMD::Fetch(peers));
                     }
                 }
                 None => {

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -111,9 +111,11 @@ fn inflight_blocks_timeout() {
     assert!(inflight_blocks.insert(1.into(), (7, h256!("0x7").pack()).into()));
 
     let peers = inflight_blocks.prune(0);
-    assert_eq!(peers, HashSet::from_iter(vec![1.into(), 2.into()]));
+    assert_eq!(peers, HashSet::from_iter(vec![1.into()]));
     assert!(inflight_blocks.insert(3.into(), (2, h256!("0x2").pack()).into()));
     assert!(inflight_blocks.insert(3.into(), (3, h256!("0x3").pack()).into()));
+
+    assert_eq!(inflight_blocks.peer_can_fetch_count(2.into()), 16 >> 4);
 
     assert_eq!(
         inflight_blocks


### PR DESCRIPTION
Problems with the current scheduler:
1. The calculation is too frequent
2. Inability to adapt to complex network environments, e.g., increased network latency as the number of nodes increases, network latency exceeding expectations, etc.

This PR implements an adaptive scheduler based on past data, removing most of the redundant calculations. Translating the overall data into 4 intervals:

| fast | normal | penalty | double penalty |

The dividing line is the 1/3 position, 4/5 position, 1/10 position.

There is a 14/30 normal area, 1/10 penalty area, 1/10 double penalty area, 1/3 accelerated reward area.

Replace the 30-second clear-out strategy with a doubling penalty.

10%-20% increase in sync performance from testing, from 220-240 block/s to 250-270 block/s on a dual-core machine

the simulation test: https://github.com/nervosnetwork/sync-scheduler-simulation-test