### PR TITLE
improvement: don't cache all data of header map in memory during IBD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
  "ckb-dao-utils",
+ "ckb-db",
  "ckb-error",
  "ckb-fee-estimator",
  "ckb-logger",
@@ -995,6 +996,7 @@ dependencies = [
  "rand 0.6.5",
  "ratelimit_meter",
  "sentry",
+ "tempfile",
 ]
 
 [[package]]

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -60,7 +60,10 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         shared.genesis_hash()
     );
 
-    let sync_shared = Arc::new(SyncShared::new(shared.clone()));
+    let sync_shared = Arc::new(SyncShared::with_tmpdir(
+        shared.clone(),
+        args.config.tmp_dir.as_ref(),
+    ));
     let network_state = Arc::new(
         NetworkState::from_config(args.config.network).expect("Init network state failed"),
     );

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 ckb-chain = { path = "../chain" }
 ckb-shared = { path = "../shared" }
 ckb-store = { path = "../store" }
+ckb-db = { path = "../db" }
 ckb-types = {path = "../util/types"}
 ckb-network = { path = "../network" }
 ckb-logger = {path = "../util/logger"}
@@ -27,9 +28,14 @@ ckb-tx-pool = { path = "../tx-pool" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 crossbeam-channel = "0.3"
 ratelimit_meter = "5.0"
+tempfile = "3.0"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }
 rand = "0.6"
 ckb-dao = { path = "../util/dao" }
 ckb-dao-utils = { path = "../util/dao/utils" }
+
+[features]
+default = []
+stats = []

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -91,7 +91,7 @@ impl<'a> CompactBlockProcess<'a> {
             };
 
             let state = shared.state().peers();
-            state.may_set_best_known_header(self.peer, &header_view);
+            state.may_set_best_known_header(self.peer, header_view);
 
             return StatusCode::CompactBlockAlreadyStored.with_context(block_hash);
         } else if status.contains(BlockStatus::BLOCK_INVALID) {

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -342,7 +342,7 @@ where
                 .expect("header with HEADER_VALID should exist");
             state
                 .peers()
-                .may_set_best_known_header(self.peer, &header_view);
+                .may_set_best_known_header(self.peer, header_view);
             return result;
         }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -1428,10 +1428,10 @@ mod tests {
             state.insert(5.into(), state_5);
             state.insert(6.into(), state_6);
         }
-        peers.may_set_best_known_header(0.into(), &mock_header_view(1));
-        peers.may_set_best_known_header(2.into(), &mock_header_view(3));
-        peers.may_set_best_known_header(3.into(), &mock_header_view(1));
-        peers.may_set_best_known_header(5.into(), &mock_header_view(3));
+        peers.may_set_best_known_header(0.into(), mock_header_view(1));
+        peers.may_set_best_known_header(2.into(), mock_header_view(3));
+        peers.may_set_best_known_header(3.into(), mock_header_view(1));
+        peers.may_set_best_known_header(5.into(), mock_header_view(3));
         {
             // Protected peer 0 start sync
             peers

--- a/sync/src/types/header_map/backend.rs
+++ b/sync/src/types/header_map/backend.rs
@@ -1,0 +1,25 @@
+use std::path;
+
+use ckb_types::packed::Byte32;
+
+use crate::types::HeaderView;
+
+pub(crate) trait KeyValueBackend {
+    fn new<P>(tmpdir: Option<P>) -> Self
+    where
+        P: AsRef<path::Path>;
+
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn is_opened(&self) -> bool;
+    fn open(&mut self);
+    fn try_close(&mut self) -> bool;
+
+    fn contains_key(&self, key: &Byte32) -> bool;
+    fn get(&self, key: &Byte32) -> Option<HeaderView>;
+    fn insert(&mut self, value: &HeaderView) -> Option<HeaderView>;
+    fn remove(&mut self, key: &Byte32) -> Option<HeaderView>;
+}

--- a/sync/src/types/header_map/backend_rocksdb.rs
+++ b/sync/src/types/header_map/backend_rocksdb.rs
@@ -1,0 +1,147 @@
+use std::path;
+
+use ckb_db::internal::{
+    ops::{Delete as _, GetPinned as _, Open as _, Put as _},
+    DB,
+};
+use ckb_logger::{debug, warn};
+use ckb_types::{packed::Byte32, prelude::*};
+use tempfile::TempDir;
+
+use super::KeyValueBackend;
+use crate::types::HeaderView;
+
+pub(crate) struct RocksDBBackend {
+    tmpdir: Option<path::PathBuf>,
+    resource: Option<(TempDir, DB)>,
+    count: usize,
+}
+
+impl KeyValueBackend for RocksDBBackend {
+    fn new<P>(tmpdir: Option<P>) -> Self
+    where
+        P: AsRef<path::Path>,
+    {
+        Self {
+            tmpdir: tmpdir.map(|p| p.as_ref().to_path_buf()),
+            resource: None,
+            count: 0,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.count
+    }
+
+    fn is_opened(&self) -> bool {
+        self.resource.is_some()
+    }
+
+    fn open(&mut self) {
+        if !self.is_opened() {
+            let mut builder = tempfile::Builder::new();
+            builder.prefix("ckb-tmp-");
+            let cache_dir_res = if let Some(ref tmpdir) = self.tmpdir {
+                builder.tempdir_in(tmpdir)
+            } else {
+                builder.tempdir()
+            };
+            if let Ok(cache_dir) = cache_dir_res {
+                if let Ok(db) = DB::open_default(cache_dir.path()) {
+                    debug!(
+                        "open a key-value database({}) to save header map into disk",
+                        cache_dir.path().to_str().unwrap_or("")
+                    );
+                    self.resource.replace((cache_dir, db));
+                } else {
+                    panic!("failed to open a key-value database to save header map into disk");
+                }
+            } else {
+                panic!("failed to create a tempdir to save header map into disk");
+            }
+        }
+    }
+
+    fn try_close(&mut self) -> bool {
+        if self.is_opened() {
+            if self.is_empty() {
+                if let Some((cache_dir, db)) = self.resource.take() {
+                    drop(db);
+                    let _ignore = cache_dir.close();
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    fn contains_key(&self, key: &Byte32) -> bool {
+        if let Some((_, ref db)) = self.resource {
+            db.get_pinned(key.as_slice())
+                .unwrap_or_else(|err| panic!("read header map from disk should be ok, but {}", err))
+                .is_some()
+        } else {
+            false
+        }
+    }
+
+    fn get(&self, key: &Byte32) -> Option<HeaderView> {
+        if let Some((_, ref db)) = self.resource {
+            db.get_pinned(key.as_slice())
+                .unwrap_or_else(|err| panic!("read header map from disk should be ok, but {}", err))
+                .map(|slice| HeaderView::from_slice_should_be_ok(&slice))
+        } else {
+            None
+        }
+    }
+
+    fn insert(&mut self, value: &HeaderView) -> Option<HeaderView> {
+        if let Some((_, ref db)) = self.resource {
+            let key = value.hash();
+            let old_value_opt = db
+                .get_pinned(key.as_slice())
+                .unwrap_or_else(|err| panic!("read header map from disk should be ok, but {}", err))
+                .map(|slice| HeaderView::from_slice_should_be_ok(&slice));
+            if db.put(key.as_slice(), &value.to_vec()).is_err() {
+                panic!("failed to insert item into header map");
+            }
+            if old_value_opt.is_none() {
+                self.count += 1;
+            }
+            old_value_opt
+        } else {
+            None
+        }
+    }
+
+    fn remove(&mut self, key: &Byte32) -> Option<HeaderView> {
+        let mut do_count = false;
+        let value_opt = if let Some((_, ref db)) = self.resource {
+            let value_opt = db
+                .get_pinned(key.as_slice())
+                .unwrap_or_else(|err| panic!("read header map from disk should be ok, but {}", err))
+                .map(|slice| HeaderView::from_slice_should_be_ok(&slice));
+            if value_opt.is_some() {
+                if db.delete(key.as_slice()).is_ok() {
+                    do_count = true;
+                    value_opt
+                } else {
+                    warn!("failed to delete a value from database");
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if do_count {
+            self.count -= 1;
+            self.try_close();
+        }
+        value_opt
+    }
+}

--- a/sync/src/types/header_map/kernel_lru.rs
+++ b/sync/src/types/header_map/kernel_lru.rs
@@ -1,0 +1,275 @@
+use std::path;
+
+#[cfg(feature = "stats")]
+use ckb_logger::trace;
+use ckb_types::packed::Byte32;
+
+use super::{KeyValueBackend, KeyValueMemory};
+use crate::types::HeaderView;
+
+pub(crate) struct HeaderMapLruKernel<Backend>
+where
+    Backend: KeyValueBackend,
+{
+    primary: KeyValueMemory<Byte32, HeaderView>,
+    backend: Backend,
+    // Configuration
+    primary_limit: usize,
+    backend_close_threshold: usize,
+    // Statistics
+    #[cfg(feature = "stats")]
+    stats: HeaderMapLruKernelStats,
+}
+
+#[cfg(feature = "stats")]
+#[derive(Default)]
+struct HeaderMapLruKernelStats {
+    frequency: usize,
+
+    trace_progress: usize,
+
+    primary_contain: usize,
+    primary_select: usize,
+    primary_insert: usize,
+    primary_delete: usize,
+
+    backend_contain: usize,
+    backend_insert: usize,
+    backend_delete: usize,
+}
+
+impl<Backend> HeaderMapLruKernel<Backend>
+where
+    Backend: KeyValueBackend,
+{
+    pub(crate) fn new<P>(
+        tmpdir: Option<P>,
+        primary_limit: usize,
+        backend_close_threshold: usize,
+    ) -> Self
+    where
+        P: AsRef<path::Path>,
+    {
+        let primary = Default::default();
+        let backend = Backend::new(tmpdir);
+
+        #[cfg(not(feature = "stats"))]
+        {
+            Self {
+                primary,
+                backend,
+                primary_limit,
+                backend_close_threshold,
+            }
+        }
+
+        #[cfg(feature = "stats")]
+        {
+            Self {
+                primary,
+                backend,
+                primary_limit,
+                backend_close_threshold,
+                stats: HeaderMapLruKernelStats::new(50_000),
+            }
+        }
+    }
+
+    pub(crate) fn contains_key(&mut self, hash: &Byte32) -> bool {
+        #[cfg(feature = "stats")]
+        {
+            self.mut_stats().tick_primary_contain();
+        }
+        if self.primary.contains_key(hash) {
+            return true;
+        }
+        if !self.backend.is_opened() {
+            return false;
+        }
+        #[cfg(feature = "stats")]
+        {
+            self.mut_stats().tick_backend_contain();
+        }
+        self.backend.contains_key(hash)
+    }
+
+    pub(crate) fn get(&mut self, hash: &Byte32) -> Option<HeaderView> {
+        #[cfg(feature = "stats")]
+        {
+            self.mut_stats().tick_primary_select();
+        }
+        if let Some(view) = self.primary.get_refresh(hash) {
+            return Some(view);
+        }
+        if !self.backend.is_opened() {
+            return None;
+        }
+        #[cfg(feature = "stats")]
+        {
+            self.mut_stats().tick_backend_delete();
+        }
+        if let Some(view) = self.backend.remove(hash) {
+            if self.primary.len() >= self.primary_limit {
+                #[cfg(feature = "stats")]
+                {
+                    self.mut_stats().tick_primary_delete();
+                    self.mut_stats().tick_backend_insert();
+                }
+                if let Some((_, view_old)) = self.primary.pop_front() {
+                    self.backend.insert(&view_old);
+                }
+            } else if self.primary.len() < self.backend_close_threshold {
+                self.backend.try_close();
+            }
+            #[cfg(feature = "stats")]
+            {
+                self.mut_stats().tick_primary_insert();
+            }
+            self.primary.insert(view.hash(), view.clone());
+            Some(view)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn insert(&mut self, view: HeaderView) -> Option<HeaderView> {
+        #[cfg(feature = "stats")]
+        {
+            self.trace();
+            self.mut_stats().tick_primary_insert();
+        }
+        if let Some(view) = self.primary.insert(view.hash(), view.clone()) {
+            return Some(view);
+        }
+        let view_opt = self.backend.remove(&view.hash());
+        if self.primary.len() > self.primary_limit {
+            self.backend.open();
+            #[cfg(feature = "stats")]
+            {
+                self.mut_stats().tick_primary_delete();
+                self.mut_stats().tick_backend_insert();
+            }
+            if let Some((_, view_old)) = self.primary.pop_front() {
+                self.backend.insert(&view_old);
+            }
+        }
+        view_opt
+    }
+
+    pub(crate) fn remove(&mut self, hash: &Byte32) -> Option<HeaderView> {
+        #[cfg(feature = "stats")]
+        {
+            self.trace();
+            self.mut_stats().tick_primary_delete();
+        }
+        if let Some(view) = self.primary.remove(hash) {
+            return Some(view);
+        }
+        if !self.backend.is_opened() {
+            return None;
+        }
+        #[cfg(feature = "stats")]
+        {
+            self.mut_stats().tick_backend_delete();
+        }
+        let view_opt = self.backend.remove(hash);
+        if self.primary.len() < self.backend_close_threshold {
+            self.backend.try_close();
+        }
+        view_opt
+    }
+
+    #[cfg(feature = "stats")]
+    fn trace(&mut self) {
+        let progress = self.stats().trace_progress();
+        let frequency = self.stats().frequency();
+        if progress % frequency == 0 {
+            trace!(
+                "Header Map Statistics\
+            \n>\t| storage | length  |  limit  | contain |   select   | insert  | delete  |\
+            \n>\t|---------+---------+---------+---------+------------+---------+---------|\
+            \n>\t| primary |{:>9}|{:>9}|{:>9}|{:>12}|{:>9}|{:>9}|\
+            \n>\t| backend |{:>9}|{:>9}|{:>9}|{:>12}|{:>9}|{:>9}|\
+            ",
+                self.primary.len(),
+                self.primary_limit,
+                self.stats().primary_contain,
+                self.stats().primary_select,
+                self.stats().primary_insert,
+                self.stats().primary_delete,
+                self.backend.len(),
+                self.backend.is_opened(),
+                self.stats().backend_contain,
+                '-',
+                self.stats().backend_insert,
+                self.stats().backend_delete,
+            );
+            self.mut_stats().trace_progress_reset();
+        } else {
+            self.mut_stats().trace_progress_tick();
+        }
+    }
+
+    #[cfg(feature = "stats")]
+    fn stats(&self) -> &HeaderMapLruKernelStats {
+        &self.stats
+    }
+
+    #[cfg(feature = "stats")]
+    fn mut_stats(&mut self) -> &mut HeaderMapLruKernelStats {
+        &mut self.stats
+    }
+}
+
+#[cfg(feature = "stats")]
+impl HeaderMapLruKernelStats {
+    fn new(frequency: usize) -> Self {
+        let mut ret = Self::default();
+        ret.frequency = frequency;
+        ret
+    }
+
+    fn frequency(&self) -> usize {
+        self.frequency
+    }
+
+    fn trace_progress(&self) -> usize {
+        self.trace_progress
+    }
+
+    fn trace_progress_reset(&mut self) {
+        self.trace_progress = 1;
+    }
+
+    fn trace_progress_tick(&mut self) {
+        self.trace_progress += 1;
+    }
+
+    fn tick_primary_contain(&mut self) {
+        self.primary_contain += 1;
+    }
+
+    fn tick_backend_contain(&mut self) {
+        self.backend_contain += 1;
+    }
+
+    fn tick_primary_select(&mut self) {
+        self.primary_select += 1;
+    }
+
+    fn tick_primary_insert(&mut self) {
+        self.primary_insert += 1;
+    }
+
+    fn tick_backend_insert(&mut self) {
+        self.backend_insert += 1;
+    }
+
+    fn tick_primary_delete(&mut self) {
+        self.primary_delete += 1;
+    }
+
+    fn tick_backend_delete(&mut self) {
+        self.backend_delete += 1;
+    }
+}

--- a/sync/src/types/header_map/memory.rs
+++ b/sync/src/types/header_map/memory.rs
@@ -1,0 +1,53 @@
+use std::{clone, cmp, default, hash};
+
+use ckb_util::shrink_to_fit;
+use ckb_util::LinkedHashMap;
+
+use crate::types::SHRINK_THREHOLD;
+
+pub(crate) struct KeyValueMemory<K, V>(LinkedHashMap<K, V>)
+where
+    K: cmp::Eq + hash::Hash;
+
+impl<K, V> default::Default for KeyValueMemory<K, V>
+where
+    K: cmp::Eq + hash::Hash,
+{
+    fn default() -> Self {
+        Self(default::Default::default())
+    }
+}
+
+impl<K, V> KeyValueMemory<K, V>
+where
+    K: cmp::Eq + hash::Hash,
+    V: clone::Clone,
+{
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn contains_key(&self, key: &K) -> bool {
+        self.0.contains_key(key)
+    }
+
+    pub(crate) fn get_refresh(&mut self, key: &K) -> Option<V> {
+        self.0.get_refresh(key).cloned()
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.0.insert(key, value)
+    }
+
+    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
+        let ret = self.0.remove(key);
+        shrink_to_fit!(self.0, SHRINK_THREHOLD);
+        ret
+    }
+
+    pub(crate) fn pop_front(&mut self) -> Option<(K, V)> {
+        let ret = self.0.pop_front();
+        shrink_to_fit!(self.0, SHRINK_THREHOLD);
+        ret
+    }
+}

--- a/sync/src/types/header_map/mod.rs
+++ b/sync/src/types/header_map/mod.rs
@@ -1,0 +1,48 @@
+use std::path;
+
+use ckb_types::packed::Byte32;
+use ckb_util::Mutex;
+
+use crate::types::HeaderView;
+
+mod backend;
+mod backend_rocksdb;
+mod kernel_lru;
+mod memory;
+
+pub(crate) use self::{
+    backend::KeyValueBackend, backend_rocksdb::RocksDBBackend, kernel_lru::HeaderMapLruKernel,
+    memory::KeyValueMemory,
+};
+
+pub struct HeaderMapLru(Mutex<HeaderMapLruKernel<RocksDBBackend>>);
+
+impl HeaderMapLru {
+    pub(crate) fn new<P>(
+        tmpdir: Option<P>,
+        primary_limit: usize,
+        backend_close_threshold: usize,
+    ) -> Self
+    where
+        P: AsRef<path::Path>,
+    {
+        let inner = HeaderMapLruKernel::new(tmpdir, primary_limit, backend_close_threshold);
+        Self(Mutex::new(inner))
+    }
+
+    pub(crate) fn contains_key(&self, hash: &Byte32) -> bool {
+        self.0.lock().contains_key(hash)
+    }
+
+    pub(crate) fn get(&self, hash: &Byte32) -> Option<HeaderView> {
+        self.0.lock().get(hash)
+    }
+
+    pub(crate) fn insert(&self, view: HeaderView) -> Option<HeaderView> {
+        self.0.lock().insert(view)
+    }
+
+    pub(crate) fn remove(&self, hash: &Byte32) -> Option<HeaderView> {
+        self.0.lock().remove(hash)
+    }
+}

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -27,6 +27,7 @@ pub enum AppConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CKBAppConfig {
     pub data_dir: PathBuf,
+    pub tmp_dir: Option<PathBuf>,
     pub logger: LogConfig,
     pub sentry: SentryConfig,
     #[serde(default)]
@@ -161,6 +162,9 @@ impl CKBAppConfig {
             .db
             .update_path_if_not_set(self.data_dir.join("indexer_db"));
         self.network.path = self.data_dir.join("network");
+        if self.tmp_dir.is_none() {
+            self.tmp_dir = Some(self.data_dir.join("tmp"));
+        }
         let log_dir = self.data_dir.join("logs");
         let log_file = log_dir.join(subcommand_name.to_string() + ".log");
 
@@ -173,6 +177,9 @@ impl CKBAppConfig {
         self.db.path = mkdir(self.db.path)?;
         self.indexer.db.path = mkdir(self.indexer.db.path)?;
         self.network.path = mkdir(self.network.path)?;
+        if let Some(tmp_dir) = self.tmp_dir {
+            self.tmp_dir = Some(mkdir(tmp_dir)?);
+        }
         if self.logger.log_to_file {
             mkdir(log_dir)?;
             self.logger.file = Some(touch(log_file)?);


### PR DESCRIPTION
- Open a temporary rocksdb (default is `${ckb_data_dir}/tmp/ckb-tmp-*`) to store a part data of header map which exceeded the configured quota.

- Why not use the same rocksdb as block data?

  - It is just temporary data, all data was destroyed when ckb shutdown, so the format of data can be changed in any commits, we don't have to do migrations on it.

  - I don't want to create columns, it requires migrations. Also too many columns will affect performance. 

  - If I use current existed columns, then traverse all data will be difficult.

    At present, no data in chain database have key-prefix.
    For example, if we use key `header-${header_hash}` to save headers, key `uncle-${uncle_hash}` to save uncles,  key `block-${block_hash}` to save blocks, then we can save them in a same column and we can traverse each of them use the key prefix (`header-*`, `uncle-*`, `block-*`) easily.
    But we save almost all data just via `${hash}`, we can't know the type of data if we put them in a same column.

    So I can't use current existed columns without breaking the data traversing.

  - After IBD, there is about 450 MiB for current mainnet which height is about 2_200_000 with default rocksdb configuration (we can optimize the configuration later), but the size of header map is very small (in most of the time).
    So we can just delete the entire rocksdb, we don't care about how to compress data and free space for rocksdb.

- I use two thresholds to control the balance of memory and disk:
  - The count of headers in memory is less than or equal to `primary_limit`.
  - If the rocksdb will be closed when the count header of headers in memory is less than `primary_limit - backend_close_threshold` and there is no headers in rocksdb.

- I use a lot of `panic`, same as what we did in `ckb-store`. I trust the rocksdb and assume it always works well.

- I wrote two simple serialization and deserialization functions, because I think it is a private data structure, there is no need to make it too public (move to `ckb-types`) or bring heavy serialization and deserialization dependencies into this crate.

- Enable the `stats` feature to collect the statistics, the result of syncing mainnet from `0` to `2247420` is :
  ```
  2020-07-06 15:53:32.875 +08:00 NetworkRuntime TRACE ckb_sync::types::header_map::kernel_lru  Header Map Statistics
  >       | storage | length  |  limit  | contain |   select   | insert  | delete  |
  >       |---------+---------+---------+---------+------------+---------+---------|
  >       | primary |     4974|   300000|  2252392|   196946199|  4243176|  4238382|
  >       | backend |        0|    false|        0|           0|  1990779|  2457795|
  ```