### PR TITLE
Split test case BlockTransactionsRelayParentOfOrphanBlock

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -21,7 +21,6 @@ ckb-hash = { path = "../util/hash", version = "= 0.40.0-pre" }
 ckb-util = { path = "../util", version = "= 0.40.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.40.0-pre" }
 ckb-crypto = { path = "../util/crypto", version = "= 0.40.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.40.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.40.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.40.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.40.0-pre" }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -480,6 +480,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(SyncTooNewBlock),
         Box::new(RelayTooNewBlock),
         Box::new(LastCommonHeaderForPeerWithWorseChain),
+        Box::new(BlockTransactionsRelayParentOfOrphanBlock),
     ];
     specs.shuffle(&mut thread_rng());
     specs

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -74,30 +74,6 @@ impl<'a, CS: ChainStore<'a>> DaoCalculator<'a, CS, DataLoaderWrapper<'a, CS>> {
         Ok(Capacity::shannons(reward))
     }
 
-    /// Returns the sum of primary block reward and secondary block reward for `target` block.
-    ///
-    /// Notice unlike primary_block_reward and secondary_epoch_reward above,
-    /// this starts calculating from parent, not target header.
-    ///
-    /// NOTE: Used for testing only!
-    #[doc(hidden)]
-    pub fn base_block_reward(&self, parent: &HeaderView) -> Result<Capacity, Error> {
-        let target_number = self
-            .consensus
-            .finalize_target(parent.number() + 1)
-            .ok_or(DaoError::InvalidHeader)?;
-        let target = self
-            .store
-            .get_block_hash(target_number)
-            .and_then(|hash| self.store.get_block_header(&hash))
-            .ok_or(DaoError::InvalidHeader)?;
-
-        let primary_block_reward = self.primary_block_reward(&target)?;
-        let secondary_block_reward = self.secondary_block_reward(&target)?;
-
-        Ok(primary_block_reward.safe_add(secondary_block_reward)?)
-    }
-
     /// Calculates the new dao field after packaging these transactions. It returns the dao field in [`Byte32`] format. Please see [`extract_dao_data`] if you intend to see the detailed content.
     ///
     /// [`Byte32`]: ../ckb_types/packed/struct.Byte32.html


### PR DESCRIPTION
1. Add a test case [`BlockTransactionsRelayParentOfOrphanBlock`](https://github.com/keroro520/ckb/blob/9ce5bb90fd8dda31b3e3e3733c26770f3be3b1c5/test/src/specs/relay/compact_block.rs#L309-L314)
2. Simplify the test case CompactBlockRelayParentOfOrphanBlock.
3. Remove the useless  function`base_block_reward` in ckb-dao.