### PR TITLE
chore(ci): Use draft release to package CKB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ script: make test
 before_cache:
   - rm -rf $HOME/.cargo/registry
 
+before_deploy:
+  - 'export TRAVIS_TAG="${TRAVIS_BRANCH##*/}"'
+  - git tag $TRAVIS_TAG
 deploy:
   provider: releases
   api_key: "$GITHUB_TOKEN"
@@ -47,12 +50,12 @@ deploy:
     - "releases/ckb_${TRAVIS_TAG}_${REL_PKG}.asc"
   skip_cleanup: true
   overwrite: true
-  prerelease: true
+  draft: true
   on:
-    tags: true
-    condition: '"$GITHUB_TOKEN" != "" && "$REL_PKG" != ""'
+    all_branches: true
+    condition: '$TRAVIS_BRANCH =~ ^pkg/'
 
-if: 'type != pull_request or head_branch != develop'
+if: 'tag IS NOT present and (type != pull_request or head_branch != develop)'
 
 matrix:
   allow_failures:
@@ -153,7 +156,7 @@ matrix:
         - if make cov; then bash <(curl -s https://codecov.io/bash); fi
 
     - name: Package for macOS
-      if: 'tag IS present AND env(GITHUB_TOKEN) IS present'
+      if: 'branch =~ /^pkg\// AND env(GITHUB_TOKEN) IS present'
       os: osx
       env: REL_PKG=x86_64-apple-darwin.zip
       script:
@@ -162,7 +165,7 @@ matrix:
         - gpg --import devtools/ci/travis-secret.asc
         - devtools/ci/package.sh target/release/ckb
     - name: Package for Linux
-      if: 'tag IS present AND env(GITHUB_TOKEN) IS present'
+      if: 'branch =~ /^pkg\// AND env(GITHUB_TOKEN) IS present'
       language: ruby
       addons: { apt: { packages: [] } }
       env: REL_PKG=x86_64-unknown-linux-gnu.tar.gz BUILDER_IMAGE=nervos/ckb-docker-builder:xenial-rust-1.45.2
@@ -174,7 +177,7 @@ matrix:
         - devtools/ci/package.sh target/release/ckb
         - if [ -n "${QINIU_SECRET_KEY:-}" ]; then travis_wait devtools/ci/qput-7z "releases/ckb_${TRAVIS_TAG}_x86_64-unknown-linux-gnu"; fi
     - name: Package for Centos
-      if: 'tag IS present AND env(GITHUB_TOKEN) IS present'
+      if: 'branch =~ /^pkg\// AND env(GITHUB_TOKEN) IS present'
       language: ruby
       addons: { apt: { packages: [] } }
       env: REL_PKG=x86_64-unknown-centos-gnu.tar.gz BUILDER_IMAGE=nervos/ckb-docker-builder:centos-7-rust-1.45.2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
     include:
     - '*'
   tags:
-    include:
+    exclude:
     - '*'
 
 variables:
@@ -57,7 +57,7 @@ jobs:
 
   - job: Package
     timeoutInMinutes: 0
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/pkg/')
     pool:
       vmImage: 'windows-2019'
     steps:
@@ -106,5 +106,5 @@ jobs:
             $(Build.ArtifactStagingDirectory)/*.zip
             $(Build.ArtifactStagingDirectory)/*.asc
           assetUploadMode: replace
-          isPreRelease: true
+          isDraft: true
           addChangeLog: false

--- a/devtools/ci/package.sh
+++ b/devtools/ci/package.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -eu
 
-TRAVIS_TAG="${TRAVIS_TAG:-"$(git describe)"}"
+if [ -z "${TRAVIS_TAG:-}" ]; then
+  if [ -n "${TRAVIS_BRANCH}" ]; then
+    TRAVIS_TAG="${TRAVIS_BRANCH##*/}"
+  else
+    TRAVIS_TAG="$(git describe)"
+  fi
+fi
+
 CKB_CLI_VERSION="${CKB_CLI_VERSION:-"$TRAVIS_TAG"}"
 if [ -z "${REL_PKG:-}" ]; then
   if [ "$(uname)" = Darwin ]; then
@@ -13,6 +20,8 @@ fi
 
 PKG_NAME="ckb_${TRAVIS_TAG}_${REL_PKG%%.*}"
 ARCHIVE_NAME="ckb_${TRAVIS_TAG}_${REL_PKG}"
+
+echo "ARCHIVE_NAME=$ARCHIVE_NAME"
 
 rm -rf releases
 mkdir releases


### PR DESCRIPTION
Using draft release so that we can publish the releases when all the builds are ready.