### PR TITLE
pref: change storage molecule table to struct

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,4 @@
+mod migrations;
 pub mod shared;
 
 pub use ckb_snapshot::{Snapshot, SnapshotMgr};

--- a/shared/src/migrations.rs
+++ b/shared/src/migrations.rs
@@ -1,0 +1,54 @@
+use ckb_db::{Migration, Result, RocksDB};
+use ckb_store::{
+    COLUMN_BLOCK_HEADER, COLUMN_EPOCH, COLUMN_META, COLUMN_TRANSACTION_INFO, COLUMN_UNCLES,
+    META_CURRENT_EPOCH_KEY,
+};
+
+pub struct ChangeMoleculeTableToStruct;
+
+impl Migration for ChangeMoleculeTableToStruct {
+    fn migrate(&self, db: &RocksDB) -> Result<()> {
+        let txn = db.transaction();
+
+        let header_view_migration = |key: &[u8], value: &[u8]| -> Result<()> {
+            // (1 total size field + 2 fields) * 4 byte per field
+            txn.put(COLUMN_BLOCK_HEADER, key, &value[12..])?;
+            Ok(())
+        };
+        db.traverse(COLUMN_BLOCK_HEADER, header_view_migration)?;
+
+        let uncles_migration = |key: &[u8], value: &[u8]| -> Result<()> {
+            // (1 total size field + 2 fields) * 4 byte per field
+            txn.put(COLUMN_UNCLES, key, &value[12..])?;
+            Ok(())
+        };
+        db.traverse(COLUMN_UNCLES, uncles_migration)?;
+
+        let transaction_info_migration = |key: &[u8], value: &[u8]| -> Result<()> {
+            // (1 total size field + 3 fields) * 4 byte per field
+            txn.put(COLUMN_TRANSACTION_INFO, key, &value[16..])?;
+            Ok(())
+        };
+        db.traverse(COLUMN_TRANSACTION_INFO, transaction_info_migration)?;
+
+        let epoch_ext_migration = |key: &[u8], value: &[u8]| -> Result<()> {
+            // COLUMN_EPOCH stores epoch_number => last_block_hash_in_previous_epoch and last_block_hash_in_previous_epoch => epoch_ext
+            // only migrates epoch_ext
+            if key.len() == 32 {
+                // (1 total size field + 8 fields) * 4 byte per field
+                txn.put(COLUMN_EPOCH, key, &value[36..])?;
+            }
+            Ok(())
+        };
+        db.traverse(COLUMN_EPOCH, epoch_ext_migration)?;
+        if let Some(current_epoch) = txn.get(COLUMN_META, META_CURRENT_EPOCH_KEY)? {
+            txn.put(COLUMN_META, META_CURRENT_EPOCH_KEY, &current_epoch[36..])?;
+        }
+
+        txn.commit()
+    }
+
+    fn version(&self) -> &str {
+        "20200703124523"
+    }
+}

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -1,4 +1,4 @@
-use crate::{Snapshot, SnapshotMgr};
+use crate::{migrations, Snapshot, SnapshotMgr};
 use arc_swap::Guard;
 use ckb_app_config::{BlockAssemblerConfig, DBConfig, NotifyConfig, StoreConfig, TxPoolConfig};
 use ckb_chain_spec::consensus::Consensus;
@@ -229,6 +229,7 @@ impl SharedBuilder {
     pub fn with_db_config(config: &DBConfig) -> Self {
         let mut migrations = Migrations::default();
         migrations.add_migration(Box::new(DefaultMigration::new(INIT_DB_VERSION)));
+        migrations.add_migration(Box::new(migrations::ChangeMoleculeTableToStruct));
 
         let db = RocksDB::open(config, COLUMNS, migrations);
         SharedBuilder {

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -27,5 +27,5 @@ pub const COLUMN_EPOCH: Col = "9";
 pub const COLUMN_CELL_SET: Col = "10";
 pub const COLUMN_UNCLES: Col = "11";
 
-const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
-const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";
+pub const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";
+pub const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -24,7 +24,7 @@ vector OutPointVec <OutPoint>;
 
 /* Types for Storage */
 
-table HeaderView {
+struct HeaderView {
     hash:               Byte32,
     data:               Header,
 }
@@ -48,7 +48,7 @@ table BlockExt {
     verified:           BoolOpt,
 }
 
-table EpochExt {
+struct EpochExt {
     previous_epoch_hash_rate:           Uint256,
     last_block_hash_in_previous_epoch:  Byte32,
     compact_target:                     Uint32,
@@ -64,7 +64,7 @@ struct TransactionKey {
     index:          BeUint32,
 }
 
-table TransactionInfo {
+struct TransactionInfo {
     block_number:   Uint64,
     block_epoch:    Uint64,
     key:            TransactionKey,


### PR DESCRIPTION
storage structs `HeaderView`, `EpochExt` and `TransactionInfo` are fixed size, we should use molecule `struct` instead of `table`, it reduces storage size and improves the performance a little bit.

run a simple test with `ckb replay --profile 1 20000 --tmp-target /tmp` on my local pc:
```
before: avg 37.2 sec
after: avg 36.1 sec
```

f.y.i, this migration took 15 ~ 20 sec to finish on my local pc with current tip number, I think it's acceptable.
 