### PR TITLE
chore: remove duplicate code of peer protocols insert/remove

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -755,7 +755,6 @@ impl ServiceHandle for EventHandler {
     }
 
     fn handle_proto(&mut self, context: &mut ServiceContext, event: ProtocolEvent) {
-        // For special protocols: ping/discovery/identify/disconnect_message
         match event {
             ProtocolEvent::Connected {
                 session_context,

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -755,6 +755,7 @@ impl ServiceHandle for EventHandler {
     }
 
     fn handle_proto(&mut self, context: &mut ServiceContext, event: ProtocolEvent) {
+        // For special protocols: ping/discovery/identify/disconnect_message
         match event {
             ProtocolEvent::Connected {
                 session_context,

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -691,7 +691,7 @@ impl CKBProtocolHandler for Relayer {
 
     fn connected(
         &mut self,
-        nc: Arc<dyn CKBProtocolContext + Sync>,
+        _nc: Arc<dyn CKBProtocolContext + Sync>,
         peer_index: PeerIndex,
         version: &str,
     ) {
@@ -701,28 +701,13 @@ impl CKBProtocolHandler for Relayer {
             version,
             peer_index
         );
-        let protocol = nc.protocol_id();
-        let version = version.to_string();
-        nc.with_peer_mut(
-            peer_index,
-            Box::new(move |peer| {
-                peer.protocols.insert(protocol, version);
-            }),
-        );
     }
 
-    fn disconnected(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, peer_index: PeerIndex) {
+    fn disconnected(&mut self, _nc: Arc<dyn CKBProtocolContext + Sync>, peer_index: PeerIndex) {
         info_target!(
             crate::LOG_TARGET_RELAY,
             "RelayProtocol.disconnected peer={}",
             peer_index
-        );
-        let protocol = nc.protocol_id();
-        nc.with_peer_mut(
-            peer_index,
-            Box::new(move |peer| {
-                peer.protocols.remove(&protocol);
-            }),
         );
         // remove all rate limiter keys that have been expireable for 1 minutes:
         self.rate_limiter.lock().cleanup(Duration::from_secs(60));

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -601,29 +601,13 @@ impl CKBProtocolHandler for Synchronizer {
         &mut self,
         nc: Arc<dyn CKBProtocolContext + Sync>,
         peer_index: PeerIndex,
-        version: &str,
+        _version: &str,
     ) {
         info!("SyncProtocol.connected peer={}", peer_index);
-        let protocol = nc.protocol_id();
-        let version = version.to_string();
-        nc.with_peer_mut(
-            peer_index,
-            Box::new(move |peer| {
-                peer.protocols.insert(protocol, version);
-            }),
-        );
         self.on_connected(nc.as_ref(), peer_index);
     }
 
-    fn disconnected(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, peer_index: PeerIndex) {
-        let protocol = nc.protocol_id();
-        nc.with_peer_mut(
-            peer_index,
-            Box::new(move |peer| {
-                peer.protocols.remove(&protocol);
-            }),
-        );
-
+    fn disconnected(&mut self, _nc: Arc<dyn CKBProtocolContext + Sync>, peer_index: PeerIndex) {
         let sync_state = self.shared().state();
         if let Some(peer_state) = sync_state.disconnected(peer_index) {
             info!("SyncProtocol.disconnected peer={}", peer_index);


### PR DESCRIPTION
Peer protocols are updated via: https://github.com/nervosnetwork/ckb/blob/b8a4743c4ae9368f5d56880c74d7edb7580d0d45/network/src/network.rs#L765 and https://github.com/nervosnetwork/ckb/blob/b8a4743c4ae9368f5d56880c74d7edb7580d0d45/network/src/network.rs#L792

it's unnecessary to update it again in each protocol handler

=========update=========
Changed the sync/relay protocol hander mode to `ProtocolHandle::Callback` according to review comment