### PR TITLE
chore: skip fee estimate rpc test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,6 @@ dependencies = [
  "jsonrpc-ws-server",
  "num_cpus",
  "pretty_assertions",
- "rand 0.7.0",
  "reqwest",
  "sentry",
  "serde",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -50,4 +50,3 @@ ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 tempfile = "3.0"
 pretty_assertions = "0.6.1"
 ckb-dao-utils = { path = "../util/dao/utils" }
-rand = "0.7"

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -599,7 +599,8 @@
         ],
         "result": {
             "fee_rate": "0x7d0"
-        }
+        },
+        "skip": true
     },
     {
         "description": "Send new transaction into transaction pool.",


### PR DESCRIPTION
to speedup unit test, this PR skip rpc `fee_estimate` in unit test and cleanup some unnecessary helper methods, corresponding rpc has been covered in integration test