### PR TITLE
chore: split json rpc type `Node` to `LocalNode` and `RemoteNode`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1866,7 +1866,6 @@ http://localhost:8114
                 "score": "0x1"
             }
         ],
-        "is_outbound": null,
         "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
         "version": "0.0.0"
     }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -328,7 +328,6 @@
                     "score": "0x1"
                 }
             ],
-            "is_outbound": null,
             "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
             "version": "0.0.0"
         },

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -1,5 +1,5 @@
 use crate::error::RPCError;
-use ckb_jsonrpc_types::{BannedAddr, Node, NodeAddress, Timestamp};
+use ckb_jsonrpc_types::{BannedAddr, LocalNode, NodeAddress, RemoteNode, Timestamp};
 use ckb_network::{MultiaddrExt, NetworkController};
 use faketime::unix_time_as_millis;
 use jsonrpc_core::Result;
@@ -13,11 +13,11 @@ const DEFAULT_BAN_DURATION: u64 = 24 * 60 * 60 * 1000; // 1 day
 pub trait NetworkRpc {
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"local_node_info","params": []}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "local_node_info")]
-    fn local_node_info(&self) -> Result<Node>;
+    fn local_node_info(&self) -> Result<LocalNode>;
 
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"get_peers","params": []}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "get_peers")]
-    fn get_peers(&self) -> Result<Vec<Node>>;
+    fn get_peers(&self) -> Result<Vec<RemoteNode>>;
 
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"get_banned_addresses","params": []}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "get_banned_addresses")]
@@ -40,10 +40,9 @@ pub(crate) struct NetworkRpcImpl {
 }
 
 impl NetworkRpc for NetworkRpcImpl {
-    fn local_node_info(&self) -> Result<Node> {
-        Ok(Node {
+    fn local_node_info(&self) -> Result<LocalNode> {
+        Ok(LocalNode {
             version: self.network_controller.node_version().to_string(),
-            is_outbound: None,
             node_id: self.network_controller.node_id(),
             addresses: self
                 .network_controller
@@ -57,7 +56,7 @@ impl NetworkRpc for NetworkRpcImpl {
         })
     }
 
-    fn get_peers(&self) -> Result<Vec<Node>> {
+    fn get_peers(&self) -> Result<Vec<RemoteNode>> {
         let peers = self.network_controller.connected_peers();
         let mut nodes = Vec::with_capacity(peers.len());
         for (peer_id, peer) in peers.into_iter() {
@@ -84,8 +83,8 @@ impl NetworkRpc for NetworkRpcImpl {
                 }
             }
 
-            nodes.push(Node {
-                is_outbound: Some(peer.is_outbound()),
+            nodes.push(RemoteNode {
+                is_outbound: peer.is_outbound(),
                 version: peer
                     .identify_info
                     .map(|info| info.client_version)

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -6,9 +6,9 @@ mod error;
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockReward, BlockTemplate,
     BlockView, Capacity, CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle,
-    DryRunResult, EpochNumber, EpochView, EstimateResult, HeaderView, LiveCell, LockHashIndexState,
-    Node, OutPoint, PeerState, Timestamp, Transaction, TransactionWithStatus, TxPoolInfo, Uint64,
-    Version,
+    DryRunResult, EpochNumber, EpochView, EstimateResult, HeaderView, LiveCell, LocalNode,
+    LockHashIndexState, OutPoint, PeerState, RemoteNode, Timestamp, Transaction,
+    TransactionWithStatus, TxPoolInfo, Uint64, Version,
 };
 use ckb_types::core::{
     BlockNumber as CoreBlockNumber, Capacity as CoreCapacity, EpochNumber as CoreEpochNumber,
@@ -126,13 +126,13 @@ impl RpcClient {
             .expect("rpc call get_epoch_by_number")
     }
 
-    pub fn local_node_info(&self) -> Node {
+    pub fn local_node_info(&self) -> LocalNode {
         self.inner
             .local_node_info()
             .expect("rpc call local_node_info")
     }
 
-    pub fn get_peers(&self) -> Vec<Node> {
+    pub fn get_peers(&self) -> Vec<RemoteNode> {
         self.inner.get_peers().expect("rpc call get_peers")
     }
 
@@ -333,8 +333,8 @@ jsonrpc!(pub struct Inner {
     pub fn get_current_epoch(&self) -> EpochView;
     pub fn get_epoch_by_number(&self, number: EpochNumber) -> Option<EpochView>;
 
-    pub fn local_node_info(&self) -> Node;
-    pub fn get_peers(&self) -> Vec<Node>;
+    pub fn local_node_info(&self) -> LocalNode;
+    pub fn get_peers(&self) -> Vec<RemoteNode>;
     pub fn get_banned_addresses(&self) -> Vec<BannedAddr>;
     pub fn set_ban(
         &self,

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -32,7 +32,7 @@ pub use self::fixed_bytes::Byte32;
 pub use self::indexer::{
     CellTransaction, LiveCell, LockHashCapacity, LockHashIndexState, TransactionPoint,
 };
-pub use self::net::{BannedAddr, Node, NodeAddress};
+pub use self::net::{BannedAddr, LocalNode, NodeAddress, RemoteNode};
 pub use self::pool::{OutputsValidator, TxPoolInfo};
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::sync::PeerState;

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -1,13 +1,19 @@
 use crate::{Timestamp, Uint64};
 use serde::{Deserialize, Serialize};
 
-// TODO add more fields from PeerIdentifyInfo
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-pub struct Node {
+pub struct LocalNode {
     pub version: String,
     pub node_id: String,
     pub addresses: Vec<NodeAddress>,
-    pub is_outbound: Option<bool>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct RemoteNode {
+    pub version: String,
+    pub node_id: String,
+    pub addresses: Vec<NodeAddress>,
+    pub is_outbound: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
We are planing to add more fields to network related rpc `local_node_info` and `get_peers`, for example, add uptime to `local_node_info`, add best_known_header to `get_peers`, this PR split json rpc type `Node` to `LocalNode` and `RemoteNode`, make it easier to add different fields to these rpc in the future.

This PR is compatible with previous version, only one field `is_outbound` is removed from `local_node_info`, which is always null in old rpc.