### PR TITLE
doc: CKB platform support into tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ CKB supports scripting in any programming language with its own [CKB-VM](https:/
 
 [Nervos project](https://www.nervos.org) defines [a suite of scalable and interoperable blockchain protocols](https://github.com/nervosnetwork/rfcs) to create a self-evolving distributed economy, [CKB](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0002-ckb/0002-ckb.md) is among them.
 
+Support for different platforms are organized into [three tiers](docs/platform-support.md), each with a different set of guarantees.
+
 **Notice**: The ckb process will send stack trace to sentry on Rust panics.
 This is enabled by default before mainnet, which can be opted out by setting
 the option `dsn` to empty in the config file.
@@ -67,5 +69,6 @@ Mainnet Lina or Testnet Aggron, switch to the branch [master].
 
 - [Quick Start](docs/quick-start.md)
 - [Configure CKB](docs/configure.md)
+- [Platform Support](docs/platform-support.md)
 
 You can find a more comprehensive document website at [https://docs.nervos.org](https://docs.nervos.org).

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,50 @@
+# CKB Platform Support
+
+Support for different platforms are organized into three tiers, each with a different set of guarantees.
+
+The CKB Rust code base uses the [Assembly based interpreter mode](https://github.com/nervosnetwork/ckb-vm#notes-on-different-modes) (ASM mode) of the CKB VM. This must be considered as a consensus rule in Lina, the mainnet and Aggron, the testnet.
+
+Miners connecting to Lina (the mainnet) and Aggron (the testnet) must use Tier 1 or Tier 2 platforms, where Tier 1 is recommended.
+
+The other nodes should use Tier 1 or Tier 2 platforms as well.
+
+## Tier 1
+
+Tier 1 platforms can be thought of fully conforming to the CKB consensus and having the guaranteed performance to work.
+
+We ensure that these platforms will satisfy the following requirements:
+
+-   Official binary releases are provided for the platforms.
+-   They are fully tested via CI (Continuous Integration).
+-   Issues related to these platforms have the top priority.
+
+| OS | Arch | CKB VM Mode |
+| --- | --- | --- |
+| Ubuntu 16.04 | x64 | ASM |
+| macOS | x64 | ASM |
+
+## Tier 2
+
+Tier 2 platforms are known to work. But either there are known performance issues or we don't run enough tests in these platforms.
+
+The official binary releases are also provided for the Tier 2 platforms.
+
+| OS | Arch | CKB VM Mode |
+| --- | --- | --- |
+| Windows \* | x64 | ASM |
+| Ubuntu 18.04 | x64 | ASM |
+| Ubuntu 20.04 | x64 | ASM |
+| Debian Stretch | x64 | ASM |
+| Debian Buster | x64 | ASM |
+| Arch Linux | x64 | ASM |
+| CentOS 7 | x64 | ASM |
+
+\* The Rust code base uses RocksDB to store data, which has known issues in Windows.
+
+## Tier 3
+
+Tier 3 platforms are those which the Rust code base has support for,  but which are not built or tested automatically. Or they have no the working ASM mode of CKB VM thus they are not guaranteed to fully conform to the CKB consensus.
+
+| OS | Arch | CKB VM Mode |
+| --- | --- | --- |
+| Any OS in Tier 1 and 2 | AArch64 | Rust |


### PR DESCRIPTION
Support for different platforms are organized into three tiers, each with a different set of guarantees.

The Rust implementation uses the [Assembly based interpreter mode](https://github.com/nervosnetwork/ckb-vm#notes-on-different-modes) (ASM mode) of the CKB VM. This must be considered as a consensus rule in Lina, the mainnet and Aggron, the testnet.

Miners connecting to Lina (the mainnet) and Aggron (the testnet) must use Tier 1 or Tier 2 platforms, where Tier 1 is recommended.

The other nodes should use Tier 1 or Tier 2 platforms as well.
