### PR TITLE
fix: network should work without rpc

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -162,7 +162,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
         .enable_stats(shared.clone(), synchronizer, Arc::clone(&alert_notifier))
         .enable_experiment(shared.clone())
         .enable_integration_test(shared.clone(), network_controller.clone(), chain_controller)
-        .enable_alert(alert_verifier, alert_notifier, network_controller)
+        .enable_alert(alert_verifier, alert_notifier, network_controller.clone())
         .enable_debug();
     let io_handler = builder.build();
 
@@ -177,6 +177,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
 
     info_target!(crate::LOG_TARGET_MAIN, "Finishing work, please wait...");
     drop(rpc_server);
+    drop(network_controller);
 
     Ok(())
 }


### PR DESCRIPTION
#### How to Reproduce?

Edit section `[rpc]` in `ckb.toml`:

```toml
modules = []
```

p.s. `NetworkController` contains all other `Controllers`, so we can only extend its lifetime to let all controllers work well.