### PR TITLE
refactor: use generic key / value in template context

### DIFF
--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -144,18 +144,22 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
         args.root_dir.display()
     );
 
-    let mut context = TemplateContext {
-        spec: &args.chain,
-        rpc_port: &args.rpc_port,
-        p2p_port: &args.p2p_port,
-        log_to_file: args.log_to_file,
-        log_to_stdout: args.log_to_stdout,
-        block_assembler: &block_assembler,
-        spec_source: "bundled",
-    };
+    let log_to_file = args.log_to_file.to_string();
+    let log_to_stdout = args.log_to_stdout.to_string();
+    let mut context = TemplateContext::new(
+        &args.chain,
+        vec![
+            ("rpc_port", args.rpc_port.as_str()),
+            ("p2p_port", args.p2p_port.as_str()),
+            ("log_to_file", log_to_file.as_str()),
+            ("log_to_stdout", log_to_stdout.as_str()),
+            ("block_assembler", block_assembler.as_str()),
+            ("spec_source", "bundled"),
+        ],
+    );
 
     if let Some(spec_file) = args.import_spec {
-        context.spec_source = "file";
+        context.insert("spec_source", "file");
 
         let specs_dir = args.root_dir.join("specs");
         fs::create_dir_all(&specs_dir)?;

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -221,15 +221,17 @@ mod tests {
     #[test]
     fn test_export() {
         let root_dir = mkdir();
-        let context = TemplateContext {
-            spec: "dev",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: true,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "dev",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "true"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         Resource::bundled_ckb_config()
             .export(&context, root_dir.path())
             .expect("export ckb.toml");

--- a/resource/src/template.rs
+++ b/resource/src/template.rs
@@ -7,18 +7,30 @@ const START_MARKER: &str = " # {{";
 const END_MAKER: &str = "# }}";
 const WILDCARD_BRANCH: &str = "# _ => ";
 
+use std::collections::HashMap;
 use std::io;
 
 pub struct Template<T>(T);
 
 pub struct TemplateContext<'a> {
-    pub spec: &'a str,
-    pub spec_source: &'a str,
-    pub rpc_port: &'a str,
-    pub p2p_port: &'a str,
-    pub log_to_file: bool,
-    pub log_to_stdout: bool,
-    pub block_assembler: &'a str,
+    spec: &'a str,
+    kvs: HashMap<&'a str, &'a str>,
+}
+
+impl<'a> TemplateContext<'a> {
+    pub fn new<I>(spec: &'a str, kvs: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a str)>,
+    {
+        Self {
+            spec,
+            kvs: kvs.into_iter().collect(),
+        }
+    }
+
+    pub fn insert(&mut self, key: &'a str, value: &'a str) {
+        self.kvs.insert(key, value);
+    }
 }
 
 impl<T> Template<T> {
@@ -33,13 +45,11 @@ fn writeln<W: io::Write>(w: &mut W, s: &str, context: &TemplateContext) -> io::R
     writeln!(
         w,
         "{}",
-        s.replace("\\n", "\n")
-            .replace("{rpc_port}", context.rpc_port)
-            .replace("{p2p_port}", context.p2p_port)
-            .replace("{log_to_file}", &format!("{}", context.log_to_file))
-            .replace("{log_to_stdout}", &format!("{}", context.log_to_stdout))
-            .replace("{block_assembler}", context.block_assembler)
-            .replace("{spec_source}", context.spec_source)
+        context
+            .kvs
+            .iter()
+            .fold(s.replace("\\n", "\n"), |s, (key, value)| s
+                .replace(format!("{{{}}}", key).as_str(), value))
     )
 }
 

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -350,12 +350,17 @@ fn request_of(method: &str, params: Value) -> Value {
 
 // Get the actual result of the given case
 fn result_of(client: &reqwest::Client, uri: &str, method: &str, params: Value) -> Value {
-    let request = request_of(method, params);
+    let request = request_of(method, params.clone());
     match client
         .post(uri)
         .json(&request)
         .send()
-        .expect("send request")
+        .unwrap_or_else(|_| {
+            panic!(
+                "send request error, method: {:?}, params: {:?}",
+                method, params
+            )
+        })
         .json::<JsonResponse>()
     {
         Err(err) => panic!("{} response error: {:?}", method, err),

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -256,15 +256,17 @@ mod tests {
     #[test]
     fn test_export_dev_config_files() {
         let dir = mkdir();
-        let context = TemplateContext {
-            spec: "dev",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: true,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "dev",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "true"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         {
             Resource::bundled_ckb_config()
                 .export(&context, dir.path())
@@ -303,15 +305,17 @@ mod tests {
     #[test]
     fn test_log_to_stdout_only() {
         let dir = mkdir();
-        let context = TemplateContext {
-            spec: "dev",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: false,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "dev",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "false"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         {
             Resource::bundled_ckb_config()
                 .export(&context, dir.path())
@@ -339,15 +343,17 @@ mod tests {
     #[test]
     fn test_export_testnet_config_files() {
         let dir = mkdir();
-        let context = TemplateContext {
-            spec: "testnet",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: true,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "testnet",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "true"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         {
             Resource::bundled_ckb_config()
                 .export(&context, dir.path())
@@ -386,15 +392,17 @@ mod tests {
     #[test]
     fn test_export_integration_config_files() {
         let dir = mkdir();
-        let context = TemplateContext {
-            spec: "integration",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: true,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "integration",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "true"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         {
             Resource::bundled_ckb_config()
                 .export(&context, dir.path())
@@ -431,15 +439,17 @@ mod tests {
     #[test]
     fn test_export_dev_config_files_assembly() {
         let dir = mkdir();
-        let context = TemplateContext {
-            spec: "dev",
-            rpc_port: "7000",
-            p2p_port: "8000",
-            log_to_file: true,
-            log_to_stdout: true,
-            block_assembler: "",
-            spec_source: "bundled",
-        };
+        let context = TemplateContext::new(
+            "dev",
+            vec![
+                ("rpc_port", "7000"),
+                ("p2p_port", "8000"),
+                ("log_to_file", "true"),
+                ("log_to_stdout", "true"),
+                ("block_assembler", ""),
+                ("spec_source", "bundled"),
+            ],
+        );
         {
             Resource::bundled_ckb_config()
                 .export(&context, dir.path())


### PR DESCRIPTION
This PR changed `TemplateContext` key/value from fixed field to hashmap, it made the `ckb-resource` crate easier to use in 3rd party applications