### PR TITLE
feat: advance last_common_header even the peer is worse than us

### DIFF
--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -92,12 +92,7 @@ impl<'a> BlockFetcher<'a> {
             // last_common_header, is expected to provide a more realistic picture. Hence here we
             // specially advance this peer's last_common_header at the case of both us on the same
             // active chain.
-            if self
-                .active_chain
-                .get_block_hash(best_known.number())
-                .map(|block_hash| block_hash == best_known.hash())
-                .unwrap_or(true)
-            {
+            if self.active_chain.is_main_chain(&best_known.hash()) {
                 let last_common = best_known;
                 self.synchronizer
                     .peers()

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1735,6 +1735,10 @@ impl ActiveChain {
         self.snapshot.epoch_ext().clone()
     }
 
+    pub fn is_main_chain(&self, hash: &packed::Byte32) -> bool {
+        self.snapshot.is_main_chain(hash)
+    }
+
     pub fn is_initial_block_download(&self) -> bool {
         // Once this function has returned false, it must remain false.
         if self.state.ibd_finished.load(Ordering::Relaxed) {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -394,6 +394,7 @@ fn all_specs() -> SpecMap {
         Box::new(RpcTruncate),
         Box::new(SyncTooNewBlock),
         Box::new(RelayTooNewBlock),
+        Box::new(LastCommonHeaderForPeerWithWorseChain),
     ];
     specs.into_iter().map(|spec| (spec.name(), spec)).collect()
 }

--- a/test/src/specs/sync/last_common_header.rs
+++ b/test/src/specs/sync/last_common_header.rs
@@ -1,0 +1,54 @@
+use crate::utils::{build_compact_block, wait_until};
+use crate::{Net, Spec, TestProtocol};
+use ckb_network::SupportProtocols;
+
+pub struct LastCommonHeaderForPeerWithWorseChain;
+
+impl Spec for LastCommonHeaderForPeerWithWorseChain {
+    crate::name!("last_common_header_for_peer_with_worse_chain");
+
+    crate::setup!(num_nodes: 1, connect_all: false, protocols: vec![TestProtocol::sync(), TestProtocol::relay()]);
+
+    // As for the peers of which main chain is worse than ours, we should ensure the
+    // last_common_header updating as well.
+    fn run(&self, net: &mut Net) {
+        let node0 = &net.nodes[0];
+
+        // Node0's main chain tip is 5
+        node0.generate_blocks(5);
+        let worse = (1..=4)
+            .map(|number| node0.get_block_by_number(number))
+            .collect::<Vec<_>>();
+
+        // Net relay blocks[1..4] to node0, let node0 knows our best chain is at 4.
+        net.connect(node0);
+        let (peer_id, _, _) = net.receive();
+        for block in worse {
+            net.send(
+                SupportProtocols::Relay.protocol_id(),
+                peer_id,
+                build_compact_block(&block),
+            );
+        }
+
+        // peer.last_common_header is expect to be advanced to peer.best_known_header
+        let last_common_header_synced = wait_until(10, || {
+            let sync_state = node0
+                .rpc_client()
+                .get_peers()
+                .into_iter()
+                .filter(|remote_node| remote_node.node_id == net.node_id())
+                .last()
+                .and_then(|node| node.sync_state);
+            if sync_state
+                .as_ref()
+                .map(|sync_state| sync_state.last_common_header_number == Some(4.into()))
+                .unwrap_or(false)
+            {
+                return true;
+            }
+            false
+        });
+        assert!(last_common_header_synced);
+    }
+}

--- a/test/src/specs/sync/mod.rs
+++ b/test/src/specs/sync/mod.rs
@@ -4,6 +4,7 @@ mod get_blocks;
 mod ibd_process;
 mod invalid_block;
 mod invalid_locator_size;
+mod last_common_header;
 mod sync_timeout;
 mod utils;
 
@@ -13,4 +14,5 @@ pub use get_blocks::*;
 pub use ibd_process::*;
 pub use invalid_block::*;
 pub use invalid_locator_size::*;
+pub use last_common_header::*;
 pub use sync_timeout::*;


### PR DESCRIPTION
`last_common_header` is like a cursor of block-sync mechanism between the local node and remote peers. The local node only fetches blocks from peers who have a better chain. It means it is not necessary to timely advance the `last_common_header` of peers whose chain is worse than the local. 

However, https://github.com/nervosnetwork/ckb/pull/2196 adds `last_common_header` to RPC `get_peers`. It expects that the returned `last_common_header` to provide a more realistic picture. Hence I create this PR, timely advance the `last_common_header` of peers even their chains are worse than the local. 