### PR TITLE
chore(integration): print test results after integration test finished

### DIFF
--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -27,10 +27,12 @@ pub enum Notify {
     Error {
         spec_error: Box<dyn Any + Send>,
         spec_name: String,
+        seconds: u64,
         node_log_paths: Vec<PathBuf>,
     },
     Panick {
         spec_name: String,
+        seconds: u64,
         node_log_paths: Vec<PathBuf>,
     },
     Stop,
@@ -128,6 +130,7 @@ impl Worker {
             outbox
                 .send(Notify::Panick {
                     spec_name: spec.name().to_string(),
+                    seconds: now.elapsed().as_secs(),
                     node_log_paths,
                 })
                 .unwrap();
@@ -136,6 +139,7 @@ impl Worker {
                 .send(Notify::Error {
                     spec_error,
                     spec_name: spec.name().to_string(),
+                    seconds: now.elapsed().as_secs(),
                     node_log_paths,
                 })
                 .unwrap();


### PR DESCRIPTION
After all integration test cases finished, it would be better have a brief report to check test results.

The test results in this PR show like this:

```
TEST                                               | STATUS     | DURATION
HandlingDescendantsOfProposed                      | Passed     | 5 s
RelayInvalidTransaction                            | Passed     | 5 s
AlertPropagation                                   | Passed     | 17 s
ChainFork4                                         | Passed     | 19 s
...
BlockSyncWithUncle                                 | Failed     | 9 s
Total elapsed time: 425.92992889s
```