### PR TITLE
chore: hide the AnyError since it's only an internal type

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -12,7 +12,7 @@ pub use internal::{InternalError, InternalErrorKind, OtherError, SilentError};
 use prelude::*;
 
 /// A wrapper around a dynamic error type.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AnyError(Arc<anyhow::Error>);
 
 /// TODO(doc): @keroro520
@@ -58,6 +58,12 @@ impl Deref for AnyError {
 }
 
 impl fmt::Display for AnyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for AnyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }


### PR DESCRIPTION
The `AnyError` was `anyhow::Error` at first:
https://github.com/nervosnetwork/ckb/blob/2e067a7c5b02eed6a9b565b5c2c5a73197bb227f/error/src/lib.rs#L7

But `anyhow::Error` is not cloneable, so we use `AnyError` to wrapper around it.
https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/error/src/lib.rs#L16

So, we shouldn't let users to know the `AnyError`. For example:
> {"code":-301,"message":"TransactionFailedToResolve: OutPoint(Unknown([OutPoint(0xb3d1846ad3af896eb11f83826bd13f57a464c012d1e17c8182cf988f4720abf600000000)]))","data":"Error { kind: OutPoint, inner: AnyError(Unknown([OutPoint(0xb3d1846ad3af896eb11f83826bd13f57a464c012d1e17c8182cf988f4720abf60
0000000)])) }"}

But the follow codes use `fmt::Debug` to format the error, and return the `String` to the users:
https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/rpc/src/error.rs#L141
https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/rpc/src/error.rs#L150

Ref: [CKB PR 2386: refactor: replace `failure` by `thiserror` and `anyhow`](https://github.com/nervosnetwork/ckb/pull/2386)