### PR TITLE
fix: resolve network background service cleanup issue when rpc tcp server is on

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -156,7 +156,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
         .enable_debug();
     let io_handler = builder.build();
 
-    let _rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
+    let rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
 
     let exit_handler_clone = exit_handler.clone();
     ctrlc::set_handler(move || {
@@ -166,6 +166,7 @@ pub fn run(args: RunArgs, version: Version) -> Result<(), ExitCode> {
     exit_handler.wait_for_exit();
 
     info_target!(crate::LOG_TARGET_MAIN, "Finishing work, please wait...");
+    drop(rpc_server);
 
     Ok(())
 }


### PR DESCRIPTION
network background services (peer store dump, etc) can not be dropped automatically when rpc tcp service is on, this PR drop the rpc_server explicitly to resolve this issue. (I don't know the root reason, but it works)