### PR TITLE
chore: add debug log to disconnect fn

### DIFF
--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod ping;
 #[cfg(test)]
 mod test;
 
-use ckb_logger::trace;
+use ckb_logger::{debug, trace};
 use futures::{Future, FutureExt};
 use p2p::{
     builder::MetaBuilder,
@@ -380,6 +380,7 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
         Ok(())
     }
     fn disconnect(&self, peer_index: PeerIndex, message: &str) -> Result<(), Error> {
+        debug!("disconnect peer: {}, message: {}", peer_index, message);
         disconnect_with_message(&self.p2p_control, peer_index, message)?;
         Ok(())
     }


### PR DESCRIPTION
This PR added a debug level log to `disconnect` fn , make it easier to count or analysis disconnect  reason, e.g. count the disconnection frequency of sync scheduler:

```
ag "disconnect peer.*sync disconnect" data/logs
5535516:2020-06-22 16:42:00.570 +09:00 NetworkRuntime DEBUG ckb_network::protocols  disconnect peer: SessionId(6), message: sync disconnect
5547983:2020-06-22 16:42:19.008 +09:00 NetworkRuntime DEBUG ckb_network::protocols  disconnect peer: SessionId(7), message: sync disconnect
5557093:2020-06-22 16:42:32.435 +09:00 NetworkRuntime DEBUG ckb_network::protocols  disconnect peer: SessionId(8), message: sync disconnect
5557094:2020-06-22 16:42:32.435 +09:00 NetworkRuntime DEBUG ckb_network::protocols  disconnect peer: SessionId(5), message: sync disconnect
5564416:2020-06-22 16:42:43.746 +09:00 NetworkRuntime DEBUG ckb_network::protocols  disconnect peer: SessionId(9), message: sync disconnect

```