### PR TITLE
feat: take full control of main logger filter via RPC

### DIFF
--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -263,10 +263,7 @@ impl Setup {
         let network_dir = network_config.path.clone();
         let network_peer_store_path = network_config.peer_store_path();
         let network_secret_key_path = network_config.secret_key_path();
-        let logs_dir = config
-            .logger
-            .file
-            .and_then(|path| path.parent().map(|dir| dir.to_path_buf()));
+        let logs_dir = Some(config.logger.log_dir);
 
         let force = matches.is_present(cli::ARG_FORCE);
         let all = matches.is_present(cli::ARG_ALL);

--- a/util/jsonrpc-types/src/debug.rs
+++ b/util/jsonrpc-types/src/debug.rs
@@ -4,3 +4,11 @@ use serde::{Deserialize, Serialize};
 pub struct ExtraLoggerConfig {
     pub filter: String,
 }
+
+#[derive(Clone, Default, Serialize, Deserialize, Debug)]
+pub struct MainLoggerConfig {
+    pub filter: Option<String>,
+    pub to_stdout: Option<bool>,
+    pub to_file: Option<bool>,
+    pub color: Option<bool>,
+}

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::blockchain::{
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellOutputWithOutPoint, CellWithStatus};
 pub use self::chain_info::ChainInfo;
-pub use self::debug::ExtraLoggerConfig;
+pub use self::debug::{ExtraLoggerConfig, MainLoggerConfig};
 pub use self::experiment::{DryRunResult, EstimateResult};
 pub use self::fixed_bytes::Byte32;
 pub use self::indexer::{


### PR DESCRIPTION
### Issues:
- After #2175 , the name of rpc `set_logger_filter` is not proper (`the main logger` or `a extra logger`), change to `update_main_logger`  (in module `Debug`).
  And let `update_main_logger` take full control of main logger filter, not only filter.
- `panic` when failed to open a log file doesn't output any error messages.
  Use `eprintln!(..)` and `process::exit(..)` instead of `panic`.
- `panic` in logger service thread doesn't stop ckb process, but only stop logger service.
  Just ignore the error logger, keep the logger service running.

### Usages:
```shell
# Disable output logs to file.
curl -H 'content-type: application/json' -d \
  '{ "id": 2, "jsonrpc": "2.0", "method": "update_main_logger", "params": [{"to_file": false}] }' \
  http://localhost:8114 
# Enable output logs to stdout with color.
curl -H 'content-type: application/json' -d \
  '{ "id": 2, "jsonrpc": "2.0", "method": "update_main_logger", "params": [{"to_stdout": false, "color": true}] }' \
  http://localhost:8114 
# Update the filter of main logger.
curl -H 'content-type: application/json' -d \
  '{ "id": 2, "jsonrpc": "2.0", "method": "update_main_logger", "params": [{"filter": "error,ckb-chain=info"}] }' \
  http://localhost:8114 
```