### PR TITLE
ci: skip RUSTSEC-2020-0077 temporarily

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ ignore = [
     "RUSTSEC-2020-0036", # TODO failure is officially deprecated/unmaintained, but still a lot of required crates are dependent on it
     "RUSTSEC-2020-0043", # TODO ws allows remote attacker to run the process out of memory, since it is no longer actively maintained, we couldn't fix it in the short term
     "RUSTSEC-2020-0056", # We did not use the `stdweb` library, only `wasm32-unknown-unknown` would use `getrandom` and `wasm-bindgen`, `stdweb` would only be used in cargo-web
+    "RUSTSEC-2020-0077", # TODO memmap is unmaintained, but ckb-vm is dependent on it, so we allow it temporarily
 ]
 
 [licenses]


### PR DESCRIPTION
Could be fixed after  [CKB-VM Issue-119: Replace `memmap` crate since it is unmaintained](https://github.com/nervosnetwork/ckb-vm/issues/119) fixed.