### PR TITLE
fix: rpc get_peers deadlock caused by conflicting lock order

### DIFF
--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -108,6 +108,7 @@ impl NetworkRpc for NetworkRpcImpl {
                     }
                 }
 
+                let inflight_blocks = self.sync_shared.state().read_inflight_blocks();
                 RemoteNode {
                     is_outbound: peer.is_outbound(),
                     version: peer
@@ -147,18 +148,10 @@ impl NetworkRpc for NetworkRpcImpl {
                                 .map(|header| header.number().into()),
                             unknown_header_list_size: (state.unknown_header_list.len() as u64)
                                 .into(),
-                            inflight_count: (self
-                                .sync_shared
-                                .state()
-                                .read_inflight_blocks()
-                                .peer_inflight_count(*peer_index)
+                            inflight_count: (inflight_blocks.peer_inflight_count(*peer_index)
                                 as u64)
                                 .into(),
-                            can_fetch_count: (self
-                                .sync_shared
-                                .state()
-                                .read_inflight_blocks()
-                                .peer_can_fetch_count(*peer_index)
+                            can_fetch_count: (inflight_blocks.peer_can_fetch_count(*peer_index)
                                 as u64)
                                 .into(),
                         }),


### PR DESCRIPTION
This PR fixes a deadlock bug caused by conflicting lock order in `block_fetcher.rs` and `net.rs`

`block_fetcher.rs`
SyncState#inflight_blocks write lock acquisition
https://github.com/nervosnetwork/ckb/blob/37dac610489e2a15636cb6d192f831b9af2fc8f5/sync/src/synchronizer/block_fetcher.rs#L98

SyncState#peers#state write lock acquisition
https://github.com/nervosnetwork/ckb/blob/37dac610489e2a15636cb6d192f831b9af2fc8f5/sync/src/synchronizer/block_fetcher.rs#L124

v.s

`net.rs`
SyncState#peers#state read lock acquisition
https://github.com/nervosnetwork/ckb/blob/719d937fbdddaeca8d9b70c96344b548e889eb7b/rpc/src/module/net.rs#L124

SyncState#inflight_blocks read lock acquisition
https://github.com/nervosnetwork/ckb/blob/719d937fbdddaeca8d9b70c96344b548e889eb7b/rpc/src/module/net.rs#L150

This deadlock has a chance of being triggered by calling `get_peers` rpc at the same time as IBD, it's found on integration test log: https://gist.github.com/quake/78f9db87ebd0a8e776adcb24b881869a