### PR TITLE
feat: add more fields to `local_node_info` rpc

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1286,6 +1286,10 @@ impl NetworkController {
     pub fn set_active(&self, active: bool) {
         self.network_state.active.store(active, Ordering::Relaxed);
     }
+
+    pub fn protocols(&self) -> Vec<(ProtocolId, String, Vec<String>)> {
+        self.network_state.protocols.read().clone()
+    }
 }
 
 impl Drop for NetworkController {

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -121,22 +121,26 @@ fn net_service_start(name: String) -> Node {
     let network_state =
         Arc::new(NetworkState::from_config(config.clone()).expect("Init network state failed"));
 
-    network_state
-        .protocol_ids
-        .write()
-        .insert(SupportProtocols::Ping.protocol_id());
-    network_state
-        .protocol_ids
-        .write()
-        .insert(SupportProtocols::Discovery.protocol_id());
-    network_state
-        .protocol_ids
-        .write()
-        .insert(SupportProtocols::Identify.protocol_id());
-    network_state
-        .protocol_ids
-        .write()
-        .insert(SupportProtocols::Feeler.protocol_id());
+    network_state.protocols.write().push((
+        SupportProtocols::Ping.protocol_id(),
+        SupportProtocols::Ping.name(),
+        SupportProtocols::Ping.support_versions(),
+    ));
+    network_state.protocols.write().push((
+        SupportProtocols::Discovery.protocol_id(),
+        SupportProtocols::Discovery.name(),
+        SupportProtocols::Discovery.support_versions(),
+    ));
+    network_state.protocols.write().push((
+        SupportProtocols::Identify.protocol_id(),
+        SupportProtocols::Identify.name(),
+        SupportProtocols::Identify.support_versions(),
+    ));
+    network_state.protocols.write().push((
+        SupportProtocols::Feeler.protocol_id(),
+        SupportProtocols::Feeler.name(),
+        SupportProtocols::Feeler.support_versions(),
+    ));
 
     // Ping protocol
     let (ping_sender, ping_receiver) = channel(std::u8::MAX as usize);

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1841,6 +1841,15 @@ http://localhost:8114
 
 Returns the local node information.
 
+#### Returns
+
+    active - Whether p2p networking is enabled
+    addresses - The addresses of node listen to
+    connections - The number of connections
+    node_id - The id of node
+    protocols::id - Supported p2p protocol id
+    protocols::name - Supported p2p protocol name
+    protocols::support_versions - Supported p2p protocol versions
 
 #### Examples
 
@@ -1861,6 +1870,7 @@ http://localhost:8114
     "id": 2,
     "jsonrpc": "2.0",
     "result": {
+        "active": true,
         "addresses": [
             {
                 "address": "/ip4/192.168.0.2/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
@@ -1871,9 +1881,25 @@ http://localhost:8114
                 "score": "0x1"
             }
         ],
-        "is_active": true,
+        "connections": "0xb",
         "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
-        "version": "0.0.0"
+        "protocols": [
+            {
+                "id": "0x0",
+                "name": "/ckb/ping",
+                "support_versions": [
+                    "0.0.1"
+                ]
+            },
+            {
+                "id": "0x1",
+                "name": "/ckb/discovery",
+                "support_versions": [
+                    "0.0.1"
+                ]
+            }
+        ],
+        "version": "0.34.0 (f37f598 2020-07-17)"
     }
 }
 ```

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -318,6 +318,7 @@
         "module": "net",
         "params": [],
         "result": {
+            "active": true,
             "addresses": [
                 {
                     "address": "/ip4/192.168.0.2/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
@@ -328,10 +329,49 @@
                     "score": "0x1"
                 }
             ],
-            "is_active": true,
+            "connections": "0xb",
             "node_id": "QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS",
-            "version": "0.0.0"
+            "protocols": [
+                {
+                    "id": "0x0",
+                    "name": "/ckb/ping",
+                    "support_versions": [
+                        "0.0.1"
+                    ]
+                },
+                {
+                    "id": "0x1",
+                    "name": "/ckb/discovery",
+                    "support_versions": [
+                        "0.0.1"
+                    ]
+                }
+            ],
+            "version": "0.34.0 (f37f598 2020-07-17)"
         },
+        "returns": [
+            {
+                "active": "Whether p2p networking is enabled"
+            },
+            {
+                "addresses": "The addresses of node listen to"
+            },
+            {
+                "connections": "The number of connections"
+            },
+            {
+                "node_id": "The id of node"
+            },
+            {
+                "protocols::id": "Supported p2p protocol id"
+            },
+            {
+                "protocols::name": "Supported p2p protocol name"
+            },
+            {
+                "protocols::support_versions": "Supported p2p protocol versions"
+            }
+        ],
         "skip": true
     },
     {

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -1,7 +1,7 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
-    BannedAddr, LocalNode, NodeAddress, PeerSyncState, RemoteNode, RemoteNodeProtocol, SyncState,
-    Timestamp,
+    BannedAddr, LocalNode, LocalNodeProtocol, NodeAddress, PeerSyncState, RemoteNode,
+    RemoteNodeProtocol, SyncState, Timestamp,
 };
 use ckb_network::{MultiaddrExt, NetworkController};
 use ckb_sync::SyncShared;
@@ -65,7 +65,7 @@ impl NetworkRpc for NetworkRpcImpl {
         Ok(LocalNode {
             version: self.network_controller.version().to_owned(),
             node_id: self.network_controller.node_id(),
-            is_active: self.network_controller.is_active(),
+            active: self.network_controller.is_active(),
             addresses: self
                 .network_controller
                 .public_urls(MAX_ADDRS)
@@ -75,6 +75,17 @@ impl NetworkRpc for NetworkRpcImpl {
                     score: u64::from(score).into(),
                 })
                 .collect(),
+            protocols: self
+                .network_controller
+                .protocols()
+                .into_iter()
+                .map(|(protocol_id, name, support_versions)| LocalNodeProtocol {
+                    id: (protocol_id.value() as u64).into(),
+                    name,
+                    support_versions,
+                })
+                .collect::<Vec<_>>(),
+            connections: (self.network_controller.connected_peers().len() as u64).into(),
         })
     }
 

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -35,7 +35,8 @@ pub use self::indexer::{
     CellTransaction, LiveCell, LockHashCapacity, LockHashIndexState, TransactionPoint,
 };
 pub use self::net::{
-    BannedAddr, LocalNode, NodeAddress, PeerSyncState, RemoteNode, RemoteNodeProtocol, SyncState,
+    BannedAddr, LocalNode, LocalNodeProtocol, NodeAddress, PeerSyncState, RemoteNode,
+    RemoteNodeProtocol, SyncState,
 };
 pub use self::pool::{OutputsValidator, TxPoolInfo};
 pub use self::proposal_short_id::ProposalShortId;

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -5,8 +5,17 @@ use serde::{Deserialize, Serialize};
 pub struct LocalNode {
     pub version: String,
     pub node_id: String,
-    pub is_active: bool,
+    pub active: bool,
     pub addresses: Vec<NodeAddress>,
+    pub protocols: Vec<LocalNodeProtocol>,
+    pub connections: Uint64,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct LocalNodeProtocol {
+    pub id: Uint64,
+    pub name: String,
+    pub support_versions: Vec<String>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
add `active`, `connections` and `protocols` fields to local_node_info (waiting for https://github.com/nervosnetwork/ckb/pull/2144)