### PR TITLE
fix: panic if db options is empty

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -64,8 +64,9 @@ impl RocksDB {
                 }
             })?;
 
-        if let Some(db_opt) = config.options.as_ref() {
-            let rocksdb_options: Vec<(&str, &str)> = db_opt
+        if !config.options.is_empty() {
+            let rocksdb_options: Vec<(&str, &str)> = config
+                .options
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
@@ -179,11 +180,24 @@ mod tests {
             .unwrap();
         let config = DBConfig {
             path: tmp_dir.as_ref().to_path_buf(),
-            options: Some({
+            options: {
                 let mut opts = HashMap::new();
                 opts.insert("disable_auto_compactions".to_owned(), "true".to_owned());
                 opts
-            }),
+            },
+        };
+        RocksDB::open(&config, 2); // no panic
+    }
+
+    #[test]
+    fn test_set_rocksdb_options_empty() {
+        let tmp_dir = tempfile::Builder::new()
+            .prefix("test_set_rocksdb_options_empty")
+            .tempdir()
+            .unwrap();
+        let config = DBConfig {
+            path: tmp_dir.as_ref().to_path_buf(),
+            options: HashMap::new(),
         };
         RocksDB::open(&config, 2); // no panic
     }
@@ -197,11 +211,11 @@ mod tests {
             .unwrap();
         let config = DBConfig {
             path: tmp_dir.as_ref().to_path_buf(),
-            options: Some({
+            options: {
                 let mut opts = HashMap::new();
                 opts.insert("letsrock".to_owned(), "true".to_owned());
                 opts
-            }),
+            },
         };
         RocksDB::open(&config, 2); // panic
     }

--- a/util/app-config/src/configs/db.rs
+++ b/util/app-config/src/configs/db.rs
@@ -6,5 +6,6 @@ use std::path::PathBuf;
 pub struct Config {
     #[serde(default)]
     pub path: PathBuf,
-    pub options: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub options: HashMap<String, String>,
 }


### PR DESCRIPTION
Append `[db.options]` to `ckb.toml` and don't add any options, then `ckb run -C .` will panic since:
- In `rust-rocksdb`:
https://github.com/nervosnetwork/ckb/blob/32042c81f1ec4fdaf7358b63dc2417d9363d9944/db/src/db.rs#L72-L74
- In [`rocksdb::db/c.cc::rocksdb_set_options(..)`](https://github.com/facebook/rocksdb/blob/a9a973869afd987a6b728b833b2896dbb38bc02f/db/c.cc#L2216-L2217)
  ```c++
          SaveError(errptr,
              db->rep->SetOptions(options_map));
  ```
- In [`rocksdb::db/db_impl/db_impl.cc::SetOptions(..)`](
https://github.com/facebook/rocksdb/blob/a9a973869afd987a6b728b833b2896dbb38bc02f/db/db_impl/db_impl.cc#L951-L956)
  ```c++
    if (options_map.empty()) {
      ROCKS_LOG_WARN(immutable_db_options_.info_log,
                     "SetOptions() on column family [%s], empty input",
                     cfd->GetName().c_str());
      return Status::InvalidArgument("empty input");
    }
  ```
