### PR TITLE
chore: reduce lock on protocols received

### DIFF
--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -24,10 +24,10 @@ pub struct Peer {
     // Client or Server
     pub identify_info: Option<PeerIdentifyInfo>,
     /// TODO(doc): @driftluo
-    pub last_message_time: Option<Instant>,
+    pub last_ping_protocol_message_received_at: Option<Instant>,
     /// TODO(doc): @driftluo
-    pub ping: Option<Duration>,
-    /// TODO(doc): @driftluo
+    pub ping_rtt: Option<Duration>,
+    /// Indicates whether it is a probe connection of the fleer protocol
     pub is_feeler: bool,
     /// TODO(doc): @driftluo
     pub connected_time: Instant,
@@ -54,8 +54,8 @@ impl Peer {
             connected_addr,
             listened_addrs: Vec::new(),
             identify_info: None,
-            ping: None,
-            last_message_time: None,
+            ping_rtt: None,
+            last_ping_protocol_message_received_at: None,
             connected_time: Instant::now(),
             is_feeler: false,
             peer_id,

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -131,11 +131,11 @@ impl PeerRegistry {
             EVICTION_PROTECT_PEERS,
             |peer1, peer2| {
                 let peer1_ping = peer1
-                    .ping
+                    .ping_rtt
                     .map(|p| p.as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 let peer2_ping = peer2
-                    .ping
+                    .ping_rtt
                     .map(|p| p.as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 peer2_ping.cmp(&peer1_ping)
@@ -148,11 +148,11 @@ impl PeerRegistry {
             EVICTION_PROTECT_PEERS,
             |peer1, peer2| {
                 let peer1_last_message = peer1
-                    .last_message_time
+                    .last_ping_protocol_message_received_at
                     .map(|t| t.elapsed().as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 let peer2_last_message = peer2
-                    .last_message_time
+                    .last_ping_protocol_message_received_at
                     .map(|t| t.elapsed().as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 peer2_last_message.cmp(&peer1_last_message)

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -22,7 +22,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tokio_util::codec::length_delimited;
 
@@ -300,12 +300,6 @@ impl ServiceProtocol for CKBHandler {
     }
 
     fn received(&mut self, context: ProtocolContextMutRef, data: Bytes) {
-        self.network_state.with_peer_registry_mut(|reg| {
-            if let Some(peer) = reg.get_peer_mut(context.session.id) {
-                peer.last_message_time = Some(Instant::now());
-            }
-        });
-
         if !self.network_state.is_active() {
             return;
         }

--- a/network/src/protocols/ping.rs
+++ b/network/src/protocols/ping.rs
@@ -19,8 +19,7 @@ use std::{
     str,
     sync::Arc,
     task::{Context, Poll},
-    time::Instant,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 
 const SEND_PING_TOKEN: u64 = 0;
@@ -37,6 +36,7 @@ pub struct PingHandler {
     connected_session_ids: HashMap<SessionId, PingStatus>,
     network_state: Arc<NetworkState>,
     control_receiver: Receiver<()>,
+    start_time: Instant,
 }
 
 impl PingHandler {
@@ -46,7 +46,7 @@ impl PingHandler {
         network_state: Arc<NetworkState>,
     ) -> (PingHandler, Sender<()>) {
         let (control_sender, control_receiver) = channel(CONTROL_CHANNEL_BUFFER_SIZE);
-
+        let now = Instant::now();
         (
             PingHandler {
                 interval,
@@ -54,18 +54,34 @@ impl PingHandler {
                 connected_session_ids: Default::default(),
                 network_state,
                 control_receiver,
+                start_time: now,
             },
             control_sender,
         )
     }
 
-    fn ping_received(&self, id: SessionId) {
+    fn ping_received(&mut self, id: SessionId) {
         trace!("received ping from: {:?}", id);
-        self.mark_time(id, None);
+        self.network_state.with_peer_registry_mut(|reg| {
+            if let Some(peer) = reg.get_peer_mut(id) {
+                peer.last_ping_protocol_message_received_at = Some(Instant::now());
+            }
+        });
+    }
+
+    fn pong_received(&mut self, id: SessionId, last_ping: Instant) {
+        let now = Instant::now();
+        self.network_state.with_peer_registry_mut(|reg| {
+            if let Some(peer) = reg.get_peer_mut(id) {
+                peer.ping_rtt = Some(now.duration_since(last_ping));
+                peer.last_ping_protocol_message_received_at = Some(now);
+            }
+        });
     }
 
     fn ping_peers(&mut self, context: &ProtocolContext) {
-        let now = SystemTime::now();
+        let now = Instant::now();
+        let send_nonce = nonce(&now, self.start_time);
         let peers: Vec<SessionId> = self
             .connected_session_ids
             .iter_mut()
@@ -74,14 +90,15 @@ impl PingHandler {
                     None
                 } else {
                     ps.processing = true;
-                    ps.last_ping = now;
+                    ps.last_ping_sent_at = now;
+                    ps.nonce = send_nonce;
                     Some(*session_id)
                 }
             })
             .collect();
         if !peers.is_empty() {
             debug!("start ping peers: {:?}", peers);
-            let ping_msg = PingMessage::build_ping(nonce(&now));
+            let ping_msg = PingMessage::build_ping(send_nonce);
             let proto_id = context.proto_id;
             if context
                 .filter_broadcast(TargetSession::Multi(peers), proto_id, ping_msg)
@@ -91,23 +108,10 @@ impl PingHandler {
             }
         }
     }
-
-    fn mark_time(&self, id: SessionId, ping_time: Option<Duration>) {
-        self.network_state.with_peer_registry_mut(|reg| {
-            if let Some(mut peer) = reg.get_peer_mut(id) {
-                if ping_time.is_some() {
-                    peer.ping = ping_time;
-                }
-                peer.last_message_time = Some(Instant::now());
-            }
-        });
-    }
 }
 
-fn nonce(t: &SystemTime) -> u32 {
-    t.duration_since(UNIX_EPOCH)
-        .map(|dur| dur.as_secs())
-        .unwrap_or_default() as u32
+fn nonce(t: &Instant, start_time: Instant) -> u32 {
+    t.duration_since(start_time).as_secs() as u32
 }
 
 /// PingStatus of a peer
@@ -116,18 +120,19 @@ struct PingStatus {
     /// Are we currently pinging this peer?
     processing: bool,
     /// The time we last send ping to this peer.
-    last_ping: SystemTime,
+    last_ping_sent_at: Instant,
+    nonce: u32,
 }
 
 impl PingStatus {
     /// A meaningless value, peer must send a pong has same nonce to respond a ping.
     fn nonce(&self) -> u32 {
-        nonce(&self.last_ping)
+        self.nonce
     }
 
     /// Time duration since we last send ping.
     fn elapsed(&self) -> Duration {
-        self.last_ping.elapsed().unwrap_or_default()
+        self.last_ping_sent_at.elapsed()
     }
 }
 
@@ -156,8 +161,9 @@ impl ServiceProtocol for PingHandler {
                 self.connected_session_ids
                     .entry(session.id)
                     .or_insert_with(|| PingStatus {
-                        last_ping: SystemTime::now(),
+                        last_ping_sent_at: Instant::now(),
                         processing: false,
+                        nonce: 0,
                     });
                 debug!(
                     "proto id [{}] open on session [{}], address: [{}], type: [{:?}], version: {}",
@@ -221,8 +227,8 @@ impl ServiceProtocol for PingHandler {
                         if let Some(status) = self.connected_session_ids.get_mut(&session.id) {
                             if (true, nonce) == (status.processing, status.nonce()) {
                                 status.processing = false;
-                                let ping_time = status.elapsed();
-                                self.mark_time(session.id, Some(ping_time));
+                                let last_ping_sent_at = status.last_ping_sent_at;
+                                self.pong_received(session.id, last_ping_sent_at);
                                 return;
                             }
                         }

--- a/network/src/services/protocol_type_checker.rs
+++ b/network/src/services/protocol_type_checker.rs
@@ -86,7 +86,7 @@ impl ProtocolTypeCheckerService {
                 }
 
                 // check open protocol type
-                if let Err(err) = self.opened_procotol_type(peer) {
+                if let Err(err) = self.opened_protocol_type(peer) {
                     debug!(
                         "close peer {:?} due to open protocols error: {}",
                         peer.peer_id, err
@@ -103,7 +103,7 @@ impl ProtocolTypeCheckerService {
         });
     }
 
-    fn opened_procotol_type(&self, peer: &Peer) -> Result<ProtocolType, ProtocolTypeError> {
+    fn opened_protocol_type(&self, peer: &Peer) -> Result<ProtocolType, ProtocolTypeError> {
         if peer
             .protocols
             .contains_key(&SupportProtocols::Feeler.protocol_id())

--- a/network/src/tests/peer_registry.rs
+++ b/network/src/tests/peer_registry.rs
@@ -160,7 +160,7 @@ fn test_accept_inbound_peer_eviction() {
             .get_key_by_peer_id(&peer_id)
             .expect("get_key_by_peer_id failed");
         if let Some(peer) = peers_registry.get_peer_mut(session_id) {
-            peer.ping = Some(Duration::from_secs(0));
+            peer.ping_rtt = Some(Duration::from_secs(0));
         };
     }
 
@@ -173,7 +173,7 @@ fn test_accept_inbound_peer_eviction() {
             .get_key_by_peer_id(&peer_id)
             .expect("get_key_by_peer_id failed");
         if let Some(peer) = peers_registry.get_peer_mut(session_id) {
-            peer.last_message_time = Some(now + Duration::from_secs(10));
+            peer.last_ping_protocol_message_received_at = Some(now + Duration::from_secs(10));
         };
     }
     // protect half peers which have the longest connection time

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -607,7 +607,7 @@ impl NetRpc for NetRpcImpl {
                     addresses: node_addresses.values().cloned().collect(),
                     connected_duration: peer.connected_time.elapsed().as_secs().into(),
                     last_ping_duration: peer
-                        .ping
+                        .ping_rtt
                         .map(|duration| (duration.as_millis() as u64).into()),
                     sync_state: self
                         .sync_shared


### PR DESCRIPTION
1. Reduce the performance cost of frequently acquiring global locks by removing other protocols registered on received
2. Reduce ping received calculation