### PR TITLE
feat: deprecated rpc method by adding `deprecated.` prefix to the rpc name

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -14,7 +14,11 @@ def sort_cases_by_module(cases):
 
 
 def print_title(case):
-    print("### `{}`".format(case["method"]))
+    if case.get("deprecated") is None:
+        print("### `{}`".format(case["method"]))
+    else:
+        print("### ~~`{}`~~".format(case["method"]))
+        print("**DEPRECATED** {}".format(case["deprecated"]))
     newline(1)
 
 

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -106,6 +106,11 @@ modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment
 # ws_listen_address = "127.0.0.1:28114"
 reject_ill_transactions = true
 
+# By default deprecated rpc methods are disabled.
+enable_deprecated_rpc = false # {{
+# integration => enable_deprecated_rpc = true
+# }}
+
 [tx_pool]
 max_mem_size = 20_000_000 # 20mb
 max_cycles = 200_000_000_000

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -399,7 +399,8 @@ http://localhost:8114
 }
 ```
 
-### `get_cells_by_lock_hash`
+### ~~`get_cells_by_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Returns the information about live cells collection by the hash of lock script.
 
@@ -1067,7 +1068,8 @@ http://localhost:8114
 
 ## Indexer
 
-### `index_lock_hash`
+### ~~`index_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Create index for live cells and transactions by the hash of lock script.
 
@@ -1105,7 +1107,8 @@ http://localhost:8114
 }
 ```
 
-### `get_lock_hash_index_states`
+### ~~`get_lock_hash_index_states`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Get lock hash index states
 
@@ -1138,7 +1141,8 @@ http://localhost:8114
 }
 ```
 
-### `get_live_cells_by_lock_hash`
+### ~~`get_live_cells_by_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Returns the live cells collection by the hash of lock script.
 
@@ -1434,7 +1438,8 @@ http://localhost:8114
 }
 ```
 
-### `get_transactions_by_lock_hash`
+### ~~`get_transactions_by_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` has not been indexed yet.
 
@@ -1584,7 +1589,8 @@ http://localhost:8114
 }
 ```
 
-### `get_capacity_by_lock_hash`
+### ~~`get_capacity_by_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Returns the total capacity by the hash of lock script.
 
@@ -1625,7 +1631,8 @@ http://localhost:8114
 }
 ```
 
-### `deindex_lock_hash`
+### ~~`deindex_lock_hash`~~
+**DEPRECATED** This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution
 
 Remove index for live cells and transactions by the hash of lock script.
 

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -181,6 +181,7 @@
         }
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Returns the information about live cells collection by the hash of lock script.",
         "method": "get_cells_by_lock_hash",
         "module": "chain",
@@ -1144,6 +1145,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Create index for live cells and transactions by the hash of lock script.",
         "method": "index_lock_hash",
         "module": "indexer",
@@ -1166,6 +1168,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Get lock hash index states",
         "method": "get_lock_hash_index_states",
         "module": "indexer",
@@ -1179,6 +1182,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Returns the live cells collection by the hash of lock script.",
         "method": "get_live_cells_by_lock_hash",
         "module": "indexer",
@@ -1471,6 +1475,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Returns the transactions collection by the hash of lock script. Returns empty array when the `lock_hash` has not been indexed yet.",
         "method": "get_transactions_by_lock_hash",
         "module": "indexer",
@@ -1609,6 +1614,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Returns the total capacity by the hash of lock script.",
         "method": "get_capacity_by_lock_hash",
         "module": "indexer",
@@ -1638,6 +1644,7 @@
         ]
     },
     {
+        "deprecated": "This method is deprecated since version 0.36.0 for reasons of flexibility, please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution",
         "description": "Remove index for live cells and transactions by the hash of lock script.",
         "method": "deindex_lock_hash",
         "module": "indexer",

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -147,6 +147,15 @@ impl RPCError {
             )
         )
     }
+
+    pub fn rpc_method_is_deprecated() -> Error {
+        Self::custom(
+            RPCError::Deprecated,
+            "This RPC method is deprecated, it will be removed in future release. \
+            Please check the related information in the CKB release notes and RPC document. \
+            You may enable deprecated methods via adding `enable_deprecated_rpc = true` to the `[rpc]` section in ckb.toml.",
+        )
+    }
 }
 
 #[cfg(test)]

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -41,7 +41,7 @@ pub trait ChainRpc {
     #[rpc(name = "get_tip_header")]
     fn get_tip_header(&self) -> Result<HeaderView>;
 
-    #[rpc(name = "get_cells_by_lock_hash")]
+    #[rpc(name = "deprecated.get_cells_by_lock_hash")]
     fn get_cells_by_lock_hash(
         &self,
         _lock_hash: H256,

--- a/rpc/src/module/indexer.rs
+++ b/rpc/src/module/indexer.rs
@@ -8,7 +8,7 @@ use jsonrpc_derive::rpc;
 
 #[rpc(server)]
 pub trait IndexerRpc {
-    #[rpc(name = "get_live_cells_by_lock_hash")]
+    #[rpc(name = "deprecated.get_live_cells_by_lock_hash")]
     fn get_live_cells_by_lock_hash(
         &self,
         _lock_hash: H256,
@@ -17,7 +17,7 @@ pub trait IndexerRpc {
         _reverse_order: Option<bool>,
     ) -> Result<Vec<LiveCell>>;
 
-    #[rpc(name = "get_transactions_by_lock_hash")]
+    #[rpc(name = "deprecated.get_transactions_by_lock_hash")]
     fn get_transactions_by_lock_hash(
         &self,
         _lock_hash: H256,
@@ -26,20 +26,20 @@ pub trait IndexerRpc {
         _reverse_order: Option<bool>,
     ) -> Result<Vec<CellTransaction>>;
 
-    #[rpc(name = "index_lock_hash")]
+    #[rpc(name = "deprecated.index_lock_hash")]
     fn index_lock_hash(
         &self,
         _lock_hash: H256,
         _index_from: Option<BlockNumber>,
     ) -> Result<LockHashIndexState>;
 
-    #[rpc(name = "deindex_lock_hash")]
+    #[rpc(name = "deprecated.deindex_lock_hash")]
     fn deindex_lock_hash(&self, _lock_hash: H256) -> Result<()>;
 
-    #[rpc(name = "get_lock_hash_index_states")]
+    #[rpc(name = "deprecated.get_lock_hash_index_states")]
     fn get_lock_hash_index_states(&self) -> Result<Vec<LockHashIndexState>>;
 
-    #[rpc(name = "get_capacity_by_lock_hash")]
+    #[rpc(name = "deprecated.get_capacity_by_lock_hash")]
     fn get_capacity_by_lock_hash(&self, _lock_hash: H256) -> Result<Option<LockHashCapacity>>;
 }
 

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -52,13 +52,13 @@ impl<'a> ServiceBuilder<'a> {
         min_fee_rate: FeeRate,
         reject_ill_transactions: bool,
     ) -> Self {
-        let rpc_method =
+        let rpc_methods =
             PoolRpcImpl::new(shared, sync_shared, min_fee_rate, reject_ill_transactions)
                 .to_delegate();
         if self.config.pool_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Pool", rpc_method);
+            self.update_disabled_methods("Pool", rpc_methods);
         }
         self
     }
@@ -70,16 +70,16 @@ impl<'a> ServiceBuilder<'a> {
         chain: ChainController,
         enable: bool,
     ) -> Self {
-        let rpc_method = MinerRpcImpl {
+        let rpc_methods = MinerRpcImpl {
             shared,
             chain,
             network_controller,
         }
         .to_delegate();
         if enable && self.config.miner_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Miner", rpc_method);
+            self.update_disabled_methods("Miner", rpc_methods);
         }
         self
     }
@@ -89,15 +89,15 @@ impl<'a> ServiceBuilder<'a> {
         network_controller: NetworkController,
         sync_shared: Arc<SyncShared>,
     ) -> Self {
-        let rpc_method = NetworkRpcImpl {
+        let rpc_methods = NetworkRpcImpl {
             network_controller,
             sync_shared,
         }
         .to_delegate();
         if self.config.net_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Net", rpc_method);
+            self.update_disabled_methods("Net", rpc_methods);
         }
         self
     }
@@ -108,26 +108,26 @@ impl<'a> ServiceBuilder<'a> {
         synchronizer: Synchronizer,
         alert_notifier: Arc<Mutex<AlertNotifier>>,
     ) -> Self {
-        let rpc_method = StatsRpcImpl {
+        let rpc_methods = StatsRpcImpl {
             shared,
             synchronizer,
             alert_notifier,
         }
         .to_delegate();
         if self.config.stats_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Stats", rpc_method);
+            self.update_disabled_methods("Stats", rpc_methods);
         }
         self
     }
 
     pub fn enable_experiment(mut self, shared: Shared) -> Self {
-        let rpc_method = ExperimentRpcImpl { shared }.to_delegate();
+        let rpc_methods = ExperimentRpcImpl { shared }.to_delegate();
         if self.config.experiment_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Experiment", rpc_method);
+            self.update_disabled_methods("Experiment", rpc_methods);
         }
         self
     }
@@ -138,16 +138,16 @@ impl<'a> ServiceBuilder<'a> {
         network_controller: NetworkController,
         chain: ChainController,
     ) -> Self {
-        let rpc_method = IntegrationTestRpcImpl {
+        let rpc_methods = IntegrationTestRpcImpl {
             shared,
             network_controller,
             chain,
         }
         .to_delegate();
         if self.config.integration_test_enable() {
-            self.io_handler.extend_with(rpc_method);
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("IntegrationTest", rpc_method);
+            self.update_disabled_methods("IntegrationTest", rpc_methods);
         }
         self
     }
@@ -158,27 +158,27 @@ impl<'a> ServiceBuilder<'a> {
         alert_notifier: Arc<Mutex<AlertNotifier>>,
         network_controller: NetworkController,
     ) -> Self {
-        let rpc_method =
+        let rpc_methods =
             AlertRpcImpl::new(alert_verifier, alert_notifier, network_controller).to_delegate();
         if self.config.alert_enable() {
-            self.io_handler.extend_with(rpc_method)
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Alert", rpc_method);
+            self.update_disabled_methods("Alert", rpc_methods);
         }
         self
     }
 
     pub fn enable_indexer(mut self, indexer_config: &IndexerConfig, shared: Shared) -> Self {
         let store = DefaultIndexerStore::new(indexer_config, shared);
-        let rpc_method = IndexerRpcImpl {
+        let rpc_methods = IndexerRpcImpl {
             store: store.clone(),
         }
         .to_delegate();
         if self.config.indexer_enable() {
             store.start(Some("IndexerStore"));
-            self.io_handler.extend_with(rpc_method)
+            self.add_methods(rpc_methods);
         } else {
-            self.update_disabled_methods("Indexer", rpc_method);
+            self.update_disabled_methods("Indexer", rpc_methods);
         }
         self
     }

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -1,9 +1,5 @@
-use crate::module::{
-    ChainRpc, ChainRpcImpl, ExperimentRpc, ExperimentRpcImpl, IndexerRpc, IndexerRpcImpl, MinerRpc,
-    MinerRpcImpl, NetworkRpc, NetworkRpcImpl, PoolRpc, PoolRpcImpl, StatsRpc, StatsRpcImpl,
-};
-use crate::RpcServer;
-use ckb_app_config::{IndexerConfig, NetworkAlertConfig, NetworkConfig};
+use crate::{RpcServer, ServiceBuilder};
+use ckb_app_config::{IndexerConfig, NetworkAlertConfig, NetworkConfig, RpcConfig, RpcModule};
 use ckb_chain::chain::{ChainController, ChainService};
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao::DaoCalculator;
@@ -31,10 +27,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use jsonrpc_core::IoHandler;
-use jsonrpc_http_server::ServerBuilder;
-use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
-use jsonrpc_server_utils::hosts::DomainsValidation;
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, json, to_string, Map, Value};
@@ -182,7 +174,7 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
     };
     let sync_shared = Arc::new(SyncShared::new(shared.clone()));
     let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
-    let indexer_store = {
+    let indexer_config = {
         let mut indexer_config = IndexerConfig::default();
         indexer_config.db.path = dir.join("indexer");
         let indexer_store = DefaultIndexerStore::new(&indexer_config, shared.clone());
@@ -190,7 +182,7 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
         indexer_store.insert_lock_hash(&always_success_script.calc_script_hash(), Some(0));
         // use hardcoded TXN_ATTACH_BLOCK_NUMS (100) value here to setup testing data.
         (0..=height / 100).for_each(|_| indexer_store.sync_index_states());
-        indexer_store
+        indexer_config
     };
 
     let notify_controller = NotifyService::new(Default::default()).start(Some("test"));
@@ -218,71 +210,54 @@ fn setup_node(height: u64) -> (Shared, ChainController, RpcServer) {
     };
 
     // Start rpc services
-    let mut io = IoHandler::new();
-    io.extend_with(
-        ChainRpcImpl {
-            shared: shared.clone(),
-        }
-        .to_delegate(),
-    );
-    io.extend_with(
-        PoolRpcImpl::new(
+    let rpc_config = RpcConfig {
+        listen_address: "127.0.0.01:0".to_owned(),
+        tcp_listen_address: None,
+        ws_listen_address: None,
+        max_request_body_size: 20_000_000,
+        threads: None,
+        // enable all rpc modules in unit test
+        modules: vec![
+            RpcModule::Net,
+            RpcModule::Chain,
+            RpcModule::Miner,
+            RpcModule::Pool,
+            RpcModule::Experiment,
+            RpcModule::Stats,
+            RpcModule::Indexer,
+            RpcModule::IntegrationTest,
+            RpcModule::Alert,
+            RpcModule::Subscription,
+            RpcModule::Debug,
+        ],
+        reject_ill_transactions: true,
+        // enable deprecated rpc in unit test
+        enable_deprecated_rpc: true,
+    };
+
+    let builder = ServiceBuilder::new(&rpc_config)
+        .enable_chain(shared.clone())
+        .enable_pool(
             shared.clone(),
             Arc::clone(&sync_shared),
             FeeRate::zero(),
             true,
         )
-        .to_delegate(),
-    );
-    io.extend_with(
-        NetworkRpcImpl {
-            network_controller: network_controller.clone(),
-            sync_shared,
-        }
-        .to_delegate(),
-    );
-    io.extend_with(
-        StatsRpcImpl {
-            shared: shared.clone(),
-            synchronizer,
-            alert_notifier,
-        }
-        .to_delegate(),
-    );
-    io.extend_with(
-        IndexerRpcImpl {
-            store: indexer_store,
-        }
-        .to_delegate(),
-    );
-    io.extend_with(
-        ExperimentRpcImpl {
-            shared: shared.clone(),
-        }
-        .to_delegate(),
-    );
-    io.extend_with(
-        MinerRpcImpl {
-            shared: shared.clone(),
-            chain: chain_controller.clone(),
-            network_controller,
-        }
-        .to_delegate(),
-    );
-    let http = ServerBuilder::new(io)
-        .cors(DomainsValidation::AllowOnly(vec![
-            AccessControlAllowOrigin::Null,
-            AccessControlAllowOrigin::Any,
-        ]))
-        .threads(1)
-        .max_request_body_size(20_000_000)
-        .start_http(&"127.0.0.1:0".parse().unwrap())
-        .expect("JsonRpc initialize");
-    let rpc_server = RpcServer {
-        http,
-        _tcp: None,
-        _ws: None,
-    };
+        .enable_miner(
+            shared.clone(),
+            network_controller.clone(),
+            chain_controller.clone(),
+            true,
+        )
+        .enable_net(network_controller.clone(), sync_shared)
+        .enable_stats(shared.clone(), synchronizer, Arc::clone(&alert_notifier))
+        .enable_experiment(shared.clone())
+        .enable_integration_test(shared.clone(), network_controller, chain_controller.clone())
+        .enable_indexer(&indexer_config, shared.clone())
+        .enable_debug();
+    let io_handler = builder.build();
+
+    let rpc_server = RpcServer::new(rpc_config, io_handler, shared.notify_controller());
 
     (shared, chain_controller, rpc_server)
 }

--- a/util/app-config/src/configs/rpc.rs
+++ b/util/app-config/src/configs/rpc.rs
@@ -28,6 +28,8 @@ pub struct Config {
     // Rejects txs with scripts that might trigger known bugs
     #[serde(default)]
     pub reject_ill_transactions: bool,
+    #[serde(default)]
+    pub enable_deprecated_rpc: bool,
 }
 
 impl Config {


### PR DESCRIPTION
resolve https://github.com/nervosnetwork/ckb/issues/2247, rpc method can be deprecated by adding `deprecated.` prefix to the rpc name:
```diff
+    #[rpc(name = "deprecated.get_cells_by_lock_hash")]
-    #[rpc(name = "get_cells_by_lock_hash")]
    fn get_cells_by_lock_hash
```