### PR TITLE
feat: add RPC `clear_tx_pool`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -50,6 +50,7 @@ Subscriptions require a full duplex connection. CKB offers such connections in t
 *   [`Pool`](#pool)
     *   [`send_transaction`](#send_transaction)
     *   [`tx_pool_info`](#tx_pool_info)
+    *   [`clear_tx_pool`](#clear_tx_pool)
 *   [`Stats`](#stats)
     *   [`get_blockchain_info`](#get_blockchain_info)
     *   [`get_peers_state`](#get_peers_state)
@@ -2106,6 +2107,33 @@ http://localhost:8114
         "total_tx_cycles": "0x219",
         "total_tx_size": "0x112"
     }
+}
+```
+
+### `clear_tx_pool`
+
+Remove all transactions from the tx-pool
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "clear_tx_pool",
+    "params": []
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": null
 }
 ```
 

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -805,6 +805,13 @@
         }
     },
     {
+        "description": "Remove all transactions from the tx-pool",
+        "method": "clear_tx_pool",
+        "module": "pool",
+        "params": [],
+        "result": null
+    },
+    {
         "description": "Get block by number",
         "method": "get_block_by_number",
         "module": "chain",

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -28,6 +28,10 @@ pub trait PoolRpc {
     // curl -d '{"params": [], "method": "tx_pool_info", "jsonrpc": "2.0", "id": 2}' -H 'content-type:application/json' http://localhost:8114
     #[rpc(name = "tx_pool_info")]
     fn tx_pool_info(&self) -> Result<TxPoolInfo>;
+
+    // curl -d '{"params": [], "method": "clear_tx_pool", "jsonrpc": "2.0", "id": 2}' -H 'content-type:application/json' http://localhost:8114
+    #[rpc(name = "clear_tx_pool")]
+    fn clear_tx_pool(&self) -> Result<()>;
 }
 
 pub(crate) struct PoolRpcImpl {
@@ -142,6 +146,15 @@ impl PoolRpc for PoolRpcImpl {
             min_fee_rate: self.min_fee_rate.as_u64().into(),
             last_txs_updated_at: tx_pool_info.last_txs_updated_at.into(),
         })
+    }
+
+    fn clear_tx_pool(&self) -> Result<()> {
+        let tx_pool = self.shared.tx_pool_controller();
+        tx_pool
+            .clear_pool()
+            .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
+
+        Ok(())
     }
 }
 

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -382,7 +382,8 @@ fn params_of(shared: &Shared, method: &str) -> Value {
         | "get_current_epoch"
         | "get_blockchain_info"
         | "tx_pool_info"
-        | "get_lock_hash_index_states" => vec![],
+        | "get_lock_hash_index_states"
+        | "clear_tx_pool" => vec![],
         "get_epoch_by_number" => vec![json!("0x0")],
         "get_block_hash" | "get_block_by_number" | "get_header_by_number" => {
             vec![json!(tip_number)]


### PR DESCRIPTION
The adding RPC `cleat_tx_pool` removes all the memoried transactions from tx-pool.