### PR TITLE
ci: collect integration failures on azure via sentry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
     - name: PR Integration
       if: 'tag IS NOT present AND branch != develop AND branch !~ /^rc\// AND (type = pull_request OR repo != nervosnetwork/ckb)'
       os: linux
-      script: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration
+      script: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4 --no-report" integration
     - name: Linters
       if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, staging2, trying) OR repo != nervosnetwork/ckb)'
       os: linux
@@ -142,11 +142,11 @@ matrix:
     - name: Integration on macOS
       if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, staging, staging2, trying) OR branch =~ /^rc\// OR (branch = develop AND commit_message !~ /^Merge #\d+/))'
       os: osx
-      script: make CKB_TEST_ARGS="--max-time 1200 -c 1" integration
+      script: make CKB_TEST_ARGS="--max-time 1200 -c 1 --no-report" integration
     - name: Integration on Linux
       if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, staging, staging2, trying) OR branch =~ /^rc\// OR (branch = develop AND commit_message !~ /^Merge #\d+/))'
       os: linux
-      script: make CKB_TEST_ARGS="--max-time 1200 -c 1" integration
+      script: make CKB_TEST_ARGS="--max-time 1200 -c 1 --no-report" integration
     - name: Code Coverage
       if: 'tag IS NOT present AND ((branch = master AND type != pull_request) OR head_branch =~ /^rc\//)'
       os: linux

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERBOSE := $(if ${CI},--verbose,)
 CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from \
 	-A clippy::mutable_key_type
 CKB_TEST_ARGS := ${CKB_TEST_ARGS} -c 4
-INTEGRATION_RUST_LOG := info,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
+INTEGRATION_RUST_LOG := info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
 
 ##@ Testing
 .PHONY: test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,10 +50,11 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.46.0-x86_64-pc-windows-msvc'
-      - pwsh: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4" integration
+      - pwsh: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4 --no-report" integration
         displayName: Run integration tests
         env:
           CI: true
+          SENTRY_DSN: 'https://15373165fbf2439b99ba46684dfbcb12@sentry.nervos.org/7'
 
   - job: Package
     timeoutInMinutes: 0

--- a/ckb-bin/src/setup_guard.rs
+++ b/ckb-bin/src/setup_guard.rs
@@ -4,6 +4,8 @@ use ckb_build_info::Version;
 use ckb_logger_service::{self, LoggerInitGuard};
 use ckb_metrics_service::{self, Guard as MetricsInitGuard};
 
+const CKB_LOG_ENV: &str = "CKB_LOG";
+
 pub struct SetupGuard {
     _logger_guard: LoggerInitGuard,
     #[cfg(feature = "with_sentry")]
@@ -25,7 +27,7 @@ impl SetupGuard {
         if logger_config.emit_sentry_breadcrumbs.is_none() {
             logger_config.emit_sentry_breadcrumbs = Some(setup.is_sentry_enabled);
         }
-        let logger_guard = ckb_logger_service::init(logger_config)?;
+        let logger_guard = ckb_logger_service::init(Some(CKB_LOG_ENV), logger_config)?;
 
         let sentry_guard = if setup.is_sentry_enabled {
             let sentry_config = setup.config.sentry();
@@ -72,7 +74,7 @@ impl SetupGuard {
         async_handle: Handle,
     ) -> Result<Self, ExitCode> {
         let logger_config = setup.config.logger().to_owned();
-        let logger_guard = ckb_logger_service::init(logger_config)?;
+        let logger_guard = ckb_logger_service::init(Some(CKB_LOG_ENV), logger_config)?;
 
         let metrics_config = setup.config.metrics().to_owned();
         let metrics_guard =

--- a/devtools/azure/windows-dependencies.yml
+++ b/devtools/azure/windows-dependencies.yml
@@ -12,6 +12,8 @@ steps:
   displayName: Install LLVM
 - script: scoop install yasm
   displayName: Install yasm
+- script: scoop install sentry-cli
+  displayName: Install Sentry Client
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
     rustup-init.exe -y --default-host ${{ parameters.rustup_toolchain }}

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -74,9 +74,34 @@ function run-integration {
   New-Item -ItemType Junction -Path test/target -Value "$(pwd)/target"
 
   pushd test
+
   Set-Env RUST_BACKTRACE 1
   Set-Env RUST_LOG $env:INTEGRATION_RUST_LOG
-  iex "cargo run -- --bin target/debug/ckb $($env:CKB_TEST_ARGS)"
+
+  if ($env:CKB_INTEGRATION_TEST_TMP -eq $null) {
+    Set-Env CKB_INTEGRATION_TEST_TMP "target/ckb-test/tmp"
+  }
+  if ($env:CKB_INTEGRATION_FAILURE_FILE -eq $null) {
+    Set-Env CKB_INTEGRATION_FAILURE_FILE "$env:CKB_INTEGRATION_TEST_TMP/integration.failure"
+  }
+  New-Item -Path "$env:CKB_INTEGRATION_TEST_TMP" -Type Directory -ErrorAction SilentlyContinue
+
+  $ckb_bin="target/debug/ckb"
+  $logfile="$env:CKB_INTEGRATION_TEST_TMP/integration.log"
+  $ckb_release=$(iex "$ckb_bin --version")
+
+  iex "cargo run -- --bin $ckb_bin --log-file ${logfile} $($env:CKB_TEST_ARGS)"
+  $errcode=$LASTEXITCODE
+
+  if ($errcode -ne 0) {
+    if ($env:SENTRY_DSN -ne $null) {
+      foreach($line in Get-Content $env:CKB_INTEGRATION_FAILURE_FILE) {
+        sentry-cli send-event -m "$line" -r "$ckb_release" --logfile "$logfile"
+      }
+    }
+    exit $errcode
+  }
+
   popd
 }
 
@@ -91,7 +116,7 @@ try {
     Set-Env CKB_TEST_ARGS "-c 4"
   }
   if ($env:INTEGRATION_RUST_LOG -eq $null) {
-    Set-Env INTEGRATION_RUST_LOG "ckb-network=error"
+    Set-Env INTEGRATION_RUST_LOG "info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug"
   }
 
   foreach ($arg in $args) {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -27,12 +27,13 @@ ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.40.0-
 ckb-resource = { path = "../resource", version = "= 0.40.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.40.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.40.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.40.0-pre" }
+ckb-logger-config = { path = "../util/logger-config", version = "= 0.40.0-pre" }
+ckb-logger-service = { path = "../util/logger-service", version = "= 0.40.0-pre" }
 ckb-error = { path = "../error", version = "= 0.40.0-pre" }
 tempfile = "3.0"
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
 rand = "0.7"
-log = "0.4"
-env_logger = "0.6"
 faketime = "0.2"
 serde_json = "1.0"
 lazy_static = "1.4.0"

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,4 +1,5 @@
 use ckb_channel::unbounded;
+use ckb_logger::{error, info};
 use ckb_test::specs::*;
 use ckb_test::{
     global::{self, BINARY_PATH, PORT_COUNTER, VENDOR_PATH},
@@ -8,7 +9,6 @@ use ckb_test::{
 use ckb_types::core::ScriptHashType;
 use ckb_util::Mutex;
 use clap::{value_t, App, Arg};
-use log::{error, info};
 use rand::{seq::SliceRandom, thread_rng};
 use std::any::Any;
 use std::cmp::min;
@@ -16,6 +16,7 @@ use std::env;
 use std::fs::{read_to_string, File};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -49,12 +50,18 @@ fn main() {
         0
     };
     let worker_count = value_t!(matches, "concurrent", usize).unwrap_or_else(|err| err.exit());
-    let vendor = value_t!(matches, "vendor", PathBuf).unwrap_or_else(|_| current_dir());
+    let vendor =
+        value_t!(matches, "vendor", PathBuf).unwrap_or_else(|_| current_dir().join("vendor"));
+    let log_file_opt = matches
+        .value_of("log-file")
+        .map(PathBuf::from_str)
+        .transpose()
+        .unwrap_or_else(|err| panic!("failed to parse the log file path since {}", err));
     let fail_fast = !matches.is_present("no-fail-fast");
     let report = !matches.is_present("no-report");
     let verbose = matches.is_present("verbose");
 
-    let _ = {
+    let logger_guard = {
         let filter = if !verbose {
             env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string())
         } else {
@@ -64,7 +71,19 @@ fn main() {
                 module_path!(),
             )
         };
-        env_logger::builder().parse_filters(&filter).try_init()
+        let mut logger_config = ckb_logger_config::Config::default();
+        logger_config.filter = Some(filter);
+        if let Some(log_file) = log_file_opt {
+            if log_file.is_relative() {
+                logger_config.log_dir = current_dir();
+            }
+            logger_config.file = log_file;
+            logger_config.log_to_file = true;
+        } else {
+            logger_config.log_to_file = false;
+        }
+        ckb_logger_service::init(None, logger_config)
+            .unwrap_or_else(|err| panic!("failed to init the logger service since {}", err))
     };
 
     if matches.is_present("list-specs") {
@@ -221,6 +240,8 @@ fn main() {
     if !spec_errors.is_empty() {
         std::process::exit(1);
     }
+
+    drop(logger_guard);
 }
 
 fn clap_app() -> App<'static, 'static> {
@@ -274,6 +295,12 @@ fn clap_app() -> App<'static, 'static> {
                 .long("no-report")
                 .help("Do not show integration test report"),
         )
+        .arg(
+            Arg::with_name("log-file")
+                .long("log-file")
+                .takes_value(true)
+                .help("Write log outputs into file."),
+        )
 }
 
 fn filter_specs(
@@ -296,9 +323,7 @@ fn filter_specs(
 }
 
 fn current_dir() -> PathBuf {
-    env::current_dir()
-        .expect("can't get current_dir")
-        .join("vendor")
+    env::current_dir().expect("can't get current_dir")
 }
 
 fn canonicalize_path<P: AsRef<Path>>(path: P) -> PathBuf {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -519,6 +519,9 @@ fn tail_node_logs(node_log_paths: &[PathBuf]) {
         .unwrap_or_default()
         .parse()
         .unwrap_or(2000);
+    if tail_n == 0 {
+        return;
+    }
 
     for (i, node_log) in node_log_paths.iter().enumerate() {
         let content = read_to_string(node_log).expect("failed to read node's log");

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -1,17 +1,17 @@
 use crate::utils::{find_available_port, message_name, temp_path, wait_until};
 use crate::Node;
 use ckb_app_config::NetworkConfig;
+use ckb_async_runtime::new_global_runtime;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_channel::{self as channel, unbounded, Receiver, RecvTimeoutError, Sender};
+use ckb_logger::info;
 use ckb_network::{
     bytes::Bytes, CKBProtocol, CKBProtocolContext, CKBProtocolHandler, DefaultExitHandler,
     NetworkController, NetworkService, NetworkState, PeerIndex, ProtocolId, SupportProtocols,
 };
+use ckb_stop_handler::StopHandler;
 use ckb_util::Mutex;
 use std::collections::HashMap;
-
-use ckb_async_runtime::new_global_runtime;
-use ckb_stop_handler::StopHandler;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -161,7 +161,7 @@ impl Net {
             .get(node_id)
             .unwrap_or_else(|| panic!("not connected peer {}", node.p2p_address()));
         let net_message = receiver.recv_timeout(timeout)?;
-        log::info!(
+        info!(
             "Net received from peer-{}, message_name: {}",
             peer_index,
             message_name(&net_message.2)

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -6,6 +6,7 @@ use ckb_app_config::CKBAppConfig;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_chain_spec::ChainSpec;
 use ckb_jsonrpc_types::TxPoolInfo;
+use ckb_logger::{debug, error};
 use ckb_types::{
     core::{
         self, capacity_bytes, BlockBuilder, BlockNumber, BlockView, Capacity, HeaderView,
@@ -28,8 +29,8 @@ struct ProcessGuard(pub Child);
 impl Drop for ProcessGuard {
     fn drop(&mut self) {
         match self.0.kill() {
-            Err(e) => log::error!("Could not kill ckb process: {}", e),
-            Ok(_) => log::debug!("Successfully killed ckb process"),
+            Err(e) => error!("Could not kill ckb process: {}", e),
+            Ok(_) => debug!("Successfully killed ckb process"),
         }
         let _ = self.0.wait();
     }
@@ -48,7 +49,6 @@ pub struct Node {
 impl Node {
     pub fn new(spec_name: &str, node_name: &str) -> Self {
         let working_dir = temp_path(spec_name, node_name);
-        // log::info!("New {}-{} on: {}", spec_name, node_name, working_dir);
 
         // Copy node template into node's working directory
         let cells_dir = working_dir.join("specs").join("cells");
@@ -496,7 +496,7 @@ impl Node {
             match child_process.try_wait() {
                 Ok(None) => sleep(std::time::Duration::from_secs(1)),
                 Ok(Some(status)) => {
-                    log::error!(
+                    error!(
                         "Error: node crashed: {}, log_path: {}",
                         status,
                         self.log_path().display()
@@ -504,7 +504,7 @@ impl Node {
                     process::exit(status.code().unwrap());
                 }
                 Err(error) => {
-                    log::error!(
+                    error!(
                         "Error: node crashed with reason: {}, log_path: {}",
                         error,
                         self.log_path().display()

--- a/test/src/specs/p2p/disconnect.rs
+++ b/test/src/specs/p2p/disconnect.rs
@@ -1,6 +1,6 @@
 use crate::utils::wait_until;
 use crate::{Node, Spec};
-use log::info;
+use ckb_logger::info;
 
 pub struct Disconnect;
 

--- a/test/src/specs/p2p/malformed_message.rs
+++ b/test/src/specs/p2p/malformed_message.rs
@@ -1,12 +1,12 @@
 use crate::util::mining::out_ibd_mode;
 use crate::utils::wait_until;
 use crate::{Net, Node, Spec};
+use ckb_logger::info;
 use ckb_network::{bytes::Bytes, SupportProtocols};
 use ckb_types::{
     packed::{GetHeaders, SyncMessage},
     prelude::*,
 };
-use log::info;
 
 pub struct MalformedMessage;
 

--- a/test/src/specs/p2p/whitelist.rs
+++ b/test/src/specs/p2p/whitelist.rs
@@ -2,7 +2,7 @@ use crate::util::mining::mine;
 use crate::utils::{sleep, wait_until};
 use crate::{Node, Spec};
 
-use log::info;
+use ckb_logger::info;
 use std::collections::HashSet;
 
 pub struct WhitelistOnSessionLimit;

--- a/test/src/specs/relay/block_relay.rs
+++ b/test/src/specs/relay/block_relay.rs
@@ -2,8 +2,8 @@ use crate::node::waiting_for_sync;
 use crate::util::mining::{mine, out_ibd_mode};
 use crate::utils::{now_ms, sleep, wait_until};
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::prelude::*;
-use log::info;
 use std::time::Duration;
 
 pub struct RelayTooNewBlock;

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -4,6 +4,7 @@ use crate::util::mining::{mine, out_ibd_mode};
 use crate::util::transaction::{always_success_transaction, always_success_transactions};
 use crate::utils::{build_relay_tx_hashes, build_relay_txs, sleep, wait_until};
 use crate::{Net, Node, Spec};
+use ckb_logger::info;
 use ckb_network::SupportProtocols;
 use ckb_sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
 use ckb_types::{
@@ -11,7 +12,6 @@ use ckb_types::{
     packed::{GetRelayTransactions, RelayMessage},
     prelude::*,
 };
-use log::info;
 
 pub struct TransactionRelayBasic;
 

--- a/test/src/specs/relay/transaction_relay_low_fee_rate.rs
+++ b/test/src/specs/relay/transaction_relay_low_fee_rate.rs
@@ -4,6 +4,7 @@ use crate::util::cell::{as_input, as_output, gen_spendable};
 use crate::util::log_monitor::monitor_log_until_expected_show;
 use crate::util::mining::out_ibd_mode;
 use crate::{Node, Spec};
+use ckb_logger::debug;
 use ckb_types::core::{FeeRate, TransactionBuilder};
 
 pub struct TransactionRelayLowFeeRate;
@@ -32,7 +33,7 @@ impl Spec for TransactionRelayLowFeeRate {
             .dry_run_transaction(low_fee.data().into())
             .cycles;
 
-        log::debug!("make sure node1 has the cell");
+        debug!("make sure node1 has the cell");
         waiting_for_sync(nodes);
 
         node0

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -7,13 +7,13 @@ use crate::utils::{
 };
 use crate::{Net, Node, Spec};
 use ckb_jsonrpc_types::ChainInfo;
+use ckb_logger::info;
 use ckb_network::{bytes::Bytes, SupportProtocols};
 use ckb_types::{
     core::BlockView,
     packed::{self, Byte32, SyncMessage},
     prelude::*,
 };
-use log::info;
 use std::time::Duration;
 
 pub struct BlockSyncFromOne;
@@ -301,7 +301,7 @@ impl Spec for BlockSyncRelayerCollaboration {
         net.send(node0, SupportProtocols::Relay, build_compact_block(&last));
 
         let ret = wait_until(10, || rpc_client.get_tip_block_number() >= tip_number + 17);
-        log::info!("{}", rpc_client.get_tip_block_number());
+        info!("{}", rpc_client.get_tip_block_number());
         assert!(ret, "node0 should grow up");
     }
 }

--- a/test/src/specs/sync/chain_forks.rs
+++ b/test/src/specs/sync/chain_forks.rs
@@ -4,13 +4,13 @@ use crate::util::check::{is_transaction_committed, is_transaction_pending};
 use crate::util::mining::{mine, mine_until_out_bootstrap_period, out_ibd_mode};
 use crate::util::transaction::always_success_transaction;
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::{
     core::{capacity_bytes, BlockView, Capacity, TransactionView},
     h256,
     prelude::*,
     H256,
 };
-use log::info;
 use std::thread::sleep;
 use std::time::Duration;
 

--- a/test/src/specs/sync/get_blocks.rs
+++ b/test/src/specs/sync/get_blocks.rs
@@ -1,10 +1,10 @@
 use crate::util::mining::mine;
 use crate::utils::{build_headers, wait_until};
 use crate::{Net, Node, Spec};
+use ckb_logger::info;
 use ckb_network::SupportProtocols;
 use ckb_sync::{BLOCK_DOWNLOAD_TIMEOUT, INIT_BLOCKS_IN_TRANSIT_PER_PEER};
 use ckb_types::{core::HeaderView, packed, prelude::*};
-use log::info;
 use std::time::{Duration, Instant};
 
 pub struct GetBlocksTimeout;

--- a/test/src/specs/sync/ibd_process.rs
+++ b/test/src/specs/sync/ibd_process.rs
@@ -1,7 +1,7 @@
 use crate::util::mining::mine;
 use crate::utils::{sleep, wait_until};
 use crate::{Node, Spec};
-use log::info;
+use ckb_logger::info;
 
 pub struct IBDProcess;
 

--- a/test/src/specs/sync/invalid_locator_size.rs
+++ b/test/src/specs/sync/invalid_locator_size.rs
@@ -1,6 +1,7 @@
 use crate::util::mining::out_ibd_mode;
 use crate::utils::wait_until;
 use crate::{Net, Node, Spec};
+use ckb_logger::info;
 use ckb_network::SupportProtocols;
 use ckb_sync::MAX_LOCATOR_SIZE;
 use ckb_types::{
@@ -9,7 +10,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use log::info;
 
 pub struct InvalidLocatorSize;
 

--- a/test/src/specs/sync/sync_timeout.rs
+++ b/test/src/specs/sync/sync_timeout.rs
@@ -1,7 +1,7 @@
 use crate::node::{disconnect_all, waiting_for_sync};
 use crate::util::mining::mine;
 use crate::{Node, Spec};
-use log::info;
+use ckb_logger::info;
 
 pub struct SyncTimeout;
 

--- a/test/src/specs/tx_pool/cellbase_maturity.rs
+++ b/test/src/specs/tx_pool/cellbase_maturity.rs
@@ -2,8 +2,8 @@ use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::utils::assert_send_transaction_fail;
 use crate::{Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
 
+use ckb_logger::info;
 use ckb_types::core::BlockNumber;
-use log::info;
 
 const MATURITY: BlockNumber = 5;
 

--- a/test/src/specs/tx_pool/depend_tx_in_same_block.rs
+++ b/test/src/specs/tx_pool/depend_tx_in_same_block.rs
@@ -1,7 +1,7 @@
 use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::{core::TransactionView, packed::ProposalShortId};
-use log::info;
 
 pub struct DepentTxInSameBlock;
 

--- a/test/src/specs/tx_pool/different_txs_with_same_input.rs
+++ b/test/src/specs/tx_pool/different_txs_with_same_input.rs
@@ -1,11 +1,11 @@
 use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::{
     core::{capacity_bytes, Capacity, TransactionView},
     packed::CellOutputBuilder,
     prelude::*,
 };
-use log::info;
 
 pub struct DifferentTxsWithSameInput;
 

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -2,8 +2,8 @@ use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::utils::assert_send_transaction_fail;
 use crate::{Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
 
+use ckb_logger::info;
 use ckb_types::core::FeeRate;
-use log::info;
 
 pub struct SizeLimit;
 

--- a/test/src/specs/tx_pool/pool_reconcile.rs
+++ b/test/src/specs/tx_pool/pool_reconcile.rs
@@ -1,7 +1,7 @@
 use crate::node::waiting_for_sync;
 use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::{Node, Spec};
-use log::info;
+use ckb_logger::info;
 
 pub struct PoolReconcile;
 

--- a/test/src/specs/tx_pool/pool_resurrect.rs
+++ b/test/src/specs/tx_pool/pool_resurrect.rs
@@ -1,7 +1,7 @@
 use crate::node::waiting_for_sync;
 use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::{Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
-use log::info;
+use ckb_logger::info;
 
 pub struct PoolResurrect;
 

--- a/test/src/specs/tx_pool/proposal_expire_rule.rs
+++ b/test/src/specs/tx_pool/proposal_expire_rule.rs
@@ -1,7 +1,7 @@
 use crate::util::mining::mine_until_out_bootstrap_period;
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::core::BlockNumber;
-use log::info;
 
 pub struct ProposalExpireRuleForCommittingAndExpiredAtOneTime;
 

--- a/test/src/specs/tx_pool/reference_header_maturity.rs
+++ b/test/src/specs/tx_pool/reference_header_maturity.rs
@@ -2,8 +2,8 @@ use crate::util::check::is_transaction_committed;
 use crate::util::mining::{mine, mine_until_out_bootstrap_period};
 use crate::utils::assert_send_transaction_fail;
 use crate::{Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
+use ckb_logger::info;
 use ckb_types::core::EpochNumberWithFraction;
-use log::info;
 
 const CELLBASE_MATURITY_VALUE: u64 = 3;
 

--- a/test/src/specs/tx_pool/send_defected_binary.rs
+++ b/test/src/specs/tx_pool/send_defected_binary.rs
@@ -4,6 +4,7 @@ use crate::util::mining::mine;
 use crate::{Node, Spec};
 use ckb_crypto::secp::{Generator, Privkey};
 use ckb_hash::{blake2b_256, new_blake2b};
+use ckb_logger::info;
 use ckb_types::{
     bytes::Bytes,
     core::{capacity_bytes, Capacity, DepType, ScriptHashType, TransactionBuilder},
@@ -11,7 +12,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use log::info;
 
 pub struct SendDefectedBinary {
     privkey: Privkey,

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -4,6 +4,7 @@ use crate::utils::wait_until;
 use crate::{Node, Spec};
 use ckb_crypto::secp::{Generator, Privkey};
 use ckb_hash::{blake2b_256, new_blake2b};
+use ckb_logger::info;
 use ckb_types::{
     bytes::Bytes,
     core::{
@@ -14,7 +15,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use log::info;
 
 pub struct SendLargeCyclesTxInBlock {
     privkey: Privkey,

--- a/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
+++ b/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
@@ -1,12 +1,12 @@
 use crate::util::mining::mine_until_out_bootstrap_period;
 use crate::utils::wait_until;
 use crate::{Node, Spec};
+use ckb_logger::info;
 use ckb_types::{
     core::{FeeRate, TransactionView},
     packed,
     prelude::*,
 };
-use log::info;
 
 pub struct SendLowFeeRateTx;
 

--- a/test/src/specs/tx_pool/send_multisig_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_multisig_secp_tx.rs
@@ -6,6 +6,7 @@ use ckb_chain_spec::{build_genesis_type_id_script, OUTPUT_INDEX_SECP256K1_BLAKE1
 use ckb_crypto::secp::{Generator, Privkey};
 use ckb_hash::{blake2b_256, new_blake2b};
 use ckb_jsonrpc_types::JsonBytes;
+use ckb_logger::info;
 use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_MULTISIG_ALL;
 use ckb_types::{
     bytes::Bytes,
@@ -14,7 +15,6 @@ use ckb_types::{
     prelude::*,
     H160, H256,
 };
-use log::info;
 
 pub struct SendMultiSigSecpTxUseDepGroup {
     // secp lock script's hash type

--- a/test/src/specs/tx_pool/send_secp_tx.rs
+++ b/test/src/specs/tx_pool/send_secp_tx.rs
@@ -4,6 +4,7 @@ use crate::util::mining::mine;
 use crate::{Node, Spec};
 use ckb_crypto::secp::{Generator, Privkey};
 use ckb_hash::{blake2b_256, new_blake2b};
+use ckb_logger::info;
 use ckb_types::{
     bytes::Bytes,
     core::{capacity_bytes, Capacity, DepType, ScriptHashType, TransactionBuilder},
@@ -11,7 +12,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use log::info;
 
 pub struct SendSecpTxUseDepGroup {
     // secp lock script's hash type

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -5,8 +5,8 @@ use crate::utils::{
 };
 use crate::{Node, Spec, DEFAULT_TX_PROPOSAL_WINDOW};
 
+use ckb_logger::info;
 use ckb_types::core::BlockNumber;
-use log::info;
 use std::thread::sleep;
 use std::time::Duration;
 

--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -1,7 +1,7 @@
 use crate::{utils::nodes_panicked, Spec};
 use ckb_channel::{unbounded, Receiver, Sender};
+use ckb_logger::{error, info};
 use ckb_util::Mutex;
-use log::{error, info};
 use std::any::Any;
 use std::panic;
 use std::path::PathBuf;


### PR DESCRIPTION
#### Why use `ckb-logger` instead of `env_logger` in integration tests?

Because it's difficult to capture output of `Invoke-Expression` into a output file.

No matter with `Out-File`, `Tee-Object` or just redirect the output, it's always blocked and it will output all logs only when the process stopped.

So, if your input  `Ctrl-C` before the process stopped, no logs will be appended in the output file.

#### Why disable `report` for the integration tests?

The sentry server could only save the last 100 lines. 

I would rather save the last 100 logs than the time elapsed report.

#### Preview

[This error](https://dev.azure.com/nervosnetwork/ckb/_build/results?buildId=15794&view=logs&j=133bd042-0fac-58b5-e6e7-01018e6dc4d4&t=b22eb6cd-ede2-5164-159f-eec2a8c1e51e&l=1808) can be found in our Sentry.