### PR TITLE
feat: request the approval for database migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
 name = "ckb-bin"
 version = "0.40.0-pre"
 dependencies = [
+ "atty",
  "base64",
  "ckb-app-config",
  "ckb-async-runtime",

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -43,6 +43,7 @@ base64 = "0.13.0"
 tempfile = "3.0"
 rayon = "1.0"
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
+atty = "0.2"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -2,6 +2,8 @@ use ckb_app_config::{ExitCode, MigrateArgs};
 use ckb_async_runtime::Handle;
 use ckb_shared::shared::SharedBuilder;
 
+use crate::helper::prompt;
+
 pub fn migrate(args: MigrateArgs, async_handle: Handle) -> Result<(), ExitCode> {
     let builder = SharedBuilder::new(&args.config.db, None, async_handle);
 
@@ -10,6 +12,28 @@ pub fn migrate(args: MigrateArgs, async_handle: Handle) -> Result<(), ExitCode> 
             return Ok(());
         } else {
             return Err(ExitCode::Cli);
+        }
+    }
+
+    if !args.force {
+        if atty::is(atty::Stream::Stdin) && atty::is(atty::Stream::Stdout) {
+            let input = prompt("\
+            \n\
+            Doing migration will take quite a long time before CKB could work again.\n\
+            Another choice is to delete all data, then synchronize them again.\n\
+            \n\
+            Once the migration started, the data will be no longer compatible with all older versions CKB,\n\
+            so we strongly recommended you to backup the old data before migrating.\n\
+            \nIf you want to migrate the data, please input YES, otherwise, the current process will exit.\n\
+            > ",
+            );
+            if input.trim().to_lowercase() != "yes" {
+                eprintln!("The migration was declined since the user didn't confirm.");
+                return Err(ExitCode::Failure);
+            }
+        } else {
+            eprintln!("Run error: use --force to migrate without interactive prompt");
+            return Err(ExitCode::Failure);
         }
     }
 

--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -19,7 +19,7 @@ pub fn migrate(args: MigrateArgs, async_handle: Handle) -> Result<(), ExitCode> 
         return Ok(());
     }
 
-    if !args.force {
+    if builder.require_expensive_migrations() && !args.force {
         if atty::is(atty::Stream::Stdin) && atty::is(atty::Stream::Stdout) {
             let input = prompt("\
             \n\

--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -15,6 +15,10 @@ pub fn migrate(args: MigrateArgs, async_handle: Handle) -> Result<(), ExitCode> 
         }
     }
 
+    if !builder.migration_check() {
+        return Ok(());
+    }
+
     if !args.force {
         if atty::is(atty::Stream::Stdin) && atty::is(atty::Stream::Stdout) {
             let input = prompt("\

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -38,7 +38,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
             async_handle,
         );
 
-        if shared_builder.migration_check() {
+        if shared_builder.require_expensive_migrations() {
             eprintln!(
                 "For optimal performance, CKB wants to migrate the data into new format.\n\
                 You can use the old version CKB if you don't want to do the migration.\n\

--- a/db-migration/src/lib.rs
+++ b/db-migration/src/lib.rs
@@ -43,7 +43,7 @@ impl Migrations {
             Some(version_bytes) => {
                 String::from_utf8(version_bytes.to_vec()).expect("version bytes to utf8")
             }
-            None => return true,
+            None => return false,
         };
 
         self.migrations

--- a/db-schema/src/lib.rs
+++ b/db-schema/src/lib.rs
@@ -42,5 +42,5 @@ pub const META_CURRENT_EPOCH_KEY: &[u8] = b"CURRENT_EPOCH";
 
 /// CHAIN_SPEC_HASH_KEY tracks the hash of chain spec which created current database
 pub const CHAIN_SPEC_HASH_KEY: &[u8] = b"chain-spec-hash";
-/// CHAIN_SPEC_HASH_KEY tracks the current database version.
+/// MIGRATION_VERSION_KEY tracks the current database version.
 pub const MIGRATION_VERSION_KEY: &[u8] = b"db-version";

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -499,6 +499,11 @@ impl SharedBuilder {
         self.migrations.check(&self.db)
     }
 
+    /// Check whether database requires expensive migrations.
+    pub fn require_expensive_migrations(&self) -> bool {
+        self.migrations.expensive(&self.db)
+    }
+
     /// TODO(doc): @quake
     pub fn consensus(mut self, value: Consensus) -> Self {
         self.consensus = Some(value);

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -167,4 +167,6 @@ pub struct MigrateArgs {
     pub config: Box<CKBAppConfig>,
     /// Check whether it is required to do migration instead of really perform the migration.
     pub check: bool,
+    /// Do migration without interactive prompt.
+    pub force: bool,
 }

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -335,6 +335,12 @@ fn migrate() -> App<'static, 'static> {
                     otherwise ExitCode(64) is returned",
                 ),
         )
+        .arg(
+            Arg::with_name(ARG_FORCE)
+                .long(ARG_FORCE)
+                .conflicts_with(ARG_MIGRATE_CHECK)
+                .help("Do migration without interactive prompt"),
+        )
 }
 
 fn list_hashes() -> App<'static, 'static> {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -99,8 +99,13 @@ impl Setup {
     pub fn migrate<'m>(self, matches: &ArgMatches<'m>) -> Result<MigrateArgs, ExitCode> {
         let config = self.config.into_ckb()?;
         let check = matches.is_present(cli::ARG_MIGRATE_CHECK);
+        let force = matches.is_present(cli::ARG_FORCE);
 
-        Ok(MigrateArgs { config, check })
+        Ok(MigrateArgs {
+            config,
+            check,
+            force,
+        })
     }
 
     /// Executes `ckb miner`.


### PR DESCRIPTION
- docs: fix a typo
- chore: no migration version means the database is uninitialized
  At present, `migration_check` will return `true` if the database is uninitialized.
  But an uninitialized database doesn't have data required to migrate.
  This is important when do `migration_check` in `ckb run`.
- feat: request the approval for database migrations
