### PR TITLE
Add fail-points to test robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "ctrlc",
+ "fail",
  "serde",
  "serde_plain",
  "tempfile",
@@ -973,6 +974,7 @@ dependencies = [
  "ckb-util",
  "ckb-verification",
  "crossbeam-channel",
+ "fail",
  "failure",
  "faketime",
  "futures 0.3.4",
@@ -1524,6 +1526,17 @@ checksum = "6fdb60074c9b82c91f8702fa5351b85d22b668dae7f73bf06b44a09bc372380f"
 dependencies = [
  "hashbrown",
  "smallvec 0.6.10",
+]
+
+[[package]]
+name = "fail"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
+dependencies = [
+ "lazy_static",
+ "log 0.4.8",
+ "rand 0.7.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,4 @@ jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_
 default = []
 deadlock_detection = ["ckb-bin/deadlock_detection"]
 profiling = ["jemallocator/profiling", "ckb-bin/profiling"]
+failpoints = ["ckb-bin/failpoints"]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -33,7 +33,9 @@ ckb-memory-tracker = { path = "../util/memory-tracker" }
 ckb-verification = { path = "../verification" }
 base64 = "0.10.1"
 tempfile = "3.0"
+fail = "0.4"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]
 profiling = ["ckb-memory-tracker/profiling"]
+failpoints = ["fail/failpoints"]

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -17,6 +17,7 @@ use ckb_sync::{NetTimeProtocol, NetworkProtocol, Relayer, SyncShared, Synchroniz
 use ckb_types::{core::cell::setup_system_cell_cache, prelude::*};
 use ckb_util::{Condvar, Mutex};
 use ckb_verification::{GenesisVerifier, Verifier};
+use fail;
 use std::sync::Arc;
 
 const SECP256K1_BLAKE160_SIGHASH_ALL_ARG_LEN: usize = 20;
@@ -169,6 +170,12 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     let io_handler = builder.build();
 
     let _rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
+
+    if fail::has_failpoints() {
+        for (failpoint, actions) in args.config.failpoints.iter() {
+            fail::cfg(failpoint, actions).expect("setup failpoint");
+        }
+    }
 
     wait_for_exit(exit_condvar);
 

--- a/docs/ckb-debugging.md
+++ b/docs/ckb-debugging.md
@@ -56,6 +56,26 @@ interval = 600
   jeprof --show_bytes --pdf target/debug/ckb ckb-jeprof.$TIMESTAMP.heap > call-graph.pdf
   ```
 
+## Fail-point
+
+### Enable fail-points
+
+- Compile ckb with feature `failpoints`:
+
+  ```shell
+  cargo build --release --features failpoints
+  ```
+
+- Specify which fail-points and error partterns to enable in `ckb.toml`. You can find more detail from [fail-rs](https://github.com/tikv/fail-rs/blob/v0.4.0/src/lib.rs#L638-L667). Here is an example:
+
+  ```toml
+  [failpoints]
+  recv_relaytransactions      = "0.1%return"
+  recv_getblockproposal       = "0.2%panic"
+  send_inibd                  = "sleep(100)"
+  send_relaytransactions      = "0.1%print(message)"
+  ```
+
 ## References:
 
 - [JEMALLOC: Use Case: Leak Checking](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Leak-Checking)

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -27,6 +27,7 @@ ckb-tx-pool = { path = "../tx-pool" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 crossbeam-channel = "0.3"
 ratelimit_meter = "5.0"
+fail = "0.4"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -10,6 +10,7 @@ mod relayer;
 mod status;
 mod synchronizer;
 mod types;
+pub mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/sync/src/net_time_checker.rs
+++ b/sync/src/net_time_checker.rs
@@ -1,3 +1,4 @@
+use crate::utils::send_time;
 use crate::BAD_MESSAGE_BAN_TIME;
 use ckb_logger::{debug, info, warn};
 use ckb_network::{bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
@@ -113,9 +114,7 @@ impl CKBProtocolHandler for NetTimeProtocol {
     ) {
         // send local time to inbound peers
         if let Some(true) = nc.get_peer(peer_index).map(|peer| peer.is_inbound()) {
-            let now = faketime::unix_time_as_millis();
-            let time = packed::Time::new_builder().timestamp(now.pack()).build();
-            if let Err(err) = nc.send_message_to(peer_index, time.as_bytes()) {
+            if let Err(err) = send_time(nc.as_ref(), peer_index) {
                 debug!("net_time_checker send message error: {:?}", err);
             }
         }

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -44,6 +44,19 @@ impl<'a> BlockTransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_blocktransactions", |_| {
+                let block_hash = self.block_transactions.block_hash();
+                let indexes_length = self.block_transactions.transactions().len();
+                let uncle_indexes_length = self.block_transactions.uncles().len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_blocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) from {}",
+                     block_hash, indexes_length, uncle_indexes_length, self.peer,
+                );
+                Status::ignored()
+            })
+        }
+
         let shared = self.relayer.shared();
         let active_chain = shared.active_chain();
         let block_hash = self.block_transactions.block_hash();

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -49,6 +49,21 @@ impl<'a> CompactBlockProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_compactblock", |_| {
+                let header = self.compact_block.header().into_view();
+                let number = header.number();
+                let block_hash = header.hash();
+                ckb_logger::debug!(
+                    "[failpoint] recv_compactblock(number={}, block_hash: {:?}) from {}",
+                    number,
+                    block_hash,
+                    self.peer,
+                );
+                Status::ignored()
+            })
+        }
+
         let shared = self.relayer.shared();
         {
             let compact_block = &self.compact_block;

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -7,7 +7,7 @@ use ckb_types::{packed, prelude::*};
 use std::sync::Arc;
 
 pub struct GetBlockProposalProcess<'a> {
-    message: packed::GetBlockProposalReader<'a>,
+    get_block_proposal: packed::GetBlockProposal,
     relayer: &'a Relayer,
     nc: Arc<dyn CKBProtocolContext>,
     peer: PeerIndex,
@@ -20,8 +20,9 @@ impl<'a> GetBlockProposalProcess<'a> {
         nc: Arc<dyn CKBProtocolContext>,
         peer: PeerIndex,
     ) -> Self {
+        let get_block_proposal = message.to_entity();
         GetBlockProposalProcess {
-            message,
+            get_block_proposal,
             nc,
             relayer,
             peer,
@@ -31,7 +32,7 @@ impl<'a> GetBlockProposalProcess<'a> {
     pub fn execute(self) -> Status {
         let shared = self.relayer.shared();
         {
-            let get_block_proposal = self.message;
+            let get_block_proposal = &self.get_block_proposal;
             let limit = shared.consensus().max_block_proposals_limit()
                 * (shared.consensus().max_uncles_num() as u64);
             if (get_block_proposal.proposals().len() as u64) > limit {
@@ -43,7 +44,7 @@ impl<'a> GetBlockProposalProcess<'a> {
         }
 
         let proposals: Vec<packed::ProposalShortId> =
-            self.message.proposals().to_entity().into_iter().collect();
+            self.get_block_proposal.proposals().into_iter().collect();
 
         let fetched_transactions = {
             let tx_pool = self.relayer.shared.shared().tx_pool_controller();

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -30,6 +30,20 @@ impl<'a> GetBlockProposalProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_getblockproposal", |_| {
+                let block_hash = self.get_block_proposal.block_hash();
+                let length = self.get_block_proposal.proposals().len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_getblockproposal(block_hash={:?}, len={}) from {}",
+                    block_hash,
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         let shared = self.relayer.shared();
         {
             let get_block_proposal = &self.get_block_proposal;

--- a/sync/src/relayer/get_block_transactions_process.rs
+++ b/sync/src/relayer/get_block_transactions_process.rs
@@ -31,6 +31,19 @@ impl<'a> GetBlockTransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_getblocktransactions", |_| {
+                let block_hash = self.get_block_transactions.block_hash();
+                let indexes_length = self.get_block_transactions.indexes().len();
+                let uncle_indexes_length = self.get_block_transactions.uncle_indexes().len();
+                ckb_logger::debug!(
+                    "recv_getblocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) from {}",
+                    block_hash, indexes_length, uncle_indexes_length, self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         let shared = self.relayer.shared();
         {
             let get_block_transactions = &self.get_block_transactions;

--- a/sync/src/relayer/get_transactions_process.rs
+++ b/sync/src/relayer/get_transactions_process.rs
@@ -31,6 +31,18 @@ impl<'a> GetTransactionsProcess<'a> {
 
     pub fn execute(self) -> Status {
         {
+            fail::fail_point!("recv_getrelaytransactions", |_| {
+                let length = self.get_relay_transactions.tx_hashes().len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_getrelaytransactions(len={}) from {}",
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
+        {
             let get_transactions = &self.get_relay_transactions;
             if get_transactions.tx_hashes().len() > MAX_RELAY_TXS_NUM_PER_BATCH {
                 return StatusCode::ProtocolMessageIsMalformed.with_context(format!(

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -149,7 +149,7 @@ impl Relayer {
                 GetBlockProposalProcess::new(reader, self, nc, peer).execute()
             }
             packed::RelayMessageUnionReader::BlockProposal(reader) => {
-                BlockProposalProcess::new(reader, self).execute()
+                BlockProposalProcess::new(reader, self, peer).execute()
             }
         }
     }

--- a/sync/src/relayer/tests/block_proposal_process.rs
+++ b/sync/src/relayer/tests/block_proposal_process.rs
@@ -1,6 +1,7 @@
 use crate::relayer::block_proposal_process::BlockProposalProcess;
 use crate::relayer::tests::helper::{build_chain, new_transaction};
 use crate::Status;
+use ckb_network::PeerIndex;
 use ckb_types::packed::{self, ProposalShortId};
 use ckb_types::prelude::*;
 
@@ -19,7 +20,7 @@ fn test_no_unknown() {
         .transactions(transactions.into_iter().map(|tx| tx.data()).pack())
         .build();
 
-    let process = BlockProposalProcess::new(content.as_reader(), &relayer);
+    let process = BlockProposalProcess::new(content.as_reader(), &relayer, PeerIndex::new(1));
     assert_eq!(process.execute(), Status::ignored());
 }
 
@@ -34,7 +35,7 @@ fn test_no_asked() {
         .transactions(transactions.into_iter().map(|tx| tx.data()).pack())
         .build();
 
-    let process = BlockProposalProcess::new(content.as_reader(), &relayer);
+    let process = BlockProposalProcess::new(content.as_reader(), &relayer, PeerIndex::new(1));
     assert_eq!(process.execute(), Status::ignored());
 
     let known = relayer.shared.state().already_known_tx(&transaction.hash());
@@ -60,7 +61,7 @@ fn test_ok() {
         .transactions(transactions.into_iter().map(|tx| tx.data()).pack())
         .build();
 
-    let process = BlockProposalProcess::new(content.as_reader(), &relayer);
+    let process = BlockProposalProcess::new(content.as_reader(), &relayer, PeerIndex::new(1));
     assert_eq!(process.execute(), Status::ok());
 
     let known = relayer.shared.state().already_known_tx(&transaction.hash());

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -1,6 +1,6 @@
 use crate::relayer::block_transactions_process::BlockTransactionsProcess;
 use crate::relayer::tests::helper::{build_chain, MockProtocalContext};
-use crate::{Status, StatusCode};
+use crate::{NetworkProtocol, Status, StatusCode};
 use ckb_network::PeerIndex;
 use ckb_store::ChainStore;
 use ckb_tx_pool::{PlugTarget, TxEntry};
@@ -317,11 +317,7 @@ fn test_collision_and_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc
-        .as_ref()
-        .sent_messages_to
-        .borrow()
-        .contains(&(peer_index, data)));
+    assert!(nc.has_sent(NetworkProtocol::RELAY.into(), peer_index, data));
 
     // update cached missing_index
     {
@@ -427,9 +423,9 @@ fn test_missing() {
     let message = packed::RelayMessage::new_builder().set(content).build();
 
     // send missing indexes messages
-    assert!(nc
-        .as_ref()
-        .sent_messages_to
-        .borrow()
-        .contains(&(peer_index, message.as_bytes())));
+    assert!(nc.has_sent(
+        NetworkProtocol::RELAY.into(),
+        peer_index,
+        message.as_bytes()
+    ))
 }

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -433,11 +433,7 @@ fn test_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc
-        .as_ref()
-        .sent_messages_to
-        .borrow()
-        .contains(&(peer_index, data)));
+    assert!(nc.has_sent(NetworkProtocol::RELAY.into(), peer_index, data));
 
     // insert inflight proposal
     assert!(relayer
@@ -454,11 +450,7 @@ fn test_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send proposal request
-    assert!(nc
-        .as_ref()
-        .sent_messages_to
-        .borrow()
-        .contains(&(peer_index, data)));
+    assert!(nc.has_sent(NetworkProtocol::RELAY.into(), peer_index, data));
 }
 
 #[test]
@@ -668,9 +660,5 @@ fn test_collision() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc
-        .as_ref()
-        .sent_messages_to
-        .borrow()
-        .contains(&(peer_index, data)));
+    assert!(nc.has_sent(NetworkProtocol::RELAY.into(), peer_index, data));
 }

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -166,7 +166,18 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
 #[derive(Default)]
 pub(crate) struct MockProtocalContext {
     pub sent_messages: RefCell<Vec<(ProtocolId, PeerIndex, P2pBytes)>>,
-    pub sent_messages_to: RefCell<Vec<(PeerIndex, P2pBytes)>>,
+}
+
+impl MockProtocalContext {
+    pub fn has_sent(&self, protocol: ProtocolId, peer: PeerIndex, data: P2pBytes) -> bool {
+        self.sent_messages
+            .borrow()
+            .contains(&(protocol, peer, data))
+    }
+
+    pub fn push(&self, protocol: ProtocolId, peer: PeerIndex, data: P2pBytes) {
+        self.sent_messages.borrow_mut().push((protocol, peer, data))
+    }
 }
 
 impl CKBProtocolContext for MockProtocalContext {
@@ -203,16 +214,12 @@ impl CKBProtocolContext for MockProtocalContext {
         peer_index: PeerIndex,
         data: P2pBytes,
     ) -> Result<(), Error> {
-        self.sent_messages
-            .borrow_mut()
-            .push((proto_id, peer_index, data));
+        self.push(proto_id, peer_index, data);
         Ok(())
     }
-    fn send_message_to(&self, peer_index: PeerIndex, data: P2pBytes) -> Result<(), Error> {
-        self.sent_messages_to.borrow_mut().push((peer_index, data));
-        Ok(())
+    fn send_message_to(&self, _peer_index: PeerIndex, _data: P2pBytes) -> Result<(), Error> {
+        unimplemented!();
     }
-
     fn filter_broadcast(&self, _target: TargetSession, _data: P2pBytes) -> Result<(), Error> {
         unimplemented!();
     }

--- a/sync/src/relayer/transaction_hashes_process.rs
+++ b/sync/src/relayer/transaction_hashes_process.rs
@@ -29,6 +29,18 @@ impl<'a> TransactionHashesProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_relaytransactionhashes", |_| {
+                let length = self.relay_transaction_hashes.tx_hashes().len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_relaytransactionhashes(len={}) from {}",
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         let state = self.relayer.shared().state();
         {
             let relay_transaction_hashes = &self.relay_transaction_hashes;

--- a/sync/src/relayer/transactions_process.rs
+++ b/sync/src/relayer/transactions_process.rs
@@ -41,6 +41,18 @@ impl<'a> TransactionsProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_relaytransactions", |_| {
+                let length = self.relay_transactions.transactions().len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_relaytransactions(len={}) from {}",
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         let shared_state = self.relayer.shared().state();
         let txs: Vec<(TransactionView, Cycle)> = {
             let tx_filter = shared_state.tx_filter();

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -30,13 +30,15 @@ impl<'a> BlockProcess<'a> {
     pub fn execute(self) -> Status {
         {
             fail::fail_point!("recv_sendblock", |_| {
-                debug!(
-                    "[failpoint] recv_sendblock(number={}, block_hash={:?} from {}",
-                    self.block.number(),
-                    self.block.hash(),
-                    self.peer,
+                let number = self.block.number();
+                let block_hash = self.block.hash();
+                ckb_logger::debug!(
+                    "[failpoint] recv_sendblock(number={}, block_hash={:?}) from {}",
+                    number,
+                    block_hash,
+                    self.peer
                 );
-                Status::ok()
+                Status::ignored()
             })
         }
 

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -31,6 +31,18 @@ impl<'a> GetBlocksProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_getblocks", |_| {
+                let length = self.block_hashes.len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_getblocks(len={}) from {}",
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         // use MAX_HEADERS_LEN as limit, we may increase the value of INIT_BLOCKS_IN_TRANSIT_PER_PEER in the future
         if self.block_hashes.len() > MAX_HEADERS_LEN {
             return StatusCode::ProtocolMessageIsMalformed.with_context(format!(

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -1,6 +1,7 @@
 use crate::synchronizer::Synchronizer;
-use crate::{NetworkProtocol, Status, StatusCode, MAX_LOCATOR_SIZE};
-use ckb_logger::{debug, info};
+use crate::utils::{send_inibd, send_sendheaders};
+use crate::{Status, StatusCode, MAX_LOCATOR_SIZE};
+use ckb_logger::{debug, error, info};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{
     core,
@@ -75,20 +76,15 @@ impl<'a> GetHeadersProcess<'a> {
             self.synchronizer.peers().getheaders_received(self.peer);
             let headers: Vec<core::HeaderView> =
                 active_chain.get_locator_response(block_number, &hash_stop);
-            // response headers
 
-            debug!("headers len={}", headers.len());
-
-            let content = packed::SendHeaders::new_builder()
-                .headers(headers.into_iter().map(|x| x.data()).pack())
-                .build();
-            let message = packed::SyncMessage::new_builder().set(content).build();
-
-            if let Err(err) = self.nc.send_message_to(self.peer, message.as_bytes()) {
+            if let Err(err) = send_sendheaders(
+                self.nc,
+                self.peer,
+                headers.into_iter().map(|h| h.data()).collect(),
+            ) {
                 return StatusCode::Network
-                    .with_context(format!("Send SendHeaders error: {:?}", err,));
+                    .with_context(format!("send_sendheaders error: {:?}", err));
             }
-            crate::synchronizer::log_sent_metric(message.to_enum().item_name());
         } else {
             return StatusCode::GetHeadersMissCommonAncestors
                 .with_context(format!("{:#x?}", block_locator_hashes,));
@@ -97,14 +93,8 @@ impl<'a> GetHeadersProcess<'a> {
     }
 
     fn send_in_ibd(&self) {
-        let content = packed::InIBD::new_builder().build();
-        let message = packed::SyncMessage::new_builder().set(content).build();
-
-        if let Err(err) =
-            self.nc
-                .send_message(NetworkProtocol::SYNC.into(), self.peer, message.as_bytes())
-        {
-            debug!("synchronizer send in ibd error: {:?}", err);
+        if let Err(err) = send_inibd(self.nc, self.peer) {
+            error!("send_inibd error: {:?}", err);
         }
     }
 }

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -46,7 +46,7 @@ impl<'a> GetHeadersProcess<'a> {
                     "[failpoint] recv_getheaders({:?} from {}",
                     self.block_locator_hashes, self.peer
                 );
-                Status::ok()
+                Status::ignored()
             })
         }
 

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -134,6 +134,18 @@ impl<'a> HeadersProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_sendheaders", |_| {
+                let length = self.headers.len();
+                ckb_logger::debug!(
+                    "[failpoint] recv_sendheaders(length={}) from {}",
+                    length,
+                    self.peer
+                );
+                Status::ignored()
+            })
+        }
+
         debug!("HeadersProcess begin");
         let shared = self.synchronizer.shared();
         let headers = &self.headers;

--- a/sync/src/synchronizer/in_ibd_process.rs
+++ b/sync/src/synchronizer/in_ibd_process.rs
@@ -23,6 +23,13 @@ impl<'a> InIBDProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        {
+            fail::fail_point!("recv_inibd", |_| {
+                ckb_logger::debug!("[failpoint] recv_inibd from {}", self.peer);
+                Status::ignored()
+            })
+        }
+
         info!("getheader with ibd peer {:?}", self.peer);
         if let Some(state) = self.synchronizer.peers().state.write().get_mut(&self.peer) {
             // Don't assume that the peer is sync_started.

--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -28,7 +28,7 @@ pub fn send_getheaders(
     log_sent_sync_metric("getheaders");
 
     fail_point!("send_getheaders", |_| {
-        debug!("[fail_point] send_getheaders to {}", peer);
+        debug!("[failpoint] send_getheaders to {}", peer);
         Ok(())
     });
 
@@ -48,7 +48,7 @@ pub fn send_sendheaders(
     log_sent_sync_metric("sendheaders");
 
     fail_point!("send_sendheaders", |_| {
-        debug!("[fail_point] send_sendheaders(len={}) to {}", length, peer);
+        debug!("[failpoint] send_sendheaders(len={}) to {}", length, peer);
         Ok(())
     });
 
@@ -68,7 +68,7 @@ pub fn send_getblocks(
     log_sent_sync_metric("getblocks");
 
     fail_point!("send_getblocks", |_| {
-        debug!("[fail_point] send_getblocks(len={}) to {}", length, peer);
+        debug!("[failpoint] send_getblocks(len={}) to {}", length, peer);
         Ok(())
     });
 
@@ -93,7 +93,7 @@ pub fn send_sendblock(
 
     fail_point!("send_sendblock", |_| {
         debug!(
-            "[fail_point] send_sendblock(number={}, block_hash={:?}) to {}",
+            "[failpoint] send_sendblock(number={}, block_hash={:?}) to {}",
             number, block_hash, peer
         );
         Ok(())
@@ -110,7 +110,7 @@ pub fn send_inibd(nc: &dyn CKBProtocolContext, peer: PeerIndex) -> Result<(), Er
     log_sent_sync_metric("inibd");
 
     fail_point!("send_inibd", |_| {
-        debug!("[fail_point] send_inibd to {}", peer);
+        debug!("[failpoint] send_inibd to {}", peer);
         Ok(())
     });
 
@@ -138,7 +138,7 @@ pub fn send_getblockproposal(
 
     fail_point!("send_getblockproposal", |_| {
         debug!(
-            "[fail_point] send_getblockproposal(block_hash={:?}, len={}) to {}",
+            "[failpoint] send_getblockproposal(block_hash={:?}, len={}) to {}",
             block_hash, length, peer
         );
         Ok(())
@@ -162,10 +162,7 @@ pub fn send_blockproposal(
     log_sent_relay_metric("blockproposal");
 
     fail_point!("send_blockproposal", |_| {
-        debug!(
-            "[fail_point] send_blockproposal(len={}) to {}",
-            length, peer
-        );
+        debug!("[failpoint] send_blockproposal(len={}) to {}", length, peer);
         Ok(())
     });
 
@@ -188,7 +185,7 @@ pub fn send_relaytransactions(
 
     fail_point!("send_relaytransactions", |_| {
         debug!(
-            "[fail_point] send_relaytransactions(len={}) to {}",
+            "[failpoint] send_relaytransactions(len={}) to {}",
             length, peer
         );
         Ok(())
@@ -220,7 +217,7 @@ pub fn send_getblocktransactions(
     log_sent_relay_metric("getBlocktransactions");
 
     fail_point!("send_getblocktransactions", |_| {
-        debug!("[fail_point] send_getblocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}", block_hash, indexes_length, uncle_indexes_length, peer);
+        debug!("[failpoint] send_getblocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}", block_hash, indexes_length, uncle_indexes_length, peer);
         Ok(())
     });
 
@@ -251,7 +248,7 @@ pub fn send_blocktransactions(
 
     fail_point!("send_blocktransactions", |_| {
         debug!(
-            "[fail_point] send_blocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}",
+            "[failpoint] send_blocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}",
             block_hash, indexes_length, uncle_indexes_length, peer,
         );
         Ok(())
@@ -276,7 +273,7 @@ pub fn send_getrelaytransactions(
 
     fail_point!("send_getrelaytransactions", |_| {
         debug!(
-            "[fail_point] send_getrelaytransactions(len={}) to {}",
+            "[failpoint] send_getrelaytransactions(len={}) to {}",
             length, peer
         );
         Ok(())

--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -1,0 +1,301 @@
+use ckb_logger::{debug, metric};
+use ckb_network::{CKBProtocolContext, Error, PeerIndex};
+use ckb_types::packed::{BlockTransactions, GetHeaders, UncleBlock};
+use ckb_types::{
+    core,
+    packed::{
+        BlockProposal, Byte32, GetBlockProposal, GetBlockTransactions, GetBlocks,
+        GetRelayTransactions, Header, InIBD, ProposalShortId, RelayMessage, RelayTransaction,
+        RelayTransactions, SendBlock, SendHeaders, SyncMessage, Transaction,
+    },
+    prelude::*,
+};
+use fail::fail_point;
+
+pub fn send_getheaders(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    locator_hashes: Vec<Byte32>,
+    hash_stop: Byte32,
+) -> Result<(), Error> {
+    let content = GetHeaders::new_builder()
+        .block_locator_hashes(locator_hashes.pack())
+        .hash_stop(hash_stop)
+        .build();
+    let message = SyncMessage::new_builder().set(content).build();
+
+    debug!("send_getheaders to {}", peer);
+    log_sent_sync_metric("getheaders");
+
+    fail_point!("send_getheaders", |_| {
+        debug!("[fail_point] send_getheaders to {}", peer);
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_sendheaders(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    headers: Vec<Header>,
+) -> Result<(), Error> {
+    let length = headers.len();
+    let content = SendHeaders::new_builder().headers(headers.pack()).build();
+    let message = SyncMessage::new_builder().set(content).build();
+
+    debug!("send_sendheaders(len={}) to {}", length, peer);
+    log_sent_sync_metric("sendheaders");
+
+    fail_point!("send_sendheaders", |_| {
+        debug!("[fail_point] send_sendheaders(len={}) to {}", length, peer);
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_getblocks(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    hashes: Vec<Byte32>,
+) -> Result<(), Error> {
+    let length = hashes.len();
+    let content = GetBlocks::new_builder().block_hashes(hashes.pack()).build();
+    let message = SyncMessage::new_builder().set(content).build();
+
+    debug!("send_getblocks(len={}) to {}", length, peer);
+    log_sent_sync_metric("getblocks");
+
+    fail_point!("send_getblocks", |_| {
+        debug!("[fail_point] send_getblocks(len={}) to {}", length, peer);
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_sendblock(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    block: core::BlockView,
+) -> Result<(), Error> {
+    let number = block.number();
+    let block_hash = block.hash();
+    let content = SendBlock::new_builder().block(block.data()).build();
+    let message = SyncMessage::new_builder().set(content).build();
+
+    debug!(
+        "send_sendblock(number={}, block_hash={:?}) to {}",
+        number, block_hash, peer
+    );
+    log_sent_sync_metric("sendblock");
+
+    fail_point!("send_sendblock", |_| {
+        debug!(
+            "[fail_point] send_sendblock(number={}, block_hash={:?}) to {}",
+            number, block_hash, peer
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_inibd(nc: &dyn CKBProtocolContext, peer: PeerIndex) -> Result<(), Error> {
+    let content = InIBD::new_builder().build();
+    let message = SyncMessage::new_builder().set(content).build();
+
+    debug!("send_inibd to {}", peer);
+    log_sent_sync_metric("inibd");
+
+    fail_point!("send_inibd", |_| {
+        debug!("[fail_point] send_inibd to {}", peer);
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_getblockproposal(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    block_hash: Byte32,
+    proposals: Vec<ProposalShortId>,
+) -> Result<(), Error> {
+    let length = proposals.len();
+    let content = GetBlockProposal::new_builder()
+        .block_hash(block_hash.clone())
+        .proposals(proposals.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!(
+        "send_getblockproposal(block_hash={:?}, len={}) to {}",
+        block_hash, length, peer
+    );
+    log_sent_relay_metric("getblockproposal");
+
+    fail_point!("send_getblockproposal", |_| {
+        debug!(
+            "[fail_point] send_getblockproposal(block_hash={:?}, len={}) to {}",
+            block_hash, length, peer
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_blockproposal(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    transactions: Vec<Transaction>,
+) -> Result<(), Error> {
+    let length = transactions.len();
+    let content = BlockProposal::new_builder()
+        .transactions(transactions.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!("send_blockproposal(len={}) to {}", length, peer);
+    log_sent_relay_metric("blockproposal");
+
+    fail_point!("send_blockproposal", |_| {
+        debug!(
+            "[fail_point] send_blockproposal(len={}) to {}",
+            length, peer
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_relaytransactions(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    transactions: Vec<RelayTransaction>,
+) -> Result<(), Error> {
+    let length = transactions.len();
+    let content = RelayTransactions::new_builder()
+        .transactions(transactions.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!("send_relaytransactions(len={}) to {}", length, peer);
+    log_sent_relay_metric("relaytransactions");
+
+    fail_point!("send_relaytransactions", |_| {
+        debug!(
+            "[fail_point] send_relaytransactions(len={}) to {}",
+            length, peer
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_getblocktransactions(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    block_hash: Byte32,
+    indexes: Vec<u32>,
+    uncle_indexes: Vec<u32>,
+) -> Result<(), Error> {
+    let indexes_length = indexes.len();
+    let uncle_indexes_length = uncle_indexes.len();
+    let content = GetBlockTransactions::new_builder()
+        .block_hash(block_hash.clone())
+        .indexes(indexes.pack())
+        .uncle_indexes(uncle_indexes.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!(
+        "send_getblocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}",
+        block_hash, indexes_length, uncle_indexes_length, peer
+    );
+    log_sent_relay_metric("getBlocktransactions");
+
+    fail_point!("send_getblocktransactions", |_| {
+        debug!("[fail_point] send_getblocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}", block_hash, indexes_length, uncle_indexes_length, peer);
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_blocktransactions(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    block_hash: Byte32,
+    transactions: Vec<Transaction>,
+    uncles: Vec<UncleBlock>,
+) -> Result<(), Error> {
+    let indexes_length = transactions.len();
+    let uncle_indexes_length = uncles.len();
+    let content = BlockTransactions::new_builder()
+        .block_hash(block_hash.clone())
+        .transactions(transactions.pack())
+        .uncles(uncles.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!(
+        "send_blocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}",
+        block_hash, indexes_length, uncle_indexes_length, peer
+    );
+    log_sent_relay_metric("getBlocktransactions");
+
+    fail_point!("send_blocktransactions", |_| {
+        debug!(
+            "[fail_point] send_blocktransactions(block_hash: {:?}, indexes_len={}, uncle_indexes_len={}) to {}",
+            block_hash, indexes_length, uncle_indexes_length, peer,
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+pub fn send_getrelaytransactions(
+    nc: &dyn CKBProtocolContext,
+    peer: PeerIndex,
+    tx_hashes: Vec<Byte32>,
+) -> Result<(), Error> {
+    let length = tx_hashes.len();
+    let content = GetRelayTransactions::new_builder()
+        .tx_hashes(tx_hashes.pack())
+        .build();
+    let message = RelayMessage::new_builder().set(content).build();
+
+    debug!("send_getrelaytransactions(len={}) to {}", length, peer);
+    log_sent_relay_metric("getrelaytransactions");
+
+    fail_point!("send_getrelaytransactions", |_| {
+        debug!(
+            "[fail_point] send_getrelaytransactions(len={}) to {}",
+            length, peer
+        );
+        Ok(())
+    });
+
+    nc.send_message_to(peer, message.as_bytes())
+}
+
+fn log_sent_sync_metric(item_name: &str) {
+    metric!({
+        "topic": "sent",
+        "fields": { item_name: 1 }
+    });
+}
+
+fn log_sent_relay_metric(item_name: &str) {
+    metric!({
+        "topic": "sent",
+        "tags": { "target": crate::LOG_TARGET_RELAY },
+        "fields": { item_name: 1 }
+    });
+}

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -17,6 +17,7 @@ use ckb_resource::Resource;
 use super::configs::*;
 use super::sentry_config::SentryConfig;
 use super::{cli, ExitCode};
+use std::collections::HashMap;
 
 pub enum AppConfig {
     CKB(Box<CKBAppConfig>),
@@ -46,6 +47,8 @@ pub struct CKBAppConfig {
     pub alert_signature: Option<NetworkAlertConfig>,
     #[serde(default)]
     pub notify: NotifyConfig,
+    #[serde(default)]
+    pub failpoints: HashMap<String, String>,
 }
 
 // change the order of fields will break integration test, see module doc.


### PR DESCRIPTION
  - Specify the actions of fail-points via the configuration `fail-points` in `ckb.toml`.
  - Add fail-points at the front of sending/receiving network messages.
  - Create `sync/src/utils.rs` to wrap most of the operations of sending messages.
  - Refactor some code.
  - Run 2 nodes from the fresh state, the one configured with `0.1%` probability of network messages lost, another is normal. The former takes `170` minutes and the latter takes `120` minutes to synchronize to the TIP.