### PR TITLE
ci: fix the log output of integration tests and output more logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERBOSE := $(if ${CI},--verbose,)
 CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from \
 	-A clippy::mutable_key_type
 CKB_TEST_ARGS := ${CKB_TEST_ARGS} -c 4
-INTEGRATION_RUST_LOG := ckb-network=error
+INTEGRATION_RUST_LOG := info,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
 
 ##@ Testing
 .PHONY: test

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -37,7 +37,7 @@ struct TestResult {
 fn main() {
     env::set_var("RUST_BACKTRACE", "full");
     let _ = {
-        let filter = env::var("CKB_LOG").unwrap_or_else(|_| "info".to_string());
+        let filter = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
         env_logger::builder().parse_filters(&filter).try_init()
     };
 


### PR DESCRIPTION
- In `Makefile` we set `RUST_LOG` but in `main.rs` we parse `CKB_LOG` for the log filter.
    https://github.com/nervosnetwork/ckb/blob/d04f413879a7e62d2f21eebefda9c4f58cec22f2/Makefile#L37-L43
    https://github.com/nervosnetwork/ckb/blob/d04f413879a7e62d2f21eebefda9c4f58cec22f2/test/src/main.rs#L39-L42
- Use `RUST_LOG` not `CKB_LOG`, because `CKB_LOG` will override the configurations of nodes which started by `ckb-tests`.
- Add more log outputs.