### PR TITLE
refactor: integration service - mining part

### DIFF
--- a/test/src/assertion/mod.rs
+++ b/test/src/assertion/mod.rs
@@ -1,0 +1,2 @@
+pub mod reward_assertion;
+pub mod tx_assertion;

--- a/test/src/assertion/reward_assertion.rs
+++ b/test/src/assertion/reward_assertion.rs
@@ -1,0 +1,199 @@
+use crate::Node;
+use ckb_types::core::{BlockEconomicState, BlockNumber, BlockReward, Capacity, MinerReward};
+use ckb_types::packed::{Byte32, OutPoint};
+use ckb_types::prelude::*;
+use std::collections::HashMap;
+
+// Check the proposed-rewards and committed-rewards is correct
+pub fn assert_chain_rewards(node: &Node) {
+    let mut fee_collector = FeeCollector::build(node);
+    let finalization_delay_length = node.consensus().finalization_delay_length();
+    let tip_number = node.get_tip_block_number();
+    assert!(tip_number > finalization_delay_length);
+
+    for block_number in finalization_delay_length + 1..=tip_number {
+        let block_hash = node.rpc_client().get_block_hash(block_number).unwrap();
+        let early_number = block_number - finalization_delay_length;
+        let early_block = node.get_block_by_number(early_number);
+        let target_hash = early_block.hash();
+        let txs_fee: u64 = early_block
+            .transactions()
+            .iter()
+            .map(|tx| fee_collector.peek(tx.hash()))
+            .sum();
+        let proposed_fee: u64 = early_block
+            .union_proposal_ids_iter()
+            .map(|pid| {
+                let fee = fee_collector.remove(pid);
+                Capacity::shannons(fee)
+                    .safe_mul_ratio(node.consensus().proposer_reward_ratio())
+                    .unwrap()
+                    .as_u64()
+            })
+            .sum();
+        let committed_fee: u64 = early_block
+            .transactions()
+            .iter()
+            .skip(1)
+            .map(|tx| {
+                let fee = fee_collector.remove(tx.hash());
+                fee - Capacity::shannons(fee)
+                    .safe_mul_ratio(node.consensus().proposer_reward_ratio())
+                    .unwrap()
+                    .as_u64()
+            })
+            .sum();
+        assert_proposed_reward(node, block_number, &block_hash, proposed_fee);
+        assert_committed_reward(node, block_number, &block_hash, committed_fee);
+        assert_block_reward(
+            node,
+            early_number,
+            &target_hash,
+            Some((block_hash, txs_fee)),
+        );
+    }
+    {
+        let target_number = 0;
+        let target_hash = node.get_header_by_number(target_number).hash();
+        assert_block_reward(node, target_number, &target_hash, None);
+    }
+    for target_number in (tip_number - finalization_delay_length + 1)..=tip_number {
+        let target_hash = node.get_header_by_number(target_number).hash();
+        assert_block_reward(node, target_number, &target_hash, None);
+    }
+}
+
+fn assert_block_reward(
+    node: &Node,
+    block_number: BlockNumber,
+    target_hash: &Byte32,
+    ext: Option<(Byte32, u64)>,
+) {
+    let actual = node
+        .rpc_client()
+        .get_block_economic_state(target_hash.clone());
+    if let Some((block_hash, txs_fee)) = ext {
+        assert!(
+            actual.is_some(),
+            "assert_block_reward failed at block[{}]: should not be none",
+            block_number
+        );
+        let actual: BlockEconomicState = actual.unwrap().into();
+        let expected: BlockReward = node
+            .rpc_client()
+            .get_cellbase_output_capacity_details(block_hash)
+            .unwrap()
+            .into();
+        let expected: MinerReward = expected.into();
+        assert_eq!(
+            expected, actual.miner_reward,
+            "assert_block_reward failed at block[{}]: miner_reward should be same",
+            block_number
+        );
+        assert!(
+            actual.issuance.primary == actual.miner_reward.primary,
+            "assert_block_reward failed at block[{}]: all primary to miner",
+            block_number
+        );
+        assert!(
+            actual.issuance.secondary > actual.miner_reward.secondary,
+            "assert_block_reward failed at block[{}]: not all secondary to miner",
+            block_number
+        );
+        assert_eq!(
+            txs_fee,
+            actual.txs_fee.as_u64(),
+            "assert_block_reward failed at block[{}]: txs_fee should be same",
+            block_number
+        );
+    } else {
+        assert_eq!(
+            actual, None,
+            "assert_block_reward failed at block[{}]: should be none",
+            block_number
+        );
+    }
+}
+
+fn assert_proposed_reward(
+    node: &Node,
+    block_number: BlockNumber,
+    block_hash: &Byte32,
+    expected: u64,
+) {
+    let actual = node
+        .rpc_client()
+        .get_cellbase_output_capacity_details(block_hash.clone())
+        .unwrap()
+        .proposal_reward
+        .value();
+    assert_eq!(
+        expected, actual,
+        "assert_proposed_reward failed at block[{}]",
+        block_number
+    );
+}
+
+fn assert_committed_reward(
+    node: &Node,
+    block_number: BlockNumber,
+    block_hash: &Byte32,
+    expected: u64,
+) {
+    let actual = node
+        .rpc_client()
+        .get_cellbase_output_capacity_details(block_hash.clone())
+        .unwrap()
+        .tx_fee
+        .value();
+    assert_eq!(
+        expected, actual,
+        "assert_committed_reward failed at block[{}]",
+        block_number
+    );
+}
+
+#[derive(Default)]
+struct FeeCollector {
+    inner: HashMap<String, u64>,
+}
+
+impl FeeCollector {
+    fn build(node: &Node) -> Self {
+        let mut this = Self::default();
+        let mut cells = HashMap::new();
+        for number in 0..node.get_tip_block_number() {
+            let block = node.get_block_by_number(number);
+            for (tx_index, tx) in block.transactions().iter().enumerate() {
+                for (index, output) in tx.outputs().into_iter().enumerate() {
+                    let capacity: u64 = output.capacity().unpack();
+                    cells.insert(OutPoint::new(tx.hash(), index as u32), capacity);
+                }
+
+                if tx_index == 0 {
+                    continue;
+                }
+                let outputs_capacity = tx.outputs_capacity().unwrap().as_u64();
+                let inputs_capacity: u64 = tx
+                    .input_pts_iter()
+                    .map(|previous_out_point| *cells.get(&previous_out_point).unwrap())
+                    .sum();
+                let fee = inputs_capacity - outputs_capacity;
+                this.inner.insert(tx.hash().to_string(), fee);
+                this.inner.insert(tx.proposal_short_id().to_string(), fee);
+            }
+        }
+        this
+    }
+
+    fn remove<S: ToString>(&mut self, key: S) -> u64 {
+        self.inner.remove(&key.to_string()).unwrap_or(0u64)
+    }
+
+    fn peek<S: ToString>(&mut self, key: S) -> u64 {
+        self.inner
+            .get(&key.to_string())
+            .map(ToOwned::to_owned)
+            .unwrap_or(0u64)
+    }
+}

--- a/test/src/assertion/tx_assertion.rs
+++ b/test/src/assertion/tx_assertion.rs
@@ -1,0 +1,57 @@
+use crate::Node;
+use ckb_types::core::{BlockView, TransactionView};
+use ckb_types::prelude::*;
+use std::collections::HashSet;
+
+pub fn assert_proposed_txs(block: &BlockView, expected: &[TransactionView]) {
+    let mut actual_proposals: Vec<_> = block.union_proposal_ids_iter().collect();
+    let mut expected_proposals: Vec<_> = expected.iter().map(|tx| tx.proposal_short_id()).collect();
+    actual_proposals.sort_by(|a, b| a.as_bytes().cmp(&b.as_bytes()));
+    expected_proposals.sort_by(|a, b| a.as_bytes().cmp(&b.as_bytes()));
+    assert_eq!(
+        expected_proposals, actual_proposals,
+        "assert_proposed_txs failed, expected: {:?}, actual: {:?}",
+        expected_proposals, actual_proposals
+    );
+}
+
+pub fn assert_committed_txs(block: &BlockView, expected: &[TransactionView]) {
+    let actual_committed_hashes: Vec<_> = block
+        .transactions()
+        .iter()
+        .skip(1)
+        .map(|tx| tx.hash())
+        .collect();
+    let expected_committed_hashes: Vec<_> = expected.iter().map(|tx| tx.hash()).collect();
+    assert_eq!(
+        &expected_committed_hashes, &actual_committed_hashes,
+        "assert_committed_txs failed, expected: {:?}, actual: {:?}",
+        expected_committed_hashes, actual_committed_hashes
+    );
+}
+
+// Check the given transactions were committed
+pub fn assert_transactions_committed(node: &Node, transactions: &[TransactionView]) {
+    let tip_number = node.get_tip_block_number();
+    let mut hashes: HashSet<_> = transactions.iter().map(|tx| tx.hash()).collect();
+    (1..tip_number).for_each(|number| {
+        let block = node.get_block_by_number(number);
+        block.transactions().iter().skip(1).for_each(|tx| {
+            hashes.remove(&tx.hash());
+        });
+    });
+    assert!(hashes.is_empty());
+}
+
+// Check the given transaction aren't committed
+pub fn assert_transaction_not_committed(node: &Node, transaction: &TransactionView) {
+    let tip_number = node.get_tip_block_number();
+    let tx_hash = transaction.hash();
+    (1..tip_number).for_each(|number| {
+        let block = node.get_block_by_number(number);
+        assert!(!block
+            .transactions()
+            .iter()
+            .any(|tx| { tx.hash() == tx_hash }));
+    });
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod assertion;
 mod net;
 mod node;
 mod rpc;
 pub mod specs;
 mod txo;
+pub mod util;
 pub mod utils;
 pub mod worker;
 
@@ -15,4 +17,5 @@ pub use txo::{TXOSet, TXO};
 
 // ckb doesn't support tx proposal window configuration, use a hardcoded value for integration test.
 pub const DEFAULT_TX_PROPOSAL_WINDOW: (BlockNumber, BlockNumber) = (2, 10);
+pub const FINALIZATION_DELAY_LENGTH: BlockNumber = DEFAULT_TX_PROPOSAL_WINDOW.1 + 1;
 pub const SYSTEM_CELL_ALWAYS_SUCCESS_INDEX: u32 = 5;

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -292,6 +292,7 @@ fn all_specs() -> SpecMap {
         Box::new(DAOWithSatoshiCellOccupied),
         Box::new(SpendSatoshiCell::new()),
         Box::new(MiningBasic),
+        Box::new(BlockTemplates),
         Box::new(BootstrapCellbase),
         Box::new(TemplateSizeLimit),
         Box::new(PoolReconcile),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -1,6 +1,6 @@
 use crate::rpc::RpcClient;
 use crate::utils::{temp_path, wait_until};
-use crate::SYSTEM_CELL_ALWAYS_SUCCESS_INDEX;
+use crate::{DEFAULT_TX_PROPOSAL_WINDOW, SYSTEM_CELL_ALWAYS_SUCCESS_INDEX};
 use ckb_app_config::{BlockAssemblerConfig, CKBAppConfig};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_chain_spec::ChainSpec;
@@ -277,6 +277,10 @@ impl Node {
 
     pub fn generate_blocks(&self, blocks_num: usize) -> Vec<Byte32> {
         (0..blocks_num).map(|_| self.generate_block()).collect()
+    }
+
+    pub fn generate_blocks_until_contains_valid_cellbase(&self) -> Vec<Byte32> {
+        self.generate_blocks((DEFAULT_TX_PROPOSAL_WINDOW.1 + 2) as usize)
     }
 
     // generate a new block and submit it through rpc.

--- a/test/src/specs/mining/basic.rs
+++ b/test/src/specs/mining/basic.rs
@@ -1,53 +1,65 @@
-use crate::{Net, Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use crate::assertion::tx_assertion::*;
+use crate::DEFAULT_TX_PROPOSAL_WINDOW;
+use crate::{Net, Spec};
 use ckb_jsonrpc_types::BlockTemplate;
-use ckb_types::{core::BlockView, packed::ProposalShortId, prelude::*};
-use log::info;
+use ckb_types::{core::BlockView, prelude::*};
 use std::convert::Into;
-use std::thread::sleep;
-use std::time::Duration;
 
 pub struct MiningBasic;
 
 impl Spec for MiningBasic {
     crate::name!("mining_basic");
 
+    // Basic life cycle of transactions:
+    //     1. Submit transaction 'tx' into transactions_pool after height i
+    //     2. Expect tx will be included in block[i+1] proposal zone;
+    //     3. Expect tx will be included in block[i + 1 + proposal_window.closest]
+    //        commit zone.
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
+        node.generate_blocks_until_contains_valid_cellbase();
 
-        self.test_basic(node);
-        self.test_block_template_cache(node);
+        let transaction = [node.new_transaction_spend_tip_cellbase()];
+        node.submit_transaction(&transaction[0]);
+
+        let block1_hash = node.generate_block();
+        let block1: BlockView = node.rpc_client().get_block(block1_hash).unwrap().into();
+
+        assert_proposed_txs(&block1, &transaction);
+
+        // skip (proposal_window.closest - 1) block
+        (0..DEFAULT_TX_PROPOSAL_WINDOW.0 - 1).for_each(|_| {
+            node.generate_block();
+        });
+
+        let block3_hash = node.generate_block();
+        let block3: BlockView = node.rpc_client().get_block(block3_hash).unwrap().into();
+
+        assert_committed_txs(&block3, &transaction);
     }
 }
 
-impl MiningBasic {
-    pub const BLOCK_TEMPLATE_TIMEOUT: u64 = 3;
+pub struct BlockTemplates;
 
-    pub fn test_basic(&self, node: &Node) {
-        node.generate_blocks((DEFAULT_TX_PROPOSAL_WINDOW.1 + 2) as usize);
-        info!("Use generated block's cellbase as tx input");
-        let transaction_hash = node.generate_transaction();
-        let block1_hash = node.generate_block();
-        let _ = node.generate_block(); // skip
-        let block3_hash = node.generate_block();
+impl Spec for BlockTemplates {
+    crate::name!("block_template");
 
-        let block1: BlockView = node.rpc_client().get_block(block1_hash).unwrap().into();
-        let block3: BlockView = node.rpc_client().get_block(block3_hash).unwrap().into();
+    // Block template:
+    //    1. Tip block hash should be parent_hash in block template;
+    //    2. Block template should be updated if tip block updated.
 
-        info!("Generated tx should be included in next block's proposal txs");
-        assert!(block1
-            .union_proposal_ids_iter()
-            .any(|id| ProposalShortId::from_tx_hash(&transaction_hash).eq(&id)));
+    fn run(&self, net: &mut Net) {
+        let node = &net.nodes[0];
+        let rpc_client = node.rpc_client();
 
-        info!("Generated tx should be included in next + n block's commit txs, current n = 2");
-        assert!(block3
-            .transactions()
-            .into_iter()
-            .any(|tx| transaction_hash.eq(&tx.hash())));
-    }
+        let is_block_template_equal = |template1: &BlockTemplate, template2: &BlockTemplate| {
+            let mut temp = template1.clone();
+            temp.current_time = template2.current_time;
+            &temp == template2
+        };
 
-    pub fn test_block_template_cache(&self, node: &Node) {
         let block1 = node.new_block(None, None, None);
-        sleep(Duration::new(Self::BLOCK_TEMPLATE_TIMEOUT + 1, 0)); // Wait block timeout cache timeout
         let block2 = node
             .new_block_builder(None, None, None)
             .header(
@@ -58,36 +70,29 @@ impl MiningBasic {
                     .build(),
             )
             .build();
-        assert_ne!(block1.header().timestamp(), block2.header().timestamp());
+        assert!(block1.header().timestamp() < block2.header().timestamp());
+        assert_eq!(block1.parent_hash(), block2.parent_hash());
 
-        // According to the first-received policy,
-        // the first block is always the best block
-        let rpc_client = node.rpc_client();
-        assert_eq!(block1.hash(), node.submit_block(&block1));
-        assert_eq!(block1.hash(), rpc_client.get_tip_header().hash.pack());
-
+        node.submit_block(&block1);
+        node.submit_block(&block2);
+        assert_eq!(
+            block1.hash(),
+            rpc_client.get_tip_header().hash.pack(),
+            "Block1 should be the tip block according first-received policy"
+        );
         let template1 = rpc_client.get_block_template(None, None, None);
-        sleep(Duration::new(0, 200));
-        let template2 = rpc_client.get_block_template(None, None, None);
-        assert_eq!(block1.hash(), template1.parent_hash.pack());
-        assert!(
-            is_block_template_equal(&template1, &template2),
-            "templates keep same since block template cache",
+        assert_eq!(
+            block1.hash(),
+            template1.parent_hash.pack(),
+            "Block1 should be block template's parent block since it's tip block"
         );
 
-        assert_eq!(block2.hash(), node.submit_block(&block2));
-        assert_eq!(block1.hash(), rpc_client.get_tip_header().hash.pack());
-        let template3 = rpc_client.get_block_template(None, None, None);
-        assert_eq!(block1.hash(), template3.parent_hash.pack());
+        let block3 = node.new_block(None, None, None);
+        node.submit_block(&block3);
+        let template2 = rpc_client.get_block_template(None, None, None);
         assert!(
-            template3.current_time.value() > template1.current_time.value(),
-            "New tip block, new template",
+            !is_block_template_equal(&template1, &template2),
+            "Template should be updated after tip block updated"
         );
     }
-}
-
-fn is_block_template_equal(template1: &BlockTemplate, template2: &BlockTemplate) -> bool {
-    let mut temp = template1.clone();
-    temp.current_time = template2.current_time;
-    &temp == template2
 }

--- a/test/src/specs/mining/bootstrap.rs
+++ b/test/src/specs/mining/bootstrap.rs
@@ -14,12 +14,13 @@ pub struct BootstrapCellbase;
 impl Spec for BootstrapCellbase {
     crate::name!("bootstrap_cellbase");
 
+    // Since mining reward is delay sent in ckb, the 0 - PROPOSAL_WINDOW.furthest blocks'
+    //    cellbase's outputs is empty, which called as bootstrap_cellbase
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
 
-        let blk_hashes: Vec<_> = (0..=DEFAULT_TX_PROPOSAL_WINDOW.1)
-            .map(|_| node.generate_block())
-            .collect();
+        let blk_hashes = node.generate_blocks((DEFAULT_TX_PROPOSAL_WINDOW.1 + 1) as usize);
 
         let miner = packed::Script::new_builder()
             .args(Bytes::from(vec![2, 1]).pack())
@@ -37,10 +38,15 @@ impl Spec for BootstrapCellbase {
                 && blk.transactions()[0].outputs().as_reader().is_empty()
         };
 
-        assert!(blk_hashes.iter().all(is_bootstrap_cellbase));
+        blk_hashes.iter().enumerate().for_each(|(index, blk_hash)| {
+            assert!(
+                is_bootstrap_cellbase(blk_hash),
+                "The {} block's cellbase should be bootstrap_cellbase",
+                index
+            );
+        });
 
         let hash = node.generate_block();
-
         let blk: BlockView = node.rpc_client().get_block(hash).unwrap().into();
         assert!(
             blk.transactions()[0].is_cellbase()
@@ -51,7 +57,8 @@ impl Spec for BootstrapCellbase {
                     .unwrap()
                     .to_entity()
                     .lock()
-                    == miner
+                    == miner,
+            "PROPOSAL_WINDOW.furthest + 1 block's cellbase should not be bootstrap_cellbase"
         )
     }
 

--- a/test/src/specs/mining/fee.rs
+++ b/test/src/specs/mining/fee.rs
@@ -1,11 +1,8 @@
+use crate::assertion::{reward_assertion::*, tx_assertion::*};
 use crate::utils::generate_utxo_set;
-use crate::{Net, Node, Spec};
-use ckb_types::core::{
-    BlockEconomicState, BlockNumber, BlockReward, BlockView, Capacity, MinerReward, TransactionView,
-};
-use ckb_types::packed::{Byte32, OutPoint};
+use crate::{Net, Spec};
+use crate::{DEFAULT_TX_PROPOSAL_WINDOW, FINALIZATION_DELAY_LENGTH};
 use ckb_types::prelude::*;
-use std::collections::{HashMap, HashSet};
 
 pub struct FeeOfTransaction;
 
@@ -21,22 +18,21 @@ impl Spec for FeeOfTransaction {
     //      `block[i + 1 + FINALIZATION_DELAY_LENGTH]`
     //   5. Expect that the miner receives the committed reward of `tx` from
     //      `block[i + 1 + PROPOSAL_WINDOW_CLOSEST + FINALIZATION_DELAY_LENGTH]`
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
-        let closest = node.consensus().tx_proposal_window().closest();
-        let finalization_delay_length = node.consensus().finalization_delay_length();
+        let closest = DEFAULT_TX_PROPOSAL_WINDOW.0;
 
         let txs = generate_utxo_set(node, 1).bang_random_fee(vec![node.always_success_cell_dep()]);
         node.submit_transaction(&txs[0]);
 
-        let number_to_submit = node.get_tip_block_number();
-        let number_to_propose = number_to_submit + 1;
+        let number_to_propose = node.get_tip_block_number() + 1;
         let number_to_commit = number_to_propose + closest;
-        node.generate_blocks(2 * finalization_delay_length as usize);
-        assert_proposals(&node.get_block_by_number(number_to_propose), &txs);
-        assert_committed(&node.get_block_by_number(number_to_commit), &txs);
+        node.generate_blocks(2 * FINALIZATION_DELAY_LENGTH as usize);
 
-        assert_transactions_committed(node, &txs);
+        assert_proposed_txs(&node.get_block_by_number(number_to_propose), &txs);
+        assert_committed_txs(&node.get_block_by_number(number_to_commit), &txs);
+
         assert_chain_rewards(node);
     }
 }
@@ -51,22 +47,22 @@ impl Spec for FeeOfMaxBlockProposalsLimit {
     //   1. Submit `MAX_BLOCK_PROPOSALS_LIMIT` transactions into transactions_pool after height `i`
     //   2. Expect that the miner receives the proposed reward of `tx` from
     //      `block[i + 1 + FINALIZATION_DELAY_LENGTH]`
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
         let max_block_proposals_limit = node.consensus().max_block_proposals_limit();
-        let finalization_delay_length = node.consensus().finalization_delay_length();
         let txs = generate_utxo_set(node, max_block_proposals_limit as usize)
             .bang_random_fee(vec![node.always_success_cell_dep()]);
         txs.iter().for_each(|tx| {
             node.submit_transaction(tx);
         });
 
-        let number_to_submit = node.get_tip_block_number();
-        let number_to_propose = number_to_submit + 1;
-        node.generate_blocks(2 * finalization_delay_length as usize);
-        assert_proposals(&node.get_block_by_number(number_to_propose), &txs);
+        let number_to_propose = node.get_tip_block_number() + 1;
+        node.generate_blocks(2 * FINALIZATION_DELAY_LENGTH as usize);
 
+        assert_proposed_txs(&node.get_block_by_number(number_to_propose), &txs);
         assert_transactions_committed(node, &txs);
+
         assert_chain_rewards(node);
     }
 }
@@ -81,10 +77,10 @@ impl Spec for FeeOfMultipleMaxBlockProposalsLimit {
     //   1. Submit `3 * MAX_BLOCK_PROPOSALS_LIMIT` transactions into transactions_pool after height `i`
     //   2. Expect that the miner propose those transactions in the next `3` blocks, every block
     //      contains `MAX_BLOCK_PROPOSALS_LIMIT` transactions
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
         let max_block_proposals_limit = node.consensus().max_block_proposals_limit();
-        let finalization_delay_length = node.consensus().finalization_delay_length();
 
         let multiple = 3;
         let txs = generate_utxo_set(node, (multiple * max_block_proposals_limit) as usize)
@@ -99,10 +95,12 @@ impl Spec for FeeOfMultipleMaxBlockProposalsLimit {
             assert_eq!(
                 max_block_proposals_limit as usize,
                 block.union_proposal_ids_iter().count(),
+                "block should contain {} blocks in proposal zone",
+                max_block_proposals_limit,
             );
         });
+        node.generate_blocks(2 * FINALIZATION_DELAY_LENGTH as usize);
 
-        node.generate_blocks(2 * finalization_delay_length as usize);
         assert_transactions_committed(node, &txs);
         assert_chain_rewards(node);
     }
@@ -112,40 +110,33 @@ pub struct ProposeButNotCommit;
 
 impl Spec for ProposeButNotCommit {
     crate::name!("propose_but_not_commit");
-
     crate::setup!(num_nodes: 2, connect_all: false);
 
     // Case: Propose a transaction but never commit it
+    //     1. feed_node propose a tx in the latest block but not commit;
+    //     2. target_node fork from feed_node which tip block doesn't proposal tx;
+    //     3. target_node keep growing, but it will never commit 'tx'
+    //        since its trasactions_pool does not have 'tx'
+
     fn run(&self, net: &mut Net) {
         let target_node = &net.nodes[0];
         let feed_node = &net.nodes[1];
 
-        // We use `feed_node` to construct a chain proposed `txs` in the tip block.
-        //
-        // The returned `feed_blocks`, which represents the main fork of
-        // `feed_node`, only proposes `txs` in the last block and never commit
-        let feed_blocks: Vec<_> = {
-            let txs = generate_utxo_set(feed_node, 1)
-                .bang_random_fee(vec![feed_node.always_success_cell_dep()]);
-            feed_node.submit_transaction(&txs[0]);
-            feed_node.generate_block();
+        let txs = generate_utxo_set(feed_node, 1)
+            .bang_random_fee(vec![feed_node.always_success_cell_dep()]);
+        feed_node.submit_transaction(&txs[0]);
+        feed_node.generate_block();
 
-            (1..feed_node.get_tip_block_number())
-                .map(|number| feed_node.get_block_by_number(number))
-                .collect()
-        };
+        let feed_blocks: Vec<_> = (1..feed_node.get_tip_block_number())
+            .map(|number| feed_node.get_block_by_number(number))
+            .collect();
 
-        // `target_node` propose `tx`
         feed_blocks.iter().for_each(|block| {
             target_node.submit_block(&block);
         });
+        target_node.generate_blocks(2 * FINALIZATION_DELAY_LENGTH as usize);
 
-        // `target_node` keeps growing, but it will never commit `tx` since its transactions_pool
-        // have not `tx`.
-        let finalization_delay_length = feed_node.consensus().finalization_delay_length();
-        target_node.generate_blocks(2 * finalization_delay_length as usize);
-
-        assert_chain_rewards(target_node);
+        assert_transaction_not_committed(target_node, &txs[0]);
     }
 }
 
@@ -155,6 +146,7 @@ impl Spec for ProposeDuplicated {
     crate::name!("propose_duplicated");
 
     // Case: Uncle contains a proposal, and the new block contains the same one.
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
         let txs = generate_utxo_set(node, 1).bang_random_fee(vec![node.always_success_cell_dep()]);
@@ -188,246 +180,9 @@ impl Spec for ProposeDuplicated {
         node.submit_transaction(tx);
         node.submit_block(&block);
 
-        let finalization_delay_length = node.consensus().finalization_delay_length();
-        node.generate_blocks(2 * finalization_delay_length as usize);
+        node.generate_blocks(2 * FINALIZATION_DELAY_LENGTH as usize);
 
         assert_transactions_committed(node, &txs);
         assert_chain_rewards(node);
-    }
-}
-
-// Check the given transactions were proposed and committed
-fn assert_transactions_committed(node: &Node, transactions: &[TransactionView]) {
-    let tip_number = node.get_tip_block_number();
-    let mut hashes: HashSet<_> = transactions.iter().map(|tx| tx.hash()).collect();
-    (1..tip_number).for_each(|number| {
-        let block = node.get_block_by_number(number);
-        block.transactions().iter().skip(1).for_each(|tx| {
-            hashes.remove(&tx.hash());
-        });
-    });
-    assert!(hashes.is_empty());
-}
-
-// Check the proposed-rewards and committed-rewards is correct
-fn assert_chain_rewards(node: &Node) {
-    let mut fee_collector = FeeCollector::build(node);
-    let finalization_delay_length = node.consensus().finalization_delay_length();
-    let tip_number = node.get_tip_block_number();
-    assert!(tip_number > finalization_delay_length);
-
-    for block_number in finalization_delay_length + 1..=tip_number {
-        let block_hash = node.rpc_client().get_block_hash(block_number).unwrap();
-        let early_number = block_number - finalization_delay_length;
-        let early_block = node.get_block_by_number(early_number);
-        let target_hash = early_block.hash();
-        let txs_fee: u64 = early_block
-            .transactions()
-            .iter()
-            .map(|tx| fee_collector.peek(tx.hash()))
-            .sum();
-        let proposed_fee: u64 = early_block
-            .union_proposal_ids_iter()
-            .map(|pid| {
-                let fee = fee_collector.remove(pid);
-                Capacity::shannons(fee)
-                    .safe_mul_ratio(node.consensus().proposer_reward_ratio())
-                    .unwrap()
-                    .as_u64()
-            })
-            .sum();
-        let committed_fee: u64 = early_block
-            .transactions()
-            .iter()
-            .skip(1)
-            .map(|tx| {
-                let fee = fee_collector.remove(tx.hash());
-                fee - Capacity::shannons(fee)
-                    .safe_mul_ratio(node.consensus().proposer_reward_ratio())
-                    .unwrap()
-                    .as_u64()
-            })
-            .sum();
-        assert_proposed_reward(node, block_number, &block_hash, proposed_fee);
-        assert_committed_reward(node, block_number, &block_hash, committed_fee);
-        assert_block_reward(
-            node,
-            early_number,
-            &target_hash,
-            Some((block_hash, txs_fee)),
-        );
-    }
-    {
-        let target_number = 0;
-        let target_hash = node.get_header_by_number(target_number).hash();
-        assert_block_reward(node, target_number, &target_hash, None);
-    }
-    for target_number in (tip_number - finalization_delay_length + 1)..=tip_number {
-        let target_hash = node.get_header_by_number(target_number).hash();
-        assert_block_reward(node, target_number, &target_hash, None);
-    }
-}
-
-fn assert_proposals(block: &BlockView, expected: &[TransactionView]) {
-    let mut actual_proposals: Vec<_> = block.union_proposal_ids_iter().collect();
-    let mut expected_proposals: Vec<_> = expected.iter().map(|tx| tx.proposal_short_id()).collect();
-    actual_proposals.sort_by(|a, b| a.as_bytes().cmp(&b.as_bytes()));
-    expected_proposals.sort_by(|a, b| a.as_bytes().cmp(&b.as_bytes()));
-    assert_eq!(
-        expected_proposals,
-        actual_proposals,
-        "assert_proposals failed at block[{}]",
-        block.number()
-    );
-}
-
-fn assert_committed(block: &BlockView, expected: &[TransactionView]) {
-    let actual_committed_hashes: Vec<_> = block
-        .transactions()
-        .iter()
-        .skip(1)
-        .map(|tx| tx.hash())
-        .collect();
-    let expected_committed_hashes: Vec<_> = expected.iter().map(|tx| tx.hash()).collect();
-    assert_eq!(
-        &expected_committed_hashes,
-        &actual_committed_hashes,
-        "assert_committed failed at block[{}]",
-        block.number(),
-    );
-}
-
-fn assert_block_reward(
-    node: &Node,
-    block_number: BlockNumber,
-    target_hash: &Byte32,
-    ext: Option<(Byte32, u64)>,
-) {
-    let actual = node
-        .rpc_client()
-        .get_block_economic_state(target_hash.clone());
-    if let Some((block_hash, txs_fee)) = ext {
-        assert!(
-            actual.is_some(),
-            "assert_block_reward failed at block[{}]: should not be none",
-            block_number
-        );
-        let actual: BlockEconomicState = actual.unwrap().into();
-        let expected: BlockReward = node
-            .rpc_client()
-            .get_cellbase_output_capacity_details(block_hash)
-            .unwrap()
-            .into();
-        let expected: MinerReward = expected.into();
-        assert_eq!(
-            expected, actual.miner_reward,
-            "assert_block_reward failed at block[{}]: miner_reward should be same",
-            block_number
-        );
-        assert!(
-            actual.issuance.primary == actual.miner_reward.primary,
-            "assert_block_reward failed at block[{}]: all primary to miner",
-            block_number
-        );
-        assert!(
-            actual.issuance.secondary > actual.miner_reward.secondary,
-            "assert_block_reward failed at block[{}]: not all secondary to miner",
-            block_number
-        );
-        assert_eq!(
-            txs_fee,
-            actual.txs_fee.as_u64(),
-            "assert_block_reward failed at block[{}]: txs_fee should be same",
-            block_number
-        );
-    } else {
-        assert_eq!(
-            actual, None,
-            "assert_block_reward failed at block[{}]: should be none",
-            block_number
-        );
-    }
-}
-
-fn assert_proposed_reward(
-    node: &Node,
-    block_number: BlockNumber,
-    block_hash: &Byte32,
-    expected: u64,
-) {
-    let actual = node
-        .rpc_client()
-        .get_cellbase_output_capacity_details(block_hash.clone())
-        .unwrap()
-        .proposal_reward
-        .value();
-    assert_eq!(
-        expected, actual,
-        "assert_proposed_reward failed at block[{}]",
-        block_number
-    );
-}
-
-fn assert_committed_reward(
-    node: &Node,
-    block_number: BlockNumber,
-    block_hash: &Byte32,
-    expected: u64,
-) {
-    let actual = node
-        .rpc_client()
-        .get_cellbase_output_capacity_details(block_hash.clone())
-        .unwrap()
-        .tx_fee
-        .value();
-    assert_eq!(
-        expected, actual,
-        "assert_committed_reward failed at block[{}]",
-        block_number
-    );
-}
-
-#[derive(Default)]
-struct FeeCollector {
-    inner: HashMap<String, u64>,
-}
-
-impl FeeCollector {
-    fn build(node: &Node) -> Self {
-        let mut this = Self::default();
-        let mut cells = HashMap::new();
-        for number in 0..node.get_tip_block_number() {
-            let block = node.get_block_by_number(number);
-            for (tx_index, tx) in block.transactions().iter().enumerate() {
-                for (index, output) in tx.outputs().into_iter().enumerate() {
-                    let capacity: u64 = output.capacity().unpack();
-                    cells.insert(OutPoint::new(tx.hash(), index as u32), capacity);
-                }
-
-                if tx_index == 0 {
-                    continue;
-                }
-                let outputs_capacity = tx.outputs_capacity().unwrap().as_u64();
-                let inputs_capacity: u64 = tx
-                    .input_pts_iter()
-                    .map(|previous_out_point| *cells.get(&previous_out_point).unwrap())
-                    .sum();
-                let fee = inputs_capacity - outputs_capacity;
-                this.inner.insert(tx.hash().to_string(), fee);
-                this.inner.insert(tx.proposal_short_id().to_string(), fee);
-            }
-        }
-        this
-    }
-
-    fn remove<S: ToString>(&mut self, key: S) -> u64 {
-        self.inner.remove(&key.to_string()).unwrap_or(0u64)
-    }
-
-    fn peek<S: ToString>(&mut self, key: S) -> u64 {
-        self.inner
-            .get(&key.to_string())
-            .map(ToOwned::to_owned)
-            .unwrap_or(0u64)
     }
 }

--- a/test/src/specs/mining/uncle.rs
+++ b/test/src/specs/mining/uncle.rs
@@ -1,7 +1,6 @@
 use crate::{Net, Node, Spec};
 use ckb_types::core::{BlockView, EpochNumberWithFraction};
 use ckb_types::prelude::*;
-use log::info;
 
 // Convention:
 //   main-block: a block on the main fork
@@ -17,16 +16,20 @@ impl Spec for UncleInheritFromForkBlock {
     crate::setup!(num_nodes: 2, connect_all: false);
 
     // Case: A uncle inherited from a fork-block in side fork is invalid, because that breaks
-    //       the uncle rule "B1's parent is either B2's ancestor or embedded in B2 or its ancestors
-    //       as an uncle"
+    //       the uncle rule "B1's parent is either B2's ancestor or embedded in B2
+    //       or its ancestors as an uncle"
+    //    1. Build a chain which embedded `uncle` as an uncle;
+    //    2. Force reorg, so that the parent of `uncle` become fork-block;
+    //    3. Submit block with `uncle`, which is inherited from a fork-block, should be failed;
+    //    4. Add all the fork-blocks as uncle blocks into the chain and re-submit block with
+    //       `uncle` should be success
+
     fn run(&self, net: &mut Net) {
         let target_node = &net.nodes[0];
         let feed_node = &net.nodes[1];
 
-        info!("(1) Build a chain which embedded `uncle` as an uncle");
         let uncle = construct_uncle(target_node);
 
-        info!("(2) Force reorg, so that the parent of `uncle` become fork-block");
         let longer_fork = (0..=target_node.get_tip_block_number()).map(|_| {
             let block = feed_node.new_block(None, None, None);
             feed_node.submit_block(&block);
@@ -36,9 +39,6 @@ impl Spec for UncleInheritFromForkBlock {
             target_node.submit_block(&block);
         });
 
-        info!(
-            "(3) Submit block with `uncle`, which is inherited from a fork-block, should be failed"
-        );
         let block = target_node
             .new_block_builder(None, None, None)
             .set_uncles(vec![uncle.as_uncle()])
@@ -46,11 +46,18 @@ impl Spec for UncleInheritFromForkBlock {
         let ret = target_node
             .rpc_client()
             .submit_block("0".to_owned(), block.data().into());
-        assert!(ret.is_err(), "{:?}", ret);
+        assert!(
+            ret.is_err(),
+            "Submit block with uncle inherited from a fork-block should be failed, but got {:?}",
+            ret
+        );
         let err = ret.unwrap_err();
-        assert!(err.to_string().contains("DescendantLimit"), "{:?}", err);
+        assert!(
+            err.to_string().contains("DescendantLimit"),
+            "The result should contain 'DescendantLimit', but got {:?}",
+            err
+        );
 
-        info!("(4) Add all the fork-blocks as uncle blocks into the chain. And now re-submit block with `uncle` should be success");
         until_no_uncles_left(target_node);
         let block = target_node
             .new_block_builder(None, None, None)
@@ -68,14 +75,18 @@ impl Spec for UncleInheritFromForkUncle {
     crate::setup!(num_nodes: 2, connect_all: false);
 
     // Case: A uncle inherited from a fork-uncle in side fork is invalid, because that breaks
-    //       the uncle rule "B1's parent is either B2's ancestor or embedded in B2 or its ancestors
-    //       as an uncle"
+    //       the uncle rule "B1's parent is either B2's ancestor or embedded in B2
+    //       or its ancestors as an uncle"
+    //    1. Build a chain which embedded `uncle_parent` as an uncle;
+    //    2. Force reorg, so that `uncle_parent` become a fork-uncle;
+    //    3. Submit block with `uncle`, which is inherited from fork-uncle `uncle_parent`,
+    //       should be failed
+    //    4. Add all the fork-blocks as uncle blocks into the chain and now re-submit block with
+    //       `uncle_child` should be success
     fn run(&self, net: &mut Net) {
         let target_node = &net.nodes[0];
         let feed_node = &net.nodes[1];
-        net.exit_ibd_mode();
 
-        info!("(1) Build a chain which embedded `uncle_parent` as an uncle");
         let uncle_parent = construct_uncle(target_node);
         target_node.submit_block(&uncle_parent);
 
@@ -96,7 +107,6 @@ impl Spec for UncleInheritFromForkUncle {
             )
             .build();
 
-        info!("(2) Force reorg, so that `uncle_parent` become a fork-uncle");
         let longer_fork = (0..=target_node.get_tip_block_number()).map(|_| {
             let block = feed_node.new_block(None, None, None);
             feed_node.submit_block(&block);
@@ -106,7 +116,6 @@ impl Spec for UncleInheritFromForkUncle {
             target_node.submit_block(&block);
         });
 
-        info!("(3) Submit block with `uncle`, which is inherited from fork-uncle `uncle_parent`, should be failed");
         let block = target_node
             .new_block_builder(None, None, None)
             .set_uncles(vec![uncle_child.as_uncle()])
@@ -114,11 +123,18 @@ impl Spec for UncleInheritFromForkUncle {
         let ret = target_node
             .rpc_client()
             .submit_block("0".to_owned(), block.data().into());
-        assert!(ret.is_err(), "{:?}", ret);
+        assert!(
+            ret.is_err(),
+            "Submit block with uncle inherited from a fork-uncle should be failed, but got {:?}",
+            ret
+        );
         let err = ret.unwrap_err();
-        assert!(err.to_string().contains("DescendantLimit"), "{:?}", err);
+        assert!(
+            err.to_string().contains("DescendantLimit"),
+            "The result should contain 'DescendantLimit', but got {:?}",
+            err
+        );
 
-        info!("(4) Add all the fork-blocks as uncle blocks into the chain. And now re-submit block with `uncle_child` should be success");
         until_no_uncles_left(target_node);
         let block = target_node
             .new_block_builder(None, None, None)
@@ -134,6 +150,11 @@ impl Spec for PackUnclesIntoEpochStarting {
     crate::name!("pack_uncles_into_epoch_starting");
 
     // Case: Miner should not add uncles into the epoch starting
+    //    1. Chain grow until CURRENT_EPOCH_END - 1 and submit uncle;
+    //    2. Expect the next mining block(CURRENT_EPOCH_END) contains the uncle;
+    //    3. Submit CURRENT_EPOCH_END block with empty uncles;
+    //    4. Expect the next mining block(NEXT_EPOCH_START) not contains uncle.
+
     fn run(&self, net: &mut Net) {
         let node = &net.nodes[0];
         let uncle = construct_uncle(node);
@@ -143,28 +164,25 @@ impl Spec for PackUnclesIntoEpochStarting {
         };
         let current_epoch_end = next_epoch_start - 1;
 
-        info!(
-            "(1) Grow until CURRENT_EPOCH_END-1({})",
-            current_epoch_end - 1
-        );
         node.generate_blocks((current_epoch_end - node.get_tip_block_number() - 1) as usize);
-        assert_eq!(current_epoch_end - 1, node.get_tip_block_number());
-
-        info!("(2) Submit the target uncle");
         node.submit_block(&uncle);
 
-        info!("(3) Expect the next mining block(CURRENT_EPOCH_END) contains the target uncle");
         let block = node.new_block(None, None, None);
-        assert_eq!(1, block.uncles().into_iter().count());
+        assert_eq!(
+            1,
+            block.uncles().into_iter().count(),
+            "Current_epoch_end block should contain the uncle"
+        );
 
-        // Clear the uncles in the next block, we don't want to pack the target `uncle` now.
-        info!("(4) Submit the next block with empty uncles");
         let block_with_empty_uncles = block.as_advanced_builder().set_uncles(vec![]).build();
         node.submit_block(&block_with_empty_uncles);
 
-        info!("(5) Expect the next mining block(NEXT_EPOCH_START) not contains the target uncle");
         let block = node.new_block(None, None, None);
-        assert_eq!(0, block.uncles().into_iter().count());
+        assert_eq!(
+            0,
+            block.uncles().into_iter().count(),
+            "Next_epoch_start block should not contain the uncle"
+        );
     }
 }
 

--- a/test/src/util/mod.rs
+++ b/test/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod tx;

--- a/test/src/util/tx.rs
+++ b/test/src/util/tx.rs
@@ -1,0 +1,35 @@
+use crate::Node;
+use ckb_types::{
+    bytes::Bytes,
+    core::{Capacity, TransactionView},
+    prelude::*,
+};
+
+pub fn new_transaction_with_fee_and_size(
+    node: &Node,
+    parent_tx: &TransactionView,
+    fee: Capacity,
+    tx_size: usize,
+) -> TransactionView {
+    let input_capacity: Capacity = parent_tx
+        .outputs()
+        .get(0)
+        .expect("parent output")
+        .capacity()
+        .unpack();
+    let capacity = input_capacity.safe_sub(fee).unwrap();
+    let tx = node.new_transaction_with_since_capacity(parent_tx.hash(), 0, capacity);
+    let original_tx_size = tx.data().serialized_size_in_block();
+    let tx = tx
+        .as_advanced_builder()
+        .set_outputs_data(vec![
+            Bytes::from(vec![0u8; tx_size - original_tx_size]).pack()
+        ])
+        .build();
+    assert_eq!(
+        tx.data().serialized_size_in_block(),
+        tx_size,
+        "tx size incorrect"
+    );
+    tx
+}


### PR DESCRIPTION
Refactor about integration service mining relate cases:
1. Add comment for explain what does the case do;
2. Update some assertions and add relate info if assert failed;

Besides there also add a new folder `test/src/assertion` which contains some assert functions, a new folder `test/src/util` which contains some functions used in cases setup.