### PR TITLE
chore: add MSRV policy for all crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The `master` branch is regularly built and tested, however, it is not guaranteed
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md), and security policy is described in [SECURITY.md](SECURITY.md). To propose new protocol or standard for Nervos, see [Nervos RFC](https://github.com/nervosnetwork/rfcs).
 
+## Minimum Supported Rust Version policy (MSRV)
+
+The crate `ckb`'s minimum supported rustc version is 1.46.0.
+
 ---
 
 ## Documentations

--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -24,7 +24,7 @@ CKB JSON-RPC only supports HTTP now. If you need SSL, please set up a proxy via 
 
 Subscriptions require a full duplex connection. CKB offers such connections in the form of TCP (enable with `rpc.tcp_listen_address` configuration option) and WebSockets (enable with `rpc.ws_listen_address`).
 
-# JSONRPC Deprecation Process
+## JSONRPC Deprecation Process
 
 A CKB RPC method is deprecated in three steps.
 
@@ -35,6 +35,10 @@ The CKB dev team will disable any deprecated RPC methods starting from the next 
 Once a deprecated method is disabled, the CKB dev team will remove it in a future minor version release.
 
 For example, a method is marked as deprecated in 0.35.0, it can be disabled in 0.36.0 and removed in 0.37.0. The minor versions are released monthly, so there's at least a two-month buffer for a deprecated RPC method.
+
+## Minimum Supported Rust Version policy (MSRV)
+
+The crate `ckb-rpc`'s minimum supported rustc version is 1.46.0.
 
 """
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -10,7 +10,7 @@ CKB JSON-RPC only supports HTTP now. If you need SSL, please set up a proxy via 
 
 Subscriptions require a full duplex connection. CKB offers such connections in the form of TCP (enable with `rpc.tcp_listen_address` configuration option) and WebSockets (enable with `rpc.ws_listen_address`).
 
-# JSONRPC Deprecation Process
+## JSONRPC Deprecation Process
 
 A CKB RPC method is deprecated in three steps.
 
@@ -21,6 +21,10 @@ The CKB dev team will disable any deprecated RPC methods starting from the next 
 Once a deprecated method is disabled, the CKB dev team will remove it in a future minor version release.
 
 For example, a method is marked as deprecated in 0.35.0, it can be disabled in 0.36.0 and removed in 0.37.0. The minor versions are released monthly, so there's at least a two-month buffer for a deprecated RPC method.
+
+## Minimum Supported Rust Version policy (MSRV)
+
+The crate `ckb-rpc`'s minimum supported rustc version is 1.46.0.
 
 
 ## Table of Contents


### PR DESCRIPTION
Add the MSRV plicy in README.md if it exists, otherwise generate one before `cargo publish`. 

Example: https://crates.io/crates/ckb-util/0.39.0-pre