### PR TITLE
test: fix potential failure in integration test GetBlocksTimeout

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -616,7 +616,7 @@ impl Synchronizer {
                         .expect("download thread can't start");
                 }
             },
-            _ => {
+            None => {
                 for peer in self.get_peers_to_fetch(ibd, &disconnect_list) {
                     if let Some(fetch) = self.get_blocks_to_fetch(peer, ibd) {
                         for item in fetch {


### PR DESCRIPTION
#### Issue

- `GetBlocks` is sent by `BlockFetchCMD` in thread `BlockDownload`.
  https://github.com/nervosnetwork/ckb/blob/a1bd7d2f5909d4cd60a8b58fac8aa5d0ca30d078/sync/src/synchronizer/mod.rs#L631
  https://github.com/nervosnetwork/ckb/blob/a1bd7d2f5909d4cd60a8b58fac8aa5d0ca30d078/sync/src/synchronizer/mod.rs#L604-L607

- `HeadersProcess` is asynchronously running in global runtime.

- `GetBlocks` and `HeadersProcess` are parallel.

- Choose integration test `GetBlocksTimeout` as the example to explain the issue:

  - After sent all headers to node1, the test check the next `SyncMessage` immediately.
    https://github.com/nervosnetwork/ckb/blob/a1bd7d2f5909d4cd60a8b58fac8aa5d0ca30d078/test/src/specs/sync/get_blocks.rs#L29-L40
     And only check the type of `SyncMessage`.
    https://github.com/nervosnetwork/ckb/blob/a1bd7d2f5909d4cd60a8b58fac8aa5d0ca30d078/test/src/specs/sync/get_blocks.rs#L56-L66

    - Nearly all the time, `HeadersProcess` can finish all tasks, **but when not, the check will fail**.

      If `BlockFetchCMD` runs when `HeadersProcess` only finished processing 3 headers, a `GetBlocks(length = 3)` will be sent, after `HeadersProcess` finished processing all headers, a `GetBlocks(length = 13)` will be sent again.
      **The test should check the last hash in the last `GetBlocks`. Or, check if the summation of all `GetBlocks` lengths are 16.**

#### Reproduce

Update the follow codes:
https://github.com/nervosnetwork/ckb/blob/a1bd7d2f5909d4cd60a8b58fac8aa5d0ca30d078/test/src/specs/sync/get_blocks.rs#L31
to:
```rust
        for header in &headers {
            ::std::thread::sleep(::std::time::Duration::from_millis(500));
            net.send(
                &node1,
                SupportProtocols::Sync,
                build_headers(&vec![header.to_owned()]),
            );
        }
```