### PR TITLE
feat: add rpc generate_block_with_template to IntegrationTest rpc module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "ckb-chain-iter",
  "ckb-chain-spec",
  "ckb-channel",
+ "ckb-db",
  "ckb-instrument",
  "ckb-jsonrpc-types",
  "ckb-logger",
@@ -720,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-librocksdb-sys"
-version = "6.7.4"
+version = "6.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995341a6dea5f0d8ff4570bebbde3691349842d2c671472e09ea2ee2e3e0b083"
+checksum = "6a78d3b9b5fd3b4990ddd2083f6a6d4389b6c8e603a4f2896914165113beed2d"
 dependencies = [
  "cc",
  "glob",
@@ -1014,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rocksdb"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809a3a50c82a5fd7429c5141e64d8c4c37451ceb25fe3b51fce7fd5d929ad521"
+checksum = "a645f6745c3519bbcbeed80486e59cb3f74d2ac08a1d9621c399b892508aca6e"
 dependencies = [
  "ckb-librocksdb-sys",
  "libc",
@@ -1219,6 +1220,7 @@ dependencies = [
  "ckb-verification",
  "faketime",
  "num_cpus",
+ "tempfile",
 ]
 
 [[package]]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -39,6 +39,7 @@ ckb-chain-iter = { path = "../util/chain-iter", version = "= 0.41.0-pre" }
 ckb-verification = { path = "../verification", version = "= 0.41.0-pre" }
 ckb-verification-traits = { path = "../verification/traits", version = "= 0.41.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.41.0-pre" }
+ckb-db = { path = "../db", version = "= 0.41.0-pre" }
 base64 = "0.13.0"
 tempfile = "3.0"
 rayon = "1.0"

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
         (cli::CMD_STATS, Some(matches)) => subcommand::stats(setup.stats(&matches)?, handle),
         (cli::CMD_RESET_DATA, Some(matches)) => subcommand::reset_data(setup.reset_data(&matches)?),
         (cli::CMD_MIGRATE, Some(matches)) => subcommand::migrate(setup.migrate(&matches)?, handle),
+        (cli::CMD_DB_REPAIR, Some(matches)) => subcommand::db_repair(setup.db_repair(&matches)?),
         _ => unreachable!(),
     }
 }

--- a/ckb-bin/src/subcommand/db_repair.rs
+++ b/ckb-bin/src/subcommand/db_repair.rs
@@ -1,0 +1,11 @@
+use ckb_app_config::{ExitCode, RepairArgs};
+use ckb_db::RocksDB;
+
+pub fn db_repair(args: RepairArgs) -> Result<(), ExitCode> {
+    RocksDB::repair(&args.config.db.path).map_err(|err| {
+        eprintln!("repair error: {:?}", err);
+        ExitCode::Failure
+    })?;
+
+    Ok(())
+}

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -1,3 +1,4 @@
+mod db_repair;
 mod export;
 mod import;
 mod init;
@@ -10,6 +11,7 @@ mod reset_data;
 mod run;
 mod stats;
 
+pub use self::db_repair::db_repair;
 pub use self::export::export;
 pub use self::import::import;
 pub use self::init::init;

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-app-config = { path = "../util/app-config", version = "= 0.41.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.41.0-pre" }
 ckb-error = { path = "../error", version = "= 0.41.0-pre" }
-tempfile = "3.0"
 libc = "0.2"
-rocksdb = { package = "ckb-rocksdb", version = "=0.14.1", features = ["snappy"] }
+rocksdb = { package = "ckb-rocksdb", version = "=0.15.1", features = ["snappy"] }
 ckb-db-schema = { path = "../db-schema", version = "= 0.41.0-pre" }
+tempfile = "3.0"

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -1,12 +1,23 @@
 use crate::error::RPCError;
 use ckb_app_config::BlockAssemblerConfig;
 use ckb_chain::chain::ChainController;
-use ckb_jsonrpc_types::{Block, Cycle, JsonBytes, Script, Transaction};
+use ckb_dao::DaoCalculator;
+use ckb_jsonrpc_types::{Block, BlockTemplate, Cycle, JsonBytes, Script, Transaction};
 use ckb_logger::error;
 use ckb_network::{NetworkController, SupportProtocols};
-use ckb_shared::shared::Shared;
+use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::ChainStore;
-use ckb_types::{core, packed, prelude::*, H256};
+use ckb_types::{
+    core::{
+        cell::{
+            resolve_transaction, OverlayCellProvider, ResolvedTransaction, TransactionsProvider,
+        },
+        BlockView,
+    },
+    packed,
+    prelude::*,
+    H256,
+};
 use ckb_verification_traits::Switch;
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
@@ -31,6 +42,9 @@ pub trait IntegrationTestRpc {
 
     #[rpc(name = "broadcast_transaction")]
     fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256>;
+
+    #[rpc(name = "generate_block_with_template")]
+    fn generate_block_with_template(&self, block_template: BlockTemplate) -> Result<H256>;
 }
 
 pub(crate) struct IntegrationTestRpcImpl {
@@ -42,7 +56,7 @@ pub(crate) struct IntegrationTestRpcImpl {
 impl IntegrationTestRpc for IntegrationTestRpcImpl {
     fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Result<Option<H256>> {
         let block: packed::Block = data.into();
-        let block: Arc<core::BlockView> = Arc::new(block.into_view());
+        let block: Arc<BlockView> = Arc::new(block.into_view());
         let ret = self
             .chain
             .internal_process_block(Arc::clone(&block), Switch::DISABLE_ALL);
@@ -119,25 +133,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?
             .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
 
-        let block: packed::Block = block_template.into();
-        let block_view = Arc::new(block.into_view());
-        let content = packed::CompactBlock::build_from_block(&block_view, &HashSet::new());
-        let message = packed::RelayMessage::new_builder().set(content).build();
-
-        // insert block to chain
-        self.chain
-            .process_block(Arc::clone(&block_view))
-            .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
-
-        // announce new block
-        if let Err(err) = self
-            .network_controller
-            .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
-        {
-            error!("Broadcast new block failed: {:?}", err);
-        }
-
-        Ok(block_view.header().hash().unpack())
+        self.process_and_announce_block(block_template.into())
     }
 
     fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256> {
@@ -164,5 +160,72 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
         } else {
             Ok(hash.unpack())
         }
+    }
+
+    fn generate_block_with_template(&self, block_template: BlockTemplate) -> Result<H256> {
+        let snapshot: &Snapshot = &self.shared.snapshot();
+        let consensus = snapshot.consensus();
+        let parent_header = snapshot
+            .get_block_header(&block_template.parent_hash.pack())
+            .expect("parent header should be stored");
+        let mut seen_inputs = HashSet::new();
+
+        let txs: Vec<_> = block_template
+            .transactions
+            .iter()
+            .map(|tx_template| {
+                let transaction: packed::Transaction = tx_template.data.clone().into();
+                transaction.into_view()
+            })
+            .collect();
+
+        let transactions_provider = TransactionsProvider::new(txs.as_slice().iter());
+        let overlay_cell_provider = OverlayCellProvider::new(&transactions_provider, snapshot);
+
+        let rtxs = txs.iter().map(|tx| {
+            resolve_transaction(
+                tx.clone(),
+                &mut seen_inputs,
+                &overlay_cell_provider,
+                snapshot,
+            ).map_err(|err| {
+                error!(
+                    "resolve transactions error when generating block with block template, error: {:?}",
+                    err
+                );
+                RPCError::invalid_params(err.to_string())
+            })
+        }).collect::<Result<Vec<ResolvedTransaction>>>()?;
+
+        let mut update_dao_template = block_template;
+        update_dao_template.dao = DaoCalculator::new(consensus, snapshot.as_data_provider())
+            .dao_field(&rtxs, &parent_header)
+            .expect("dao calculation should be OK")
+            .into();
+        let block = update_dao_template.into();
+        self.process_and_announce_block(block)
+    }
+}
+
+impl IntegrationTestRpcImpl {
+    fn process_and_announce_block(&self, block: packed::Block) -> Result<H256> {
+        let block_view = Arc::new(block.into_view());
+        let content = packed::CompactBlock::build_from_block(&block_view, &HashSet::new());
+        let message = packed::RelayMessage::new_builder().set(content).build();
+
+        // insert block to chain
+        self.chain
+            .process_block(Arc::clone(&block_view))
+            .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
+
+        // announce new block
+        if let Err(err) = self
+            .network_controller
+            .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
+        {
+            error!("Broadcast new block failed: {:?}", err);
+        }
+
+        Ok(block_view.header().hash().unpack())
     }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -32,3 +32,4 @@ ckb-migration-template = { path = "migration-template", version = "= 0.41.0-pre"
 ckb-constant = { path = "../util/constant", version = "= 0.41.0-pre" }
 num_cpus = "1.10"
 faketime = "0.2.0"
+tempfile = "3.0"

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -481,6 +481,10 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RelayTooNewBlock),
         Box::new(LastCommonHeaderForPeerWithWorseChain),
         Box::new(BlockTransactionsRelayParentOfOrphanBlock),
+        Box::new(CellBeingSpentThenCellDepInSameBlockTestSubmitBlock),
+        Box::new(CellBeingCellDepThenSpentInSameBlockTestSubmitBlock),
+        Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate),
+        Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple),
     ];
     specs.shuffle(&mut thread_rng());
     specs

--- a/test/src/specs/tx_pool/dead_cell_deps.rs
+++ b/test/src/specs/tx_pool/dead_cell_deps.rs
@@ -1,0 +1,289 @@
+use crate::util::cell::gen_spendable;
+use crate::util::check::is_transaction_committed;
+use crate::util::mining::{mine, mine_until_bool};
+use crate::util::transaction::always_success_transaction;
+use crate::{Node, Spec};
+use ckb_logger::info;
+use ckb_types::{
+    core::cell::CellMetaBuilder,
+    core::{Capacity, DepType},
+    packed::{CellDepBuilder, OutPoint},
+    prelude::*,
+};
+
+/// There are 3 transactions, A, B and C:
+///   - A was already committed before;
+///   - B spends A;
+///   - A is one of C's cell-deps.
+///
+/// A block, which commits C and B in order, should be valid.
+///
+/// The difference between case `CellBeingSpentThenCellDepInSameBlockTestSubmitBlock` is the order
+/// of committed transactions. This case commits `[C, B]`.
+pub struct CellBeingCellDepThenSpentInSameBlockTestSubmitBlock;
+
+impl Spec for CellBeingCellDepThenSpentInSameBlockTestSubmitBlock {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        let initial_inputs = gen_spendable(node0, 2);
+        let input_a = &initial_inputs[0];
+        let input_c = &initial_inputs[1];
+
+        // Commit transaction A
+        let tx_a = {
+            let tx_a = always_success_transaction(node0, input_a);
+            node0.submit_transaction(&tx_a);
+            mine_until_bool(node0, || is_transaction_committed(node0, &tx_a));
+            tx_a
+        };
+
+        // Create transaction B which spends A
+        let tx_b = {
+            let input =
+                CellMetaBuilder::from_cell_output(tx_a.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(tx_a.hash(), 0))
+                    .build();
+            always_success_transaction(node0, &input)
+        };
+
+        // Create transaction C which depends A
+        let tx_c = {
+            let tx = always_success_transaction(node0, input_c);
+            let cell_dep_to_tx_a = CellDepBuilder::default()
+                .dep_type(DepType::Code.into())
+                .out_point(OutPoint::new(tx_a.hash(), 0))
+                .build();
+            tx.as_advanced_builder().cell_dep(cell_dep_to_tx_a).build()
+        };
+
+        // Propose B and C, to prepare testing
+        let block = node0
+            .new_block_builder(None, None, None)
+            .proposal(tx_b.proposal_short_id())
+            .proposal(tx_c.proposal_short_id())
+            .build();
+        node0.submit_block(&block);
+        mine(node0, node0.consensus().tx_proposal_window().closest());
+
+        // Create block commits B and C in order
+        let block = node0
+            .new_block_builder(None, None, None)
+            .transactions(vec![tx_c, tx_b])
+            .build();
+
+        let ret = node0
+            .rpc_client()
+            .submit_block("".to_owned(), block.data().into());
+        assert!(
+            ret.is_ok(),
+            "a block commits transactions [C, B] should be valid, ret: {:?}",
+            ret
+        );
+    }
+}
+
+/// There are 3 transactions, A, B and C:
+///   - A was already committed before;
+///   - B spends A;
+///   - A is one of C's cell-deps.
+///
+/// A block, which commits B and C in order, should be invalid because that C's cell-dep A is dead
+/// (as C spends A, A is dead).
+///
+/// The difference between case `CellBeingSpentThenCellDepInSameBlockTestSubmitBlock` is the order
+/// of committed transactions. This case commits `[B, C]`.
+pub struct CellBeingSpentThenCellDepInSameBlockTestSubmitBlock;
+
+impl Spec for CellBeingSpentThenCellDepInSameBlockTestSubmitBlock {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        let initial_inputs = gen_spendable(node0, 2);
+        let input_a = &initial_inputs[0];
+        let input_c = &initial_inputs[1];
+
+        // Commit transaction A
+        let tx_a = {
+            let tx_a = always_success_transaction(node0, input_a);
+            node0.submit_transaction(&tx_a);
+            mine_until_bool(node0, || is_transaction_committed(node0, &tx_a));
+            tx_a
+        };
+
+        // Create transaction B which spends A
+        let tx_b = {
+            let input =
+                CellMetaBuilder::from_cell_output(tx_a.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(tx_a.hash(), 0))
+                    .build();
+            always_success_transaction(node0, &input)
+        };
+
+        // Create transaction C which depends A
+        let tx_c = {
+            let tx = always_success_transaction(node0, input_c);
+            let cell_dep_to_tx_a = CellDepBuilder::default()
+                .dep_type(DepType::Code.into())
+                .out_point(OutPoint::new(tx_a.hash(), 0))
+                .build();
+            tx.as_advanced_builder().cell_dep(cell_dep_to_tx_a).build()
+        };
+
+        // Propose B and C, to prepare testing
+        let block = node0
+            .new_block_builder(None, None, None)
+            .proposal(tx_b.proposal_short_id())
+            .proposal(tx_c.proposal_short_id())
+            .build();
+        node0.submit_block(&block);
+        mine(node0, node0.consensus().tx_proposal_window().closest());
+
+        // Create block commits B and C in order
+        let block = node0
+            .new_block_builder(None, None, None)
+            .transactions(vec![tx_b, tx_c])
+            .build();
+
+        let ret = node0
+            .rpc_client()
+            .submit_block("".to_owned(), block.data().into());
+        assert!(
+            ret.is_err(),
+            "a block commits transactions [B, C] should be invalid, ret: {:?}",
+            ret
+        );
+    }
+}
+
+pub struct CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple;
+
+impl Spec for CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple {
+    crate::setup!(num_nodes: 10);
+
+    fn run(&self, nodes: &mut Vec<Node>) {
+        while let Some(node) = nodes.pop() {
+            info!(
+                "Run CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate on Node.{}",
+                nodes.len()
+            );
+            CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate {}.run(&mut vec![node])
+        }
+    }
+}
+
+/// There are 3 transactions, A, B and C:
+///   - A was already committed before;
+///   - B spends A;
+///   - A is one of C's cell-deps.
+///
+/// Propose transactions B and C and enter the proposal window;
+/// Submit transactions B and C;
+/// Try to get block template and mine new blocks.
+pub struct CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate;
+
+impl Spec for CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        let initial_inputs = gen_spendable(node0, 2);
+        let input_a = &initial_inputs[0];
+        let input_c = &initial_inputs[1];
+
+        // Commit transaction A
+        let tx_a = {
+            let tx_a = always_success_transaction(node0, input_a);
+            node0.submit_transaction(&tx_a);
+            mine_until_bool(node0, || is_transaction_committed(node0, &tx_a));
+            tx_a
+        };
+
+        // Create transaction B which spends A
+        let mut tx_b = {
+            let input =
+                CellMetaBuilder::from_cell_output(tx_a.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(tx_a.hash(), 0))
+                    .build();
+            always_success_transaction(node0, &input)
+        };
+
+        // Create transaction C which depends A
+        let mut tx_c = {
+            let tx = always_success_transaction(node0, input_c);
+            let cell_dep_to_tx_a = CellDepBuilder::default()
+                .dep_type(DepType::Code.into())
+                .out_point(OutPoint::new(tx_a.hash(), 0))
+                .build();
+            tx.as_advanced_builder().cell_dep(cell_dep_to_tx_a).build()
+        };
+
+        let b_weightier_than_c = rand::random::<u32>() % 2 == 0;
+        if b_weightier_than_c {
+            // make B's fee >> C's fee, which means B's tx-weight > C's tx-weight
+            let minimum_outputs_capacity = tx_b
+                .output(0)
+                .unwrap()
+                .as_builder()
+                .build_exact_capacity(Capacity::zero())
+                .unwrap()
+                .capacity();
+            let minimum_output = tx_b
+                .output(0)
+                .unwrap()
+                .as_builder()
+                .capacity(minimum_outputs_capacity)
+                .build();
+            tx_b = tx_b
+                .as_advanced_builder()
+                .set_outputs(vec![minimum_output])
+                .build();
+        } else {
+            // make B's fee << C's fee, which means B's tx-weight < C's tx-weight
+            let minimum_outputs_capacity = tx_c
+                .output(0)
+                .unwrap()
+                .as_builder()
+                .build_exact_capacity(Capacity::zero())
+                .unwrap()
+                .capacity();
+            let minimum_output = tx_c
+                .output(0)
+                .unwrap()
+                .as_builder()
+                .capacity(minimum_outputs_capacity)
+                .build();
+            tx_c = tx_c
+                .as_advanced_builder()
+                .set_outputs(vec![minimum_output])
+                .build();
+        }
+
+        // Propose B and C, to prepare testing
+        let block = node0
+            .new_block_builder(None, None, None)
+            .proposal(tx_b.proposal_short_id())
+            .proposal(tx_c.proposal_short_id())
+            .build();
+        node0.submit_block(&block);
+        mine(node0, node0.consensus().tx_proposal_window().closest());
+
+        // Submit B and C
+        //
+        // NOTE: It MUST submit C before B. If submit C after B, the proposed pool will reject C as
+        // it thinks that B has already spent A; A is one of C's cell-deps; hence C is invalid. This
+        // is current tx-pool implementation limitation but not consensus rule.
+        node0.submit_transaction(&tx_c);
+        node0.submit_transaction(&tx_b);
+
+        // Inside `mine`, RPC `get_block_template` will be involved, that's our testing interface.
+        mine(node0, node0.consensus().tx_proposal_window().farthest());
+        if b_weightier_than_c {
+            // B's tx-weight > C's tx-weight
+            assert!(is_transaction_committed(node0, &tx_b));
+        } else {
+            // B's tx-weight < C's tx-weight,
+            assert!(is_transaction_committed(node0, &tx_b));
+            assert!(is_transaction_committed(node0, &tx_c));
+        }
+    }
+}

--- a/test/src/specs/tx_pool/mod.rs
+++ b/test/src/specs/tx_pool/mod.rs
@@ -1,5 +1,6 @@
 mod cellbase_maturity;
 mod collision;
+mod dead_cell_deps;
 mod depend_tx_in_same_block;
 mod descendant;
 mod different_txs_with_same_input;
@@ -21,6 +22,7 @@ mod valid_since;
 
 pub use cellbase_maturity::*;
 pub use collision::*;
+pub use dead_cell_deps::*;
 pub use depend_tx_in_same_block::*;
 pub use descendant::*;
 pub use different_txs_with_same_input::*;

--- a/test/src/util/cell.rs
+++ b/test/src/util/cell.rs
@@ -95,13 +95,8 @@ pub fn as_outputs(cells: &[CellMeta]) -> Vec<CellOutput> {
 }
 
 pub fn as_input(cell: &CellMeta) -> CellInput {
-    let block_number = cell
-        .transaction_info
-        .as_ref()
-        .map(|txinfo| txinfo.block_number)
-        .unwrap();
     let out_point = cell.out_point.clone();
-    CellInput::new(out_point, block_number)
+    CellInput::new(out_point, 0)
 }
 
 pub fn as_output(cell: &CellMeta) -> CellOutput {

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -182,6 +182,12 @@ pub struct MigrateArgs {
     pub force: bool,
 }
 
+/// Parsed command line arguments for `ckb db-repair`.
+pub struct RepairArgs {
+    /// Parsed `ckb.toml`.
+    pub config: Box<CKBAppConfig>,
+}
+
 impl CustomizeSpec {
     /// No specified parameters for chain spec.
     pub fn is_unset(&self) -> bool {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -29,6 +29,8 @@ pub const CMD_GEN_SECRET: &str = "gen";
 pub const CMD_FROM_SECRET: &str = "from-secret";
 /// Subcommand `migrate`.
 pub const CMD_MIGRATE: &str = "migrate";
+/// Subcommand `db-repair`.
+pub const CMD_DB_REPAIR: &str = "db-repair";
 
 /// Command line argument `--config-dir`.
 pub const ARG_CONFIG_DIR: &str = "config-dir";
@@ -136,6 +138,7 @@ fn basic_app<'b>() -> App<'static, 'b> {
         .subcommand(reset_data())
         .subcommand(peer_id())
         .subcommand(migrate())
+        .subcommand(db_repair())
 }
 
 /// Parse the command line arguments by supplying the version information.
@@ -343,6 +346,10 @@ fn migrate() -> App<'static, 'static> {
                 .conflicts_with(ARG_MIGRATE_CHECK)
                 .help("Do migration without interactive prompt"),
         )
+}
+
+fn db_repair() -> App<'static, 'static> {
+    SubCommand::with_name(CMD_DB_REPAIR).about("Try repair ckb database")
 }
 
 fn list_hashes() -> App<'static, 'static> {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -9,7 +9,7 @@ mod sentry_config;
 
 pub use app_config::{AppConfig, CKBAppConfig, MinerAppConfig};
 pub use args::{
-    ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, ReplayArgs,
+    ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, RepairArgs, ReplayArgs,
     ResetDataArgs, RunArgs, StatsArgs,
 };
 pub use configs::*;
@@ -106,6 +106,13 @@ impl Setup {
             check,
             force,
         })
+    }
+
+    /// `db-repair` subcommand
+    pub fn db_repair<'m>(self, _matches: &ArgMatches<'m>) -> Result<RepairArgs, ExitCode> {
+        let config = self.config.into_ckb()?;
+
+        Ok(RepairArgs { config })
     }
 
     /// Executes `ckb miner`.


### PR DESCRIPTION
This PR adds `generate_block_with_template` rpc, so that dApps can get block template from `get_block_template` rpc, and then add or remove tx / proposal / uncle data in block template, and finally submit it via this rpc to control the newly generated block data.

btw, I think that we should add rpc doc to the `IntegrationTest` module, will create a new PR later.