### PR TITLE
chore: refactor NetworkGroup trait

### DIFF
--- a/network/src/network_group.rs
+++ b/network/src/network_group.rs
@@ -10,13 +10,9 @@ pub enum Group {
     IP6([u8; 4]),
 }
 
-pub trait NetworkGroup {
-    fn network_group(&self) -> Group;
-}
-
-impl NetworkGroup for Multiaddr {
-    fn network_group(&self) -> Group {
-        if let Ok(ip_addr) = self.extract_ip_addr().map(|ip_port| ip_port.ip) {
+impl From<&Multiaddr> for Group {
+    fn from(multiaddr: &Multiaddr) -> Group {
+        if let Ok(ip_addr) = multiaddr.extract_ip_addr().map(|ip_port| ip_port.ip) {
             if ip_addr.is_loopback() {
                 return Group::LocalNetwork;
             }

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -1,4 +1,4 @@
-use crate::network_group::{Group, NetworkGroup};
+use crate::network_group::Group;
 use crate::{multiaddr::Multiaddr, ProtocolId, ProtocolVersion, SessionType};
 use p2p::{secio::PeerId, SessionId};
 use std::collections::HashMap;
@@ -77,7 +77,7 @@ impl Peer {
 
     /// Get net group
     pub fn network_group(&self) -> Group {
-        self.connected_addr.network_group()
+        (&self.connected_addr).into()
     }
 
     /// Opened protocol version

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::{PeerStoreError, Result},
-    network_group::{Group, NetworkGroup},
+    network_group::Group,
     peer_store::{
         addr_manager::AddrManager,
         ban_list::BanList,
@@ -234,9 +234,8 @@ impl PeerStore {
             // find candidate peers by network group
             let mut peers_by_network_group: HashMap<Group, Vec<_>> = HashMap::default();
             for addr in self.addr_manager.addrs_iter() {
-                let network_group = addr.addr.network_group();
                 peers_by_network_group
-                    .entry(network_group)
+                    .entry((&addr.addr).into())
                     .or_default()
                     .push(addr);
             }


### PR DESCRIPTION
`NetworkGroup` is just a trait for type conversion, for which we should use the built-in `From` trait