### PR TITLE
small tx-pool refactoring 

### DIFF
--- a/error/src/internal.rs
+++ b/error/src/internal.rs
@@ -13,12 +13,6 @@ pub enum InternalErrorKind {
     /// e.g. `Capacity::safe_add`
     CapacityOverflow,
 
-    /// The transaction_pool is already full
-    TransactionPoolFull,
-
-    /// The transaction already exist in transaction_pool
-    PoolTransactionDuplicated,
-
     /// Persistent data had corrupted
     DataCorrupted,
 

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,5 +1,5 @@
 use ckb_error::{Error as CKBError, InternalError, InternalErrorKind};
-use ckb_tx_pool::error::SubmitTxError;
+use ckb_tx_pool::error::Reject;
 use jsonrpc_core::{Error, ErrorCode, Value};
 use std::fmt::{Debug, Display};
 
@@ -33,6 +33,7 @@ pub enum RPCError {
     PoolRejectedTransactionByMaxAncestorsCountLimit = -1105,
     PoolIsFull = -1106,
     PoolRejectedDuplicatedTransaction = -1107,
+    PoolRejectedMalformedTransaction = -1108,
 }
 
 impl RPCError {
@@ -82,21 +83,22 @@ impl RPCError {
                 err.unwrap_cause_or_self(),
             ),
             SubmitTransaction => {
-                let submit_tx_err = match err.downcast_ref::<SubmitTxError>() {
+                let reject = match err.downcast_ref::<Reject>() {
                     Some(err) => err,
                     None => return Self::ckb_internal_error(err),
                 };
 
-                let kind = match *submit_tx_err {
-                    SubmitTxError::LowFeeRate(_, _) => {
-                        RPCError::PoolRejectedTransactionByMinFeeRate
-                    }
-                    SubmitTxError::ExceededMaximumAncestorsCount => {
+                let kind = match *reject {
+                    Reject::LowFeeRate(_, _) => RPCError::PoolRejectedTransactionByMinFeeRate,
+                    Reject::ExceededMaximumAncestorsCount => {
                         RPCError::PoolRejectedTransactionByMaxAncestorsCountLimit
                     }
+                    Reject::Full(_, _) => RPCError::PoolIsFull,
+                    Reject::Duplicated(_) => RPCError::PoolRejectedDuplicatedTransaction,
+                    Reject::Malformed(_) => RPCError::PoolRejectedMalformedTransaction,
                 };
 
-                RPCError::custom_with_error(kind, submit_tx_err)
+                RPCError::custom_with_error(kind, reject)
             }
             Internal => {
                 let internal_err = match err.downcast_ref::<InternalError>() {
@@ -106,10 +108,6 @@ impl RPCError {
 
                 let kind = match internal_err.kind() {
                     InternalErrorKind::CapacityOverflow => RPCError::IntegerOverflow,
-                    InternalErrorKind::TransactionPoolFull => RPCError::PoolIsFull,
-                    InternalErrorKind::PoolTransactionDuplicated => {
-                        RPCError::PoolRejectedDuplicatedTransaction
-                    }
                     InternalErrorKind::DataCorrupted => RPCError::DatabaseIsCorrupt,
                     InternalErrorKind::Database => RPCError::DatabaseError,
                     InternalErrorKind::Config => RPCError::ConfigError,
@@ -162,24 +160,33 @@ mod tests {
 
     #[test]
     fn test_submit_tx_error_from_ckb_error() {
-        let err: CKBError = SubmitTxError::LowFeeRate(100, 50).into();
+        let err: CKBError = Reject::LowFeeRate(100, 50).into();
         assert_eq!(
             "PoolRejectedTransactionByMinFeeRate: Transaction fee rate must >= 100 shannons/KB, got: 50",
             RPCError::from_ckb_error(err).message
         );
 
-        let err: CKBError = SubmitTxError::ExceededMaximumAncestorsCount.into();
+        let err: CKBError = Reject::ExceededMaximumAncestorsCount.into();
         assert_eq!(
             "PoolRejectedTransactionByMaxAncestorsCountLimit: Transaction exceeded maximum ancestors count limit, try send it later",
             RPCError::from_ckb_error(err).message
         );
-    }
 
-    #[test]
-    fn test_internal_error_from_ckb_error() {
-        let err: CKBError = InternalErrorKind::TransactionPoolFull.into();
+        let err: CKBError = Reject::Full("size".to_owned(), 10).into();
         assert_eq!(
-            "PoolIsFull: TransactionPoolFull",
+            "PoolIsFull: Transaction pool exceeded maximum size limit(10), try send it later",
+            RPCError::from_ckb_error(err).message
+        );
+
+        let err: CKBError = Reject::Duplicated(Byte32::new([0; 32])).into();
+        assert_eq!(
+            "PoolRejectedDuplicatedTransaction: Transaction(Byte32(0x0000000000000000000000000000000000000000000000000000000000000000)) already exist in transaction_pool",
+            RPCError::from_ckb_error(err).message
+        );
+
+        let err: CKBError = Reject::Malformed("cellbase like".to_owned()).into();
+        assert_eq!(
+            "PoolRejectedMalformedTransaction: Malformed cellbase like transaction",
             RPCError::from_ckb_error(err).message
         );
     }

--- a/test/src/specs/tx_pool/collision.rs
+++ b/test/src/specs/tx_pool/collision.rs
@@ -30,7 +30,7 @@ impl Spec for TransactionHashCollisionDifferentWitnessHashes {
             .err()
             .unwrap()
             .to_string()
-            .contains("PoolTransactionDuplicated"));
+            .contains("PoolRejectedDuplicatedTransaction"));
     }
 }
 
@@ -54,7 +54,7 @@ impl Spec for DuplicatedTransaction {
             .err()
             .unwrap()
             .to_string()
-            .contains("PoolTransactionDuplicated"));
+            .contains("PoolRejectedDuplicatedTransaction"));
     }
 }
 

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -48,7 +48,7 @@ impl Spec for SizeLimit {
 
         info!("The next tx reach size limit");
         let tx = node.new_transaction(hash);
-        assert_send_transaction_fail(node, &tx, "TransactionPoolFull");
+        assert_send_transaction_fail(node, &tx, "Transaction pool exceeded maximum size limit");
 
         node.assert_tx_pool_serialized_size(max_tx_num * one_tx_size);
         (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {
@@ -111,7 +111,7 @@ impl Spec for CyclesLimit {
 
         info!("The next tx reach cycles limit");
         let tx = node.new_transaction(hash);
-        assert_send_transaction_fail(node, &tx, "TransactionPoolFull");
+        assert_send_transaction_fail(node, &tx, "Transaction pool exceeded maximum cycles limit");
 
         node.assert_tx_pool_cycles(max_tx_num * one_tx_cycles);
         (0..DEFAULT_TX_PROPOSAL_WINDOW.0).for_each(|_| {

--- a/tx-pool/src/component/container.rs
+++ b/tx-pool/src/component/container.rs
@@ -1,7 +1,7 @@
 //! The primary module containing the implementations of the transaction pool
 //! and its top-level members.
 
-use crate::{component::entry::TxEntry, error::SubmitTxError};
+use crate::{component::entry::TxEntry, error::Reject};
 use ckb_types::{core::Capacity, packed::ProposalShortId};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
@@ -161,7 +161,7 @@ impl SortedTxMap {
         }
     }
 
-    pub fn add_entry(&mut self, mut entry: TxEntry) -> Result<Option<TxEntry>, SubmitTxError> {
+    pub fn add_entry(&mut self, mut entry: TxEntry) -> Result<Option<TxEntry>, Reject> {
         let short_id = entry.transaction.proposal_short_id();
 
         // find in pool parents
@@ -185,7 +185,7 @@ impl SortedTxMap {
         self.update_ancestors_stat_for_entry(&mut entry, &parents);
 
         if entry.ancestors_count > self.max_ancestors_count {
-            return Err(SubmitTxError::ExceededMaximumAncestorsCount);
+            return Err(Reject::ExceededMaximumAncestorsCount);
         }
 
         // check duplicate tx

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -1,6 +1,6 @@
 use crate::component::container::{AncestorsScoreSortKey, SortedTxMap};
 use crate::component::entry::TxEntry;
-use crate::error::SubmitTxError;
+use crate::error::Reject;
 use ckb_fee_estimator::FeeRate;
 use ckb_types::{
     core::{
@@ -28,7 +28,7 @@ impl PendingQueue {
         self.inner.size()
     }
 
-    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Result<Option<TxEntry>, SubmitTxError> {
+    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Result<Option<TxEntry>, Reject> {
         self.inner.add_entry(entry)
     }
 

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -1,6 +1,6 @@
 use crate::component::container::SortedTxMap;
 use crate::component::entry::TxEntry;
-use crate::error::SubmitTxError;
+use crate::error::Reject;
 use ckb_types::{
     bytes::Bytes,
     core::{
@@ -196,7 +196,7 @@ impl ProposedPool {
         removed
     }
 
-    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Result<Option<TxEntry>, SubmitTxError> {
+    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Result<Option<TxEntry>, Reject> {
         let inputs = entry.transaction.input_pts_iter();
         let outputs = entry.transaction.output_pts();
 

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -3,10 +3,10 @@ use super::component::{DefectEntry, TxEntry};
 use crate::component::orphan::OrphanPool;
 use crate::component::pending::PendingQueue;
 use crate::component::proposed::ProposedPool;
-use crate::error::SubmitTxError;
+use crate::error::Reject;
 use ckb_app_config::TxPoolConfig;
 use ckb_dao::DaoCalculator;
-use ckb_error::{Error, ErrorKind, InternalErrorKind};
+use ckb_error::{Error, ErrorKind};
 use ckb_logger::{debug, error, trace};
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
@@ -140,7 +140,7 @@ impl TxPool {
     }
 
     // If did have this value present, false is returned.
-    pub fn add_pending(&mut self, entry: TxEntry) -> Result<bool, SubmitTxError> {
+    pub fn add_pending(&mut self, entry: TxEntry) -> Result<bool, Reject> {
         if self
             .gap
             .contains_key(&entry.transaction.proposal_short_id())
@@ -152,12 +152,12 @@ impl TxPool {
     }
 
     // add_gap inserts proposed but still uncommittable transaction.
-    pub fn add_gap(&mut self, entry: TxEntry) -> Result<bool, SubmitTxError> {
+    pub fn add_gap(&mut self, entry: TxEntry) -> Result<bool, Reject> {
         trace!("add_gap {}", entry.transaction.hash());
         self.gap.add_entry(entry).map(|entry| entry.is_none())
     }
 
-    pub fn add_proposed(&mut self, entry: TxEntry) -> Result<bool, SubmitTxError> {
+    pub fn add_proposed(&mut self, entry: TxEntry) -> Result<bool, Reject> {
         trace!("add_proposed {}", entry.transaction.hash());
         self.touch_last_txs_updated_at();
         self.proposed.add_entry(entry).map(|entry| entry.is_none())
@@ -549,9 +549,7 @@ impl TxPool {
                 if tx_pool.add_gap(entry)? {
                     Ok(())
                 } else {
-                    Err(InternalErrorKind::PoolTransactionDuplicated
-                        .reason(tx_hash)
-                        .into())
+                    Err(Reject::Duplicated(tx_hash).into())
                 }
             },
         )
@@ -609,9 +607,7 @@ impl TxPool {
                 if tx_pool.add_pending(entry)? {
                     Ok(())
                 } else {
-                    Err(InternalErrorKind::PoolTransactionDuplicated
-                        .reason(tx_hash)
-                        .into())
+                    Err(Reject::Duplicated(tx_hash).into())
                 }
             },
         )

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -19,7 +19,7 @@ use ckb_types::{
     packed::{Byte32, OutPoint, ProposalShortId},
 };
 use ckb_verification::cache::CacheEntry;
-use ckb_verification::{ContextualTransactionVerifier, TransactionVerifier};
+use ckb_verification::{TimeRelativeTransactionVerifier, TransactionVerifier};
 use faketime::unix_time_as_millis;
 use lru_cache::LruCache;
 use std::collections::HashMap;
@@ -341,7 +341,7 @@ impl TxPool {
 
         match cache_entry {
             Some(cache_entry) => {
-                ContextualTransactionVerifier::new(
+                TimeRelativeTransactionVerifier::new(
                     &rtx,
                     snapshot,
                     tip_number + 1,

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -24,7 +24,7 @@ use ckb_types::{
     prelude::*,
 };
 use ckb_util::LinkedHashSet;
-use ckb_verification::{cache::CacheEntry, ContextualTransactionVerifier, TransactionVerifier};
+use ckb_verification::{cache::CacheEntry, TimeRelativeTransactionVerifier, TransactionVerifier};
 use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::collections::HashSet;
@@ -593,7 +593,7 @@ fn verify_rtxs(
         .map(|tx| {
             let tx_hash = tx.transaction.hash();
             if let Some(cache_entry) = txs_verify_cache.get(&tx_hash) {
-                ContextualTransactionVerifier::new(
+                TimeRelativeTransactionVerifier::new(
                     &tx,
                     snapshot,
                     tip_number + 1,

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -5,6 +5,7 @@ use crate::pool::{TxPool, TxPoolInfo};
 use crate::process::PlugTarget;
 use ckb_app_config::{BlockAssemblerConfig, TxPoolConfig};
 use ckb_async_runtime::{new_runtime, Handle};
+use ckb_chain_spec::consensus::Consensus;
 use ckb_error::Error;
 use ckb_jsonrpc_types::BlockTemplate;
 use ckb_logger::error;
@@ -279,12 +280,14 @@ impl TxPoolServiceBuilder {
         snapshot_mgr: Arc<SnapshotMgr>,
     ) -> TxPoolServiceBuilder {
         let last_txs_updated_at = Arc::new(AtomicU64::new(0));
+        let consensus = snapshot.cloned_consensus();
         let tx_pool = TxPool::new(tx_pool_config, snapshot, Arc::clone(&last_txs_updated_at));
         let block_assembler = block_assembler_config.map(BlockAssembler::new);
 
         TxPoolServiceBuilder {
             service: Some(TxPoolService::new(
                 tx_pool,
+                consensus,
                 block_assembler,
                 txs_verify_cache,
                 last_txs_updated_at,
@@ -323,6 +326,7 @@ impl TxPoolServiceBuilder {
 #[derive(Clone)]
 pub struct TxPoolService {
     pub(crate) tx_pool: Arc<RwLock<TxPool>>,
+    pub(crate) consensus: Arc<Consensus>,
     pub(crate) tx_pool_config: Arc<TxPoolConfig>,
     pub(crate) block_assembler: Option<BlockAssembler>,
     pub(crate) txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
@@ -333,6 +337,7 @@ pub struct TxPoolService {
 impl TxPoolService {
     pub fn new(
         tx_pool: TxPool,
+        consensus: Arc<Consensus>,
         block_assembler: Option<BlockAssembler>,
         txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
         last_txs_updated_at: Arc<AtomicU64>,
@@ -341,6 +346,7 @@ impl TxPoolService {
         let tx_pool_config = Arc::new(tx_pool.config);
         Self {
             tx_pool: Arc::new(RwLock::new(tx_pool)),
+            consensus,
             tx_pool_config,
             block_assembler,
             txs_verify_cache,

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -110,6 +110,10 @@ impl Snapshot {
         &self.consensus
     }
 
+    pub fn cloned_consensus(&self) -> Arc<Consensus> {
+        Arc::clone(&self.consensus)
+    }
+
     pub fn proposals(&self) -> &ProposalView {
         &self.proposals
     }

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -2,8 +2,8 @@ use crate::cache::{CacheEntry, TxVerifyCache};
 use crate::error::{BlockTransactionsError, EpochError};
 use crate::uncles_verifier::{UncleProvider, UnclesVerifier};
 use crate::{
-    BlockErrorKind, CellbaseError, CommitError, ContextualTransactionVerifier, TransactionVerifier,
-    UnknownParentError,
+    BlockErrorKind, CellbaseError, CommitError, TimeRelativeTransactionVerifier,
+    TransactionVerifier, UnknownParentError,
 };
 use ckb_async_runtime::Handle;
 use ckb_chain_spec::consensus::Consensus;
@@ -392,7 +392,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
             .map(|(index, tx)| {
                 let tx_hash = tx.transaction.hash();
                 if let Some(cache_entry) = fetched_cache.get(&tx_hash) {
-                    ContextualTransactionVerifier::new(
+                    TimeRelativeTransactionVerifier::new(
                         &tx,
                         self.context,
                         self.block_number,

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::error::{
 pub use crate::genesis_verifier::GenesisVerifier;
 pub use crate::header_verifier::{HeaderResolver, HeaderVerifier};
 pub use crate::transaction_verifier::{
-    ContextualTransactionVerifier, ScriptVerifier, Since, SinceMetric, TransactionVerifier,
+    ScriptVerifier, Since, SinceMetric, TimeRelativeTransactionVerifier, TransactionVerifier,
 };
 
 pub const ALLOWED_FUTURE_BLOCKTIME: u64 = 15 * 1000; // 15 Second

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -24,7 +24,8 @@ pub use crate::error::{
 pub use crate::genesis_verifier::GenesisVerifier;
 pub use crate::header_verifier::{HeaderResolver, HeaderVerifier};
 pub use crate::transaction_verifier::{
-    ScriptVerifier, Since, SinceMetric, TimeRelativeTransactionVerifier, TransactionVerifier,
+    ContextualTransactionVerifier, NonContextualTransactionVerifier, ScriptVerifier, Since,
+    SinceMetric, TimeRelativeTransactionVerifier, TransactionVerifier,
 };
 
 pub const ALLOWED_FUTURE_BLOCKTIME: u64 = 15 * 1000; // 15 Second

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -60,17 +60,90 @@ where
     }
 }
 
-pub struct TransactionVerifier<'a, M, CS> {
+pub struct NonContextualTransactionVerifier<'a> {
     pub version: VersionVerifier<'a>,
     pub size: SizeVerifier<'a>,
     pub empty: EmptyVerifier<'a>,
-    pub maturity: MaturityVerifier<'a>,
-    pub capacity: CapacityVerifier<'a>,
     pub duplicate_deps: DuplicateDepsVerifier<'a>,
     pub outputs_data_verifier: OutputsDataVerifier<'a>,
-    pub script: ScriptVerifier<'a, CS>,
+}
+
+impl<'a> NonContextualTransactionVerifier<'a> {
+    pub fn new(tx: &'a TransactionView, consensus: &'a Consensus) -> Self {
+        NonContextualTransactionVerifier {
+            version: VersionVerifier::new(tx, consensus.tx_version()),
+            size: SizeVerifier::new(tx, consensus.max_block_bytes()),
+            empty: EmptyVerifier::new(tx),
+            duplicate_deps: DuplicateDepsVerifier::new(tx),
+            outputs_data_verifier: OutputsDataVerifier::new(tx),
+        }
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        self.version.verify()?;
+        self.size.verify()?;
+        self.empty.verify()?;
+        self.duplicate_deps.verify()?;
+        self.outputs_data_verifier.verify()?;
+        Ok(())
+    }
+}
+
+pub struct ContextualTransactionVerifier<'a, M, CS> {
+    pub maturity: MaturityVerifier<'a>,
     pub since: SinceVerifier<'a, M>,
+    pub capacity: CapacityVerifier<'a>,
+    pub script: ScriptVerifier<'a, CS>,
     pub fee_calculator: FeeCalculator<'a, CS>,
+}
+
+impl<'a, M, CS> ContextualTransactionVerifier<'a, M, CS>
+where
+    M: BlockMedianTimeContext,
+    CS: ChainStore<'a>,
+{
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        rtx: &'a ResolvedTransaction,
+        median_time_context: &'a M,
+        block_number: BlockNumber,
+        epoch_number_with_fraction: EpochNumberWithFraction,
+        parent_hash: Byte32,
+        consensus: &'a Consensus,
+        chain_store: &'a CS,
+    ) -> Self {
+        ContextualTransactionVerifier {
+            maturity: MaturityVerifier::new(
+                &rtx,
+                epoch_number_with_fraction,
+                consensus.cellbase_maturity(),
+            ),
+            script: ScriptVerifier::new(rtx, chain_store),
+            capacity: CapacityVerifier::new(rtx, consensus.dao_type_hash()),
+            since: SinceVerifier::new(
+                rtx,
+                median_time_context,
+                block_number,
+                epoch_number_with_fraction,
+                parent_hash,
+            ),
+            fee_calculator: FeeCalculator::new(rtx, &consensus, &chain_store),
+        }
+    }
+
+    pub fn verify(&self, max_cycles: Cycle) -> Result<CacheEntry, Error> {
+        self.maturity.verify()?;
+        self.capacity.verify()?;
+        self.since.verify()?;
+        let cycles = self.script.verify(max_cycles)?;
+        let fee = self.fee_calculator.transaction_fee()?;
+        Ok(CacheEntry::new(cycles, fee))
+    }
+}
+
+pub struct TransactionVerifier<'a, M, CS> {
+    pub non_contextual: NonContextualTransactionVerifier<'a>,
+    pub contextual: ContextualTransactionVerifier<'a, M, CS>,
 }
 
 impl<'a, M, CS> TransactionVerifier<'a, M, CS>
@@ -89,41 +162,22 @@ where
         chain_store: &'a CS,
     ) -> Self {
         TransactionVerifier {
-            version: VersionVerifier::new(&rtx.transaction, consensus.tx_version()),
-            size: SizeVerifier::new(&rtx.transaction, consensus.max_block_bytes()),
-            empty: EmptyVerifier::new(&rtx.transaction),
-            maturity: MaturityVerifier::new(
-                &rtx,
-                epoch_number_with_fraction,
-                consensus.cellbase_maturity(),
-            ),
-            duplicate_deps: DuplicateDepsVerifier::new(&rtx.transaction),
-            outputs_data_verifier: OutputsDataVerifier::new(&rtx.transaction),
-            script: ScriptVerifier::new(rtx, chain_store),
-            capacity: CapacityVerifier::new(rtx, consensus.dao_type_hash()),
-            since: SinceVerifier::new(
+            non_contextual: NonContextualTransactionVerifier::new(&rtx.transaction, consensus),
+            contextual: ContextualTransactionVerifier::new(
                 rtx,
                 median_time_context,
                 block_number,
                 epoch_number_with_fraction,
                 parent_hash,
+                consensus,
+                chain_store,
             ),
-            fee_calculator: FeeCalculator::new(rtx, &consensus, &chain_store),
         }
     }
 
     pub fn verify(&self, max_cycles: Cycle) -> Result<CacheEntry, Error> {
-        self.version.verify()?;
-        self.size.verify()?;
-        self.empty.verify()?;
-        self.maturity.verify()?;
-        self.capacity.verify()?;
-        self.duplicate_deps.verify()?;
-        self.outputs_data_verifier.verify()?;
-        self.since.verify()?;
-        let cycles = self.script.verify(max_cycles)?;
-        let fee = self.fee_calculator.transaction_fee()?;
-        Ok(CacheEntry::new(cycles, fee))
+        self.non_contextual.verify()?;
+        self.contextual.verify(max_cycles)
     }
 }
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -20,12 +20,12 @@ use lru_cache::LruCache;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
-pub struct ContextualTransactionVerifier<'a, M> {
+pub struct TimeRelativeTransactionVerifier<'a, M> {
     pub maturity: MaturityVerifier<'a>,
     pub since: SinceVerifier<'a, M>,
 }
 
-impl<'a, M> ContextualTransactionVerifier<'a, M>
+impl<'a, M> TimeRelativeTransactionVerifier<'a, M>
 where
     M: BlockMedianTimeContext,
 {
@@ -37,7 +37,7 @@ where
         parent_hash: Byte32,
         consensus: &'a Consensus,
     ) -> Self {
-        ContextualTransactionVerifier {
+        TimeRelativeTransactionVerifier {
             maturity: MaturityVerifier::new(
                 &rtx,
                 epoch_number_with_fraction,


### PR DESCRIPTION
proposal changes:
* rename ContextualTransactionVerifier -> TimeRelativeTransactionVerifier
* split NonContextualTransactionVerifier from TransactionVerifier
* check syntactic correctness first before 
* refactory tx-pool rejection error
* re-broadcast when duplicated tx submit