### PR TITLE
chore: add make script for Windows PowerShell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,6 @@ integration: submodule-init setup-ckb-test ## Run integration tests in "test" di
 	cargo build --features deadlock_detection
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
 
-.PHONY: integration-windows
-integration-windows: submodule-init
-	cp -f Cargo.lock test/Cargo.lock
-	cargo build --features deadlock_detection
-	mv target test/
-	cd test && RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -- --bin target/debug/ckb ${CKB_TEST_ARGS}
-
 .PHONY: integration-release
 integration-release: submodule-init setup-ckb-test
 	cargo build --release --features deadlock_detection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - script: make test
+      - powershell: devtools/windows/make test
         displayName: Run unit tests
         env:
           CI: true
@@ -50,7 +50,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - script: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration-windows
+      - powershell: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration
         displayName: Run integration tests
         env:
           CI: true
@@ -64,7 +64,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - script: make prod
+      - powershell: devtools/windows/make prod
         displayName: Build
       - script: |
           curl -LO https://github.com/nervosnetwork/ckb-cli/releases/download/$(CKBClientVersion)/ckb-cli_$(CKBClientVersion)_x86_64-pc-windows-msvc.zip

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -1,0 +1,95 @@
+$ErrorActionPreference = "Stop"
+$RememberEnv = @{}
+$Verbose = @()
+if ($env:CI -ne $null) {
+  $Verbose = @("--verbose")
+}
+
+function Set-Env {
+  param(
+    [string] $Key,
+    [string] $Value
+  )
+
+  if (-not $RememberEnv.ContainsKey($Key)) {
+    $RememberEnv[$Key] = (Get-Item -Path "env:$Key" -ErrorAction SilentlyContinue).Value
+  }
+  echo "set $Key=$Value"
+  Set-Item -Path "env:$Key" -Value $Value
+}
+
+function Restore-Env {
+  foreach ($item in $RememberEnv.GetEnumerator()) {
+    if ($item.Value -eq $null) {
+      echo "unset $($item.Key)"
+      Remove-Item -Path "env:$($item.Key)"
+    } else {
+      echo "set $($item.Key)=$($item.Value)"
+      Set-Item -Path "env:$($item.Key)" -Value $item.Value
+    }
+  }
+}
+
+function Enable-DebugSymbols {
+  $content = Get-Content Cargo.toml | % {
+    $_
+    if ($_ -eq '[profile.release]') {
+      "debug = true"
+    }
+  }
+  ($content -join "`n") + "`n" | Set-Content -NoNewline -Path Cargo.toml
+}
+
+function Disable-DebugSymbols {
+  $content = Get-Content Cargo.toml | ? {
+    $_ -ne "debug = true"
+  }
+  ($content -join "`n") + "`n" | Set-Content -NoNewline -Path Cargo.toml
+}
+
+function run-prod {
+  Set-Env RUSTFLAGS "--cfg disable_faketime"
+  cargo build @Verbose --release
+}
+
+function run-prod-with-debug {
+  try {
+    Enable-DebugSymbols
+    run-prod
+  } finally {
+    Disable-DebugSymbols
+  }
+}
+
+function run-test {
+  cargo test @Verbose --all -- --nocapture
+}
+
+function run-integration {
+  git submodule update --init
+  cp -Fo Cargo.lock test/Cargo.lock
+  rm -Re -Fo -ErrorAction SilentlyContinue test/target
+  New-Item -ItemType Junction -Path test/target -Value "$(pwd)/target"
+
+  cargo build --features deadlock_detection
+
+  pushd test
+  Set-Env RUST_BACKTRACE 1
+  Set-Env RUST_LOG $env:INTEGRATION_RUST_LOG
+  iex "cargo run -- --bin target/debug/ckb $($env:CKB_TEST_ARGS)"
+  popd
+}
+
+try {
+  foreach ($arg in $args) {
+    $parts = $arg -Split '=', 2
+      if ($parts.Count -eq 2) {
+        Set-Env $parts[0] $parts[1]
+      } else {
+        echo "Run $arg"
+        & "run-$arg"
+      }
+  }
+} finally {
+  Restore-Env
+}

--- a/docs/ckb-on-windows.md
+++ b/docs/ckb-on-windows.md
@@ -56,8 +56,7 @@ with the workload: "Desktop development with C++".
 - Build [CKB].
 
   ```posh
-  $env:RUSTFLAGS = "--cfg disable_faketime"
-  cargo build --release
+  devtools/windows/make prod
   ```
 
 [CKB]: https://github.com/nervosnetwork/ckb


### PR DESCRIPTION
The script uses PowerShell and can run tasks similar to the targets defined in Makefile, thus we don't need to install make and other bash command line utilities.