### PR TITLE
chore: prefix integration test log with case name and node index

### DIFF
--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -33,13 +33,16 @@ impl Net {
         start_port: Arc<AtomicU16>,
         vendor_dir: PathBuf,
         setup: Setup,
+        case_name: &str,
     ) -> Self {
         let p2p_port = start_port.fetch_add(1, Ordering::SeqCst);
         let nodes: Vec<Node> = (0..setup.num_nodes)
-            .map(|_| {
+            .enumerate()
+            .map(|(index, _)| {
+                let node_index = "node".to_owned() + &index.to_string();
                 let p2p_port = start_port.fetch_add(1, Ordering::SeqCst);
                 let rpc_port = start_port.fetch_add(1, Ordering::SeqCst);
-                Node::new(binary, p2p_port, rpc_port)
+                Node::new(binary, p2p_port, rpc_port, case_name, &node_index)
             })
             .collect();
 
@@ -48,7 +51,7 @@ impl Net {
             controller: None,
             p2p_port,
             setup,
-            working_dir: temp_path(),
+            working_dir: temp_path(case_name, "net"),
             vendor_dir,
         }
     }

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -50,11 +50,17 @@ impl Drop for ProcessGuard {
 }
 
 impl Node {
-    pub fn new(binary: &str, p2p_port: u16, rpc_port: u16) -> Self {
+    pub fn new(
+        binary: &str,
+        p2p_port: u16,
+        rpc_port: u16,
+        case_name: &str,
+        node_index: &str,
+    ) -> Self {
         let rpc_client = RpcClient::new(&format!("http://127.0.0.1:{}/", rpc_port));
         Self {
             binary: binary.to_string(),
-            working_dir: temp_path(),
+            working_dir: temp_path(case_name, node_index),
             p2p_port,
             rpc_port,
             rpc_client,

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -216,9 +216,10 @@ pub fn is_committed(tx_status: &TransactionWithStatus) -> bool {
 ///
 /// We use `tempdir` only for generating a random path, and expect the corresponding directory
 /// that `tempdir` creates be deleted when go out of this function.
-pub fn temp_path() -> String {
+pub fn temp_path(case_name: &str, id: &str) -> String {
     let mut builder = tempfile::Builder::new();
-    builder.prefix("ckb-it-");
+    let prefix = ["ckb-it", case_name, id, ""].join("-");
+    builder.prefix(&prefix);
     let tempdir = if let Ok(val) = env::var("CKB_INTEGRATION_TEST_TMP") {
         builder.tempdir_in(val)
     } else {

--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -114,7 +114,13 @@ impl Worker {
         let binary = self.binary.clone();
         let vendor = self.vendor.clone();
         let outbox = self.outbox.clone();
-        let mut net = Net::new(&binary, Arc::clone(&self.start_port), vendor, spec.setup());
+        let mut net = Net::new(
+            &binary,
+            Arc::clone(&self.start_port),
+            vendor,
+            spec.setup(),
+            spec.name(),
+        );
         let now = Instant::now();
         let node_dirs: Vec<_> = net
             .nodes


### PR DESCRIPTION
Update integration test log from `ckb-it-xxx` to `ckb-it-case_name-node_index-xxx`.

Because of node_id initialize after the node start, and node start need a working_dir which contains the node log, so I use `node_index` in the test case instead of `node_id`. 