### PR TITLE
test: fix potential failure in integration tests, such as DifferentTxsWithSameInput

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -375,6 +375,27 @@ impl Node {
         );
     }
 
+    pub fn wait_for_tx_pool(&self) {
+        let rpc_client = self.rpc_client();
+        let mut chain_tip = rpc_client.get_tip_header();
+        let mut tx_pool_tip = rpc_client.tx_pool_info();
+        let instant = Instant::now();
+        while instant.elapsed() < Duration::from_secs(10) {
+            if chain_tip.hash == tx_pool_tip.tip_hash {
+                return;
+            }
+            chain_tip = rpc_client.get_tip_header();
+            tx_pool_tip = rpc_client.tx_pool_info();
+        }
+        panic!(
+            "timeout to wait for tx pool,\n\tchain   tip: {:?}, {:#x},\n\ttx-pool tip: {}, {:#x}",
+            chain_tip.inner.number.value(),
+            chain_tip.hash,
+            tx_pool_tip.tip_number.value(),
+            tx_pool_tip.tip_hash,
+        );
+    }
+
     pub fn new_block(
         &self,
         bytes_limit: Option<u64>,

--- a/test/src/util/mining.rs
+++ b/test/src/util/mining.rs
@@ -74,6 +74,7 @@ where
         let block = with(builder);
         node.submit_block(&block);
     }
+    node.wait_for_tx_pool();
 }
 
 pub fn mine_until_bool<P>(node: &Node, predicate: P)
@@ -99,6 +100,7 @@ where
 {
     loop {
         if let Some(t) = until() {
+            node.wait_for_tx_pool();
             return t;
         }
 


### PR DESCRIPTION
#### Issue

- `ChainController::process_block(..)` is synchronized, it will wait for the response.

  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/chain/src/chain.rs#L200-L208

- But when `ChainService::process_block(..)`, it will send `ChainReorg(..)` to `TxPoolController` without waiting for the response.
 
  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/chain/src/chain.rs#L454-L461
  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/tx-pool/src/service.rs#L195-L198

- So, with a very small probability, the `ChainReorg(..)` may not have been processed by `TxPoolService` before we use transactions in the new tip block.

  Then the error `TransactionFailedToResolve: Resolve failed Unknown([OutPoint(0x..)])` could be thrown.

  Similar to #2478.

#### Reproduce

Append `::std::thread::sleep(::std::time::Duration::from_millis(100));` to line 619 in the follow code section to delay `TxPool` update `ChainReorg(..)` can reproduce this issue.
https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/tx-pool/src/service.rs#L617-L628

#### Affected

This issue causes a lot of integration tests failures, for example:

- `DifferentTxsWithSameInput`

  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/test/src/specs/tx_pool/different_txs_with_same_input.rs#L16-L17

- `ConflictInGap`

  https://github.com/nervosnetwork/ckb/blob/6e34d89a44aaeba3ffbfbf62c173e6a0a6547273/test/src/specs/tx_pool/collision.rs#L92-L94