### PR TITLE
chore: modify discovery announce interval

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -813,7 +813,12 @@ impl<T: ExitHandler> NetworkService<T> {
             discovery_local_address: config.discovery_local_address,
         };
         let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(addr_mgr)))
+            ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(
+                addr_mgr,
+                config
+                    .discovery_announce_check_interval_secs
+                    .map(Duration::from_secs),
+            )))
         });
 
         // Identify protocol

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -31,7 +31,7 @@ mod addr;
 mod protocol;
 mod state;
 
-const CHECK_INTERVAL: Duration = Duration::from_secs(3);
+const ANNOUNCE_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 const ANNOUNCE_THRESHOLD: usize = 10;
 // The maximum number of new addresses to accumulate before announcing.
 const MAX_ADDR_TO_SEND: usize = 1000;
@@ -42,18 +42,15 @@ const ANNOUNCE_INTERVAL: Duration = Duration::from_secs(3600 * 24);
 
 pub struct DiscoveryProtocol<M> {
     sessions: HashMap<SessionId, SessionState>,
-    dynamic_query_cycle: Option<Duration>,
+    announce_check_interval: Option<Duration>,
     addr_mgr: M,
-
-    check_interval: Option<Duration>,
 }
 
 impl<M: AddressManager> DiscoveryProtocol<M> {
-    pub fn new(addr_mgr: M) -> DiscoveryProtocol<M> {
+    pub fn new(addr_mgr: M, announce_check_interval: Option<Duration>) -> DiscoveryProtocol<M> {
         DiscoveryProtocol {
             sessions: HashMap::default(),
-            dynamic_query_cycle: Some(Duration::from_secs(7)),
-            check_interval: None,
+            announce_check_interval,
             addr_mgr,
         }
     }
@@ -65,7 +62,8 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
         context
             .set_service_notify(
                 context.proto_id,
-                self.check_interval.unwrap_or(CHECK_INTERVAL),
+                self.announce_check_interval
+                    .unwrap_or(ANNOUNCE_CHECK_INTERVAL),
                 0,
             )
             .expect("set discovery notify fail")
@@ -217,10 +215,7 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
 
     fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
         let now = Instant::now();
-
-        let dynamic_query_cycle = self.dynamic_query_cycle.unwrap_or(ANNOUNCE_INTERVAL);
         let addr_mgr = &self.addr_mgr;
-
         // get announce list
         let announce_list: Vec<_> = self
             .sessions
@@ -230,7 +225,7 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
                 state.send_messages(context, *id);
                 // check timer
                 state
-                    .check_timer(now, dynamic_query_cycle)
+                    .check_timer(now, ANNOUNCE_INTERVAL)
                     .filter(|addr| addr_mgr.is_valid_addr(addr))
                     .cloned()
             })
@@ -301,7 +296,7 @@ pub struct DiscoveryAddressManager {
 }
 
 impl AddressManager for DiscoveryAddressManager {
-    // Register open ping protocol
+    // Register open discovery protocol
     fn register(&self, id: SessionId, pid: ProtocolId, version: &str) {
         self.network_state.with_peer_registry_mut(|reg| {
             reg.get_peer_mut(id).map(|peer| {
@@ -310,7 +305,7 @@ impl AddressManager for DiscoveryAddressManager {
         });
     }
 
-    // remove registered ping protocol
+    // remove registered discovery protocol
     fn unregister(&self, id: SessionId, pid: ProtocolId) {
         self.network_state.with_peer_registry_mut(|reg| {
             let _ = reg.get_peer_mut(id).map(|peer| {

--- a/network/src/protocols/test.rs
+++ b/network/src/protocols/test.rs
@@ -152,7 +152,7 @@ fn net_service_start(name: String) -> Node {
         discovery_local_address: config.discovery_local_address,
     };
     let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
-        ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(addr_mgr)))
+        ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(addr_mgr, None)))
     });
 
     // Identify protocol
@@ -346,14 +346,15 @@ fn test_discovery_behavior() {
         &node2,
         TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
     );
+    wait_connect_state(&node1, 1);
+
     node3.dial(
         &node2,
         TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
     );
-
-    wait_connect_state(&node1, 1);
-    wait_connect_state(&node2, 2);
     wait_connect_state(&node3, 1);
+
+    wait_connect_state(&node2, 2);
 
     wait_discovery(&node3);
 

--- a/test/src/specs/p2p/discovery.rs
+++ b/test/src/specs/p2p/discovery.rs
@@ -26,5 +26,6 @@ impl Spec for Discovery {
         // enable outbound peer service to connect discovered peers
         config.network.connect_outbound_interval_secs = 1;
         config.network.discovery_local_address = true;
+        config.network.discovery_announce_check_interval_secs = Some(1);
     }
 }

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -33,6 +33,9 @@ pub struct Config {
     /// Whether to probe and store local addresses.
     #[serde(default)]
     pub discovery_local_address: bool,
+    /// The interval between discovery announce message checking.
+    #[serde(default)]
+    pub discovery_announce_check_interval_secs: Option<u64>,
     /// Interval between pings in seconds.
     ///
     /// A node pings peer regularly to see whether the connection is alive.


### PR DESCRIPTION
the timer interval of checking `DiscoveryMessage::Nodes` announce message should be 24 hours, I think it was incorrectly set to 7 seconds in old code, this PR resolved this issue and corrected some code comments