### PR TITLE
perf: spawn fee_estimate

### DIFF
--- a/tx-pool/src/fee_estimate.rs
+++ b/tx-pool/src/fee_estimate.rs
@@ -1,0 +1,29 @@
+use ckb_fee_estimator::Estimator as FeeEstimator;
+use ckb_fee_estimator::FeeRate;
+use ckb_types::{core::BlockNumber, packed::Byte32};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub type FeeRateSample = (BlockNumber, Vec<(Byte32, FeeRate)>);
+
+pub async fn track_tx(fee_estimator: Arc<RwLock<FeeEstimator>>, sample: FeeRateSample) {
+    let (height, sample) = sample;
+    let mut guard = fee_estimator.write().await;
+    for (tx_hash, fee_rate) in sample {
+        guard.track_tx(tx_hash, fee_rate, height);
+    }
+}
+
+pub async fn estimate(fee_estimator: Arc<RwLock<FeeEstimator>>, expect_confirm: usize) -> FeeRate {
+    let guard = fee_estimator.read().await;
+    guard.estimate(expect_confirm)
+}
+
+pub async fn process_block(
+    fee_estimator: Arc<RwLock<FeeEstimator>>,
+    height: BlockNumber,
+    txs: impl Iterator<Item = Byte32>,
+) {
+    let mut guard = fee_estimator.write().await;
+    guard.process_block(height, txs)
+}

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -1,6 +1,7 @@
 mod block_assembler;
 mod component;
 pub mod error;
+mod fee_estimate;
 pub mod pool;
 mod process;
 pub mod service;


### PR DESCRIPTION
`fee_estimator` acquire tx-pool lock previously, in some cases, may cause performance issues.
move out `fee_estimator` from tx-pool, spawn fee_estimator process for now.

