### PR TITLE
refactor: Improve error when submitting block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "ckb-hash",
  "ckb-types",
  "eaglesong",
+ "log 0.4.11",
  "serde",
 ]
 

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -11,3 +11,4 @@ ckb-types = { path = "../util/types" }
 ckb-hash = { path = "../util/hash"}
 serde = { version = "1.0", features = ["derive"] }
 eaglesong = "0.1"
+log = "0.4"

--- a/pow/src/eaglesong.rs
+++ b/pow/src/eaglesong.rs
@@ -1,6 +1,8 @@
 use super::PowEngine;
 use ckb_types::{packed::Header, prelude::*, utilities::compact_to_target, U256};
 use eaglesong::eaglesong;
+use log::Level::Debug;
+use log::{debug, log_enabled};
 
 pub struct EaglesongPowEngine;
 
@@ -14,10 +16,43 @@ impl PowEngine for EaglesongPowEngine {
         let (block_target, overflow) = compact_to_target(header.raw().compact_target().unpack());
 
         if block_target.is_zero() || overflow {
+            debug!(
+                "compact_target is invalid: {:#x}",
+                header.raw().compact_target()
+            );
             return false;
         }
 
         if U256::from_big_endian(&output[..]).expect("bound checked") > block_target {
+            if log_enabled!(Debug) {
+                use ckb_types::bytes::Bytes;
+                debug!(
+                    "PowEngine::verify error: expected target {:#x}, got {:#x}",
+                    block_target,
+                    U256::from_big_endian(&output[..]).unwrap()
+                );
+
+                debug!(
+                    "PowEngine::verify error: header raw 0x{:x}",
+                    &header.raw().as_bytes()
+                );
+                debug!(
+                    "PowEngine::verify error: pow hash {:#x}",
+                    &header.as_reader().calc_pow_hash()
+                );
+                debug!(
+                    "PowEngine::verify error: nonce {:#x}",
+                    header.nonce().unpack()
+                );
+                debug!(
+                    "PowEngine::verify error: pow input: 0x{:x}",
+                    Bytes::from(input.to_vec())
+                );
+                debug!(
+                    "PowEngine::verify error: pow output: 0x{:x}",
+                    Bytes::from(output.to_vec())
+                );
+            }
             return false;
         }
 

--- a/pow/src/eaglesong_blake2b.rs
+++ b/pow/src/eaglesong_blake2b.rs
@@ -2,6 +2,8 @@ use super::PowEngine;
 use ckb_hash::blake2b_256;
 use ckb_types::{packed::Header, prelude::*, utilities::compact_to_target, U256};
 use eaglesong::eaglesong;
+use log::Level::Debug;
+use log::{debug, log_enabled};
 
 pub struct EaglesongBlake2bPowEngine;
 
@@ -18,10 +20,51 @@ impl PowEngine for EaglesongBlake2bPowEngine {
         let (block_target, overflow) = compact_to_target(header.raw().compact_target().unpack());
 
         if block_target.is_zero() || overflow {
+            debug!(
+                "compact_target is invalid: {:#x}",
+                header.raw().compact_target()
+            );
             return false;
         }
 
         if U256::from_big_endian(&output[..]).expect("bound checked") > block_target {
+            if log_enabled!(Debug) {
+                use ckb_types::bytes::Bytes;
+
+                let mut output_tmp = [0u8; 32];
+                eaglesong(&input, &mut output_tmp);
+
+                debug!(
+                    "PowEngine::verify error: expected target {:#x}, got {:#x}",
+                    block_target,
+                    U256::from_big_endian(&output[..]).unwrap()
+                );
+
+                debug!(
+                    "PowEngine::verify error: header raw 0x{:x}",
+                    &header.raw().as_bytes()
+                );
+                debug!(
+                    "PowEngine::verify error: pow hash {:#x}",
+                    &header.as_reader().calc_pow_hash()
+                );
+                debug!(
+                    "PowEngine::verify error: nonce {:#x}",
+                    header.nonce().unpack()
+                );
+                debug!(
+                    "PowEngine::verify error: pow input: 0x{:x}",
+                    Bytes::from(input.to_vec())
+                );
+                debug!(
+                    "PowEngine::verify error: eaglesong output: 0x{:#x}",
+                    Bytes::from(output_tmp.to_vec())
+                );
+                debug!(
+                    "PowEngine::verify error: pow output: 0x{:#x}",
+                    Bytes::from(output.to_vec())
+                );
+            }
             return false;
         }
 

--- a/verification/src/convert.rs
+++ b/verification/src/convert.rs
@@ -1,7 +1,7 @@
 use crate::error::{
-    BlockError, BlockErrorKind, BlockTransactionsError, CellbaseError, CommitError, EpochError,
-    HeaderError, HeaderErrorKind, InvalidParentError, NumberError, PowError, TimestampError,
-    TransactionError, UnclesError, UnknownParentError,
+    BlockError, BlockErrorKind, BlockTransactionsError, BlockVersionError, CellbaseError,
+    CommitError, EpochError, HeaderError, HeaderErrorKind, InvalidParentError, NumberError,
+    PowError, TimestampError, TransactionError, UnclesError, UnknownParentError,
 };
 use ckb_error::{
     impl_error_conversion_with_adaptor, impl_error_conversion_with_kind, Error, ErrorKind,
@@ -29,6 +29,7 @@ impl_error_conversion_with_kind!(
     HeaderErrorKind::InvalidParent,
     HeaderError
 );
+impl_error_conversion_with_kind!(BlockVersionError, HeaderErrorKind::Version, HeaderError);
 impl_error_conversion_with_kind!(PowError, HeaderErrorKind::Pow, HeaderError);
 impl_error_conversion_with_kind!(TimestampError, HeaderErrorKind::Timestamp, HeaderError);
 impl_error_conversion_with_kind!(NumberError, HeaderErrorKind::Number, HeaderError);
@@ -49,6 +50,7 @@ impl_error_conversion_with_kind!(CellbaseError, BlockErrorKind::Cellbase, BlockE
 impl_error_conversion_with_kind!(UnclesError, BlockErrorKind::Uncles, BlockError);
 
 impl_error_conversion_with_adaptor!(InvalidParentError, HeaderError, Error);
+impl_error_conversion_with_adaptor!(BlockVersionError, HeaderError, Error);
 impl_error_conversion_with_adaptor!(PowError, HeaderError, Error);
 impl_error_conversion_with_adaptor!(TimestampError, HeaderError, Error);
 impl_error_conversion_with_adaptor!(NumberError, HeaderError, Error);

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -228,7 +228,17 @@ pub enum UnclesError {
 }
 
 #[derive(Fail, Debug, PartialEq, Eq, Clone)]
-#[fail(display = "InvalidParentError(parent_hash: {})gg '", parent_hash)]
+#[fail(
+    display = "BlockVersionError(expected: {}, actual: {})",
+    expected, actual
+)]
+pub struct BlockVersionError {
+    pub expected: Version,
+    pub actual: Version,
+}
+
+#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[fail(display = "InvalidParentError(parent_hash: {})", parent_hash)]
 pub struct InvalidParentError {
     pub parent_hash: Byte32,
 }
@@ -414,6 +424,20 @@ mod tests {
         assert_eq!(
             is_too_new,
             vec![false, false, false, false, false, false, false, true]
+        );
+    }
+
+    #[test]
+    fn test_version_error_display() {
+        let e: Error = BlockVersionError {
+            expected: 0,
+            actual: 1,
+        }
+        .into();
+
+        assert_eq!(
+            "Header(Version(BlockVersionError(expected: 0, actual: 1)))",
+            format!("{}", e)
         );
     }
 }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -248,7 +248,9 @@ pub enum PowError {
     #[fail(display = "Boundary(expected: {}, actual: {})", expected, actual)]
     Boundary { expected: Byte32, actual: Byte32 },
 
-    #[fail(display = "InvalidNonce")]
+    #[fail(
+        display = "InvalidNonce: please set logger.filter to \"info,ckb-pow=debug\" to see detailed PoW verification information in the log"
+    )]
     InvalidNonce,
 }
 

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -1,6 +1,6 @@
 use super::Verifier;
 use crate::{
-    HeaderErrorKind, NumberError, PowError, TimestampError, UnknownParentError,
+    BlockVersionError, NumberError, PowError, TimestampError, UnknownParentError,
     ALLOWED_FUTURE_BLOCKTIME,
 };
 use ckb_chain_spec::consensus::Consensus;
@@ -64,7 +64,11 @@ impl<'a> VersionVerifier<'a> {
 
     pub fn verify(&self) -> Result<(), Error> {
         if self.header.version() != self.block_version {
-            return Err(HeaderErrorKind::Version.into());
+            return Err(BlockVersionError {
+                expected: self.block_version,
+                actual: self.header.version(),
+            }
+            .into());
         }
         Ok(())
     }

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -17,9 +17,9 @@ mod tests;
 pub use crate::block_verifier::{BlockVerifier, HeaderResolverWrapper};
 pub use crate::contextual_block_verifier::{ContextualBlockVerifier, Switch, VerifyContext};
 pub use crate::error::{
-    BlockError, BlockErrorKind, BlockTransactionsError, CellbaseError, CommitError, EpochError,
-    HeaderError, HeaderErrorKind, InvalidParentError, NumberError, PowError, TimestampError,
-    TransactionError, UnclesError, UnknownParentError,
+    BlockError, BlockErrorKind, BlockTransactionsError, BlockVersionError, CellbaseError,
+    CommitError, EpochError, HeaderError, HeaderErrorKind, InvalidParentError, NumberError,
+    PowError, TimestampError, TransactionError, UnclesError, UnknownParentError,
 };
 pub use crate::genesis_verifier::GenesisVerifier;
 pub use crate::header_verifier::{HeaderResolver, HeaderVerifier};

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -1,5 +1,5 @@
 use crate::header_verifier::{NumberVerifier, PowVerifier, TimestampVerifier, VersionVerifier};
-use crate::{HeaderErrorKind, NumberError, PowError, TimestampError, ALLOWED_FUTURE_BLOCKTIME};
+use crate::{BlockVersionError, NumberError, PowError, TimestampError, ALLOWED_FUTURE_BLOCKTIME};
 use ckb_error::assert_error_eq;
 use ckb_pow::PowEngine;
 use ckb_test_chain_utils::MockMedianTime;
@@ -19,7 +19,13 @@ pub fn test_version() {
         .build();
     let verifier = VersionVerifier::new(&header, BLOCK_VERSION);
 
-    assert_error_eq!(verifier.verify().unwrap_err(), HeaderErrorKind::Version);
+    assert_error_eq!(
+        verifier.verify().unwrap_err(),
+        BlockVersionError {
+            expected: BLOCK_VERSION,
+            actual: BLOCK_VERSION + 1
+        }
+    );
 }
 
 #[cfg(not(disable_faketime))]


### PR DESCRIPTION
Include more info in the error messages:

* Add expected version and actual value in header version error.

Add logs to ease debugging PoW. It can be enabled by setting the log level:

```
[logger]
filter = "info,ckb-pow=debug"
```