### PR TITLE
chore: add with_dns_seeding feature to ckb-network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_
 default = []
 deadlock_detection = ["ckb-bin/deadlock_detection"]
 with_sentry = ["ckb-bin/with_sentry"]
+with_dns_seeding = ["ckb-bin/with_dns_seeding"]
 profiling = ["jemallocator/profiling", "ckb-bin/profiling"]
 
 [patch.crates-io]

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ build-for-profiling: ## Build binary with for profiling.
 
 .PHONY: prod
 prod: ## Build binary for production release.
-	RUSTFLAGS="--cfg disable_faketime" cargo build ${VERBOSE} --release --features with_sentry
+	RUSTFLAGS="--cfg disable_faketime" cargo build ${VERBOSE} --release --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod-docker
 prod-docker:
-	RUSTFLAGS="--cfg disable_faketime --cfg docker" cargo build --verbose --release --features with_sentry
+	RUSTFLAGS="--cfg disable_faketime --cfg docker" cargo build --verbose --release --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod-test
 prod-test:

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -47,3 +47,4 @@ sentry = { version = "0.17.0", optional = true }
 deadlock_detection = ["ckb-util/deadlock_detection"]
 profiling = ["ckb-memory-tracker/profiling"]
 with_sentry = ["sentry", "ckb-network/with_sentry", "ckb-sync/with_sentry", "ckb-app-config/with_sentry", "ckb-logger-service/with_sentry"]
+with_dns_seeding = ["ckb-network/with_dns_seeding"]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,14 +20,13 @@ tokio-util = { version = "0.3.0", features = ["codec"] }
 futures = "0.3"
 p2p = { version="0.3.3", package="tentacle", features = ["molc"] }
 faketime = "0.2.0"
-lazy_static = "1.3.0"
-bs58 = "0.3.0"
+lazy_static = { version = "1.3.0", optional = true }
+bs58 = { version = "0.3.0", optional = true }
 sentry = { version = "0.17.0", optional = true }
-faster-hex = "0.4"
+faster-hex = { version = "0.4", optional = true }
 ckb-hash = {path = "../util/hash", version = "= 0.39.0-pre"}
-secp256k1 = {version = "0.19", features = ["recovery"] }
-trust-dns-resolver = { version = "0.19" }
-num_cpus = "1.10"
+secp256k1 = {version = "0.19", features = ["recovery"], optional = true }
+trust-dns-resolver = { version = "0.19", optional = true }
 snap = "1"
 ckb-types = { path = "../util/types", version = "= 0.39.0-pre" }
 ipnetwork = "0.14"
@@ -37,11 +36,13 @@ ckb-spawn = { path = "../util/spawn", version = "= 0.39.0-pre" }
 
 [features]
 with_sentry = ["sentry"]
+with_dns_seeding = ["lazy_static", "bs58", "faster-hex", "trust-dns-resolver", "secp256k1"]
 
 [dev-dependencies]
 tempfile = "3.0"
 criterion = "0.3"
 proptest = "0.9"
+num_cpus = "1.10"
 
 [[bench]]
 name = "peer_store"

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -14,8 +14,8 @@ use crate::protocols::{
     support_protocols::SupportProtocols,
 };
 use crate::services::{
-    dns_seeding::DnsSeedingService, dump_peer_store::DumpPeerStoreService,
-    outbound_peer::OutboundPeerService, protocol_type_checker::ProtocolTypeCheckerService,
+    dump_peer_store::DumpPeerStoreService, outbound_peer::OutboundPeerService,
+    protocol_type_checker::ProtocolTypeCheckerService,
 };
 use crate::{Behaviour, CKBProtocol, Peer, PeerIndex, ProtocolId, PublicKey, ServiceControl};
 use ckb_app_config::NetworkConfig;
@@ -963,9 +963,12 @@ impl<T: ExitHandler> NetworkService<T> {
             bg_services.push(Box::pin(outbound_peer_service) as Pin<Box<_>>);
         };
 
+        #[cfg(feature = "with_dns_seeding")]
         if config.dns_seeding_service_enabled() {
-            let dns_seeding_service =
-                DnsSeedingService::new(Arc::clone(&network_state), config.dns_seeds.clone());
+            let dns_seeding_service = crate::services::dns_seeding::DnsSeedingService::new(
+                Arc::clone(&network_state),
+                config.dns_seeds.clone(),
+            );
             bg_services.push(Box::pin(dns_seeding_service.start()) as Pin<Box<_>>);
         };
 

--- a/network/src/services/mod.rs
+++ b/network/src/services/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "with_dns_seeding")]
 pub(crate) mod dns_seeding;
 pub(crate) mod dump_peer_store;
 pub(crate) mod outbound_peer;


### PR DESCRIPTION
This PR extracts dns seeding related function to a feature flag, make it easy to compile ckb-network crate to wasm target.