### PR TITLE
feat: update last_common_header only in find_blocks_to_fetch

### DIFF
--- a/sync/src/orphan_block_pool.rs
+++ b/sync/src/orphan_block_pool.rs
@@ -1,16 +1,14 @@
-use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
 use ckb_util::RwLock;
 use std::collections::{HashMap, VecDeque};
 
 pub type ParentHash = packed::Byte32;
-pub type OrphanBlock = (PeerIndex, core::BlockView);
 
 // NOTE: Never use `LruCache` as container. We have to ensure synchronizing between
 // orphan_block_pool and block_status_map, but `LruCache` would prune old items implicitly.
 #[derive(Default)]
 pub struct OrphanBlockPool {
-    blocks: RwLock<HashMap<ParentHash, HashMap<packed::Byte32, OrphanBlock>>>,
+    blocks: RwLock<HashMap<ParentHash, HashMap<packed::Byte32, core::BlockView>>>,
     parents: RwLock<HashMap<packed::Byte32, ParentHash>>,
 }
 
@@ -26,23 +24,23 @@ impl OrphanBlockPool {
     }
 
     /// Insert orphaned block, for which we have already requested its parent block
-    pub fn insert(&self, peer: PeerIndex, block: core::BlockView) {
+    pub fn insert(&self, block: core::BlockView) {
         let hash = block.header().hash();
         let parent_hash = block.data().header().raw().parent_hash();
         self.blocks
             .write()
             .entry(parent_hash.clone())
             .or_insert_with(HashMap::default)
-            .insert(hash.clone(), (peer, block));
+            .insert(hash.clone(), block);
         self.parents.write().insert(hash, parent_hash);
     }
 
-    pub fn remove_blocks_by_parent(&self, hash: &packed::Byte32) -> Vec<OrphanBlock> {
+    pub fn remove_blocks_by_parent(&self, hash: &packed::Byte32) -> Vec<core::BlockView> {
         let mut guard = self.blocks.write();
         let mut queue: VecDeque<packed::Byte32> = VecDeque::new();
         queue.push_back(hash.to_owned());
 
-        let mut removed: Vec<OrphanBlock> = Vec::new();
+        let mut removed: Vec<core::BlockView> = Vec::new();
         while let Some(parent_hash) = queue.pop_front() {
             if let Some(orphaned) = guard.remove(&parent_hash) {
                 let (hashes, blocks): (Vec<_>, Vec<_>) = orphaned.into_iter().unzip();
@@ -63,14 +61,14 @@ impl OrphanBlockPool {
         self.parents.read().get(hash).and_then(|parent_hash| {
             guard
                 .get(parent_hash)
-                .and_then(|value| value.get(hash).map(|v| v.1.clone()))
+                .and_then(|value| value.get(hash).cloned())
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OrphanBlockPool, PeerIndex};
+    use super::OrphanBlockPool;
     use ckb_chain_spec::consensus::ConsensusBuilder;
     use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
     use ckb_types::prelude::*;
@@ -99,13 +97,12 @@ mod tests {
         for _ in 1..block_number {
             let new_block = gen_block(&parent);
             blocks.push(new_block.clone());
-            pool.insert(PeerIndex::new(0usize), new_block.clone());
+            pool.insert(new_block.clone());
             parent = new_block.header();
         }
 
         let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
-        let orphan: HashSet<BlockView> =
-            HashSet::from_iter(orphan.into_iter().map(|(_, block)| block));
+        let orphan: HashSet<BlockView> = HashSet::from_iter(orphan.into_iter());
         let block: HashSet<BlockView> = HashSet::from_iter(blocks.into_iter());
         assert_eq!(orphan, block)
     }

--- a/sync/src/orphan_block_pool.rs
+++ b/sync/src/orphan_block_pool.rs
@@ -115,7 +115,7 @@ mod tests {
         let mut hashes = Vec::new();
         for _ in 1..1024 {
             let new_block = gen_block(&header);
-            pool.insert(PeerIndex::new(0usize), new_block.clone());
+            pool.insert(new_block.clone());
             header = new_block.header();
             hashes.push(header.hash());
         }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -96,7 +96,7 @@ impl<'a> CompactBlockProcess<'a> {
             };
 
             let state = shared.state().peers();
-            state.new_header_received(self.peer, &header_view);
+            state.may_set_best_known_header(self.peer, &header_view);
             state.set_last_common_header(self.peer, header);
 
             return StatusCode::CompactBlockAlreadyStored.with_context(block_hash);

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -97,7 +97,6 @@ impl<'a> CompactBlockProcess<'a> {
 
             let state = shared.state().peers();
             state.may_set_best_known_header(self.peer, &header_view);
-            state.set_last_common_header(self.peer, header);
 
             return StatusCode::CompactBlockAlreadyStored.with_context(block_hash);
         } else if status.contains(BlockStatus::BLOCK_INVALID) {

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -92,7 +92,7 @@ impl<'a> CompactBlockProcess<'a> {
                 .expect("parent block must exist");
             let header_view = {
                 let total_difficulty = parent.total_difficulty() + header.difficulty();
-                crate::types::HeaderView::new(header.clone(), total_difficulty)
+                crate::types::HeaderView::new(header, total_difficulty)
             };
 
             let state = shared.state().peers();

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -271,7 +271,7 @@ impl Relayer {
         let boxed = Arc::new(block);
         if self
             .shared()
-            .insert_new_block(&self.chain, peer, Arc::clone(&boxed))
+            .insert_new_block(&self.chain, Arc::clone(&boxed))
             .unwrap_or(false)
         {
             debug_target!(

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -65,7 +65,9 @@ impl<'a> BlockFetcher<'a> {
         let fixed_last_common_header = self
             .active_chain
             .last_common_ancestor(&last_common_header, &best.inner())?;
-        self.synchronizer.peers().set_last_common_header(self.peer, fixed_last_common_header.clone());
+        self.synchronizer
+            .peers()
+            .set_last_common_header(self.peer, fixed_last_common_header.clone());
 
         Some(fixed_last_common_header)
     }
@@ -152,7 +154,9 @@ impl<'a> BlockFetcher<'a> {
                 if status.contains(BlockStatus::BLOCK_STORED) {
                     // If the block is stored, its ancestor must on store
                     // So we can skip the search of this space directly
-                    self.synchronizer.peers().set_last_common_header(self.peer, header.clone());
+                    self.synchronizer
+                        .peers()
+                        .set_last_common_header(self.peer, header.clone());
                     break;
                 } else if status.contains(BlockStatus::BLOCK_RECEIVED) {
                     // Do not download repeatedly

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -97,7 +97,7 @@ impl<'a> BlockFetcher<'a> {
 
         let mut inflight = self.synchronizer.shared().state().write_inflight_blocks();
         let mut start = last_common.number() + 1;
-        let end = min(best_known.number(), start + BLOCK_DOWNLOAD_WINDOW);
+        let mut end = min(best_known.number(), start + BLOCK_DOWNLOAD_WINDOW);
         let n_fetch = min(
             end.saturating_sub(start) as usize + 1,
             inflight.peer_can_fetch_count(self.peer),
@@ -124,6 +124,7 @@ impl<'a> BlockFetcher<'a> {
                     self.synchronizer
                         .peers()
                         .set_last_common_header(self.peer, header.clone());
+                    end = min(best_known.number(), header.number() + BLOCK_DOWNLOAD_WINDOW);
                     break;
                 } else if status.contains(BlockStatus::BLOCK_RECEIVED) {
                     // Do not download repeatedly

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -67,8 +67,6 @@ impl<'a> BlockFetcher<'a> {
     }
 
     pub fn fetch(self) -> Option<Vec<Vec<packed::Byte32>>> {
-        let best_known = self.peer_best_known_header()?;
-
         if self.reached_inflight_limit() {
             trace!(
                 "[block_fetcher] inflight count reach limit, can't download any more from peer {}",
@@ -77,6 +75,8 @@ impl<'a> BlockFetcher<'a> {
             return None;
         }
 
+        // Update `best_known_header` based on `unknown_header_list`. It must be involved before
+        // our acquiring the newest `best_known_header`.
         if let IBDState::In = self.ibd {
             self.synchronizer
                 .shared
@@ -85,6 +85,7 @@ impl<'a> BlockFetcher<'a> {
         }
 
         // This peer has nothing interesting.
+        let best_known = self.peer_best_known_header()?;
         if !self.is_better_chain(&best_known) {
             return None;
         }

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -2,7 +2,7 @@ use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::types::{ActiveChain, HeaderView, IBDState};
 use crate::BLOCK_DOWNLOAD_WINDOW;
-use ckb_logger::trace;
+use ckb_logger::{debug, trace};
 use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
 use std::cmp::min;
@@ -158,8 +158,8 @@ impl<'a> BlockFetcher<'a> {
                 "[block fetch empty] fixed_last_common_header = {} \
                 best_known_header = {}, tip = {}, inflight_len = {}, \
                 inflight_state = {:?}",
-                fixed_last_common_header.number(),
-                best_known_header.number(),
+                last_common.number(),
+                best_known.number(),
                 tip,
                 inflight.total_inflight_count(),
                 *inflight

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -9,7 +9,7 @@ use ckb_types::{packed, prelude::*};
 pub struct BlockProcess<'a> {
     message: packed::SendBlockReader<'a>,
     synchronizer: &'a Synchronizer,
-    peer: PeerIndex,
+    _peer: PeerIndex,
 }
 
 impl<'a> BlockProcess<'a> {
@@ -21,7 +21,7 @@ impl<'a> BlockProcess<'a> {
         BlockProcess {
             message,
             synchronizer,
-            peer,
+            _peer: peer,
         }
     }
 
@@ -36,10 +36,7 @@ impl<'a> BlockProcess<'a> {
         let state = shared.state();
 
         if state.new_block_received(&block) {
-            if let Err(err) = self
-                .synchronizer
-                .process_new_block(self.peer, block.clone())
-            {
+            if let Err(err) = self.synchronizer.process_new_block(block.clone()) {
                 state.insert_block_status(block.hash(), BlockStatus::BLOCK_INVALID);
                 return StatusCode::BlockIsInvalid.with_context(format!(
                     "{}, error: {}",

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -47,13 +47,6 @@ impl<'a> BlockProcess<'a> {
                     err,
                 ));
             }
-        } else if shared
-            .active_chain()
-            .contains_block_status(&block.hash(), BlockStatus::BLOCK_STORED)
-        {
-            state
-                .peers()
-                .set_last_common_header(self.peer, block.header());
         }
 
         Status::ok()

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -345,7 +345,9 @@ where
             let header_view = shared
                 .get_header_view(&self.header.hash())
                 .expect("header with HEADER_VALID should exist");
-            state.peers().may_set_best_known_header(self.peer, &header_view);
+            state
+                .peers()
+                .may_set_best_known_header(self.peer, &header_view);
             return result;
         }
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -345,7 +345,7 @@ where
             let header_view = shared
                 .get_header_view(&self.header.hash())
                 .expect("header with HEADER_VALID should exist");
-            state.peers().new_header_received(self.peer, &header_view);
+            state.peers().may_set_best_known_header(self.peer, &header_view);
             return result;
         }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -199,11 +199,6 @@ impl Synchronizer {
         // stopping synchronization even when orphan_pool maintains dirty items by bugs.
         if status.contains(BlockStatus::BLOCK_STORED) {
             debug!("block {} already stored", block_hash);
-            // update last common header
-            self.shared
-                .state()
-                .peers()
-                .set_last_common_header(peer, block.header());
             Ok(false)
         } else if status.contains(BlockStatus::HEADER_VALID) {
             self.shared

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -1437,10 +1437,10 @@ mod tests {
             state.insert(5.into(), state_5);
             state.insert(6.into(), state_6);
         }
-        peers.new_header_received(0.into(), &mock_header_view(1));
-        peers.new_header_received(2.into(), &mock_header_view(3));
-        peers.new_header_received(3.into(), &mock_header_view(1));
-        peers.new_header_received(5.into(), &mock_header_view(3));
+        peers.may_set_best_known_header(0.into(), &mock_header_view(1));
+        peers.may_set_best_known_header(2.into(), &mock_header_view(3));
+        peers.may_set_best_known_header(3.into(), &mock_header_view(1));
+        peers.may_set_best_known_header(5.into(), &mock_header_view(3));
         {
             // Protected peer 0 start sync
             peers

--- a/sync/src/tests/sync_shared.rs
+++ b/sync/src/tests/sync_shared.rs
@@ -2,7 +2,6 @@ use crate::block_status::BlockStatus;
 use crate::tests::util::{build_chain, inherit_block};
 use crate::SyncShared;
 use ckb_chain::chain::ChainService;
-use ckb_network::PeerIndex;
 use ckb_shared::shared::SharedBuilder;
 use ckb_store::{self, ChainStore};
 use ckb_test_chain_utils::always_success_cellbase;
@@ -21,13 +20,13 @@ fn test_insert_new_block() {
 
     assert_eq!(
         shared
-            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
+            .insert_new_block(&chain, Arc::clone(&new_block))
             .expect("insert valid block"),
         true,
     );
     assert_eq!(
         shared
-            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&new_block))
+            .insert_new_block(&chain, Arc::clone(&new_block))
             .expect("insert duplicated valid block"),
         false,
     );
@@ -49,7 +48,7 @@ fn test_insert_invalid_block() {
     };
 
     assert!(shared
-        .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_block))
+        .insert_new_block(&chain, Arc::clone(&invalid_block))
         .is_err(),);
 }
 
@@ -95,13 +94,13 @@ fn test_insert_parent_unknown_block() {
 
     assert_eq!(
         shared
-            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&valid_orphan))
+            .insert_new_block(&chain, Arc::clone(&valid_orphan))
             .expect("insert orphan block"),
         false,
     );
     assert_eq!(
         shared
-            .insert_new_block(&chain, PeerIndex::new(1), Arc::clone(&invalid_orphan))
+            .insert_new_block(&chain, Arc::clone(&invalid_orphan))
             .expect("insert orphan block"),
         false,
     );
@@ -117,7 +116,7 @@ fn test_insert_parent_unknown_block() {
     // After inserting parent of an orphan block
     assert_eq!(
         shared
-            .insert_new_block(&chain, PeerIndex::new(2), Arc::clone(&parent))
+            .insert_new_block(&chain, Arc::clone(&parent))
             .expect("insert parent of orphan block"),
         true,
     );
@@ -158,7 +157,7 @@ fn test_switch_invalid_fork() {
         let block = make_invalid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
-                .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
+                .insert_new_block(&chain, Arc::new(block.clone()))
                 .expect("insert fork"),
             true,
         );
@@ -179,7 +178,7 @@ fn test_switch_invalid_fork() {
     loop {
         let block = inherit_block(shared.shared(), &parent_hash.clone()).build();
         if shared
-            .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
+            .insert_new_block(&chain, Arc::new(block.clone()))
             .is_err()
         {
             break;
@@ -229,7 +228,7 @@ fn test_switch_valid_fork() {
         let block = make_valid_block(shared.shared(), parent_hash.clone());
         assert_eq!(
             shared
-                .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
+                .insert_new_block(&chain, Arc::new(block.clone()))
                 .expect("insert fork"),
             true,
         );
@@ -252,7 +251,7 @@ fn test_switch_valid_fork() {
         let block = inherit_block(shared.shared(), &parent_hash.clone()).build();
         assert_eq!(
             shared
-                .insert_new_block(&chain, PeerIndex::new(1), Arc::new(block.clone()))
+                .insert_new_block(&chain, Arc::new(block.clone()))
                 .expect("insert fork"),
             true,
         );

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1706,7 +1706,7 @@ impl ActiveChain {
     }
 
     pub fn unknown_block_status(&self, block_hash: &Byte32) -> bool {
-        self.get_block_status(block_hash) == BlockStatus::UNKNOWN
+        self.contains_block_status(block_hash, BlockStatus::UNKNOWN)
     }
 }
 

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1012,7 +1012,7 @@ impl SyncShared {
         }
 
         // Attempt to accept the given block if its parent already exist in database
-        let ret = self.accept_block(chain, pi, Arc::clone(&block));
+        let ret = self.accept_block(chain, Arc::clone(&block));
         if ret.is_err() {
             debug!("accept block {:?} {:?}", block, ret);
             return ret;
@@ -1040,7 +1040,7 @@ impl SyncShared {
             }
 
             let block = Arc::new(block);
-            if let Err(err) = self.accept_block(chain, peer, Arc::clone(&block)) {
+            if let Err(err) = self.accept_block(chain, Arc::clone(&block)) {
                 debug!(
                     "accept descendant orphan block {} error {:?}",
                     block.header().hash(),
@@ -1053,7 +1053,6 @@ impl SyncShared {
     fn accept_block(
         &self,
         chain: &ChainController,
-        peer: PeerIndex,
         block: Arc<core::BlockView>,
     ) -> Result<bool, FailureError> {
         let ret = chain.process_block(Arc::clone(&block));
@@ -1070,9 +1069,6 @@ impl SyncShared {
             // status via fetching block_ext from the database.
             self.state.remove_block_status(&block.as_ref().hash());
             self.state.remove_header_view(&block.as_ref().hash());
-            self.state
-                .peers()
-                .set_last_common_header(peer, block.header());
         }
 
         Ok(ret?)

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1026,7 +1026,7 @@ impl SyncShared {
     }
 
     pub fn try_search_orphan_pool(&self, chain: &ChainController, parent_hash: &Byte32) {
-        let descendants = self.state.remove_orphan_by_parent(&block.as_ref().hash());
+        let descendants = self.state.remove_orphan_by_parent(parent_hash);
         for block in descendants {
             // If we can not find the block's parent in database, that means it was failed to accept
             // its parent, so we treat it as an invalid block as well.


### PR DESCRIPTION
* `peer.best_known_block` refers to the best-known block we know this peer has announced; `peer.last_common_header` refers to the last block we both stored between local and peer. This PR proposes the logic to update the two fields:

  - When we receive `CompactBlock` or `SentHeader` from `peer`, we update the `peer.best_known_block` if the arrival one has greater `total_difficulty`.
  - When we insert a block which is from `peer`, we don't update the corresponding `last_common_header`(remove lines [CompactBlock](https://github.com/nervosnetwork/ckb/pull/2081/files#diff-98eccb89a5611099d6adca819c9c8b08L100), [SendBlock](https://github.com/nervosnetwork/ckb/pull/2081/files#diff-402ee94ba649e0f53da25c4da84ec58dL50-L56)).
  - We update the `last_common_header` only in `find_blocks_to_fetch`. There are 2 places, 
    1. [`fn update_last_common_header` fixes `last_common_header` when the peer has reorganized](https://github.com/nervosnetwork/ckb/pull/2081/files#diff-86d69964b227ca1248fadb84da967a96R62-R64);
    2. [Updates `last_common_header` when we know a better block has already stored](https://github.com/nervosnetwork/ckb/pull/2081/files#diff-86d69964b227ca1248fadb84da967a96R120-R124).

* Fix bug: [`status == BLOCK_STORED` => `status.contains(BLOCK_STORED)`](https://github.com/nervosnetwork/ckb/pull/2081/files#diff-86d69964b227ca1248fadb84da967a96L151)

* Enhence `last_common_ancestor`.