### PR TITLE
improvement: reduce times of querying header map

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -88,7 +88,7 @@ impl<'a> CompactBlockProcess<'a> {
         if status.contains(BlockStatus::BLOCK_STORED) {
             // update last common header and best known
             let parent = shared
-                .get_header_view(&header.data().raw().parent_hash())
+                .get_header_view(&header.data().raw().parent_hash(), Some(true))
                 .expect("parent block must exist");
             let header_view = {
                 let total_difficulty = parent.total_difficulty() + header.difficulty();
@@ -103,7 +103,8 @@ impl<'a> CompactBlockProcess<'a> {
             return StatusCode::BlockIsInvalid.with_context(block_hash);
         }
 
-        let parent = shared.get_header_view(&header.data().raw().parent_hash());
+        let store_first = tip.number() + 1 >= header.number();
+        let parent = shared.get_header_view(&header.data().raw().parent_hash(), Some(store_first));
         if parent.is_none() {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
@@ -157,7 +158,7 @@ impl<'a> CompactBlockProcess<'a> {
                             .map(|(compact_block, _)| compact_block.header().into_view())
                             .or_else(|| {
                                 shared
-                                    .get_header_view(&block_hash)
+                                    .get_header_view(&block_hash, None)
                                     .map(|header_view| header_view.into_inner())
                             })
                     }

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -338,12 +338,13 @@ where
 
         // FIXME If status == BLOCK_INVALID then return early. But which error
         // type should we return?
-        if self
-            .active_chain
-            .contains_block_status(&self.header.hash(), BlockStatus::HEADER_VALID)
-        {
+        let status = self.active_chain.get_block_status(&self.header.hash());
+        if status.contains(BlockStatus::HEADER_VALID) {
             let header_view = shared
-                .get_header_view(&self.header.hash())
+                .get_header_view(
+                    &self.header.hash(),
+                    Some(status.contains(BlockStatus::BLOCK_STORED)),
+                )
                 .expect("header with HEADER_VALID should exist");
             state
                 .peers()


### PR DESCRIPTION
I added some log outputs when do tests, I got the follow results:

- Sync chain from height `0` to `tip`:
  - If always query the header map first.
    - Query the header map first but not found: about `tip/2 ~ tip` times (mark as `x`)
    - If not found in the header map, it must be in the store.
  - If query header from store first when the block in that height was already inserted into the chain database.
    - Query the header map first but not found: about `tip/4 ~ tip/6` times (mark as `y`)
    - Query the store first but not found: `0`
- The result of my last test: `tip = 2_230_953; x = 1_179_787; y = 552_325`