### PR TITLE
feat: add `set_network_active` rpc

### DIFF
--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -226,6 +226,10 @@ impl ServiceProtocol for CKBHandler {
             }
         });
 
+        if !self.network_state.is_active() {
+            return;
+        }
+
         let pending_data_size = context.session.pending_data_size();
         let send_paused = pending_data_size >= self.network_state.config.max_send_buffer();
         let nc = DefaultCKBProtocolContext {
@@ -244,6 +248,10 @@ impl ServiceProtocol for CKBHandler {
                 peer.protocols.remove(&self.proto_id);
             }
         });
+
+        if !self.network_state.is_active() {
+            return;
+        }
 
         let pending_data_size = context.session.pending_data_size();
         let send_paused = pending_data_size >= self.network_state.config.max_send_buffer();
@@ -264,6 +272,10 @@ impl ServiceProtocol for CKBHandler {
             }
         });
 
+        if !self.network_state.is_active() {
+            return;
+        }
+
         trace!(
             "[received message]: {}, {}, length={}",
             self.proto_id,
@@ -283,6 +295,10 @@ impl ServiceProtocol for CKBHandler {
     }
 
     fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+        if !self.network_state.is_active() {
+            return;
+        }
+
         if token == std::u64::MAX {
             trace!("protocol handler heart beat {}", self.proto_id);
         } else {

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -48,6 +48,7 @@ Subscriptions require a full duplex connection. CKB offers such connections in t
     *   [`get_banned_addresses`](#get_banned_addresses)
     *   [`set_ban`](#set_ban)
     *   [`sync_state`](#sync_state)
+    *   [`set_network_active`](#set_network_active)
 *   [`Pool`](#pool)
     *   [`send_transaction`](#send_transaction)
     *   [`tx_pool_info`](#tx_pool_info)
@@ -1868,6 +1869,7 @@ http://localhost:8114
                 "score": "0x1"
             }
         ],
+        "is_active": true,
         "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
         "version": "0.0.0"
     }
@@ -2016,6 +2018,13 @@ Returns sync state of this client
     fast_time - The download scheduler's time analysis data, the fast is the 1/3 of the cut-off point, unit ms
     normal_time - The download scheduler's time analysis data, the normal is the 4/5 of the cut-off point, unit ms
     low_time - The download scheduler's time analysis data, the low is the 9/10 of the cut-off point, unit ms
+### `set_network_active`
+
+Disable/enable all p2p network activity
+
+#### Parameters
+
+    state - true to enable networking, false to disable
 
 #### Examples
 
@@ -2025,6 +2034,10 @@ echo '{
     "jsonrpc": "2.0",
     "method": "sync_state",
     "params": []
+    "method": "set_network_active",
+    "params": [
+        false
+    ]
 }' \
 | tr -d '\n' \
 | curl -H 'content-type: application/json' -d @- \
@@ -2045,6 +2058,7 @@ http://localhost:8114
         "normal_time": "0x4e2",
         "orphan_blocks_count": "0x0"
     }
+    "result": null
 }
 ```
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2006,7 +2006,7 @@ http://localhost:8114
 
 ### `sync_state`
 
-Returns sync state of this client
+Returns sync state of this node
 
 #### Returns
 
@@ -2018,13 +2018,6 @@ Returns sync state of this client
     fast_time - The download scheduler's time analysis data, the fast is the 1/3 of the cut-off point, unit ms
     normal_time - The download scheduler's time analysis data, the normal is the 4/5 of the cut-off point, unit ms
     low_time - The download scheduler's time analysis data, the low is the 9/10 of the cut-off point, unit ms
-### `set_network_active`
-
-Disable/enable all p2p network activity
-
-#### Parameters
-
-    state - true to enable networking, false to disable
 
 #### Examples
 
@@ -2034,10 +2027,6 @@ echo '{
     "jsonrpc": "2.0",
     "method": "sync_state",
     "params": []
-    "method": "set_network_active",
-    "params": [
-        false
-    ]
 }' \
 | tr -d '\n' \
 | curl -H 'content-type: application/json' -d @- \
@@ -2058,6 +2047,37 @@ http://localhost:8114
         "normal_time": "0x4e2",
         "orphan_blocks_count": "0x0"
     }
+}
+```
+
+### `set_network_active`
+
+Disable/enable all p2p network activity
+
+#### Parameters
+
+    state - true to enable networking, false to disable
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "set_network_active",
+    "params": [
+        false
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
     "result": null
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -328,6 +328,7 @@
                     "score": "0x1"
                 }
             ],
+            "is_active": true,
             "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
             "version": "0.0.0"
         },
@@ -414,7 +415,7 @@
         ]
     },
     {
-        "description": "Returns sync state of this client",
+        "description": "Returns sync state of this node",
         "method": "sync_state",
         "module": "net",
         "params": [],
@@ -452,6 +453,21 @@
             },
             {
                 "low_time": "The download scheduler's time analysis data, the low is the 9/10 of the cut-off point, unit ms"
+            }
+        ],
+        "skip": true
+    },
+    {
+        "description": "Disable/enable all p2p network activity",
+        "method": "set_network_active",
+        "module": "net",
+        "params": [
+            false
+        ],
+        "result": null,
+        "types": [
+            {
+                "state": "true to enable networking, false to disable"
             }
         ],
         "skip": true

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -38,6 +38,10 @@ pub trait NetworkRpc {
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"sync_state","params": []}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "sync_state")]
     fn sync_state(&self) -> Result<SyncState>;
+
+    // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"set_network_active","params": [false]}' -H 'content-type:application/json' 'http://localhost:8114'
+    #[rpc(name = "set_network_active")]
+    fn set_network_active(&self, state: bool) -> Result<()>;
 }
 
 pub(crate) struct NetworkRpcImpl {
@@ -50,6 +54,7 @@ impl NetworkRpc for NetworkRpcImpl {
         Ok(LocalNode {
             version: self.network_controller.version().to_owned(),
             node_id: self.network_controller.node_id(),
+            is_active: self.network_controller.is_active(),
             addresses: self
                 .network_controller
                 .public_urls(MAX_ADDRS)
@@ -175,5 +180,10 @@ impl NetworkRpc for NetworkRpcImpl {
         };
 
         Ok(sync_state)
+    }
+
+    fn set_network_active(&self, state: bool) -> Result<()> {
+        self.network_controller.set_active(state);
+        Ok(())
     }
 }

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct LocalNode {
     pub version: String,
     pub node_id: String,
+    pub is_active: bool,
     pub addresses: Vec<NodeAddress>,
 }
 


### PR DESCRIPTION
allows user to pause and restart p2p network message processing through rpc