### PR TITLE
fix: Fix collaboration issues between two protocol

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -390,6 +390,7 @@ fn all_specs() -> SpecMap {
         Box::new(DAOVerify),
         Box::new(AvoidDuplicatedProposalsWithUncles),
         Box::new(TemplateTxSelect),
+        Box::new(BlockSyncRelayerCollaboration),
     ];
     specs.into_iter().map(|spec| (spec.name(), spec)).collect()
 }


### PR DESCRIPTION
relayer and sync have some known problems in the critical zone of switching, which are inherent to the request/response architecture.

Previous attempts to fix the problem by allowing duplicate downloads, but this solution results in wasted network resources and slowed sync speed.

This typical problem can be solved by the node itself, and the current PR gives a temporary solution to try to check the orphan pool with a very low-frequency timer.

