### PR TITLE
feat: add ping_peers rpc

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -23,7 +23,10 @@ use ckb_app_config::NetworkConfig;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_util::{Condvar, Mutex, RwLock};
-use futures::{channel::oneshot, Future, StreamExt};
+use futures::{
+    channel::{mpsc::Sender, oneshot},
+    Future, StreamExt,
+};
 use ipnetwork::IpNetwork;
 use p2p::{
     builder::ServiceBuilder,
@@ -854,6 +857,7 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
 pub struct NetworkService<T> {
     p2p_service: Service<EventHandler<T>>,
     network_state: Arc<NetworkState>,
+    ping_controller: Sender<()>,
     // Background services
     bg_services: Vec<Pin<Box<dyn Future<Output = ()> + 'static + Send>>>,
     version: String,
@@ -877,12 +881,10 @@ impl<T: ExitHandler> NetworkService<T> {
         let ping_timeout = Duration::from_secs(config.ping_timeout_secs);
 
         let ping_network_state = Arc::clone(&network_state);
+        let (ping_handler, ping_controller) =
+            PingHandler::new(ping_interval, ping_timeout, ping_network_state);
         let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(PingHandler::new(
-                ping_interval,
-                ping_timeout,
-                ping_network_state,
-            )))
+            ProtocolHandle::Callback(Box::new(ping_handler))
         });
 
         // Discovery protocol
@@ -971,6 +973,7 @@ impl<T: ExitHandler> NetworkService<T> {
         NetworkService {
             p2p_service,
             network_state,
+            ping_controller,
             bg_services,
             version,
         }
@@ -1012,9 +1015,14 @@ impl<T: ExitHandler> NetworkService<T> {
                 .dial_identify(self.p2p_service.control(), &peer_id, addr);
         }
 
-        let p2p_control = self.p2p_service.control().to_owned();
-        let network_state = Arc::clone(&self.network_state);
-        let version = self.version.clone();
+        let Self {
+            mut p2p_service,
+            network_state,
+            ping_controller,
+            bg_services,
+            version,
+        } = self;
+        let p2p_control = p2p_service.control().to_owned();
 
         // Mainly for test: give an empty thread_name
         let mut thread_builder = thread::Builder::new();
@@ -1023,92 +1031,95 @@ impl<T: ExitHandler> NetworkService<T> {
         }
         let (sender, receiver) = std_mpsc::channel();
         let (start_sender, start_receiver) = std_mpsc::channel();
-        let network_state_1 = Arc::clone(&network_state);
         // Main network thread
-        let thread = thread_builder
-            .spawn(move || {
-                let inner_p2p_control = self.p2p_service.control().to_owned();
-                let num_threads = max(num_cpus::get(), 4);
-                let network_state = Arc::clone(&network_state_1);
-                let mut p2p_service = self.p2p_service;
-                let mut runtime = runtime::Builder::new()
-                    .core_threads(num_threads)
-                    .enable_all()
-                    .threaded_scheduler()
-                    .thread_name("NetworkRuntime")
-                    .build()
-                    .expect("Network tokio runtime init failed");
-                let handle = runtime.spawn(async move {
-                    // listen local addresses
-                    for addr in &config.listen_addresses {
-                        match p2p_service.listen(addr.to_owned()).await {
-                            Ok(listen_address) => {
-                                info!(
-                                    "Listen on address: {}",
-                                    network_state_1.to_external_url(&listen_address)
-                                );
-                                network_state_1
-                                    .listened_addrs
-                                    .write()
-                                    .push(listen_address.clone());
+        let thread = {
+            let network_state = Arc::clone(&network_state);
+            let p2p_control = p2p_control.clone();
+            thread_builder
+                .spawn(move || {
+                    let num_threads = max(num_cpus::get(), 4);
+                    let mut runtime = runtime::Builder::new()
+                        .core_threads(num_threads)
+                        .enable_all()
+                        .threaded_scheduler()
+                        .thread_name("NetworkRuntime")
+                        .build()
+                        .expect("Network tokio runtime init failed");
+
+                    let handle = {
+                        let network_state = Arc::clone(&network_state);
+                        runtime.spawn(async move {
+                            // listen local addresses
+                            for addr in &config.listen_addresses {
+                                match p2p_service.listen(addr.to_owned()).await {
+                                    Ok(listen_address) => {
+                                        info!(
+                                            "Listen on address: {}",
+                                            network_state.to_external_url(&listen_address)
+                                        );
+                                        network_state
+                                            .listened_addrs
+                                            .write()
+                                            .push(listen_address.clone());
+                                    }
+                                    Err(err) => {
+                                        warn!(
+                                            "listen on address {} failed, due to error: {}",
+                                            addr.clone(),
+                                            err
+                                        );
+                                        start_sender
+                                            .send(Err(Error::P2P(P2PError::Transport(err))))
+                                            .expect("channel abnormal shutdown");
+                                        return;
+                                    }
+                                };
                             }
-                            Err(err) => {
-                                warn!(
-                                    "listen on address {} failed, due to error: {}",
-                                    addr.clone(),
-                                    err
-                                );
-                                start_sender
-                                    .send(Err(Error::P2P(P2PError::Transport(err))))
-                                    .expect("channel abnormal shutdown");
-                                return;
+                            start_sender.send(Ok(())).unwrap();
+                            loop {
+                                if p2p_service.next().await.is_none() {
+                                    break;
+                                }
                             }
-                        };
-                    }
-                    start_sender.send(Ok(())).unwrap();
-                    loop {
-                        if p2p_service.next().await.is_none() {
-                            break;
+                        })
+                    };
+
+                    // NOTE: for ensure background task finished
+                    let bg_signals = bg_services
+                        .into_iter()
+                        .map(|bg_service| {
+                            let (signal_sender, signal_receiver) = oneshot::channel::<()>();
+                            let task = futures::future::select(bg_service, signal_receiver);
+                            runtime.spawn(task);
+                            signal_sender
+                        })
+                        .collect::<Vec<_>>();
+
+                    debug!("Waiting for the shutdown signal ...");
+
+                    // Recevied stop signal, doing cleanup
+                    let _ = receiver.recv();
+                    debug!("Recevied the shutdown signal.");
+                    for peer in network_state.peer_registry.read().peers().values() {
+                        info!("Disconnect peer {}", peer.connected_addr);
+                        if let Err(err) =
+                            disconnect_with_message(&p2p_control, peer.session_id, "shutdown")
+                        {
+                            debug!("Disconnect failed {:?}, error: {:?}", peer.session_id, err);
                         }
                     }
-                });
-
-                // NOTE: for ensure background task finished
-                let bg_signals = self
-                    .bg_services
-                    .into_iter()
-                    .map(|bg_service| {
-                        let (signal_sender, signal_receiver) = oneshot::channel::<()>();
-                        let task = futures::future::select(bg_service, signal_receiver);
-                        runtime.spawn(task);
-                        signal_sender
-                    })
-                    .collect::<Vec<_>>();
-
-                debug!("Waiting for the shutdown signal ...");
-                // Recevied stop signal, doing cleanup
-                let _ = receiver.recv();
-                debug!("Recevied the shutdown signal.");
-
-                for peer in network_state.peer_registry.read().peers().values() {
-                    info!("Disconnect peer {}", peer.connected_addr);
-                    if let Err(err) =
-                        disconnect_with_message(&inner_p2p_control, peer.session_id, "shutdown")
-                    {
-                        debug!("Disconnect failed {:?}, error: {:?}", peer.session_id, err);
+                    // Drop senders to stop all corresponding background task
+                    drop(bg_signals);
+                    if let Err(err) = p2p_control.shutdown() {
+                        warn!("send shutdown message to p2p error: {:?}", err);
                     }
-                }
-                // Drop senders to stop all corresponding background task
-                drop(bg_signals);
-                if let Err(err) = inner_p2p_control.shutdown() {
-                    warn!("send shutdown message to p2p error: {:?}", err);
-                }
 
-                debug!("Waiting tokio runtime to finish ...");
-                runtime.block_on(handle).unwrap();
-                debug!("Shutdown network service finished!");
-            })
-            .expect("Start NetworkService failed");
+                    debug!("Waiting tokio runtime to finish ...");
+                    runtime.block_on(handle).unwrap();
+                    debug!("Shutdown network service finished!");
+                })
+                .expect("Start NetworkService failed")
+        };
 
         if let Ok(Err(e)) = start_receiver.recv() {
             return Err(e);
@@ -1119,6 +1130,7 @@ impl<T: ExitHandler> NetworkService<T> {
             version,
             network_state,
             p2p_control,
+            ping_controller,
             stop,
         })
     }
@@ -1129,6 +1141,7 @@ pub struct NetworkController {
     version: String,
     network_state: Arc<NetworkState>,
     p2p_control: ServiceControl,
+    ping_controller: Sender<()>,
     stop: StopHandler<()>,
 }
 
@@ -1275,6 +1288,11 @@ impl NetworkController {
 
     pub fn protocols(&self) -> Vec<(ProtocolId, String, Vec<String>)> {
         self.network_state.protocols.read().clone()
+    }
+
+    pub fn ping_peers(&self) {
+        let mut ping_controller = self.ping_controller.clone();
+        let _ignore = ping_controller.try_send(());
     }
 }
 

--- a/network/src/protocols/ping.rs
+++ b/network/src/protocols/ping.rs
@@ -1,14 +1,11 @@
 use crate::network::disconnect_with_message;
 use crate::NetworkState;
 use ckb_logger::{debug, error, trace, warn};
-use std::{
-    collections::HashMap,
-    str,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-use std::{sync::Arc, time::Instant};
-
 use ckb_types::{packed, prelude::*};
+use futures::{
+    channel::mpsc::{channel, Receiver, Sender},
+    prelude::*,
+};
 use p2p::{
     bytes::Bytes,
     context::{ProtocolContext, ProtocolContextMutRef},
@@ -16,9 +13,19 @@ use p2p::{
     traits::ServiceProtocol,
     SessionId,
 };
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    str,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 const SEND_PING_TOKEN: u64 = 0;
 const CHECK_TIMEOUT_TOKEN: u64 = 1;
+const CONTROL_CHANNEL_BUFFER_SIZE: usize = 2;
 
 /// Ping protocol handler.
 ///
@@ -29,6 +36,7 @@ pub struct PingHandler {
     timeout: Duration,
     connected_session_ids: HashMap<SessionId, PingStatus>,
     network_state: Arc<NetworkState>,
+    control_receiver: Receiver<()>,
 }
 
 impl PingHandler {
@@ -36,19 +44,52 @@ impl PingHandler {
         interval: Duration,
         timeout: Duration,
         network_state: Arc<NetworkState>,
-    ) -> PingHandler {
-        PingHandler {
-            interval,
-            timeout,
-            connected_session_ids: Default::default(),
-            network_state,
-        }
+    ) -> (PingHandler, Sender<()>) {
+        let (control_sender, control_receiver) = channel(CONTROL_CHANNEL_BUFFER_SIZE);
+
+        (
+            PingHandler {
+                interval,
+                timeout,
+                connected_session_ids: Default::default(),
+                network_state,
+                control_receiver,
+            },
+            control_sender,
+        )
     }
 
-    // received ping
-    fn ping(&self, id: SessionId) {
-        trace!("get ping from: {:?}", id);
+    fn ping_received(&self, id: SessionId) {
+        trace!("received ping from: {:?}", id);
         self.mark_time(id, None);
+    }
+
+    fn ping_peers(&mut self, context: &ProtocolContext) {
+        let now = SystemTime::now();
+        let peers: Vec<SessionId> = self
+            .connected_session_ids
+            .iter_mut()
+            .filter_map(|(session_id, ps)| {
+                if ps.processing {
+                    None
+                } else {
+                    ps.processing = true;
+                    ps.last_ping = now;
+                    Some(*session_id)
+                }
+            })
+            .collect();
+        if !peers.is_empty() {
+            debug!("start ping peers: {:?}", peers);
+            let ping_msg = PingMessage::build_ping(nonce(&now));
+            let proto_id = context.proto_id;
+            if context
+                .filter_broadcast(TargetSession::Multi(peers), proto_id, ping_msg)
+                .is_err()
+            {
+                debug!("send message fail");
+            }
+        }
     }
 
     fn mark_time(&self, id: SessionId, ping_time: Option<Duration>) {
@@ -167,7 +208,7 @@ impl ServiceProtocol for PingHandler {
             Some(msg) => {
                 match msg {
                     PingPayload::Ping(nonce) => {
-                        self.ping(session.id);
+                        self.ping_received(session.id);
                         if context
                             .send_message(PingMessage::build_pong(nonce))
                             .is_err()
@@ -199,33 +240,7 @@ impl ServiceProtocol for PingHandler {
 
     fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
         match token {
-            SEND_PING_TOKEN => {
-                let now = SystemTime::now();
-                let peers: Vec<SessionId> = self
-                    .connected_session_ids
-                    .iter_mut()
-                    .filter_map(|(session_id, ps)| {
-                        if ps.processing {
-                            None
-                        } else {
-                            ps.processing = true;
-                            ps.last_ping = now;
-                            Some(*session_id)
-                        }
-                    })
-                    .collect();
-                if !peers.is_empty() {
-                    debug!("start ping peers: {:?}", peers);
-                    let ping_msg = PingMessage::build_ping(nonce(&now));
-                    let proto_id = context.proto_id;
-                    if context
-                        .filter_broadcast(TargetSession::Multi(peers), proto_id, ping_msg)
-                        .is_err()
-                    {
-                        debug!("send message fail");
-                    }
-                }
-            }
+            SEND_PING_TOKEN => self.ping_peers(context),
             CHECK_TIMEOUT_TOKEN => {
                 let timeout = self.timeout;
                 for (id, _ps) in self
@@ -243,6 +258,20 @@ impl ServiceProtocol for PingHandler {
             }
             _ => panic!("unknown token {}", token),
         }
+    }
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        context: &mut ProtocolContext,
+    ) -> Poll<Option<()>> {
+        self.control_receiver
+            .poll_next_unpin(cx)
+            .map(|control_message| {
+                control_message.map(|_| {
+                    self.ping_peers(context);
+                })
+            })
     }
 }
 

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -148,13 +148,10 @@ fn net_service_start(name: String) -> Node {
     let ping_timeout = Duration::from_secs(10);
 
     let ping_network_state = Arc::clone(&network_state);
-    let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
-        ProtocolHandle::Callback(Box::new(PingHandler::new(
-            ping_interval,
-            ping_timeout,
-            ping_network_state,
-        )))
-    });
+    let (ping_handler, _ping_controller) =
+        PingHandler::new(ping_interval, ping_timeout, ping_network_state);
+    let ping_meta = SupportProtocols::Ping
+        .build_meta_with_service_handle(move || ProtocolHandle::Callback(Box::new(ping_handler)));
 
     // Discovery protocol
     let addr_mgr = DiscoveryAddressManager {

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -51,6 +51,7 @@ Subscriptions require a full duplex connection. CKB offers such connections in t
     *   [`set_network_active`](#set_network_active)
     *   [`add_node`](#add_node)
     *   [`remove_node`](#remove_node)
+    *   [`ping_peers`](#ping_peers)
 *   [`Pool`](#pool)
     *   [`send_transaction`](#send_transaction)
     *   [`tx_pool_info`](#tx_pool_info)
@@ -2288,6 +2289,33 @@ echo '{
     "params": [
         "QmUsZHPbjjzU627UZFt4k8j6ycEcNvXRnVGxCPKqwbAfQS"
     ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8114
+```
+
+```json
+{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": null
+}
+```
+
+### `ping_peers`
+
+Requests that a ping be sent to all connected peers, to measure ping time. Results provided in get_peers rpc last_ping_duration field is milliseconds.
+
+
+#### Examples
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "ping_peers",
+    "params": []
 }' \
 | tr -d '\n' \
 | curl -H 'content-type: application/json' -d @- \

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -704,6 +704,14 @@
         ]
     },
     {
+        "description": "Requests that a ping be sent to all connected peers, to measure ping time. Results provided in get_peers rpc last_ping_duration field is milliseconds.",
+        "method": "ping_peers",
+        "module": "net",
+        "params": [],
+        "result": null,
+        "skip": true
+    },
+    {
         "description": "Return state info of blockchain",
         "method": "get_blockchain_info",
         "module": "stats",

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -53,6 +53,9 @@ pub trait NetworkRpc {
     // curl -d '{"id": 2, "jsonrpc": "2.0", "method":"remove_node","params": ["QmUsZHPbjjzU627UZFt4k8j6ycEcNvXRnVGxCPKqwbAfQS"]}' -H 'content-type:application/json' 'http://localhost:8114'
     #[rpc(name = "remove_node")]
     fn remove_node(&self, peer_id: String) -> Result<()>;
+
+    #[rpc(name = "ping_peers")]
+    fn ping_peers(&self) -> Result<()>;
 }
 
 pub(crate) struct NetworkRpcImpl {
@@ -271,6 +274,11 @@ impl NetworkRpc for NetworkRpcImpl {
     fn remove_node(&self, peer_id: String) -> Result<()> {
         self.network_controller
             .remove_node(&peer_id.parse().expect("invalid peer_id"));
+        Ok(())
+    }
+
+    fn ping_peers(&self) -> Result<()> {
+        self.network_controller.ping_peers();
         Ok(())
     }
 }


### PR DESCRIPTION
This PR added a `ping_peers` rpc, which requests that a ping be sent to all connected peers, to measure ping time. 

for reviewer's reference: the code change of `network/src/network.rs` is using struct deconstruction and scoped clone to replace the original multiple rename clone.

before:
```
let foo = Arc::new(...);
let foo_clone = foo.clone();
thread::spawn(move || {
    let foo_clone_1 = foo_clone.clone();
    thread::spawn(move || {
        foo_clone_1.bar();
    });
    foo_clone.bar();
});
foo.bar();
```

now:
```
let foo = Arc::new(...);
{
    let foo = foo.clone();
    thread::spawn(move || {
        {
            let foo = foo.clone();
            thread::spawn(move || {
                foo.bar();
            });
        }
        foo.bar();
    });
}
foo.bar();
```

makes it easier to read and add new variables.
