### PR TITLE
refactor: re-export crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "ckb-chain",
  "ckb-chain-iter",
  "ckb-chain-spec",
+ "ckb-channel",
  "ckb-instrument",
  "ckb-jsonrpc-types",
  "ckb-logger",
@@ -400,7 +401,6 @@ dependencies = [
  "ckb-util",
  "ckb-verification",
  "clap",
- "crossbeam-channel 0.3.9",
  "ctrlc",
  "rayon",
  "sentry",
@@ -421,6 +421,7 @@ dependencies = [
  "bitflags",
  "ckb-app-config",
  "ckb-chain-spec",
+ "ckb-channel",
  "ckb-dao",
  "ckb-dao-utils",
  "ckb-error",
@@ -436,7 +437,6 @@ dependencies = [
  "ckb-tx-pool",
  "ckb-types",
  "ckb-verification",
- "crossbeam-channel 0.3.9",
  "faketime",
  "lazy_static",
 ]
@@ -465,6 +465,13 @@ dependencies = [
  "failure",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "ckb-channel"
+version = "0.36.0-pre"
+dependencies = [
+ "crossbeam-channel 0.3.9",
 ]
 
 [[package]]
@@ -658,9 +665,9 @@ dependencies = [
  "ansi_term 0.12.1",
  "backtrace",
  "chrono",
+ "ckb-channel",
  "ckb-logger-config",
  "ckb-util",
- "crossbeam-channel 0.3.9",
  "env_logger",
  "log 0.4.11",
  "once_cell",
@@ -720,6 +727,7 @@ name = "ckb-miner"
 version = "0.36.0-pre"
 dependencies = [
  "ckb-app-config",
+ "ckb-channel",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-logger",
@@ -727,7 +735,6 @@ dependencies = [
  "ckb-stop-handler",
  "ckb-types",
  "console",
- "crossbeam-channel 0.3.9",
  "eaglesong",
  "failure",
  "futures 0.1.29",
@@ -762,7 +769,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "criterion",
- "crossbeam-channel 0.3.9",
  "faketime",
  "faster-hex 0.4.1",
  "futures 0.3.4",
@@ -807,10 +813,10 @@ name = "ckb-notify"
 version = "0.36.0-pre"
 dependencies = [
  "ckb-app-config",
+ "ckb-channel",
  "ckb-logger",
  "ckb-stop-handler",
  "ckb-types",
- "crossbeam-channel 0.3.9",
 ]
 
 [[package]]
@@ -912,6 +918,7 @@ dependencies = [
  "ckb-app-config",
  "ckb-chain",
  "ckb-chain-spec",
+ "ckb-channel",
  "ckb-dao",
  "ckb-dao-utils",
  "ckb-error",
@@ -935,7 +942,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
- "crossbeam-channel 0.3.9",
  "failure",
  "faketime",
  "futures 0.1.29",
@@ -1024,8 +1030,8 @@ dependencies = [
 name = "ckb-stop-handler"
 version = "0.36.0-pre"
 dependencies = [
+ "ckb-channel",
  "ckb-logger",
- "crossbeam-channel 0.3.9",
  "futures 0.1.29",
  "parking_lot 0.7.1",
  "tokio 0.2.22",
@@ -1053,6 +1059,7 @@ dependencies = [
  "ckb-app-config",
  "ckb-chain",
  "ckb-chain-spec",
+ "ckb-channel",
  "ckb-dao",
  "ckb-dao-utils",
  "ckb-db",
@@ -1069,7 +1076,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
- "crossbeam-channel 0.3.9",
  "failure",
  "faketime",
  "futures 0.3.4",
@@ -1147,12 +1153,12 @@ version = "0.36.0-pre"
 dependencies = [
  "bit-vec",
  "bytes 0.5.6",
+ "ckb-channel",
  "ckb-error",
  "ckb-fixed-hash",
  "ckb-hash",
  "ckb-occupied-capacity",
  "ckb-rational",
- "crossbeam-channel 0.3.9",
  "failure",
  "merkle-cbt",
  "molecule",
@@ -1191,7 +1197,6 @@ dependencies = [
  "ckb-test-chain-utils",
  "ckb-traits",
  "ckb-types",
- "crossbeam-channel 0.3.9",
  "enum-display-derive",
  "failure",
  "faketime",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -14,7 +14,6 @@ ckb-chain-spec = { path = "../spec" }
 ckb-store = { path = "../store" }
 ckb-verification = { path = "../verification" }
 faketime = "0.2.0"
-crossbeam-channel = "0.3"
 ckb-stop-handler = { path = "../util/stop-handler" }
 ckb-dao = { path = "../util/dao" }
 ckb-proposal-table = { path = "../util/proposal-table" }
@@ -22,6 +21,7 @@ ckb-error = { path = "../error" }
 ckb-app-config = { path = "../util/app-config" }
 bitflags = "1.0"
 ckb-rust-unstable-port = { path = "../util/rust-unstable-port" }
+ckb-channel = { path = "../util/channel" }
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils" }

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -10,13 +10,13 @@ clap = { version = "2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_plain = "0.3.0"
 toml = "0.5"
-crossbeam-channel = "0.3"
 ckb-app-config = { path = "../util/app-config" }
 ckb-logger = { path = "../util/logger" }
 ckb-logger-service = { path = "../util/logger-service" }
 ckb-metrics-service = { path = "../util/metrics-service" }
 ckb-util = { path = "../util" }
 ckb-types = { path = "../util/types" }
+ckb-channel = { path = "../util/channel" }
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 ckb-chain = { path = "../chain" }
 ckb-shared = { path = "../shared" }

--- a/ckb-bin/src/subcommand/miner.rs
+++ b/ckb-bin/src/subcommand/miner.rs
@@ -1,6 +1,6 @@
 use ckb_app_config::{ExitCode, MinerArgs, MinerConfig};
+use ckb_channel::unbounded;
 use ckb_miner::{Client, Miner};
-use crossbeam_channel::unbounded;
 use std::thread;
 
 pub fn miner(args: MinerArgs) -> Result<(), ExitCode> {

--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -73,12 +73,12 @@ function search_crate() {
     local depcnt=0
     local grepopts="-rh"
     tmpcnt=$({\
-        ${GREP} ${grepopts} "\(^\| \)extern crate ${crate}\(::\|;\)" "${source}" \
+        ${GREP} ${grepopts} "\(^\| \)extern crate ${crate}\(::\|;\| as \)" "${source}" \
             || true; }\
         | wc -l)
     depcnt=$((depcnt + tmpcnt))
     tmpcnt=$({\
-        ${GREP} ${grepopts} "\(^\| \)use ${crate}\(::\|;\)" "${source}" \
+        ${GREP} ${grepopts} "\(^\| \)use ${crate}\(::\|;\| as \)" "${source}" \
             || true; }\
         | wc -l)
     depcnt=$((depcnt + tmpcnt))

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2018"
 ckb-logger = { path = "../util/logger" }
 ckb-app-config = { path = "../util/app-config" }
 ckb-types = { path = "../util/types" }
+ckb-channel = { path = "../util/channel" }
 ckb-hash = { path = "../util/hash" }
 ckb-pow = { path = "../pow" }
 rand = "0.6"
 serde = { version = "1.0", features = ["derive"] }
-crossbeam-channel = "0.3"
 serde_json = "1.0"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 hyper = "0.12"

--- a/miner/src/client.rs
+++ b/miner/src/client.rs
@@ -1,5 +1,6 @@
 use crate::Work;
 use ckb_app_config::MinerClientConfig;
+use ckb_channel::Sender;
 use ckb_jsonrpc_types::{
     error::Error as RpcFail, error::ErrorCode as RpcFailCode, id::Id, params::Params,
     request::MethodCall, response::Output, version::Version, Block as JsonBlock, BlockTemplate,
@@ -7,7 +8,6 @@ use ckb_jsonrpc_types::{
 use ckb_logger::{debug, error, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_types::{packed::Block, H256};
-use crossbeam_channel::Sender;
 use failure::Error;
 use futures::sync::{mpsc, oneshot};
 use hyper::error::Error as HyperError;

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -2,6 +2,7 @@ use crate::client::Client;
 use crate::worker::{start_worker, WorkerController, WorkerMessage};
 use crate::Work;
 use ckb_app_config::MinerWorkerConfig;
+use ckb_channel::{select, unbounded, Receiver};
 use ckb_logger::{debug, error, info};
 use ckb_pow::PowEngine;
 use ckb_types::{
@@ -9,7 +10,6 @@ use ckb_types::{
     prelude::*,
     utilities::compact_to_target,
 };
-use crossbeam_channel::{select, unbounded, Receiver};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use lru_cache::LruCache;
 use std::sync::Arc;

--- a/miner/src/worker/dummy.rs
+++ b/miner/src/worker/dummy.rs
@@ -1,8 +1,8 @@
 use super::{Worker, WorkerMessage};
 use ckb_app_config::DummyConfig;
+use ckb_channel::{Receiver, Sender};
 use ckb_logger::error;
 use ckb_types::packed::Byte32;
-use crossbeam_channel::{Receiver, Sender};
 use indicatif::ProgressBar;
 use rand::{
     distributions::{self as dist, Distribution as _},

--- a/miner/src/worker/eaglesong_simple.rs
+++ b/miner/src/worker/eaglesong_simple.rs
@@ -1,10 +1,10 @@
 use super::{Worker, WorkerMessage};
 use ckb_app_config::ExtraHashFunction;
+use ckb_channel::{Receiver, Sender};
 use ckb_hash::blake2b_256;
 use ckb_logger::{debug, error};
 use ckb_pow::pow_message;
 use ckb_types::{packed::Byte32, U256};
-use crossbeam_channel::{Receiver, Sender};
 use eaglesong::eaglesong;
 use indicatif::ProgressBar;
 use std::thread;

--- a/miner/src/worker/mod.rs
+++ b/miner/src/worker/mod.rs
@@ -2,10 +2,10 @@ mod dummy;
 mod eaglesong_simple;
 
 use ckb_app_config::MinerWorkerConfig;
+use ckb_channel::{unbounded, Sender};
 use ckb_logger::error;
 use ckb_pow::{DummyPowEngine, EaglesongBlake2bPowEngine, EaglesongPowEngine, PowEngine};
 use ckb_types::{packed::Byte32, U256};
-use crossbeam_channel::{unbounded, Sender};
 use dummy::Dummy;
 use eaglesong_simple::EaglesongSimple;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,7 +15,6 @@ ckb-app-config = { path = "../util/app-config" }
 tokio = { version = "0.2.11", features = ["time", "io-util", "tcp", "dns", "rt-threaded", "blocking", "stream"] }
 tokio-util = { version = "0.3.0", features = ["codec"] }
 futures = "0.3"
-crossbeam-channel = "0.3"
 p2p = { version="0.3.0", package="tentacle", features = ["molc"] }
 faketime = "0.2.0"
 lazy_static = "1.3.0"

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -49,7 +49,7 @@ use std::{
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        mpsc as std_mpsc, Arc,
     },
     thread,
     time::{Duration, Instant},
@@ -1036,8 +1036,8 @@ impl<T: ExitHandler> NetworkService<T> {
         if let Some(name) = thread_name {
             thread_builder = thread_builder.name(name.to_string());
         }
-        let (sender, receiver) = crossbeam_channel::bounded(1);
-        let (start_sender, start_receiver) = crossbeam_channel::bounded(1);
+        let (sender, receiver) = std_mpsc::channel();
+        let (start_sender, start_receiver) = std_mpsc::channel();
         let network_state_1 = Arc::clone(&network_state);
         // Main network thread
         let thread = thread_builder
@@ -1128,7 +1128,7 @@ impl<T: ExitHandler> NetworkService<T> {
             return Err(e);
         }
 
-        let stop = StopHandler::new(SignalSender::Crossbeam(sender), thread);
+        let stop = StopHandler::new(SignalSender::Std(sender), thread);
         Ok(NetworkController {
             version,
             network_state,

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -199,7 +199,7 @@ fn net_service_start(name: String) -> Node {
     let peer_id = network_state.local_peer_id().clone();
 
     let control = p2p_service.control().clone();
-    let (addr_sender, addr_receiver) = crossbeam_channel::bounded(1);
+    let (addr_sender, addr_receiver) = ::std::sync::mpsc::channel();
 
     thread::spawn(move || {
         let num_threads = ::std::cmp::max(num_cpus::get(), 4);

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 ckb-logger = { path = "../util/logger" }
 ckb-app-config  = { path = "../util/app-config" }
 ckb-types = { path = "../util/types" }
+ckb-channel = { path = "../util/channel" }
 ckb-stop-handler = { path = "../util/stop-handler" }
-crossbeam-channel = "0.3"
 
 [dev-dependencies]

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -1,11 +1,11 @@
 use ckb_app_config::NotifyConfig;
+use ckb_channel::{bounded, select, Receiver, RecvError, Sender};
 use ckb_logger::{debug, error, trace};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_types::{
     core::{service::Request, BlockView},
     packed::Alert,
 };
-use crossbeam_channel::{bounded, select, Receiver, RecvError, Sender};
 use std::collections::HashMap;
 use std::process::Command;
 use std::thread;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,7 @@ ckb-store = { path = "../store" }
 ckb-sync = { path = "../sync" }
 ckb-chain = { path = "../chain" }
 ckb-logger = { path = "../util/logger"}
+ckb-channel = { path = "../util/channel" }
 ckb-logger-service = { path = "../util/logger-service"}
 ckb-network-alert = { path = "../util/network-alert" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
@@ -27,7 +28,6 @@ jsonrpc-tcp-server = "~14.1"
 jsonrpc-ws-server = "~14.1"
 jsonrpc-server-utils = "~14.1"
 jsonrpc-pubsub = "~14.1"
-crossbeam-channel = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num_cpus = "1.10"

--- a/rpc/src/module/subscription.rs
+++ b/rpc/src/module/subscription.rs
@@ -1,6 +1,6 @@
+use ckb_channel::select;
 use ckb_logger::error;
 use ckb_notify::NotifyController;
-use crossbeam_channel::select;
 use jsonrpc_core::{futures::Future, Metadata, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -20,6 +20,7 @@ faketime = "0.2.0"
 bitflags = "1.0"
 ckb-verification = { path = "../verification" }
 ckb-chain-spec = { path = "../spec" }
+ckb-channel = { path = "../util/channel" }
 ckb-traits = { path = "../traits" }
 failure = "0.1.5"
 lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
@@ -28,7 +29,6 @@ futures = "0.3"
 ckb-error = {path = "../error"}
 ckb-tx-pool = { path = "../tx-pool" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
-crossbeam-channel = "0.3"
 ratelimit_meter = "5.0"
 tempfile = "3.0"
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT,
 };
 use ckb_chain::chain::ChainController;
+use ckb_channel as channel;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_metrics::metrics;
 use ckb_network::{
@@ -49,7 +50,7 @@ enum FetchCMD {
 struct BlockFetchCMD {
     sync: Synchronizer,
     p2p_control: ServiceControl,
-    recv: crossbeam_channel::Receiver<FetchCMD>,
+    recv: channel::Receiver<FetchCMD>,
 }
 
 impl BlockFetchCMD {
@@ -93,7 +94,7 @@ impl BlockFetchCMD {
 pub struct Synchronizer {
     chain: ChainController,
     pub shared: Arc<SyncShared>,
-    fetch_channel: Option<crossbeam_channel::Sender<FetchCMD>>,
+    fetch_channel: Option<channel::Sender<FetchCMD>>,
 }
 
 impl Synchronizer {
@@ -476,7 +477,7 @@ impl Synchronizer {
                 None => {
                     let p2p_control = raw.clone();
                     let sync = self.clone();
-                    let (sender, recv) = crossbeam_channel::bounded(2);
+                    let (sender, recv) = channel::bounded(2);
                     let peers = self.get_peers_to_fetch(ibd, &disconnect_list);
                     sender.send(FetchCMD::Fetch(peers)).unwrap();
                     self.fetch_channel = Some(sender);

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,6 +11,7 @@ toml = "0.5.0"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 ckb-app-config = { path = "../util/app-config" }
 ckb-network = { path = "../network" }
+ckb-channel = { path = "../util/channel" }
 ckb-sync = { path = "../sync" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 ckb-types = { path = "../util/types" }
@@ -27,7 +28,6 @@ reqwest = "0.9"
 rand = "0.6"
 log = "0.4"
 env_logger = "0.6"
-crossbeam-channel = "0.3"
 faketime = "0.2"
 failure = "0.1.5"
 serde_json = "1.0"

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,3 +1,4 @@
+use ckb_channel::unbounded;
 use ckb_test::specs::*;
 use ckb_test::{
     utils::node_log,
@@ -7,7 +8,6 @@ use ckb_test::{
 use ckb_types::core::ScriptHashType;
 use ckb_util::Mutex;
 use clap::{value_t, App, Arg};
-use crossbeam_channel::unbounded;
 use log::{error, info};
 use rand::{seq::SliceRandom, thread_rng};
 use std::any::Any;

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -2,12 +2,12 @@ use crate::specs::TestProtocol;
 use crate::utils::{temp_path, wait_until};
 use crate::{Node, Setup};
 use ckb_app_config::NetworkConfig;
+use ckb_channel::{self as channel, Receiver, RecvTimeoutError, Sender};
 use ckb_network::{
     bytes::Bytes, CKBProtocol, CKBProtocolContext, CKBProtocolHandler, DefaultExitHandler,
     NetworkController, NetworkService, NetworkState, PeerIndex, ProtocolId,
 };
 use ckb_types::core::{BlockNumber, BlockView};
-use crossbeam_channel::{self, Receiver, RecvTimeoutError, Sender};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{
@@ -94,7 +94,7 @@ impl Net {
         );
         assert!(self.controller.is_none());
 
-        let (tx, rx) = crossbeam_channel::unbounded();
+        let (tx, rx) = channel::unbounded();
         let config = NetworkConfig {
             listen_addresses: vec![format!("/ip4/127.0.0.1/tcp/{}", self.p2p_port())
                 .parse()

--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -1,6 +1,6 @@
 use crate::{utils::nodes_panicked, Net, Spec};
+use ckb_channel::{unbounded, Receiver, Sender};
 use ckb_util::Mutex;
-use crossbeam_channel::{unbounded, Receiver, Sender};
 use log::{error, info};
 use std::any::Any;
 use std::panic;

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ckb-channel"
+version = "0.36.0-pre"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+crossbeam-channel = "~0.3"

--- a/util/channel/src/lib.rs
+++ b/util/channel/src/lib.rs
@@ -1,0 +1,3 @@
+pub use crossbeam_channel::{
+    bounded, select, unbounded, Receiver, RecvError, RecvTimeoutError, Sender,
+};

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 [dependencies]
 ckb-util = { path = ".." }
 ckb-logger-config = { path = "../logger-config" }
+ckb-channel = { path = "../channel" }
 ansi_term = "0.12"
 log = "0.4"
 env_logger = "0.6"
 once_cell = "1.3.1"
 regex = "1.1.6"
 chrono = "0.4"
-crossbeam-channel = "0.3"
 backtrace = "0.3"
 sentry = "0.16.0"

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -1,7 +1,7 @@
 use ansi_term::Colour;
 use backtrace::Backtrace;
 use chrono::prelude::{DateTime, Local};
-use crossbeam_channel::unbounded;
+use ckb_channel::{self, unbounded};
 use env_logger::filter::{Builder, Filter};
 use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
 use once_cell::sync::OnceCell;
@@ -14,7 +14,7 @@ use std::{fs, panic, process, sync, thread};
 use ckb_logger_config::Config;
 use ckb_util::{strings, Mutex, RwLock};
 
-static CONTROL_HANDLE: OnceCell<crossbeam_channel::Sender<Message>> = OnceCell::new();
+static CONTROL_HANDLE: OnceCell<ckb_channel::Sender<Message>> = OnceCell::new();
 static RE: OnceCell<regex::Regex> = OnceCell::new();
 
 enum Message {
@@ -36,7 +36,7 @@ enum Message {
 
 #[derive(Debug)]
 pub struct Logger {
-    sender: crossbeam_channel::Sender<Message>,
+    sender: ckb_channel::Sender<Message>,
     handle: Mutex<Option<thread::JoinHandle<()>>>,
     filter: sync::Arc<RwLock<Filter>>,
     emit_sentry_breadcrumbs: bool,

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 parking_lot = "=0.7.1"
-crossbeam-channel = "0.3"
 ckb-logger = { path = "../logger" }
 futures = "0.1"
 tokio = { version = "0.2", features = ["sync", "blocking", "rt-threaded"] }
+ckb-channel = { path = "../channel" }

--- a/util/stop-handler/src/lib.rs
+++ b/util/stop-handler/src/lib.rs
@@ -1,7 +1,7 @@
 use ckb_logger::error;
-use crossbeam_channel::Sender;
 use futures::sync::oneshot;
 use parking_lot::Mutex;
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use tokio::sync::oneshot as tokio_oneshot;
@@ -9,7 +9,8 @@ use tokio::sync::oneshot as tokio_oneshot;
 #[derive(Debug)]
 pub enum SignalSender {
     Future(oneshot::Sender<()>),
-    Crossbeam(Sender<()>),
+    Crossbeam(ckb_channel::Sender<()>),
+    Std(mpsc::Sender<()>),
     Tokio(tokio_oneshot::Sender<()>),
 }
 
@@ -17,6 +18,11 @@ impl SignalSender {
     pub fn send(self) {
         match self {
             SignalSender::Crossbeam(tx) => {
+                if let Err(e) = tx.send(()) {
+                    error!("handler signal send error {:?}", e);
+                };
+            }
+            SignalSender::Std(tx) => {
                 if let Err(e) = tx.send(()) {
                     error!("handler signal send error {:?}", e);
                 };

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { version="0.5.4", features = ["serde"] }
 merkle-cbt = "0.2"
 ckb-occupied-capacity = { path = "../occupied-capacity" }
 ckb-hash = { path = "../hash" }
-crossbeam-channel = "0.3"
+ckb-channel = { path = "../channel" }
 bit-vec = "0.5.1"
 failure = "0.1.5"
 ckb-error = { path = "../../error" }

--- a/util/types/src/core/service.rs
+++ b/util/types/src/core/service.rs
@@ -1,17 +1,17 @@
-use crossbeam_channel::{self, Sender};
+use ckb_channel::Sender;
+use std::sync::mpsc;
 
-const ONESHOT_CHANNEL_SIZE: usize = 1;
 pub const SIGNAL_CHANNEL_SIZE: usize = 1;
 pub const DEFAULT_CHANNEL_SIZE: usize = 32;
 
 pub struct Request<A, R> {
-    pub responder: Sender<R>,
+    pub responder: mpsc::Sender<R>,
     pub arguments: A,
 }
 
 impl<A, R> Request<A, R> {
     pub fn call(sender: &Sender<Request<A, R>>, arguments: A) -> Option<R> {
-        let (responder, response) = crossbeam_channel::bounded(ONESHOT_CHANNEL_SIZE);
+        let (responder, response) = mpsc::channel();
         let _ = sender.send(Request {
             responder,
             arguments,

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -23,7 +23,6 @@ failure = "0.1.5"
 ckb-error = { path = "../error" }
 enum-display-derive = "0.1.0"
 tokio = { version = "0.2", features = ["sync", "blocking", "rt-threaded"] }
-crossbeam-channel = "0.3"
 ckb-async-runtime = { path = "../util/runtime" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

re-export crossbeam-channel from facade wrapper, unify version specify.
use tilde requirements specify for crossbeam-channel, prevent automate dependency updates.

crossbeam-channel 0.4.3 has UB, may lead to jemalloc deadlock.

```
    frame #0: 0x00007fb34acd5620 libpthread.so.0`__lll_lock_wait + 48
    frame #1: 0x00007fb34accddf3 libpthread.so.0`__pthread_mutex_lock + 227
    frame #2: 0x000056423ada57fc ckb`_rjem_je_malloc_mutex_lock_slow at mutex.h:141:2
    frame #3: 0x000056423ada57f4 ckb`_rjem_je_malloc_mutex_lock_slow at mutex.c:84
    frame #4: 0x000056423ad6e1a8 ckb`_rjem_je_arena_tcache_fill_small at mutex.h:205:4
    frame #5: 0x000056423ad6e1a0 ckb`_rjem_je_arena_tcache_fill_small at arena.c:1261
    frame #6: 0x000056423adc1494 ckb`_rjem_je_tcache_alloc_small_hard at tcache.c:93:2
    frame #7: 0x000056423ad68618 ckb`mallocx at tcache_inlines.h:60:9
    frame #8: 0x000056423ad685e0 ckb`mallocx at jemalloc.c:1709
    frame #9: 0x000056423ad685e0 ckb`mallocx at jemalloc.c:1905
    frame #10: 0x000056423ad685e0 ckb`mallocx at jemalloc.c:2005
    frame #11: 0x000056423ad68324 ckb`mallocx at jemalloc.c:2588
    frame #12: 0x000056423b16a56c ckb`alloc::raw_vec::RawVec$LT$T$C$A$GT$::reserve::h10a313223974a7d1 + 188
    frame #13: 0x000056423b1a25f9 ckb`crossbeam_channel::flavors::array::Channel$LT$T$GT$::with_capacity::had6f123b9bc217e1 + 121
```
https://github.com/crossbeam-rs/crossbeam/pull/533
https://github.com/nervosnetwork/ckb/pull/2235

also crossbeam-channel is not optimize for oneshot case. replace it if it is convenient.
