### PR TITLE
chore: upgrade console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,16 +1338,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
  "terminal_size",
- "termios",
  "unicode-width",
  "winapi 0.3.8",
  "winapi-util",
@@ -4712,15 +4711,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "redox_termios",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -16,7 +16,7 @@ ckb-logger = { path = "../util/logger", version = "= 0.38.0-pre" }
 ckb-error = { path = "../error", version = "= 0.38.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.38.0-pre" }
 indicatif = "0.15"
-console = "0.12"
+console = "0.13"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -26,5 +26,5 @@ lru = "0.6.0"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.38.0-pre" }
 failure = "0.1.5"
 indicatif = "0.15"
-console = "0.12.0"
+console = "0.13.0"
 eaglesong = "0.1"

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -61,7 +61,7 @@ impl Miner {
         let pb = mp.add(ProgressBar::new(100));
         pb.set_style(ProgressStyle::default_bar().template("{msg:.green}"));
 
-        let stderr_is_tty = console::Term::stderr().is_term();
+        let stderr_is_tty = console::Term::stderr().features().is_attended();
 
         thread::spawn(move || {
             mp.join().expect("MultiProgress join failed");


### PR DESCRIPTION
due to indicatif's console depends on the writing problem, the `console` must be forced to upgrade to the latest version