### PR TITLE
chore: remove tmp directory dependencies

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -29,10 +29,10 @@ snap = "1"
 ckb-types = { path = "../util/types" }
 ipnetwork = "0.14"
 serde_json = "1.0"
-tempfile = "3.0.7"
 bloom-filters = "0.1"
 
 [dev-dependencies]
+tempfile = "3.0"
 criterion = "0.3"
 proptest = "0.9"
 

--- a/network/src/peer_store/peer_store_db.rs
+++ b/network/src/peer_store/peer_store_db.rs
@@ -93,12 +93,11 @@ impl PeerStore {
     pub fn dump_to_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
         // create dir
         create_dir_all(&path)?;
-        // dump file to temp dir
-        let tmp_dir = tempfile::tempdir()?;
-        // make sure temp dir exists
-        create_dir_all(tmp_dir.path())?;
-        let tmp_addr_manager = tmp_dir.path().join(DEFAULT_ADDR_MANAGER_DB);
-        let tmp_ban_list = tmp_dir.path().join(DEFAULT_BAN_LIST_DB);
+        // dump file to a temporary sub-directory
+        let tmp_dir = path.as_ref().join("tmp");
+        create_dir_all(&tmp_dir)?;
+        let tmp_addr_manager = tmp_dir.join(DEFAULT_ADDR_MANAGER_DB);
+        let tmp_ban_list = tmp_dir.join(DEFAULT_BAN_LIST_DB);
         self.addr_manager().dump(
             OpenOptions::new()
                 .write(true)


### PR DESCRIPTION
I got a `PermissionDenied` error when running a lightnode on android which is using the `ckb-network` as a lib:
```
08-28 15:35:55.052  9853  9881 I RustStdoutStderr: 2020-08-28 15:35:55.052 +09:00 NetworkRuntime WARN ckb_network::services::dump_peer_store  Dump peer store error, path: "/storage/emulated/0/Android/data/rust.example.android/files/db/peer_store" error: Io(Custom { kind: PermissionDenied, error: PathError { path: "/data/local/tmp/.tmponp0Nt", err: Os { code: 13, kind: PermissionDenied, message: "Permission denied" } } })
```

This PR removes tmp directory dependencies, make it possible to using `ckb-network` as a lib on android and also running ckb full node on a system without tmp directory mouting