### PR TITLE
chore(integration): add sentry section into ckb.toml in integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ integration: submodule-init setup-ckb-test ## Run integration tests in "test" di
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ../target/debug/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-release
-integration-release: submodule-init setup-ckb-test
-	cargo build --release --features deadlock_detection
+integration-release: submodule-init setup-ckb-test prod
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh --release -- --bin ../target/release/ckb ${CKB_TEST_ARGS}
 
 ##@ Document

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -40,6 +40,7 @@ pub struct CKBAppConfig {
     pub logger: LogConfig,
     /// TODO(doc): @doitian
     #[cfg(feature = "with_sentry")]
+    #[serde(default)]
     pub sentry: SentryConfig,
     /// TODO(doc): @doitian
     #[serde(default)]

--- a/util/app-config/src/sentry_config.rs
+++ b/util/app-config/src/sentry_config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct SentryConfig {
     pub dsn: String,
     pub org_ident: Option<String>,


### PR DESCRIPTION
After https://github.com/nervosnetwork/ckb/pull/2351, integration test cannot run for ckb which builds with `--features with_sentry`.