### PR TITLE
refactor: replace `failure` by `thiserror` and `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,11 +558,11 @@ name = "ckb-crypto"
 version = "0.39.0-pre"
 dependencies = [
  "ckb-fixed-hash",
- "failure",
  "faster-hex 0.4.1",
  "lazy_static",
  "rand 0.6.5",
  "secp256k1",
+ "thiserror",
 ]
 
 [[package]]
@@ -651,9 +651,9 @@ dependencies = [
 name = "ckb-fixed-hash-core"
 version = "0.39.0-pre"
 dependencies = [
- "failure",
  "faster-hex 0.4.1",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -807,6 +807,7 @@ version = "0.39.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-channel",
+ "ckb-error",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-logger",
@@ -815,7 +816,6 @@ dependencies = [
  "ckb-types",
  "console",
  "eaglesong",
- "failure",
  "futures 0.1.29",
  "hyper 0.12.35",
  "hyper-tls",
@@ -831,8 +831,8 @@ name = "ckb-multisig"
 version = "0.39.0-pre"
 dependencies = [
  "ckb-crypto",
+ "ckb-error",
  "ckb-logger",
- "failure",
  "rand 0.6.5",
 ]
 
@@ -876,6 +876,7 @@ version = "0.39.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-crypto",
+ "ckb-error",
  "ckb-jsonrpc-types",
  "ckb-logger",
  "ckb-multisig",
@@ -883,7 +884,6 @@ dependencies = [
  "ckb-notify",
  "ckb-types",
  "ckb-util",
- "failure",
  "faketime",
  "lru",
  "semver",
@@ -1169,7 +1169,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
- "failure",
  "faketime",
  "futures 0.3.8",
  "lru",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,7 +542,6 @@ dependencies = [
  "ckb-rational",
  "ckb-resource",
  "ckb-types",
- "failure",
  "serde",
  "toml",
 ]
@@ -582,8 +587,6 @@ dependencies = [
  "byteorder",
  "ckb-error",
  "ckb-types",
- "derive_more",
- "failure",
 ]
 
 [[package]]
@@ -621,9 +624,10 @@ version = "0.39.0-pre"
 name = "ckb-error"
 version = "0.39.0-pre"
 dependencies = [
+ "anyhow",
  "ckb-occupied-capacity",
  "derive_more",
- "failure",
+ "thiserror",
 ]
 
 [[package]]
@@ -1021,7 +1025,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
- "failure",
  "faketime",
  "futures 0.1.29",
  "jsonrpc-core",
@@ -1064,7 +1067,6 @@ dependencies = [
  "ckb-types",
  "ckb-vm",
  "ckb-vm-definitions",
- "failure",
  "faster-hex 0.4.1",
  "goblin",
  "proptest",
@@ -1234,7 +1236,6 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
- "failure",
  "faketime",
  "lru",
  "tokio 0.2.23",
@@ -1252,7 +1253,6 @@ dependencies = [
  "ckb-hash",
  "ckb-occupied-capacity",
  "ckb-rational",
- "failure",
  "merkle-cbt",
  "molecule",
  "numext-fixed-uint",
@@ -1291,7 +1291,6 @@ dependencies = [
  "ckb-traits",
  "ckb-types",
  "derive_more",
- "failure",
  "faketime",
  "lru",
  "rand 0.6.5",
@@ -4766,18 +4765,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -72,7 +72,7 @@ impl ChainController {
     ) -> Result<bool, Error> {
         Request::call(&self.process_block_sender, (block, switch)).unwrap_or_else(|| {
             Err(InternalErrorKind::System
-                .reason("Chain service has gone")
+                .other("Chain service has gone")
                 .into())
         })
     }
@@ -83,7 +83,7 @@ impl ChainController {
     pub fn truncate(&self, target_tip_hash: Byte32) -> Result<(), Error> {
         Request::call(&self.truncate_sender, target_tip_hash).unwrap_or_else(|| {
             Err(InternalErrorKind::System
-                .reason("Chain service has gone")
+                .other("Chain service has gone")
                 .into())
         })
     }

--- a/db-migration/src/lib.rs
+++ b/db-migration/src/lib.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 fn internal_error(reason: String) -> Error {
-    InternalErrorKind::Database.reason(reason).into()
+    InternalErrorKind::Database.other(reason).into()
 }
 
 /// TODO(doc): @quake

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -4,8 +4,7 @@
 //! which provides key-value store interface
 
 use ckb_error::{Error, InternalErrorKind};
-use std::fmt::{Debug, Display};
-use std::result;
+use std::{fmt, result};
 
 pub mod db;
 pub mod iter;
@@ -25,6 +24,6 @@ pub use rocksdb::{
 /// The type returned by database methods.
 pub type Result<T> = result::Result<T, Error>;
 
-fn internal_error<S: Display + Debug + Sync + Send + 'static>(reason: S) -> Error {
-    InternalErrorKind::Database.reason(reason).into()
+fn internal_error<S: fmt::Display>(reason: S) -> Error {
+    InternalErrorKind::Database.other(reason).into()
 }

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -8,9 +8,8 @@ description = "TODO(doc): @keroro520 crate description"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-failure = "0.1.5"
+thiserror = "1.0.22"
+anyhow = "1.0.34"
 ckb-occupied-capacity = { path = "../util/occupied-capacity", version = "= 0.39.0-pre" }
 derive_more = { version = "0.99.0", default-features = false, features = ["display"] }

--- a/error/src/convert.rs
+++ b/error/src/convert.rs
@@ -1,13 +1,11 @@
-use crate::{Error, InternalError, InternalErrorKind};
+use crate::{
+    impl_error_conversion_with_adaptor, impl_error_conversion_with_kind, Error, InternalError,
+    InternalErrorKind,
+};
 
-impl From<ckb_occupied_capacity::Error> for InternalError {
-    fn from(_error: ckb_occupied_capacity::Error) -> Self {
-        InternalErrorKind::CapacityOverflow.into()
-    }
-}
-
-impl From<ckb_occupied_capacity::Error> for Error {
-    fn from(_error: ckb_occupied_capacity::Error) -> Self {
-        InternalErrorKind::CapacityOverflow.into()
-    }
-}
+impl_error_conversion_with_kind!(
+    ckb_occupied_capacity::Error,
+    InternalErrorKind::CapacityOverflow,
+    InternalError
+);
+impl_error_conversion_with_adaptor!(ckb_occupied_capacity::Error, InternalError, Error);

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1,12 +1,13 @@
 //! TODO(doc): @keroro520
 mod convert;
 mod internal;
+pub mod prelude;
 pub mod util;
 
+pub use anyhow::Error as AnyError;
 use derive_more::Display;
-use failure::{Backtrace, Context, Fail};
-pub use internal::{InternalError, InternalErrorKind};
-use std::fmt;
+pub use internal::{InternalError, InternalErrorKind, OtherError, SilentError};
+use prelude::*;
 
 /// TODO(doc): @keroro520
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Display)]
@@ -31,55 +32,4 @@ pub enum ErrorKind {
     Spec,
 }
 
-/// TODO(doc): @keroro520
-#[derive(Debug)]
-pub struct Error {
-    kind: Context<ErrorKind>,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(cause) = self.cause() {
-            if f.alternate() {
-                write!(f, "{}: {}", self.kind(), cause)
-            } else {
-                write!(f, "{}({})", self.kind(), cause)
-            }
-        } else {
-            write!(f, "{}", self.kind())
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Self {
-        Self { kind: inner }
-    }
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.kind.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.kind.backtrace()
-    }
-}
-
-impl Error {
-    /// TODO(doc): @keroro520
-    pub fn kind(&self) -> &ErrorKind {
-        self.kind.get_context()
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
-        self.cause().and_then(|cause| cause.downcast_ref::<T>())
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn unwrap_cause_or_self(&self) -> &dyn Fail {
-        self.cause().unwrap_or(self)
-    }
-}
+def_error_base_on_kind!(Error, ErrorKind);

--- a/error/src/prelude.rs
+++ b/error/src/prelude.rs
@@ -1,0 +1,5 @@
+//! This module includes several traits.
+//!
+//! Few traits are re-exported from other crates.
+
+pub use thiserror::{self, Error};

--- a/error/src/util.rs
+++ b/error/src/util.rs
@@ -52,10 +52,10 @@ macro_rules! impl_error_conversion_with_adaptor {
 macro_rules! def_error_base_on_kind {
     ($error:ident, $error_kind:ty, $comment_error:expr, $comment_because:expr, $comment_simple:expr) => {
         #[doc = $comment_error]
-        #[derive(Error, Debug)]
+        #[derive(Error, Debug, Clone)]
         pub struct $error {
             kind: $error_kind,
-            source: $crate::AnyError,
+            inner: $crate::AnyError,
         }
 
         impl ::std::fmt::Display for $error {
@@ -86,7 +86,7 @@ macro_rules! def_error_base_on_kind {
             {
                 $error {
                     kind: self,
-                    source: reason.into(),
+                    inner: reason.into(),
                 }
             }
 
@@ -97,7 +97,7 @@ macro_rules! def_error_base_on_kind {
             {
                 $error {
                     kind: self,
-                    source: $crate::OtherError::new(reason.to_string()).into(),
+                    inner: $crate::OtherError::new(reason.to_string()).into(),
                 }
             }
         }
@@ -108,30 +108,22 @@ macro_rules! def_error_base_on_kind {
                 self.kind
             }
 
-            /// Attempt to downcast the error object to a concrete type.
-            pub fn downcast<E>(self) -> Result<E, $crate::AnyError>
-            where
-                E: ::std::fmt::Display + ::std::fmt::Debug + Send + Sync + 'static,
-            {
-                self.source.downcast::<E>()
-            }
-
             /// Downcast this error object by reference.
             pub fn downcast_ref<E>(&self) -> Option<&E>
             where
                 E: ::std::fmt::Display + ::std::fmt::Debug + Send + Sync + 'static,
             {
-                self.source.downcast_ref::<E>()
+                self.inner.downcast_ref::<E>()
             }
 
             /// The lowest level cause of this error — this error's cause's cause's cause etc.
             pub fn root_cause(&self) -> &(dyn ::std::error::Error + 'static) {
-                self.source.root_cause()
+                self.inner.root_cause()
             }
 
             /// The lower-level source of this error, if any.
             pub fn cause(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
-                self.source.chain().next()
+                self.inner.chain().next()
             }
         }
     };

--- a/error/src/util.rs
+++ b/error/src/util.rs
@@ -29,7 +29,7 @@ macro_rules! impl_error_conversion_with_kind {
     ($source:ty, $kind:expr, $target:ty) => {
         impl ::std::convert::From<$source> for $target {
             fn from(error: $source) -> Self {
-                error.context($kind).into()
+                $kind.because(error)
             }
         }
     };
@@ -44,5 +44,111 @@ macro_rules! impl_error_conversion_with_adaptor {
                 ::std::convert::Into::<$adaptor>::into(error).into()
             }
         }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! def_error_base_on_kind {
+    ($error:ident, $error_kind:ty, $comment_error:expr, $comment_because:expr, $comment_simple:expr) => {
+        #[doc = $comment_error]
+        #[derive(Error, Debug)]
+        pub struct $error {
+            kind: $error_kind,
+            source: $crate::AnyError,
+        }
+
+        impl ::std::fmt::Display for $error {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                if let Some(err) = self.cause() {
+                    if f.alternate() {
+                        write!(f, "{}: {}", self.kind(), err)
+                    } else {
+                        write!(f, "{}({})", self.kind(), err)
+                    }
+                } else {
+                    write!(f, "{}", self.kind())
+                }
+            }
+        }
+
+        impl ::std::convert::From<$error_kind> for $error {
+            fn from(kind: $error_kind) -> Self {
+                kind.because($crate::SilentError)
+            }
+        }
+
+        impl $error_kind {
+            #[doc = $comment_because]
+            pub fn because<E>(self, reason: E) -> $error
+            where
+                E: ::std::error::Error + Send + Sync + 'static,
+            {
+                $error {
+                    kind: self,
+                    source: reason.into(),
+                }
+            }
+
+            #[doc = $comment_simple]
+            pub fn other<T>(self, reason: T) -> $error
+            where
+                T: ::std::fmt::Display,
+            {
+                $error {
+                    kind: self,
+                    source: $crate::OtherError::new(reason.to_string()).into(),
+                }
+            }
+        }
+
+        impl $error {
+            /// Returns the general category of this error.
+            pub fn kind(&self) -> $error_kind {
+                self.kind
+            }
+
+            /// Attempt to downcast the error object to a concrete type.
+            pub fn downcast<E>(self) -> Result<E, $crate::AnyError>
+            where
+                E: ::std::fmt::Display + ::std::fmt::Debug + Send + Sync + 'static,
+            {
+                self.source.downcast::<E>()
+            }
+
+            /// Downcast this error object by reference.
+            pub fn downcast_ref<E>(&self) -> Option<&E>
+            where
+                E: ::std::fmt::Display + ::std::fmt::Debug + Send + Sync + 'static,
+            {
+                self.source.downcast_ref::<E>()
+            }
+
+            /// The lowest level cause of this error — this error's cause's cause's cause etc.
+            pub fn root_cause(&self) -> &(dyn ::std::error::Error + 'static) {
+                self.source.root_cause()
+            }
+
+            /// The lower-level source of this error, if any.
+            pub fn cause(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+                self.source.chain().next()
+            }
+        }
+    };
+    ($error:ident, $error_kind:ty, $comment_error:expr) => {
+        def_error_base_on_kind!(
+            $error,
+            $error_kind,
+            $comment_error,
+            concat!("Creates `", stringify!($error), "` base on `", stringify!($error_kind), "` with an error as the reason."),
+            concat!("Creates `", stringify!($error), "` base on `", stringify!($error_kind), "` with a simple string as the reason.")
+        );
+    };
+    ($error:ident, $error_kind:ty) => {
+        def_error_base_on_kind!(
+            $error,
+            $error_kind,
+            "/// TODO(doc): @keroro520"
+        );
     };
 }

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -24,7 +24,7 @@ hyper-tls = "0.3"
 futures = "0.1"
 lru = "0.6.0"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.39.0-pre" }
-failure = "0.1.5"
+ckb-error = { path = "../error", version = "= 0.39.0-pre" }
 indicatif = "0.15"
 console = "0.13.0"
 eaglesong = "0.1"

--- a/miner/src/client.rs
+++ b/miner/src/client.rs
@@ -1,6 +1,7 @@
 use crate::Work;
 use ckb_app_config::MinerClientConfig;
 use ckb_channel::Sender;
+use ckb_error::AnyError;
 use ckb_jsonrpc_types::{
     error::Error as RpcFail, error::ErrorCode as RpcFailCode, id::Id, params::Params,
     request::MethodCall, response::Output, version::Version, Block as JsonBlock, BlockTemplate,
@@ -8,7 +9,6 @@ use ckb_jsonrpc_types::{
 use ckb_logger::{debug, error, warn};
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_types::{packed::Block, H256};
-use failure::Error;
 use futures::sync::{mpsc, oneshot};
 use hyper::error::Error as HyperError;
 use hyper::header::{HeaderValue, CONTENT_TYPE};
@@ -210,7 +210,7 @@ impl Client {
         self.rpc.request(method, params).and_then(parse_response)
     }
 
-    fn notify_new_work(&self, block_template: BlockTemplate) -> Result<(), Error> {
+    fn notify_new_work(&self, block_template: BlockTemplate) -> Result<(), AnyError> {
         let work: Work = block_template.into();
         self.new_work_tx.send(work)?;
         Ok(())

--- a/miner/src/error.rs
+++ b/miner/src/error.rs
@@ -1,15 +1,15 @@
-use failure::Fail;
+use ckb_error::prelude::*;
 
 /// TODO(doc): @quake
-#[derive(Debug, PartialEq, Clone, Eq, Fail)]
+#[derive(Error, Debug, PartialEq, Clone, Eq)]
 pub enum Error {
     /// TODO(doc): @quake
-    #[fail(display = "InvalidInput")]
+    #[error("InvalidInput")]
     InvalidInput,
     /// TODO(doc): @quake
-    #[fail(display = "InvalidOutput")]
+    #[error("InvalidOutput")]
     InvalidOutput,
     /// TODO(doc): @quake
-    #[fail(display = "InvalidParams {}", _0)]
+    #[error("InvalidParams {0}")]
     InvalidParams(String),
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,7 +45,6 @@ ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.39.
 ckb-tx-pool = { path = "../tx-pool", version = "= 0.39.0-pre" }
 ckb-script = { path = "../script", version = "= 0.39.0-pre" }
 ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 
 [dev-dependencies]
 reqwest = "0.9.16"

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -206,9 +206,9 @@ impl RPCError {
 
     /// TODO(doc): @doitian
     pub fn from_any_error(err: AnyError) -> Error {
-        match err.downcast::<CKBError>() {
-            Ok(ckb_error) => Self::from_ckb_error(ckb_error),
-            Err(err) => Self::ckb_internal_error(err),
+        match err.downcast_ref::<CKBError>() {
+            Some(ckb_error) => Self::from_ckb_error(ckb_error.clone()),
+            None => Self::ckb_internal_error(err.clone()),
         }
     }
 

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,4 +1,4 @@
-use ckb_error::{Error as CKBError, ErrorKind, InternalError, InternalErrorKind};
+use ckb_error::{AnyError, Error as CKBError, ErrorKind, InternalError, InternalErrorKind};
 use ckb_tx_pool::error::Reject;
 use jsonrpc_core::{Error, ErrorCode, Value};
 use std::fmt::{Debug, Display};
@@ -177,16 +177,13 @@ impl RPCError {
     /// TODO(doc): @doitian
     pub fn from_ckb_error(err: CKBError) -> Error {
         match err.kind() {
-            ErrorKind::Dao => {
-                Self::custom_with_error(RPCError::DaoError, err.unwrap_cause_or_self())
-            }
+            ErrorKind::Dao => Self::custom_with_error(RPCError::DaoError, err.root_cause()),
             ErrorKind::OutPoint => {
                 Self::custom_with_error(RPCError::TransactionFailedToResolve, err)
             }
-            ErrorKind::Transaction => Self::custom_with_error(
-                RPCError::TransactionFailedToVerify,
-                err.unwrap_cause_or_self(),
-            ),
+            ErrorKind::Transaction => {
+                Self::custom_with_error(RPCError::TransactionFailedToVerify, err.root_cause())
+            }
             ErrorKind::Internal => {
                 let internal_err = match err.downcast_ref::<InternalError>() {
                     Some(err) => err,
@@ -208,7 +205,7 @@ impl RPCError {
     }
 
     /// TODO(doc): @doitian
-    pub fn from_failure_error(err: failure::Error) -> Error {
+    pub fn from_any_error(err: AnyError) -> Error {
         match err.downcast::<CKBError>() {
             Ok(ckb_error) => Self::from_ckb_error(ckb_error),
             Err(err) => Self::ckb_internal_error(err),

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -254,7 +254,7 @@ impl MinerRpc for MinerRpcImpl {
             })?
             .map_err(|err| {
                 error!("get_block_template result error {}", err);
-                RPCError::from_failure_error(err)
+                RPCError::from_any_error(err)
             })
     }
 

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -26,7 +26,6 @@ faster-hex = "0.4"
 ckb-logger = { path = "../util/logger", version = "= 0.39.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 ckb-error = { path = "../error", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 ckb-chain-spec = { path = "../spec", version = "= 0.39.0-pre" }
 goblin = "0.2"
 ckb-vm-definitions = "0.19.1"

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -49,7 +49,7 @@ impl Shared {
         let (tip_header, epoch) = Self::init_store(&store, &consensus)?;
         let total_difficulty = store
             .get_block_ext(&tip_header.hash())
-            .ok_or_else(|| InternalErrorKind::Database.reason("failed to get tip's block_ext"))?
+            .ok_or_else(|| InternalErrorKind::Database.other("failed to get tip's block_ext"))?
             .total_difficulty;
         let (proposal_table, proposal_view) = Self::init_proposal_table(&store, &consensus);
 
@@ -143,7 +143,7 @@ impl Shared {
                     }
                 } else {
                     Err(InternalErrorKind::Database
-                        .reason("genesis does not exist in database")
+                        .other("genesis does not exist in database")
                         .into())
                 }
             }

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -19,5 +19,4 @@ ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.39.0-pre" }
 ckb-rational = { path = "../util/rational", version = "= 0.39.0-pre" }
 ckb-crypto = { path = "../util/crypto", version = "= 0.39.0-pre"}
 ckb-hash = { path = "../util/hash", version = "= 0.39.0-pre"}
-failure = "0.1.5"
 ckb-error = { path = "../error", version = "= 0.39.0-pre" }

--- a/spec/src/error.rs
+++ b/spec/src/error.rs
@@ -1,23 +1,19 @@
-use ckb_error::{Error, ErrorKind};
+use ckb_error::{prelude::*, Error, ErrorKind};
 use ckb_types::packed::Byte32;
-use failure::Fail;
 
 /// The error type for Spec operations
-#[derive(Fail, Debug, Clone, Eq, PartialEq)]
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum SpecError {
     /// The file not found
-    #[fail(display = "FileNotFound")]
+    #[error("FileNotFound")]
     FileNotFound(String),
 
     /// The specified chain name is reserved.
-    #[fail(display = "ChainNameNotAllowed: {}", _0)]
+    #[error("ChainNameNotAllowed: {0}")]
     ChainNameNotAllowed(String),
 
     /// The actual calculated genesis hash is not match with provided
-    #[fail(
-        display = "GenesisMismatch(expected: {}, actual: {})",
-        expected, actual
-    )]
+    #[error("GenesisMismatch(expected: {expected}, actual: {actual})")]
     GenesisMismatch {
         /// The provided expected hash
         expected: Byte32,
@@ -28,6 +24,6 @@ pub enum SpecError {
 
 impl From<SpecError> for Error {
     fn from(error: SpecError) -> Self {
-        error.context(ErrorKind::Spec).into()
+        ErrorKind::Spec.because(error)
     }
 }

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -25,7 +25,6 @@ ckb-verification = { path = "../verification", version = "= 0.39.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.39.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.39.0-pre" }
 ckb-traits = { path = "../traits", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 lru = "0.6.0"
 sentry = { version = "0.17.0", optional = true }
 futures = "0.3"

--- a/sync/src/relayer/transactions_process.rs
+++ b/sync/src/relayer/transactions_process.rs
@@ -212,7 +212,7 @@ fn is_malformed(error: &Error) -> bool {
                 .downcast_ref::<InternalError>()
                 .expect("error kind checked")
                 .kind()
-                == &InternalErrorKind::CapacityOverflow
+                == InternalErrorKind::CapacityOverflow
         }
         _ => false,
     }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use ckb_chain::chain::ChainController;
 use ckb_channel as channel;
+use ckb_error::AnyError;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_metrics::metrics;
 use ckb_network::{
@@ -30,7 +31,6 @@ use ckb_types::{
     packed::{self, Byte32},
     prelude::*,
 };
-use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use std::{
     collections::HashSet,
@@ -301,7 +301,7 @@ impl Synchronizer {
 
     /// TODO(doc): @driftluo
     //TODO: process block which we don't request
-    pub fn process_new_block(&self, block: core::BlockView) -> Result<bool, FailureError> {
+    pub fn process_new_block(&self, block: core::BlockView) -> Result<bool, AnyError> {
         let block_hash = block.hash();
         let status = self.shared.active_chain().get_block_status(&block_hash);
         // NOTE: Filtering `BLOCK_STORED` but not `BLOCK_RECEIVED`, is for avoiding

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 use ckb_app_config::SyncConfig;
 use ckb_chain::{chain::ChainController, switch::Switch};
 use ckb_chain_spec::consensus::Consensus;
+use ckb_error::AnyError;
 use ckb_logger::{debug, debug_target, error, trace};
 use ckb_metrics::{metrics, Timer};
 use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
@@ -26,7 +27,6 @@ use ckb_util::LinkedHashSet;
 use ckb_util::{Mutex, MutexGuard};
 use ckb_util::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use ckb_verification::HeaderResolverWrapper;
-use failure::Error as FailureError;
 use faketime::unix_time_as_millis;
 use lru::LruCache;
 use std::cmp;
@@ -1268,7 +1268,7 @@ impl SyncShared {
         &self,
         chain: &ChainController,
         block: Arc<core::BlockView>,
-    ) -> Result<bool, FailureError> {
+    ) -> Result<bool, AnyError> {
         // Insert the given block into orphan_block_pool if its parent is not found
         if !self.is_parent_stored(&block) {
             debug!(
@@ -1329,7 +1329,7 @@ impl SyncShared {
         &self,
         chain: &ChainController,
         block: Arc<core::BlockView>,
-    ) -> Result<bool, FailureError> {
+    ) -> Result<bool, AnyError> {
         let ret = {
             let mut assume_valid_target = self.state.assume_valid_target();
             if let Some(ref target) = *assume_valid_target {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -28,13 +28,13 @@ ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.39.0-
 ckb-resource = { path = "../resource", version = "= 0.39.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.39.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.39.0-pre" }
+ckb-error = { path = "../error", version = "= 0.39.0-pre" }
 tempfile = "3.0"
 reqwest = "0.9"
 rand = "0.6"
 log = "0.4"
 env_logger = "0.6"
 faketime = "0.2"
-failure = "0.1.5"
 serde_json = "1.0"
 lazy_static = "1.4.0"
 byteorder = "1.3.1"

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -3,6 +3,7 @@ mod id_generator;
 mod macros;
 mod error;
 
+use ckb_error::AnyError;
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockReward, BlockTemplate,
     BlockView, Capacity, CellOutputWithOutPoint, CellTransaction, CellWithStatus, ChainInfo, Cycle,
@@ -15,7 +16,6 @@ use ckb_types::core::{
     Version as CoreVersion,
 };
 use ckb_types::{packed::Byte32, prelude::*, H256};
-use failure::Error;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -169,7 +169,7 @@ impl RpcClient {
             .expect("rpc call get_block_template")
     }
 
-    pub fn submit_block(&self, work_id: String, block: Block) -> Result<Byte32, Error> {
+    pub fn submit_block(&self, work_id: String, block: Block) -> Result<Byte32, AnyError> {
         self.inner.submit_block(work_id, block).map(|x| x.pack())
     }
 
@@ -185,7 +185,7 @@ impl RpcClient {
             .pack()
     }
 
-    pub fn send_transaction_result(&self, tx: Transaction) -> Result<H256, Error> {
+    pub fn send_transaction_result(&self, tx: Transaction) -> Result<H256, AnyError> {
         self.inner
             .send_transaction(tx, Some("passthrough".to_string()))
     }
@@ -196,7 +196,7 @@ impl RpcClient {
             .expect("rpc call dry_run_transaction")
     }
 
-    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> Result<H256, Error> {
+    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> Result<H256, AnyError> {
         self.inner.broadcast_transaction(tx, cycles)
     }
 

--- a/test/src/rpc/macros.rs
+++ b/test/src/rpc/macros.rs
@@ -24,7 +24,7 @@ macro_rules! jsonrpc {
 
             $(
                 $(#[$attr])*
-                pub fn $method(&$selff $(, $arg_name: $arg_ty)*) -> Result<$return_ty, failure::Error> {
+                pub fn $method(&$selff $(, $arg_name: $arg_ty)*) -> Result<$return_ty, ckb_error::AnyError> {
                     let method = String::from(stringify!($method));
                     let params = serialize_parameters!($($arg_name,)*);
                     let id = $selff.id_generator.next();

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -10,9 +10,9 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use failure::_core::time::Duration;
 use log::info;
 use std::thread::sleep;
+use std::time::Duration;
 
 pub struct ChainFork1;
 

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-types = { path = "../util/types", version = "= 0.39.0-pre" }
 ckb-logger = {path = "../util/logger", version = "= 0.39.0-pre"}
 ckb-verification = { path = "../verification", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 faketime = "0.2"
 lru = "0.6.0"
 ckb-dao = { path = "../util/dao", version = "= 0.39.0-pre" }

--- a/tx-pool/src/error.rs
+++ b/tx-pool/src/error.rs
@@ -1,69 +1,68 @@
 //! The error type for Tx-pool operations
 
-use ckb_error::{Error, ErrorKind};
+use ckb_error::{
+    impl_error_conversion_with_adaptor, impl_error_conversion_with_kind, prelude::*, Error,
+    ErrorKind, InternalError, InternalErrorKind, OtherError,
+};
 use ckb_fee_estimator::FeeRate;
 use ckb_types::packed::Byte32;
-use failure::Fail;
-use tokio::sync::mpsc::error::TrySendError as TokioTrySendError;
+use tokio::sync::{mpsc::error::TrySendError, oneshot::error::RecvError};
 
 /// TX reject message
-#[derive(Debug, PartialEq, Clone, Eq, Fail)]
+#[derive(Error, Debug, PartialEq, Clone, Eq)]
 pub enum Reject {
     /// Transaction fee lower than config
-    #[fail(
-        display = "The min fee rate is {} shannons/KB, so the transaction fee should be {} shannons at least, but only got {}",
-        _0, _1, _2
-    )]
+    #[error("The min fee rate is {0} shannons/KB, so the transaction fee should be {1} shannons at least, but only got {2}")]
     LowFeeRate(FeeRate, u64, u64),
 
     /// Transaction exceeded maximum ancestors count limit
-    #[fail(display = "Transaction exceeded maximum ancestors count limit, try send it later")]
+    #[error("Transaction exceeded maximum ancestors count limit, try send it later")]
     ExceededMaximumAncestorsCount,
 
     /// Transaction pool exceeded maximum size or cycles limit,
-    #[fail(
-        display = "Transaction pool exceeded maximum {} limit({}), try send it later",
-        _0, _1
-    )]
+    #[error("Transaction pool exceeded maximum {0} limit({1}), try send it later")]
     Full(String, u64),
 
     /// Transaction already exist in transaction_pool
-    #[fail(display = "Transaction({}) already exist in transaction_pool", _0)]
+    #[error("Transaction({0}) already exist in transaction_pool")]
     Duplicated(Byte32),
 
     /// Malformed transaction
-    #[fail(display = "Malformed {} transaction", _0)]
+    #[error("Malformed {0} transaction")]
     Malformed(String),
 }
 
-impl From<Reject> for Error {
-    fn from(error: Reject) -> Self {
-        error.context(ErrorKind::SubmitTransaction).into()
-    }
-}
+impl_error_conversion_with_kind!(Reject, ErrorKind::SubmitTransaction, Error);
 
 /// The error type for block assemble related
-#[derive(Debug, PartialEq, Clone, Eq, Fail)]
+#[derive(Error, Debug, PartialEq, Clone, Eq)]
 pub enum BlockAssemblerError {
     /// Input is invalid
-    #[fail(display = "InvalidInput")]
+    #[error("InvalidInput")]
     InvalidInput,
     /// Parameters is invalid
-    #[fail(display = "InvalidParams {}", _0)]
+    #[error("InvalidParams {0}")]
     InvalidParams(String),
     /// BlockAssembler is disabled
-    #[fail(display = "Disabled")]
+    #[error("Disabled")]
     Disabled,
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "TrySendError {}.", _0)]
-pub(crate) struct TrySendError(String);
+impl_error_conversion_with_kind!(
+    BlockAssemblerError,
+    InternalErrorKind::BlockAssembler,
+    InternalError
+);
+impl_error_conversion_with_adaptor!(BlockAssemblerError, InternalError, Error);
 
-pub(crate) fn handle_try_send_error<T>(error: TokioTrySendError<T>) -> (T, TrySendError) {
-    let e = TrySendError(format!("{}", error));
+pub(crate) fn handle_try_send_error<T>(error: TrySendError<T>) -> (T, OtherError) {
+    let e = OtherError::new(format!("TrySendError {}", error));
     let m = match error {
-        TokioTrySendError::Full(t) | TokioTrySendError::Closed(t) => t,
+        TrySendError::Full(t) | TrySendError::Closed(t) => t,
     };
     (m, e)
+}
+
+pub(crate) fn handle_recv_error(error: RecvError) -> OtherError {
+    OtherError::new(format!("RecvError {}", error))
 }

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.39.0-pre" }
 lazy_static = "1.3"
 secp256k1 = { version = "0.17", features = ["recovery"], optional = true }
-failure = "0.1.5"
+thiserror = "1.0.22"
 rand = "0.6"
 faster-hex = "0.4"
 

--- a/util/crypto/src/secp/error.rs
+++ b/util/crypto/src/secp/error.rs
@@ -1,26 +1,26 @@
-use failure::Fail;
 use secp256k1::Error as SecpError;
+use thiserror::Error;
 
 /// The error type wrap SecpError
-#[derive(Debug, PartialEq, Eq, Fail)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Invalid privkey
-    #[fail(display = "invalid privkey")]
+    #[error("invalid privkey")]
     InvalidPrivKey,
     /// Invalid pubkey
-    #[fail(display = "invalid pubkey")]
+    #[error("invalid pubkey")]
     InvalidPubKey,
     /// Invalid signature
-    #[fail(display = "invalid signature")]
+    #[error("invalid signature")]
     InvalidSignature,
     /// Invalid message
-    #[fail(display = "invalid message")]
+    #[error("invalid message")]
     InvalidMessage,
     /// Invalid recovery_id
-    #[fail(display = "invalid recovery_id")]
+    #[error("invalid recovery_id")]
     InvalidRecoveryId,
     /// Any error not part of this list.
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     Other(String),
 }
 

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -542,7 +542,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Internal(CapacityOverflow)"));
+            .contains("Internal(CapacityOverflow(OccupiedCapacity: overflow))"));
     }
 
     #[test]

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -12,5 +12,3 @@ repository = "https://github.com/nervosnetwork/ckb"
 byteorder = "1.3.1"
 ckb-types = { path = "../../types", version = "= 0.39.0-pre" }
 ckb-error = { path = "../../../error", version = "= 0.39.0-pre" }
-failure = "0.1.5"
-derive_more = { version = "0.99.0", default-features = false, features = ["display"] }

--- a/util/dao/utils/src/error.rs
+++ b/util/dao/utils/src/error.rs
@@ -1,24 +1,27 @@
-use ckb_error::{Error, ErrorKind};
-use derive_more::Display;
-use failure::Fail;
+use ckb_error::{prelude::*, Error, ErrorKind};
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Clone, Eq, Display)]
+#[derive(Error, Debug, PartialEq, Clone, Eq)]
 pub enum DaoError {
     /// TODO(doc): @keroro520
+    #[error("InvalidHeader")]
     InvalidHeader,
     /// TODO(doc): @keroro520
+    #[error("InvalidOutPoint")]
     InvalidOutPoint,
     /// TODO(doc): @keroro520
+    #[error("InvalidDaoFormat")]
     InvalidDaoFormat,
     /// TODO(doc): @keroro520
+    #[error("Overflow")]
     Overflow,
     /// TODO(doc): @keroro520
+    #[error("ZeroC")]
     ZeroC,
 }
 
 impl From<DaoError> for Error {
     fn from(error: DaoError) -> Self {
-        error.context(ErrorKind::Dao).into()
+        ErrorKind::Dao.because(error)
     }
 }

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -9,6 +9,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "1.0.22"
 serde = { version = "1.0", features = ["derive"] }
 faster-hex = "0.4"

--- a/util/fixed-hash/core/src/error.rs
+++ b/util/fixed-hash/core/src/error.rs
@@ -1,14 +1,14 @@
 //! Conversion errors.
 
-use failure::Fail;
+use thiserror::Error;
 
 /// The associated error of [`FromStr`] which can be returned from parsing a string.
 ///
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html#associatedtype.Err
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum FromStrError {
     /// Invalid character.
-    #[fail(display = "invalid character code `{}` at {}", chr, idx)]
+    #[error("invalid character code `{chr}` at {idx}")]
     InvalidCharacter {
         /// The value of the invalid character.
         chr: u8,
@@ -16,14 +16,14 @@ pub enum FromStrError {
         idx: usize,
     },
     /// Invalid length.
-    #[fail(display = "invalid length: {}", _0)]
+    #[error("invalid length: {0}")]
     InvalidLength(usize),
 }
 
 /// The error which can be returned when convert a byte slice back into a Hash.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum FromSliceError {
     /// Invalid length.
-    #[fail(display = "invalid length: {}", _0)]
+    #[error("invalid length: {0}")]
     InvalidLength(usize),
 }

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
+ckb-error = { path = "../../error", version = "= 0.39.0-pre" }
 ckb-logger = { path = "../logger", version = "= 0.39.0-pre" }
 ckb-crypto = { path = "../crypto", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/util/multisig/src/error.rs
+++ b/util/multisig/src/error.rs
@@ -1,23 +1,18 @@
 //! Multi-signature error.
-use failure::Context;
 
-/// Multi-signature error.
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
+use ckb_error::{def_error_base_on_kind, prelude::*};
 
 /// Multi-signature error kinds.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Error, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
     /// The count of signatures should be less than the count of private keys.
-    #[fail(display = "The count of sigs should less than pks.")]
+    #[error("The count of sigs should less than pks.")]
     SigCountOverflow,
     /// The count of signatures is less than the threshold.
-    #[fail(display = "The count of sigs less than threshold.")]
+    #[error("The count of sigs less than threshold.")]
     SigNotEnough,
     /// The verified signatures count is less than the threshold.
-    #[fail(display = "Failed to meet threshold {:?}.", _0)]
+    #[error("Failed to meet threshold {threshold}, actual: {pass_sigs}.")]
     Threshold {
         /// The required count of valid signatures.
         threshold: usize,
@@ -26,23 +21,4 @@ pub enum ErrorKind {
     },
 }
 
-impl Error {
-    /// Gets the error kind.
-    pub fn kind(&self) -> ErrorKind {
-        *self.inner.get_context()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
-}
+def_error_base_on_kind!(Error, ErrorKind, "Multi-signature error.");

--- a/util/multisig/src/lib.rs
+++ b/util/multisig/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! A m-of-n signature mechanism requires m valid signatures signed by m different keys from
 //! the pre-configured n keys.
-#[macro_use]
-extern crate failure;
 
 pub mod error;
 pub mod secp256k1;

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -17,8 +17,8 @@ ckb-notify = { path = "../../notify", version = "= 0.39.0-pre"}
 ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.39.0-pre" }
 ckb-logger = { path = "../logger", version = "= 0.39.0-pre"}
 ckb-app-config = { path = "../app-config", version = "= 0.39.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.39.0-pre" }
 faketime = "0.2.0"
-failure = "0.1.5"
 lru = "0.6"
 semver = "0.9"
 

--- a/util/network-alert/src/verifier.rs
+++ b/util/network-alert/src/verifier.rs
@@ -1,9 +1,9 @@
 //! TODO(doc): @driftluo
 use ckb_app_config::NetworkAlertConfig;
+use ckb_error::AnyError;
 use ckb_logger::{debug, trace};
 use ckb_multisig::secp256k1::{verify_m_of_n, Message, Pubkey, Signature};
 use ckb_types::{packed, prelude::*};
-use failure::Error;
 use std::collections::HashSet;
 
 /// TODO(doc): @driftluo
@@ -25,7 +25,7 @@ impl Verifier {
     }
 
     /// TODO(doc): @driftluo
-    pub fn verify_signatures(&self, alert: &packed::Alert) -> Result<(), Error> {
+    pub fn verify_signatures(&self, alert: &packed::Alert) -> Result<(), AnyError> {
         trace!("verify alert {:?}", alert);
         let message = Message::from_slice(alert.calc_alert_hash().as_slice())?;
         let signatures: Vec<Signature> = alert

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -18,7 +18,6 @@ ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.39.0-pre
 ckb-hash = { path = "../hash", version = "= 0.39.0-pre" }
 ckb-channel = { path = "../channel", version = "= 0.39.0-pre" }
 bit-vec = "0.5.1"
-failure = "0.1.5"
 ckb-error = { path = "../../error", version = "= 0.39.0-pre" }
 ckb-rational = { path = "../rational", version = "= 0.39.0-pre" }
 once_cell = "1.3.1"

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -1,4 +1,4 @@
-use failure::{err_msg, Error as FailureError};
+use ckb_error::OtherError;
 use std::convert::TryFrom;
 
 use crate::packed;
@@ -19,13 +19,13 @@ impl Default for ScriptHashType {
 }
 
 impl TryFrom<packed::Byte> for ScriptHashType {
-    type Error = FailureError;
+    type Error = OtherError;
 
     fn try_from(v: packed::Byte) -> Result<Self, Self::Error> {
         match Into::<u8>::into(v) {
             0 => Ok(ScriptHashType::Data),
             1 => Ok(ScriptHashType::Type),
-            _ => Err(err_msg(format!("Invalid script hash type {}", v))),
+            _ => Err(OtherError::new(format!("Invalid script hash type {}", v))),
         }
     }
 }
@@ -67,13 +67,13 @@ impl Default for DepType {
 }
 
 impl TryFrom<packed::Byte> for DepType {
-    type Error = FailureError;
+    type Error = OtherError;
 
     fn try_from(v: packed::Byte) -> Result<Self, Self::Error> {
         match Into::<u8>::into(v) {
             0 => Ok(DepType::Code),
             1 => Ok(DepType::DepGroup),
-            _ => Err(err_msg(format!("Invalid dep type {}", v))),
+            _ => Err(OtherError::new(format!("Invalid dep type {}", v))),
         }
     }
 }

--- a/util/types/src/core/error.rs
+++ b/util/types/src/core/error.rs
@@ -1,43 +1,42 @@
 //! TODO(doc): @keroro520
 
 use crate::generated::packed::{Byte32, OutPoint};
-use ckb_error::{Error, ErrorKind};
-use failure::Fail;
+use ckb_error::{prelude::*, Error, ErrorKind};
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum OutPointError {
     /// The specified cell is already dead
-    #[fail(display = "Dead({:?})", _0)]
+    #[error("Dead({0:?})")]
     Dead(OutPoint),
 
     /// The specified cells is unknown in the chain
-    #[fail(display = "Unknown({:?})", _0)]
+    #[error("Unknown({0:?})")]
     Unknown(Vec<OutPoint>),
 
     /// Input or dep cell reference to a newer cell in the same block
     // TODO: Maybe replace with `UnknownInputCell`?
-    #[fail(display = "OutOfOrder({:?})", _0)]
+    #[error("OutOfOrder({0:?})")]
     OutOfOrder(OutPoint),
 
     /// The output is referenced as a dep-group output, but the data
     /// is invalid format
-    #[fail(display = "InvalidDepGroup({:?})", _0)]
+    #[error("InvalidDepGroup({0:?})")]
     InvalidDepGroup(OutPoint),
 
     // TODO: This error should be move into HeaderError or TransactionError
     /// TODO(doc): @keroro520
-    #[fail(display = "InvalidHeader({})", _0)]
+    #[error("InvalidHeader({0})")]
     InvalidHeader(Byte32),
 
     // TODO: This error should be move into HeaderError or TransactionError
     /// TODO(doc): @keroro520
-    #[fail(display = "ImmatureHeader({})", _0)]
+    #[error("ImmatureHeader({0})")]
     ImmatureHeader(Byte32),
 }
 
 impl From<OutPointError> for Error {
     fn from(error: OutPointError) -> Self {
-        error.context(ErrorKind::OutPoint).into()
+        ErrorKind::OutPoint.because(error)
     }
 }

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -22,7 +22,6 @@ ckb-dao = { path = "../util/dao", version = "= 0.39.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.39.0-pre" }
 ckb-logger = {path = "../util/logger", version = "= 0.39.0-pre"}
 ckb-reward-calculator= { path = "../util/reward-calculator", version = "= 0.39.0-pre" }
-failure = "0.1.5"
 ckb-error = { path = "../error", version = "= 0.39.0-pre" }
 derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
 tokio = { version = "0.2", features = ["sync", "blocking", "rt-threaded"] }

--- a/verification/src/convert.rs
+++ b/verification/src/convert.rs
@@ -6,19 +6,6 @@ use crate::error::{
 use ckb_error::{
     impl_error_conversion_with_adaptor, impl_error_conversion_with_kind, Error, ErrorKind,
 };
-use failure::{Context, Fail};
-
-impl From<HeaderErrorKind> for HeaderError {
-    fn from(kind: HeaderErrorKind) -> Self {
-        Context::new(kind).into()
-    }
-}
-
-impl From<BlockErrorKind> for BlockError {
-    fn from(kind: BlockErrorKind) -> Self {
-        Context::new(kind).into()
-    }
-}
 
 impl_error_conversion_with_kind!(TransactionError, ErrorKind::Transaction, Error);
 impl_error_conversion_with_kind!(HeaderError, ErrorKind::Header, Error);

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -1,11 +1,9 @@
-use ckb_error::Error;
+use ckb_error::{def_error_base_on_kind, prelude::*, Error};
 use ckb_types::{
     core::{Capacity, Version},
     packed::{Byte32, OutPoint},
 };
 use derive_more::Display;
-use failure::{Backtrace, Context, Fail};
-use std::fmt;
 
 #[derive(Clone, Debug, Display, Eq, PartialEq)]
 pub enum TransactionErrorSource {
@@ -18,16 +16,13 @@ pub enum TransactionErrorSource {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {
     /// output.occupied_capacity() > output.capacity()
-    #[fail(
-        display = "InsufficientCellCapacity({}[{}]): expected occupied capacity ({:#x}) <= capacity ({:#x})",
-        source, index, occupied_capacity, capacity
-    )]
+    #[error("InsufficientCellCapacity({inner}[{index}]): expected occupied capacity ({occupied_capacity:#x}) <= capacity ({capacity:#x})")]
     InsufficientCellCapacity {
         /// TODO(doc): @keroro520
-        source: TransactionErrorSource,
+        inner: TransactionErrorSource,
         /// TODO(doc): @keroro520
         index: usize,
         /// TODO(doc): @keroro520
@@ -37,10 +32,7 @@ pub enum TransactionError {
     },
 
     /// SUM([o.capacity for o in outputs]) > SUM([i.capacity for i in inputs])
-    #[fail(
-        display = "OutputsSumOverflow: expected outputs capacity ({:#x}) <= inputs capacity ({:#x})",
-        outputs_sum, inputs_sum
-    )]
+    #[error("OutputsSumOverflow: expected outputs capacity ({outputs_sum:#x}) <= inputs capacity ({inputs_sum:#x})")]
     OutputsSumOverflow {
         /// TODO(doc): @keroro520
         inputs_sum: Capacity,
@@ -49,31 +41,28 @@ pub enum TransactionError {
     },
 
     /// inputs.is_empty() || outputs.is_empty()
-    #[fail(display = "Empty({})", source)]
+    #[error("Empty({inner})")]
     Empty {
         /// TODO(doc): @keroro520
-        source: TransactionErrorSource,
+        inner: TransactionErrorSource,
     },
 
     /// Duplicated dep-out-points within the same transaction
-    #[fail(display = "DuplicateCellDeps({})", out_point)]
+    #[error("DuplicateCellDeps({out_point})")]
     DuplicateCellDeps {
         /// TODO(doc): @keroro520
         out_point: OutPoint,
     },
 
     /// Duplicated headers deps without within the same transaction
-    #[fail(display = "DuplicateHeaderDeps({})", hash)]
+    #[error("DuplicateHeaderDeps({hash})")]
     DuplicateHeaderDeps {
         /// TODO(doc): @keroro520
         hash: Byte32,
     },
 
     /// outputs.len() != outputs_data.len()
-    #[fail(
-        display = "OutputsDataLengthMismatch: expected outputs data length ({}) = outputs length ({})",
-        outputs_data_len, outputs_len
-    )]
+    #[error("OutputsDataLengthMismatch: expected outputs data length ({outputs_data_len}) = outputs length ({outputs_len})")]
     OutputsDataLengthMismatch {
         /// TODO(doc): @keroro520
         outputs_len: usize,
@@ -82,19 +71,15 @@ pub enum TransactionError {
     },
 
     /// The format of `transaction.since` is invalid
-    #[fail(
-        display = "InvalidSince(Inputs[{}]): the field since is invalid",
-        index
-    )]
+    #[error("InvalidSince(Inputs[{index}]): the field since is invalid")]
     InvalidSince {
         /// TODO(doc): @keroro520
         index: usize,
     },
 
     /// The transaction is not mature which is required by `transaction.since`
-    #[fail(
-        display = "Immature(Inputs[{}]): the transaction is immature because of the since requirement",
-        index
+    #[error(
+        "Immature(Inputs[{index}]): the transaction is immature because of the since requirement"
     )]
     Immature {
         /// TODO(doc): @keroro520
@@ -102,16 +87,16 @@ pub enum TransactionError {
     },
 
     /// The transaction is not mature which is required by cellbase maturity rule
-    #[fail(display = "CellbaseImmaturity({}[{}])", source, index)]
+    #[error("CellbaseImmaturity({inner}[{index}])")]
     CellbaseImmaturity {
         /// TODO(doc): @keroro520
-        source: TransactionErrorSource,
+        inner: TransactionErrorSource,
         /// TODO(doc): @keroro520
         index: usize,
     },
 
     /// The transaction version is mismatched with the system can hold
-    #[fail(display = "MismatchedVersion: expected {}, got {}", expected, actual)]
+    #[error("MismatchedVersion: expected {}, got {}", expected, actual)]
     MismatchedVersion {
         /// TODO(doc): @keroro520
         expected: Version,
@@ -120,10 +105,7 @@ pub enum TransactionError {
     },
 
     /// The transaction size is too large
-    #[fail(
-        display = "ExceededMaximumBlockBytes: expected transaction serialized size ({}) < block size limit ({})",
-        actual, limit
-    )]
+    #[error("ExceededMaximumBlockBytes: expected transaction serialized size ({actual}) < block size limit ({limit})")]
     ExceededMaximumBlockBytes {
         /// TODO(doc): @keroro520
         limit: u64,
@@ -133,7 +115,7 @@ pub enum TransactionError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Display)]
 pub enum HeaderErrorKind {
     /// TODO(doc): @keroro520
     InvalidParent,
@@ -149,20 +131,10 @@ pub enum HeaderErrorKind {
     Version,
 }
 
-/// TODO(doc): @keroro520
-#[derive(Debug)]
-pub struct HeaderError {
-    kind: Context<HeaderErrorKind>,
-}
+def_error_base_on_kind!(HeaderError, HeaderErrorKind);
 
 /// TODO(doc): @keroro520
-#[derive(Debug)]
-pub struct BlockError {
-    kind: Context<BlockErrorKind>,
-}
-
-/// TODO(doc): @keroro520
-#[derive(Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Display)]
 pub enum BlockErrorKind {
     /// TODO(doc): @keroro520
     ProposalTransactionDuplicate,
@@ -207,9 +179,11 @@ pub enum BlockErrorKind {
     ExceededMaximumBlockBytes,
 }
 
+def_error_base_on_kind!(BlockError, BlockErrorKind);
+
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug)]
-#[fail(display = "BlockTransactionsError(index: {}, error: {})", index, error)]
+#[derive(Error, Debug)]
+#[error("BlockTransactionsError(index: {index}, error: {error})")]
 pub struct BlockTransactionsError {
     /// TODO(doc): @keroro520
     pub index: u32,
@@ -218,15 +192,15 @@ pub struct BlockTransactionsError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
-#[fail(display = "UnknownParentError(parent_hash: {})", parent_hash)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[error("UnknownParentError(parent_hash: {parent_hash})")]
 pub struct UnknownParentError {
     /// TODO(doc): @keroro520
     pub parent_hash: Byte32,
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Error, Debug, PartialEq, Eq, Clone, Display)]
 pub enum CommitError {
     /// TODO(doc): @keroro520
     AncestorNotFound,
@@ -235,7 +209,7 @@ pub enum CommitError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone, Display)]
+#[derive(Error, Debug, PartialEq, Eq, Clone, Display)]
 pub enum CellbaseError {
     /// TODO(doc): @keroro520
     InvalidInput,
@@ -258,10 +232,10 @@ pub enum CellbaseError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum UnclesError {
     /// TODO(doc): @keroro520
-    #[fail(display = "OverCount(max: {}, actual: {})", max, actual)]
+    #[error("OverCount(max: {max}, actual: {actual})")]
     OverCount {
         /// TODO(doc): @keroro520
         max: u32,
@@ -270,10 +244,7 @@ pub enum UnclesError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(
-        display = "InvalidDepth(min: {}, max: {}, actual: {})",
-        min, max, actual
-    )]
+    #[error("InvalidDepth(min: {min}, max: {max}, actual: {actual})")]
     InvalidDepth {
         /// TODO(doc): @keroro520
         max: u64,
@@ -284,7 +255,7 @@ pub enum UnclesError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(display = "InvalidHash(expected: {}, actual: {})", expected, actual)]
+    #[error("InvalidHash(expected: {expected}, actual: {actual})")]
     InvalidHash {
         /// TODO(doc): @keroro520
         expected: Byte32,
@@ -293,48 +264,45 @@ pub enum UnclesError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(display = "InvalidNumber")]
+    #[error("InvalidNumber")]
     InvalidNumber,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "InvalidTarget")]
+    #[error("InvalidTarget")]
     InvalidTarget,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "InvalidDifficultyEpoch")]
+    #[error("InvalidDifficultyEpoch")]
     InvalidDifficultyEpoch,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "ProposalsHash")]
+    #[error("ProposalsHash")]
     ProposalsHash,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "ProposalDuplicate")]
+    #[error("ProposalDuplicate")]
     ProposalDuplicate,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "Duplicate({})", _0)]
+    #[error("Duplicate({0})")]
     Duplicate(Byte32),
 
     /// TODO(doc): @keroro520
-    #[fail(display = "DoubleInclusion({})", _0)]
+    #[error("DoubleInclusion({0})")]
     DoubleInclusion(Byte32),
 
     /// TODO(doc): @keroro520
-    #[fail(display = "DescendantLimit")]
+    #[error("DescendantLimit")]
     DescendantLimit,
 
     /// TODO(doc): @keroro520
-    #[fail(display = "ExceededMaximumProposalsLimit")]
+    #[error("ExceededMaximumProposalsLimit")]
     ExceededMaximumProposalsLimit,
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
-#[fail(
-    display = "BlockVersionError(expected: {}, actual: {})",
-    expected, actual
-)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[error("BlockVersionError(expected: {expected}, actual: {actual})")]
 pub struct BlockVersionError {
     /// TODO(doc): @keroro520
     pub expected: Version,
@@ -343,18 +311,18 @@ pub struct BlockVersionError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
-#[fail(display = "InvalidParentError(parent_hash: {})", parent_hash)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[error("InvalidParentError(parent_hash: {parent_hash})")]
 pub struct InvalidParentError {
     /// TODO(doc): @keroro520
     pub parent_hash: Byte32,
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum PowError {
     /// TODO(doc): @keroro520
-    #[fail(display = "Boundary(expected: {}, actual: {})", expected, actual)]
+    #[error("Boundary(expected: {expected}, actual: {actual})")]
     Boundary {
         /// TODO(doc): @keroro520
         expected: Byte32,
@@ -363,17 +331,15 @@ pub enum PowError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(
-        display = "InvalidNonce: please set logger.filter to \"info,ckb-pow=debug\" to see detailed PoW verification information in the log"
-    )]
+    #[error("InvalidNonce: please set logger.filter to \"info,ckb-pow=debug\" to see detailed PoW verification information in the log")]
     InvalidNonce,
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum TimestampError {
     /// TODO(doc): @keroro520
-    #[fail(display = "BlockTimeTooOld(min: {}, actual: {})", min, actual)]
+    #[error("BlockTimeTooOld(min: {min}, actual: {actual})")]
     BlockTimeTooOld {
         /// TODO(doc): @keroro520
         min: u64,
@@ -382,7 +348,7 @@ pub enum TimestampError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(display = "BlockTimeTooNew(max: {}, actual: {})", max, actual)]
+    #[error("BlockTimeTooNew(max: {max}, actual: {actual})")]
     BlockTimeTooNew {
         /// TODO(doc): @keroro520
         max: u64,
@@ -402,8 +368,8 @@ impl TimestampError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
-#[fail(display = "NumberError(expected: {}, actual: {})", expected, actual)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[error("NumberError(expected: {expected}, actual: {actual})")]
 pub struct NumberError {
     /// TODO(doc): @keroro520
     pub expected: u64,
@@ -412,13 +378,10 @@ pub struct NumberError {
 }
 
 /// TODO(doc): @keroro520
-#[derive(Fail, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum EpochError {
     /// TODO(doc): @keroro520
-    #[fail(
-        display = "TargetMismatch(expected: {:x}, actual: {:x})",
-        expected, actual
-    )]
+    #[error("TargetMismatch(expected: {expected:x}, actual: {actual:x})")]
     TargetMismatch {
         /// TODO(doc): @keroro520
         expected: u32,
@@ -427,7 +390,7 @@ pub enum EpochError {
     },
 
     /// TODO(doc): @keroro520
-    #[fail(display = "NumberMismatch(expected: {}, actual: {})", expected, actual)]
+    #[error("NumberMismatch(expected: {expected}, actual: {actual})")]
     NumberMismatch {
         /// TODO(doc): @keroro520
         expected: u64,
@@ -456,58 +419,7 @@ impl TransactionError {
     }
 }
 
-impl fmt::Display for HeaderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(cause) = self.cause() {
-            write!(f, "{}({})", self.kind(), cause)
-        } else {
-            write!(f, "{}", self.kind())
-        }
-    }
-}
-
-impl fmt::Display for BlockError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(cause) = self.cause() {
-            write!(f, "{}({})", self.kind(), cause)
-        } else {
-            write!(f, "{}", self.kind())
-        }
-    }
-}
-
-impl From<Context<HeaderErrorKind>> for HeaderError {
-    fn from(kind: Context<HeaderErrorKind>) -> Self {
-        Self { kind }
-    }
-}
-
-impl Fail for HeaderError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner().cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner().backtrace()
-    }
-}
-
 impl HeaderError {
-    /// TODO(doc): @keroro520
-    pub fn kind(&self) -> &HeaderErrorKind {
-        self.kind.get_context()
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
-        self.cause().and_then(|cause| cause.downcast_ref::<T>())
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn inner(&self) -> &Context<HeaderErrorKind> {
-        &self.kind
-    }
-
     /// TODO(doc): @keroro520
     // Note: if the header is invalid, that may also be grounds for disconnecting the peer,
     // However, there is a circumstance where that does not hold:
@@ -519,39 +431,6 @@ impl HeaderError {
         self.downcast_ref::<TimestampError>()
             .map(|e| e.is_too_new())
             .unwrap_or(false)
-    }
-}
-
-impl From<Context<BlockErrorKind>> for BlockError {
-    fn from(kind: Context<BlockErrorKind>) -> Self {
-        Self { kind }
-    }
-}
-
-impl Fail for BlockError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner().cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner().backtrace()
-    }
-}
-
-impl BlockError {
-    /// TODO(doc): @keroro520
-    pub fn kind(&self) -> &BlockErrorKind {
-        self.kind.get_context()
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
-        self.cause().and_then(|cause| cause.downcast_ref::<T>())
-    }
-
-    /// TODO(doc): @keroro520
-    pub fn inner(&self) -> &Context<BlockErrorKind> {
-        &self.kind
     }
 }
 

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -32,7 +32,7 @@ pub fn test_empty() {
     assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::Empty {
-            source: TransactionErrorSource::Inputs,
+            inner: TransactionErrorSource::Inputs,
         }
     );
 }
@@ -105,7 +105,7 @@ pub fn test_capacity_outofbound() {
     assert_error_eq!(
         verifier.verify().unwrap_err(),
         TransactionError::InsufficientCellCapacity {
-            source: TransactionErrorSource::Outputs,
+            inner: TransactionErrorSource::Outputs,
             index: 0,
             capacity: capacity_bytes!(50),
             occupied_capacity: capacity_bytes!(92),
@@ -165,7 +165,7 @@ pub fn test_inputs_cellbase_maturity() {
             assert_error_eq!(
                 verifier.verify().unwrap_err(),
                 TransactionError::CellbaseImmaturity {
-                    source: TransactionErrorSource::Inputs,
+                    inner: TransactionErrorSource::Inputs,
                     index: 0
                 },
                 "base_epoch = {}, current_epoch = {}, cellbase_maturity = {}",
@@ -271,7 +271,7 @@ pub fn test_deps_cellbase_maturity() {
             assert_error_eq!(
                 verifier.verify().unwrap_err(),
                 TransactionError::CellbaseImmaturity {
-                    source: TransactionErrorSource::CellDeps,
+                    inner: TransactionErrorSource::CellDeps,
                     index: 0
                 },
                 "base_epoch = {}, current_epoch = {}, cellbase_maturity = {}",

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -341,12 +341,12 @@ impl<'a> EmptyVerifier<'a> {
     pub fn verify(&self) -> Result<(), Error> {
         if self.transaction.inputs().is_empty() {
             Err(TransactionError::Empty {
-                source: TransactionErrorSource::Inputs,
+                inner: TransactionErrorSource::Inputs,
             }
             .into())
         } else if self.transaction.outputs().is_empty() && !self.transaction.is_cellbase() {
             Err(TransactionError::Empty {
-                source: TransactionErrorSource::Outputs,
+                inner: TransactionErrorSource::Outputs,
             }
             .into())
         } else {
@@ -399,7 +399,7 @@ impl<'a> MaturityVerifier<'a> {
             .position(cellbase_immature)
         {
             return Err(TransactionError::CellbaseImmaturity {
-                source: TransactionErrorSource::Inputs,
+                inner: TransactionErrorSource::Inputs,
                 index,
             }
             .into());
@@ -412,7 +412,7 @@ impl<'a> MaturityVerifier<'a> {
             .position(cellbase_immature)
         {
             return Err(TransactionError::CellbaseImmaturity {
-                source: TransactionErrorSource::CellDeps,
+                inner: TransactionErrorSource::CellDeps,
                 index,
             }
             .into());
@@ -500,7 +500,7 @@ impl<'a> CapacityVerifier<'a> {
             if output.is_lack_of_capacity(data_occupied_capacity)? {
                 return Err((TransactionError::InsufficientCellCapacity {
                     index,
-                    source: TransactionErrorSource::Outputs,
+                    inner: TransactionErrorSource::Outputs,
                     capacity: output.capacity().unpack(),
                     occupied_capacity: output.occupied_capacity(data_occupied_capacity)?,
                 })


### PR DESCRIPTION
### Reasons
- [RUSTSEC-2020-0036: `failure`: `failure` is officially deprecated/unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0036.html)
- Most errors in `CKB` are not implement `::std::error::Error`.

### Commits
- [refactor: replace `failure` by `thiserror` and `anyhow` for `ckb-error` and crates which depend on it](https://github.com/nervosnetwork/ckb/pull/2386/commits/1694aec4f879cce5401b46a6b3dfd3188dc5aea8)
  This commit is the key commit for this PR, other commits are just equivalent transformations.
- [refactor: replace `failure` by `thiserror` and `anyhow` for all other ckb crates](https://github.com/nervosnetwork/ckb/pull/2386/commits/2e067a7c5b02eed6a9b565b5c2c5a73197bb227f)
  Just equivalent transformations.
- [feat: let `AnyError` be cloneable](https://github.com/nervosnetwork/ckb/pull/2386/commits/24a90e833ac94b997a9f965388adb393c5a96d8f)

~~p.s. This PR is base on an unmerged PR: [CKB PR-2387: ci: skip RUSTSEC-2020-0077 temporarily](https://github.com/nervosnetwork/ckb/pull/2387).~~

### Tips for Reviewers

- The field name `source` has special function in `thiserror`, so I rename the fields which were named `source` to `inner`.

  > The Error trait's source() method is implemented to return whichever field has a #[source] attribute or is named source, if any.

- Replaced `FailureError` by `AnyError(Arc<anyhow::Error>)`

- Replaced `pub struct $error { kind: failure::Context<$error_kind}> }` by `pub struct $error { kind: $error_kind, inner: AnyError }`

- Re-export `thiserror` in `ckb-error`.

- The old errors which has an error kind had different implementations of `::std::fmt::Display`.

  For example:
  - Some checked `alternate` but others didn't.
  - Some are `{kind}: {reason}`, some are `{kind}({reason})` and others are `{kind}`.

  Since I use a macro to unify all errors which has an error kind, all implementations of `::std::fmt::Display` are same now.
  And few implementations are not as same as the old implementations.

  For example, `Internal(CapacityOverflow)` became `Internal(CapacityOverflow(OccupiedCapacity: overflow))`.

- I only add documentations for new items which were introduced in this PR.

  I left those already existed `TODO(doc)`, some of them are integrated into the macro `def_error_base_on_kind`, call the macro with one more argument can add those documentations.