### PR TITLE
test: fix test "test_prepare_uncles"; it could failed with a very small chance

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -201,7 +201,7 @@ fn test_prepare_uncles() {
         .unwrap()
         .unwrap();
     // block number 3, epoch 0
-    while (Into::<u64>::into(block_template.number)) != 3 {
+    while (Into::<u64>::into(block_template.number)) != 3 || block_template.uncles.is_empty() {
         block_template = tx_pool
             .get_block_template(None, None, None)
             .unwrap()


### PR DESCRIPTION
#### Issue

- `ChainController::process_block(..)` is synchronized, it will wait for the response.

  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/chain/src/chain.rs#L200-L208

- But when `ChainService::process_block(..)`, it will send `NewUncle(..)` to `TxPoolController` without waiting for the response.
 
  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/chain/src/chain.rs#L491-L497

- So, with a very small probability, the uncle block may not have been processed by `TxPoolService`.

  So the follow line will throw the error: `panicked at 'index out of bounds: the len is 0 but the index is 0`.

  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/chain/src/tests/block_assembler.rs#L210

#### Reproduce

Append `::std::thread::sleep(::std::time::Duration::from_millis(500));` to line 629 in the follow code section to delay `TxPool` update `NewUncle` can reproduce this issue.
https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/tx-pool/src/service.rs#L629-L637