### PR TITLE
perf: partial read tx hashes

### DIFF
--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -142,9 +142,9 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
             )
             .take_while(|(key, _)| key.starts_with(prefix))
             .map(|(_key, value)| {
-                let reader =
-                    packed::TransactionViewReader::from_slice_should_be_ok(&value.as_ref());
-                reader.hash().to_entity()
+                packed::TransactionViewReader::new_unchecked(&value.as_ref())
+                    .hash()
+                    .to_entity()
             })
             .collect();
 


### PR DESCRIPTION
According to the profiler result of sync test, deserializing all transactions in a block and reading only its hash each time is an a factor that affects performance. This PR changed it to using partial reads, theoretically able to improve sync performance by ~2% 