### PR TITLE
feat: add more fields to rpc `get_peers`

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -16,7 +16,9 @@ use crate::services::{
     dns_seeding::DnsSeedingService, dump_peer_store::DumpPeerStoreService,
     outbound_peer::OutboundPeerService, protocol_type_checker::ProtocolTypeCheckerService,
 };
-use crate::{Behaviour, CKBProtocol, Peer, ProtocolId, ProtocolVersion, PublicKey, ServiceControl};
+use crate::{
+    Behaviour, CKBProtocol, Peer, PeerIndex, ProtocolId, ProtocolVersion, PublicKey, ServiceControl,
+};
 use ckb_app_config::NetworkConfig;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
@@ -1208,14 +1210,13 @@ impl NetworkController {
             .unban_network(address);
     }
 
-    pub fn connected_peers(&self) -> Vec<(PeerId, Peer)> {
-        let peers = self
-            .network_state
-            .with_peer_registry(|reg| reg.peers().values().cloned().collect::<Vec<_>>());
-        peers
-            .into_iter()
-            .map(|peer| (peer.peer_id.clone(), peer))
-            .collect()
+    pub fn connected_peers(&self) -> Vec<(PeerIndex, Peer)> {
+        self.network_state.with_peer_registry(|reg| {
+            reg.peers()
+                .iter()
+                .map(|(peer_index, peer)| (*peer_index, peer.clone()))
+                .collect::<Vec<_>>()
+        })
     }
 
     fn try_broadcast(

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1882,6 +1882,22 @@ http://localhost:8114
 
 Returns the connected peers information.
 
+#### Returns
+
+    addresses - Observed remote peer listening address
+    connected_duration - The connection duration in seconds
+    is_outbound - Outbound or inbound peer
+    last_ping_duration - Last ping duration in milliseconds
+    node_id - The id of remote peer
+    protocols - Opened protocols of remote peer
+    sync_state::best_known_header_hash - Best known header hash of remote peer
+    sync_state::best_known_header_number - Best known header number of remote peer
+    sync_state::last_common_header_hash - Last common header hash of remote peer
+    sync_state::last_common_header_number - Last common header number of remote peer
+    sync_state::unknown_header_list_size - The total size of unknown header list
+    sync_state::inflight_count - The count of concurrency downloading blocks
+    sync_state::can_fetch_count - The count of blocks are available for concurrency download
+    version - The peer version
 
 #### Examples
 
@@ -1913,9 +1929,54 @@ http://localhost:8114
                     "score": "0x64"
                 }
             ],
+            "connected_duration": "0x2f",
             "is_outbound": true,
+            "last_ping_duration": "0x1a",
             "node_id": "QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
-            "version": "0.31.0 (4231360 2020-04-20)"
+            "protocols": [
+                {
+                    "id": "0x4",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x2",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x1",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x64",
+                    "version": "1"
+                },
+                {
+                    "id": "0x6e",
+                    "version": "1"
+                },
+                {
+                    "id": "0x66",
+                    "version": "1"
+                },
+                {
+                    "id": "0x65",
+                    "version": "1"
+                },
+                {
+                    "id": "0x0",
+                    "version": "0.0.1"
+                }
+            ],
+            "sync_state": {
+                "best_known_header_hash": null,
+                "best_known_header_number": null,
+                "can_fetch_count": "0x80",
+                "inflight_count": "0xa",
+                "last_common_header_hash": null,
+                "last_common_header_number": null,
+                "unknown_header_list_size": "0x20"
+            },
+            "version": "0.34.0 (f37f598 2020-07-17)"
         },
         {
             "addresses": [
@@ -1924,9 +1985,54 @@ http://localhost:8114
                     "score": "0x1"
                 }
             ],
-            "is_outbound": false,
-            "node_id": "QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
-            "version": "0.29.0 (a6733e6 2020-02-26)"
+            "connected_duration": "0x95",
+            "is_outbound": true,
+            "last_ping_duration": "0x41",
+            "node_id": "QmSrkzhdBMmfCGx8tQGwgXxzBg8kLtX8qMcqECMuKWsxDV",
+            "protocols": [
+                {
+                    "id": "0x0",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x2",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x6e",
+                    "version": "1"
+                },
+                {
+                    "id": "0x66",
+                    "version": "1"
+                },
+                {
+                    "id": "0x1",
+                    "version": "0.0.1"
+                },
+                {
+                    "id": "0x65",
+                    "version": "1"
+                },
+                {
+                    "id": "0x64",
+                    "version": "1"
+                },
+                {
+                    "id": "0x4",
+                    "version": "0.0.1"
+                }
+            ],
+            "sync_state": {
+                "best_known_header_hash": "0x2157c72b3eddd41a7a14c361173cd22ef27d7e0a29eda2e511ee0b3598c0b895",
+                "best_known_header_number": "0xdb835",
+                "can_fetch_count": "0x80",
+                "inflight_count": "0xa",
+                "last_common_header_hash": "0xc63026bd881d880bb142c855dc8153187543245f0a94391c831c75df31f263c4",
+                "last_common_header_number": "0x4dc08",
+                "unknown_header_list_size": "0x1f"
+            },
+            "version": "0.30.1 (5cc1b75 2020-03-23)"
         }
     ]
 }

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -351,9 +351,54 @@
                         "score": "0x64"
                     }
                 ],
+                "connected_duration": "0x2f",
                 "is_outbound": true,
+                "last_ping_duration": "0x1a",
                 "node_id": "QmXwUgF48ULy6hkgfqrEwEfuHW7WyWyWauueRDAYQHNDfN",
-                "version": "0.31.0 (4231360 2020-04-20)"
+                "protocols": [
+                    {
+                        "id": "0x4",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x2",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x1",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x64",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x6e",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x66",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x65",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x0",
+                        "version": "0.0.1"
+                    }
+                ],
+                "sync_state": {
+                    "best_known_header_hash": null,
+                    "best_known_header_number": null,
+                    "last_common_header_hash": null,
+                    "last_common_header_number": null,
+                    "unknown_header_list_size": "0x20",
+                    "inflight_count": "0xa",
+                    "can_fetch_count": "0x80"
+                },
+                "version": "0.34.0 (f37f598 2020-07-17)"
             },
             {
                 "addresses": [
@@ -362,9 +407,98 @@
                         "score": "0x1"
                     }
                 ],
-                "is_outbound": false,
-                "node_id": "QmVTMd7SEXfxS5p4EEM5ykTe1DwWWVewEM3NwjLY242vr2",
-                "version": "0.29.0 (a6733e6 2020-02-26)"
+                "connected_duration": "0x95",
+                "is_outbound": true,
+                "last_ping_duration": "0x41",
+                "node_id": "QmSrkzhdBMmfCGx8tQGwgXxzBg8kLtX8qMcqECMuKWsxDV",
+                "protocols": [
+                    {
+                        "id": "0x0",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x2",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x6e",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x66",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x1",
+                        "version": "0.0.1"
+                    },
+                    {
+                        "id": "0x65",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x64",
+                        "version": "1"
+                    },
+                    {
+                        "id": "0x4",
+                        "version": "0.0.1"
+                    }
+                ],
+                "sync_state": {
+                    "best_known_header_hash": "0x2157c72b3eddd41a7a14c361173cd22ef27d7e0a29eda2e511ee0b3598c0b895",
+                    "best_known_header_number": "0xdb835",
+                    "last_common_header_hash": "0xc63026bd881d880bb142c855dc8153187543245f0a94391c831c75df31f263c4",
+                    "last_common_header_number": "0x4dc08",
+                    "unknown_header_list_size": "0x1f",
+                    "inflight_count": "0xa",
+                    "can_fetch_count": "0x80"
+                },
+                "version": "0.30.1 (5cc1b75 2020-03-23)"
+            }
+        ],
+        "returns": [
+            {
+                "addresses": "Observed remote peer listening address"
+            },
+            {
+                "connected_duration": "The connection duration in seconds"
+            },
+            {
+                "is_outbound": "Outbound or inbound peer"
+            },
+            {
+                "last_ping_duration": "Last ping duration in milliseconds"
+            },
+            {
+                "node_id": "The id of remote peer"
+            },
+            {
+                "protocols": "Opened protocols of remote peer"
+            },
+            {
+                "sync_state::best_known_header_hash": "Best known header hash of remote peer"
+            },
+            {
+                "sync_state::best_known_header_number": "Best known header number of remote peer"
+            },
+            {
+                "sync_state::last_common_header_hash": "Last common header hash of remote peer"
+            },
+            {
+                "sync_state::last_common_header_number": "Last common header number of remote peer"
+            },
+            {
+                "sync_state::unknown_header_list_size": "The total size of unknown header list"
+            },
+            {
+                "sync_state::inflight_count": "The count of concurrency downloading blocks"
+            },
+            {
+                "sync_state::can_fetch_count": "The count of blocks are available for concurrency download"
+            },
+            {
+                "version": "The peer version"
             }
         ],
         "skip": true

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -1,5 +1,8 @@
 use crate::error::RPCError;
-use ckb_jsonrpc_types::{BannedAddr, LocalNode, NodeAddress, RemoteNode, SyncState, Timestamp};
+use ckb_jsonrpc_types::{
+    BannedAddr, LocalNode, NodeAddress, PeerSyncState, RemoteNode, RemoteNodeProtocol, SyncState,
+    Timestamp,
+};
 use ckb_network::{MultiaddrExt, NetworkController};
 use ckb_sync::SyncShared;
 use faketime::unix_time_as_millis;
@@ -76,44 +79,102 @@ impl NetworkRpc for NetworkRpcImpl {
     }
 
     fn get_peers(&self) -> Result<Vec<RemoteNode>> {
-        let peers = self.network_controller.connected_peers();
-        let mut nodes = Vec::with_capacity(peers.len());
-        for (peer_id, peer) in peers.into_iter() {
-            let mut addresses = vec![&peer.connected_addr];
-            addresses.extend(peer.listened_addrs.iter());
+        let peers: Vec<RemoteNode> = self
+            .network_controller
+            .connected_peers()
+            .iter()
+            .map(|(peer_index, peer)| {
+                let peer_id = peer.peer_id.clone();
+                let mut addresses = vec![&peer.connected_addr];
+                addresses.extend(peer.listened_addrs.iter());
 
-            let mut node_addresses = HashMap::with_capacity(addresses.len());
-            for address in addresses {
-                if let Ok(ip_port) = address.extract_ip_addr() {
-                    let p2p_address = address.attach_p2p(&peer_id).expect("always ok");
-                    let score = self
-                        .network_controller
-                        .addr_info(&ip_port)
-                        .map(|addr_info| addr_info.score)
-                        .unwrap_or(1);
-                    let non_negative_score = if score > 0 { score as u64 } else { 0 };
-                    node_addresses.insert(
-                        ip_port,
-                        NodeAddress {
-                            address: p2p_address.to_string(),
-                            score: non_negative_score.into(),
-                        },
-                    );
+                let mut node_addresses = HashMap::with_capacity(addresses.len());
+                for address in addresses {
+                    if let Ok(ip_port) = address.extract_ip_addr() {
+                        let p2p_address = address.attach_p2p(&peer_id).expect("always ok");
+                        let score = self
+                            .network_controller
+                            .addr_info(&ip_port)
+                            .map(|addr_info| addr_info.score)
+                            .unwrap_or(1);
+                        let non_negative_score = if score > 0 { score as u64 } else { 0 };
+                        node_addresses.insert(
+                            ip_port,
+                            NodeAddress {
+                                address: p2p_address.to_string(),
+                                score: non_negative_score.into(),
+                            },
+                        );
+                    }
                 }
-            }
 
-            nodes.push(RemoteNode {
-                is_outbound: peer.is_outbound(),
-                version: peer
-                    .identify_info
-                    .map(|info| info.client_version)
-                    .unwrap_or_else(|| "unknown".to_string()),
-                node_id: peer_id.to_base58(),
-                addresses: node_addresses.values().cloned().collect(),
-            });
-        }
+                RemoteNode {
+                    is_outbound: peer.is_outbound(),
+                    version: peer
+                        .identify_info
+                        .as_ref()
+                        .map(|info| info.client_version.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    node_id: peer_id.to_base58(),
+                    addresses: node_addresses.values().cloned().collect(),
+                    connected_duration: peer.connected_time.elapsed().as_secs().into(),
+                    last_ping_duration: peer
+                        .ping
+                        .map(|duration| (duration.as_millis() as u64).into()),
+                    sync_state: self
+                        .sync_shared
+                        .state()
+                        .peers()
+                        .state
+                        .read()
+                        .get(&peer_index)
+                        .map(|state| PeerSyncState {
+                            best_known_header_hash: state
+                                .best_known_header
+                                .as_ref()
+                                .map(|header| header.hash().into()),
+                            best_known_header_number: state
+                                .best_known_header
+                                .as_ref()
+                                .map(|header| header.number().into()),
+                            last_common_header_hash: state
+                                .last_common_header
+                                .as_ref()
+                                .map(|header| header.hash().into()),
+                            last_common_header_number: state
+                                .last_common_header
+                                .as_ref()
+                                .map(|header| header.number().into()),
+                            unknown_header_list_size: (state.unknown_header_list.len() as u64)
+                                .into(),
+                            inflight_count: (self
+                                .sync_shared
+                                .state()
+                                .read_inflight_blocks()
+                                .peer_inflight_count(*peer_index)
+                                as u64)
+                                .into(),
+                            can_fetch_count: (self
+                                .sync_shared
+                                .state()
+                                .read_inflight_blocks()
+                                .peer_can_fetch_count(*peer_index)
+                                as u64)
+                                .into(),
+                        }),
+                    protocols: peer
+                        .protocols
+                        .iter()
+                        .map(|(protocol_id, protocol_version)| RemoteNodeProtocol {
+                            id: (protocol_id.value() as u64).into(),
+                            version: protocol_version.clone(),
+                        })
+                        .collect(),
+                }
+            })
+            .collect();
 
-        Ok(nodes)
+        Ok(peers)
     }
 
     fn get_banned_addresses(&self) -> Result<Vec<BannedAddr>> {

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -210,7 +210,7 @@ impl Spec for BlockSyncDuplicatedAndReconnect {
         // `node` should send back a corresponding GetBlocks message
         let ctrl = net.controller();
         let peer = ctrl.0.connected_peers()[peer_id.value() - 1].clone();
-        ctrl.0.remove_node(&peer.0);
+        ctrl.0.remove_node(&peer.1.peer_id);
         wait_until(5, || {
             rpc_client.get_peers().is_empty() && ctrl.0.connected_peers().is_empty()
         });

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -34,7 +34,9 @@ pub use self::fixed_bytes::Byte32;
 pub use self::indexer::{
     CellTransaction, LiveCell, LockHashCapacity, LockHashIndexState, TransactionPoint,
 };
-pub use self::net::{BannedAddr, LocalNode, NodeAddress, RemoteNode, SyncState};
+pub use self::net::{
+    BannedAddr, LocalNode, NodeAddress, PeerSyncState, RemoteNode, RemoteNodeProtocol, SyncState,
+};
 pub use self::pool::{OutputsValidator, TxPoolInfo};
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::sync::PeerState;

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumber, Timestamp, Uint64};
+use crate::{BlockNumber, Byte32, Timestamp, Uint64};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
@@ -15,6 +15,27 @@ pub struct RemoteNode {
     pub node_id: String,
     pub addresses: Vec<NodeAddress>,
     pub is_outbound: bool,
+    pub connected_duration: Uint64,
+    pub last_ping_duration: Option<Uint64>,
+    pub sync_state: Option<PeerSyncState>,
+    pub protocols: Vec<RemoteNodeProtocol>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct RemoteNodeProtocol {
+    pub id: Uint64,
+    pub version: String,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct PeerSyncState {
+    pub best_known_header_hash: Option<Byte32>,
+    pub best_known_header_number: Option<Uint64>,
+    pub last_common_header_hash: Option<Byte32>,
+    pub last_common_header_number: Option<Uint64>,
+    pub unknown_header_list_size: Uint64,
+    pub inflight_count: Uint64,
+    pub can_fetch_count: Uint64,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
added `connected_duration`, `last_ping_duration`, `protocols` and `sync_state` to `get_peers` rpc