### PR TITLE
chore: upgrade deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
  "ckb-db",
  "ckb-logger",
  "ckb-metrics",
- "futures 0.3.8",
+ "futures 0.3.12",
  "heim",
  "jemalloc-ctl",
  "jemalloc-sys",
@@ -876,7 +876,7 @@ dependencies = [
  "criterion",
  "faketime",
  "faster-hex 0.4.1",
- "futures 0.3.8",
+ "futures 0.3.12",
  "ipnetwork",
  "lazy_static",
  "num_cpus",
@@ -1288,7 +1288,7 @@ dependencies = [
  "ckb-verification",
  "ckb-verification-traits",
  "faketime",
- "futures 0.3.8",
+ "futures 0.3.12",
  "governor",
  "lru",
  "rand 0.7.3",
@@ -2038,9 +2038,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-cpupool"
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2090,15 +2090,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -2108,15 +2108,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
@@ -2129,9 +2129,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2140,7 +2140,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -2231,7 +2231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f302dc68f4035178051bff107a8181379b8baa3354654672c2f1e7134af983"
 dependencies = [
  "dashmap",
- "futures 0.3.8",
+ "futures 0.3.12",
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
@@ -3803,9 +3803,9 @@ checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -4259,7 +4259,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4660,12 +4660,12 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59bb81c7a61247cdaded1df12b943925c0fd6d3f8c6bd66a260965029a9e45a"
+checksum = "a26a7ac0f98ac59b4ad419efc9f6b373e62940432e5d0ba1ddc9d1faac0c82e0"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.12",
  "igd",
  "js-sys",
  "libc",
@@ -4705,7 +4705,7 @@ dependencies = [
  "bs58",
  "bytes 0.5.6",
  "chacha20poly1305",
- "futures 0.3.8",
+ "futures 0.3.12",
  "hmac",
  "log",
  "molecule",
@@ -5102,12 +5102,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb73b9a7c31227710e2a1eb2f41b71fb694fd53382144a933cdb346c93f0fb4"
+checksum = "3645b514654423f5704977e21a26f57cad6830d645e203a3d155f9a71e517115"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.12",
  "log",
  "tokio 0.2.25",
  "tokio-util",
@@ -5157,7 +5157,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "enum-as-inner",
- "futures 0.3.8",
+ "futures 0.3.12",
  "idna",
  "lazy_static",
  "log",
@@ -5176,7 +5176,7 @@ checksum = "6759e8efc40465547b0dfce9500d733c65f969a4cbbfbe3ccf68daaa46ef179e"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
- "futures 0.3.8",
+ "futures 0.3.12",
  "ipconfig",
  "lazy_static",
  "log",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,7 +18,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.40.0-pre" }
 tokio = { version = "0.2.11", features = ["sync", "macros"] }
 tokio-util = { version = "0.3.0", features = ["codec"] }
 futures = "0.3"
-p2p = { version="0.3.7", package="tentacle", features = ["molc"] }
+p2p = { version="0.3.8", package="tentacle", features = ["molc"] }
 faketime = "0.2.0"
 lazy_static = { version = "1.3.0", optional = true }
 bs58 = { version = "0.3.0", optional = true }


### PR DESCRIPTION
futures:
```
# 0.3.12 - 2021-01-15
* Fixed `Unpin` impl of `future::{MaybeDone, TryMaybeDone}` where trait bounds were accidentally added in 0.3.9. (#2317)

# 0.3.11 - 2021-01-14
* Fixed heap buffer overflow in `AsyncReadExt::{read_to_end, read_to_string}` (#2314)

# 0.3.10 - 2021-01-13
* Fixed type-inference in `sink::unfold` by specifying more of its types (breaking change -- see #2311)

# 0.3.9 - 2021-01-08
* Significantly improved compile time when `async-await` crate feature is disabled (#2273)
* Added `stream::repeat_with` (#2279)
* Added `StreamExt::unzip` (#2263)
* Added `sink::unfold` (#2268)
* Added `SinkExt::feed` (#2155)
* Implemented `FusedFuture` for `oneshot::Receiver` (#2300)
* Implemented `Clone` for `sink::With` (#2290)
* Re-exported `MapOkOrElse`, `MapInto`, `OkInto`, `TryFlatten`, `WriteAllVectored` (#2275)
```

tentacle:
```
# Bug Fix
- Port futures-rs fix on channel(#308)
- Don't use loop on yamux(#307)
- Fix yamux close(#309)
```