### PR TITLE
feat: add tx subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "ckb-fee-estimator",
  "ckb-jsonrpc-types",
  "ckb-logger",
+ "ckb-notify",
  "ckb-reward-calculator",
  "ckb-snapshot",
  "ckb-stop-handler",

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2553,6 +2553,9 @@ Subscribe to a topic, if successful it returns the subscription id. For each eve
 #### Parameters
 
 * topic - Subscription topic (enum: new_tip_header | new_tip_block | new_transaction)
+    * new_tip_header: subscriber will get notified when new block is added to best chain tip
+    * new_tip_block: subscriber will get notified when new block is added to best chain tip
+    * new_transaction: subscriber will get notified when new transaction is submitted to pool
 #### Returns
 
 * id - Subscription id

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2552,7 +2552,7 @@ Subscribe to a topic, if successful it returns the subscription id. For each eve
 
 #### Parameters
 
-* topic - Subscription topic (enum: new_tip_header | new_tip_block)
+* topic - Subscription topic (enum: new_tip_header | new_tip_block | new_transaction)
 #### Returns
 
 * id - Subscription id

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -1880,7 +1880,7 @@
         "skip": true,
         "types": [
             {
-                "topic": "Subscription topic (enum: new_tip_header | new_tip_block)"
+                "topic": "Subscription topic (enum: new_tip_header | new_tip_block | new_transaction)"
             }
         ]
     },

--- a/rpc/json/rpc.json
+++ b/rpc/json/rpc.json
@@ -1880,7 +1880,7 @@
         "skip": true,
         "types": [
             {
-                "topic": "Subscription topic (enum: new_tip_header | new_tip_block | new_transaction)"
+                "topic": "Subscription topic (enum: new_tip_header | new_tip_block | new_transaction)\n    * new_tip_header: subscriber will get notified when new block is added to best chain tip\n    * new_tip_block: subscriber will get notified when new block is added to best chain tip\n    * new_transaction: subscriber will get notified when new transaction is submitted to pool"
             }
         ]
     },

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -44,7 +44,7 @@ impl RpcServer {
             .as_ref()
             .map(|tcp_listen_address| {
                 let subscription_rpc_impl =
-                    SubscriptionRpcImpl::new(notify_controller.clone(), Some("TcpSubscription"));
+                    SubscriptionRpcImpl::new(notify_controller.clone(), "TcpSubscription");
                 let mut handler = io_handler.clone();
                 if config.subscription_enable() {
                     handler.extend_with(subscription_rpc_impl.to_delegate());
@@ -72,7 +72,7 @@ impl RpcServer {
 
         let _ws = config.ws_listen_address.as_ref().map(|ws_listen_address| {
             let subscription_rpc_impl =
-                SubscriptionRpcImpl::new(notify_controller.clone(), Some("WsSubscription"));
+                SubscriptionRpcImpl::new(notify_controller.clone(), "WsSubscription");
             let mut handler = io_handler.clone();
             if config.subscription_enable() {
                 handler.extend_with(subscription_rpc_impl.to_delegate());

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -59,6 +59,7 @@ impl Shared {
             Arc::clone(&consensus),
         ));
         let snapshot_mgr = Arc::new(SnapshotMgr::new(Arc::clone(&snapshot)));
+        let notify_controller = NotifyService::new(notify_config).start(Some("NotifyService"));
 
         let tx_pool_builder = TxPoolServiceBuilder::new(
             tx_pool_config,
@@ -66,11 +67,10 @@ impl Shared {
             block_assembler_config,
             Arc::clone(&txs_verify_cache),
             Arc::clone(&snapshot_mgr),
+            notify_controller.clone(),
         );
 
         let tx_pool_controller = tx_pool_builder.start();
-
-        let notify_controller = NotifyService::new(notify_config).start(Some("NotifyService"));
 
         let shared = Shared {
             store,

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -27,3 +27,4 @@ ckb-async-runtime = { path = "../util/runtime" }
 ckb-stop-handler = { path = "../util/stop-handler" }
 ckb-fee-estimator = { path = "../util/fee-estimator" }
 ckb-app-config = { path = "../util/app-config" }
+ckb-notify = { path = "../notify" }

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -9,6 +9,7 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_error::Error;
 use ckb_jsonrpc_types::BlockTemplate;
 use ckb_logger::error;
+use ckb_notify::NotifyController;
 use ckb_snapshot::{Snapshot, SnapshotMgr};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_types::{
@@ -307,6 +308,7 @@ impl TxPoolServiceBuilder {
         block_assembler_config: Option<BlockAssemblerConfig>,
         txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
         snapshot_mgr: Arc<SnapshotMgr>,
+        notify_controller: NotifyController,
     ) -> TxPoolServiceBuilder {
         let last_txs_updated_at = Arc::new(AtomicU64::new(0));
         let consensus = snapshot.cloned_consensus();
@@ -321,6 +323,7 @@ impl TxPoolServiceBuilder {
                 txs_verify_cache,
                 last_txs_updated_at,
                 snapshot_mgr,
+                notify_controller,
             )),
         }
     }
@@ -361,6 +364,7 @@ pub struct TxPoolService {
     pub(crate) txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
     pub(crate) last_txs_updated_at: Arc<AtomicU64>,
     snapshot_mgr: Arc<SnapshotMgr>,
+    pub(crate) notify_controller: NotifyController,
 }
 
 impl TxPoolService {
@@ -371,6 +375,7 @@ impl TxPoolService {
         txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
         last_txs_updated_at: Arc<AtomicU64>,
         snapshot_mgr: Arc<SnapshotMgr>,
+        notify_controller: NotifyController,
     ) -> Self {
         let tx_pool_config = Arc::new(tx_pool.config);
         Self {
@@ -381,6 +386,7 @@ impl TxPoolService {
             txs_verify_cache,
             last_txs_updated_at,
             snapshot_mgr,
+            notify_controller,
         }
     }
 

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::net::{
     BannedAddr, LocalNode, LocalNodeProtocol, NodeAddress, PeerSyncState, RemoteNode,
     RemoteNodeProtocol, SyncState,
 };
-pub use self::pool::{OutputsValidator, TxPoolInfo};
+pub use self::pool::{OutputsValidator, PoolTransactionEntry, TxPoolInfo};
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::sync::PeerState;
 pub use self::uints::{Uint128, Uint32, Uint64};

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumber, Timestamp, Uint64};
+use crate::{BlockNumber, Capacity, Cycle, Timestamp, TransactionView, Uint64};
 use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +13,14 @@ pub struct TxPoolInfo {
     pub total_tx_cycles: Uint64,
     pub min_fee_rate: Uint64,
     pub last_txs_updated_at: Timestamp,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct PoolTransactionEntry {
+    pub transaction: TransactionView,
+    pub cycles: Cycle,
+    pub size: Uint64,
+    pub fee: Capacity,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
This PR added a `new_transaction` topic to subscription rpc, user will get notified when new transaction is submitted to pool.

tcp tx subscription example:
```
telnet localhost 18114
> {"id": 2, "jsonrpc": "2.0", "method": "subscribe", "params": ["new_transaction"]}
< {"jsonrpc":"2.0","result":"0x3","id":2}
< {"jsonrpc":"2.0","method":"subscribe","params":{"result":"... pool transaction entry json string...","subscription":"0x3"}}
```