### PR TITLE
refactor: replace legacy lru-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +744,7 @@ dependencies = [
  "hyper 0.12.35",
  "hyper-tls",
  "indicatif",
- "lru-cache",
+ "lru",
  "rand 0.6.5",
  "serde",
  "serde_json",
@@ -802,7 +808,7 @@ dependencies = [
  "ckb-util",
  "failure",
  "faketime",
- "lru-cache",
+ "lru",
  "semver",
 ]
 
@@ -1047,7 +1053,7 @@ dependencies = [
  "ckb-traits",
  "ckb-types",
  "ckb-util",
- "lru-cache",
+ "lru",
 ]
 
 [[package]]
@@ -1078,7 +1084,7 @@ dependencies = [
  "failure",
  "faketime",
  "futures 0.3.4",
- "lru-cache",
+ "lru",
  "rand 0.6.5",
  "ratelimit_meter",
  "sentry",
@@ -1143,7 +1149,7 @@ dependencies = [
  "ckb-verification",
  "failure",
  "faketime",
- "lru-cache",
+ "lru",
  "tokio 0.2.22",
 ]
 
@@ -1200,7 +1206,7 @@ dependencies = [
  "enum-display-derive",
  "failure",
  "faketime",
- "lru-cache",
+ "lru",
  "rand 0.6.5",
  "rayon",
  "tokio 0.2.22",
@@ -1703,7 +1709,7 @@ version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fdb60074c9b82c91f8702fa5351b85d22b668dae7f73bf06b44a09bc372380f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.5.0",
  "smallvec 0.6.10",
 ]
 
@@ -2021,6 +2027,16 @@ name = "hashbrown"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+
+[[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash",
+ "autocfg 1.0.0",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -2707,12 +2723,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/lru-cache?rev=a35fdb8#a35fdb81a309dd494c8edc02c0ff44e0597a4be4"
+name = "lru"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
 dependencies = [
- "fnv",
- "linked-hash-map",
+ "hashbrown 0.8.2",
 ]
 
 [[package]]

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -19,7 +19,7 @@ ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
 hyper = "0.12"
 hyper-tls = "0.3"
 futures = "0.1"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6.0"
 ckb-stop-handler = { path = "../util/stop-handler" }
 failure = "0.1.5"
 indicatif = "0.15"

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -11,7 +11,7 @@ use ckb_types::{
     utilities::compact_to_target,
 };
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::sync::Arc;
 use std::thread;
 
@@ -78,7 +78,7 @@ impl Miner {
                     Ok(work) => {
                         let pow_hash= work.block.header().calc_pow_hash();
                         let (target, _,) = compact_to_target(work.block.header().raw().compact_target().unpack());
-                        self.works.insert(pow_hash.clone(), work);
+                        self.works.put(pow_hash.clone(), work);
                         self.notify_workers(WorkerMessage::NewWork{pow_hash, target});
                     },
                     _ => {
@@ -103,7 +103,7 @@ impl Miner {
     }
 
     fn submit_nonce(&mut self, pow_hash: Byte32, nonce: u128) {
-        if let Some(work) = self.works.get_refresh(&pow_hash).cloned() {
+        if let Some(work) = self.works.get(&pow_hash).cloned() {
             self.notify_workers(WorkerMessage::Stop);
             let raw_header = work.block.header().raw();
             let header = Header::new_builder()

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 ckb-types = { path = "../util/types" }
 ckb-db = { path = "../db" }
 ckb-chain-spec = { path = "../spec" }
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6.0"
 ckb-traits = { path = "../traits" }
 ckb-util = { path = "../util" }
 ckb-error = { path = "../error" }

--- a/store/src/cache.rs
+++ b/store/src/cache.rs
@@ -5,7 +5,7 @@ use ckb_types::{
     packed::{Byte32, ProposalShortIdVec},
 };
 use ckb_util::Mutex;
-use lru_cache::LruCache;
+use lru::LruCache;
 
 pub struct StoreCache {
     pub headers: Mutex<LruCache<Byte32, HeaderView>>,

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -49,7 +49,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
     /// Get header by block header hash
     fn get_block_header(&'a self, hash: &packed::Byte32) -> Option<HeaderView> {
         if let Some(cache) = self.cache() {
-            if let Some(header) = cache.headers.lock().get_refresh(hash) {
+            if let Some(header) = cache.headers.lock().get(hash) {
                 return Some(header.clone());
             }
         };
@@ -60,7 +60,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
         if let Some(cache) = self.cache() {
             ret.map(|header| {
-                cache.headers.lock().insert(hash.clone(), header.clone());
+                cache.headers.lock().put(hash.clone(), header.clone());
                 header
             })
         } else {
@@ -86,7 +86,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
     /// Get all transaction-hashes in block body by block header hash
     fn get_block_txs_hashes(&'a self, hash: &packed::Byte32) -> Vec<packed::Byte32> {
         if let Some(cache) = self.cache() {
-            if let Some(hashes) = cache.block_tx_hashes.lock().get_refresh(hash) {
+            if let Some(hashes) = cache.block_tx_hashes.lock().get(hash) {
                 return hashes.clone();
             }
         };
@@ -106,10 +106,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
             .collect();
 
         if let Some(cache) = self.cache() {
-            cache
-                .block_tx_hashes
-                .lock()
-                .insert(hash.clone(), ret.clone());
+            cache.block_tx_hashes.lock().put(hash.clone(), ret.clone());
         }
 
         ret
@@ -121,7 +118,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
         hash: &packed::Byte32,
     ) -> Option<packed::ProposalShortIdVec> {
         if let Some(cache) = self.cache() {
-            if let Some(data) = cache.block_proposals.lock().get_refresh(hash) {
+            if let Some(data) = cache.block_proposals.lock().get(hash) {
                 return Some(data.clone());
             }
         };
@@ -135,10 +132,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
         if let Some(cache) = self.cache() {
             ret.map(|data| {
-                cache
-                    .block_proposals
-                    .lock()
-                    .insert(hash.clone(), data.clone());
+                cache.block_proposals.lock().put(hash.clone(), data.clone());
                 data
             })
         } else {
@@ -149,7 +143,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
     /// Get block uncles by block header hash
     fn get_block_uncles(&'a self, hash: &packed::Byte32) -> Option<UncleBlockVecView> {
         if let Some(cache) = self.cache() {
-            if let Some(data) = cache.block_uncles.lock().get_refresh(hash) {
+            if let Some(data) = cache.block_uncles.lock().get(hash) {
                 return Some(data.clone());
             }
         };
@@ -161,10 +155,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
         if let Some(cache) = self.cache() {
             ret.map(|uncles| {
-                cache
-                    .block_uncles
-                    .lock()
-                    .insert(hash.clone(), uncles.clone());
+                cache.block_uncles.lock().put(hash.clone(), uncles.clone());
                 uncles
             })
         } else {
@@ -247,7 +238,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
     fn get_cell_data(&'a self, out_point: &OutPoint) -> Option<(Bytes, packed::Byte32)> {
         let key = out_point.to_cell_key();
         if let Some(cache) = self.cache() {
-            if let Some(cached) = cache.cell_data.lock().get_refresh(&key) {
+            if let Some(cached) = cache.cell_data.lock().get(&key) {
                 return Some(cached.clone());
             }
         };
@@ -274,7 +265,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
         if let Some(cache) = self.cache() {
             ret.map(|cached| {
-                cache.cell_data.lock().insert(key, cached.clone());
+                cache.cell_data.lock().put(key, cached.clone());
                 cached
             })
         } else {
@@ -326,7 +317,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
     fn block_exists(&'a self, hash: &packed::Byte32) -> bool {
         if let Some(cache) = self.cache() {
-            if cache.headers.lock().get_refresh(hash).is_some() {
+            if cache.headers.lock().get(hash).is_some() {
                 return true;
             }
         };
@@ -336,7 +327,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
     // Get cellbase by block hash
     fn get_cellbase(&'a self, hash: &packed::Byte32) -> Option<TransactionView> {
         if let Some(cache) = self.cache() {
-            if let Some(data) = cache.cellbase.lock().get_refresh(hash) {
+            if let Some(data) = cache.cellbase.lock().get(hash) {
                 return Some(data.clone());
             }
         };
@@ -349,7 +340,7 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
         });
         if let Some(cache) = self.cache() {
             ret.map(|data| {
-                cache.cellbase.lock().insert(hash.clone(), data.clone());
+                cache.cellbase.lock().put(hash.clone(), data.clone());
                 data
             })
         } else {

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -23,7 +23,7 @@ ckb-chain-spec = { path = "../spec" }
 ckb-channel = { path = "../util/channel" }
 ckb-traits = { path = "../traits" }
 failure = "0.1.5"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6.0"
 sentry = "0.17.0"
 futures = "0.3"
 ckb-error = {path = "../error"}

--- a/sync/src/relayer/transaction_hashes_process.rs
+++ b/sync/src/relayer/transaction_hashes_process.rs
@@ -93,7 +93,7 @@ impl<'a> TransactionHashesProcess<'a> {
                 if let Some(next_ask_timeout) =
                     peer_state.add_ask_for_tx(tx_hash.clone(), last_ask_timeout)
                 {
-                    inflight_transactions.insert(tx_hash, next_ask_timeout);
+                    inflight_transactions.put(tx_hash, next_ask_timeout);
                 }
             }
         }

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -13,7 +13,7 @@ ckb-logger = {path = "../util/logger"}
 ckb-verification = { path = "../verification" }
 failure = "0.1.5"
 faketime = "0.2"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6.0"
 ckb-dao = { path = "../util/dao" }
 ckb-reward-calculator = { path = "../util/reward-calculator" }
 ckb-store = { path = "../store" }

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -19,7 +19,7 @@ use ckb_types::{
     prelude::*,
 };
 use failure::Error as FailureError;
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::collections::HashSet;
 use std::sync::{atomic::AtomicU64, Arc};
 use tokio::sync::Mutex;

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -22,7 +22,7 @@ use ckb_types::{
 use ckb_verification::cache::CacheEntry;
 use ckb_verification::{TimeRelativeTransactionVerifier, TransactionVerifier};
 use faketime::unix_time_as_millis;
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{
@@ -30,7 +30,6 @@ use std::sync::{
     Arc,
 };
 
-#[derive(Clone)]
 pub struct TxPool {
     pub(crate) config: TxPoolConfig,
     /// The short id that has not been proposed
@@ -212,7 +211,7 @@ impl TxPool {
 
     pub fn contains_proposal_id(&self, id: &ProposalShortId) -> bool {
         self.pending.contains_key(id)
-            || self.conflict.contains_key(id)
+            || self.conflict.contains(id)
             || self.proposed.contains_key(id)
             || self.orphan.contains_key(id)
     }
@@ -222,7 +221,7 @@ impl TxPool {
             || self.gap.contains_key(id)
             || self.proposed.contains_key(id)
             || self.orphan.contains_key(id)
-            || self.conflict.contains_key(id)
+            || self.conflict.contains(id)
     }
 
     pub fn get_tx_with_cycles(
@@ -253,7 +252,7 @@ impl TxPool {
             })
             .or_else(|| {
                 self.conflict
-                    .get(id)
+                    .peek(id)
                     .cloned()
                     .map(|entry| (entry.transaction, entry.cache_entry.map(|c| c.cycles)))
             })
@@ -265,7 +264,7 @@ impl TxPool {
             .or_else(|| self.gap.get_tx(id))
             .or_else(|| self.proposed.get_tx(id))
             .or_else(|| self.orphan.get_tx(id))
-            .or_else(|| self.conflict.get(id).map(|e| &e.transaction))
+            .or_else(|| self.conflict.peek(id).map(|e| &e.transaction))
             .cloned()
     }
 
@@ -288,7 +287,7 @@ impl TxPool {
             .or_else(|| self.gap.get_tx(id))
             .or_else(|| self.pending.get_tx(id))
             .or_else(|| self.orphan.get_tx(id))
-            .or_else(|| self.conflict.get(id).map(|e| &e.transaction))
+            .or_else(|| self.conflict.peek(id).map(|e| &e.transaction))
             .cloned()
     }
 
@@ -303,7 +302,7 @@ impl TxPool {
                 self.update_statics_for_remove_tx(entry.size, entry.cycles);
             }
             self.committed_txs_hash_cache
-                .insert(tx.proposal_short_id(), hash.to_owned());
+                .put(tx.proposal_short_id(), hash.to_owned());
         }
     }
 
@@ -493,7 +492,7 @@ impl TxPool {
                             OutPointError::Dead(_) => {
                                 if self
                                     .conflict
-                                    .insert(short_id, DefectEntry::new(tx, 0, cache_entry, size))
+                                    .put(short_id, DefectEntry::new(tx, 0, cache_entry, size))
                                     .is_some()
                                 {
                                     self.update_statics_for_remove_tx(
@@ -709,7 +708,7 @@ impl TxPool {
         self.get_tx_from_proposed_and_others(proposal_id)
             .or_else(|| {
                 self.committed_txs_hash_cache
-                    .get(proposal_id)
+                    .peek(proposal_id)
                     .and_then(|tx_hash| self.snapshot().get_transaction(tx_hash).map(|(tx, _)| tx))
             })
     }

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -16,7 +16,7 @@ ckb-logger = { path = "../logger"}
 ckb-app-config = { path = "../app-config" }
 faketime = "0.2.0"
 failure = "0.1.5"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6"
 semver = "0.9"
 
 [dev-dependencies]

--- a/util/network-alert/src/alert_relayer.rs
+++ b/util/network-alert/src/alert_relayer.rs
@@ -15,7 +15,7 @@ use ckb_network::{bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerInde
 use ckb_notify::NotifyController;
 use ckb_types::{packed, prelude::*};
 use ckb_util::Mutex;
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ const KNOWN_LIST_SIZE: usize = 64;
 
 /// AlertRelayer
 /// relay alert messages
-#[derive(Clone)]
+
 pub struct AlertRelayer {
     notifier: Arc<Mutex<Notifier>>,
     verifier: Arc<Verifier>,
@@ -58,12 +58,12 @@ impl AlertRelayer {
 
     // return true if it this first time the peer know this alert
     fn mark_as_known(&mut self, peer: PeerIndex, alert_id: u32) -> bool {
-        match self.known_lists.get_refresh(&peer) {
+        match self.known_lists.get_mut(&peer) {
             Some(alert_ids) => alert_ids.insert(alert_id),
             None => {
                 let mut alert_ids = HashSet::new();
                 alert_ids.insert(alert_id);
-                self.known_lists.insert(peer, alert_ids);
+                self.known_lists.put(peer, alert_ids);
                 true
             }
         }

--- a/util/network-alert/src/notifier.rs
+++ b/util/network-alert/src/notifier.rs
@@ -1,7 +1,7 @@
 use ckb_logger::debug;
 use ckb_notify::NotifyController;
 use ckb_types::{packed::Alert, prelude::*};
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::collections::HashMap;
 
 const CANCEL_FILTER_SIZE: usize = 128;
@@ -97,7 +97,7 @@ impl Notifier {
     }
 
     pub fn cancel(&mut self, cancel_id: u32) {
-        self.cancel_filter.insert(cancel_id, ());
+        self.cancel_filter.put(cancel_id, ());
         self.received_alerts.remove(&cancel_id);
         self.noticed_alerts.retain(|a| {
             let id: u32 = a.raw().id().unpack();
@@ -117,7 +117,7 @@ impl Notifier {
     }
 
     pub fn has_received(&self, id: u32) -> bool {
-        self.received_alerts.contains_key(&id) || self.cancel_filter.contains_key(&id)
+        self.received_alerts.contains_key(&id) || self.cancel_filter.contains(&id)
     }
 
     // all unexpired alerts

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -12,7 +12,7 @@ ckb-script = { path = "../script" }
 ckb-pow = { path = "../pow" }
 faketime = "0.2.0"
 rayon = "1.0"
-lru-cache = { git = "https://github.com/nervosnetwork/lru-cache", rev = "a35fdb8" }
+lru = "0.6.0"
 ckb-traits = { path = "../traits" }
 ckb-chain-spec = { path = "../spec" }
 ckb-dao = { path = "../util/dao" }

--- a/verification/src/cache.rs
+++ b/verification/src/cache.rs
@@ -3,7 +3,7 @@ use ckb_types::{
     packed::Byte32,
 };
 
-pub type TxVerifyCache = lru_cache::LruCache<Byte32, CacheEntry>;
+pub type TxVerifyCache = lru::LruCache<Byte32, CacheEntry>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CacheEntry {

--- a/verification/src/contextual_block_verifier.rs
+++ b/verification/src/contextual_block_verifier.rs
@@ -362,7 +362,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
             let guard = txs_verify_cache.read().await;
             let ret = keys
                 .into_iter()
-                .filter_map(|hash| guard.get(&hash).cloned().map(|value| (hash, value)))
+                .filter_map(|hash| guard.peek(&hash).cloned().map(|value| (hash, value)))
                 .collect();
 
             if let Err(e) = sender.send(ret) {
@@ -443,7 +443,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
         handle.spawn(async move {
             let mut guard = txs_verify_cache.write().await;
             for (k, v) in ret {
-                guard.insert(k, v);
+                guard.put(k, v);
             }
         });
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -16,7 +16,7 @@ use ckb_types::{
     packed::Byte32,
     prelude::*,
 };
-use lru_cache::LruCache;
+use lru::LruCache;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
@@ -565,14 +565,14 @@ where
     }
 
     fn block_median_time(&self, block_hash: &Byte32) -> u64 {
-        if let Some(median_time) = self.median_timestamps_cache.borrow().get(block_hash) {
+        if let Some(median_time) = self.median_timestamps_cache.borrow().peek(block_hash) {
             return *median_time;
         }
 
         let median_time = self.block_median_time_context.block_median_time(block_hash);
         self.median_timestamps_cache
             .borrow_mut()
-            .insert(block_hash.clone(), median_time);
+            .put(block_hash.clone(), median_time);
         median_time
     }
 


### PR DESCRIPTION
We forked `lru-cache` cause we need such `peek` function, `lru` seems a good alternative.
