### PR TITLE
ci: set env var to put nodes data into upload dir

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -17,6 +17,7 @@ set +e
 
 test_id=$(date +"%Y%m%d-%H%M%S")
 test_tmp_dir=${CKB_INTEGRATION_TEST_TMP:-$(pwd)/target/ckb-test/${test_id}}
+export CKB_INTEGRATION_TEST_TMP="${test_tmp_dir}"
 mkdir -p "${test_tmp_dir}"
 test_log_file="${test_tmp_dir}/integration.log"
 


### PR DESCRIPTION
When integration tests failed in Travis CI, the nodes data directories are not uploaded.

Set the environment variable to put the nodes data directories into the upload directory.
https://github.com/nervosnetwork/ckb/blob/1fc0dc0981f8bbd9a720773972e47ef7f5f08413/test/src/utils.rs#L215

The equivalent code in Azure CI:
https://github.com/nervosnetwork/ckb/blob/1fc0dc0981f8bbd9a720773972e47ef7f5f08413/devtools/windows/make.ps1#L90-L93