### PR TITLE
chore: amend a log message which could cause users to be panic

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1085,10 +1085,11 @@ impl<T: ExitHandler> NetworkService<T> {
                     })
                     .collect::<Vec<_>>();
 
-                debug!("receiving shutdown signal ...");
-
+                debug!("Waiting for the shutdown signal ...");
                 // Recevied stop signal, doing cleanup
                 let _ = receiver.recv();
+                debug!("Recevied the shutdown signal.");
+
                 for peer in network_state.peer_registry.read().peers().values() {
                     info!("Disconnect peer {}", peer.connected_addr);
                     if let Err(err) =


### PR DESCRIPTION
For example, the 8~10 lines of the log file for our all integration tests at present are:

> Failed to open AddrManager db, file: "XXX/addr_manager.db", error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
> Failed to open BanList db, file: "XXX/ban_list.db", error: Os { code: 2, kind: NotFound, message: "No such file or directory" } 
> receiving shutdown signal ...

I think it's a bit confusing and scary.