### PR TITLE
fix: update proposal table after chain reorg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "ckb-jsonrpc-types",
  "ckb-logger",
  "ckb-proposal-table",
+ "ckb-rust-unstable-port",
  "ckb-shared",
  "ckb-stop-handler",
  "ckb-store",
@@ -880,6 +881,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "ckb-rust-unstable-port"
+version = "0.35.0-pre"
+dependencies = [
+ "is_sorted",
 ]
 
 [[package]]
@@ -2259,6 +2267,12 @@ checksum = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "is_sorted"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "util/runtime",
     "util/jsonrpc-types",
     "util/fee-estimator",
+    "util/rust-unstable-port",
     "db",
     "db-migration",
     "resource",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -20,6 +20,7 @@ ckb-proposal-table = { path = "../util/proposal-table" }
 ckb-error = { path = "../error" }
 ckb-app-config = { path = "../util/app-config" }
 bitflags = "1.0"
+ckb-rust-unstable-port = { path = "../util/rust-unstable-port" }
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -3,11 +3,12 @@ use crate::{
     chain::{ChainService, ForkChanges},
     switch::Switch,
 };
-use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
 use ckb_shared::shared::SharedBuilder;
 use ckb_store::ChainStore;
 use ckb_types::{
     core::{BlockBuilder, BlockExt, BlockView},
+    packed,
     prelude::Pack,
     U256,
 };
@@ -404,4 +405,82 @@ fn repeatedly_switch_fork() {
     chain_service
         .process_block(Arc::new(new_block5), Switch::DISABLE_ALL)
         .unwrap();
+}
+
+// [ 1 <- 2 <- 3 ] <- 4 <- 5 <- 6 <- 7 <- 8 <- 9 <- 10 <- 11
+//              \
+//               \
+//                - 4' <- 5' <- 6'
+
+#[test]
+fn test_fork_proposal_table() {
+    let builder = SharedBuilder::default();
+    let mut consensus = Consensus::default();
+    consensus.tx_proposal_window = ProposalWindow(2, 3);
+
+    let (shared, table) = builder.consensus(consensus).build().unwrap();
+    let mut chain_service = ChainService::new(shared.clone(), table);
+
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
+
+    let mock_store = MockStore::new(&genesis, shared.store());
+    let mut mock = MockChain::new(genesis, shared.consensus());
+
+    for i in 1..12 {
+        let ids = vec![packed::ProposalShortId::new([
+            0u8, 0, 0, 0, 0, 0, 0, 0, 0, i,
+        ])];
+        mock.gen_block_with_proposal_ids(40u64, ids, &mock_store);
+    }
+
+    for blk in mock.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+    }
+
+    for _ in 1..9 {
+        mock.rollback(&mock_store);
+    }
+
+    for i in 4..7 {
+        let ids = vec![packed::ProposalShortId::new([
+            1u8, 0, 0, 0, 0, 0, 0, 0, 0, i,
+        ])];
+        mock.gen_block_with_proposal_ids(200u64, ids, &mock_store);
+    }
+
+    for blk in mock.blocks().iter().skip(3) {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+    }
+
+    // snapshot proposals is prepare for tx-pool, validate on tip + 1
+    let snapshot = shared.snapshot();
+    let proposals = snapshot.proposals();
+
+    assert_eq!(
+        &HashSet::from_iter(
+            vec![
+                packed::ProposalShortId::new([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 4]),
+                packed::ProposalShortId::new([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 5])
+            ]
+            .into_iter()
+        ),
+        proposals.set()
+    );
+
+    assert_eq!(
+        &HashSet::from_iter(
+            vec![packed::ProposalShortId::new([
+                1u8, 0, 0, 0, 0, 0, 0, 0, 0, 6
+            ])]
+            .into_iter()
+        ),
+        proposals.gap()
+    );
 }

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -410,7 +410,7 @@ fn repeatedly_switch_fork() {
 // [ 1 <- 2 <- 3 ] <- 4 <- 5 <- 6 <- 7 <- 8 <- 9 <- 10 <- 11
 //              \
 //               \
-//                - 4' <- 5' <- 6'
+//                - 4' <- 5'
 
 #[test]
 fn test_fork_proposal_table() {
@@ -446,7 +446,7 @@ fn test_fork_proposal_table() {
         mock.rollback(&mock_store);
     }
 
-    for i in 4..7 {
+    for i in 4..6 {
         let ids = vec![packed::ProposalShortId::new([
             1u8, 0, 0, 0, 0, 0, 0, 0, 0, i,
         ])];
@@ -466,8 +466,8 @@ fn test_fork_proposal_table() {
     assert_eq!(
         &HashSet::from_iter(
             vec![
-                packed::ProposalShortId::new([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 4]),
-                packed::ProposalShortId::new([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 5])
+                packed::ProposalShortId::new([0u8, 0, 0, 0, 0, 0, 0, 0, 0, 3]),
+                packed::ProposalShortId::new([1u8, 0, 0, 0, 0, 0, 0, 0, 0, 4])
             ]
             .into_iter()
         ),
@@ -477,7 +477,7 @@ fn test_fork_proposal_table() {
     assert_eq!(
         &HashSet::from_iter(
             vec![packed::ProposalShortId::new([
-                1u8, 0, 0, 0, 0, 0, 0, 0, 0, 6
+                1u8, 0, 0, 0, 0, 0, 0, 0, 0, 5
             ])]
             .into_iter()
         ),

--- a/chain/src/tests/mod.rs
+++ b/chain/src/tests/mod.rs
@@ -3,5 +3,6 @@ mod block_assembler;
 mod delay_verify;
 mod find_fork;
 mod reward;
+mod truncate;
 mod uncle;
 mod util;

--- a/chain/src/tests/truncate.rs
+++ b/chain/src/tests/truncate.rs
@@ -1,0 +1,48 @@
+use crate::tests::util::{MockChain, MockStore};
+use crate::{chain::ChainService, switch::Switch};
+use ckb_chain_spec::consensus::Consensus;
+use ckb_shared::shared::SharedBuilder;
+use ckb_store::ChainStore;
+use std::sync::Arc;
+
+#[test]
+fn test_truncate() {
+    let builder = SharedBuilder::default();
+
+    let (shared, table) = builder.consensus(Consensus::default()).build().unwrap();
+    let mut chain_service = ChainService::new(shared.clone(), table);
+
+    let genesis = shared
+        .store()
+        .get_block_header(&shared.store().get_block_hash(0).unwrap())
+        .unwrap();
+
+    let mock_store = MockStore::new(&genesis, shared.store());
+    let mut mock = MockChain::new(genesis, shared.consensus());
+
+    for _ in 0..10 {
+        mock.gen_empty_block_with_diff(40u64, &mock_store);
+    }
+
+    for blk in mock.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+    }
+
+    let target = shared.snapshot().tip_header().clone();
+
+    for _ in 0..10 {
+        mock.gen_empty_block_with_diff(40u64, &mock_store);
+    }
+
+    for blk in mock.blocks() {
+        chain_service
+            .process_block(Arc::new(blk.clone()), Switch::DISABLE_ALL)
+            .unwrap();
+    }
+
+    chain_service.truncate(&target.hash()).unwrap();
+
+    assert_eq!(shared.snapshot().tip_header(), &target);
+}

--- a/util/rust-unstable-port/Cargo.toml
+++ b/util/rust-unstable-port/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ckb-rust-unstable-port"
+version = "0.35.0-pre"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+is_sorted = "0.1.1"

--- a/util/rust-unstable-port/src/lib.rs
+++ b/util/rust-unstable-port/src/lib.rs
@@ -1,0 +1,1 @@
+pub use is_sorted::IsSorted;

--- a/util/test-chain-utils/src/mock_store.rs
+++ b/util/test-chain-utils/src/mock_store.rs
@@ -51,6 +51,15 @@ impl MockStore {
             .unwrap();
         db_txn.commit().unwrap();
     }
+
+    pub fn remove_block(&self, block: &BlockView) {
+        let db_txn = self.0.begin_transaction();
+        db_txn
+            .delete_block(&block.header().hash(), block.transactions().len())
+            .unwrap();
+        db_txn.detach_block(&block).unwrap();
+        db_txn.commit().unwrap();
+    }
 }
 
 impl CellProvider for MockStore {


### PR DESCRIPTION
Previously, proposal-table update not considered in chain rollback, it's almost impossible to happen in hashrate-based chain. But can be triggered by `truncate` RPC.

Proposal fix: 
* check whether need reload proposal_table from block when the fork occurs.
* make sure fork blocks is sorted