### PR TITLE
ci: fix the bors via setting the right pr status

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,9 @@
 status = [
-  "continuous-integration/travis-ci/push"
+  "Travis CI - Branch"
 ]
 
 pr_status = [
-  "continuous-integration/travis-ci/pull"
+  "Travis CI - Pull Request"
 ]
 
 timeout_sec = 7200


### PR DESCRIPTION
`"Travis CI - Branch"` is equal to `"continuous-integration/travis-ci/push"`.
`"Travis CI - Pull Request"` is **NOT** equal to `"continuous-integration/travis-ci/pull"`.

I try to find which service changed it (GitHub, Travis or Bors), but no result.
I only can confirm that the name was changed.