### PR TITLE
feat: create log monitor for integration test check status between nodes

### DIFF
--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -150,7 +150,7 @@ pub fn sleep(secs: u64) {
     thread::sleep(tweaked_duration(secs));
 }
 
-fn tweaked_duration(secs: u64) -> Duration {
+pub fn tweaked_duration(secs: u64) -> Duration {
     let sec_coefficient = env::var("CKB_TEST_SEC_COEFFICIENT")
         .unwrap_or_default()
         .parse()


### PR DESCRIPTION
1. Reading node's log directly is an easier way to implement log monitor than using `Stdio::piped`. 
2. Because we could get result by checking if there exists a specify keyword in log at the most, so I use `str::contains()` instead of regex.
3. I updated the cases in `block_relay.rs` as an example, and I think all `wait_util()` can be updated with using log monitor, and some RPC call also can be replaced.