### PR TITLE
chore: several minor changes about thread and runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,6 @@ dependencies = [
 name = "ckb-async-runtime"
 version = "0.35.0-pre"
 dependencies = [
- "crossbeam-channel",
  "tokio 0.2.22",
 ]
 
@@ -382,6 +381,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "ctrlc",
+ "rayon",
  "serde",
  "serde_plain",
  "tempfile",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -35,6 +35,7 @@ ckb-chain-iter = { path = "../util/chain-iter" }
 ckb-verification = { path = "../verification" }
 base64 = "0.10.1"
 tempfile = "3.0"
+rayon = "1.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -46,6 +46,11 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         &shared.store().cell_provider(),
     );
 
+    rayon::ThreadPoolBuilder::new()
+        .thread_name(|i| format!("RayonGlobal-{}", i))
+        .build_global()
+        .expect("Init the global thread pool for rayon failed");
+
     ckb_memory_tracker::track_current_process(
         args.config.memory_tracker.interval,
         Some(shared.store().db().inner()),

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -338,7 +338,7 @@ impl TxPoolServiceBuilder {
                 }
             }
         };
-        let (handle, thread) = new_runtime(server);
+        let (handle, thread) = new_runtime("Global", None, server);
         let stop = StopHandler::new(SignalSender::Tokio(signal_sender), thread);
         TxPoolController {
             sender,

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -462,7 +462,7 @@ impl Log for Logger {
             }
 
             let thread = thread::current();
-            let thread_name = thread.name().unwrap_or_default();
+            let thread_name = thread.name().unwrap_or("*unnamed*");
 
             let with_color = {
                 let thread_name = format!("{}", Colour::Blue.bold().paint(thread_name));

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -5,8 +5,5 @@ license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "0.2", features = ["sync", "blocking", "rt-threaded"] }
-crossbeam-channel = "0.3"

--- a/util/runtime/src/lib.rs
+++ b/util/runtime/src/lib.rs
@@ -1,29 +1,44 @@
-use std::future::Future;
-use std::thread;
-use tokio::runtime;
-pub use tokio::runtime::Handle;
+use std::{future::Future, sync, thread};
 
-pub fn new_runtime<F, R>(block: F) -> (Handle, thread::JoinHandle<()>)
+pub use tokio::runtime::{Builder, Handle};
+
+pub fn new_runtime<F, R>(
+    name_prefix: &str,
+    runtime_builder_opt: Option<Builder>,
+    block: F,
+) -> (Handle, thread::JoinHandle<()>)
 where
     F: FnOnce(Handle) -> R + Send + 'static,
     R: Future,
 {
-    let (tx, rx) = crossbeam_channel::bounded(1);
+    let barrier = sync::Arc::new(sync::Barrier::new(2));
+    let barrier_clone = sync::Arc::clone(&barrier);
+
+    let service_name = format!("{}Service", name_prefix);
+    let runtime_name = format!("{}Runtime", name_prefix);
+
+    let mut runtime = runtime_builder_opt
+        .unwrap_or_else(|| {
+            let mut builder = Builder::new();
+            builder.threaded_scheduler();
+            builder
+        })
+        .thread_name(&runtime_name)
+        .build()
+        .unwrap_or_else(|_| panic!("tokio runtime {} initialized", runtime_name));
+
+    let handle = runtime.handle().clone();
+    let executor = handle.clone();
+
     let handler = thread::Builder::new()
+        .name(service_name)
         .spawn(move || {
-            let mut runtime = runtime::Builder::new()
-                .threaded_scheduler()
-                .thread_name("GlobalRuntime-")
-                .build()
-                .expect("Global tokio runtime init");
-
-            let handle = runtime.handle();
-            let future = block(handle.clone());
-            tx.send(handle.clone()).expect("Send global tokio runtime");
-
+            let future = block(handle);
+            barrier_clone.wait();
             runtime.block_on(future);
         })
-        .expect("Start Global tokio runtime");
-    let executor = rx.recv().expect("Recv global tokio runtime");
+        .unwrap_or_else(|_| panic!("tokio runtime {} started", runtime_name));
+
+    barrier.wait();
     (executor, handler)
 }


### PR DESCRIPTION
- Simplify dependencies of `ckb-async-runtime`.
  - Use `::std::sync::Barrier` instead of `crossbeam-channel`.
- Let method `ckb-async-runtime::new_runtime` more general.
  - Accept name prefix for threads.
  - Accept `tokio::runtime::Builder` as an optional parameter, so we can set options for the runtime.
- After we upgrade `tokio` from 0.1 to 0.2, the thread name of `tokio` runtime threads has a redundant suffix "-".
  - [`tokio-0.1.x::runtime::Builder::name_prefix(...)`](https://docs.rs/tokio/0.1.22/tokio/runtime/struct.Builder.html#method.name_prefix)
  - [`tokio-0.2.x::runtime::Builder::thread_name(...)`](https://docs.rs/tokio/0.2.22/tokio/runtime/struct.Builder.html#method.thread_name)
- Use a default thread name in logs instead of an empty string.
  Without color, a log record with empty thread name is a bit hard to parse.
- Give name to rayon threads to improve the debuggability slightly.