### PR TITLE
chore: trace memory for some data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,10 +617,13 @@ version = "0.34.0-pre"
 dependencies = [
  "ckb-db",
  "ckb-logger",
+ "ckb-util",
+ "crossbeam-channel",
  "futures 0.3.4",
  "heim",
  "jemalloc-ctl",
  "jemalloc-sys",
+ "lazy_static",
 ]
 
 [[package]]
@@ -963,6 +966,7 @@ dependencies = [
  "ckb-error",
  "ckb-fee-estimator",
  "ckb-logger",
+ "ckb-memory-tracker",
  "ckb-network",
  "ckb-shared",
  "ckb-store",
@@ -1030,6 +1034,7 @@ dependencies = [
  "ckb-fee-estimator",
  "ckb-jsonrpc-types",
  "ckb-logger",
+ "ckb-memory-tracker",
  "ckb-reward-calculator",
  "ckb-snapshot",
  "ckb-stop-handler",

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -27,6 +27,7 @@ ckb-tx-pool = { path = "../tx-pool" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 crossbeam-channel = "0.3"
 ratelimit_meter = "5.0"
+ckb-memory-tracker = { path = "../util/memory-tracker" }
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -28,3 +28,4 @@ ckb-async-runtime = { path = "../util/runtime" }
 ckb-stop-handler = { path = "../util/stop-handler" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 ckb-app-config = { path = "../util/app-config" }
+ckb-memory-tracker = { path = "../util/memory-tracker" }

--- a/tx-pool/src/component/orphan.rs
+++ b/tx-pool/src/component/orphan.rs
@@ -1,21 +1,22 @@
 use crate::component::entry::DefectEntry;
+use ckb_memory_tracker::collections::{TracedHashMap, TracedTag};
 use ckb_types::{
     core::TransactionView,
     packed::{OutPoint, ProposalShortId},
 };
 use ckb_verification::cache::CacheEntry;
+use std::collections::hash_map;
 use std::collections::VecDeque;
-use std::collections::{hash_map, HashMap};
 use std::iter::ExactSizeIterator;
 
 pub(crate) const TTL: u64 = 4 * 60 * 60;
 pub(crate) const PRUNE_THRESHOLD: usize = 1500;
 
 ///not verified, may contain conflict transactions
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct OrphanPool {
-    pub(crate) vertices: HashMap<ProposalShortId, DefectEntry>,
-    pub(crate) edges: HashMap<OutPoint, Vec<ProposalShortId>>,
+    pub(crate) vertices: TracedHashMap<ProposalShortId, DefectEntry>,
+    pub(crate) edges: TracedHashMap<OutPoint, Vec<ProposalShortId>>,
     pub(crate) prune_threshold: usize,
 }
 
@@ -25,9 +26,15 @@ impl OrphanPool {
     }
 
     pub(crate) fn raw_new(prune_threshold: usize) -> Self {
-        OrphanPool {
+        TracedTag::push("vertices");
+        let vertices = Default::default();
+        TracedTag::replace_last("edges");
+        let edges = Default::default();
+        TracedTag::pop();
+        Self {
+            vertices,
+            edges,
             prune_threshold,
-            ..Default::default()
         }
     }
 

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -2,6 +2,7 @@ use crate::component::container::{AncestorsScoreSortKey, SortedTxMap};
 use crate::component::entry::TxEntry;
 use crate::error::SubmitTxError;
 use ckb_fee_estimator::FeeRate;
+use ckb_memory_tracker::collections::TracedTag;
 use ckb_types::{
     core::{
         cell::{CellMetaBuilder, CellProvider, CellStatus},
@@ -19,9 +20,10 @@ pub(crate) struct PendingQueue {
 
 impl PendingQueue {
     pub(crate) fn new(max_ancestors_count: usize) -> Self {
-        PendingQueue {
-            inner: SortedTxMap::new(max_ancestors_count),
-        }
+        TracedTag::push("inner");
+        let inner = SortedTxMap::new(max_ancestors_count);
+        TracedTag::pop();
+        Self { inner }
     }
 
     pub(crate) fn size(&self) -> usize {

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -8,6 +8,7 @@ use ckb_app_config::TxPoolConfig;
 use ckb_dao::DaoCalculator;
 use ckb_error::{Error, ErrorKind, InternalErrorKind};
 use ckb_logger::{debug_target, error_target, trace_target};
+use ckb_memory_tracker::collections::TracedTag;
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_types::{
@@ -72,12 +73,24 @@ impl TxPool {
         let conflict_cache_size = config.max_conflict_cache_size;
         let committed_txs_hash_cache_size = config.max_committed_txs_hash_cache_size;
 
+        TracedTag::push("tx-pool");
+        TracedTag::push("pending");
+        let pending = PendingQueue::new(config.max_ancestors_count);
+        TracedTag::replace_last("gap");
+        let gap = PendingQueue::new(config.max_ancestors_count);
+        TracedTag::replace_last("proposed");
+        let proposed = ProposedPool::new(config.max_ancestors_count);
+        TracedTag::replace_last("orphan");
+        let orphan = OrphanPool::new();
+        TracedTag::pop();
+        TracedTag::pop();
+
         TxPool {
             config,
-            pending: PendingQueue::new(config.max_ancestors_count),
-            gap: PendingQueue::new(config.max_ancestors_count),
-            proposed: ProposedPool::new(config.max_ancestors_count),
-            orphan: OrphanPool::new(),
+            pending,
+            gap,
+            proposed,
+            orphan,
             conflict: LruCache::new(conflict_cache_size),
             committed_txs_hash_cache: LruCache::new(committed_txs_hash_cache_size),
             last_txs_updated_at,

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT"
 [dependencies]
 ckb-logger = { path = "../logger" }
 ckb-db = { path = "../../db" }
+ckb-util = { path = "../../util" }
+lazy_static = "1.4"
+crossbeam-channel = "0.3"
+heim = "0.0.10"
+futures = "0.3.1"
 
 # TODO Why don't disable this crate by "target.*" in the crates which are dependent on this crate?
 #
@@ -17,11 +22,10 @@ ckb-db = { path = "../../db" }
 # References:
 # - [Cargo Issue-1197: Target-specific features](https://github.com/rust-lang/cargo/issues/1197)
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
-heim = "0.0.10"
-futures = "0.3.1"
 jemalloc-ctl = "0.3.3"
 jemalloc-sys = "0.3.2"
 
 [features]
 default = []
 profiling = []
+disable-jemalloc = []

--- a/util/memory-tracker/src/collections/hash_map.rs
+++ b/util/memory-tracker/src/collections/hash_map.rs
@@ -1,0 +1,206 @@
+use std::{
+    borrow::Borrow,
+    collections::{
+        self as base,
+        hash_map::{Entry, IntoIter, Iter, IterMut, RandomState},
+    },
+    fmt,
+    hash::{BuildHasher, Hash},
+    ops,
+    sync::Arc,
+    time,
+};
+
+use ckb_logger::trace;
+
+use super::{MeasureRecord, TracedTag};
+
+#[derive(Clone)]
+pub struct HashMap<K, V, S = RandomState> {
+    tag: Arc<String>,
+    base: base::HashMap<K, V, S>,
+    interval: u64,
+    last_updated: time::Instant,
+}
+
+impl<K, V, S> HashMap<K, V, S> {
+    fn tag(&self) -> Arc<String> {
+        Arc::clone(&self.tag)
+    }
+
+    fn measure(&mut self) {
+        let record = MeasureRecord::HashMap {
+            len: self.len(),
+            cap: self.capacity(),
+        };
+        super::measure(self.tag(), record);
+        self.last_updated = time::Instant::now();
+    }
+
+    fn try_measure(&mut self) {
+        if self.last_updated.elapsed().as_secs() >= self.interval {
+            self.measure();
+        }
+    }
+}
+
+impl<K, V, S> HashMap<K, V, S>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    pub fn trace_n(&self, n: usize) {
+        let tag = self.tag();
+        let mut iter = self.base.iter();
+        for _ in 0..n {
+            if let Some((key, value)) = iter.next() {
+                trace!("map({})[{:?}] = [{:?}]", tag, key, value);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl<K: Hash + Eq, V> HashMap<K, V, RandomState> {
+    pub fn new() -> Self {
+        let mut ret = Self {
+            tag: TracedTag::current(),
+            base: base::HashMap::new(),
+            interval: crate::interval(),
+            last_updated: time::Instant::now(),
+        };
+        ret.measure();
+        ret
+    }
+}
+
+impl<K, V, S> Default for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn default() -> Self {
+        let mut ret = Self {
+            tag: TracedTag::current(),
+            base: base::HashMap::default(),
+            interval: crate::interval(),
+            last_updated: time::Instant::now(),
+        };
+        ret.measure();
+        ret
+    }
+}
+
+impl<K, V, S> From<HashMap<K, V, S>> for base::HashMap<K, V, S> {
+    fn from(map: HashMap<K, V, S>) -> Self {
+        map.base
+    }
+}
+
+impl<K, V, S> ops::Deref for HashMap<K, V, S> {
+    type Target = base::HashMap<K, V, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl<K, V, S> ops::DerefMut for HashMap<K, V, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.try_measure();
+        &mut self.base
+    }
+}
+
+impl<K, V, S> HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> HashMap<K, V, S> {
+        Self {
+            tag: TracedTag::current(),
+            base: base::HashMap::with_capacity_and_hasher(capacity, hash_builder),
+            interval: crate::interval(),
+            last_updated: time::Instant::now(),
+        }
+    }
+
+    pub fn entry(&mut self, k: K) -> Entry<'_, K, V> {
+        self.try_measure();
+        self.base.entry(k)
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        let tmp = self.base.insert(k, v);
+        self.try_measure();
+        tmp
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let tmp = self.base.remove(k);
+        self.try_measure();
+        tmp
+    }
+}
+
+impl<K, V, S> PartialEq for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: PartialEq,
+    S: BuildHasher,
+{
+    fn eq(&self, other: &HashMap<K, V, S>) -> bool {
+        self.base.eq(&other.base)
+    }
+}
+
+impl<K, V, S> Eq for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: Eq,
+    S: BuildHasher,
+{
+}
+
+impl<K, V, S> fmt::Debug for HashMap<K, V, S>
+where
+    K: Eq + Hash + fmt::Debug,
+    V: fmt::Debug,
+    S: BuildHasher,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.base, f)
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a HashMap<K, V, S> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    #[inline]
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a mut HashMap<K, V, S> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+    #[inline]
+    fn into_iter(self) -> IterMut<'a, K, V> {
+        self.iter_mut()
+    }
+}
+
+impl<K, V, S> IntoIterator for HashMap<K, V, S> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+    #[inline]
+    fn into_iter(self) -> IntoIter<K, V> {
+        self.base.into_iter()
+    }
+}

--- a/util/memory-tracker/src/collections/hash_set.rs
+++ b/util/memory-tracker/src/collections/hash_set.rs
@@ -1,0 +1,153 @@
+use super::{MeasureRecord, TracedTag};
+use std::{
+    borrow::Borrow,
+    collections::{self as base, hash_map::RandomState},
+    fmt,
+    hash::{BuildHasher, Hash},
+    ops,
+    sync::Arc,
+    time,
+};
+
+#[derive(Clone)]
+pub struct HashSet<T, S = RandomState> {
+    tag: Arc<String>,
+    base: base::HashSet<T, S>,
+    interval: u64,
+    last_updated: time::Instant,
+}
+
+impl<T, S> HashSet<T, S> {
+    fn tag(&self) -> Arc<String> {
+        Arc::clone(&self.tag)
+    }
+
+    fn measure(&mut self) {
+        let record = MeasureRecord::HashSet {
+            len: self.len(),
+            cap: self.capacity(),
+        };
+        super::measure(self.tag(), record);
+        self.last_updated = time::Instant::now();
+    }
+
+    fn try_measure(&mut self) {
+        if self.last_updated.elapsed().as_secs() >= self.interval {
+            self.measure();
+        }
+    }
+}
+
+impl<T: Hash + Eq> HashSet<T, RandomState> {
+    pub fn new() -> Self {
+        let mut ret = Self {
+            tag: TracedTag::current(),
+            base: base::HashSet::new(),
+            interval: crate::interval(),
+            last_updated: time::Instant::now(),
+        };
+        ret.measure();
+        ret
+    }
+}
+impl<T, S> Default for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn default() -> Self {
+        let mut ret = Self {
+            tag: TracedTag::current(),
+            base: base::HashSet::default(),
+            interval: crate::interval(),
+            last_updated: time::Instant::now(),
+        };
+        ret.measure();
+        ret
+    }
+}
+
+impl<T, S> From<HashSet<T, S>> for base::HashSet<T, S> {
+    fn from(set: HashSet<T, S>) -> Self {
+        set.base
+    }
+}
+
+impl<T, S> ops::Deref for HashSet<T, S> {
+    type Target = base::HashSet<T, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl<T, S> ops::DerefMut for HashSet<T, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.try_measure();
+        &mut self.base
+    }
+}
+
+impl<T, S> HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    pub fn insert(&mut self, value: T) -> bool {
+        let tmp = self.base.insert(value);
+        self.try_measure();
+        tmp
+    }
+
+    pub fn replace(&mut self, value: T) -> Option<T> {
+        let tmp = self.base.replace(value);
+        self.try_measure();
+        tmp
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let tmp = self.base.remove(value);
+        self.try_measure();
+        tmp
+    }
+
+    pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let tmp = self.base.take(value);
+        self.try_measure();
+        tmp
+    }
+}
+
+impl<T, S> PartialEq for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    fn eq(&self, other: &HashSet<T, S>) -> bool {
+        self.base.eq(&other.base)
+    }
+}
+
+impl<T, S> Eq for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
+impl<T, S> fmt::Debug for HashSet<T, S>
+where
+    T: Eq + Hash + fmt::Debug,
+    S: BuildHasher,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.base, f)
+    }
+}

--- a/util/memory-tracker/src/collections/mod.rs
+++ b/util/memory-tracker/src/collections/mod.rs
@@ -1,0 +1,78 @@
+use std::{collections::HashMap, sync::Arc};
+
+use ckb_logger::debug;
+use ckb_util::RwLock;
+use crossbeam_channel::Sender;
+
+mod hash_map;
+mod hash_set;
+
+pub use hash_map::HashMap as TracedHashMap;
+pub use hash_set::HashSet as TracedHashSet;
+
+pub enum MeasureRecord {
+    HashMap { len: usize, cap: usize },
+    HashSet { len: usize, cap: usize },
+}
+
+pub type MeasureRecordSender = Arc<RwLock<Option<Sender<(Arc<String>, MeasureRecord)>>>>;
+
+lazy_static::lazy_static! {
+    pub(crate) static ref STATISTICS: Arc<RwLock<HashMap<Arc<String>, MeasureRecord>>> = Default::default();
+    pub(crate) static ref MEASURE_SENDER: MeasureRecordSender = Arc::new(RwLock::new(None));
+    static ref TRACED_TAG: RwLock<Vec<&'static str>> = Default::default();
+    static ref DEFAULT_TAG: Arc<String> = Arc::new("not-set".to_owned());
+}
+
+pub fn measure(tag: Arc<String>, record: MeasureRecord) {
+    if crate::interval() > 0 {
+        let _ignore = MEASURE_SENDER
+            .read()
+            .as_ref()
+            .map(|sender| sender.send((tag, record)));
+    }
+}
+
+pub(crate) fn track_collections() {
+    let guard = (&*STATISTICS).read();
+    let mut stats = guard.iter().collect::<Vec<_>>();
+    stats.sort_by(|a, b| a.0.cmp(b.0));
+    for (tag, measure) in stats {
+        match measure {
+            MeasureRecord::HashMap { len, cap } => debug!(
+                "{:20} {{ tag: {:40}, len: {:8}, cap: {:8} }}",
+                "HashMap", tag, len, cap
+            ),
+            MeasureRecord::HashSet { len, cap } => debug!(
+                "{:20} {{ tag: {:40}, len: {:8}, cap: {:8} }}",
+                "HashSet", tag, len, cap
+            ),
+        };
+    }
+}
+
+pub struct TracedTag;
+
+impl TracedTag {
+    pub fn current() -> Arc<String> {
+        let tmp = (&*TRACED_TAG).read().join(".");
+        if tmp.is_empty() {
+            Arc::clone(&DEFAULT_TAG)
+        } else {
+            Arc::new(tmp)
+        }
+    }
+
+    pub fn push(tag: &'static str) {
+        (&*TRACED_TAG).write().push(tag);
+    }
+
+    pub fn replace_last(tag: &'static str) {
+        Self::pop();
+        Self::push(tag);
+    }
+
+    pub fn pop() {
+        (&*TRACED_TAG).write().pop();
+    }
+}

--- a/util/memory-tracker/src/jemalloc/mocked_statistics.rs
+++ b/util/memory-tracker/src/jemalloc/mocked_statistics.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+pub(super) struct JeMallocMIBs;
+
+pub(super) struct JeMallocMemoryStatistics;
+
+impl fmt::Display for JeMallocMemoryStatistics {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "JeMalloc: disabled")
+    }
+}
+
+impl JeMallocMIBs {
+    pub(super) fn initialize() -> Option<Self> {
+        None
+    }
+
+    pub(super) fn stats(&self) -> Option<JeMallocMemoryStatistics> {
+        None
+    }
+}

--- a/util/memory-tracker/src/jemalloc/mod.rs
+++ b/util/memory-tracker/src/jemalloc/mod.rs
@@ -1,0 +1,14 @@
+mod profiling;
+mod report;
+
+#[cfg(any(target_env = "msvc", target_os = "macos", feature = "disable-jemalloc"))]
+mod mocked_statistics;
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    not(feature = "disable-jemalloc")
+))]
+mod statistics;
+
+pub use profiling::jemalloc_profiling_dump;
+pub use report::{JeMallocMemoryReport, JeMallocReportHandle};

--- a/util/memory-tracker/src/jemalloc/profiling.rs
+++ b/util/memory-tracker/src/jemalloc/profiling.rs
@@ -1,7 +1,12 @@
-use ckb_logger::info;
-use std::{ffi, mem, ptr};
-
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    not(feature = "disable-jemalloc"),
+    feature = "profiling"
+))]
 pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {
+    use ckb_logger::info;
+    use std::{ffi, mem, ptr};
     let mut filename0 = format!("{}\0", filename);
     let opt_name = "prof.dump";
     let opt_c_name = ffi::CString::new(opt_name).unwrap();
@@ -17,4 +22,14 @@ pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(any(
+    target_env = "msvc",
+    target_os = "macos",
+    feature = "disable-jemalloc",
+    not(feature = "profiling")
+))]
+pub fn jemalloc_profiling_dump(_: &str) -> Result<(), String> {
+    Err("jemalloc profiling dump: unsupported".to_string())
 }

--- a/util/memory-tracker/src/jemalloc/report.rs
+++ b/util/memory-tracker/src/jemalloc/report.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    not(feature = "disable-jemalloc")
+))]
+use super::statistics::{JeMallocMIBs, JeMallocMemoryStatistics};
+
+#[cfg(any(target_env = "msvc", target_os = "macos", feature = "disable-jemalloc"))]
+use super::mocked_statistics::{JeMallocMIBs, JeMallocMemoryStatistics};
+
+pub struct JeMallocReportHandle {
+    mibs: Option<JeMallocMIBs>,
+}
+
+pub struct JeMallocMemoryReport {
+    stats: Option<JeMallocMemoryStatistics>,
+}
+
+impl fmt::Display for JeMallocMemoryReport {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref stats) = self.stats {
+            write!(f, "{}", stats)
+        } else {
+            write!(f, "JeMalloc {{ null }}")
+        }
+    }
+}
+
+impl JeMallocReportHandle {
+    pub fn initialize() -> Self {
+        Self {
+            mibs: JeMallocMIBs::initialize(),
+        }
+    }
+
+    pub fn report(&self) -> JeMallocMemoryReport {
+        self.mibs
+            .as_ref()
+            .and_then(JeMallocMIBs::stats)
+            .map(JeMallocMemoryReport::new)
+            .unwrap_or_else(JeMallocMemoryReport::null)
+    }
+}
+
+impl JeMallocMemoryReport {
+    fn new(stats: JeMallocMemoryStatistics) -> Self {
+        Self { stats: Some(stats) }
+    }
+
+    fn null() -> Self {
+        Self { stats: None }
+    }
+}

--- a/util/memory-tracker/src/jemalloc/statistics.rs
+++ b/util/memory-tracker/src/jemalloc/statistics.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+
+use ckb_logger::error;
+use jemalloc_ctl::{epoch, stats};
+
+use crate::utils::PropertyValue;
+
+macro_rules! init_mib {
+    ($key:ty) => {
+        <$key>::mib()
+            .map_err(|err| {
+                error!(
+                    "failed to lookup jemalloc mib for {}: {}",
+                    stringify!($key),
+                    err
+                );
+            })
+            .ok()
+    };
+}
+
+macro_rules! mib_read {
+    ($mib:expr) => {
+        match $mib.read() {
+            Ok(value) => PropertyValue::Value(value as u64),
+            Err(err) => {
+                let error = format!(
+                    "failed to read jemalloc stats for {}: {}",
+                    stringify!($mib),
+                    err
+                );
+                PropertyValue::Error(error)
+            }
+        }
+    };
+}
+
+// MIB: Management Information Base
+pub(super) struct JeMallocMIBs {
+    epoch: jemalloc_ctl::epoch_mib,
+    allocated: stats::allocated_mib,
+    resident: stats::resident_mib,
+    active: stats::active_mib,
+    mapped: stats::mapped_mib,
+    retained: stats::retained_mib,
+    metadata: stats::metadata_mib,
+}
+
+pub(super) struct JeMallocMemoryStatistics {
+    // Bytes allocated by the application.
+    allocated: PropertyValue<u64>,
+    // Bytes in physically resident data pages mapped by the allocator.
+    resident: PropertyValue<u64>,
+    // Bytes in active pages allocated by the application.
+    active: PropertyValue<u64>,
+    // Bytes in active extents mapped by the allocator.
+    mapped: PropertyValue<u64>,
+    // Bytes in virtual memory mappings that were retained
+    // rather than being returned to the operating system
+    retained: PropertyValue<u64>,
+    // Bytes dedicated to jemalloc metadata.
+    metadata: PropertyValue<u64>,
+}
+
+impl fmt::Display for JeMallocMemoryStatistics {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("JeMalloc")
+            .field("allocated", &self.allocated)
+            .field("resident", &self.resident)
+            .field("active", &self.active)
+            .field("mapped", &self.mapped)
+            .field("retained", &self.retained)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
+}
+
+impl JeMallocMIBs {
+    pub(super) fn initialize() -> Option<Self> {
+        Some(Self {
+            epoch: init_mib!(epoch)?,
+            allocated: init_mib!(stats::allocated)?,
+            resident: init_mib!(stats::resident)?,
+            active: init_mib!(stats::active)?,
+            mapped: init_mib!(stats::mapped)?,
+            retained: init_mib!(stats::retained)?,
+            metadata: init_mib!(stats::metadata)?,
+        })
+    }
+
+    pub(super) fn stats(&self) -> Option<JeMallocMemoryStatistics> {
+        self.epoch
+            .advance()
+            .map(|_| JeMallocMemoryStatistics {
+                allocated: mib_read!(self.allocated),
+                resident: mib_read!(self.resident),
+                active: mib_read!(self.active),
+                mapped: mib_read!(self.mapped),
+                retained: mib_read!(self.retained),
+                metadata: mib_read!(self.metadata),
+            })
+            .map_err(|err| {
+                error!("failed to refresh the jemalloc stats: {}", err);
+            })
+            .ok()
+    }
+}

--- a/util/memory-tracker/src/rocksdb.rs
+++ b/util/memory-tracker/src/rocksdb.rs
@@ -1,32 +1,47 @@
+use std::fmt;
+
 use ckb_db::internal::ops::{GetColumnFamilys, GetProperty, GetPropertyCF};
 use ckb_logger::trace;
 
-use crate::utils::{sum_int_values, PropertyValue};
+use crate::utils::{sum_sizes, PropertyValue, Size};
 
 // Ref: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+#[derive(Default, Clone)]
 pub struct RocksDBMemoryStatistics {
-    pub total_memory: PropertyValue<u64>,
-    pub block_cache_usage: PropertyValue<u64>,
-    pub estimate_table_readers_mem: PropertyValue<u64>,
-    pub cur_size_all_mem_tables: PropertyValue<u64>,
-    pub block_cache_pinned_usage: PropertyValue<u64>,
-    pub block_cache_capacity: PropertyValue<u64>,
+    pub(crate) total_memory: PropertyValue<Size>,
+    pub(crate) block_cache_usage: PropertyValue<Size>,
+    pub(crate) estimate_table_readers_mem: PropertyValue<Size>,
+    pub(crate) cur_size_all_mem_tables: PropertyValue<Size>,
+    pub(crate) block_cache_pinned_usage: PropertyValue<Size>,
+    pub(crate) block_cache_capacity: PropertyValue<Size>,
+}
+
+impl fmt::Display for RocksDBMemoryStatistics {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("RocksDB")
+            .field("total", &self.total_memory)
+            .field("cache", &self.block_cache_usage)
+            .field("readers", &self.estimate_table_readers_mem)
+            .field("memtables", &self.cur_size_all_mem_tables)
+            .field("pinned", &self.block_cache_pinned_usage)
+            .field("cache-capacity", &self.block_cache_capacity)
+            .finish()
+    }
 }
 
 pub trait TrackRocksDBMemory {
     fn gather_memory_stats(&self) -> RocksDBMemoryStatistics {
-        let block_cache_usage = self.gather_int_values("rocksdb.block-cache-usage");
-        let estimate_table_readers_mem =
-            self.gather_int_values("rocksdb.estimate-table-readers-mem");
-        let cur_size_all_mem_tables = self.gather_int_values("rocksdb.cur-size-all-mem-tables");
-        let block_cache_pinned_usage = self.gather_int_values("rocksdb.block-cache-pinned-usage");
-        let total_memory = sum_int_values(&[
+        let block_cache_usage = self.gather_sizes("rocksdb.block-cache-usage");
+        let estimate_table_readers_mem = self.gather_sizes("rocksdb.estimate-table-readers-mem");
+        let cur_size_all_mem_tables = self.gather_sizes("rocksdb.cur-size-all-mem-tables");
+        let block_cache_pinned_usage = self.gather_sizes("rocksdb.block-cache-pinned-usage");
+        let total_memory = sum_sizes(&[
             block_cache_usage.clone(),
             estimate_table_readers_mem.clone(),
             cur_size_all_mem_tables.clone(),
             block_cache_pinned_usage.clone(),
         ]);
-        let block_cache_capacity = self.gather_int_values("rocksdb.block-cache-capacity");
+        let block_cache_capacity = self.gather_sizes("rocksdb.block-cache-capacity");
         RocksDBMemoryStatistics {
             total_memory,
             block_cache_usage,
@@ -36,13 +51,13 @@ pub trait TrackRocksDBMemory {
             block_cache_capacity,
         }
     }
-    fn gather_int_values(&self, key: &str) -> PropertyValue<u64>;
+    fn gather_sizes(&self, key: &str) -> PropertyValue<Size>;
 }
 
 pub struct DummyRocksDB;
 
 impl TrackRocksDBMemory for DummyRocksDB {
-    fn gather_int_values(&self, _: &str) -> PropertyValue<u64> {
+    fn gather_sizes(&self, _: &str) -> PropertyValue<Size> {
         PropertyValue::Null
     }
 }
@@ -51,16 +66,25 @@ impl<RocksDB> TrackRocksDBMemory for RocksDB
 where
     RocksDB: GetColumnFamilys + GetProperty + GetPropertyCF,
 {
-    fn gather_int_values(&self, key: &str) -> PropertyValue<u64> {
+    fn gather_sizes(&self, key: &str) -> PropertyValue<Size> {
         let mut values = Vec::new();
+        let value_default = self
+            .property_int_value(key)
+            .map_err(|err| format!("{}", err))
+            .into();
+        trace!("{}(_): {}", key, value_default);
+        values.push(value_default);
         for (cf_name, cf) in self.get_cfs() {
             let value_col = self
                 .property_int_value_cf(cf, key)
                 .map_err(|err| format!("{}", err))
                 .into();
             trace!("{}({}): {}", key, cf_name, value_col);
+            if cf_name == "default" {
+                continue;
+            }
             values.push(value_col);
         }
-        sum_int_values(&values)
+        sum_sizes(&values)
     }
 }

--- a/util/memory-tracker/src/service.rs
+++ b/util/memory-tracker/src/service.rs
@@ -1,0 +1,97 @@
+use std::{fmt, sync, thread, time};
+
+use ckb_logger::{debug, error, info, trace};
+use crossbeam_channel::{select, unbounded};
+
+use crate::{
+    collections,
+    jemalloc::{JeMallocMemoryReport, JeMallocReportHandle},
+    process::{ProcessReport, ProcessTracker},
+    rocksdb::{RocksDBMemoryStatistics, TrackRocksDBMemory},
+};
+
+struct ComprehensiveReport {
+    process: ProcessReport,
+    jemalloc: JeMallocMemoryReport,
+    rocksdb: Option<RocksDBMemoryStatistics>,
+}
+
+impl fmt::Display for ComprehensiveReport {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, " process: {}", self.process)?;
+        write!(f, ", allocator: {}", self.jemalloc)?;
+        if let Some(ref stats) = self.rocksdb {
+            write!(f, ", database: {}", stats)?;
+        }
+        write!(f, " }}")
+    }
+}
+
+pub fn track_current_process<DBTracker: 'static + TrackRocksDBMemory + Sync + Send>(
+    interval: u64,
+    db_tracker_opt: Option<sync::Arc<DBTracker>>,
+) {
+    if interval == 0 {
+        info!("track current process: disable");
+        return;
+    }
+
+    info!(
+        "track current process: enable (interval: {} seconds)",
+        interval
+    );
+    crate::set_interval(interval);
+    let wait_secs = time::Duration::from_secs(interval);
+
+    let (sender, receiver) = unbounded();
+    collections::MEASURE_SENDER.write().replace(sender);
+
+    let jemalloc_handle = JeMallocReportHandle::initialize();
+
+    let thread_res = thread::Builder::new()
+        .name("MemoryTracker".to_string())
+        .spawn(move || {
+            trace!("MemoryTracker is running ...");
+
+            let process_tracker = ProcessTracker::initialize();
+
+            let mut now = time::Instant::now();
+            loop {
+                if now.elapsed().as_secs() >= interval {
+                    now = time::Instant::now();
+
+                    let jemalloc_report = jemalloc_handle.report();
+                    let process_report = process_tracker.report();
+                    let rocksdb_report_opt =
+                        db_tracker_opt.as_ref().map(|t| t.gather_memory_stats());
+
+                    let full_report = ComprehensiveReport {
+                        jemalloc: jemalloc_report,
+                        process: process_report,
+                        rocksdb: rocksdb_report_opt,
+                    };
+
+                    debug!("{}", full_report);
+
+                    collections::track_collections();
+                }
+                select! {
+                    recv(receiver) -> item => {
+                        if let Ok((tag, record)) = item {
+                            collections::STATISTICS.write().insert(tag, record);
+                        }
+                    }
+                    default(wait_secs) => {
+                    }
+                }
+            }
+        });
+
+    if let Err(err) = thread_res {
+        error!(
+            "failed to spawn the thread to track current process: {}",
+            err
+        );
+    }
+}

--- a/util/memory-tracker/src/utils.rs
+++ b/util/memory-tracker/src/utils.rs
@@ -1,10 +1,33 @@
 use std::fmt;
 
+#[derive(Clone, Copy)]
+pub struct Size(u64);
+
+#[derive(Clone, Copy)]
 pub enum HumanReadableSize {
     Bytes(u64),
     KiBytes(f64),
     MiBytes(f64),
     GiBytes(f64),
+}
+
+#[derive(Clone)]
+pub enum PropertyValue<T> {
+    Value(T),
+    Null,
+    Error(String),
+}
+
+impl fmt::Display for Size {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", HumanReadableSize::from(*self))
+    }
+}
+
+impl From<u64> for Size {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
 }
 
 impl fmt::Display for HumanReadableSize {
@@ -18,8 +41,9 @@ impl fmt::Display for HumanReadableSize {
     }
 }
 
-impl From<u64> for HumanReadableSize {
-    fn from(v: u64) -> Self {
+impl From<Size> for HumanReadableSize {
+    fn from(sz: Size) -> Self {
+        let v = sz.0;
         match v {
             _ if v < 1024 => Self::Bytes(v),
             _ if v < 1024 * 1024 => Self::KiBytes((v as f64) / 1024.0),
@@ -29,41 +53,64 @@ impl From<u64> for HumanReadableSize {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum PropertyValue<T> {
-    Value(T),
-    Null,
-    Error(String),
-}
-
-impl fmt::Display for PropertyValue<u64> {
+impl<T> fmt::Display for PropertyValue<T>
+where
+    T: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Value(v) => write!(f, "{}", HumanReadableSize::from(*v)),
+            Self::Value(v) => write!(f, "{}", v),
             Self::Null => write!(f, "null"),
             Self::Error(_) => write!(f, "err"),
         }
     }
 }
 
-impl<T> From<Result<Option<T>, String>> for PropertyValue<T> {
-    fn from(res: Result<Option<T>, String>) -> Self {
+impl<T> fmt::Debug for PropertyValue<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self, f)
+    }
+}
+
+impl<T> Default for PropertyValue<T> {
+    fn default() -> Self {
+        Self::Null
+    }
+}
+
+impl<T, V> From<Result<Option<V>, String>> for PropertyValue<T>
+where
+    V: Into<T>,
+{
+    fn from(res: Result<Option<V>, String>) -> Self {
         match res {
-            Ok(Some(v)) => Self::Value(v),
+            Ok(Some(v)) => Self::Value(v.into()),
             Ok(None) => Self::Null,
             Err(e) => Self::Error(e),
         }
     }
 }
 
-pub fn sum_int_values(values: &[PropertyValue<u64>]) -> PropertyValue<u64> {
+impl<T> PropertyValue<T> {
+    pub fn new<V>(v: V) -> Self
+    where
+        V: Into<T>,
+    {
+        Self::Value(v.into())
+    }
+}
+
+pub fn sum_sizes(values: &[PropertyValue<Size>]) -> PropertyValue<Size> {
     let mut total = 0;
     let mut errors = 0;
     let mut nulls = 0;
     for value in values {
         match value {
             PropertyValue::Value(v) => {
-                total += v;
+                total += v.0;
             }
             PropertyValue::Null => {
                 nulls += 1;
@@ -76,6 +123,6 @@ pub fn sum_int_values(values: &[PropertyValue<u64>]) -> PropertyValue<u64> {
     if errors > 0 || nulls > 0 {
         PropertyValue::Error(format!("{} errors, {} nulls", errors, nulls))
     } else {
-        PropertyValue::Value(total)
+        PropertyValue::new(total)
     }
 }


### PR DESCRIPTION
### Brief

Rebase from the closed #1927, but remove the feature `measure-collections`.
So, **the operations of tracing those data structures will always exist**.

But if you set `[memory_tracker] interval = 0`, the statistics will be ignore as soon as possible.

```rust
pub fn measure(tag: Arc<String>, record: MeasureRecord) {
    if crate::interval() > 0 {
        // ... send the record to the collector thread ....
    }
}
```

### Features

- There are many data structures (mostly `HashMap`) to store states in memory. Some of them have no size limit.
  This PR add a logs to trace the size of these data structures, so that we can analyze them.
  I find #2145 with this function.

- **[NEW!]** Before this PR, the whole memory tracker function was disabled in Windows and MacOS.
  In this PR, I split those statistics into four parts: process (1), jemalloc (2), rocksdb (3), collections (4).
  In Linux , all of them are enabled, otherwise only 1, 3 and 4 enabled.

- Can trace `HeaderMap` in #2147 via the follow struct:
  ```rust
  MeasureRecord::SpooledHashMapWithRocksDB {
      mem_len: usize,
      mem_cap: usize,
      disk_cnt: usize,
      db_stats: RocksDBMemoryStatistics,
  },
  ```