### PR TITLE
refactor: move network protocol related variables to SupportProtocols

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -19,7 +19,10 @@ pub use crate::{
     peer::{Peer, PeerIdentifyInfo},
     peer_registry::PeerRegistry,
     peer_store::{types::MultiaddrExt, Score},
-    protocols::{CKBProtocol, CKBProtocolContext, CKBProtocolHandler, PeerIndex},
+    protocols::{
+        support_protocols::SupportProtocols, CKBProtocol, CKBProtocolContext, CKBProtocolHandler,
+        PeerIndex,
+    },
 };
 pub use p2p::{
     bytes, multiaddr,
@@ -29,26 +32,5 @@ pub use p2p::{
     ProtocolId,
 };
 pub use tokio;
-
-// Max message frame length for sync protocol: 2MB
-//   NOTE: update this value when block size limit changed
-pub const MAX_FRAME_LENGTH_SYNC: usize = 2 * 1024 * 1024;
-// Max message frame length for relay protocol: 4MB
-//   NOTE: update this value when block size limit changed
-pub const MAX_FRAME_LENGTH_RELAY: usize = 4 * 1024 * 1024;
-// Max message frame length for time protocol: 1KB
-pub const MAX_FRAME_LENGTH_TIME: usize = 1024;
-// Max message frame length for alert protocol: 128KB
-pub const MAX_FRAME_LENGTH_ALERT: usize = 128 * 1024;
-// Max message frame length for discovery protocol: 512KB
-pub const MAX_FRAME_LENGTH_DISCOVERY: usize = 512 * 1024;
-// Max message frame length for ping protocol: 1KB
-pub const MAX_FRAME_LENGTH_PING: usize = 1024;
-// Max message frame length for identify protocol: 2KB
-pub const MAX_FRAME_LENGTH_IDENTIFY: usize = 2 * 1024;
-// Max message frame length for disconnectmsg protocol: 1KB
-pub const MAX_FRAME_LENGTH_DISCONNECTMSG: usize = 1024;
-// Max message frame length for feeler protocol: 1KB
-pub const MAX_FRAME_LENGTH_FEELER: usize = 1024;
 
 pub type ProtocolVersion = String;

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -10,16 +10,13 @@ use crate::protocols::{
     feeler::Feeler,
     identify::{IdentifyCallback, IdentifyProtocol},
     ping::{PingHandler, PingService},
+    support_protocols::SupportProtocols,
 };
 use crate::services::{
     dns_seeding::DnsSeedingService, dump_peer_store::DumpPeerStoreService,
     outbound_peer::OutboundPeerService, protocol_type_checker::ProtocolTypeCheckerService,
 };
-use crate::{
-    Behaviour, CKBProtocol, Peer, ProtocolId, ProtocolVersion, PublicKey, ServiceControl,
-    MAX_FRAME_LENGTH_DISCONNECTMSG, MAX_FRAME_LENGTH_DISCOVERY, MAX_FRAME_LENGTH_FEELER,
-    MAX_FRAME_LENGTH_IDENTIFY, MAX_FRAME_LENGTH_PING,
-};
+use crate::{Behaviour, CKBProtocol, Peer, ProtocolId, ProtocolVersion, PublicKey, ServiceControl};
 use ckb_app_config::NetworkConfig;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
@@ -30,15 +27,15 @@ use futures::{
 };
 use ipnetwork::IpNetwork;
 use p2p::{
-    builder::{MetaBuilder, ServiceBuilder},
+    builder::ServiceBuilder,
     bytes::Bytes,
     context::{ServiceContext, SessionContext},
     error::{DialerErrorKind, HandshakeErrorKind, ProtocolHandleErrorKind, SendErrorKind},
     multiaddr::{self, Multiaddr},
     secio::{self, error::SecioError, PeerId},
     service::{
-        BlockingFlag, ProtocolEvent, ProtocolHandle, Service, ServiceError, ServiceEvent,
-        TargetProtocol, TargetSession,
+        ProtocolEvent, ProtocolHandle, Service, ServiceError, ServiceEvent, TargetProtocol,
+        TargetSession,
     },
     traits::ServiceHandle,
     utils::extract_peer_id,
@@ -54,13 +51,6 @@ use std::{
     usize,
 };
 use tokio::runtime;
-use tokio_util::codec::length_delimited;
-
-pub(crate) const PING_PROTOCOL_ID: usize = 0;
-pub(crate) const DISCOVERY_PROTOCOL_ID: usize = 1;
-pub(crate) const IDENTIFY_PROTOCOL_ID: usize = 2;
-pub(crate) const FEELER_PROTOCOL_ID: usize = 3;
-pub(crate) const DISCONNECT_MESSAGE_PROTOCOL_ID: usize = 4;
 
 const P2P_SEND_TIMEOUT: Duration = Duration::from_secs(6);
 const P2P_TRY_SEND_INTERVAL: Duration = Duration::from_millis(100);
@@ -447,7 +437,7 @@ impl NetworkState {
             p2p_control,
             peer_id,
             addr,
-            TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()),
+            TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
             false,
         ) {
             debug!("dial_identify error: {}", err);
@@ -460,7 +450,7 @@ impl NetworkState {
             p2p_control,
             peer_id,
             addr,
-            TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()),
+            TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
             false,
         ) {
             debug!("dial_feeler error {}", err);
@@ -480,7 +470,7 @@ impl NetworkState {
                 p2p_control,
                 self.local_peer_id(),
                 addr,
-                TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()),
+                TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
                 true,
             ) {
                 debug!("try_dial_observed_addrs error {}", err);
@@ -871,10 +861,6 @@ impl<T: ExitHandler> NetworkService<T> {
         exit_handler: T,
     ) -> Self {
         let config = &network_state.config;
-
-        let mut no_blocking_flag = BlockingFlag::default();
-        no_blocking_flag.disable_all();
-
         // == Build special protocols
 
         // TODO: how to deny banned node to open those protocols?
@@ -883,98 +869,40 @@ impl<T: ExitHandler> NetworkService<T> {
         let ping_interval = Duration::from_secs(config.ping_interval_secs);
         let ping_timeout = Duration::from_secs(config.ping_timeout_secs);
 
-        let ping_meta = MetaBuilder::default()
-            .id(PING_PROTOCOL_ID.into())
-            .name(move |_| "/ckb/ping".to_string())
-            .codec(|| {
-                Box::new(
-                    length_delimited::Builder::new()
-                        .max_frame_length(MAX_FRAME_LENGTH_PING)
-                        .new_codec(),
-                )
-            })
-            .service_handle(move || {
-                ProtocolHandle::Both(Box::new(PingHandler::new(
-                    ping_interval,
-                    ping_timeout,
-                    ping_sender,
-                )))
-            })
-            .flag(no_blocking_flag)
-            .build();
+        let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
+            ProtocolHandle::Both(Box::new(PingHandler::new(
+                ping_interval,
+                ping_timeout,
+                ping_sender,
+            )))
+        });
 
         // Discovery protocol
         let disc_network_state = Arc::clone(&network_state);
-        let disc_meta = MetaBuilder::default()
-            .id(DISCOVERY_PROTOCOL_ID.into())
-            .name(move |_| "/ckb/discovery".to_string())
-            .codec(|| {
-                Box::new(
-                    length_delimited::Builder::new()
-                        .max_frame_length(MAX_FRAME_LENGTH_DISCOVERY)
-                        .new_codec(),
-                )
-            })
-            .service_handle(move || {
-                ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(
-                    disc_network_state,
-                    config.discovery_local_address,
-                )))
-            })
-            .flag(no_blocking_flag)
-            .build();
+        let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
+            ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(
+                disc_network_state,
+                config.discovery_local_address,
+            )))
+        });
 
         // Identify protocol
         let identify_callback =
             IdentifyCallback::new(Arc::clone(&network_state), name, version.clone());
-        let identify_meta = MetaBuilder::default()
-            .id(IDENTIFY_PROTOCOL_ID.into())
-            .name(move |_| "/ckb/identify".to_string())
-            .codec(|| {
-                Box::new(
-                    length_delimited::Builder::new()
-                        .max_frame_length(MAX_FRAME_LENGTH_IDENTIFY)
-                        .new_codec(),
-                )
-            })
-            .service_handle(move || {
-                ProtocolHandle::Both(Box::new(IdentifyProtocol::new(identify_callback)))
-            })
-            .flag(no_blocking_flag)
-            .build();
+        let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
+            ProtocolHandle::Both(Box::new(IdentifyProtocol::new(identify_callback)))
+        });
 
         // Feeler protocol
-        // TODO: versions
-        let feeler_meta = MetaBuilder::default()
-            .id(FEELER_PROTOCOL_ID.into())
-            .name(move |_| "/ckb/flr".to_string())
-            .codec(|| {
-                Box::new(
-                    length_delimited::Builder::new()
-                        .max_frame_length(MAX_FRAME_LENGTH_FEELER)
-                        .new_codec(),
-                )
-            })
-            .service_handle({
-                let network_state = Arc::clone(&network_state);
-                move || ProtocolHandle::Both(Box::new(Feeler::new(Arc::clone(&network_state))))
-            })
-            .flag(no_blocking_flag)
-            .build();
+        let feeler_meta = SupportProtocols::Feeler.build_meta_with_service_handle({
+            let network_state = Arc::clone(&network_state);
+            move || ProtocolHandle::Both(Box::new(Feeler::new(Arc::clone(&network_state))))
+        });
 
-        let disconnect_message_meta = MetaBuilder::default()
-            .id(DISCONNECT_MESSAGE_PROTOCOL_ID.into())
-            .name(move |_| "/ckb/disconnectmsg".to_string())
-            .codec(|| {
-                Box::new(
-                    length_delimited::Builder::new()
-                        .max_frame_length(MAX_FRAME_LENGTH_DISCONNECTMSG)
-                        .new_codec(),
-                )
-            })
-            .service_handle(move || ProtocolHandle::Both(Box::new(DisconnectMessageProtocol)))
-            .flag(no_blocking_flag)
-            .build();
+        let disconnect_message_meta = SupportProtocols::DisconnectMessage
+            .build_meta_with_service_handle(move || {
+                ProtocolHandle::Both(Box::new(DisconnectMessageProtocol))
+            });
 
         // == Build p2p service struct
         let mut protocol_metas = protocols
@@ -1354,7 +1282,11 @@ pub(crate) fn disconnect_with_message(
     if !message.is_empty() {
         let data = Bytes::from(message.as_bytes().to_vec());
         // Must quick send, otherwise this message will be dropped.
-        control.quick_send_message_to(peer_index, DISCONNECT_MESSAGE_PROTOCOL_ID.into(), data)?;
+        control.quick_send_message_to(
+            peer_index,
+            SupportProtocols::DisconnectMessage.protocol_id(),
+            data,
+        )?;
     }
     control.disconnect(peer_index)
 }

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -16,7 +16,7 @@ use p2p::{
 
 mod protocol;
 
-use crate::{network::FEELER_PROTOCOL_ID, NetworkState, PeerIdentifyInfo};
+use crate::{NetworkState, PeerIdentifyInfo, SupportProtocols};
 use ckb_types::{packed, prelude::*};
 
 use protocol::IdentifyMessage;
@@ -415,7 +415,7 @@ impl Callback for IdentifyCallback {
                     {
                         let _ = context.open_protocols(
                             context.session.id,
-                            TargetProtocol::Single(FEELER_PROTOCOL_ID.into()),
+                            TargetProtocol::Single(SupportProtocols::Feeler.protocol_id()),
                         );
                     } else if flags.contains(self.identify.flags) {
                         registry_client_version(client_version);
@@ -423,7 +423,7 @@ impl Callback for IdentifyCallback {
                         // The remote end can support all local protocols.
                         let protos = self
                             .network_state
-                            .get_protocol_ids(|id| id != FEELER_PROTOCOL_ID.into());
+                            .get_protocol_ids(|id| id != SupportProtocols::Feeler.protocol_id());
 
                         let _ = context
                             .open_protocols(context.session.id, TargetProtocol::Multi(protos));

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -3,6 +3,8 @@ pub(crate) mod discovery;
 pub(crate) mod feeler;
 pub(crate) mod identify;
 pub(crate) mod ping;
+pub(crate) mod support_protocols;
+
 #[cfg(test)]
 mod test;
 
@@ -110,6 +112,23 @@ pub struct CKBProtocol {
 }
 
 impl CKBProtocol {
+    // a helper constructor to build `CKBProtocol` with `SupportProtocols` enum
+    pub fn new_with_support_protocol(
+        support_protocol: support_protocols::SupportProtocols,
+        handler: Box<dyn CKBProtocolHandler>,
+        network_state: Arc<NetworkState>,
+    ) -> Self {
+        CKBProtocol {
+            id: support_protocol.protocol_id(),
+            max_frame_length: support_protocol.max_frame_length(),
+            protocol_name: support_protocol.name(),
+            supported_versions: support_protocol.support_versions(),
+            flag: support_protocol.flag(),
+            network_state,
+            handler,
+        }
+    }
+
     pub fn new(
         protocol_name: String,
         id: ProtocolId,

--- a/network/src/protocols/support_protocols.rs
+++ b/network/src/protocols/support_protocols.rs
@@ -1,0 +1,134 @@
+use crate::ProtocolId;
+use p2p::{
+    builder::MetaBuilder,
+    service::{BlockingFlag, ProtocolHandle, ProtocolMeta},
+    traits::ServiceProtocol,
+};
+use tokio_util::codec::length_delimited;
+
+pub enum SupportProtocols {
+    Ping,
+    Discovery,
+    Identify,
+    Feeler,
+    DisconnectMessage,
+    Sync,
+    Relay,
+    Time,
+    Alert,
+}
+
+impl SupportProtocols {
+    pub fn protocol_id(&self) -> ProtocolId {
+        match self {
+            SupportProtocols::Ping => 0,
+            SupportProtocols::Discovery => 1,
+            SupportProtocols::Identify => 2,
+            SupportProtocols::Feeler => 3,
+            SupportProtocols::DisconnectMessage => 4,
+            SupportProtocols::Sync => 100,
+            SupportProtocols::Relay => 101,
+            SupportProtocols::Time => 102,
+            SupportProtocols::Alert => 110,
+        }
+        .into()
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            SupportProtocols::Ping => "/ckb/ping",
+            SupportProtocols::Discovery => "/ckb/discovery",
+            SupportProtocols::Identify => "/ckb/identify",
+            SupportProtocols::Feeler => "/ckb/flr",
+            SupportProtocols::DisconnectMessage => "/ckb/disconnectmsg",
+            SupportProtocols::Sync => "/ckb/syn",
+            SupportProtocols::Relay => "/ckb/rel",
+            SupportProtocols::Time => "/ckb/tim",
+            SupportProtocols::Alert => "/ckb/alt",
+        }
+        .to_owned()
+    }
+
+    pub fn support_versions(&self) -> Vec<String> {
+        // we didn't invoke MetaBuilder#support_versions fn for these protocols (Ping/Discovery/Identify/Feeler/DisconnectMessage)
+        // in previous code, so the default 0.0.1 value is used ( https://github.com/nervosnetwork/tentacle/blob/master/src/builder.rs#L312 )
+        // have to keep 0.0.1 for compatibility...
+        match self {
+            SupportProtocols::Ping => vec!["0.0.1".to_owned()],
+            SupportProtocols::Discovery => vec!["0.0.1".to_owned()],
+            SupportProtocols::Identify => vec!["0.0.1".to_owned()],
+            SupportProtocols::Feeler => vec!["0.0.1".to_owned()],
+            SupportProtocols::DisconnectMessage => vec!["0.0.1".to_owned()],
+            SupportProtocols::Sync => vec!["1".to_owned()],
+            SupportProtocols::Relay => vec!["1".to_owned()],
+            SupportProtocols::Time => vec!["1".to_owned()],
+            SupportProtocols::Alert => vec!["1".to_owned()],
+        }
+    }
+
+    pub fn max_frame_length(&self) -> usize {
+        match self {
+            SupportProtocols::Ping => 1024,              // 1   KB
+            SupportProtocols::Discovery => 512 * 1024,   // 512 KB
+            SupportProtocols::Identify => 2 * 1024,      // 2   KB
+            SupportProtocols::Feeler => 1024,            // 1   KB
+            SupportProtocols::DisconnectMessage => 1024, // 1   KB
+            SupportProtocols::Sync => 2 * 1024 * 1024,   // 2   MB
+            SupportProtocols::Relay => 4 * 1024 * 1024,  // 4   MB
+            SupportProtocols::Time => 1024,              // 1   KB
+            SupportProtocols::Alert => 128 * 1024,       // 128 KB
+        }
+    }
+
+    pub fn flag(&self) -> BlockingFlag {
+        match self {
+            SupportProtocols::Ping
+            | SupportProtocols::Discovery
+            | SupportProtocols::Identify
+            | SupportProtocols::Feeler
+            | SupportProtocols::DisconnectMessage
+            | SupportProtocols::Time
+            | SupportProtocols::Alert => {
+                let mut no_blocking_flag = BlockingFlag::default();
+                no_blocking_flag.disable_all();
+                no_blocking_flag
+            }
+            SupportProtocols::Sync | SupportProtocols::Relay => {
+                let mut blocking_recv_flag = BlockingFlag::default();
+                blocking_recv_flag.disable_connected();
+                blocking_recv_flag.disable_disconnected();
+                blocking_recv_flag.disable_notify();
+                blocking_recv_flag
+            }
+        }
+    }
+
+    // a helper fn to build `ProtocolMeta`
+    pub fn build_meta_with_service_handle<
+        SH: FnOnce() -> ProtocolHandle<Box<dyn ServiceProtocol + Send + 'static + Unpin>>,
+    >(
+        self,
+        service_handle: SH,
+    ) -> ProtocolMeta {
+        let meta_builder: MetaBuilder = self.into();
+        meta_builder.service_handle(service_handle).build()
+    }
+}
+
+impl Into<MetaBuilder> for SupportProtocols {
+    fn into(self) -> MetaBuilder {
+        let max_frame_length = self.max_frame_length();
+        MetaBuilder::default()
+            .id(self.protocol_id())
+            .support_versions(self.support_versions())
+            .flag(self.flag())
+            .name(move |_| self.name())
+            .codec(move || {
+                Box::new(
+                    length_delimited::Builder::new()
+                        .max_frame_length(max_frame_length)
+                        .new_codec(),
+                )
+            })
+    }
+}

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -7,8 +7,7 @@ use super::{
 
 use crate::{
     network::{DefaultExitHandler, EventHandler},
-    network::{DISCOVERY_PROTOCOL_ID, FEELER_PROTOCOL_ID, IDENTIFY_PROTOCOL_ID, PING_PROTOCOL_ID},
-    NetworkState, PeerIdentifyInfo,
+    NetworkState, PeerIdentifyInfo, SupportProtocols,
 };
 
 use std::{
@@ -21,7 +20,7 @@ use std::{
 use ckb_app_config::NetworkConfig;
 use futures::{channel::mpsc::channel, StreamExt};
 use p2p::{
-    builder::{MetaBuilder, ServiceBuilder},
+    builder::ServiceBuilder,
     multiaddr::{Multiaddr, Protocol},
     service::{ProtocolHandle, ServiceControl, TargetProtocol},
     utils::multiaddr_to_socketaddr,
@@ -125,64 +124,51 @@ fn net_service_start(name: String) -> Node {
     network_state
         .protocol_ids
         .write()
-        .insert(PING_PROTOCOL_ID.into());
+        .insert(SupportProtocols::Ping.protocol_id());
     network_state
         .protocol_ids
         .write()
-        .insert(DISCOVERY_PROTOCOL_ID.into());
+        .insert(SupportProtocols::Discovery.protocol_id());
     network_state
         .protocol_ids
         .write()
-        .insert(IDENTIFY_PROTOCOL_ID.into());
+        .insert(SupportProtocols::Identify.protocol_id());
     network_state
         .protocol_ids
         .write()
-        .insert(FEELER_PROTOCOL_ID.into());
+        .insert(SupportProtocols::Feeler.protocol_id());
 
     // Ping protocol
     let (ping_sender, ping_receiver) = channel(std::u8::MAX as usize);
     let ping_interval = Duration::from_secs(5);
     let ping_timeout = Duration::from_secs(10);
 
-    let ping_meta = MetaBuilder::default()
-        .id(PING_PROTOCOL_ID.into())
-        .service_handle(move || {
-            ProtocolHandle::Both(Box::new(PingHandler::new(
-                ping_interval,
-                ping_timeout,
-                ping_sender,
-            )))
-        })
-        .build();
+    let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
+        ProtocolHandle::Both(Box::new(PingHandler::new(
+            ping_interval,
+            ping_timeout,
+            ping_sender,
+        )))
+    });
 
     // Discovery protocol
     let disc_network_state = Arc::clone(&network_state);
-    let disc_meta = MetaBuilder::default()
-        .id(DISCOVERY_PROTOCOL_ID.into())
-        .service_handle(move || {
-            ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(disc_network_state, true)))
-        })
-        .build();
+    let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
+        ProtocolHandle::Both(Box::new(DiscoveryProtocol::new(disc_network_state, true)))
+    });
 
     // Identify protocol
     let identify_callback =
         IdentifyCallback::new(Arc::clone(&network_state), name, "0.1.0".to_string());
-    let identify_meta = MetaBuilder::default()
-        .id(IDENTIFY_PROTOCOL_ID.into())
-        .service_handle(move || {
-            ProtocolHandle::Both(Box::new(IdentifyProtocol::new(identify_callback)))
-        })
-        .build();
+    let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
+        ProtocolHandle::Both(Box::new(IdentifyProtocol::new(identify_callback)))
+    });
 
     // Feeler protocol
-    let feeler_meta = MetaBuilder::default()
-        .id(FEELER_PROTOCOL_ID.into())
-        .name(move |_| "/ckb/flr".to_string())
-        .service_handle({
-            let network_state = Arc::clone(&network_state);
-            move || ProtocolHandle::Both(Box::new(Feeler::new(Arc::clone(&network_state))))
-        })
-        .build();
+    let feeler_meta = SupportProtocols::Feeler.build_meta_with_service_handle({
+        let network_state = Arc::clone(&network_state);
+        move || ProtocolHandle::Both(Box::new(Feeler::new(Arc::clone(&network_state))))
+    });
 
     let service_builder = ServiceBuilder::default()
         .insert_protocol(ping_meta)
@@ -293,18 +279,27 @@ fn test_identify_behavior() {
     let node2 = net_service_start("/test/2".to_string());
     let node3 = net_service_start("/test/1".to_string());
 
-    node1.dial(&node3, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node3,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 1);
     wait_connect_state(&node3, 1);
 
     // identify will ban node when they are on the different net
-    node2.dial(&node3, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node2.dial(
+        &node3,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node2, 0);
     wait_connect_state(&node3, 1);
 
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 1);
     wait_connect_state(&node2, 0);
@@ -327,9 +322,9 @@ fn test_identify_behavior() {
     assert_eq!(
         protocols,
         vec![
-            PING_PROTOCOL_ID.into(),
-            DISCOVERY_PROTOCOL_ID.into(),
-            IDENTIFY_PROTOCOL_ID.into()
+            SupportProtocols::Ping.protocol_id(),
+            SupportProtocols::Discovery.protocol_id(),
+            SupportProtocols::Identify.protocol_id()
         ]
     );
 }
@@ -339,14 +334,17 @@ fn test_feeler_behavior() {
     let node1 = net_service_start("/test/1".to_string());
     let node2 = net_service_start("/test/1".to_string());
 
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 1);
     wait_connect_state(&node2, 1);
 
     node2.open_protocols(
         node2.connected_sessions()[0],
-        TargetProtocol::Single(FEELER_PROTOCOL_ID.into()),
+        TargetProtocol::Single(SupportProtocols::Feeler.protocol_id()),
     );
 
     wait_connect_state(&node1, 0);
@@ -359,8 +357,14 @@ fn test_discovery_behavior() {
     let node2 = net_service_start("/test/1".to_string());
     let node3 = net_service_start("/test/1".to_string());
 
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node3.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node3.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 1);
     wait_connect_state(&node2, 2);
@@ -389,7 +393,10 @@ fn test_discovery_behavior() {
             .unwrap()
     };
 
-    node3.dial_addr(addr, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node3.dial_addr(
+        addr,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 2);
     wait_connect_state(&node2, 2);
@@ -412,7 +419,10 @@ fn test_ban() {
     let node1 = net_service_start("/test/1".to_string());
     let node2 = net_service_start("/test/1".to_string());
 
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 1);
     wait_connect_state(&node2, 1);
@@ -422,10 +432,22 @@ fn test_ban() {
     wait_connect_state(&node1, 0);
     wait_connect_state(&node2, 0);
 
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node1.dial(&node2, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 0);
     wait_connect_state(&node2, 0);
@@ -440,17 +462,32 @@ fn test_bootnode_mode_inbound_eviction() {
     let node5 = net_service_start("/test/1".to_string());
     let node6 = net_service_start("/test/1".to_string());
 
-    node2.dial(&node1, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node3.dial(&node1, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
-    node4.dial(&node1, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node2.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node3.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    node4.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     // Normal connection
     wait_connect_state(&node1, 3);
-    node5.dial(&node1, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node5.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     wait_connect_state(&node1, 4);
     // Arrival eviction condition 4 + 10, eviction 2
-    node6.dial(&node1, TargetProtocol::Single(IDENTIFY_PROTOCOL_ID.into()));
+    node6.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
 
     // Normal connection, 2 + 1
     wait_connect_state(&node1, 3);

--- a/network/src/services/protocol_type_checker.rs
+++ b/network/src/services/protocol_type_checker.rs
@@ -8,10 +8,7 @@
 /// 2. feeler: only open feeler protocol is open.
 ///
 /// Other protocols will be closed after a timeout.
-use crate::{
-    network::{disconnect_with_message, FEELER_PROTOCOL_ID},
-    NetworkState, Peer, ProtocolId,
-};
+use crate::{network::disconnect_with_message, NetworkState, Peer, ProtocolId, SupportProtocols};
 use ckb_logger::{debug, warn};
 use futures::{Future, Stream};
 use p2p::service::ServiceControl;
@@ -109,7 +106,7 @@ impl ProtocolTypeCheckerService {
     fn opened_procotol_type(&self, peer: &Peer) -> Result<ProtocolType, ProtocolTypeError> {
         if peer
             .protocols
-            .contains_key(&ProtocolId::new(FEELER_PROTOCOL_ID))
+            .contains_key(&SupportProtocols::Feeler.protocol_id())
         {
             Ok(ProtocolType::Feeler)
         } else if self

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -1,9 +1,8 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::Alert;
 use ckb_logger::error;
-use ckb_network::NetworkController;
+use ckb_network::{NetworkController, SupportProtocols};
 use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
-use ckb_sync::NetworkProtocol;
 use ckb_types::{packed, prelude::*};
 use ckb_util::Mutex;
 use jsonrpc_core::Result;
@@ -58,7 +57,7 @@ impl AlertRpc for AlertRpcImpl {
             Ok(()) => {
                 if let Err(err) = self
                     .network_controller
-                    .broadcast(NetworkProtocol::ALERT.into(), alert.as_bytes())
+                    .broadcast(SupportProtocols::Alert.protocol_id(), alert.as_bytes())
                 {
                     error!("Broadcast alert failed: {:?}", err);
                 }

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -2,9 +2,8 @@ use crate::error::RPCError;
 use ckb_chain::chain::ChainController;
 use ckb_jsonrpc_types::{Block, BlockTemplate, Uint64, Version};
 use ckb_logger::{debug, error};
-use ckb_network::NetworkController;
+use ckb_network::{NetworkController, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
-use ckb_sync::NetworkProtocol;
 use ckb_types::{core, packed, prelude::*, H256};
 use ckb_verification::{HeaderResolverWrapper, HeaderVerifier, Verifier};
 use faketime::unix_time_as_millis;
@@ -105,7 +104,7 @@ impl MinerRpc for MinerRpcImpl {
             let message = packed::RelayMessage::new_builder().set(content).build();
             if let Err(err) = self
                 .network_controller
-                .quick_broadcast(NetworkProtocol::RELAY.into(), message.as_bytes())
+                .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
             {
                 error!("Broadcast new block failed: {:?}", err);
             }

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -2,10 +2,9 @@ use crate::error::RPCError;
 use ckb_chain::{chain::ChainController, switch::Switch};
 use ckb_jsonrpc_types::{Block, BlockView, Cycle, Transaction};
 use ckb_logger::error;
-use ckb_network::NetworkController;
+use ckb_network::{NetworkController, SupportProtocols};
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
-use ckb_sync::NetworkProtocol;
 use ckb_types::{core, packed, prelude::*, H256};
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
@@ -114,7 +113,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
 
         if let Err(err) = self
             .network_controller
-            .broadcast(NetworkProtocol::RELAY.into(), message.as_bytes())
+            .broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
         {
             error!("Broadcast transaction failed: {:?}", err);
             Err(RPCError::custom(RPCError::Invalid, err.to_string()))

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -46,21 +46,6 @@ pub(crate) const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
 
-use ckb_network::ProtocolId;
-
-pub enum NetworkProtocol {
-    SYNC = 100,
-    RELAY = 101,
-    TIME = 102,
-    ALERT = 110,
-}
-
-impl Into<ProtocolId> for NetworkProtocol {
-    fn into(self) -> ProtocolId {
-        (self as usize).into()
-    }
-}
-
 //  Timeout = base + per_header * (expected number of headers)
 pub const HEADERS_DOWNLOAD_TIMEOUT_BASE: u64 = 6 * 60 * 1000; // 6 minutes
 pub const HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER: u64 = 1; // 1ms/header

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -2,8 +2,8 @@ use crate::block_status::BlockStatus;
 use crate::relayer::compact_block_process::CompactBlockProcess;
 use crate::relayer::tests::helper::{build_chain, new_header_builder, MockProtocalContext};
 use crate::types::InflightBlocks;
-use crate::{NetworkProtocol, Status, StatusCode};
-use ckb_network::PeerIndex;
+use crate::{Status, StatusCode};
+use ckb_network::{PeerIndex, SupportProtocols};
 use ckb_store::ChainStore;
 use ckb_tx_pool::{PlugTarget, TxEntry};
 use ckb_types::prelude::*;
@@ -133,7 +133,11 @@ fn test_unknow_parent() {
     // send_getheaders_to_peer
     assert_eq!(
         nc.as_ref().sent_messages,
-        RefCell::new(vec![(NetworkProtocol::SYNC.into(), peer_index, data)])
+        RefCell::new(vec![(
+            SupportProtocols::Sync.protocol_id(),
+            peer_index,
+            data
+        )])
     );
 }
 

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -1,7 +1,7 @@
 use crate::synchronizer::Synchronizer;
-use crate::{NetworkProtocol, Status, StatusCode, MAX_LOCATOR_SIZE};
+use crate::{Status, StatusCode, MAX_LOCATOR_SIZE};
 use ckb_logger::{debug, info};
-use ckb_network::{CKBProtocolContext, PeerIndex};
+use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_types::{
     core,
     packed::{self, Byte32},
@@ -100,10 +100,11 @@ impl<'a> GetHeadersProcess<'a> {
         let content = packed::InIBD::new_builder().build();
         let message = packed::SyncMessage::new_builder().set(content).build();
 
-        if let Err(err) =
-            self.nc
-                .send_message(NetworkProtocol::SYNC.into(), self.peer, message.as_bytes())
-        {
+        if let Err(err) = self.nc.send_message(
+            SupportProtocols::Sync.protocol_id(),
+            self.peer,
+            message.as_bytes(),
+        ) {
             debug!("synchronizer send in ibd error: {:?}", err);
         }
     }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -22,6 +22,7 @@ use ckb_chain::chain::ChainController;
 use ckb_logger::{debug, error, info, metric, trace, warn};
 use ckb_network::{
     bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex, ServiceControl,
+    SupportProtocols,
 };
 use ckb_types::{core, packed, prelude::*};
 use failure::Error as FailureError;
@@ -80,7 +81,7 @@ impl BlockFetchCMD {
         debug!("send_getblocks len={:?} to peer={}", v_fetch.len(), peer);
         if let Err(err) = nc.send_message_to(
             peer,
-            crate::NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             message.as_bytes(),
         ) {
             debug!("synchronizer send GetBlocks error: {:?}", err);

--- a/sync/src/tests/synchronizer.rs
+++ b/sync/src/tests/synchronizer.rs
@@ -3,11 +3,12 @@ use crate::synchronizer::{
     TIMEOUT_EVICTION_TOKEN,
 };
 use crate::tests::TestNode;
-use crate::{NetworkProtocol, SyncShared, Synchronizer};
+use crate::{SyncShared, Synchronizer};
 use ckb_chain::{chain::ChainService, switch::Switch};
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
+use ckb_network::SupportProtocols;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::ChainStore;
 use ckb_test_chain_utils::always_success_cell;
@@ -37,7 +38,7 @@ fn basic_sync() {
     let (mut node1, shared1) = setup_node(1);
     let (mut node2, shared2) = setup_node(3);
 
-    node1.connect(&mut node2, NetworkProtocol::SYNC.into());
+    node1.connect(&mut node2, SupportProtocols::Sync.protocol_id());
 
     let (signal_tx1, signal_rx1) = sync_channel(DEFAULT_CHANNEL);
     thread::Builder::new()
@@ -170,7 +171,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
     let mut node = TestNode::default();
     let protocol = Arc::new(RwLock::new(synchronizer)) as Arc<_>;
     node.add_protocol(
-        NetworkProtocol::SYNC.into(),
+        SupportProtocols::Sync.protocol_id(),
         &protocol,
         &[
             SEND_GET_HEADERS_TOKEN,

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1,15 +1,14 @@
 use crate::block_status::BlockStatus;
 use crate::orphan_block_pool::OrphanBlockPool;
-use crate::BLOCK_DOWNLOAD_TIMEOUT;
-use crate::{NetworkProtocol, SUSPEND_SYNC_TIME};
 use crate::{
-    FAST_INDEX, INIT_BLOCKS_IN_TRANSIT_PER_PEER, LOW_INDEX, MAX_BLOCKS_IN_TRANSIT_PER_PEER,
-    MAX_HEADERS_LEN, MAX_TIP_AGE, NORMAL_INDEX, RETRY_ASK_TX_TIMEOUT_INCREASE, TIME_TRACE_SIZE,
+    BLOCK_DOWNLOAD_TIMEOUT, FAST_INDEX, INIT_BLOCKS_IN_TRANSIT_PER_PEER, LOW_INDEX,
+    MAX_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN, MAX_TIP_AGE, NORMAL_INDEX,
+    RETRY_ASK_TX_TIMEOUT_INCREASE, SUSPEND_SYNC_TIME, TIME_TRACE_SIZE,
 };
 use ckb_chain::chain::ChainController;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_logger::{debug, debug_target, error, metric};
-use ckb_network::{CKBProtocolContext, PeerIndex};
+use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_types::{
@@ -1737,7 +1736,11 @@ impl ActiveChain {
             .hash_stop(packed::Byte32::zero())
             .build();
         let message = packed::SyncMessage::new_builder().set(content).build();
-        if let Err(err) = nc.send_message(NetworkProtocol::SYNC.into(), peer, message.as_bytes()) {
+        if let Err(err) = nc.send_message(
+            SupportProtocols::Sync.protocol_id(),
+            peer,
+            message.as_bytes(),
+        ) {
             debug!("synchronizer send get_headers error: {:?}", err);
         }
     }

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -24,8 +24,7 @@ use crate::Net;
 use ckb_app_config::CKBAppConfig;
 use ckb_chain_spec::ChainSpec;
 use ckb_fee_estimator::FeeRate;
-use ckb_network::{ProtocolId, ProtocolVersion};
-use ckb_sync::NetworkProtocol;
+use ckb_network::{ProtocolId, ProtocolVersion, SupportProtocols};
 
 #[macro_export]
 macro_rules! name {
@@ -127,7 +126,7 @@ pub struct TestProtocol {
 impl TestProtocol {
     pub fn sync() -> Self {
         Self {
-            id: NetworkProtocol::SYNC.into(),
+            id: SupportProtocols::Sync.protocol_id(),
             protocol_name: "syn".to_string(),
             supported_versions: vec!["1".to_string()],
         }
@@ -135,7 +134,7 @@ impl TestProtocol {
 
     pub fn relay() -> Self {
         Self {
-            id: NetworkProtocol::RELAY.into(),
+            id: SupportProtocols::Relay.protocol_id(),
             protocol_name: "rel".to_string(),
             supported_versions: vec!["1".to_string()],
         }

--- a/test/src/specs/p2p/malformed_message.rs
+++ b/test/src/specs/p2p/malformed_message.rs
@@ -1,7 +1,6 @@
 use crate::utils::wait_until;
 use crate::{Net, Spec, TestProtocol};
-use ckb_network::bytes::Bytes;
-use ckb_sync::NetworkProtocol;
+use ckb_network::{bytes::Bytes, SupportProtocols};
 use ckb_types::{
     packed::{GetHeaders, SyncMessage},
     prelude::*,
@@ -34,12 +33,12 @@ impl Spec for MalformedMessage {
 
         info!("Send malformed message to node0 twice");
         net.send(
-            NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             peer_id,
             vec![0, 0, 0, 0].into(),
         );
         net.send(
-            NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             peer_id,
             vec![0, 1, 2, 3].into(),
         );
@@ -104,12 +103,12 @@ impl Spec for MalformedMessageWithWhitelist {
 
         info!("Send malformed message to node0 twice");
         net.send(
-            NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             peer_id,
             vec![0, 0, 0, 0].into(),
         );
         net.send(
-            NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             peer_id,
             vec![0, 1, 2, 3].into(),
         );

--- a/test/src/specs/relay/get_block_transactions_process.rs
+++ b/test/src/specs/relay/get_block_transactions_process.rs
@@ -1,6 +1,5 @@
 use crate::{Net, Spec, TestProtocol};
-use ckb_network::bytes::Bytes;
-use ckb_sync::NetworkProtocol;
+use ckb_network::{bytes::Bytes, SupportProtocols};
 use ckb_types::{
     core::UncleBlockView,
     packed::{self, RelayMessage},
@@ -47,7 +46,11 @@ impl Spec for MissingUncleRequest {
             net.receive(); // ignore three new block announce
         });
 
-        net.send(NetworkProtocol::RELAY.into(), peer_id, message.as_bytes());
+        net.send(
+            SupportProtocols::Relay.protocol_id(),
+            peer_id,
+            message.as_bytes(),
+        );
 
         net.should_receive(
             |data: &Bytes| {

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -1,6 +1,7 @@
 use crate::utils::{build_relay_tx_hashes, build_relay_txs, sleep, wait_until};
 use crate::{Net, Spec, TestProtocol, DEFAULT_TX_PROPOSAL_WINDOW};
-use ckb_sync::{NetworkProtocol, RETRY_ASK_TX_TIMEOUT_INCREASE};
+use ckb_network::SupportProtocols;
+use ckb_sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
 use ckb_types::{
     core::{Capacity, TransactionBuilder},
     packed::{CellInput, GetRelayTransactions, OutPoint, RelayMessage},
@@ -163,7 +164,7 @@ impl Spec for TransactionRelayTimeout {
         let dummy_tx = TransactionBuilder::default().build();
         info!("Sending RelayTransactionHashes to node");
         net.send(
-            NetworkProtocol::RELAY.into(),
+            SupportProtocols::Relay.protocol_id(),
             pi,
             build_relay_tx_hashes(&[dummy_tx.hash()]),
         );
@@ -205,7 +206,7 @@ impl Spec for RelayInvalidTransaction {
         let dummy_tx = TransactionBuilder::default().build();
         info!("Sending RelayTransactionHashes to node");
         net.send(
-            NetworkProtocol::RELAY.into(),
+            SupportProtocols::Relay.protocol_id(),
             pi,
             build_relay_tx_hashes(&[dummy_tx.hash()]),
         );
@@ -221,7 +222,7 @@ impl Spec for RelayInvalidTransaction {
         );
         info!("Sending RelayTransactions to node");
         net.send(
-            NetworkProtocol::RELAY.into(),
+            SupportProtocols::Relay.protocol_id(),
             pi,
             build_relay_txs(&[(dummy_tx, 333)]),
         );

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -4,8 +4,7 @@ use crate::utils::{
 };
 use crate::{Net, Node, Spec, TestProtocol};
 use ckb_jsonrpc_types::ChainInfo;
-use ckb_network::{bytes::Bytes, PeerIndex};
-use ckb_sync::NetworkProtocol;
+use ckb_network::{bytes::Bytes, PeerIndex, SupportProtocols};
 use ckb_types::{
     core::BlockView,
     packed::{self, Byte32, GetBlocks, SyncMessage},
@@ -368,7 +367,7 @@ impl Spec for BlockSyncRelayerCollaboration {
 
         sync_block(&net, peer_id, &first);
         net.send(
-            NetworkProtocol::RELAY.into(),
+            SupportProtocols::Relay.protocol_id(),
             peer_id,
             build_compact_block(&last),
         );
@@ -514,19 +513,23 @@ fn build_forks(node: &Node, offsets: &[u64]) -> Vec<BlockView> {
 
 fn sync_header(net: &Net, peer_id: PeerIndex, block: &BlockView) {
     net.send(
-        NetworkProtocol::SYNC.into(),
+        SupportProtocols::Sync.protocol_id(),
         peer_id,
         build_header(&block.header()),
     );
 }
 
 fn sync_block(net: &Net, peer_id: PeerIndex, block: &BlockView) {
-    net.send(NetworkProtocol::SYNC.into(), peer_id, build_block(block));
+    net.send(
+        SupportProtocols::Sync.protocol_id(),
+        peer_id,
+        build_block(block),
+    );
 }
 
 fn sync_get_blocks(net: &Net, peer_id: PeerIndex, hashes: &[Byte32]) {
     net.send(
-        NetworkProtocol::SYNC.into(),
+        SupportProtocols::Sync.protocol_id(),
         peer_id,
         build_get_blocks(hashes),
     );

--- a/test/src/specs/sync/get_blocks.rs
+++ b/test/src/specs/sync/get_blocks.rs
@@ -1,7 +1,8 @@
 use super::utils::wait_get_blocks;
 use crate::utils::{build_headers, wait_until};
 use crate::{Net, Spec, TestProtocol};
-use ckb_sync::{NetworkProtocol, BLOCK_DOWNLOAD_TIMEOUT};
+use ckb_network::SupportProtocols;
+use ckb_sync::BLOCK_DOWNLOAD_TIMEOUT;
 use ckb_types::core::HeaderView;
 use log::info;
 use std::time::Instant;
@@ -30,7 +31,11 @@ impl Spec for GetBlocksTimeout {
         net.connect(&node1);
         let (pi, _, _) = net.receive();
         info!("Send Headers to node1");
-        net.send(NetworkProtocol::SYNC.into(), pi, build_headers(&headers));
+        net.send(
+            SupportProtocols::Sync.protocol_id(),
+            pi,
+            build_headers(&headers),
+        );
         info!("Receive GetBlocks from node1");
 
         let block_download_timeout_secs = BLOCK_DOWNLOAD_TIMEOUT / 1000;

--- a/test/src/specs/sync/invalid_block.rs
+++ b/test/src/specs/sync/invalid_block.rs
@@ -1,7 +1,7 @@
 use super::utils::wait_get_blocks;
 use crate::utils::{build_block, build_get_blocks, build_headers, wait_until};
 use crate::{Net, Spec, TestProtocol};
-use ckb_sync::NetworkProtocol;
+use ckb_network::SupportProtocols;
 use ckb_types::{
     core::{BlockView, TransactionBuilder},
     packed::{self, Byte32, SyncMessage},
@@ -119,7 +119,11 @@ impl Spec for ForkContainsInvalidBlock {
         net.connect(&good_node);
         let (pi, _, _) = net.receive();
         let headers: Vec<_> = bad_chain.iter().map(|b| b.header()).collect();
-        net.send(NetworkProtocol::SYNC.into(), pi, build_headers(&headers));
+        net.send(
+            SupportProtocols::Sync.protocol_id(),
+            pi,
+            build_headers(&headers),
+        );
         assert!(wait_get_blocks(10, &net), "timeout to wait GetBlocks",);
 
         // Build good chain (good_chain.len < bad_chain.len)
@@ -129,9 +133,9 @@ impl Spec for ForkContainsInvalidBlock {
         // Sync first part of bad fork which contains an invalid block
         // Good_node cannot detect the invalid block since "block delay verification".
         let (bad_chain1, bad_chain2) = bad_chain.split_at(invalid_number + 1);
-        bad_chain1
-            .iter()
-            .for_each(|block| net.send(NetworkProtocol::SYNC.into(), pi, build_block(block)));
+        bad_chain1.iter().for_each(|block| {
+            net.send(SupportProtocols::Sync.protocol_id(), pi, build_block(block))
+        });
         let last_hash = bad_chain1.last().map(|b| b.hash()).unwrap();
         assert!(
             wait_until(10, || good_node
@@ -144,9 +148,9 @@ impl Spec for ForkContainsInvalidBlock {
 
         // Sync second part of bad fork.
         // Good_node detect the invalid block when fork.total_difficulty > tip.difficulty
-        bad_chain2
-            .iter()
-            .for_each(|block| net.send(NetworkProtocol::SYNC.into(), pi, build_block(block)));
+        bad_chain2.iter().for_each(|block| {
+            net.send(SupportProtocols::Sync.protocol_id(), pi, build_block(block))
+        });
         let last_hash = bad_chain2.last().map(|b| b.hash()).unwrap();
         assert!(
             !wait_until(10, || good_node
@@ -159,7 +163,7 @@ impl Spec for ForkContainsInvalidBlock {
 
         // Additional testing: request an invalid fork via `GetBlock` should be failed
         net.send(
-            NetworkProtocol::SYNC.into(),
+            SupportProtocols::Sync.protocol_id(),
             pi,
             build_get_blocks(&bad_hashes),
         );

--- a/test/src/specs/sync/invalid_locator_size.rs
+++ b/test/src/specs/sync/invalid_locator_size.rs
@@ -1,6 +1,7 @@
 use crate::utils::wait_until;
 use crate::{Net, Spec, TestProtocol};
-use ckb_sync::{NetworkProtocol, MAX_LOCATOR_SIZE};
+use ckb_network::SupportProtocols;
+use ckb_sync::MAX_LOCATOR_SIZE;
 use ckb_types::{
     h256,
     packed::{Byte32, GetHeaders, SyncMessage},
@@ -37,7 +38,7 @@ impl Spec for InvalidLocatorSize {
             .build()
             .as_bytes();
 
-        net.send(NetworkProtocol::SYNC.into(), peer_id, message);
+        net.send(SupportProtocols::Sync.protocol_id(), peer_id, message);
 
         let rpc_client = net.nodes[0].rpc_client();
         let ret = wait_until(10, || rpc_client.get_peers().is_empty());


### PR DESCRIPTION
To eliminate dependence of `ckb-sync` crate,  this PR refactored network protocol related variables and move them to a new enum: `SupportProtocols`