### PR TITLE
chore: integration test - put case log together

### DIFF
--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -215,9 +215,9 @@ pub fn is_committed(tx_status: &TransactionWithStatus) -> bool {
 ///
 /// We use `tempdir` only for generating a random path, and expect the corresponding directory
 /// that `tempdir` creates be deleted when go out of this function.
-pub fn temp_path(case_name: &str, id: &str) -> String {
+pub fn temp_path(case_name: &str) -> PathBuf {
     let mut builder = tempfile::Builder::new();
-    let prefix = ["ckb-it", case_name, id, ""].join("-");
+    let prefix = ["ckb-it", case_name, ""].join("-");
     builder.prefix(&prefix);
     let tempdir = if let Ok(val) = env::var("CKB_INTEGRATION_TEST_TMP") {
         builder.tempdir_in(val)
@@ -225,7 +225,7 @@ pub fn temp_path(case_name: &str, id: &str) -> String {
         builder.tempdir()
     }
     .expect("create tempdir failed");
-    let path = tempdir.path().to_str().unwrap().to_owned();
+    let path = tempdir.path().to_owned();
     tempdir.close().expect("close tempdir failed");
     path
 }

--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -128,7 +128,7 @@ impl Worker {
         let node_dirs: Vec<_> = net
             .nodes
             .iter()
-            .map(|node| node.working_dir().to_owned())
+            .map(|node| node.working_dir().display().to_string())
             .collect();
         outbox
             .send(Notify::Start {


### PR DESCRIPTION
When debug integration case in local, we may run a single case lots time, then there is a big problem how to find the logs under an execution.

Old log structure:
```
├── ckb-it-get_blocks_timeout-net-G65fZ4
├── ckb-it-get_blocks_timeout-node0-LZRUJE
├── ckb-it-get_blocks_timeout-node1-11uL3C
```
New log structure:
```
├── ckb-it-get_blocks_timeout-UccnLI
│   ├── net
│   ├── node0
│   └── node1
```

Another change is updating `node.working_dir` and `net.working_dir` from `String` to `PathBuf`