### PR TITLE
chore: remove dependencies "proc-macro-hack" for crates in the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,8 +528,7 @@ name = "ckb-fixed-hash"
 version = "0.36.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
- "ckb-fixed-hash-hack",
- "proc-macro-hack",
+ "ckb-fixed-hash-macros",
 ]
 
 [[package]]
@@ -542,11 +541,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-fixed-hash-hack"
+name = "ckb-fixed-hash-macros"
 version = "0.36.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
- "proc-macro-hack",
  "proc-macro2 0.4.27",
  "quote 0.6.11",
  "syn 0.15.29",
@@ -757,7 +755,6 @@ version = "0.36.0-pre"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -772,7 +769,6 @@ name = "ckb-occupied-capacity-macros"
 version = "0.36.0-pre"
 dependencies = [
  "ckb-occupied-capacity-core",
- "proc-macro-hack",
  "quote 0.6.11",
  "syn 0.15.29",
 ]

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2018"
 
 [dependencies]
 ckb-fixed-hash-core = { path = "core" }
-ckb-fixed-hash-hack = { path = "hack" }
-proc-macro-hack = "0.5"
+ckb-fixed-hash-macros = { path = "macros" }

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ckb-fixed-hash-hack"
+name = "ckb-fixed-hash-macros"
 version = "0.36.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
@@ -13,4 +13,3 @@ ckb-fixed-hash-core = { path = "../core" }
 quote = "0.6"
 syn = "0.15"
 proc-macro2 = "0.4"
-proc-macro-hack = "0.5"

--- a/util/fixed-hash/macros/src/lib.rs
+++ b/util/fixed-hash/macros/src/lib.rs
@@ -2,13 +2,12 @@ extern crate proc_macro;
 
 use std::str::FromStr;
 
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse_macro_input;
 
 macro_rules! impl_hack {
     ($name:ident, $type:ident) =>    {
-        #[proc_macro_hack]
+        #[proc_macro]
         pub fn $name(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let input = parse_macro_input!(input as syn::LitStr);
             let expanded = {

--- a/util/fixed-hash/src/lib.rs
+++ b/util/fixed-hash/src/lib.rs
@@ -1,12 +1,2 @@
-use proc_macro_hack::proc_macro_hack;
-
 pub use ckb_fixed_hash_core::{error, H160, H256, H512, H520};
-
-#[proc_macro_hack]
-pub use ckb_fixed_hash_hack::h160;
-#[proc_macro_hack]
-pub use ckb_fixed_hash_hack::h256;
-#[proc_macro_hack]
-pub use ckb_fixed_hash_hack::h512;
-#[proc_macro_hack]
-pub use ckb_fixed_hash_hack::h520;
+pub use ckb_fixed_hash_macros::{h160, h256, h512, h520};

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2018"
 [dependencies]
 ckb-occupied-capacity-macros = { path = "macros" }
 ckb-occupied-capacity-core = { path = "core" }
-proc-macro-hack = "0.5"

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -11,5 +11,4 @@ proc-macro = true
 [dependencies]
 quote = "0.6"
 syn = "0.15"
-proc-macro-hack = "0.5"
 ckb-occupied-capacity-core = { path = "../core" }

--- a/util/occupied-capacity/macros/src/lib.rs
+++ b/util/occupied-capacity/macros/src/lib.rs
@@ -1,12 +1,11 @@
 extern crate proc_macro;
 
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse_macro_input;
 
 use ckb_occupied_capacity_core::Capacity;
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn capacity_bytes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as syn::LitInt);
     let expanded = if let Ok(oc) = Capacity::bytes(input.value() as usize) {

--- a/util/occupied-capacity/src/lib.rs
+++ b/util/occupied-capacity/src/lib.rs
@@ -1,8 +1,4 @@
 //! Data structure measurement.
 
-use proc_macro_hack::proc_macro_hack;
-
 pub use ckb_occupied_capacity_core::{AsCapacity, Capacity, Error, Ratio, Result};
-
-#[proc_macro_hack]
 pub use ckb_occupied_capacity_macros::capacity_bytes;


### PR DESCRIPTION
Since rust 1.45.0, [function-like procedural macros in expressions, patterns, and statements are stabilized](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements), [`proc-macro-hack`](https://crates.io/crates/proc-macro-hack) is superseded by native support for `#[proc_macro]`.