### PR TITLE
improvement: add a default options file

### DIFF
--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -6,8 +6,8 @@ use ckb_app_config::{ExitCode, InitArgs};
 use ckb_chain_spec::ChainSpec;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_resource::{
-    Resource, TemplateContext, AVAILABLE_SPECS, CKB_CONFIG_FILE_NAME, MINER_CONFIG_FILE_NAME,
-    SPEC_DEV_FILE_NAME,
+    Resource, TemplateContext, AVAILABLE_SPECS, CKB_CONFIG_FILE_NAME, DB_OPTIONS_FILE_NAME,
+    MINER_CONFIG_FILE_NAME, SPEC_DEV_FILE_NAME,
 };
 use ckb_types::{prelude::*, H256};
 
@@ -191,6 +191,8 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
     Resource::bundled_ckb_config().export(&context, &args.root_dir)?;
     println!("create {}", MINER_CONFIG_FILE_NAME);
     Resource::bundled_miner_config().export(&context, &args.root_dir)?;
+    println!("create {}", DB_OPTIONS_FILE_NAME);
+    Resource::bundled_db_options().export(&context, &args.root_dir)?;
 
     Ok(())
 }

--- a/resource/build.rs
+++ b/resource/build.rs
@@ -14,7 +14,7 @@ use ckb_system_scripts::{
 fn main() {
     let mut bundled = includedir_codegen::start("BUNDLED");
 
-    for f in &["ckb.toml", "ckb-miner.toml"] {
+    for f in &["ckb.toml", "ckb-miner.toml", "default.db-options"] {
         bundled
             .add_file(f, Compression::Gzip)
             .expect("add files to resource bundle");

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -46,6 +46,11 @@ dsn = "" # {{
 # # Seconds between checking the process, 0 is disable, default is 0.
 # interval = 600
 
+[db]
+# Provide an options file to tune RocksDB for your workload and your system configuration.
+# More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
+options_file = "default.db-options"
+
 [network]
 listen_addresses = ["/ip4/0.0.0.0/tcp/8115"] # {{
 # _ => listen_addresses = ["/ip4/0.0.0.0/tcp/{p2p_port}"]

--- a/resource/default.db-options
+++ b/resource/default.db-options
@@ -1,0 +1,23 @@
+# This is a RocksDB option file.
+#
+# For detailed file format spec, please refer to the official documents
+# in https://rocksdb.org/docs/
+#
+
+[DBOptions]
+bytes_per_sync=1048576
+max_background_compactions=4
+max_background_flushes=2
+max_total_wal_size=134217728
+keep_log_file_num=32
+
+[CFOptions "default"]
+level_compaction_dynamic_level_bytes=true
+write_buffer_size=8388608
+min_write_buffer_number_to_merge=1
+max_write_buffer_number=2
+max_write_buffer_size_to_maintain=-1
+
+[TableOptions/BlockBasedTable "default"]
+cache_index_and_filter_blocks=true
+pin_l0_filter_and_index_blocks_in_cache=true

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -27,6 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/code_hashes.rs"));
 pub const CKB_CONFIG_FILE_NAME: &str = "ckb.toml";
 pub const MINER_CONFIG_FILE_NAME: &str = "ckb-miner.toml";
 pub const SPEC_DEV_FILE_NAME: &str = "specs/dev.toml";
+pub const DB_OPTIONS_FILE_NAME: &str = "default.db-options";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -61,12 +62,20 @@ impl Resource {
         Resource::file_system(root_dir.as_ref().join(MINER_CONFIG_FILE_NAME))
     }
 
+    pub fn db_options<P: AsRef<Path>>(root_dir: P) -> Resource {
+        Resource::file_system(root_dir.as_ref().join(DB_OPTIONS_FILE_NAME))
+    }
+
     pub fn bundled_ckb_config() -> Resource {
         Resource::bundled(CKB_CONFIG_FILE_NAME.to_string())
     }
 
     pub fn bundled_miner_config() -> Resource {
         Resource::bundled(MINER_CONFIG_FILE_NAME.to_string())
+    }
+
+    pub fn bundled_db_options() -> Resource {
+        Resource::bundled(DB_OPTIONS_FILE_NAME.to_string())
     }
 
     pub fn exported_in<P: AsRef<Path>>(root_dir: P) -> bool {


### PR DESCRIPTION
### Specifications

- Reduce the database directory size.
  ```
  [DBOptions]
  max_total_wal_size=134217728 # default: no size limit
  keep_log_file_num=32 # default: 1000
  ```

- [Reduce the maximum memory in IBD: drop immutable memtables faster.](https://github.com/facebook/rocksdb/commit/2f41ecfe75f0ebf33e4969083b031c7a97ebaee7)
  ```
  [CFOptions "default"]
  write_buffer_size=8388608
  min_write_buffer_number_to_merge=1
  max_write_buffer_number=2
  max_write_buffer_size_to_maintain=-1
  ```

- [Tuning according to the official document.](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning/d7cb90f771d8b8fd4ea605b6da299255709a77c2#other-general-options)
  ```
  [DBOptions]
  bytes_per_sync=1048576
  max_background_compactions=4
  max_background_flushes=2
  [CFOptions "default"]
  level_compaction_dynamic_level_bytes=true
  [TableOptions/BlockBasedTable "default"]
  cache_index_and_filter_blocks=true
  pin_l0_filter_and_index_blocks_in_cache=true
  ```

### Result

In my laptop with our poor office network, run from 0 to tip (=2_800_000), the database is 2.5 GiB and the maximum memory is 1.4 GiB during IBD.