### PR TITLE
feat: Expose fields from setup struct

### DIFF
--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -21,9 +21,9 @@ use std::path::PathBuf;
 pub(crate) const LOG_TARGET_SENTRY: &str = "sentry";
 
 pub struct Setup {
-    subcommand_name: String,
-    config: AppConfig,
-    is_sentry_enabled: bool,
+    pub subcommand_name: String,
+    pub config: AppConfig,
+    pub is_sentry_enabled: bool,
 }
 
 pub struct SetupGuard {


### PR DESCRIPTION
Previously, the fields in Setup in app-config package remains private,
meaning the only way we can initialize a Setup struct, is via the
exposed from_matches method. But since from_matches only accepts
matches initialized from clap, this means the only way we can
initialize CKB, would be from a binary via argv. This commit changes
the code so fields from Setup struct are exposed, which can enable us
to use much of CKB code as a library, not necessarily a binary.