### PR TITLE
chore(doc): fix doc about epoch in type `ChainInfo`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4318,7 +4318,7 @@ Chain information.
 
 *   `median_time`: [`Timestamp`](#type-timestamp) - The median time of the last 37 blocks.
 
-*   `epoch`: [`EpochNumber`](#type-epochnumber) - Current epoch number.
+*   `epoch`: [`EpochNumberWithFraction`](#type-epochnumberwithfraction) - The epoch information of tip block in the chain.
 
 *   `difficulty`: [`U256`](#type-u256) - Current difficulty.
 

--- a/util/jsonrpc-types/src/chain_info.rs
+++ b/util/jsonrpc-types/src/chain_info.rs
@@ -1,4 +1,4 @@
-use crate::{AlertMessage, EpochNumber, Timestamp};
+use crate::{AlertMessage, EpochNumberWithFraction, Timestamp};
 use ckb_types::U256;
 use serde::{Deserialize, Serialize};
 
@@ -14,8 +14,8 @@ pub struct ChainInfo {
     pub chain: String,
     /// The median time of the last 37 blocks.
     pub median_time: Timestamp,
-    /// Current epoch number.
-    pub epoch: EpochNumber,
+    /// The epoch information of tip block in the chain.
+    pub epoch: EpochNumberWithFraction,
     /// Current difficulty.
     ///
     /// Decoded from the epoch `compact_target`.


### PR DESCRIPTION
Chain info's epoch come from tip_header https://github.com/nervosnetwork/ckb/blob/c3133ad66de38c03685c218b97d9f7845ad83d1d/rpc/src/module/stats.rs#L102-L108

And according to  https://github.com/nervosnetwork/ckb/blob/c3133ad66de38c03685c218b97d9f7845ad83d1d/util/types/src/core/views.rs#L405
`epoch` in `HeaderView` is `EpochNumberWithFraction` instead of `EpochNumber` 