### PR TITLE
chore: remove unused fn from `DataLoader` trait

### DIFF
--- a/script/data-loader/src/lib.rs
+++ b/script/data-loader/src/lib.rs
@@ -1,6 +1,6 @@
 use ckb_types::{
     bytes::Bytes,
-    core::{cell::CellMeta, BlockExt, EpochExt, HeaderView},
+    core::{cell::CellMeta, HeaderView},
     packed::Byte32,
 };
 
@@ -9,10 +9,7 @@ use ckb_types::{
 pub trait DataLoader {
     // load cell data and its hash
     fn load_cell_data(&self, cell: &CellMeta) -> Option<(Bytes, Byte32)>;
-    // load BlockExt
-    fn get_block_ext(&self, block_hash: &Byte32) -> Option<BlockExt>;
-    // load block EpochExt
-    fn get_block_epoch(&self, block_hash: &Byte32) -> Option<EpochExt>;
+
     // load Header
     fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView>;
 }

--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -183,13 +183,12 @@ mod tests {
     use ckb_types::{
         bytes::Bytes,
         core::{
-            cell::CellMeta, BlockExt, Capacity, EpochExt, HeaderBuilder, HeaderView,
+            cell::CellMeta, Capacity, EpochNumberWithFraction, HeaderBuilder, HeaderView,
             ScriptHashType, TransactionBuilder,
         },
         packed::{Byte32, CellOutput, OutPoint, Script, ScriptBuilder},
         prelude::*,
-        utilities::DIFF_TWO,
-        H256, U256,
+        H256,
     };
     use ckb_vm::machine::DefaultCoreMachine;
     use ckb_vm::{
@@ -560,21 +559,14 @@ mod tests {
 
     struct MockDataLoader {
         headers: HashMap<Byte32, HeaderView>,
-        epochs: HashMap<Byte32, EpochExt>,
     }
 
     impl DataLoader for MockDataLoader {
         fn load_cell_data(&self, _cell: &CellMeta) -> Option<(Bytes, Byte32)> {
             None
         }
-        fn get_block_ext(&self, _block_hash: &Byte32) -> Option<BlockExt> {
-            None
-        }
         fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {
             self.headers.get(block_hash).cloned()
-        }
-        fn get_block_epoch(&self, block_hash: &Byte32) -> Option<EpochExt> {
-            self.epochs.get(block_hash).cloned()
         }
     }
 
@@ -600,10 +592,7 @@ mod tests {
 
         let mut headers = HashMap::default();
         headers.insert(header.hash(), header.clone());
-        let data_loader = MockDataLoader {
-            headers,
-            epochs: HashMap::default(),
-        };
+        let data_loader = MockDataLoader { headers };
         let header_deps = vec![header.hash()];
         let resolved_inputs = vec![];
         let resolved_cell_deps = vec![];
@@ -655,32 +644,22 @@ mod tests {
         machine.set_register(A2, 0); // offset
         machine.set_register(A3, 0); //index
         machine.set_register(A4, u64::from(Source::Transaction(SourceEntry::HeaderDep))); //source: 4 header
+        machine.set_register(A5, HeaderField::EpochNumber as u64);
         machine.set_register(A7, LOAD_HEADER_BY_FIELD_SYSCALL_NUMBER); // syscall number
 
         let data_hash: H256 = blake2b_256(&data).into();
         let header = HeaderBuilder::default()
             .transactions_root(data_hash.pack())
-            .build();
-
-        let epoch = EpochExt::new_builder()
-            .number(u64::from(data[0]))
-            .base_block_reward(Capacity::bytes(100).unwrap())
-            .remainder_reward(Capacity::bytes(100).unwrap())
-            .previous_epoch_hash_rate(U256::one())
-            .last_block_hash_in_previous_epoch(Byte32::default())
-            .start_number(1234)
-            .length(1000)
-            .compact_target(DIFF_TWO)
+            .number(2000.pack())
+            .epoch(EpochNumberWithFraction::new(1, 40, 1000).pack())
             .build();
 
         let mut correct_data = [0u8; 8];
-        LittleEndian::write_u64(&mut correct_data, epoch.number());
+        LittleEndian::write_u64(&mut correct_data, 1);
 
         let mut headers = HashMap::default();
         headers.insert(header.hash(), header.clone());
-        let mut epochs = HashMap::default();
-        epochs.insert(header.hash(), epoch);
-        let data_loader = MockDataLoader { headers, epochs };
+        let data_loader = MockDataLoader { headers };
         let header_deps = vec![header.hash()];
         let resolved_inputs = vec![];
         let resolved_cell_deps = vec![];
@@ -706,12 +685,6 @@ mod tests {
             Ok(correct_data.len() as u64)
         );
 
-        for (i, addr) in (addr..addr + correct_data.len() as u64).enumerate() {
-            prop_assert_eq!(
-                machine.memory_mut().load8(&addr),
-                Ok(u64::from(correct_data[i]))
-            );
-        }
         Ok(())
     }
 

--- a/store/src/data_loader_wrapper.rs
+++ b/store/src/data_loader_wrapper.rs
@@ -2,7 +2,7 @@ use crate::ChainStore;
 use ckb_script_data_loader::DataLoader;
 use ckb_types::{
     bytes::Bytes,
-    core::{cell::CellMeta, BlockExt, EpochExt, HeaderView},
+    core::{cell::CellMeta, HeaderView},
     packed::Byte32,
     prelude::*,
 };
@@ -23,15 +23,6 @@ impl<'a, T: ChainStore<'a>> DataLoader for DataLoaderWrapper<'a, T> {
                 self.0
                     .get_cell_data(&cell.out_point.tx_hash(), cell.out_point.index().unpack())
             })
-    }
-    // load BlockExt
-    #[inline]
-    fn get_block_ext(&self, block_hash: &Byte32) -> Option<BlockExt> {
-        self.0.get_block_ext(block_hash)
-    }
-
-    fn get_block_epoch(&self, block_hash: &Byte32) -> Option<EpochExt> {
-        self.0.get_block_epoch(block_hash)
     }
 
     fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {


### PR DESCRIPTION
`get_block_ext` fn is unused and epoch related information should be loaded via header's epoch field, cleanup code and tweak unit test.