### PR TITLE
test: waiting for tx pool in integration tests

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -594,4 +594,7 @@ pub fn waiting_for_sync<N: Borrow<Node>>(nodes: &[N]) {
     if !synced {
         panic!("timeout to wait for sync, tip_headers: {:?}", tip_headers);
     }
+    for node in nodes {
+        node.borrow().wait_for_tx_pool();
+    }
 }

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -266,9 +266,12 @@ impl Node {
     }
 
     pub fn submit_block(&self, block: &BlockView) -> Byte32 {
-        self.rpc_client()
+        let hash = self
+            .rpc_client()
             .submit_block("".to_owned(), block.data().into())
-            .unwrap()
+            .unwrap();
+        self.wait_for_tx_pool();
+        hash
     }
 
     pub fn process_block_without_verify(&self, block: &BlockView, broadcast: bool) -> Byte32 {

--- a/test/src/util/mining.rs
+++ b/test/src/util/mining.rs
@@ -74,7 +74,6 @@ where
         let block = with(builder);
         node.submit_block(&block);
     }
-    node.wait_for_tx_pool();
 }
 
 pub fn mine_until_bool<P>(node: &Node, predicate: P)
@@ -100,7 +99,6 @@ where
 {
     loop {
         if let Some(t) = until() {
-            node.wait_for_tx_pool();
             return t;
         }
 


### PR DESCRIPTION
Same issues as #2483.

As a follow-up of #2483 which only fix few integration tests, this PR could fix more.

This PR could fix potential failures for at least follow integration tests:
- For the 1st commit:
  - BlockTransactionsRelayParentOfOrphanBlock
  - ConflictInGap
  - DAOWithSatoshiCellOccupied
  - FeeOfMaxBlockProposalsLimit
  - FeeOfMultipleMaxBlockProposalsLimit
  - FeeOfTransaction
  - ForkedTransaction
  - HandlingDescendantsOfCommitted
  - HandlingDescendantsOfProposed
  - MiningBasic
  - ProposalExpireRuleForCommittingAndExpiredAtOneTime
  - ProposeOutOfOrder
  - ReorgHandleProposals
  - RpcTransactionProof
  - RpcTruncate
  - SendLargeCyclesTxInBlock
  - SpendSatoshiCell
  - WithdrawDAO
  - WithdrawDAOWithOverflowCapacity
- For the 2nd commit:
  - PoolReconcile

p.s. Check #2483 for the failure analysis report and reproduce steps.