### PR TITLE
fix: fix wasm build by locking tempfile

### DIFF
--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 phf = "0.7.21"
 includedir = "0.5.0"
-tempfile = "3.0"
+# Lock tempfile so wasm-build-test will use getrandom 0.1.*
+tempfile = "=3.1.0"
 serde = { version = "1.0", features = ["derive"] }
 ckb-types = { path = "../util/types", version = "= 0.40.0-pre" }
 ckb-system-scripts = { version = "= 0.5.1" }


### PR DESCRIPTION
Lock the version of tempfile to `= 3.1.0` to fix wasm-build-test.

WASM build test does not commit the `Cargo.lock` so it will choose the latest version according to the semver requirements.

On Jan 12, 2021, tempfile 3.2.0 has released so WASM build test starts to use it. However, this new version requires `rand 0.8`, which by turn depends on `getrandom 0.2.1`. Starting from `getrandom 0.2.0`, it does not support `wasm32-unknown-unknown` (see [getrandom unsupported targets](https://docs.rs/getrandom/0.2.0/getrandom/index.html#unsupported-targets)), so the build fails.
