### PR TITLE
fix: don't open db when disable indexer module, fix deprecated method response

### DIFF
--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -5,5 +5,5 @@ mod migrations;
 mod store;
 mod types;
 
-pub use store::{DefaultIndexerStore, IndexerStore};
+pub use store::{DefaultIndexerStore, Dummy, IndexerStore};
 pub use types::{CellTransaction, LiveCell, TransactionPoint};

--- a/indexer/src/store.rs
+++ b/indexer/src/store.rs
@@ -68,6 +68,52 @@ pub trait IndexerStore: Sync + Send {
 }
 
 #[derive(Clone)]
+pub struct Dummy;
+
+impl IndexerStore for Dummy {
+    fn get_live_cells(
+        &self,
+        _lock_hash: &Byte32,
+        _skip_num: usize,
+        _take_num: usize,
+        _reverse_order: bool,
+    ) -> Vec<LiveCell> {
+        Vec::new()
+    }
+
+    fn get_transactions(
+        &self,
+        _lock_hash: &Byte32,
+        _skip_num: usize,
+        _take_num: usize,
+        _reverse_order: bool,
+    ) -> Vec<CellTransaction> {
+        Vec::new()
+    }
+
+    fn get_capacity(&self, _lock_hash: &Byte32) -> Option<LockHashCapacity> {
+        None
+    }
+
+    fn get_lock_hash_index_states(&self) -> HashMap<Byte32, LockHashIndexState> {
+        HashMap::new()
+    }
+
+    fn insert_lock_hash(
+        &self,
+        _lock_hash: &Byte32,
+        _index_from: Option<BlockNumber>,
+    ) -> LockHashIndexState {
+        LockHashIndexState {
+            block_hash: Byte32::zero(),
+            block_number: 0,
+        }
+    }
+
+    fn remove_lock_hash(&self, _lock_hash: &Byte32) {}
+}
+
+#[derive(Clone)]
 pub struct DefaultIndexerStore {
     db: Arc<RocksDB>,
     shared: Shared,


### PR DESCRIPTION
1. deprecated method name change to "deprecated.xxx", need to remove this prefix
2. indexer module always open DB on default，and it will leave log/DB files on disk, these are not needed