### PR TITLE
chore: if the file in ".git/HEAD" isn't existed, ckb-bin will be re-linked every time when "cargo build"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn rerun_if_changed(path_str: &str) -> bool {
         || path.starts_with("docker")
         || path.starts_with("docs")
         || path.starts_with("test")
+        || path.starts_with(".github")
     {
         return false;
     }
@@ -41,7 +42,11 @@ fn main() {
 
         let head = std::fs::read_to_string(".git/HEAD").unwrap_or_default();
         if head.starts_with("ref: ") {
-            println!("cargo:rerun-if-changed=.git/{}", head[5..].trim());
+            let path_str = format!(".git/{}", head[5..].trim());
+            let path = Path::new(&path_str);
+            if path.exists() {
+                println!("cargo:rerun-if-changed={}", path_str);
+            }
         }
     }
 


### PR DESCRIPTION
### Issue

Each time when I run `make integration` or some other commands, about 15 seconds will be spent for waiting linking `ckb-bin`.

It wastes me a lot of times. (More than 40 times / 10 minutes each day.)

After this PR, when run `cargo build` or `cargo run` but nothing changed, `ckb` won't be linked again.

### How to reproduce?

There are a lots of reason why the file in ".git/HEAD" isn't existed. It's common. For example, calling `git gc`.