### PR TITLE
feat: tx_pool_info include tip hash

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2104,6 +2104,8 @@ http://localhost:8114
         "orphan": "0x0",
         "pending": "0x1",
         "proposed": "0x0",
+        "tip_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "tip_number": "0x400",
         "total_tx_cycles": "0x219",
         "total_tx_size": "0x112"
     }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -342,8 +342,8 @@
             {
                 "addresses": [
                     {
-                        "score": "0x64",
-                        "address": "/ip6/::ffff:18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN"
+                        "address": "/ip6/::ffff:18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
+                        "score": "0x64"
                     },
                     {
                         "address": "/ip4/18.185.102.19/tcp/8115/p2p/QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
@@ -355,15 +355,15 @@
                 "version": "0.31.0 (4231360 2020-04-20)"
             },
             {
-                "version": "0.29.0 (a6733e6 2020-02-26)",
                 "addresses": [
                     {
                         "address": "/ip4/174.80.182.60/tcp/52965/p2p/QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
                         "score": "0x1"
                     }
                 ],
+                "is_outbound": false,
                 "node_id": "QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
-                "is_outbound": false
+                "version": "0.29.0 (a6733e6 2020-02-26)"
             }
         ],
         "skip": true
@@ -800,6 +800,8 @@
             "orphan": "0x0",
             "pending": "0x1",
             "proposed": "0x0",
+            "tip_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+            "tip_number": "0x400",
             "total_tx_cycles": "0x219",
             "total_tx_size": "0x112"
         }
@@ -1349,15 +1351,10 @@
             "0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412"
         ],
         "result": {
+            "block_number": "0x400",
             "capacity": "0xb00fb84df292",
-            "cells_count": "0x3f5",
-            "block_number": "0x400"
+            "cells_count": "0x3f5"
         },
-        "types": [
-            {
-                "lock_hash": "Cell lock script hash"
-            }
-        ],
         "returns": [
             {
                 "capacity": "Total capacity"
@@ -1367,6 +1364,11 @@
             },
             {
                 "block_number": "At which block capacity was calculated"
+            }
+        ],
+        "types": [
+            {
+                "lock_hash": "Cell lock script hash"
             }
         ]
     },
@@ -1563,17 +1565,17 @@
             "new_tip_header"
         ],
         "result": "0x2a",
-        "types": [
-            {
-                "topic": "Subscription topic (enum: new_tip_header | new_tip_block)"
-            }
-        ],
         "returns": [
             {
                 "id": "Subscription id"
             }
         ],
-        "skip": true
+        "skip": true,
+        "types": [
+            {
+                "topic": "Subscription topic (enum: new_tip_header | new_tip_block)"
+            }
+        ]
     },
     {
         "description": "unsubscribe from a subscribed topic",
@@ -1583,16 +1585,16 @@
             "0x2a"
         ],
         "result": true,
-        "types": [
-            {
-                "id": "Subscription id"
-            }
-        ],
         "returns": [
             {
                 "result": "Unsubscribe result"
             }
         ],
-        "skip": true
+        "skip": true,
+        "types": [
+            {
+                "id": "Subscription id"
+            }
+        ]
     }
 ]

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -141,9 +141,10 @@ impl PoolRpc for PoolRpcImpl {
     }
 
     fn clear_tx_pool(&self) -> Result<()> {
+        let snapshot = Arc::clone(&self.shared.snapshot());
         let tx_pool = self.shared.tx_pool_controller();
         tx_pool
-            .clear_pool()
+            .clear_pool(snapshot)
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
 
         Ok(())

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -128,6 +128,8 @@ impl PoolRpc for PoolRpcImpl {
         let tx_pool_info = get_tx_pool_info.unwrap();
 
         Ok(TxPoolInfo {
+            tip_hash: tx_pool_info.tip_hash.unpack(),
+            tip_number: tx_pool_info.tip_number.into(),
             pending: (tx_pool_info.pending_size as u64).into(),
             proposed: (tx_pool_info.proposed_size as u64).into(),
             orphan: (tx_pool_info.orphan_size as u64).into(),

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -103,9 +103,10 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
 
         // Clear the tx_pool
+        let new_snapshot = Arc::clone(&self.shared.snapshot());
         let tx_pool = self.shared.tx_pool_controller();
         tx_pool
-            .clear_pool()
+            .clear_pool(new_snapshot)
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
 
         Ok(())

--- a/test/src/specs/indexer/basic.rs
+++ b/test/src/specs/indexer/basic.rs
@@ -57,16 +57,16 @@ impl Spec for IndexerBasic {
         });
 
         info!("Generate 3 more blocks on node0 to commit 6 txs");
-        let tx_pool_info = node0.rpc_client().tx_pool_info();
+        let tx_pool_info = node0.get_tip_tx_pool_info();
         assert_eq!(6, tx_pool_info.pending.value() as u64);
         node0.generate_blocks(1);
 
-        let tx_pool_info = node0.rpc_client().tx_pool_info();
+        let tx_pool_info = node0.get_tip_tx_pool_info();
         // in gap
         assert_eq!(6, tx_pool_info.pending.value() as u64);
         node0.generate_blocks(1);
 
-        let tx_pool_info = node0.rpc_client().tx_pool_info();
+        let tx_pool_info = node0.get_tip_tx_pool_info();
         assert_eq!(6, tx_pool_info.proposed.value() as u64);
         node0.generate_blocks(1);
 

--- a/test/src/specs/rpc/truncate.rs
+++ b/test/src/specs/rpc/truncate.rs
@@ -29,7 +29,7 @@ impl Spec for RpcTruncate {
             .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
         assert_eq!(cell1.status, "unknown", "cell1 was spent within tx1");
 
-        let tx_pool_info = node.rpc_client().tx_pool_info();
+        let tx_pool_info = node.get_tip_tx_pool_info();
         assert!(tx_pool_info.total_tx_size.value() > 0, "tx-pool holds tx2");
 
         // Truncate from `to_truncate`
@@ -56,7 +56,7 @@ impl Spec for RpcTruncate {
             .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
         assert_eq!(cell1.status, "live", "cell1 is alive after roll-backing");
 
-        let tx_pool_info = node.rpc_client().tx_pool_info();
+        let tx_pool_info = node.get_tip_tx_pool_info();
         assert_eq!(tx_pool_info.orphan.value(), 0, "tx-pool was cleared");
         assert_eq!(tx_pool_info.pending.value(), 0, "tx-pool was cleared");
         assert_eq!(tx_pool_info.proposed.value(), 0, "tx-pool was cleared");

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -24,7 +24,7 @@ impl Spec for SizeLimit {
         let mut hash = node.submit_transaction(&tx);
         txs_hash.push(hash.clone());
 
-        let tx_pool_info = node.rpc_client().tx_pool_info();
+        let tx_pool_info = node.get_tip_tx_pool_info();
         let one_tx_size = tx_pool_info.total_tx_size.value();
         let one_tx_cycles = tx_pool_info.total_tx_cycles.value();
 
@@ -87,7 +87,7 @@ impl Spec for CyclesLimit {
         let mut hash = node.submit_transaction(&tx);
         txs_hash.push(hash.clone());
 
-        let tx_pool_info = node.rpc_client().tx_pool_info();
+        let tx_pool_info = node.get_tip_tx_pool_info();
         let one_tx_cycles = tx_pool_info.total_tx_cycles.value();
         let one_tx_size = tx.data().serialized_size_in_block();
 

--- a/test/src/specs/tx_pool/pool_resurrect.rs
+++ b/test/src/specs/tx_pool/pool_resurrect.rs
@@ -30,7 +30,7 @@ impl Spec for PoolResurrect {
         node0.generate_blocks(3);
 
         info!("Pool should be empty");
-        let tx_pool_info = node0.rpc_client().tx_pool_info();
+        let tx_pool_info = node0.get_tip_tx_pool_info();
         assert_eq!(tx_pool_info.pending.value(), 0);
 
         info!("Generate 5 blocks on node1");

--- a/test/src/specs/tx_pool/txs_relay_order.rs
+++ b/test/src/specs/tx_pool/txs_relay_order.rs
@@ -40,13 +40,13 @@ impl Spec for TxsRelayOrder {
         for tx in txs.iter() {
             node0.rpc_client().send_transaction(tx.data().into());
         }
-        let tx_pool_info = node0.rpc_client().tx_pool_info();
+        let tx_pool_info = node0.get_tip_tx_pool_info();
         assert_eq!(COUNT as u64, tx_pool_info.pending.value());
         assert_eq!(0, tx_pool_info.orphan.value());
 
         // node1 should receive all txs
         sleep(10);
-        let tx_pool_info = node1.rpc_client().tx_pool_info();
+        let tx_pool_info = node1.get_tip_tx_pool_info();
         assert_eq!(
             COUNT as u64,
             tx_pool_info.pending.value() + tx_pool_info.orphan.value()

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -10,6 +10,7 @@ use ckb_error::{Error, ErrorKind, InternalErrorKind};
 use ckb_logger::{debug, error, trace};
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
+use ckb_types::core::BlockNumber;
 use ckb_types::{
     core::{
         cell::{resolve_transaction, OverlayCellProvider, ResolvedTransaction},
@@ -55,6 +56,8 @@ pub struct TxPool {
 
 #[derive(Clone, Debug)]
 pub struct TxPoolInfo {
+    pub tip_hash: Byte32,
+    pub tip_number: BlockNumber,
     pub pending_size: usize,
     pub proposed_size: usize,
     pub orphan_size: usize,
@@ -96,7 +99,10 @@ impl TxPool {
     }
 
     pub fn info(&self) -> TxPoolInfo {
+        let tip_header = self.snapshot.tip_header();
         TxPoolInfo {
+            tip_hash: tip_header.hash(),
+            tip_number: tip_header.number(),
             pending_size: self.pending.size() + self.gap.size(),
             proposed_size: self.proposed.size(),
             orphan_size: self.orphan.size(),

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -492,12 +492,11 @@ impl TxPoolService {
         });
     }
 
-    pub(crate) async fn clear_pool(&self) {
+    pub(crate) async fn clear_pool(&self, new_snapshot: Arc<Snapshot>) {
         let mut tx_pool = self.tx_pool.write().await;
         let config = tx_pool.config;
-        let snapshot = Arc::clone(&tx_pool.snapshot);
         let last_txs_updated_at = Arc::new(AtomicU64::new(0));
-        *tx_pool = TxPool::new(config, snapshot, last_txs_updated_at);
+        *tx_pool = TxPool::new(config, new_snapshot, last_txs_updated_at);
     }
 }
 

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -77,7 +77,7 @@ pub enum Message {
     FetchTxRPC(Request<ProposalShortId, Option<(bool, TransactionView)>>),
     NewUncle(Notify<UncleBlockView>),
     PlugEntry(Request<(Vec<TxEntry>, PlugTarget), ()>),
-    ClearPool(Request<(), ()>),
+    ClearPool(Request<Arc<Snapshot>, ()>),
 }
 
 #[derive(Clone)]
@@ -254,10 +254,10 @@ impl TxPoolController {
         response.recv().map_err(Into::into)
     }
 
-    pub fn clear_pool(&self) -> Result<(), FailureError> {
+    pub fn clear_pool(&self, new_snapshot: Arc<Snapshot>) -> Result<(), FailureError> {
         let mut sender = self.sender.clone();
         let (responder, response) = crossbeam_channel::bounded(1);
-        let request = Request::call((), responder);
+        let request = Request::call(new_snapshot, responder);
         sender.try_send(Message::ClearPool(request)).map_err(|e| {
             let (_m, e) = handle_try_send_error(e);
             e
@@ -497,8 +497,11 @@ async fn process(service: TxPoolService, message: Message) {
                 error!("responder send plug_entry failed {:?}", e);
             };
         }
-        Message::ClearPool(Request { responder, .. }) => {
-            service.clear_pool().await;
+        Message::ClearPool(Request {
+            responder,
+            arguments: new_snapshot,
+        }) => {
+            service.clear_pool(new_snapshot).await;
             if let Err(e) = responder.send(()) {
                 error!("responder send clear_pool failed {:?}", e)
             };

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -1,9 +1,12 @@
-use crate::{Timestamp, Uint64};
+use crate::{BlockNumber, Timestamp, Uint64};
+use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 use serde_json;
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct TxPoolInfo {
+    pub tip_hash: H256,
+    pub tip_number: BlockNumber,
     pub pending: Uint64,
     pub proposed: Uint64,
     pub orphan: Uint64,


### PR DESCRIPTION
The state of the transaction pool is related to the chain tip. So attaching `tip_hash` and `tip_number` into `TxPoolInfo` which returns by RPC `tx_pool_info` makes it more rigorous.