### PR TITLE
fix: resolve integration script and build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,12 @@ submodule-init:
 
 .PHONY: integration
 integration: submodule-init setup-ckb-test ## Run integration tests in "test" dir.
-	cargo build --features deadlock_detection with_sentry
+	cargo build --features deadlock_detection
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-release
 integration-release: submodule-init setup-ckb-test
-	cargo build --release --features deadlock_detection with_sentry
+	cargo build --release --features deadlock_detection
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
 
 ##@ Document

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -45,4 +45,4 @@ sentry = { version = "0.17.0", optional = true }
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]
 profiling = ["ckb-memory-tracker/profiling"]
-with_sentry = ["ckb-network/with_sentry", "ckb-sync/with_sentry", "ckb-app-config/with_sentry", "ckb-logger-service/with_sentry"]
+with_sentry = ["sentry", "ckb-network/with_sentry", "ckb-sync/with_sentry", "ckb-app-config/with_sentry", "ckb-logger-service/with_sentry"]


### PR DESCRIPTION
1. `with_sentry` feature should be disabled in integration test

2. fix ckb-bin compiler error