### PR TITLE
fix: the description for the low fee rate error

### DIFF
--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -154,7 +154,7 @@ impl RPCError {
     /// TODO(doc): @doitian
     pub fn from_submit_transaction_reject(reject: &Reject) -> Error {
         let code = match reject {
-            Reject::LowFeeRate(_, _) => RPCError::PoolRejectedTransactionByMinFeeRate,
+            Reject::LowFeeRate(_, _, _) => RPCError::PoolRejectedTransactionByMinFeeRate,
             Reject::ExceededMaximumAncestorsCount => {
                 RPCError::PoolRejectedTransactionByMaxAncestorsCountLimit
             }
@@ -247,6 +247,7 @@ impl RPCError {
 mod tests {
     use super::*;
     use ckb_dao_utils::DaoError;
+    use ckb_fee_estimator::FeeRate;
     use ckb_types::{core::error::OutPointError, packed::Byte32};
 
     #[test]
@@ -260,9 +261,10 @@ mod tests {
 
     #[test]
     fn test_submit_transaction_error() {
-        let err: CKBError = Reject::LowFeeRate(100, 50).into();
+        let min_fee_rate = FeeRate::from_u64(500);
+        let err: CKBError = Reject::LowFeeRate(min_fee_rate, 100, 50).into();
         assert_eq!(
-            "PoolRejectedTransactionByMinFeeRate: Transaction fee rate must >= 100 shannons/KB, got: 50",
+            "PoolRejectedTransactionByMinFeeRate: The min fee rate is 500 shannons/KB, so the transaction fee should be 100 shannons at least, but only got 50",
             RPCError::from_submit_transaction_reject(RPCError::downcast_submit_transaction_reject(&err).unwrap()).message
         );
 

--- a/test/src/specs/relay/transaction_relay_low_fee_rate.rs
+++ b/test/src/specs/relay/transaction_relay_low_fee_rate.rs
@@ -79,7 +79,7 @@ impl Spec for TransactionRelayLowFeeRate {
             node0,
             node0_log_size,
             10,
-            "error: SubmitTransaction(Transaction fee rate must >= 242 shannons/KB, got: 0)"
+            "error: SubmitTransaction(The min fee rate is 1000 shannons/KB, so the transaction fee should be 242 shannons at least, but only got 0)"
         )
         .is_some());
 

--- a/tx-pool/src/error.rs
+++ b/tx-pool/src/error.rs
@@ -1,5 +1,6 @@
 //! TODO(doc): @zhangsoledad
 use ckb_error::{Error, ErrorKind};
+use ckb_fee_estimator::FeeRate;
 use ckb_types::packed::Byte32;
 use failure::Fail;
 use tokio::sync::mpsc::error::TrySendError as TokioTrySendError;
@@ -9,10 +10,10 @@ use tokio::sync::mpsc::error::TrySendError as TokioTrySendError;
 pub enum Reject {
     /// The fee rate of transaction is lower than min fee rate
     #[fail(
-        display = "Transaction fee rate must >= {} shannons/KB, got: {}",
-        _0, _1
+        display = "The min fee rate is {} shannons/KB, so the transaction fee should be {} shannons at least, but only got {}",
+        _0, _1, _2
     )]
-    LowFeeRate(u64, u64),
+    LowFeeRate(FeeRate, u64, u64),
 
     /// TODO(doc): @zhangsoledad
     #[fail(display = "Transaction exceeded maximum ancestors count limit, try send it later")]

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -411,7 +411,12 @@ impl TxPoolService {
             let min_fee = tx_pool.config.min_fee_rate.fee(tx_size);
             // reject txs which fee lower than min fee rate
             if fee < min_fee {
-                return Err(Reject::LowFeeRate(min_fee.as_u64(), fee.as_u64()).into());
+                return Err(Reject::LowFeeRate(
+                    tx_pool.config.min_fee_rate,
+                    min_fee.as_u64(),
+                    fee.as_u64(),
+                )
+                .into());
             }
 
             let related_dep_out_points = rtx.related_dep_out_points();


### PR DESCRIPTION
The first parameter is the minimum transaction fee, not the fee rate.

https://github.com/nervosnetwork/ckb/blob/50ddac6ccd951a8e2a2f180c59a291f76e00d6e5/tx-pool/src/process.rs#L411-L414
https://github.com/nervosnetwork/ckb/blob/50ddac6ccd951a8e2a2f180c59a291f76e00d6e5/tx-pool/src/error.rs#L11-L15