### PR TITLE
Upgrade dependencies tiny-keccak base64 and rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
  "goblin",
  "proptest",
  "serde",
- "tiny-keccak 1.5.0",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1509,7 +1509,7 @@ dependencies = [
  "getrandom 0.2.0",
  "lazy_static",
  "proc-macro-hack",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -4961,15 +4961,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
  "ckb-types",
  "clap",
  "path-clean",
- "rand 0.6.5",
+ "rand 0.7.3",
  "serde",
  "serde_plain",
  "tempfile",
@@ -456,7 +456,7 @@ dependencies = [
  "criterion",
  "faketime",
  "lazy_static",
- "rand 0.6.5",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -568,7 +568,7 @@ dependencies = [
  "ckb-fixed-hash",
  "faster-hex 0.4.1",
  "lazy_static",
- "rand 0.6.5",
+ "rand 0.7.3",
  "secp256k1 0.19.0",
  "thiserror",
 ]
@@ -846,7 +846,8 @@ dependencies = [
  "hyper-tls 0.3.2",
  "indicatif",
  "lru",
- "rand 0.6.5",
+ "rand 0.7.3",
+ "rand_distr",
  "serde",
  "serde_json",
 ]
@@ -858,7 +859,7 @@ dependencies = [
  "ckb-crypto",
  "ckb-error",
  "ckb-logger",
- "rand 0.6.5",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -883,7 +884,7 @@ dependencies = [
  "lazy_static",
  "num_cpus",
  "proptest",
- "rand 0.6.5",
+ "rand 0.7.3",
  "secp256k1 0.19.0",
  "serde",
  "serde_json",
@@ -1295,7 +1296,7 @@ dependencies = [
  "futures 0.3.8",
  "governor",
  "lru",
- "rand 0.6.5",
+ "rand 0.7.3",
  "tempfile",
 ]
 
@@ -1413,7 +1414,7 @@ dependencies = [
  "derive_more",
  "faketime",
  "lru",
- "rand 0.6.5",
+ "rand 0.7.3",
  "rayon",
  "tokio 0.2.24",
 ]
@@ -3024,6 +3025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "libsecp256k1"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
  "autocfg 1.0.0",
+ "libm",
 ]
 
 [[package]]
@@ -4048,7 +4056,7 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg",
+ "rand_pcg 0.1.2",
  "rand_xorshift",
  "winapi 0.3.8",
 ]
@@ -4064,6 +4072,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -4108,6 +4117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
  "getrandom 0.1.6",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
+dependencies = [
+ "num-traits",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -4170,6 +4189,15 @@ checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
  "autocfg 0.1.2",
  "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,15 +177,6 @@ checksum = "c2734baf8ed08920ccecce1b48a2dfce4ac74a973144add031163bd21a1c5dab"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -472,7 +463,7 @@ dependencies = [
 name = "ckb-bin"
 version = "0.39.0-pre"
 dependencies = [
- "base64 0.10.1",
+ "base64",
  "ckb-app-config",
  "ckb-async-runtime",
  "ckb-build-info",
@@ -4292,7 +4283,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 0.5.6",
  "encoding_rs",
  "futures-core",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,7 +18,7 @@ ckb-types = { path = "../util/types", version = "= 0.39.0-pre" }
 ckb-shared = { path = "../shared", version = "= 0.39.0-pre" }
 ckb-store = { path = "../store", version = "= 0.39.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.39.0-pre" }
-rand = "0.6"
+rand = "0.7"
 ckb-hash = {path = "../util/hash", version = "= 0.39.0-pre"}
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.39.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.39.0-pre" }

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -38,7 +38,7 @@ ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.39.0-pre"
 ckb-chain-iter = { path = "../util/chain-iter", version = "= 0.39.0-pre" }
 ckb-verification = { path = "../verification", version = "= 0.39.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.39.0-pre" }
-base64 = "0.10.1"
+base64 = "0.13.0"
 tempfile = "3.0"
 rayon = "1.0"
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -15,7 +15,8 @@ ckb-types = { path = "../util/types", version = "= 0.39.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.39.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.39.0-pre" }
 ckb-pow = { path = "../pow", version = "= 0.39.0-pre" }
-rand = "0.6"
+rand = "0.7"
+rand_distr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.39.0-pre" }

--- a/miner/src/worker/mod.rs
+++ b/miner/src/worker/mod.rs
@@ -73,7 +73,8 @@ pub fn start_worker(
                 pb.set_prefix(&worker_name);
 
                 let (worker_tx, worker_rx) = unbounded();
-                let mut worker = Dummy::new(config, nonce_tx, worker_rx);
+                let mut worker = Dummy::try_new(config, nonce_tx, worker_rx)
+                    .expect("valid distribution parameters");
 
                 thread::Builder::new()
                     .name(worker_name.to_string())

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-rand = "0.6"
+rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 ckb-util = { path = "../util", version = "= 0.39.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.39.0-pre" }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -35,6 +35,6 @@ proptest = "0.9"
 ckb-db = { path = "../db", version = "= 0.39.0-pre" }
 ckb-store = { path = "../store", version = "= 0.39.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.39.0-pre" }
-tiny-keccak = "1.4"
+tiny-keccak = "2.0"
 ckb-crypto = { path = "../util/crypto", version = "= 0.39.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.39.0-pre" }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -459,7 +459,12 @@ mod tests {
     const CYCLE_BOUND: Cycle = 200_000;
 
     fn sha3_256<T: AsRef<[u8]>>(s: T) -> [u8; 32] {
-        tiny_keccak::sha3_256(s.as_ref())
+        use tiny_keccak::{Hasher, Sha3};
+        let mut output = [0; 32];
+        let mut sha3 = Sha3::v256();
+        sha3.update(s.as_ref());
+        sha3.finalize(&mut output);
+        output
     }
 
     // NOTE: `verify` binary is outdated and most related unit tests are testing `script` crate functions

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -36,7 +36,7 @@ tempfile = "3.0"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.39.0-pre" }
-rand = "0.6"
+rand = "0.7"
 ckb-dao = { path = "../util/dao", version = "= 0.39.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.39.0-pre" }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -31,7 +31,7 @@ ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.39.0-pre" }
 ckb-error = { path = "../error", version = "= 0.39.0-pre" }
 tempfile = "3.0"
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
-rand = "0.6"
+rand = "0.7"
 log = "0.4"
 env_logger = "0.6"
 faketime = "0.2"

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -26,7 +26,7 @@ ckb-types = { path = "../types", version = "= 0.39.0-pre" }
 ckb-fee-estimator = { path = "../fee-estimator", version = "= 0.39.0-pre" }
 secio = { version="0.4.2", features = ["molc"], package="tentacle-secio" }
 multiaddr = { version="0.2.0", package="tentacle-multiaddr" }
-rand = "0.6"
+rand = "0.7"
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
 
 [features]

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -13,7 +13,7 @@ ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.39.0-pre" }
 lazy_static = "1.3"
 secp256k1 = { version = "0.19", features = ["recovery"], optional = true }
 thiserror = "1.0.22"
-rand = "0.6"
+rand = { version = "0.7", features = ["small_rng"] }
 faster-hex = "0.4"
 
 [features]

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -14,4 +14,4 @@ ckb-logger = { path = "../logger", version = "= 0.39.0-pre" }
 ckb-crypto = { path = "../crypto", version = "= 0.39.0-pre" }
 
 [dev-dependencies]
-rand = "0.6.5"
+rand = "0.7"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -32,4 +32,4 @@ ckb-chain = { path = "../chain", version = "= 0.39.0-pre" }
 ckb-shared = { path = "../shared", version = "= 0.39.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.39.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.39.0-pre" }
-rand = "0.6"
+rand = "0.7"


### PR DESCRIPTION
Upgrade tinny-keccak, base64 and rand.

* Bump tiny-keccak from 1.5.0 to 2.0.2, see #2444 
* Bump base64 from 0.10.1 to 0.13.0, see #2437 
* Bump direct dependency of rand from 0.6.5 to 0.7.3, deprecating #2440 