### PR TITLE
chore: replace enum-derive crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
  "byteorder",
  "ckb-error",
  "ckb-types",
- "enum-display-derive",
+ "derive_more",
  "failure",
 ]
 
@@ -616,7 +616,7 @@ name = "ckb-error"
 version = "0.38.0-pre"
 dependencies = [
  "ckb-occupied-capacity",
- "enum-display-derive",
+ "derive_more",
  "failure",
 ]
 
@@ -652,8 +652,8 @@ version = "0.38.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -911,8 +911,8 @@ name = "ckb-occupied-capacity-macros"
 version = "0.38.0-pre"
 dependencies = [
  "ckb-occupied-capacity-core",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1278,7 +1278,7 @@ dependencies = [
  "ckb-test-chain-utils",
  "ckb-traits",
  "ckb-types",
- "enum-display-derive",
+ "derive_more",
  "failure",
  "faketime",
  "lru",
@@ -1668,8 +1668,8 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1734,8 +1734,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1802,16 +1802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-display-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f76eb63c4bfc6fce5000f106254701b741fc9a65ee08445fde0ff39e583f1c"
-dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,8 +1850,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -2031,8 +2021,8 @@ checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2752,8 +2742,8 @@ checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3329,8 +3319,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621fe0f044729f810c6815cdd77e8f5e0cd803ce4f6a38380ebfc1322af98661"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3364,8 +3354,8 @@ checksum = "0200f8d55c36ec1b6a8cf810115be85d4814f045e0097dfd50033ba25adb4c9e"
 dependencies = [
  "numext-fixed-uint-core",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3546,8 +3536,8 @@ checksum = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3642,8 +3632,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3653,8 +3643,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3741,7 +3731,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3794,12 +3784,6 @@ name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -4253,8 +4237,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4367,8 +4351,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4536,10 +4520,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
+ "quote",
  "serde",
  "serde_derive",
- "syn 1.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -4550,12 +4534,12 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2",
- "quote 1.0.7",
+ "quote",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -4590,33 +4574,13 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4626,9 +4590,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
- "unicode-xid 0.2.0",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4774,8 +4738,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4951,8 +4915,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5205,12 +5169,6 @@ checksum = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -5387,8 +5345,8 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5410,7 +5368,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5421,8 +5379,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5602,7 +5560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.48",
+ "quote",
+ "syn",
  "synstructure",
 ]

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 failure = "0.1.5"
 ckb-occupied-capacity = { path = "../util/occupied-capacity", version = "= 0.38.0-pre" }
-enum-display-derive = "0.1.0"
+derive_more = { version = "0.99.0", default-features = false, features = ["display"] }

--- a/error/src/internal.rs
+++ b/error/src/internal.rs
@@ -1,6 +1,7 @@
 use crate::{Error, ErrorKind};
+use derive_more::Display;
 use failure::{err_msg, Backtrace, Context, Fail};
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 
 /// TODO(doc): @keroro520
 #[derive(Debug)]
@@ -70,7 +71,10 @@ impl InternalErrorKind {
     }
 
     /// TODO(doc): @keroro520
-    pub fn reason<S: Display + Debug + Sync + Send + 'static>(self, reason: S) -> InternalError {
+    pub fn reason<S: fmt::Display + Debug + Sync + Send + 'static>(
+        self,
+        reason: S,
+    ) -> InternalError {
         InternalError {
             kind: err_msg(reason).compat().context(self),
         }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1,14 +1,12 @@
 //! TODO(doc): @keroro520
-#[macro_use]
-extern crate enum_display_derive;
-
 mod convert;
 mod internal;
 pub mod util;
 
+use derive_more::Display;
 use failure::{Backtrace, Context, Fail};
 pub use internal::{InternalError, InternalErrorKind};
-use std::fmt::{self, Display};
+use std::fmt;
 
 /// TODO(doc): @keroro520
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Display)]

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -13,4 +13,4 @@ byteorder = "1.3.1"
 ckb-types = { path = "../../types", version = "= 0.38.0-pre" }
 ckb-error = { path = "../../../error", version = "= 0.38.0-pre" }
 failure = "0.1.5"
-enum-display-derive = "0.1.0"
+derive_more = { version = "0.99.0", default-features = false, features = ["display"] }

--- a/util/dao/utils/src/error.rs
+++ b/util/dao/utils/src/error.rs
@@ -1,6 +1,6 @@
 use ckb_error::{Error, ErrorKind};
+use derive_more::Display;
 use failure::Fail;
-use std::fmt::Display;
 
 /// TODO(doc): @keroro520
 #[derive(Fail, Debug, PartialEq, Clone, Eq, Display)]

--- a/util/dao/utils/src/lib.rs
+++ b/util/dao/utils/src/lib.rs
@@ -1,7 +1,4 @@
 //! TODO(doc): @keroro520
-#[macro_use]
-extern crate enum_display_derive;
-
 mod error;
 
 use byteorder::{ByteOrder, LittleEndian};

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -24,7 +24,7 @@ ckb-logger = {path = "../util/logger", version = "= 0.38.0-pre"}
 ckb-reward-calculator= { path = "../util/reward-calculator", version = "= 0.38.0-pre" }
 failure = "0.1.5"
 ckb-error = { path = "../error", version = "= 0.38.0-pre" }
-enum-display-derive = "0.1.0"
+derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
 tokio = { version = "0.2", features = ["sync", "blocking", "rt-threaded"] }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.38.0-pre" }
 

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -3,8 +3,9 @@ use ckb_types::{
     core::{Capacity, Version},
     packed::{Byte32, OutPoint},
 };
+use derive_more::Display;
 use failure::{Backtrace, Context, Fail};
-use std::fmt::{self, Display};
+use std::fmt;
 
 #[derive(Clone, Debug, Display, Eq, PartialEq)]
 pub enum TransactionErrorSource {

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -1,7 +1,4 @@
 //! TODO(doc): @zhangsoledad
-#[macro_use]
-extern crate enum_display_derive;
-
 mod block_verifier;
 pub mod cache;
 mod contextual_block_verifier;


### PR DESCRIPTION
`enum-display-derive` is too old and brings unnecessary compilation tasks. After replacing with `derive_more`, crates such as `syn`/`quote` will only need to compile one version