### PR TITLE
chore: remove useless `Arc`

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 pub const VERSION_KEY: &str = "db-version";
 
+#[derive(Clone)]
 pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,
 }

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Shared {
-    pub(crate) store: Arc<ChainDB>,
+    pub(crate) store: ChainDB,
     pub(crate) tx_pool_controller: TxPoolController,
     pub(crate) notify_controller: NotifyController,
     pub(crate) txs_verify_cache: Arc<TokioRwLock<TxVerifyCache>>,
@@ -44,7 +44,6 @@ impl Shared {
             .total_difficulty;
         let (proposal_table, proposal_view) = Self::init_proposal_table(&store, &consensus);
 
-        let store = Arc::new(store);
         let consensus = Arc::new(consensus);
 
         let txs_verify_cache = Arc::new(TokioRwLock::new(TxVerifyCache::new(

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -15,6 +15,7 @@ use ckb_types::{
 };
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct ChainDB {
     db: RocksDB,
     cache: Arc<StoreCache>,


### PR DESCRIPTION
`Shared::store` doesn't need `Arc`, since `ChainDB` only contains `Arc`.
https://github.com/nervosnetwork/ckb/blob/12d8812c80cf6712dcdbae138c85b114788dded2/shared/src/shared.rs#L23-L24
https://github.com/nervosnetwork/ckb/blob/12d8812c80cf6712dcdbae138c85b114788dded2/store/src/db.rs#L18-L21
https://github.com/nervosnetwork/ckb/blob/12d8812c80cf6712dcdbae138c85b114788dded2/db/src/db.rs#L16-L18