### PR TITLE
chore: document DEFAULT_BYTES_PER_CYCLES and increase precision

### DIFF
--- a/tx-pool/src/component/mod.rs
+++ b/tx-pool/src/component/mod.rs
@@ -8,7 +8,10 @@ pub(crate) mod proposed;
 
 pub use self::entry::{DefectEntry, TxEntry};
 
-const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_17f64;
+/// Equal to MAX_BLOCK_BYTES / MAX_BLOCK_CYCLES, see ckb-chain-spec.
+/// The precision is set so that the difference between MAX_BLOCK_CYCLES * DEFAULT_BYTES_PER_CYCLES
+/// and MAX_BLOCK_BYTES is less than 1.
+const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_170_571_4_f64;
 
 /// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
 /// tx_pool use vbytes to estimate transaction fee rate.

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -152,7 +152,9 @@ mod tests {
             .build()
     }
 
-    const MOCK_CYCLES: Cycle = 5_000_000;
+    // Choose 5_000_839, so the vbytes is 853.0001094046, which will not lead to carry when
+    // calculating the vbytes for a package.
+    const MOCK_CYCLES: Cycle = 5_000_839;
     const MOCK_SIZE: usize = 200;
 
     #[test]

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -555,7 +555,9 @@ mod tests {
 
         let mut pool = ProposedPool::new(DEFAULT_MAX_ANCESTORS_SIZE);
 
-        let cycles = 5_000_000;
+        // Choose 5_000_839, so the vbytes is 853.0001094046, which will not lead to carry when
+        // calculating the vbytes for a package.
+        let cycles = 5_000_839;
         let size = 200;
 
         for &tx in &[&tx1, &tx2, &tx3, &tx2_1, &tx2_2, &tx2_3, &tx2_4] {


### PR DESCRIPTION
CKB block has two dimensional limits on transactions, the total cycles and total bytes. Pool uses vbytes by uniforming these two dimension:

* Convert cycles and bytes to percentage of the block respectively.
* Pick the larger one
* Multiplying the larger percent with the block bytes limit gives the vbytes.

Thus the ratio between bytes and cycles is block cycles limit dividing the bytes limit.

I increase the precision to 7 digits so that

```
abs(MAX_BLOCK_BYTES - MAX_BLOCK_CYCLES * DEFAULT_BYTES_PER_CYCLES) < 1
```