### PR TITLE
fix: fix the powershell script which run integration tests on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - powershell: devtools/windows/make test
+      - pwsh: devtools/windows/make test
         displayName: Run unit tests
         env:
           CI: true
@@ -50,7 +50,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - powershell: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration
+      - pwsh: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration
         displayName: Run integration tests
         env:
           CI: true
@@ -64,7 +64,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.41.0-x86_64-pc-windows-msvc'
-      - powershell: devtools/windows/make prod
+      - pwsh: devtools/windows/make prod
         displayName: Build
       - script: |
           curl -LO https://github.com/nervosnetwork/ckb-cli/releases/download/$(CKBClientVersion)/ckb-cli_$(CKBClientVersion)_x86_64-pc-windows-msvc.zip

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -69,6 +69,7 @@ function run-integration {
   git submodule update --init
   cp -Fo Cargo.lock test/Cargo.lock
   rm -Re -Fo -ErrorAction SilentlyContinue test/target
+  mkdir -Force -ErrorAction SilentlyContinue target
   New-Item -ItemType Junction -Path test/target -Value "$(pwd)/target"
 
   cargo build --features deadlock_detection


### PR DESCRIPTION
- Create `target` directory before link `test/target` to it.

  ```
  +   New-Item -ItemType Junction -Path test/target -Value "$(pwd)/target ...
  +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  + CategoryInfo          : ObjectNotFound: (D:\a\1\s\target:String) [New-Item], ItemNotFoundException
  + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.NewItemCommand
  ```

- Instead of `powershell`, `pwsh` can avoid `NativeCommandError`.

  ```
  +   cargo build --features deadlock_detection
  +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  + CategoryInfo          : NotSpecified: (    Updating crates.io index:String) [], RemoteException
  + FullyQualifiedErrorId : NativeCommandError
  ```

  The difference between `powershell` and `pwsh`:

  > Both of these resolve to the PowerShell@2 task. powershell runs Windows PowerShell and will only work on a Windows agent. pwsh runs PowerShell Core, which must be installed on the agent or container.

  Ref: [PowerShell task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/powershell?view=azure-devops)

  To be honest, I have no idea why `pwsh` works but `powershell` doesn't, I just tried it and it works. 
  There are several issues in [microsoft/azure-pipelines-agent, microsoft/azure-pipelines-tasks and microsoft/azure-pipelines-image-generation](https://github.com/microsoft).
  It seems to be a bug with some specific version of Powershell installed in windows-2019 image.