### PR TITLE
chore: change inflight request tx reach limit status to 1xx

### DIFF
--- a/sync/src/status.rs
+++ b/sync/src/status.rs
@@ -61,6 +61,8 @@ pub enum StatusCode {
     CompactBlockRequiresFreshTransactions = 107,
     /// CompactBlock short-ids collision
     CompactBlockMeetsShortIdsCollision = 108,
+    /// In-flight blocks limit exceeded
+    BlocksInFlightReachLimit = 109,
 
     ///////////////////////////////////
     //      Malformed Errors 4xx     //
@@ -106,8 +108,6 @@ pub enum StatusCode {
     TxPool = 501,
     /// Errors returned from the network layer
     Network = 502,
-    /// In-flight blocks limit exceeded
-    BlocksInFlightReachLimit = 503,
 }
 
 impl StatusCode {


### PR DESCRIPTION
This state is a normal state, which means that when the transaction is in the proposal phase, the node is not involved in it, and the transaction needs to be pulled remotely during compact block message processing, and the current state is pulling