### PR TITLE
feat: set non dynamic options for rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "ckb-resource",
  "ckb-types",
  "clap",
+ "num_cpus",
  "path-clean",
  "rand 0.6.5",
  "sentry",
@@ -489,6 +490,7 @@ dependencies = [
  "ckb-rocksdb",
  "libc",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -12,3 +12,6 @@ ckb-error = { path = "../error" }
 tempfile = "3.0"
 libc = "0.2"
 rocksdb = { package = "ckb-rocksdb", version = "=0.13.0", features = ["snappy"] }
+
+[dev-dependencies]
+toml = "0.5"

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -8,6 +8,9 @@ use rocksdb::{
     ffi, ColumnFamily, DBPinnableSlice, IteratorMode, OptimisticTransactionDB,
     OptimisticTransactionOptions, Options, WriteOptions,
 };
+use std::collections::HashMap;
+use std::result::Result as StdResult;
+use std::str::FromStr;
 use std::sync::Arc;
 
 pub const VERSION_KEY: &str = "db-version";
@@ -17,9 +20,135 @@ pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,
 }
 
+trait RocksDBOptionsConversion: Sized {
+    fn convert(value_str: &str) -> StdResult<Self, ()>;
+}
+
+impl<T> RocksDBOptionsConversion for T
+where
+    T: FromStr,
+{
+    fn convert(s: &str) -> StdResult<Self, ()> {
+        Self::from_str(s).map_err(|_| ())
+    }
+}
+
+macro_rules! set_option {
+    ($opts:ident, $map:ident, $func:ident, $key:literal, $type:ty) => {
+        if let Some(value) = $map.remove($key) {
+            let v: $type = RocksDBOptionsConversion::convert(&value).map_err(|_| {
+                internal_error(format!(
+                    "failed to parse value of database option \"{}\"",
+                    $key
+                ))
+            })?;
+            $opts.$func(v);
+        }
+    };
+}
+
+// Load options which are not dynamically changeable through SetDBOptions() API.
+fn load_non_dynamic_options(t: &mut HashMap<String, String>) -> Result<Options> {
+    let mut o = Options::default();
+    set_option!(o, t, increase_parallelism, "total_threads", i32);
+    set_option!(
+        o,
+        t,
+        optimize_level_style_compaction,
+        "memtable_memory_budget",
+        usize
+    );
+    set_option!(o, t, set_max_open_files, "max_open_files", i32);
+    set_option!(
+        o,
+        t,
+        set_compaction_readahead_size,
+        "compaction_readahead_size",
+        usize
+    );
+    set_option!(o, t, set_use_fsync, "use_fsync", bool);
+    set_option!(o, t, set_bytes_per_sync, "bytes_per_sync", u64);
+    set_option!(
+        o,
+        t,
+        set_allow_concurrent_memtable_write,
+        "allow_concurrent_memtable_write",
+        bool
+    );
+    set_option!(o, t, set_use_direct_reads, "use_direct_reads", bool);
+    set_option!(
+        o,
+        t,
+        set_use_direct_io_for_flush_and_compaction,
+        "use_direct_io_for_flush_and_compaction",
+        bool
+    );
+    set_option!(
+        o,
+        t,
+        set_table_cache_num_shard_bits,
+        "table_cache_numshardbits",
+        i32
+    );
+    set_option!(
+        o,
+        t,
+        set_min_write_buffer_number,
+        "min_write_buffer_number",
+        i32
+    );
+    set_option!(
+        o,
+        t,
+        set_max_manifest_file_size,
+        "max_manifest_file_size",
+        usize
+    );
+    set_option!(
+        o,
+        t,
+        set_max_background_compactions,
+        "max_background_compactions",
+        i32
+    );
+    set_option!(
+        o,
+        t,
+        set_max_background_flushes,
+        "max_background_flushes",
+        i32
+    );
+    set_option!(
+        o,
+        t,
+        set_stats_dump_period_sec,
+        "stats_dump_period_sec",
+        u32
+    );
+    set_option!(
+        o,
+        t,
+        set_advise_random_on_open,
+        "advise_random_on_open",
+        bool
+    );
+    set_option!(
+        o,
+        t,
+        set_skip_stats_update_on_db_open,
+        "skip_stats_update_on_db_open",
+        bool
+    );
+    set_option!(o, t, set_keep_log_file_num, "keep_log_file_num", usize);
+    set_option!(o, t, set_allow_mmap_writes, "allow_mmap_writes", bool);
+    set_option!(o, t, set_allow_mmap_reads, "allow_mmap_reads", bool);
+    Ok(o)
+}
+
 impl RocksDB {
     pub(crate) fn open_with_check(config: &DBConfig, columns: u32) -> Result<Self> {
-        let mut opts = Options::default();
+        let mut dyn_opts = config.options.clone();
+        let mut opts = load_non_dynamic_options(&mut dyn_opts)?;
         opts.create_if_missing(false);
         opts.create_missing_column_families(true);
 
@@ -64,9 +193,8 @@ impl RocksDB {
                 }
             })?;
 
-        if !config.options.is_empty() {
-            let rocksdb_options: Vec<(&str, &str)> = config
-                .options
+        if !dyn_opts.is_empty() {
+            let rocksdb_options: Vec<(&str, &str)> = dyn_opts
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
@@ -178,13 +306,42 @@ mod tests {
             .prefix("test_set_rocksdb_options")
             .tempdir()
             .unwrap();
+        let options: HashMap<String, String> = toml::from_str(
+            r#"
+                memtable_memory_budget = "536870912"
+                total_threads = "16"
+                max_open_files = "-1"
+                compaction_readahead_size = "0"
+                use_fsync = "false"
+                bytes_per_sync = "0"
+                allow_concurrent_memtable_write = "true"
+                use_direct_reads = "false"
+                use_direct_io_for_flush_and_compaction = "false"
+                table_cache_numshardbits = "6"
+                max_write_buffer_number = "10"
+                write_buffer_size = "67108864"
+                max_bytes_for_level_base = "268435456"
+                max_bytes_for_level_multiplier = "10"
+                max_manifest_file_size = "1073741824"
+                target_file_size_base = "67108864"
+                level0_file_num_compaction_trigger = "4"
+                level0_slowdown_writes_trigger = "20"
+                level0_stop_writes_trigger = "24"
+                max_background_compactions = "1"
+                max_background_flushes = "-1"
+                disable_auto_compactions = "false"
+                stats_dump_period_sec = "600"
+                advise_random_on_open = "true"
+                skip_stats_update_on_db_open = "false"
+                keep_log_file_num = "1000"
+                allow_mmap_writes = "false"
+                allow_mmap_reads = "false"
+            "#,
+        )
+        .unwrap();
         let config = DBConfig {
             path: tmp_dir.as_ref().to_path_buf(),
-            options: {
-                let mut opts = HashMap::new();
-                opts.insert("disable_auto_compactions".to_owned(), "true".to_owned());
-                opts
-            },
+            options,
         };
         RocksDB::open(&config, 2); // no panic
     }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -22,6 +22,7 @@ ckb-types = { path = "../types" }
 ckb-fee-estimator = { path = "../fee-estimator" }
 p2p = { version="0.3.0-alpha.4", package="tentacle", features = ["molc"] }
 rand = "0.6"
+num_cpus = "1.10"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -155,6 +155,7 @@ impl AppConfig {
 impl CKBAppConfig {
     fn derive_options(mut self, root_dir: &Path, subcommand_name: &str) -> Result<Self, ExitCode> {
         self.data_dir = canonicalize_data_dir(self.data_dir, root_dir)?;
+        self.db.set_default_for_empty_options();
 
         if subcommand_name == cli::CMD_RESET_DATA {
             self.db.path = self.data_dir.join("db");

--- a/util/app-config/src/configs/db.rs
+++ b/util/app-config/src/configs/db.rs
@@ -9,3 +9,14 @@ pub struct Config {
     #[serde(default)]
     pub options: HashMap<String, String>,
 }
+
+impl Config {
+    pub fn set_default_for_empty_options(&mut self) {
+        self.set_option_if_empty("total_threads", num_cpus::get().to_string());
+        self.set_option_if_empty("write_buffer_size", format!("{}", 16 << 20));
+    }
+
+    fn set_option_if_empty(&mut self, key: &str, value: String) {
+        self.options.entry(key.to_owned()).or_insert(value);
+    }
+}


### PR DESCRIPTION
- Not all options are dynamically changeable through `SetDBOptions()` API.
  So, set some of those options before open the RocksDB.
- Add a function `set_default_for_empty_options` to set a better initial value for options if no customize value was provided.