### PR TITLE
feat: add `generate_block` rpc to IntegrationTest module

### DIFF
--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -1,6 +1,7 @@
 use crate::error::RPCError;
+use ckb_app_config::BlockAssemblerConfig;
 use ckb_chain::{chain::ChainController, switch::Switch};
-use ckb_jsonrpc_types::{Block, BlockView, Cycle, Transaction};
+use ckb_jsonrpc_types::{Block, BlockView, Cycle, JsonBytes, Script, Transaction};
 use ckb_logger::error;
 use ckb_network::{NetworkController, SupportProtocols};
 use ckb_shared::shared::Shared;
@@ -26,6 +27,13 @@ pub trait IntegrationTestRpc {
 
     #[rpc(name = "truncate")]
     fn truncate(&self, target_tip_hash: H256) -> Result<()>;
+
+    #[rpc(name = "generate_block")]
+    fn generate_block(
+        &self,
+        block_assembler_script: Option<Script>,
+        block_assembler_message: Option<JsonBytes>,
+    ) -> Result<H256>;
 
     #[rpc(name = "broadcast_transaction")]
     fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256>;
@@ -109,6 +117,49 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
 
         Ok(())
+    }
+
+    fn generate_block(
+        &self,
+        block_assembler_script: Option<Script>,
+        block_assembler_message: Option<JsonBytes>,
+    ) -> Result<H256> {
+        let tx_pool = self.shared.tx_pool_controller();
+        let block_assembler_config = block_assembler_script.map(|script| BlockAssemblerConfig {
+            code_hash: script.code_hash,
+            hash_type: script.hash_type,
+            args: script.args,
+            message: block_assembler_message.unwrap_or_default(),
+        });
+        let block_template = tx_pool
+            .get_block_template_with_block_assembler_config(
+                None,
+                None,
+                None,
+                block_assembler_config,
+            )
+            .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?
+            .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
+
+        let block: packed::Block = block_template.into();
+        let block_view = Arc::new(block.into_view());
+        let content = packed::CompactBlock::build_from_block(&block_view, &HashSet::new());
+        let message = packed::RelayMessage::new_builder().set(content).build();
+
+        // insert block to chain
+        self.chain
+            .process_block(Arc::clone(&block_view))
+            .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
+
+        // announce new block
+        if let Err(err) = self
+            .network_controller
+            .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
+        {
+            error!("Broadcast new block failed: {:?}", err);
+        }
+
+        Ok(block_view.header().hash().unpack())
     }
 
     fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256> {

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -285,7 +285,7 @@ impl Node {
 
     // generate a new block and submit it through rpc.
     pub fn generate_block(&self) -> Byte32 {
-        self.submit_block(&self.new_block(None, None, None))
+        self.rpc_client().generate_block()
     }
 
     // Convenient way to construct an uncle block

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -6,8 +6,8 @@ mod error;
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockReward, BlockTemplate,
     BlockView, Capacity, CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle,
-    DryRunResult, EpochNumber, EpochView, EstimateResult, HeaderView, LiveCell, LocalNode,
-    LockHashIndexState, OutPoint, PeerState, RemoteNode, Timestamp, Transaction,
+    DryRunResult, EpochNumber, EpochView, EstimateResult, HeaderView, JsonBytes, LiveCell,
+    LocalNode, LockHashIndexState, OutPoint, PeerState, RemoteNode, Script, Timestamp, Transaction,
     TransactionWithStatus, TxPoolInfo, Uint64, Version,
 };
 use ckb_types::core::{
@@ -233,6 +233,13 @@ impl RpcClient {
             .expect("rpc call truncate")
     }
 
+    pub fn generate_block(&self) -> Byte32 {
+        self.inner()
+            .generate_block(None, None)
+            .expect("rpc call generate_block")
+            .pack()
+    }
+
     pub fn get_live_cells_by_lock_hash(
         &self,
         lock_hash: Byte32,
@@ -371,6 +378,7 @@ jsonrpc!(pub struct Inner {
     pub fn remove_node(&self, peer_id: String) -> ();
     pub fn process_block_without_verify(&self, _data: Block, broadcast: bool) -> Option<H256>;
     pub fn truncate(&self, target_tip_hash: H256) -> ();
+    pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
 
     pub fn get_live_cells_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<LiveCell>;
     pub fn get_transactions_by_lock_hash(&self, lock_hash: H256, page: Uint64, per_page: Uint64, reverse_order: Option<bool>) -> Vec<CellTransaction>;

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -258,13 +258,16 @@ impl TxPoolService {
         bytes_limit: Option<u64>,
         proposals_limit: Option<u64>,
         max_version: Option<Version>,
+        block_assembler_config: Option<BlockAssemblerConfig>,
     ) -> Result<BlockTemplate, FailureError> {
-        if self.block_assembler.is_none() {
+        if self.block_assembler.is_none() && block_assembler_config.is_none() {
             Err(InternalErrorKind::Config
                 .reason("BlockAssembler disabled")
                 .into())
         } else {
-            let block_assembler = self.block_assembler.clone().unwrap();
+            let block_assembler = block_assembler_config
+                .map(BlockAssembler::new)
+                .unwrap_or_else(|| self.block_assembler.clone().unwrap());
             let snapshot = self.snapshot();
             let consensus = snapshot.consensus();
             let cycles_limit = consensus.max_block_cycles();


### PR DESCRIPTION
allows user to generate block through rpc, it's a convenient feature for dApp integration test (like `truncate` rpc)

```shell
# generate a block with default block assembler config in ckb.toml
curl -d '{"id": 1, "jsonrpc": "2.0", "method":"generate_block","params": []}' \
  -H 'content-type:application/json' 'http://localhost:8114'

# generate a block with different block assember config
curl -d '{"id": 1, "jsonrpc": "2.0", "method":"generate_block","params": [{"code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8", "args": "0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7", "hash_type": "type"}]}' \
  -H 'content-type:application/json' 'http://localhost:8114'
```