### PR TITLE
chore: add log to `try_search_orphan_pool`

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1284,6 +1284,11 @@ impl SyncShared {
 
     pub fn try_search_orphan_pool(&self, chain: &ChainController, parent_hash: &Byte32) {
         let descendants = self.state.remove_orphan_by_parent(parent_hash);
+        debug!(
+            "try accepting {} descendant orphan blocks",
+            descendants.len()
+        );
+
         for block in descendants {
             // If we can not find the block's parent in database, that means it was failed to accept
             // its parent, so we treat it as an invalid block as well.


### PR DESCRIPTION
Try to resolve integration test `block_sync_relayer_collaboration` that will occasionally go wrong, add a line of log where I suspect there may be a problem.