### PR TITLE
refactor: split logger config and service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "ckb-fee-estimator",
  "ckb-jsonrpc-types",
  "ckb-logger",
- "ckb-logger-service",
+ "ckb-logger-config",
  "ckb-pow",
  "ckb-resource",
  "ckb-types",
@@ -382,6 +382,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "rayon",
+ "sentry",
  "serde",
  "serde_plain",
  "tempfile",
@@ -625,12 +626,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-logger-config"
+version = "0.36.0-pre"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ckb-logger-service"
 version = "0.36.0-pre"
 dependencies = [
  "ansi_term 0.12.1",
  "backtrace",
  "chrono",
+ "ckb-logger-config",
  "ckb-util",
  "crossbeam-channel",
  "env_logger",
@@ -638,7 +647,6 @@ dependencies = [
  "log 0.4.11",
  "regex",
  "sentry",
- "serde",
 ]
 
 [[package]]
@@ -1108,6 +1116,7 @@ dependencies = [
  "ckb-fixed-hash",
  "linked-hash-map",
  "parking_lot 0.7.1",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     # Members are ordered by dependencies. Crates at top has fewer dependencies.
     "util/build-info",
     "util/logger",
+    "util/logger-config",
     "util/logger-service",
     "util/memory-tracker",
     "util",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -36,6 +36,7 @@ ckb-verification = { path = "../verification" }
 base64 = "0.10.1"
 tempfile = "3.0"
 rayon = "1.0"
+sentry = "0.16.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -1,10 +1,14 @@
 mod helper;
+mod setup_guard;
 mod subcommand;
 
 use ckb_app_config::{cli, ExitCode, Setup};
 use ckb_build_info::Version;
 
+use setup_guard::SetupGuard;
+
 pub(crate) const LOG_TARGET_MAIN: &str = "main";
+pub(crate) const LOG_TARGET_SENTRY: &str = "sentry";
 
 pub fn run_app(version: Version) -> Result<(), ExitCode> {
     // Always print backtrace on panic.
@@ -31,7 +35,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
     }
 
     let setup = Setup::from_matches(&app_matches)?;
-    let _guard = setup.setup_app(&version)?;
+    let _guard = SetupGuard::from_setup(&setup, &version)?;
 
     match app_matches.subcommand() {
         (cli::CMD_RUN, Some(matches)) => subcommand::run(setup.run(&matches)?, version),

--- a/ckb-bin/src/setup_guard.rs
+++ b/ckb-bin/src/setup_guard.rs
@@ -1,0 +1,51 @@
+use ckb_app_config::{ExitCode, Setup};
+use ckb_build_info::Version;
+use ckb_logger::info_target;
+use ckb_logger_service::{self, LoggerInitGuard};
+
+pub struct SetupGuard {
+    _logger_guard: LoggerInitGuard,
+    _sentry_guard: Option<sentry::internals::ClientInitGuard>,
+}
+
+impl SetupGuard {
+    pub(crate) fn from_setup(setup: &Setup, version: &Version) -> Result<Self, ExitCode> {
+        // Initialization of logger must do before sentry, since `logger::init()` and
+        // `sentry_config::init()` both registers custom panic hooks, but `logger::init()`
+        // replaces all hooks previously registered.
+        let mut logger_config = setup.config.logger().to_owned();
+        if logger_config.emit_sentry_breadcrumbs.is_none() {
+            logger_config.emit_sentry_breadcrumbs = Some(setup.is_sentry_enabled);
+        }
+        let logger_guard = ckb_logger_service::init(logger_config)?;
+
+        let sentry_guard = if setup.is_sentry_enabled {
+            let sentry_config = setup.config.sentry();
+
+            info_target!(
+                crate::LOG_TARGET_SENTRY,
+                "**Notice**: \
+                 The ckb process will send stack trace to sentry on Rust panics. \
+                 This is enabled by default before mainnet, which can be opted out by setting \
+                 the option `dsn` to empty in the config file. The DSN is now {}",
+                sentry_config.dsn
+            );
+
+            let guard = sentry_config.init(&version);
+
+            sentry::configure_scope(|scope| {
+                scope.set_tag("subcommand", &setup.subcommand_name);
+            });
+
+            Some(guard)
+        } else {
+            info_target!(crate::LOG_TARGET_SENTRY, "sentry is disabled");
+            None
+        };
+
+        Ok(Self {
+            _logger_guard: logger_guard,
+            _sentry_guard: sentry_guard,
+        })
+    }
+}

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 parking_lot = "=0.7.1"
 linked-hash-map = "0.5"
+regex = "1.1.6"
 
 [dev-dependencies]
 ckb-fixed-hash = { path = "fixed-hash" }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -12,7 +12,7 @@ serde_plain = "0.3.0"
 toml = "0.5"
 path-clean = "0.1.0"
 ckb-logger = { path = "../../util/logger" }
-ckb-logger-service = { path = "../../util/logger-service" }
+ckb-logger-config = { path = "../../util/logger-config" }
 sentry = "0.16.0"
 ckb-chain-spec = {path = "../../spec"}
 ckb-jsonrpc-types = {path = "../jsonrpc-types"}

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use ckb_chain_spec::ChainSpec;
-use ckb_logger_service::Config as LogConfig;
+use ckb_logger_config::Config as LogConfig;
 use ckb_resource::Resource;
 
 use super::configs::*;

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ckb-logger-config"
+version = "0.36.0-pre"
+license = "MIT"
+authors = ["Nervos <dev@nervos.org>"]
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/util/logger-config/src/lib.rs
+++ b/util/logger-config/src/lib.rs
@@ -1,0 +1,38 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub filter: Option<String>,
+    pub color: bool,
+    #[serde(skip)]
+    pub file: PathBuf,
+    #[serde(skip)]
+    pub log_dir: PathBuf,
+    pub log_to_file: bool,
+    pub log_to_stdout: bool,
+    pub emit_sentry_breadcrumbs: Option<bool>,
+    #[serde(default)]
+    pub extra: HashMap<String, ExtraLoggerConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExtraLoggerConfig {
+    pub filter: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            filter: None,
+            color: !cfg!(windows),
+            file: Default::default(),
+            log_dir: Default::default(),
+            log_to_file: false,
+            log_to_stdout: true,
+            emit_sentry_breadcrumbs: None,
+            extra: Default::default(),
+        }
+    }
+}

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 
 [dependencies]
 ckb-util = { path = ".." }
+ckb-logger-config = { path = "../logger-config" }
 ansi_term = "0.12"
 log = "0.4"
 env_logger = "0.6"
 lazy_static = "1.3"
 regex = "1.1.6"
 chrono = "0.4"
-serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = "0.3"
 backtrace = "0.3"
 sentry = "0.16.0"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,5 +1,6 @@
 mod linked_hash_set;
 mod shrink_to_fit;
+pub mod strings;
 
 use std::time::Duration;
 

--- a/util/src/strings.rs
+++ b/util/src/strings.rs
@@ -1,0 +1,25 @@
+use regex::Regex;
+
+pub fn check_if_identifier_is_valid(ident: &str) -> Result<(), String> {
+    const IDENT_PATTERN: &str = r#"^[0-9a-zA-Z_-]+$"#;
+    if ident.is_empty() {
+        return Err("the identifier shouldn't be empty".to_owned());
+    }
+    match Regex::new(IDENT_PATTERN) {
+        Ok(re) => {
+            if !re.is_match(&ident) {
+                return Err(format!(
+                    "invaild identifier \"{}\", the identifier pattern is \"{}\"",
+                    ident, IDENT_PATTERN
+                ));
+            }
+        }
+        Err(err) => {
+            return Err(format!(
+                "invalid regular expression \"{}\": {}",
+                IDENT_PATTERN, err
+            ));
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
_Originally posted by @doitian in https://github.com/nervosnetwork/ckb/pull/2199#discussion_r465498134_

- Split logger config and service.
- Let `ckb-app-config` only be dependent on `ckb-logger-config`.
- Move the function which checks identifier into `ckb-util`.