### PR TITLE
ci: fix potential failure in integration test TransactionRelayLowFeeRate

### DIFF
--- a/test/src/specs/relay/transaction_relay_low_fee_rate.rs
+++ b/test/src/specs/relay/transaction_relay_low_fee_rate.rs
@@ -1,4 +1,5 @@
 use crate::node::connect_all;
+use crate::node::waiting_for_sync;
 use crate::util::cell::{as_input, as_output, gen_spendable};
 use crate::util::log_monitor::monitor_log_until_expected_show;
 use crate::util::mining::out_ibd_mode;
@@ -31,6 +32,10 @@ impl Spec for TransactionRelayLowFeeRate {
             .rpc_client()
             .dry_run_transaction(low_fee.data().into())
             .cycles;
+
+        log::debug!("make sure node1 has the cell");
+        waiting_for_sync(nodes);
+
         node0
             .rpc_client()
             .broadcast_transaction(low_fee.data().into(), low_cycles)


### PR DESCRIPTION
### Description

- In the function `gen_spendable(..)`, 12 blocks are created.
  https://github.com/nervosnetwork/ckb/blob/aff994e68f6bb7935e2dd371c92a27be72936c97/test/src/specs/relay/transaction_relay_low_fee_rate.rs#L21
- Then, the cell which is created in the 12th block, will be used as a spendable cell.
  https://github.com/nervosnetwork/ckb/blob/aff994e68f6bb7935e2dd371c92a27be72936c97/test/src/specs/relay/transaction_relay_low_fee_rate.rs#L24-L29
- So the spendable cell will be broadcasted from `node-0` to `node-1`.
https://github.com/nervosnetwork/ckb/blob/aff994e68f6bb7935e2dd371c92a27be72936c97/test/src/specs/relay/transaction_relay_low_fee_rate.rs#L34-L37
- Then, we expect to get a low fee rate error.
  https://github.com/nervosnetwork/ckb/blob/aff994e68f6bb7935e2dd371c92a27be72936c97/test/src/specs/relay/transaction_relay_low_fee_rate.rs#L39-L44
- But, if the transaction which uses the spendable cell as input was broadcasted faster than 12th block synchronization. **We will get an unknown outpoint error.**