### PR TITLE
docs: fix outdated documents, use `ckb-cli` instead of `ckb cli`

### DIFF
--- a/ckb-bin/src/subcommand/init.rs
+++ b/ckb-bin/src/subcommand/init.rs
@@ -125,7 +125,7 @@ pub fn init(args: InitArgs) -> Result<(), ExitCode> {
                 "# secp256k1_blake160_sighash_all example:\n\
                  # [block_assembler]\n\
                  # code_hash = \"{}\"\n\
-                 # args = \"ckb cli blake160 <compressed-pubkey>\"\n\
+                 # args = \"ckb-cli util blake2b --prefix-160 <compressed-pubkey>\"\n\
                  # hash_type = \"{}\"\n\
                  # message = \"A 0x-prefixed hex string\"",
                 default_code_hash_option.unwrap_or_default(),

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -8,7 +8,6 @@ CKB looks for configuration files in `<config-dir>`, which is the current workin
 -   `ckb miner`: `ckb-miner.toml`
 -   `ckb import`: `ckb.toml`
 -   `ckb export`: `ckb.toml`
--   `ckb cli`: no config file required yet
 
 Command line argument `-C <path>` sets the value of `<config-dir>` to `<path>`.
 


### PR DESCRIPTION
Ref: #1868