### PR TITLE
ci: fix potential failure in integration tests, such as BlockSyncRelayerCollaboration

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -616,7 +616,7 @@ impl Synchronizer {
                         .expect("download thread can't start");
                 }
             },
-            _ => {
+            None => {
                 for peer in self.get_peers_to_fetch(ibd, &disconnect_list) {
                     if let Some(fetch) = self.get_blocks_to_fetch(peer, ibd) {
                         for item in fetch {


### PR DESCRIPTION
### Description

- `GetBlocks` is sent by `BlockFetchCMD` in thread `BlockDownload`.
  https://github.com/nervosnetwork/ckb/blob/32ee42273620d15e20da2e664de00bb424eef3b3/sync/src/synchronizer/mod.rs#L631
  https://github.com/nervosnetwork/ckb/blob/32ee42273620d15e20da2e664de00bb424eef3b3/sync/src/synchronizer/mod.rs#L604-L607

- `HeadersProcess` is asynchronously running in global runtime.

- `GetBlocks` and `HeadersProcess` are parallel.

- Choose integration test `BlockSyncRelayerCollaboration` as the example to explain the issue:

  - After sent all headers to node0, the test check the next `SyncMessage` immediately.
    https://github.com/nervosnetwork/ckb/blob/32ee42273620d15e20da2e664de00bb424eef3b3/test/src/specs/sync/block_sync.rs#L283-L289
    https://github.com/nervosnetwork/ckb/blob/32ee42273620d15e20da2e664de00bb424eef3b3/test/src/specs/sync/block_sync.rs#L491-L502

    - Nearly all the time, `HeadersProcess` can finish all tasks, **but when not, the check will fail**.

      If `BlockFetchCMD` runs when `HeadersProcess` only finished processing 3 headers, a `GetBlocks(length = 3)` will be sent, after `HeadersProcess` finished processing all headers, a `GetBlocks(length = 13)` will be sent again.
      **The test should check the last `GetBlocks`, not the first.**

    - How to fix?
      - We could check if the summation of `GetBlocks` lengths are 16.
        https://github.com/nervosnetwork/ckb/blob/32ee42273620d15e20da2e664de00bb424eef3b3/sync/src/lib.rs#L30-L32
      - Or, still check the last hash. **I chose this.**

    - P.S. The description for integration test `BlockSyncRelayerCollaboration` is incorrect: the first block was mined in `out_ibd_mode(nodes);`.