### PR TITLE
fix: shrink state map

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,4 +1,5 @@
 mod linked_hash_set;
+mod shrink_to_fit;
 
 use std::time::Duration;
 

--- a/util/src/shrink_to_fit.rs
+++ b/util/src/shrink_to_fit.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! shrink_to_fit {
+    ($map:expr, $threhold:expr) => {{
+        if $map.capacity() > ($map.len() + $threhold) {
+            $map.shrink_to_fit();
+        }
+    }};
+}


### PR DESCRIPTION
Cause rust hash table capacity does not shrink automatically, we need explicit call `shrink` for predictable limit memory usage.