### PR TITLE
ci: collect entire logs for failed integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
     - name: PR Integration
       if: 'tag IS NOT present AND branch != develop AND branch !~ /^rc\// AND (type = pull_request OR repo != nervosnetwork/ckb)'
       os: linux
-      script: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4 --no-report" integration
+      script: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
     - name: Linters
       if: 'tag IS NOT present AND (type = pull_request OR branch in (master, staging, staging2, trying) OR repo != nervosnetwork/ckb)'
       os: linux
@@ -143,11 +143,11 @@ matrix:
     - name: Integration on macOS
       if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, staging, staging2, trying) OR branch =~ /^rc\// OR (branch = develop AND commit_message !~ /^Merge #\d+/))'
       os: osx
-      script: make CKB_TEST_ARGS="--max-time 1200 -c 1 --no-report" integration
+      script: make CKB_TEST_ARGS="-c 1 --no-report" integration
     - name: Integration on Linux
       if: 'tag IS NOT present AND type != pull_request AND (branch IN (master, staging, staging2, trying) OR branch =~ /^rc\// OR (branch = develop AND commit_message !~ /^Merge #\d+/))'
       os: linux
-      script: make CKB_TEST_ARGS="--max-time 1200 -c 1 --no-report" integration
+      script: make CKB_TEST_ARGS="-c 1 --no-report" integration
     - name: Code Coverage
       if: 'tag IS NOT present AND ((branch = master AND type != pull_request) OR head_branch =~ /^rc\//)'
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
       - libtool
       - clang-8
       - libc6-dev-i386
+      - expect
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 8192; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,9 @@ jobs:
         env:
           CI: true
           SENTRY_DSN: 'https://15373165fbf2439b99ba46684dfbcb12@sentry.nervos.org/7'
+          LOGBAK_USER: $(LOGBAK_USER)
+          LOGBAK_PASSWORD: $(LOGBAK_PASSWORD)
+          LOGBAK_SERVER: $(LOGBAK_SERVER)
 
   - job: Package
     timeoutInMinutes: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.46.0-x86_64-pc-windows-msvc'
-      - pwsh: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="--max-time 1200 -c 4 --no-report" integration
+      - pwsh: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
         displayName: Run integration tests
         env:
           CI: true

--- a/devtools/azure/windows-dependencies.yml
+++ b/devtools/azure/windows-dependencies.yml
@@ -8,12 +8,14 @@ steps:
     echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\scoop\shims"
     scoop help
   displayName: Add scoop to path
+- script: scoop bucket add extras
+  displayName: Add extras bucket
 - script: scoop install llvm
   displayName: Install LLVM
 - script: scoop install yasm
   displayName: Install yasm
-- script: scoop install sentry-cli
-  displayName: Install Sentry Client
+- script: scoop install 7zip putty sentry-cli
+  displayName: Install Tools for Capturing Failures
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
     rustup-init.exe -y --default-host ${{ parameters.rustup_toolchain }}

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,9 +15,14 @@ fi
 
 set +e
 
-export CKB_INTEGRATION_FAILURE_FILE="$(pwd)/integration.failure"
+test_id=$(date +"%Y%m%d-%H%M%S")
+test_tmp_dir=${CKB_INTEGRATION_TEST_TMP:-$(pwd)/target/ckb-test/${test_id}}
+mkdir -p "${test_tmp_dir}"
+test_log_file="${test_tmp_dir}/integration.log"
+
+export CKB_INTEGRATION_FAILURE_FILE="${test_tmp_dir}/integration.failure"
 echo "Unknown integration error" > "$CKB_INTEGRATION_FAILURE_FILE"
-cargo run "$@" 2>&1 | tee integration.log
+cargo run "$@" 2>&1 | tee "${test_log_file}"
 EXIT_CODE="${PIPESTATUS[0]}"
 set -e
 
@@ -39,10 +44,27 @@ if [ "$EXIT_CODE" != 0 ] && [ "${TRAVIS_REPO_SLUG:-nervosnetwork/ckb}" = "nervos
     esac
     shift
   done
-
   CKB_RELEASE="$("$CKB_BIN" --version)"
+
+  if [ -n "${TRAVIS_BUILD_ID:-}" ] && [ -n "${LOGBAK_SERVER:-}" ]; then
+    upload_id="travis-${test_id}-${TRAVIS_BUILD_ID:-0}-${TRAVIS_JOB_ID:-0}-${TRAVIS_OS_NAME:-unknown}"
+    cd "${test_tmp_dir}"/..
+    tar -czf "${upload_id}.tgz" "${test_id}"
+    expect <<EOF
+spawn sftp -o "StrictHostKeyChecking=no" "${LOGBAK_USER}@${LOGBAK_SERVER}"
+expect "assword:"
+send "${LOGBAK_PASSWORD}\r"
+expect "sftp>"
+send "put ${upload_id}.tgz ci/travis/\r"
+expect "sftp>"
+send "bye\r"
+EOF
+    cd -
+  fi
+  unset LOGBAK_USER LOGBAK_PASSWORD LOGBAK_SERVER
+
   unset encrypted_82dff4145bbf_iv encrypted_82dff4145bbf_key GITHUB_TOKEN GPG_SIGNER QINIU_ACCESS_KEY QINIU_SECRET_KEY
-  cat "$CKB_INTEGRATION_FAILURE_FILE" | xargs -t -L 1 -I '%' sentry-cli send-event -m '%' -r "$CKB_RELEASE" --logfile integration.log
+  cat "$CKB_INTEGRATION_FAILURE_FILE" | xargs -t -L 1 -I '%' sentry-cli send-event -m '%' -r "$CKB_RELEASE" --logfile "${test_log_file}"
 fi
 
 exit "$EXIT_CODE"

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -149,7 +149,7 @@ impl Node {
         &self.rpc_client
     }
 
-    fn working_dir(&self) -> PathBuf {
+    pub fn working_dir(&self) -> PathBuf {
         self.working_dir.clone()
     }
 

--- a/test/src/worker.rs
+++ b/test/src/worker.rs
@@ -23,6 +23,7 @@ pub enum Notify {
     Done {
         spec_name: String,
         seconds: u64,
+        node_paths: Vec<PathBuf>,
     },
     Error {
         spec_error: Box<dyn Any + Send>,
@@ -115,6 +116,10 @@ impl Worker {
             .unwrap();
 
         let mut nodes = spec.before_run();
+        let node_paths = nodes
+            .iter()
+            .map(|node| node.working_dir())
+            .collect::<Vec<_>>();
         let node_log_paths = nodes.iter().map(|node| node.log_path()).collect::<Vec<_>>();
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             spec.run(&mut nodes);
@@ -148,6 +153,7 @@ impl Worker {
                 .send(Notify::Done {
                     spec_name: spec.name().to_string(),
                     seconds: now.elapsed().as_secs(),
+                    node_paths,
                 })
                 .unwrap();
         }


### PR DESCRIPTION
### Features

- Collect entire logs for failed integration tests.

  Since a lot of integration tests are too difficult to reproduce, this PR will upload entire logs of integration tests to our server, include the entire data of nodes. So we could download them to diagnose what happened in CI servers.

- Remove temporary data for any integration tests after it passed **in default**, and you can disable it by `--keep-tmp-data`.

  Running integration tests will occupy a lot of disk space (almost `600 MiB` raw data in total), and it's a bit complex to remove data for passed tests after all tests done.
 
- I remove all `--max-time 1200` from `integration tests`, so we can run all tests after merged into develop.