### PR TITLE
feat: provide `--overwrite-spec` to override the chain spec in storage

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -12,8 +12,9 @@ use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_resource::Resource;
 use ckb_rpc::{RpcServer, ServiceBuilder};
 use ckb_shared::shared::{Shared, SharedBuilder};
-use ckb_store::ChainStore;
+use ckb_store::{ChainDB, ChainStore};
 use ckb_sync::{NetTimeProtocol, Relayer, SyncShared, Synchronizer};
+use ckb_types::packed::Byte32;
 use ckb_types::{core::cell::setup_system_cell_cache, prelude::*};
 use ckb_verification::{GenesisVerifier, Verifier};
 use std::sync::Arc;
@@ -192,31 +193,52 @@ fn verify_genesis(shared: &Shared) -> Result<(), ExitCode> {
 
 fn check_spec(shared: &Shared, args: &RunArgs) -> Result<(), ExitCode> {
     let store = shared.store();
-    if let Some(spec_hash) = store.get_chain_spec_hash() {
-        if args.chain_spec_hash != spec_hash && !args.skip_chain_spec_check {
-            eprintln!(
-                "chain_spec_hash mismatch Config({}) storage({}), pass command line argument --skip-spec-check if you are sure that the two different chains are compatible.",
-                args.chain_spec_hash, spec_hash
-            );
-            return Err(ExitCode::Config);
-        }
-    } else {
-        store
-            .put_chain_spec_hash(&args.chain_spec_hash)
-            .map_err(|err| {
-                eprintln!(
-                    "Touch chain_spec_hash {} error: {}",
-                    args.chain_spec_hash, err
-                );
-                ExitCode::IO
-            })?;
+    let stored_spec_hash = store.get_chain_spec_hash();
+
+    if stored_spec_hash.is_none() {
+        // fresh yet
+        write_chain_spec_hash(store, &args.chain_spec_hash)?;
         info_target!(
             crate::LOG_TARGET_MAIN,
             "Touch chain spec hash: {}",
             args.chain_spec_hash
         );
+    } else if stored_spec_hash.as_ref() == Some(&args.chain_spec_hash) {
+        // stored == configured
+        // do nothing
+    } else if args.overwrite_chain_spec {
+        // stored != configured with --overwrite-spec
+        write_chain_spec_hash(store, &args.chain_spec_hash)?;
+        info_target!(
+            crate::LOG_TARGET_MAIN,
+            "Overwrite chain spec hash from {} to {}",
+            stored_spec_hash.expect("checked"),
+            args.overwrite_chain_spec,
+        );
+    } else if args.skip_chain_spec_check {
+        // stored != configured with --skip-spec-check
+        // do nothing
+    } else {
+        // stored != configured
+        eprintln!(
+            "chain_spec_hash mismatch Config({}) storage({}), pass command line argument \
+                --skip-spec-check if you are sure that the two different chains are compatible; \
+                or pass --overwrite-spec to force overriding stored chain spec with configured chain spec",
+            args.chain_spec_hash, stored_spec_hash.expect("checked")
+        );
+        return Err(ExitCode::Config);
     }
     Ok(())
+}
+
+fn write_chain_spec_hash(store: &ChainDB, chain_spec_hash: &Byte32) -> Result<(), ExitCode> {
+    store.put_chain_spec_hash(chain_spec_hash).map_err(|err| {
+        eprintln!(
+            "store.put_chain_spec_hash {} error: {}",
+            chain_spec_hash, err
+        );
+        ExitCode::IO
+    })
 }
 
 fn sanitize_block_assembler_config(

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -36,7 +36,11 @@ pub struct RunArgs {
     pub block_assembler_advanced: bool,
     /// Whether skip chain spec hash check
     pub skip_chain_spec_check: bool,
-    /// Config chain spec hash
+    /// Whether overwrite the chain spec hash in the database with [`RunArgs::chain_spec_hash`]
+    ///
+    /// [`RunArgs::chain_spec_hash`]: ./struct.RunArgs.html#structfield.chain_spec_hash
+    pub overwrite_chain_spec: bool,
+    /// Hash of serialized configured chain spec
     pub chain_spec_hash: Byte32,
 }
 

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -98,6 +98,8 @@ pub const ARG_SANITY_CHECK: &str = "sanity-check";
 pub const ARG_FULL_VERIFICATION: &str = "full-verification";
 /// Present `skip-spec-check` arg to `run` skip spec check on setup
 pub const ARG_SKIP_CHAIN_SPEC_CHECK: &str = "skip-spec-check";
+/// Present `overwrite-spec` arg to force overriding the chain spec in the database with the present configured chain spec
+pub const ARG_OVERWRITE_CHAIN_SPEC: &str = "overwrite-spec";
 /// assume valid target cli arg name
 pub const ARG_ASSUME_VALID_TARGET: &str = "assume-valid-target";
 /// Migrate check flag arg
@@ -154,6 +156,10 @@ fn run() -> App<'static, 'static> {
             Arg::with_name(ARG_SKIP_CHAIN_SPEC_CHECK)
                 .long(ARG_SKIP_CHAIN_SPEC_CHECK)
                 .help("Skips checking the chain spec with the hash stored in the database"),
+        ).arg(
+            Arg::with_name(ARG_OVERWRITE_CHAIN_SPEC)
+                .long(ARG_OVERWRITE_CHAIN_SPEC)
+                .help("Overwrites the chain spec in the database with the present configured chain spec")
         ).arg(
         Arg::with_name(ARG_ASSUME_VALID_TARGET)
             .long(ARG_ASSUME_VALID_TARGET)

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -88,6 +88,7 @@ impl Setup {
             consensus,
             block_assembler_advanced: matches.is_present(cli::ARG_BA_ADVANCED),
             skip_chain_spec_check: matches.is_present(cli::ARG_SKIP_CHAIN_SPEC_CHECK),
+            overwrite_chain_spec: matches.is_present(cli::ARG_OVERWRITE_CHAIN_SPEC),
             chain_spec_hash,
         })
     }


### PR DESCRIPTION
Ckb stores chain spec into the database and compare the configured chain spec on starting.

A user may want to overwrite the stored chain spec when it changes the configured chain spec and makes sure the change is acceptable. Therefore this PR adds `--overwrite-spec` command option to overwrite the stored chain spec.

---

* If you want to just skip the chain spec checking without overriding the stored one:

  ```shell
  ckb run --skip-spec-check ...
  ```

* If you want to overwrite the stored chain spec with the configured one:

  ```shell
  ckb run --overwrite-spec ...
  ```