### PR TITLE
network: fix deadlock caused by conflicting lock order

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -491,8 +491,8 @@ impl NetworkState {
     }
 
     pub fn add_observed_addrs(&self, iter: impl Iterator<Item = Multiaddr>) {
-        let mut public_addrs = self.public_addrs.write();
         let mut pending_observed_addrs = self.pending_observed_addrs.write();
+        let mut public_addrs = self.public_addrs.write();
         for addr in iter {
             if let Some(score) = public_addrs.get_mut(&addr) {
                 *score = score.saturating_add(1);


### PR DESCRIPTION
This PR fixes a possible deadlock bug caused by conflicting lock order in network/src/network.rs.

|add_observed_addrs|try_dial_observed_addrs|
|---|---|
|public_addrs.write()||
||[pending_observed_addrs.write()](pending_observed_addrs.write())|[(https://github.com/nervosnetwork/ckb/blob/7f241840b7bfd724c447bf3c0ffa051f2e211d82/network/src/network.rs#L478)|
||[dial_inner](https://github.com/nervosnetwork/ckb/blob/7f241840b7bfd724c447bf3c0ffa051f2e211d82/network/src/network.rs#L481)|
||[can_dial](https://github.com/nervosnetwork/ckb/blob/7f241840b7bfd724c447bf3c0ffa051f2e211d82/network/src/network.rs#L430)|
||[public_addrs.read()//deadlock!](https://github.com/nervosnetwork/ckb/blob/7f241840b7bfd724c447bf3c0ffa051f2e211d82/network/src/network.rs#L362)|
|pending_observed_addrs.write()//deadlock!||

The fix is to swap the locations of the two locks in `add_observed_addrs`.