### PR TITLE
chore: force explictly pointing out EpochNumberWithFraction

### DIFF
--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -126,7 +126,7 @@ impl StatsRpc for StatsRpcImpl {
         Ok(ChainInfo {
             chain,
             median_time: median_time.into(),
-            epoch: epoch.into(),
+            epoch: epoch.full_value().into(),
             difficulty,
             is_initial_block_download,
             alerts,

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -941,7 +941,7 @@ impl From<Consensus> for ckb_jsonrpc_types::Consensus {
                 consensus.proposer_reward_ratio.numer().into(),
                 consensus.proposer_reward_ratio.denom().into(),
             ),
-            cellbase_maturity: consensus.cellbase_maturity.into(),
+            cellbase_maturity: consensus.cellbase_maturity.full_value().into(),
             median_time_block_count: (consensus.median_time_block_count as u64).into(),
             max_block_cycles: consensus.max_block_cycles.into(),
             max_block_bytes: consensus.max_block_bytes.into(),

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -233,7 +233,10 @@ impl TxPoolService {
             compact_target: current_epoch.compact_target().into(),
             current_time: current_time.into(),
             number: candidate_number.into(),
-            epoch: current_epoch.number_with_fraction(candidate_number).into(),
+            epoch: current_epoch
+                .number_with_fraction(candidate_number)
+                .full_value()
+                .into(),
             parent_hash: tip_hash.unpack(),
             cycles_limit: cycles_limit.into(),
             bytes_limit: bytes_limit.into(),

--- a/util/jsonrpc-types/src/uints.rs
+++ b/util/jsonrpc-types/src/uints.rs
@@ -182,12 +182,6 @@ impl From<core::Capacity> for JsonUint<u64> {
     }
 }
 
-impl From<core::EpochNumberWithFraction> for JsonUint<u64> {
-    fn from(value: core::EpochNumberWithFraction) -> Self {
-        JsonUint(value.full_value())
-    }
-}
-
 impl From<JsonUint<u64>> for core::Capacity {
     fn from(value: JsonUint<u64>) -> Self {
         core::Capacity::shannons(value.value())


### PR DESCRIPTION
During reviewing https://github.com/nervosnetwork/ckb/pull/2475, I realize that the implicit `impl From<core::EpochNumberWithFraction> for JsonUint<u64>` is may be misleading.  Better force explicitly specifying `epoch.number()` or `epoch.full_value()`.

https://github.com/nervosnetwork/ckb/blob/80320313b3e81d83bb0569312fe300099defb494/util/jsonrpc-types/src/uints.rs#L185-L189