### PR TITLE
fix: resolve rocksdb cache size issue when using `default.db-options`

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -47,6 +47,12 @@ dsn = "" # {{
 # interval = 600
 
 [db]
+# The capacity of RocksDB cache, which caches uncompressed data blocks, indexes and filters, default is 128MB.
+# Rocksdb will automatically create and use an 8MB internal cache if you set this value to 0.
+# To turning off cache, you need to set this value to 0 and set `no_block_cache = true` in the options_file,
+# however, we strongly discourage this setting, it may lead to severe performance degradation.
+cache_size = 134217728
+
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/util/app-config/src/configs/db.rs
+++ b/util/app-config/src/configs/db.rs
@@ -8,6 +8,9 @@ pub struct Config {
     /// TODO(doc): @doitian
     #[serde(default)]
     pub path: PathBuf,
+    /// The capacity of RocksDB cache, which caches uncompressed data blocks, indexes and filters, default is 128MB
+    #[serde(default)]
+    pub cache_size: Option<usize>,
     /// TODO(doc): @doitian
     #[serde(default)]
     pub options: HashMap<String, String>,


### PR DESCRIPTION
`cache_index_and_filter_blocks` is enabled in `default.db-options`, quote rocksdb doc:

```
By putting index, filter, and compression dictionary blocks in block cache, these blocks have to compete against data blocks for staying in cache
```

current rocksdb index size is around 32MB, and the default rocksdb block cache size is 8MB, which hurts the db read performance, this PR changed the default cache size to 128MB.

We should consider using [Partitioned Index](https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters) later.