### PR TITLE
chore: upgrade tentacle, enable reuse port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "ahash"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,12 @@ name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
@@ -138,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2734baf8ed08920ccecce1b48a2dfce4ac74a973144add031163bd21a1c5dab"
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +206,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -232,9 +262,9 @@ checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "bumpalo"
-version = "2.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-tools"
@@ -300,6 +330,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chacha20"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+dependencies = [
+ "cipher",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +362,15 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -582,7 +644,7 @@ name = "ckb-fixed-hash-macros"
 version = "0.38.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -1366,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1606,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array 0.12.3",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1668,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle 2.3.0",
+ "zeroize",
+]
+
+[[package]]
 name = "darwin-libproc"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,7 +1718,7 @@ version = "0.99.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -1634,8 +1735,23 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
@@ -1728,7 +1844,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
  "synstructure",
@@ -1899,7 +2015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -1949,6 +2065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2082,19 @@ checksum = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 dependencies = [
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "stdweb",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2058,15 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2257,6 +2387,37 @@ name = "hex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+dependencies = [
+ "crypto-mac 0.7.0",
+ "digest 0.8.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+dependencies = [
+ "crypto-mac 0.9.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+dependencies = [
+ "digest 0.8.0",
+ "generic-array 0.12.3",
+ "hmac 0.7.1",
+]
 
 [[package]]
 name = "hostname"
@@ -2549,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.25"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2576,7 +2737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -2681,6 +2842,22 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.0",
+ "hmac-drbg",
+ "rand 0.7.0",
+ "sha2 0.8.2",
+ "subtle 2.3.0",
+ "typenum",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -3071,16 +3248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 
 [[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "nonzero_ext"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,7 +3314,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621fe0f044729f810c6815cdd77e8f5e0cd803ce4f6a38380ebfc1322af98661"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -3182,7 +3349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0200f8d55c36ec1b6a8cf810115be85d4814f045e0097dfd50033ba25adb4c9e"
 dependencies = [
  "numext-fixed-uint-core",
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -3198,6 +3365,12 @@ name = "opaque-debug"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -3358,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -3454,7 +3627,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -3465,7 +3638,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -3499,6 +3672,15 @@ name = "platforms"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
+
+[[package]]
+name = "poly1305"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce46de8e53ee414ca4d02bfefac75d8c12fba948b76622a40b4be34dfce980"
+dependencies = [
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3538,15 +3720,6 @@ name = "proc-macro-nested"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
-dependencies = [
- "unicode-xid 0.1.0",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -3616,20 +3789,11 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-dependencies = [
- "proc-macro2 0.4.27",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -3664,7 +3828,7 @@ dependencies = [
  "autocfg 0.1.2",
  "libc",
  "rand_chacha 0.1.1",
- "rand_core 0.4.0",
+ "rand_core 0.4.2",
  "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
@@ -3680,7 +3844,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.6",
  "libc",
  "rand_chacha 0.2.0",
  "rand_core 0.5.1",
@@ -3714,14 +3878,14 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
- "rand_core 0.4.0",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3729,7 +3893,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.6",
 ]
 
 [[package]]
@@ -3766,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
 dependencies = [
  "libc",
- "rand_core 0.4.0",
+ "rand_core 0.4.2",
  "winapi 0.3.8",
 ]
 
@@ -3779,7 +3943,7 @@ dependencies = [
  "cloudabi",
  "fuchsia-cprng",
  "libc",
- "rand_core 0.4.0",
+ "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.8",
 ]
@@ -3790,7 +3954,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.6",
  "rand_core 0.5.1",
 ]
 
@@ -3801,7 +3965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
  "autocfg 0.1.2",
- "rand_core 0.4.0",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -4074,7 +4238,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -4188,7 +4352,7 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -4243,22 +4407,41 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.0",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.2",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
+name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.0",
+ "fake-simd",
+ "opaque-debug 0.2.2",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -4296,21 +4479,15 @@ checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
 ]
-
-[[package]]
-name = "sourcefile"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "spin"
@@ -4325,6 +4502,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
 name = "string"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4335,6 +4561,18 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+
+[[package]]
+name = "subtle"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
@@ -4349,22 +4587,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
-dependencies = [
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "unicode-xid 0.2.0",
 ]
@@ -4384,7 +4611,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
  "unicode-xid 0.2.0",
@@ -4406,47 +4633,55 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d575b096a4c80e84d67378c7fdd8469df54b08b37596e5ffbe6b2347c74b7c6"
+checksum = "e4f1239fa71a73627796acd21094b6a21a7e27c1e4651192fbc572653db487e0"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.7",
  "igd",
+ "js-sys",
  "libc",
  "log 0.4.11",
  "molecule",
+ "socket2",
  "tentacle-multiaddr",
  "tentacle-secio",
  "thiserror",
  "tokio 0.2.22",
  "tokio-util",
  "tokio-yamux",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "tentacle-multiaddr"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d216ab77a6719cbcdf9d10ae35d825d29c2920090c2cb5d6179d953f9e4dfc3"
+checksum = "ed6476818af8d86ba63c7f961c417c70906700166dd8fdef8b9ac7f47c629f3f"
 dependencies = [
  "bs58",
  "bytes 0.5.6",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "tentacle-secio"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea9c3062e6f891618a720befb4caef3e4ce650e21f23b4e718d80adcc483ccc"
+checksum = "aad32aea7fb5fcbc27baffc8a426dedb7311b5a071b6b940e813f39b97f47267"
 dependencies = [
  "bs58",
  "bytes 0.5.6",
+ "chacha20poly1305",
  "futures 0.3.7",
+ "getrandom 0.2.0",
+ "hmac 0.9.0",
+ "libsecp256k1",
  "log 0.4.11",
  "molecule",
  "openssl",
@@ -4454,9 +4689,11 @@ dependencies = [
  "rand 0.7.0",
  "ring",
  "secp256k1",
+ "sha2 0.9.1",
  "tokio 0.2.22",
  "tokio-util",
  "unsigned-varint",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -4522,7 +4759,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -4699,7 +4936,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.48",
 ]
@@ -4834,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927b87d25ead087be05f3aa42704a7e1e87b4e4a71ebbdf0c505489cbf52f106"
+checksum = "0087249d1db5eaa351500c05f05a165f7aeaf38fd57679b54092d89ae24eaed9"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.7",
@@ -4916,7 +5153,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 dependencies = [
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -4925,7 +5162,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"
 dependencies = [
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -4947,12 +5184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4966,15 +5197,19 @@ checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
+]
 
 [[package]]
 name = "unsigned-varint"
@@ -5060,6 +5295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,94 +5348,85 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.48"
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.48"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.11",
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.29",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.48"
+name = "wasm-bindgen-futures"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "quote 0.6.11",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+dependencies = [
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.48"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf8fe77e45ba5f91bc8f3da0c3aa5d464b3d8ed85d84f4d4c7cc106436b1d7"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.29",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.48"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c2d4d4756b2e46d3a5422e06277d02e4d3e1d62d138b76a4c681e925743623"
-
-[[package]]
-name = "wasm-bindgen-webidl"
-version = "0.2.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e47859b4eba3d3b9a5c2c299f9d6f8d0b613671315f6f0c5c7f835e524b36a"
-dependencies = [
- "failure",
- "heck",
- "log 0.4.11",
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.29",
- "wasm-bindgen-backend",
- "weedle",
-]
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.25"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d515d2f713d3a6ab198031d2181b7540f8e319e4637ec2d4a41a208335ef29"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
- "failure",
  "js-sys",
- "sourcefile",
  "wasm-bindgen",
- "wasm-bindgen-webidl",
-]
-
-[[package]]
-name = "weedle"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -5303,6 +5535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,4 +5570,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.48",
+ "synstructure",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ ignore = [
     "RUSTSEC-2020-0016", # TODO net2 has been deprecated, but still a lot of required crates are dependent on it
     "RUSTSEC-2020-0036", # TODO failure is officially deprecated/unmaintained, but still a lot of required crates are dependent on it
     "RUSTSEC-2020-0043", # TODO ws allows remote attacker to run the process out of memory, since it is no longer actively maintained, we couldn't fix it in the short term
+    "RUSTSEC-2020-0056", # We did not use the `stdweb` library, only `wasm32-unknown-unknown` would use `getrandom` and `wasm-bindgen`, `stdweb` would only be used in cargo-web
 ]
 
 [licenses]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,7 +18,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.38.0-pre" }
 tokio = { version = "0.2.11", features = ["time", "io-util", "tcp", "dns", "rt-threaded", "blocking", "stream"] }
 tokio-util = { version = "0.3.0", features = ["codec"] }
 futures = "0.3"
-p2p = { version="0.3.0", package="tentacle", features = ["molc"] }
+p2p = { version="0.3.3", package="tentacle", features = ["molc"] }
 faketime = "0.2.0"
 lazy_static = "1.3.0"
 bs58 = "0.3.0"

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -873,7 +873,7 @@ impl<T: ExitHandler> NetworkService<T> {
             .forever(true)
             .max_connection_number(1024);
 
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         let p2p_service = {
             let iter = config.listen_addresses.iter();
 
@@ -942,10 +942,13 @@ impl<T: ExitHandler> NetworkService<T> {
             service_builder.build(event_handler)
         };
 
-        #[cfg(windows)]
-        // The default permissions of windows are not enough to enable this function,
+        #[cfg(not(target_os = "linux"))]
+        // The default permissions of Windows are not enough to enable this function,
         // and the administrator permissions of group permissions must be turned on.
         // This operation is very burdensome for windows users, so it is turned off by default
+        //
+        // The integration test fails after MacOS is turned on, the behavior is different from linux.
+        // Decision to turn off it
         let p2p_service = service_builder.build(event_handler);
 
         // == Build background service tasks

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -78,7 +78,7 @@ pub struct NetworkState {
     dialing_addrs: RwLock<HashMap<PeerId, Instant>>,
     /// Node public addresses,
     /// includes manually public addrs and remote peer observed addrs
-    public_addrs: RwLock<HashMap<Multiaddr, u8>>,
+    public_addrs: RwLock<HashSet<Multiaddr>>,
     pending_observed_addrs: RwLock<HashSet<Multiaddr>>,
     local_private_key: secio::SecioKeyPair,
     local_peer_id: PeerId,
@@ -96,11 +96,11 @@ impl NetworkState {
         config.create_dir_if_not_exists()?;
         let local_private_key = config.fetch_private_key()?;
         // set max score to public addresses
-        let public_addrs: HashMap<Multiaddr, u8> = config
+        let public_addrs: HashSet<Multiaddr> = config
             .listen_addresses
             .iter()
             .chain(config.public_addresses.iter())
-            .map(|addr| (addr.to_owned(), std::u8::MAX))
+            .cloned()
             .collect();
         let peer_store = Mutex::new(PeerStore::load_from_dir_or_default(
             config.peer_store_path(),
@@ -296,19 +296,13 @@ impl NetworkState {
         self.local_private_key().peer_id().to_base58()
     }
 
-    pub(crate) fn public_addrs(&self, count: usize) -> Vec<(Multiaddr, u8)> {
+    pub(crate) fn public_addrs(&self, count: usize) -> Vec<Multiaddr> {
         self.public_addrs
             .read()
             .iter()
             .take(count)
-            .map(|(addr, score)| (addr.to_owned(), *score))
+            .cloned()
             .collect()
-    }
-
-    pub(crate) fn vote_listened_addr(&self, addr: Multiaddr, votes: u8) {
-        let mut public_addrs = self.public_addrs.write();
-        let score = public_addrs.entry(addr).or_default();
-        *score = score.saturating_add(votes);
     }
 
     pub(crate) fn connection_status(&self) -> ConnectionStatus {
@@ -320,7 +314,13 @@ impl NetworkState {
         let listened_addrs = self.listened_addrs.read();
         self.public_addrs(max_urls.saturating_sub(listened_addrs.len()))
             .into_iter()
-            .filter(|(addr, _)| !listened_addrs.contains(addr))
+            .filter_map(|addr| {
+                if !listened_addrs.contains(&addr) {
+                    Some((addr, 1))
+                } else {
+                    None
+                }
+            })
             .chain(listened_addrs.iter().map(|addr| (addr.to_owned(), 1)))
             .map(|(addr, score)| (self.to_external_url(&addr), score))
             .collect()
@@ -358,7 +358,7 @@ impl NetworkState {
             trace!("Do not dial self: {:?}, {}", peer_id, addr);
             return false;
         }
-        if self.public_addrs.read().contains_key(&addr) {
+        if self.public_addrs.read().contains(&addr) {
             trace!(
                 "Do not dial listened address(self): {:?}, {}",
                 peer_id,
@@ -475,7 +475,11 @@ impl NetworkState {
     /// this method is intent to check observed addr by dial to self
     pub(crate) fn try_dial_observed_addrs(&self, p2p_control: &ServiceControl) {
         let mut pending_observed_addrs = self.pending_observed_addrs.write();
-        for addr in pending_observed_addrs.drain() {
+        let public_addrs = self.public_addrs.read().clone();
+        for addr in pending_observed_addrs
+            .drain()
+            .chain(public_addrs.into_iter())
+        {
             trace!("try dial observed addr: {:?}", addr);
             if let Err(err) = self.dial_inner(
                 p2p_control,
@@ -492,19 +496,9 @@ impl NetworkState {
     /// TODO(doc): @driftluo
     pub fn add_observed_addrs(&self, iter: impl Iterator<Item = Multiaddr>) {
         let mut pending_observed_addrs = self.pending_observed_addrs.write();
-        let mut public_addrs = self.public_addrs.write();
         for addr in iter {
-            if let Some(score) = public_addrs.get_mut(&addr) {
-                *score = score.saturating_add(1);
-                trace!(
-                    "increase score for exists observed addr: {:?} {}",
-                    addr,
-                    score
-                );
-            } else {
-                trace!("pending observed addr: {:?}", addr,);
-                pending_observed_addrs.insert(addr);
-            }
+            trace!("pending observed addr: {:?}", addr,);
+            pending_observed_addrs.insert(addr);
         }
     }
 
@@ -590,19 +584,23 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
             } => {
                 debug!("DialerError({}) {}", address, error);
 
+                let mut public_addrs = self.network_state.public_addrs.write();
+                let addr = address
+                    .iter()
+                    .filter(|proto| match proto {
+                        multiaddr::Protocol::P2P(_) => false,
+                        _ => true,
+                    })
+                    .collect();
+
                 if let DialerErrorKind::HandshakeError(HandshakeErrorKind::SecioError(
                     SecioError::ConnectSelf,
                 )) = error
                 {
                     debug!("dial observed address success: {:?}", address);
-                    let addr = address
-                        .iter()
-                        .filter(|proto| match proto {
-                            multiaddr::Protocol::P2P(_) => false,
-                            _ => true,
-                        })
-                        .collect();
-                    self.network_state.vote_listened_addr(addr, 1);
+                    public_addrs.insert(addr);
+                } else {
+                    public_addrs.remove(&addr);
                 }
                 let peer_id = extract_peer_id(address).expect("Secio must enabled");
                 self.network_state.dial_failed(peer_id);
@@ -869,12 +867,86 @@ impl<T: ExitHandler> NetworkService<T> {
             network_state: Arc::clone(&network_state),
             exit_handler,
         };
-        let p2p_service = service_builder
+        service_builder = service_builder
             .key_pair(network_state.local_private_key.clone())
             .upnp(config.upnp)
             .forever(true)
-            .max_connection_number(1024)
-            .build(event_handler);
+            .max_connection_number(1024);
+
+        #[cfg(unix)]
+        let p2p_service = {
+            let iter = config.listen_addresses.iter();
+
+            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            enum TransportType {
+                Ws,
+                Tcp,
+            }
+
+            fn find_type(addr: &Multiaddr) -> TransportType {
+                let mut iter = addr.iter();
+
+                iter.find_map(|proto| {
+                    if let multiaddr::Protocol::Ws = proto {
+                        Some(TransportType::Ws)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(TransportType::Tcp)
+            }
+
+            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            enum BindType {
+                None,
+                Ws,
+                Tcp,
+                Both,
+            }
+            impl BindType {
+                fn transform(&mut self, other: TransportType) {
+                    match (&self, other) {
+                        (BindType::None, TransportType::Ws) => *self = BindType::Ws,
+                        (BindType::None, TransportType::Tcp) => *self = BindType::Tcp,
+                        (BindType::Ws, TransportType::Tcp) => *self = BindType::Both,
+                        (BindType::Tcp, TransportType::Ws) => *self = BindType::Both,
+                        _ => (),
+                    }
+                }
+
+                fn is_ready(&self) -> bool {
+                    // should change to Both if ckb enable ws
+                    matches!(self, BindType::Tcp)
+                }
+            }
+
+            let mut init = BindType::None;
+            for addr in iter {
+                if init.is_ready() {
+                    break;
+                }
+                match find_type(addr) {
+                    // wait ckb enable ws support
+                    TransportType::Ws => (),
+                    TransportType::Tcp => {
+                        // only bind once
+                        if matches!(init, BindType::Tcp) {
+                            continue;
+                        }
+                        service_builder = service_builder.tcp_bind(addr.clone());
+                        init.transform(TransportType::Tcp)
+                    }
+                }
+            }
+
+            service_builder.build(event_handler)
+        };
+
+        #[cfg(windows)]
+        // The default permissions of windows are not enough to enable this function,
+        // and the administrator permissions of group permissions must be turned on.
+        // This operation is very burdensome for windows users, so it is turned off by default
+        let p2p_service = service_builder.build(event_handler);
 
         // == Build background service tasks
         let dump_peer_store_service = DumpPeerStoreService::new(Arc::clone(&network_state));

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -111,7 +111,9 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
             Some(item) => {
                 match item {
                     DiscoveryMessage::GetNodes {
-                        listen_port, count, ..
+                        listen_port,
+                        count,
+                        version,
                     } => {
                         if let Some(state) = self.sessions.get_mut(&session.id) {
                             if state.received_get_nodes && check(Misbehavior::DuplicateGetNodes) {
@@ -132,6 +134,9 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
                                 if let RemoteAddress::Listen(ref addr) = state.remote_addr {
                                     self.addr_mgr.add_new_addr(session.id, addr.clone());
                                 }
+                            } else if version >= state::REUSE_PORT_VERSION {
+                                // after enable reuse port, it can be broadcast
+                                state.remote_addr.change_to_listen();
                             }
 
                             let max = ::std::cmp::max(MAX_ADDR_TO_SEND, count as usize);

--- a/network/src/protocols/discovery/state.rs
+++ b/network/src/protocols/discovery/state.rs
@@ -46,9 +46,9 @@ impl SessionState {
                 .next();
 
             let msg = encode(DiscoveryMessage::GetNodes {
-                #[cfg(unix)]
+                #[cfg(target_os = "linux")]
                 version: REUSE_PORT_VERSION,
-                #[cfg(windows)]
+                #[cfg(not(target_os = "linux"))]
                 version: FIRST_VERSION,
                 count: MAX_ADDR_TO_SEND as u32,
                 listen_port: port,

--- a/network/src/protocols/discovery/state.rs
+++ b/network/src/protocols/discovery/state.rs
@@ -16,7 +16,12 @@ use super::{
 
 // FIXME: should be a more high level version number
 
-const VERSION: u32 = 0;
+// default
+#[allow(dead_code)]
+const FIRST_VERSION: u32 = 0;
+// enable reuse port
+#[allow(dead_code)]
+pub const REUSE_PORT_VERSION: u32 = 1;
 
 pub struct SessionState {
     // received pending messages
@@ -41,7 +46,10 @@ impl SessionState {
                 .next();
 
             let msg = encode(DiscoveryMessage::GetNodes {
-                version: VERSION,
+                #[cfg(unix)]
+                version: REUSE_PORT_VERSION,
+                #[cfg(windows)]
+                version: FIRST_VERSION,
                 count: MAX_ADDR_TO_SEND as u32,
                 listen_port: port,
             });
@@ -117,6 +125,12 @@ impl RemoteAddress {
     pub(crate) fn to_inner(&self) -> &Multiaddr {
         match self {
             RemoteAddress::Init(ref addr) | RemoteAddress::Listen(ref addr) => addr,
+        }
+    }
+
+    pub(crate) fn change_to_listen(&mut self) {
+        if let RemoteAddress::Init(addr) = self {
+            *self = RemoteAddress::Listen(addr.clone());
         }
     }
 

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -363,12 +363,10 @@ impl IdentifyCallback {
     }
 
     fn listen_addrs(&self) -> Vec<Multiaddr> {
-        let mut addrs = self.network_state.public_addrs(MAX_RETURN_LISTEN_ADDRS * 2);
-        addrs.sort_by(|a, b| a.1.cmp(&b.1));
+        let addrs = self.network_state.public_addrs(MAX_RETURN_LISTEN_ADDRS * 2);
         addrs
             .into_iter()
             .take(MAX_RETURN_LISTEN_ADDRS)
-            .map(|(addr, _)| addr)
             .collect::<Vec<_>>()
     }
 }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -25,8 +25,8 @@ ckb-resource = { path = "../../resource", version = "= 0.38.0-pre"}
 ckb-build-info = { path = "../build-info", version = "= 0.38.0-pre" }
 ckb-types = { path = "../types", version = "= 0.38.0-pre" }
 ckb-fee-estimator = { path = "../fee-estimator", version = "= 0.38.0-pre" }
-secio = { version="= 0.4.0", features = ["molc"], package="tentacle-secio" }
-multiaddr = { version="0.1.0", package="tentacle-multiaddr" }
+secio = { version="0.4.2", features = ["molc"], package="tentacle-secio" }
+multiaddr = { version="0.2.0", package="tentacle-multiaddr" }
 rand = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
1. Upgrade tentacle
2. Enable reuse port on unix, Windows system has permission problems, it cannot be turned on by default
3. The discovery protocol version number has been increased to identify whether the observed address can be broadcasted