### PR TITLE
manually trigger compaction after freeze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-constant"
+version = "0.41.0-pre"
+
+[[package]]
 name = "ckb-crypto"
 version = "0.41.0-pre"
 dependencies = [
@@ -1220,6 +1224,7 @@ version = "0.41.0-pre"
 dependencies = [
  "arc-swap",
  "ckb-chain-spec",
+ "ckb-constant",
  "ckb-db",
  "ckb-db-schema",
  "ckb-error",
@@ -1229,6 +1234,7 @@ dependencies = [
  "ckb-store",
  "ckb-traits",
  "ckb-types",
+ "faketime",
 ]
 
 [[package]]
@@ -1271,6 +1277,7 @@ dependencies = [
  "ckb-chain",
  "ckb-chain-spec",
  "ckb-channel",
+ "ckb-constant",
  "ckb-dao",
  "ckb-dao-utils",
  "ckb-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ dependencies = [
  "ckb-async-runtime",
  "ckb-chain-spec",
  "ckb-channel",
+ "ckb-constant",
  "ckb-db",
  "ckb-db-migration",
  "ckb-db-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "ckb-tx-pool",
  "ckb-types",
  "ckb-verification",
+ "faketime",
  "num_cpus",
 ]
 
@@ -1225,7 +1226,6 @@ version = "0.41.0-pre"
 dependencies = [
  "arc-swap",
  "ckb-chain-spec",
- "ckb-constant",
  "ckb-db",
  "ckb-db-schema",
  "ckb-error",
@@ -1235,7 +1235,6 @@ dependencies = [
  "ckb-store",
  "ckb-traits",
  "ckb-types",
- "faketime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "util/fixed-hash",
     "util/occupied-capacity",
     "util/crypto",
+    "util/constant",
     "error",
     "util/multisig",
     "util/types",

--- a/freezer/src/freezer.rs
+++ b/freezer/src/freezer.rs
@@ -16,6 +16,10 @@ use std::sync::Arc;
 
 const LOCKNAME: &str = "FLOCK";
 
+/// freeze result represent blkhash -> (blknum, txsnum) btree-map
+/// sorted blkhash for making ranges for compaction
+type FreezeResult = BTreeMap<packed::Byte32, (BlockNumber, u32)>;
+
 struct Inner {
     pub(crate) files: FreezerFiles,
     pub(crate) tip: Option<HeaderView>,
@@ -72,7 +76,7 @@ impl Freezer {
         &self,
         threshold: BlockNumber,
         get_block_by_number: F,
-    ) -> Result<BTreeMap<packed::Byte32, (BlockNumber, u32)>, Error>
+    ) -> Result<FreezeResult, Error>
     where
         F: Fn(BlockNumber) -> Option<BlockView>,
     {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -31,3 +31,4 @@ ckb-channel = { path = "../util/channel", version = "= 0.41.0-pre" }
 ckb-migration-template = { path = "migration-template", version = "= 0.41.0-pre" }
 ckb-constant = { path = "../util/constant", version = "= 0.41.0-pre" }
 num_cpus = "1.10"
+faketime = "0.2.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -29,4 +29,5 @@ ckb-async-runtime = { path = "../util/runtime", version = "= 0.41.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.41.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.41.0-pre" }
 ckb-migration-template = { path = "migration-template", version = "= 0.41.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.41.0-pre" }
 num_cpus = "1.10"

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -261,6 +261,11 @@ impl Shared {
         let snapshot = self.snapshot();
         let current_epoch = snapshot.epoch_ext().number();
 
+        if snapshot.is_initial_block_download() {
+            ckb_logger::trace!("is_initial_block_download freeze skip");
+            return Ok(());
+        }
+
         if current_epoch <= THRESHOLD_EPOCH {
             ckb_logger::trace!("freezer loaf");
             return Ok(());

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -120,6 +120,25 @@ impl ChainDB {
         self.db.write(&write_batch.inner)
     }
 
+    /// write options set_sync = true
+    ///
+    /// see [`RocksDB::write_sync`](ckb_db::RocksDB::write_sync).
+    pub fn write_sync(&self, write_batch: &StoreWriteBatch) -> Result<(), Error> {
+        self.db.write_sync(&write_batch.inner)
+    }
+
+    /// Force the data to go through the compaction in order to consolidate it
+    ///
+    /// see [`RocksDB::compact_range`](ckb_db::RocksDB::compact_range).
+    pub fn compact_range(
+        &self,
+        col: Col,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        self.db.compact_range(col, start, end)
+    }
+
     /// TODO(doc): @quake
     pub fn init(&self, consensus: &Consensus) -> Result<(), Error> {
         let genesis = consensus.genesis_block();

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -19,20 +19,21 @@ ckb-network = { path = "../network", version = "= 0.41.0-pre" }
 ckb-logger = {path = "../util/logger", version = "= 0.41.0-pre"}
 ckb-metrics = {path = "../util/metrics", version = "= 0.41.0-pre"}
 ckb-util = { path = "../util", version = "= 0.41.0-pre" }
-faketime = "0.2.0"
-bitflags = "1.0"
 ckb-verification = { path = "../verification", version = "= 0.41.0-pre" }
 ckb-verification-traits = { path = "../verification/traits", version = "= 0.41.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.41.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.41.0-pre" }
 ckb-traits = { path = "../traits", version = "= 0.41.0-pre" }
-lru = "0.6.0"
-sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
-futures = "0.3"
 ckb-error = {path = "../error", version = "= 0.41.0-pre"}
 ckb-tx-pool = { path = "../tx-pool", version = "= 0.41.0-pre" }
+sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
+ckb-constant = { path = "../util/constant", version = "= 0.41.0-pre" }
+lru = "0.6.0"
+futures = "0.3"
 governor = "0.3.1"
 tempfile = "3.0"
+faketime = "0.2.0"
+bitflags = "1.0"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.41.0-pre" }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -19,21 +19,7 @@ pub use crate::relayer::Relayer;
 pub use crate::status::{Status, StatusCode};
 pub use crate::synchronizer::Synchronizer;
 pub use crate::types::SyncShared;
-use std::time::Duration;
-
-/// Default max get header response length, if it is greater than this value, the message will be ignored
-pub const MAX_HEADERS_LEN: usize = 2_000;
-/// The default init download block interval is 24 hours
-/// If the time of the local highest block is within this range, exit the ibd state
-pub const MAX_TIP_AGE: u64 = 24 * 60 * 60 * 1000;
-
-/// The default number of download blocks that can be requested at one time
-/* About Download Scheduler */
-pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
-/// Maximum number of download blocks that can be requested at one time
-pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
-/// The point at which the scheduler adjusts the number of tasks, by default one adjustment per 512 blocks.
-pub const CHECK_POINT_WINDOW: u64 = (MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4) as u64;
+use ckb_constant::sync::MAX_BLOCKS_IN_TRANSIT_PER_PEER;
 
 // Time recording window size, ibd period scheduler dynamically adjusts frequency
 // for acquisition/analysis generating dynamic time range
@@ -46,50 +32,3 @@ pub(crate) const NORMAL_INDEX: usize = TIME_TRACE_SIZE * 4 / 5;
 pub(crate) const LOW_INDEX: usize = TIME_TRACE_SIZE * 9 / 10;
 
 pub(crate) const LOG_TARGET_RELAY: &str = "ckb_relay";
-
-/// Inspect the headers downloading every 2 minutes
-pub const HEADERS_DOWNLOAD_INSPECT_WINDOW: u64 = 2 * 60 * 1000;
-/// Global Average Speed
-//      Expect 300 KiB/second
-//          = 1600 headers/second (300*1024/192)
-//          = 96000 headers/minute (1600*60)
-//          = 11.11 days-in-blockchain/minute-in-reality (96000*10/60/60/24)
-//      => Sync 1 year headers in blockchain will be in 32.85 minutes (365/11.11) in reality
-pub const HEADERS_DOWNLOAD_HEADERS_PER_SECOND: u64 = 1600;
-/// Acceptable Lowest Instantaneous Speed: 75.0 KiB/second (300/4)
-pub const HEADERS_DOWNLOAD_TOLERABLE_BIAS_FOR_SINGLE_SAMPLE: u64 = 4;
-/// Pow interval
-pub const POW_INTERVAL: u64 = 10;
-
-/// Protect at least this many outbound peers from disconnection due to slow
-/// behind headers chain.
-pub const MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT: usize = 4;
-/// Chain sync timout
-pub const CHAIN_SYNC_TIMEOUT: u64 = 12 * 60 * 1000; // 12 minutes
-/// Suspend sync time
-pub const SUSPEND_SYNC_TIME: u64 = 5 * 60 * 1000; // 5 minutes
-/// Eviction response time
-pub const EVICTION_HEADERS_RESPONSE_TIME: u64 = 120 * 1000; // 2 minutes
-
-/// The maximum number of entries in a locator
-pub const MAX_LOCATOR_SIZE: usize = 101;
-
-/// Block download timeout
-pub const BLOCK_DOWNLOAD_TIMEOUT: u64 = 30 * 1000; // 30s
-
-/// Block download window size
-// Size of the "block download window": how far ahead of our current height do we fetch?
-// Larger windows tolerate larger download speed differences between peers, but increase the
-// potential degree of disordering of blocks.
-pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024 * 8; // 1024 * default_outbound_peers
-
-/// Interval between repeated inquiry transactions
-pub const RETRY_ASK_TX_TIMEOUT_INCREASE: Duration = Duration::from_secs(30);
-
-/// Default ban time for message
-// ban time
-// 5 minutes
-pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
-/// Default ban time for sync useless
-// 10 minutes, peer have no common ancestor block
-pub const SYNC_USELESS_BAN_TIME: Duration = Duration::from_secs(10 * 60);

--- a/sync/src/net_time_checker.rs
+++ b/sync/src/net_time_checker.rs
@@ -1,4 +1,4 @@
-use crate::BAD_MESSAGE_BAN_TIME;
+use ckb_constant::sync::BAD_MESSAGE_BAN_TIME;
 use ckb_logger::{debug, info, warn};
 use ckb_network::{bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_types::{packed, prelude::*};

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -22,8 +22,9 @@ use self::transaction_hashes_process::TransactionHashesProcess;
 use self::transactions_process::TransactionsProcess;
 use crate::block_status::BlockStatus;
 use crate::types::{ActiveChain, SyncShared};
-use crate::{Status, StatusCode, BAD_MESSAGE_BAN_TIME};
+use crate::{Status, StatusCode};
 use ckb_chain::chain::ChainController;
+use ckb_constant::sync::BAD_MESSAGE_BAN_TIME;
 use ckb_logger::{debug_target, error_target, info_target, trace_target, warn_target};
 use ckb_metrics::metrics;
 use ckb_network::{

--- a/sync/src/status.rs
+++ b/sync/src/status.rs
@@ -1,4 +1,4 @@
-use crate::{BAD_MESSAGE_BAN_TIME, SYNC_USELESS_BAN_TIME};
+use ckb_constant::sync::{BAD_MESSAGE_BAN_TIME, SYNC_USELESS_BAN_TIME};
 use std::fmt::{self, Display, Formatter};
 use std::time::Duration;
 

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -1,7 +1,9 @@
 use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::types::{ActiveChain, HeaderView, IBDState};
-use crate::BLOCK_DOWNLOAD_WINDOW;
+use ckb_constant::sync::{
+    BLOCK_DOWNLOAD_WINDOW, CHECK_POINT_WINDOW, INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+};
 use ckb_logger::{debug, trace};
 use ckb_network::PeerIndex;
 use ckb_types::{core, packed};
@@ -164,7 +166,7 @@ impl<'a> BlockFetcher<'a> {
 
         let tip = self.active_chain.tip_number();
         let should_mark = fetch.last().map_or(false, |header| {
-            header.number().saturating_sub(crate::CHECK_POINT_WINDOW) > tip
+            header.number().saturating_sub(CHECK_POINT_WINDOW) > tip
         });
         if should_mark {
             inflight.mark_slow_block(tip);
@@ -185,7 +187,7 @@ impl<'a> BlockFetcher<'a> {
 
         Some(
             fetch
-                .chunks(crate::INIT_BLOCKS_IN_TRANSIT_PER_PEER)
+                .chunks(INIT_BLOCKS_IN_TRANSIT_PER_PEER)
                 .map(|headers| headers.iter().map(core::HeaderView::hash).collect())
                 .collect(),
         )

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -1,6 +1,7 @@
 use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
-use crate::{Status, StatusCode, INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
+use crate::{Status, StatusCode};
+use ckb_constant::sync::{INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
 use ckb_logger::debug;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{packed, prelude::*};

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -1,5 +1,6 @@
 use crate::synchronizer::Synchronizer;
-use crate::{Status, StatusCode, MAX_LOCATOR_SIZE};
+use crate::{Status, StatusCode};
+use ckb_constant::sync::MAX_LOCATOR_SIZE;
 use ckb_logger::{debug, info};
 use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_types::{

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -1,7 +1,8 @@
 use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::types::{ActiveChain, SyncShared};
-use crate::{Status, StatusCode, MAX_HEADERS_LEN};
+use crate::{Status, StatusCode};
+use ckb_constant::sync::MAX_HEADERS_LEN;
 use ckb_error::Error;
 use ckb_logger::{debug, log_enabled, warn, Level};
 use ckb_network::{CKBProtocolContext, PeerIndex};

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -13,12 +13,13 @@ use self::headers_process::HeadersProcess;
 use self::in_ibd_process::InIBDProcess;
 use crate::block_status::BlockStatus;
 use crate::types::{HeaderView, HeadersSyncController, IBDState, PeerFlags, Peers, SyncShared};
-use crate::{
-    Status, StatusCode, BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
-    MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, MAX_TIP_AGE,
-};
+use crate::{Status, StatusCode};
 use ckb_chain::chain::ChainController;
 use ckb_channel as channel;
+use ckb_constant::sync::{
+    BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
+    INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, MAX_TIP_AGE,
+};
 use ckb_error::AnyError;
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_metrics::metrics;
@@ -544,7 +545,7 @@ impl Synchronizer {
             ::std::cmp::Reverse(
                 state
                     .get(id)
-                    .map_or(crate::INIT_BLOCKS_IN_TRANSIT_PER_PEER, |d| d.task_count()),
+                    .map_or(INIT_BLOCKS_IN_TRANSIT_PER_PEER, |d| d.task_count()),
             )
         });
         peers
@@ -792,10 +793,11 @@ mod tests {
     use super::*;
     use crate::{
         types::{HeaderView, HeadersSyncController, PeerState},
-        SyncShared, MAX_TIP_AGE,
+        SyncShared,
     };
     use ckb_chain::chain::ChainService;
     use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
+    use ckb_constant::sync::MAX_TIP_AGE;
     use ckb_dao::DaoCalculator;
     use ckb_network::{
         bytes::Bytes, Behaviour, CKBProtocolContext, Peer, PeerId, PeerIndex, ProtocolId,

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -1,5 +1,5 @@
 use crate::types::{BlockNumberAndHash, InflightBlocks};
-use crate::BLOCK_DOWNLOAD_TIMEOUT;
+use ckb_constant::sync::BLOCK_DOWNLOAD_TIMEOUT;
 use ckb_types::prelude::*;
 use ckb_types::{h256, H256};
 use std::collections::HashSet;

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1800,7 +1800,7 @@ impl ActiveChain {
     }
 
     pub fn is_initial_block_download(&self) -> bool {
-        self.snapshot.is_initial_block_download()
+        self.shared.shared().is_initial_block_download()
     }
 
     pub fn get_ancestor(&self, base: &Byte32, number: BlockNumber) -> Option<core::HeaderView> {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1,15 +1,15 @@
 use crate::block_status::BlockStatus;
 use crate::orphan_block_pool::OrphanBlockPool;
-use crate::{
-    BLOCK_DOWNLOAD_TIMEOUT, FAST_INDEX, HEADERS_DOWNLOAD_HEADERS_PER_SECOND,
-    HEADERS_DOWNLOAD_INSPECT_WINDOW, HEADERS_DOWNLOAD_TOLERABLE_BIAS_FOR_SINGLE_SAMPLE,
-    INIT_BLOCKS_IN_TRANSIT_PER_PEER, LOW_INDEX, MAX_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN,
-    MAX_TIP_AGE, NORMAL_INDEX, POW_INTERVAL, RETRY_ASK_TX_TIMEOUT_INCREASE, SUSPEND_SYNC_TIME,
-    TIME_TRACE_SIZE,
-};
+use crate::{FAST_INDEX, LOW_INDEX, NORMAL_INDEX, TIME_TRACE_SIZE};
 use ckb_app_config::SyncConfig;
 use ckb_chain::chain::ChainController;
 use ckb_chain_spec::consensus::Consensus;
+use ckb_constant::sync::{
+    BLOCK_DOWNLOAD_TIMEOUT, HEADERS_DOWNLOAD_HEADERS_PER_SECOND, HEADERS_DOWNLOAD_INSPECT_WINDOW,
+    HEADERS_DOWNLOAD_TOLERABLE_BIAS_FOR_SINGLE_SAMPLE, INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+    MAX_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN, POW_INTERVAL, RETRY_ASK_TX_TIMEOUT_INCREASE,
+    SUSPEND_SYNC_TIME,
+};
 use ckb_error::AnyError;
 use ckb_logger::{debug, debug_target, error, trace};
 use ckb_metrics::{metrics, Timer};
@@ -37,7 +37,7 @@ use std::hash::Hash;
 use std::mem;
 use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -1224,7 +1224,6 @@ impl SyncShared {
         let state = SyncState {
             n_sync_started: AtomicUsize::new(0),
             n_protected_outbound_peers: AtomicUsize::new(0),
-            ibd_finished: AtomicBool::new(false),
             shared_best_header,
             header_map,
             block_status_map: Mutex::new(HashMap::new()),
@@ -1481,7 +1480,6 @@ impl SyncShared {
 pub struct SyncState {
     n_sync_started: AtomicUsize,
     n_protected_outbound_peers: AtomicUsize,
-    ibd_finished: AtomicBool,
 
     /* Status irrelevant to peers */
     shared_best_header: RwLock<HeaderView>,
@@ -1802,16 +1800,7 @@ impl ActiveChain {
     }
 
     pub fn is_initial_block_download(&self) -> bool {
-        // Once this function has returned false, it must remain false.
-        if self.state.ibd_finished.load(Ordering::Relaxed) {
-            false
-        } else if unix_time_as_millis().saturating_sub(self.tip_header().timestamp()) > MAX_TIP_AGE
-        {
-            true
-        } else {
-            self.state.ibd_finished.store(true, Ordering::Relaxed);
-            false
-        }
+        self.snapshot.is_initial_block_download()
     }
 
     pub fn get_ancestor(&self, base: &Byte32, number: BlockNumber) -> Option<core::HeaderView> {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -20,7 +20,6 @@ ckb-hash = { path = "../util/hash", version = "= 0.41.0-pre" }
 ckb-util = { path = "../util", version = "= 0.41.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.41.0-pre" }
 ckb-crypto = { path = "../util/crypto", version = "= 0.41.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.41.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.41.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.41.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.41.0-pre" }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -21,6 +21,7 @@ ckb-hash = { path = "../util/hash", version = "= 0.41.0-pre" }
 ckb-util = { path = "../util", version = "= 0.41.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.41.0-pre" }
 ckb-crypto = { path = "../util/crypto", version = "= 0.41.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.41.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.41.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.41.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.41.0-pre" }
@@ -30,6 +31,7 @@ ckb-logger = { path = "../util/logger", version = "= 0.41.0-pre" }
 ckb-logger-config = { path = "../util/logger-config", version = "= 0.41.0-pre" }
 ckb-logger-service = { path = "../util/logger-service", version = "= 0.41.0-pre" }
 ckb-error = { path = "../error", version = "= 0.41.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.41.0-pre" }
 tempfile = "3.0"
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
 rand = "0.7"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -15,7 +15,6 @@ ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.41.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.41.0-pre" }
 ckb-network = { path = "../network", version = "= 0.41.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.41.0-pre" }
-ckb-sync = { path = "../sync", version = "= 0.41.0-pre" }
 ckb-types = { path = "../util/types", version = "= 0.41.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.41.0-pre" }
 ckb-util = { path = "../util", version = "= 0.41.0-pre" }

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -4,9 +4,9 @@ use crate::util::mining::{mine, out_ibd_mode};
 use crate::util::transaction::{always_success_transaction, always_success_transactions};
 use crate::utils::{build_relay_tx_hashes, build_relay_txs, sleep, wait_until};
 use crate::{Net, Node, Spec};
+use ckb_constant::sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
 use ckb_logger::info;
 use ckb_network::SupportProtocols;
-use ckb_sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
 use ckb_types::{
     core::TransactionBuilder,
     packed::{GetRelayTransactions, RelayMessage},

--- a/test/src/specs/sync/get_blocks.rs
+++ b/test/src/specs/sync/get_blocks.rs
@@ -1,9 +1,9 @@
 use crate::util::mining::mine;
 use crate::utils::{build_headers, wait_until};
 use crate::{Net, Node, Spec};
+use ckb_constant::sync::{BLOCK_DOWNLOAD_TIMEOUT, INIT_BLOCKS_IN_TRANSIT_PER_PEER};
 use ckb_logger::info;
 use ckb_network::SupportProtocols;
-use ckb_sync::{BLOCK_DOWNLOAD_TIMEOUT, INIT_BLOCKS_IN_TRANSIT_PER_PEER};
 use ckb_types::{core::HeaderView, packed, prelude::*};
 use std::time::{Duration, Instant};
 

--- a/test/src/specs/sync/invalid_locator_size.rs
+++ b/test/src/specs/sync/invalid_locator_size.rs
@@ -1,9 +1,9 @@
 use crate::util::mining::out_ibd_mode;
 use crate::utils::wait_until;
 use crate::{Net, Node, Spec};
+use ckb_constant::sync::MAX_LOCATOR_SIZE;
 use ckb_logger::info;
 use ckb_network::SupportProtocols;
-use ckb_sync::MAX_LOCATOR_SIZE;
 use ckb_types::{
     h256,
     packed::{Byte32, GetHeaders, SyncMessage},

--- a/util/constant/Cargo.toml
+++ b/util/constant/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ckb-constant"
+version = "0.41.0-pre"
+license = "MIT"
+authors = ["Nervos Core Dev <dev@nervos.org>"]
+edition = "2018"
+description = "Ckb constant container"
+homepage = "https://github.com/nervosnetwork/ckb"
+repository = "https://github.com/nervosnetwork/ckb"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/util/constant/src/lib.rs
+++ b/util/constant/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod sync;

--- a/util/constant/src/lib.rs
+++ b/util/constant/src/lib.rs
@@ -1,1 +1,6 @@
+//! Collect constants used across ckb components.
+
+/// store constant
+pub mod store;
+/// sync constant
 pub mod sync;

--- a/util/constant/src/store.rs
+++ b/util/constant/src/store.rs
@@ -1,0 +1,4 @@
+/// This value is try to set tx key range as tight as possible,
+/// so that db iterating can stop sooner, rather than walking over the whole range of tombstones.
+/// empty_tx_size = 72
+pub const TX_INDEX_UPPER_BOUND: u32 = 597 * 1000 / 72;

--- a/util/constant/src/sync.rs
+++ b/util/constant/src/sync.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+/// The default init download block interval is 24 hours
+/// If the time of the local highest block is within this range, exit the ibd state
+pub const MAX_TIP_AGE: u64 = 24 * 60 * 60 * 1000;
+
+/// Default max get header response length, if it is greater than this value, the message will be ignored
+pub const MAX_HEADERS_LEN: usize = 2_000;
+
+/// The default number of download blocks that can be requested at one time
+/* About Download Scheduler */
+pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
+/// Maximum number of download blocks that can be requested at one time
+pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
+/// The point at which the scheduler adjusts the number of tasks, by default one adjustment per 512 blocks.
+pub const CHECK_POINT_WINDOW: u64 = (MAX_BLOCKS_IN_TRANSIT_PER_PEER * 4) as u64;
+
+/// Inspect the headers downloading every 2 minutes
+pub const HEADERS_DOWNLOAD_INSPECT_WINDOW: u64 = 2 * 60 * 1000;
+/// Global Average Speed
+//      Expect 300 KiB/second
+//          = 1600 headers/second (300*1024/192)
+//          = 96000 headers/minute (1600*60)
+//          = 11.11 days-in-blockchain/minute-in-reality (96000*10/60/60/24)
+//      => Sync 1 year headers in blockchain will be in 32.85 minutes (365/11.11) in reality
+pub const HEADERS_DOWNLOAD_HEADERS_PER_SECOND: u64 = 1600;
+/// Acceptable Lowest Instantaneous Speed: 75.0 KiB/second (300/4)
+pub const HEADERS_DOWNLOAD_TOLERABLE_BIAS_FOR_SINGLE_SAMPLE: u64 = 4;
+/// Pow interval
+pub const POW_INTERVAL: u64 = 10;
+
+/// Protect at least this many outbound peers from disconnection due to slow
+/// behind headers chain.
+pub const MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT: usize = 4;
+/// Chain sync timout
+pub const CHAIN_SYNC_TIMEOUT: u64 = 12 * 60 * 1000; // 12 minutes
+/// Suspend sync time
+pub const SUSPEND_SYNC_TIME: u64 = 5 * 60 * 1000; // 5 minutes
+/// Eviction response time
+pub const EVICTION_HEADERS_RESPONSE_TIME: u64 = 120 * 1000; // 2 minutes
+
+/// The maximum number of entries in a locator
+pub const MAX_LOCATOR_SIZE: usize = 101;
+
+/// Block download timeout
+pub const BLOCK_DOWNLOAD_TIMEOUT: u64 = 30 * 1000; // 30s
+
+/// Block download window size
+// Size of the "block download window": how far ahead of our current height do we fetch?
+// Larger windows tolerate larger download speed differences between peers, but increase the
+// potential degree of disordering of blocks.
+pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024 * 8; // 1024 * default_outbound_peers
+
+/// Interval between repeated inquiry transactions
+pub const RETRY_ASK_TX_TIMEOUT_INCREASE: Duration = Duration::from_secs(30);
+
+/// Default ban time for message
+// ban time
+// 5 minutes
+pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
+/// Default ban time for sync useless
+// 10 minutes, peer have no common ancestor block
+pub const SYNC_USELESS_BAN_TIME: Duration = Duration::from_secs(10 * 60);

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -22,3 +22,5 @@ arc-swap = "0.4"
 ckb-reward-calculator = { path = "../reward-calculator", version = "= 0.41.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.41.0-pre" }
 ckb-freezer = { path = "../../freezer", version = "= 0.41.0-pre" }
+ckb-constant = { path = "../constant", version = "= 0.41.0-pre" }
+faketime = "0.2.0"

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -22,5 +22,3 @@ arc-swap = "0.4"
 ckb-reward-calculator = { path = "../reward-calculator", version = "= 0.41.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.41.0-pre" }
 ckb-freezer = { path = "../../freezer", version = "= 0.41.0-pre" }
-ckb-constant = { path = "../constant", version = "= 0.41.0-pre" }
-faketime = "0.2.0"

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -2,7 +2,6 @@
 
 use arc_swap::{ArcSwap, Guard};
 use ckb_chain_spec::consensus::Consensus;
-use ckb_constant::sync::MAX_TIP_AGE;
 use ckb_db::{
     iter::{DBIter, IteratorMode},
     DBPinnableSlice,
@@ -23,11 +22,7 @@ use ckb_types::{
     packed::{Byte32, OutPoint, Script},
     U256,
 };
-use faketime::unix_time_as_millis;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
-static IBD_FINISHED: AtomicBool = AtomicBool::new(false);
 
 /// An Atomic wrapper for Snapshot
 pub struct SnapshotMgr {
@@ -106,20 +101,6 @@ impl Snapshot {
     /// Return reference of tip header
     pub fn tip_header(&self) -> &HeaderView {
         &self.tip_header
-    }
-
-    /// Return whether chain is in initial block download
-    pub fn is_initial_block_download(&self) -> bool {
-        // Once this function has returned false, it must remain false.
-        if IBD_FINISHED.load(Ordering::Relaxed) {
-            false
-        } else if unix_time_as_millis().saturating_sub(self.tip_header().timestamp()) > MAX_TIP_AGE
-        {
-            true
-        } else {
-            IBD_FINISHED.store(true, Ordering::Relaxed);
-            false
-        }
     }
 
     /// Return tip header number

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -108,6 +108,7 @@ impl Snapshot {
         &self.tip_header
     }
 
+    /// Return whether chain is in initial block download
     pub fn is_initial_block_download(&self) -> bool {
         // Once this function has returned false, it must remain false.
         if IBD_FINISHED.load(Ordering::Relaxed) {

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -2,6 +2,7 @@
 
 use arc_swap::{ArcSwap, Guard};
 use ckb_chain_spec::consensus::Consensus;
+use ckb_constant::sync::MAX_TIP_AGE;
 use ckb_db::{
     iter::{DBIter, IteratorMode},
     DBPinnableSlice,
@@ -22,7 +23,11 @@ use ckb_types::{
     packed::{Byte32, OutPoint, Script},
     U256,
 };
+use faketime::unix_time_as_millis;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+static IBD_FINISHED: AtomicBool = AtomicBool::new(false);
 
 /// An Atomic wrapper for Snapshot
 pub struct SnapshotMgr {
@@ -101,6 +106,19 @@ impl Snapshot {
     /// Return reference of tip header
     pub fn tip_header(&self) -> &HeaderView {
         &self.tip_header
+    }
+
+    pub fn is_initial_block_download(&self) -> bool {
+        // Once this function has returned false, it must remain false.
+        if IBD_FINISHED.load(Ordering::Relaxed) {
+            false
+        } else if unix_time_as_millis().saturating_sub(self.tip_header().timestamp()) > MAX_TIP_AGE
+        {
+            true
+        } else {
+            IBD_FINISHED.store(true, Ordering::Relaxed);
+            false
+        }
     }
 
     /// Return tip header number


### PR DESCRIPTION
### Drawbacks
Even we use `DeleteRange` apply to delete the range of keys, seems Rocksdb still hasn't implemented the feature of using seek() to skip until the end of range delete end yet.
Rocksdb iter seek slows down dramatically when there are many deletes.
### Workaround
Manually call `CompactRange()` for the range to delete,  this approach can solve the problem.