### PR TITLE
refactor: replace logs by metrics for memory tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ version = "0.36.0-pre"
 dependencies = [
  "ckb-db",
  "ckb-logger",
+ "ckb-metrics",
  "futures 0.3.4",
  "heim",
  "jemalloc-ctl",

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 ckb-logger = { path = "../logger" }
+ckb-metrics = { path = "../metrics" }
 ckb-db = { path = "../../db" }
 
 # TODO Why don't disable this crate by "target.*" in the crates which are dependent on this crate?

--- a/util/memory-tracker/src/rocksdb.rs
+++ b/util/memory-tracker/src/rocksdb.rs
@@ -1,39 +1,33 @@
 use ckb_db::internal::ops::{GetColumnFamilys, GetProperty, GetPropertyCF};
-use ckb_logger::trace;
+use ckb_metrics::metrics;
 
 use crate::utils::{sum_int_values, PropertyValue};
 
 // Ref: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
 pub struct RocksDBMemoryStatistics {
-    pub total_memory: PropertyValue<u64>,
-    pub block_cache_usage: PropertyValue<u64>,
     pub estimate_table_readers_mem: PropertyValue<u64>,
+    pub size_all_mem_tables: PropertyValue<u64>,
     pub cur_size_all_mem_tables: PropertyValue<u64>,
-    pub block_cache_pinned_usage: PropertyValue<u64>,
     pub block_cache_capacity: PropertyValue<u64>,
+    pub block_cache_usage: PropertyValue<u64>,
+    pub block_cache_pinned_usage: PropertyValue<u64>,
 }
 
 pub trait TrackRocksDBMemory {
     fn gather_memory_stats(&self) -> RocksDBMemoryStatistics {
-        let block_cache_usage = self.gather_int_values("rocksdb.block-cache-usage");
-        let estimate_table_readers_mem =
-            self.gather_int_values("rocksdb.estimate-table-readers-mem");
-        let cur_size_all_mem_tables = self.gather_int_values("rocksdb.cur-size-all-mem-tables");
-        let block_cache_pinned_usage = self.gather_int_values("rocksdb.block-cache-pinned-usage");
-        let total_memory = sum_int_values(&[
-            block_cache_usage.clone(),
-            estimate_table_readers_mem.clone(),
-            cur_size_all_mem_tables.clone(),
-            block_cache_pinned_usage.clone(),
-        ]);
-        let block_cache_capacity = self.gather_int_values("rocksdb.block-cache-capacity");
+        let estimate_table_readers_mem = self.gather_int_values("estimate-table-readers-mem");
+        let size_all_mem_tables = self.gather_int_values("size-all-mem-tables");
+        let cur_size_all_mem_tables = self.gather_int_values("cur-size-all-mem-tables");
+        let block_cache_capacity = self.gather_int_values("block-cache-capacity");
+        let block_cache_usage = self.gather_int_values("block-cache-usage");
+        let block_cache_pinned_usage = self.gather_int_values("block-cache-pinned-usage");
         RocksDBMemoryStatistics {
-            total_memory,
-            block_cache_usage,
             estimate_table_readers_mem,
+            size_all_mem_tables,
             cur_size_all_mem_tables,
-            block_cache_pinned_usage,
             block_cache_capacity,
+            block_cache_usage,
+            block_cache_pinned_usage,
         }
     }
     fn gather_int_values(&self, key: &str) -> PropertyValue<u64>;
@@ -54,11 +48,11 @@ where
     fn gather_int_values(&self, key: &str) -> PropertyValue<u64> {
         let mut values = Vec::new();
         for (cf_name, cf) in self.get_cfs() {
-            let value_col = self
-                .property_int_value_cf(cf, key)
+            let value_col: PropertyValue<u64> = self
+                .property_int_value_cf(cf, &format!("rocksdb.{}", key))
                 .map_err(|err| format!("{}", err))
                 .into();
-            trace!("{}({}): {}", key, cf_name, value_col);
+            metrics!(gauge, "ckb-sys.mem.rocksdb", value_col.as_i64(), "type" => key.to_owned(), "cf" => cf_name.to_owned());
             values.push(value_col);
         }
         sum_int_values(&values)

--- a/util/memory-tracker/src/utils.rs
+++ b/util/memory-tracker/src/utils.rs
@@ -36,6 +36,16 @@ pub enum PropertyValue<T> {
     Error(String),
 }
 
+impl PropertyValue<u64> {
+    pub(crate) fn as_i64(&self) -> i64 {
+        match self {
+            Self::Value(v) => *v as i64,
+            Self::Null => -1,
+            Self::Error(_) => -2,
+        }
+    }
+}
+
 impl fmt::Display for PropertyValue<u64> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {


### PR DESCRIPTION
Use metrics to output memory statistics, so we can draw charts in Grafana via prometheus.