### PR TITLE
chore: unify logger targets

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -44,7 +44,7 @@ pub(crate) const NORMAL_INDEX: usize = TIME_TRACE_SIZE * 4 / 5;
 // Low Zone Boundaries for the Time Window
 pub(crate) const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
-pub(crate) const LOG_TARGET_RELAY: &str = "ckb-relay";
+pub(crate) const LOG_TARGET_RELAY: &str = "ckb_relay";
 
 // Inspect the headers downloading every 2 minutes
 pub const HEADERS_DOWNLOAD_INSPECT_WINDOW: u64 = 2 * 60 * 1000;

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -5,8 +5,6 @@ pub mod pool;
 mod process;
 pub mod service;
 
-pub(crate) const LOG_TARGET_TX_POOL: &str = "ckb-tx-pool";
-
 pub use component::entry::TxEntry;
 pub use process::PlugTarget;
 pub use service::{TxPoolController, TxPoolServiceBuilder};

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -7,7 +7,7 @@ use crate::error::SubmitTxError;
 use ckb_app_config::TxPoolConfig;
 use ckb_dao::DaoCalculator;
 use ckb_error::{Error, ErrorKind, InternalErrorKind};
-use ckb_logger::{debug_target, error_target, trace_target};
+use ckb_logger::{debug, error, trace};
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_types::{
@@ -122,20 +122,16 @@ impl TxPool {
     // cycles overflow is possible, currently obtaining cycles is not accurate
     pub fn update_statics_for_remove_tx(&mut self, tx_size: usize, cycles: Cycle) {
         let total_tx_size = self.total_tx_size.checked_sub(tx_size).unwrap_or_else(|| {
-            error_target!(
-                crate::LOG_TARGET_TX_POOL,
+            error!(
                 "total_tx_size {} overflow by sub {}",
-                self.total_tx_size,
-                tx_size
+                self.total_tx_size, tx_size
             );
             0
         });
         let total_tx_cycles = self.total_tx_cycles.checked_sub(cycles).unwrap_or_else(|| {
-            error_target!(
-                crate::LOG_TARGET_TX_POOL,
+            error!(
                 "total_tx_cycles {} overflow by sub {}",
-                self.total_tx_cycles,
-                cycles
+                self.total_tx_cycles, cycles
             );
             0
         });
@@ -151,30 +147,18 @@ impl TxPool {
         {
             return Ok(false);
         }
-        trace_target!(
-            crate::LOG_TARGET_TX_POOL,
-            "add_pending {}",
-            entry.transaction.hash()
-        );
+        trace!("add_pending {}", entry.transaction.hash());
         self.pending.add_entry(entry).map(|entry| entry.is_none())
     }
 
     // add_gap inserts proposed but still uncommittable transaction.
     pub fn add_gap(&mut self, entry: TxEntry) -> Result<bool, SubmitTxError> {
-        trace_target!(
-            crate::LOG_TARGET_TX_POOL,
-            "add_gap {}",
-            entry.transaction.hash()
-        );
+        trace!("add_gap {}", entry.transaction.hash());
         self.gap.add_entry(entry).map(|entry| entry.is_none())
     }
 
     pub fn add_proposed(&mut self, entry: TxEntry) -> Result<bool, SubmitTxError> {
-        trace_target!(
-            crate::LOG_TARGET_TX_POOL,
-            "add_proposed {}",
-            entry.transaction.hash()
-        );
+        trace!("add_proposed {}", entry.transaction.hash());
         self.touch_last_txs_updated_at();
         self.proposed.add_entry(entry).map(|entry| entry.is_none())
     }
@@ -186,7 +170,7 @@ impl TxPool {
         tx: TransactionView,
         unknowns: Vec<OutPoint>,
     ) -> Option<DefectEntry> {
-        trace_target!(crate::LOG_TARGET_TX_POOL, "add_orphan {}", &tx.hash());
+        trace!("add_orphan {}", &tx.hash());
         self.orphan
             .add_tx(cache_entry, size, tx, unknowns.into_iter())
     }
@@ -288,7 +272,7 @@ impl TxPool {
     ) {
         for (tx, related_out_points) in txs {
             let hash = tx.hash();
-            trace_target!(crate::LOG_TARGET_TX_POOL, "committed {}", hash);
+            trace!("committed {}", hash);
             for entry in self.proposed.remove_committed_tx(tx, &related_out_points) {
                 self.update_statics_for_remove_tx(entry.size, entry.cycles);
             }
@@ -301,20 +285,12 @@ impl TxPool {
         for id in ids {
             for entry in self.gap.remove_entry_and_descendants(id) {
                 if let Err(err) = self.add_pending(entry) {
-                    debug_target!(
-                        crate::LOG_TARGET_TX_POOL,
-                        "move expired gap to pending error {}",
-                        err
-                    );
+                    debug!("move expired gap to pending error {}", err);
                 }
             }
             for entry in self.proposed.remove_entry_and_descendants(id) {
                 if let Err(err) = self.add_pending(entry) {
-                    debug_target!(
-                        crate::LOG_TARGET_TX_POOL,
-                        "move expired proposed to pending error {}",
-                        err
-                    );
+                    debug!("move expired proposed to pending error {}", err);
                 }
             }
         }
@@ -405,12 +381,7 @@ impl TxPool {
                         entry.size,
                         entry.cache_entry.map(|c| c.cycles).unwrap_or(0),
                     );
-                    trace_target!(
-                        crate::LOG_TARGET_TX_POOL,
-                        "proposed tx {} failed {:?}",
-                        tx_hash,
-                        ret
-                    );
+                    trace!("proposed tx {} failed {:?}", tx_hash, ret);
                 }
             } else {
                 let ret = self.pending_tx(entry.cache_entry, entry.size, entry.transaction);
@@ -419,12 +390,7 @@ impl TxPool {
                         entry.size,
                         entry.cache_entry.map(|c| c.cycles).unwrap_or(0),
                     );
-                    trace_target!(
-                        crate::LOG_TARGET_TX_POOL,
-                        "pending tx {} failed {:?}",
-                        tx_hash,
-                        ret
-                    );
+                    trace!("pending tx {} failed {:?}", tx_hash, ret);
                 }
             }
         }
@@ -438,8 +404,7 @@ impl TxPool {
         DaoCalculator::new(snapshot.consensus(), snapshot)
             .transaction_fee(&rtx)
             .map_err(|err| {
-                error_target!(
-                    crate::LOG_TARGET_TX_POOL,
+                error!(
                     "Failed to generate tx fee for {}, reason: {:?}",
                     rtx.transaction.hash(),
                     err
@@ -489,12 +454,9 @@ impl TxPool {
                             size,
                             cache_entry.map(|c| c.cycles).unwrap_or(0),
                         );
-                        debug_target!(
-                            crate::LOG_TARGET_TX_POOL,
+                        debug!(
                             "Failed to add tx to {} {}, verify failed, reason: {:?}",
-                            pool_name,
-                            tx_hash,
-                            err,
+                            pool_name, tx_hash, err,
                         );
                     }
                     ErrorKind::OutPoint => {
@@ -546,12 +508,9 @@ impl TxPool {
                         }
                     }
                     _ => {
-                        debug_target!(
-                            crate::LOG_TARGET_TX_POOL,
+                        debug!(
                             "Failed to add tx to {} {}, unknown reason: {:?}",
-                            pool_name,
-                            tx_hash,
-                            err
+                            pool_name, tx_hash, err
                         );
                         self.update_statics_for_remove_tx(
                             size,

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -8,7 +8,7 @@ use ckb_app_config::BlockAssemblerConfig;
 use ckb_dao::DaoCalculator;
 use ckb_error::{Error, InternalErrorKind};
 use ckb_jsonrpc_types::BlockTemplate;
-use ckb_logger::{debug_target, info};
+use ckb_logger::{debug, info};
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_types::{
@@ -728,29 +728,15 @@ fn _update_tx_pool_for_reorg(
     for (cycles, size, tx) in entries {
         let tx_hash = tx.hash();
         if let Err(e) = tx_pool.proposed_tx_and_descendants(cycles, size, tx) {
-            debug_target!(
-                crate::LOG_TARGET_TX_POOL,
-                "Failed to add proposed tx {}, reason: {}",
-                tx_hash,
-                e
-            );
+            debug!("Failed to add proposed tx {}, reason: {}", tx_hash, e);
         }
     }
 
     for (cycles, size, tx) in gaps {
-        debug_target!(
-            crate::LOG_TARGET_TX_POOL,
-            "tx proposed, add to gap {}",
-            tx.hash()
-        );
+        debug!("tx proposed, add to gap {}", tx.hash());
         let tx_hash = tx.hash();
         if let Err(e) = tx_pool.gap_tx(cycles, size, tx) {
-            debug_target!(
-                crate::LOG_TARGET_TX_POOL,
-                "Failed to add tx to gap {}, reason: {}",
-                tx_hash,
-                e
-            );
+            debug!("Failed to add tx to gap {}, reason: {}", tx_hash, e);
         }
     }
 

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::transaction_verifier::{
 
 pub const ALLOWED_FUTURE_BLOCKTIME: u64 = 15 * 1000; // 15 Second
 
-pub(crate) const LOG_TARGET: &str = "ckb-chain";
+pub(crate) const LOG_TARGET: &str = "ckb_chain";
 
 pub trait Verifier {
     type Target;


### PR DESCRIPTION
- Since `tx-pool` is split from `ckb-shared` after #1567, we can remove all user-specified targets for `tx-pool`.
  https://github.com/nervosnetwork/ckb/blob/dfc944a1ce7be98285cd34a45772e671f1434a6c/shared/src/lib.rs#L20
- After [CKB PR 2078: chore: use fully qualified module name as the default log target](https://github.com/nervosnetwork/ckb/pull/2078), almost all logs use `$crate::env!("CARGO_PKG_NAME").replace("-", "_")` as first part of log targets.