### PR TITLE
refactor: use generic type in NetworkService 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,6 @@ version = "0.34.0-pre"
 dependencies = [
  "bs58",
  "ckb-app-config",
- "ckb-build-info",
  "ckb-hash",
  "ckb-logger",
  "ckb-stop-handler",

--- a/ckb-bin/src/helper.rs
+++ b/ckb-bin/src/helper.rs
@@ -1,18 +1,4 @@
-use ckb_util::{Condvar, Mutex};
 use std::io::{stdin, stdout, Write};
-use std::sync::Arc;
-
-pub fn wait_for_exit(exit: Arc<(Mutex<()>, Condvar)>) {
-    // Handle possible exits
-    let e = Arc::<(Mutex<()>, Condvar)>::clone(&exit);
-    let _ = ctrlc::set_handler(move || {
-        e.1.notify_all();
-    });
-
-    // Wait for signal
-    let mut l = exit.0.lock();
-    exit.1.wait(&mut l);
-}
 
 #[cfg(not(feature = "deadlock_detection"))]
 pub fn deadlock_detection() {}

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -141,7 +141,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         version.to_string(),
         exit_handler.clone(),
     )
-    .start(version, Some("NetworkService"))
+    .start(Some("NetworkService"))
     .expect("Start network service failed");
 
     let builder = ServiceBuilder::new(&args.config.rpc)

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -25,7 +25,6 @@ faster-hex = "0.4"
 ckb-hash = {path = "../util/hash"}
 secp256k1 = {version = "0.15.0", features = ["recovery"] }
 resolve = "0.2.0"
-ckb-build-info = {path = "../util/build-info"}
 num_cpus = "1.10"
 snap = "0.2"
 ckb-types = { path = "../util/types" }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -15,7 +15,7 @@ mod tests;
 pub use crate::{
     behaviour::Behaviour,
     errors::Error,
-    network::{NetworkController, NetworkService, NetworkState},
+    network::{DefaultExitHandler, ExitHandler, NetworkController, NetworkService, NetworkState},
     peer::{Peer, PeerIdentifyInfo},
     peer_registry::PeerRegistry,
     peer_store::{types::MultiaddrExt, Score},

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -508,12 +508,34 @@ impl NetworkState {
     }
 }
 
-pub struct EventHandler {
+pub struct EventHandler<T> {
     pub(crate) network_state: Arc<NetworkState>,
-    pub(crate) exit_condvar: Arc<(Mutex<()>, Condvar)>,
+    pub(crate) exit_handler: T,
 }
 
-impl EventHandler {
+pub trait ExitHandler: Send + Unpin + 'static {
+    fn notify_exit(&self);
+}
+
+#[derive(Clone, Default)]
+pub struct DefaultExitHandler {
+    lock: Arc<Mutex<()>>,
+    exit: Arc<Condvar>,
+}
+
+impl DefaultExitHandler {
+    pub fn wait_for_exit(&self) {
+        self.exit.wait(&mut self.lock.lock());
+    }
+}
+
+impl ExitHandler for DefaultExitHandler {
+    fn notify_exit(&self) {
+        self.exit.notify_all();
+    }
+}
+
+impl<T> EventHandler<T> {
     fn inbound_eviction(&self, context: &mut ServiceContext) {
         if self.network_state.config.bootnode_mode {
             let status = self.network_state.connection_status();
@@ -548,7 +570,7 @@ impl EventHandler {
     }
 }
 
-impl ServiceHandle for EventHandler {
+impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
     fn handle_error(&mut self, context: &mut ServiceContext, error: ServiceError) {
         match error {
             ServiceError::DialerError {
@@ -641,7 +663,7 @@ impl ServiceHandle for EventHandler {
                             format!("protocol {} panic when process peer message", proto_id),
                         );
                     }
-                    self.exit_condvar.1.notify_all();
+                    self.exit_handler.notify_exit();
                 }
             }
         }
@@ -832,22 +854,22 @@ impl ServiceHandle for EventHandler {
     }
 }
 
-pub struct NetworkService {
-    p2p_service: Service<EventHandler>,
+pub struct NetworkService<T> {
+    p2p_service: Service<EventHandler<T>>,
     network_state: Arc<NetworkState>,
     // Background services
     bg_services: Vec<Pin<Box<dyn Future<Output = ()> + 'static + Send>>>,
 }
 
-impl NetworkService {
+impl<T: ExitHandler> NetworkService<T> {
     pub fn new(
         network_state: Arc<NetworkState>,
         protocols: Vec<CKBProtocol>,
         required_protocol_ids: Vec<ProtocolId>,
         name: String,
         client_version: String,
-        exit_condvar: Arc<(Mutex<()>, Condvar)>,
-    ) -> NetworkService {
+        exit_handler: T,
+    ) -> Self {
         let config = &network_state.config;
 
         let mut no_blocking_flag = BlockingFlag::default();
@@ -972,7 +994,7 @@ impl NetworkService {
         }
         let event_handler = EventHandler {
             network_state: Arc::clone(&network_state),
-            exit_condvar,
+            exit_handler,
         };
         let p2p_service = service_builder
             .key_pair(network_state.local_private_key.clone())

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 use crate::{
-    network::EventHandler,
+    network::{DefaultExitHandler, EventHandler},
     network::{DISCOVERY_PROTOCOL_ID, FEELER_PROTOCOL_ID, IDENTIFY_PROTOCOL_ID, PING_PROTOCOL_ID},
     NetworkState, PeerIdentifyInfo,
 };
@@ -19,7 +19,6 @@ use std::{
 };
 
 use ckb_app_config::NetworkConfig;
-use ckb_util::{Condvar, Mutex};
 use futures::{channel::mpsc::channel, StreamExt};
 use p2p::{
     builder::{MetaBuilder, ServiceBuilder},
@@ -197,7 +196,7 @@ fn net_service_start(name: String) -> Node {
         .forever(true)
         .build(EventHandler {
             network_state: Arc::clone(&network_state),
-            exit_condvar: Arc::new((Mutex::new(()), Condvar::new())),
+            exit_handler: DefaultExitHandler::default(),
         });
 
     let mut ping_service = PingService::new(

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -42,7 +42,7 @@ pub(crate) struct NetworkRpcImpl {
 impl NetworkRpc for NetworkRpcImpl {
     fn local_node_info(&self) -> Result<LocalNode> {
         Ok(LocalNode {
-            version: self.network_controller.node_version().to_string(),
+            version: self.network_controller.version().to_owned(),
             node_id: self.network_controller.node_id(),
             addresses: self
                 .network_controller

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -31,7 +31,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use ckb_util::{Condvar, Mutex};
 use jsonrpc_core::IoHandler;
 use jsonrpc_http_server::ServerBuilder;
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
@@ -176,7 +175,7 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
             Vec::new(),
             shared.consensus().identify_name(),
             "0.1.0".to_string(),
-            Arc::new((Mutex::new(()), Condvar::new())),
+            DefaultExitHandler::default(),
         )
         .start::<&str>(Default::default(), None)
         .expect("Start network service failed")

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -11,7 +11,7 @@ use ckb_dao_utils::genesis_dao_data;
 use ckb_fee_estimator::FeeRate;
 use ckb_indexer::{DefaultIndexerStore, IndexerStore};
 use ckb_jsonrpc_types::{Block as JsonBlock, Uint64};
-use ckb_network::{NetworkService, NetworkState};
+use ckb_network::{DefaultExitHandler, NetworkService, NetworkState};
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_notify::NotifyService;
 use ckb_shared::{

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -177,7 +177,7 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
             "0.1.0".to_string(),
             DefaultExitHandler::default(),
         )
-        .start::<&str>(Default::default(), None)
+        .start(Some("rpc-test-network"))
         .expect("Start network service failed")
     };
     let sync_shared = Arc::new(SyncShared::new(shared.clone()));

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -3,8 +3,8 @@ use crate::utils::{temp_path, wait_until};
 use crate::{Node, Setup};
 use ckb_app_config::NetworkConfig;
 use ckb_network::{
-    bytes::Bytes, CKBProtocol, CKBProtocolContext, CKBProtocolHandler, NetworkController,
-    NetworkService, NetworkState, PeerIndex, ProtocolId,
+    bytes::Bytes, CKBProtocol, CKBProtocolContext, CKBProtocolHandler, DefaultExitHandler,
+    NetworkController, NetworkService, NetworkState, PeerIndex, ProtocolId,
 };
 use ckb_types::core::{BlockNumber, BlockView};
 use crossbeam_channel::{self, Receiver, RecvTimeoutError, Sender};

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -7,7 +7,6 @@ use ckb_network::{
     NetworkService, NetworkState, PeerIndex, ProtocolId,
 };
 use ckb_types::core::{BlockNumber, BlockView};
-use ckb_util::{Condvar, Mutex};
 use crossbeam_channel::{self, Receiver, RecvTimeoutError, Sender};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -141,7 +140,7 @@ impl Net {
                 Vec::new(),
                 node.consensus().identify_name(),
                 "0.1.0".to_string(),
-                Arc::new((Mutex::new(()), Condvar::new())),
+                DefaultExitHandler::default(),
             )
             .start(Default::default(), Some("NetworkService"))
             .expect("Start network service failed"),

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -142,7 +142,7 @@ impl Net {
                 "0.1.0".to_string(),
                 DefaultExitHandler::default(),
             )
-            .start(Default::default(), Some("NetworkService"))
+            .start(Some("NetworkService"))
             .expect("Start network service failed"),
             rx,
         ));


### PR DESCRIPTION
This PR changed `NetworkService`'s exit_condvar to generic type and removed node_version from `start` fn, make it easier to use `ckb-network` crate as a lib