### PR TITLE
chore: use blake2b-ref for wasm and upgrade secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake2b-ref"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95916998c798756098a4eb1b3f2cd510659705a9817bf203d61abd30fbec3e7b"
+
+[[package]]
 name = "blake2b-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +563,7 @@ dependencies = [
  "faster-hex 0.4.1",
  "lazy_static",
  "rand 0.6.5",
- "secp256k1",
+ "secp256k1 0.19.0",
 ]
 
 [[package]]
@@ -666,6 +672,7 @@ dependencies = [
 name = "ckb-hash"
 version = "0.39.0-pre"
 dependencies = [
+ "blake2b-ref",
  "blake2b-rs",
 ]
 
@@ -854,7 +861,7 @@ dependencies = [
  "num_cpus",
  "proptest",
  "rand 0.6.5",
- "secp256k1",
+ "secp256k1 0.19.0",
  "sentry",
  "serde",
  "serde_json",
@@ -4278,7 +4285,16 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.1.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+dependencies = [
+ "secp256k1-sys 0.3.0",
 ]
 
 [[package]]
@@ -4286,6 +4302,15 @@ name = "secp256k1-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
 dependencies = [
  "cc",
 ]
@@ -4717,7 +4742,7 @@ dependencies = [
  "openssl-sys",
  "rand 0.7.0",
  "ring",
- "secp256k1",
+ "secp256k1 0.17.2",
  "sha2 0.9.1",
  "tokio 0.2.23",
  "tokio-util",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -25,7 +25,7 @@ bs58 = "0.3.0"
 sentry = { version = "0.17.0", optional = true }
 faster-hex = "0.4"
 ckb-hash = {path = "../util/hash", version = "= 0.39.0-pre"}
-secp256k1 = {version = "0.17", features = ["recovery"] }
+secp256k1 = {version = "0.19", features = ["recovery"] }
 trust-dns-resolver = { version = "0.19" }
 num_cpus = "1.10"
 snap = "1"

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.39.0-pre" }
 lazy_static = "1.3"
-secp256k1 = { version = "0.17", features = ["recovery"], optional = true }
+secp256k1 = { version = "0.19", features = ["recovery"], optional = true }
 failure = "0.1.5"
 rand = "0.6"
 faster-hex = "0.4"

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -8,5 +8,8 @@ description = "TODO(doc): @doitian crate description"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
-[dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 blake2b-rs = "0.1.5"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+blake2b-ref = "0.2.0"

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -6,6 +6,9 @@
 //! * personalization: ckb-default-hash
 //!
 //! [blake2b]: https://blake2.net/blake2.pdf
+#[cfg(target_arch = "wasm32")]
+pub use blake2b_ref::{Blake2b, Blake2bBuilder};
+#[cfg(not(target_arch = "wasm32"))]
 pub use blake2b_rs::{Blake2b, Blake2bBuilder};
 
 #[doc(hidden)]


### PR DESCRIPTION
This PR use https://github.com/jjyr/blake2b-ref.rs in wasm32 target and upgrade secp256k1 (https://github.com/rust-bitcoin/rust-secp256k1/pull/208), make it easy to compile to wasm32 on MacOS