### PR TITLE
chore: expose jsonrpc types for subscription

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -84,7 +84,10 @@ def write_method_signature(file, method_name, vars):
             file.write('    * `{}`: {}\n'.format(var.name, var.ty))
     else:
         file.write('* `{}()`\n'.format(method_name))
-    file.write('* result: {}\n'.format(vars[-1].ty))
+    if method_name == 'subscribe':
+        file.write('* result: `string`\n')
+    else:
+        file.write('* result: {}\n'.format(vars[-1].ty))
 
 
 class MarkdownParser():
@@ -674,7 +677,7 @@ class RPCDoc(object):
 
         if 'ckb_types/packed' in path:
             return
-        if path.split('/')[-1] in ['type.Result.html', 'struct.Subscriber.html', 'enum.SubscriptionId.html']:
+        if path.split('/')[-1] in ['type.Result.html', 'struct.Subscriber.html', 'enum.SubscriptionId.html', 'enum.Topic.html']:
             return
 
         with open(path) as file:

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -31,7 +31,6 @@ jsonrpc-tcp-server = "~14.1"
 jsonrpc-ws-server = "~14.1"
 jsonrpc-server-utils = "~14.1"
 jsonrpc-pubsub = "~14.1"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num_cpus = "1.10"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.38.0-pre" }
@@ -50,6 +49,7 @@ failure = "0.1.5"
 
 [dev-dependencies]
 reqwest = "0.9.16"
+serde = { version = "1.0", features = ["derive"] }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.38.0-pre" }
 tempfile = "3.0"
 pretty_assertions = "0.6.1"

--- a/rpc/src/module/subscription.rs
+++ b/rpc/src/module/subscription.rs
@@ -1,4 +1,5 @@
 use ckb_channel::select;
+use ckb_jsonrpc_types::Topic;
 use ckb_logger::error;
 use ckb_notify::NotifyController;
 use jsonrpc_core::{futures::Future, Metadata, Result};
@@ -7,7 +8,6 @@ use jsonrpc_pubsub::{
     typed::{Sink, Subscriber},
     PubSubMetadata, Session, SubscriptionId,
 };
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -38,14 +38,6 @@ impl PubSubMetadata for SubscriptionSession {
     fn session(&self) -> Option<Arc<Session>> {
         Some(Arc::clone(&self.session))
     }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum Topic {
-    NewTipHeader,
-    NewTipBlock,
-    NewTransaction,
 }
 
 /// RPC Module Subscription that CKB node will push new messages to subscribers.

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -13,6 +13,7 @@ mod net;
 mod pool;
 mod primitive;
 mod proposal_short_id;
+mod subscription;
 mod sync;
 mod uints;
 
@@ -44,6 +45,7 @@ pub use self::pool::{
     TxVerbosity,
 };
 pub use self::proposal_short_id::ProposalShortId;
+pub use self::subscription::Topic;
 pub use self::sync::PeerState;
 pub use self::uints::{Uint128, Uint32, Uint64};
 pub use jsonrpc_core::types::{error, id, params, request, response, version};

--- a/util/jsonrpc-types/src/subscription.rs
+++ b/util/jsonrpc-types/src/subscription.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+/// Specifies the topic which to be added as active subscription.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Topic {
+    /// Subscribe new tip headers.
+    NewTipHeader,
+    /// Subscribe new tip blocks.
+    NewTipBlock,
+    /// Subscribe new transactions which are submitted to the pool.
+    NewTransaction,
+}


### PR DESCRIPTION
At present, write a subscription client have to copy those codes or depend on the server crate.
It doesn't make sense.