### PR TITLE
fix: should exit with error code when setup failed

### DIFF
--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -31,7 +31,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
     }
 
     let setup = Setup::from_matches(&app_matches)?;
-    let _guard = setup.setup_app(&version);
+    let _guard = setup.setup_app(&version)?;
 
     match app_matches.subcommand() {
         (cli::CMD_RUN, Some(matches)) => subcommand::run(setup.run(&matches)?, version),


### PR DESCRIPTION
Issue: if the config was malformed and an error was thrown in `setup_app`, the process wouldn't exit.