### PR TITLE
feat: support multiple file loggers

### DIFF
--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -165,8 +165,11 @@ impl CKBAppConfig {
         if self.tmp_dir.is_none() {
             self.tmp_dir = Some(self.data_dir.join("tmp"));
         }
-        let log_dir = self.data_dir.join("logs");
-        let log_file = log_dir.join(subcommand_name.to_string() + ".log");
+        self.logger.log_dir = self.data_dir.join("logs");
+        let log_file = self
+            .logger
+            .log_dir
+            .join(subcommand_name.to_string() + ".log");
 
         if subcommand_name == cli::CMD_RESET_DATA {
             self.logger.file = Some(log_file);
@@ -181,7 +184,7 @@ impl CKBAppConfig {
             self.tmp_dir = Some(mkdir(tmp_dir)?);
         }
         if self.logger.log_to_file {
-            mkdir(log_dir)?;
+            mkdir(self.logger.log_dir.clone())?;
             self.logger.file = Some(touch(log_file)?);
         }
         self.chain.spec.absolutize(root_dir);

--- a/util/jsonrpc-types/src/debug.rs
+++ b/util/jsonrpc-types/src/debug.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize, Debug)]
+pub struct ExtraLoggerConfig {
+    pub filter: String,
+}

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -4,6 +4,7 @@ mod blockchain;
 mod bytes;
 mod cell;
 mod chain_info;
+mod debug;
 mod experiment;
 mod fixed_bytes;
 mod indexer;
@@ -27,6 +28,7 @@ pub use self::blockchain::{
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};
 pub use self::chain_info::ChainInfo;
+pub use self::debug::ExtraLoggerConfig;
 pub use self::experiment::{DryRunResult, EstimateResult};
 pub use self::fixed_bytes::Byte32;
 pub use self::indexer::{


### PR DESCRIPTION
### Features

- Support multiple file loggers in `ckb.toml`.
  For example, the follow configuration will write all `info` logs into `run.log` and `stdout`, all `trace` logs into `trace.log` and `ckb_chain=info` logs into `chain_info.log`:
  ```toml
  [logger]
  filter = "info"
  color = true
  log_to_file = true
  log_to_stdout = true
  [logger.extra.trace]
  filter = "trace"
  [logger.extra.chain_info]
  filter = "off,ckb_chain=info"
  ```
- Support configuring extra file loggers via RPC (in module `Debug`).
  ```shell
  # Add or update a file logger to write `ckb_chain=info` logs into `chain_info.log`.
  curl -H 'content-type: application/json' -d \
      '{ "id": 2, "jsonrpc": "2.0", "method": "set_extra_logger", "params": ["chain_info", {"filter": "off,ckb_chain=info"}] }' \
      http://localhost:8114
  # Remove the file logger `ckb_chain`
  curl -H 'content-type: application/json' -d \
      '{ "id": 2, "jsonrpc": "2.0", "method": "set_extra_logger", "params": ["chain_info", null] }' \
      http://localhost:8114
  ```