### PR TITLE
feat(rpc): add a controller to support reload configurations

### DIFF
--- a/ckb-bin/src/subcommand/miner.rs
+++ b/ckb-bin/src/subcommand/miner.rs
@@ -1,4 +1,4 @@
-use ckb_app_config::{ExitCode, MinerArgs, MinerConfig};
+use ckb_app_config::{exit_failure, ExitCode, MinerArgs, MinerConfig};
 use ckb_channel::unbounded;
 use ckb_miner::{Client, Miner};
 use std::thread;
@@ -21,7 +21,7 @@ pub fn miner(args: MinerArgs) -> Result<(), ExitCode> {
     thread::Builder::new()
         .name("client".to_string())
         .spawn(move || client.poll_block_template())
-        .expect("Start client failed!");
+        .map_err(|_| exit_failure!("Start client failed!"))?;
 
     miner.run();
     Ok(())

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -10,7 +10,7 @@ use ckb_network::{
 };
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_resource::Resource;
-use ckb_rpc::{RpcServer, ServiceBuilder};
+use ckb_rpc::RpcServerController;
 use ckb_shared::shared::{Shared, SharedBuilder};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_sync::{NetTimeProtocol, Relayer, SyncShared, Synchronizer};
@@ -30,6 +30,13 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
     let block_assembler_config = sanitize_block_assembler_config(&args)?;
     let miner_enable = block_assembler_config.is_some();
     let exit_handler = DefaultExitHandler::default();
+
+    let mut rpc_controller = RpcServerController::new(
+        &args.config.rpc,
+        args.config.tx_pool.min_fee_rate,
+        miner_enable,
+    );
+    rpc_controller.start_server();
 
     let (shared, table) = {
         let shared_builder = SharedBuilder::new(
@@ -61,6 +68,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
                 ExitCode::Failure
             })?
     };
+    rpc_controller.update_shared(Some(shared.clone()));
 
     // Verify genesis every time starting node
     verify_genesis(&shared)?;
@@ -98,20 +106,24 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
         "chain genesis hash: {:#x}",
         shared.genesis_hash()
     );
+    rpc_controller.update_chain_controller(Some(chain_controller.clone()));
 
     let sync_shared = Arc::new(SyncShared::with_tmpdir(
         shared.clone(),
         args.config.network.sync.clone(),
         args.config.tmp_dir.as_ref(),
     ));
+    rpc_controller.update_sync_shared(Some(Arc::clone(&sync_shared)));
+
     let network_state = Arc::new(
         NetworkState::from_config(args.config.network)
             .map_err(|_| exit_failure!("Init network state failed"))?,
     );
     let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
+    rpc_controller.update_synchronizer(Some(synchronizer.clone()));
 
     let relayer = Relayer::new(
-        chain_controller.clone(),
+        chain_controller,
         Arc::clone(&sync_shared),
         args.config.tx_pool.min_fee_rate,
         args.config.tx_pool.max_tx_verify_cycles,
@@ -126,11 +138,13 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
 
     let alert_notifier = Arc::clone(alert_relayer.notifier());
     let alert_verifier = Arc::clone(alert_relayer.verifier());
+    rpc_controller.update_alert_notifier(Some(alert_notifier));
+    rpc_controller.update_alert_verifier(Some(alert_verifier));
 
     let protocols = vec![
         CKBProtocol::new_with_support_protocol(
             SupportProtocols::Sync,
-            Box::new(synchronizer.clone()),
+            Box::new(synchronizer),
             Arc::clone(&network_state),
         ),
         CKBProtocol::new_with_support_protocol(
@@ -163,29 +177,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
     .start(shared.async_handle())
     .map_err(|_| exit_failure!("Start network service failed"))?;
 
-    let builder = ServiceBuilder::new(&args.config.rpc)
-        .enable_chain(shared.clone())
-        .enable_pool(
-            shared.clone(),
-            Arc::clone(&sync_shared),
-            args.config.tx_pool.min_fee_rate,
-            args.config.rpc.reject_ill_transactions,
-        )
-        .enable_miner(
-            shared.clone(),
-            network_controller.clone(),
-            chain_controller.clone(),
-            miner_enable,
-        )
-        .enable_net(network_controller.clone(), sync_shared)
-        .enable_stats(shared.clone(), synchronizer, Arc::clone(&alert_notifier))
-        .enable_experiment(shared.clone())
-        .enable_integration_test(shared.clone(), network_controller.clone(), chain_controller)
-        .enable_alert(alert_verifier, alert_notifier, network_controller.clone())
-        .enable_debug();
-    let io_handler = builder.build();
-
-    let rpc_server = RpcServer::new(args.config.rpc, io_handler, shared.notify_controller());
+    rpc_controller.update_network_controller(Some(network_controller));
 
     let exit_handler_clone = exit_handler.clone();
     ctrlc::set_handler(move || {
@@ -195,8 +187,7 @@ pub fn run(mut args: RunArgs, version: Version, async_handle: Handle) -> Result<
     exit_handler.wait_for_exit();
 
     info_target!(crate::LOG_TARGET_MAIN, "Finishing work, please wait...");
-    drop(rpc_server);
-    drop(network_controller);
+    rpc_controller.stop_server();
 
     Ok(())
 }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2984,6 +2984,10 @@ CKB groups RPC methods into modules, and a method is enabled only when the modul
 
 Users have to edit the config file to fix the error.
 
+### Error `NotReady`
+
+(-8): The RPC method is not ready.
+
 ### Error `P2PFailedToBroadcast`
 
 (-101): The CKB local node failed to broadcast a message to its peers.

--- a/rpc/src/controller.rs
+++ b/rpc/src/controller.rs
@@ -1,0 +1,469 @@
+use std::sync::Arc;
+
+use ckb_app_config::RpcConfig;
+use ckb_chain::chain::ChainController;
+use ckb_network::NetworkController;
+use ckb_network_alert::{notifier::Notifier as AlertNotifier, verifier::Verifier as AlertVerifier};
+use ckb_shared::shared::Shared;
+use ckb_sync::{SyncShared, Synchronizer};
+use ckb_types::core::FeeRate;
+use ckb_util::Mutex;
+
+use crate::{
+    module::{self, Pluginable as _},
+    RpcServer, ServiceBuilder,
+};
+
+#[doc(hidden)]
+pub struct RpcServerController {
+    state: RpcServerState,
+    server: Option<RpcServer>,
+    manager: RpcServerPluginManager,
+}
+
+struct RpcServerState {
+    rpc_config: RpcConfig,
+    shared: Option<Shared>,
+    chain_controller: Option<ChainController>,
+    network_controller: Option<NetworkController>,
+    synchronizer: Option<Synchronizer>,
+    sync_shared: Option<Arc<SyncShared>>,
+    alert_notifier: Option<Arc<Mutex<AlertNotifier>>>,
+    alert_verifier: Option<Arc<AlertVerifier>>,
+    min_fee_rate: FeeRate,
+    miner_enabled: bool,
+}
+
+#[derive(Default)]
+struct RpcServerPluginManager {
+    chain: module::Plugin<module::ChainRpcImpl>,
+    pool: module::Plugin<module::PoolRpcImpl>,
+    miner: module::Plugin<module::MinerRpcImpl>,
+    net: module::Plugin<module::NetRpcImpl>,
+    stats: module::Plugin<module::StatsRpcImpl>,
+    experiment: module::Plugin<module::ExperimentRpcImpl>,
+    test: module::Plugin<module::IntegrationTestRpcImpl>,
+    alert: module::Plugin<module::AlertRpcImpl>,
+}
+
+impl RpcServerState {
+    fn new(rpc_config: &RpcConfig, min_fee_rate: FeeRate, miner_enabled: bool) -> Self {
+        Self {
+            rpc_config: rpc_config.clone(),
+            shared: None,
+            chain_controller: None,
+            network_controller: None,
+            synchronizer: None,
+            sync_shared: None,
+            alert_notifier: None,
+            alert_verifier: None,
+            min_fee_rate,
+            miner_enabled,
+        }
+    }
+
+    fn start_server(&self) -> (RpcServer, RpcServerPluginManager) {
+        let mut builder = ServiceBuilder::new(&self.rpc_config);
+
+        let chain_plugin = if let Some(ref shared) = self.shared {
+            module::ChainRpcImpl {
+                shared: shared.to_owned(),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_chain(chain_plugin.clone_arc());
+
+        let pool_plugin = if let Self {
+            shared: Some(ref shared),
+            sync_shared: Some(ref sync_shared),
+            ..
+        } = self
+        {
+            module::PoolRpcImpl::new(
+                shared.to_owned(),
+                Arc::clone(sync_shared),
+                self.min_fee_rate,
+                self.rpc_config.reject_ill_transactions,
+            )
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_pool(pool_plugin.clone_arc());
+
+        let miner_plugin = if let Self {
+            shared: Some(ref shared),
+            network_controller: Some(ref network_controller),
+            chain_controller: Some(ref chain_controller),
+            ..
+        } = self
+        {
+            module::MinerRpcImpl {
+                shared: shared.to_owned(),
+                network_controller: network_controller.to_owned(),
+                chain: chain_controller.to_owned(),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_miner(miner_plugin.clone_arc(), self.miner_enabled);
+
+        let net_plugin = if let Self {
+            network_controller: Some(ref network_controller),
+            sync_shared: Some(ref sync_shared),
+            ..
+        } = self
+        {
+            module::NetRpcImpl {
+                network_controller: network_controller.to_owned(),
+                sync_shared: Arc::clone(sync_shared),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_net(net_plugin.clone_arc());
+
+        let stats_plugin = if let Self {
+            shared: Some(ref shared),
+            synchronizer: Some(ref synchronizer),
+            alert_notifier: Some(ref alert_notifier),
+            ..
+        } = self
+        {
+            module::StatsRpcImpl {
+                shared: shared.to_owned(),
+                synchronizer: synchronizer.to_owned(),
+                alert_notifier: Arc::clone(alert_notifier),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_stats(stats_plugin.clone_arc());
+
+        let experiment_plugin = if let Some(ref shared) = self.shared {
+            module::ExperimentRpcImpl {
+                shared: shared.to_owned(),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_experiment(experiment_plugin.clone_arc());
+
+        let test_plugin = if let Self {
+            shared: Some(ref shared),
+            network_controller: Some(ref network_controller),
+            chain_controller: Some(ref chain_controller),
+            ..
+        } = self
+        {
+            module::IntegrationTestRpcImpl {
+                shared: shared.to_owned(),
+                network_controller: network_controller.to_owned(),
+                chain: chain_controller.to_owned(),
+            }
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_integration_test(test_plugin.clone_arc());
+
+        let alert_plugin = if let Self {
+            network_controller: Some(ref network_controller),
+            alert_verifier: Some(ref alert_verifier),
+            alert_notifier: Some(ref alert_notifier),
+            ..
+        } = self
+        {
+            module::AlertRpcImpl::new(
+                Arc::clone(alert_verifier),
+                Arc::clone(alert_notifier),
+                network_controller.to_owned(),
+            )
+            .pluginable()
+        } else {
+            Default::default()
+        };
+        builder.enable_alert(alert_plugin.clone_arc());
+
+        builder.enable_debug();
+        let io_handler = builder.build();
+
+        let server = RpcServer::new(
+            self.rpc_config.clone(),
+            io_handler,
+            self.shared
+                .as_ref()
+                .map(|shared| shared.notify_controller()),
+        );
+        let plugin_manager = RpcServerPluginManager {
+            chain: chain_plugin,
+            pool: pool_plugin,
+            miner: miner_plugin,
+            net: net_plugin,
+            stats: stats_plugin,
+            experiment: experiment_plugin,
+            test: test_plugin,
+            alert: alert_plugin,
+        };
+        (server, plugin_manager)
+    }
+}
+
+impl RpcServerPluginManager {
+    fn update_chain(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            ..
+        } = state
+        {
+            let rpc_impl = module::ChainRpcImpl {
+                shared: shared.to_owned(),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.chain.update(inner_opt);
+    }
+
+    fn update_pool(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            sync_shared: Some(ref sync_shared),
+            min_fee_rate,
+            ref rpc_config,
+            ..
+        } = state
+        {
+            let rpc_impl = module::PoolRpcImpl::new(
+                shared.to_owned(),
+                Arc::clone(sync_shared),
+                *min_fee_rate,
+                rpc_config.reject_ill_transactions,
+            );
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.pool.update(inner_opt);
+    }
+
+    fn update_miner(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            chain_controller: Some(ref chain_controller),
+            network_controller: Some(ref network_controller),
+            ..
+        } = state
+        {
+            let rpc_impl = module::MinerRpcImpl {
+                shared: shared.to_owned(),
+                chain: chain_controller.to_owned(),
+                network_controller: network_controller.to_owned(),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.miner.update(inner_opt);
+    }
+
+    fn update_net(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            network_controller: Some(ref network_controller),
+            sync_shared: Some(ref sync_shared),
+            ..
+        } = state
+        {
+            let rpc_impl = module::NetRpcImpl {
+                network_controller: network_controller.to_owned(),
+                sync_shared: Arc::clone(sync_shared),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.net.update(inner_opt);
+    }
+
+    fn update_stats(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            synchronizer: Some(ref synchronizer),
+            alert_notifier: Some(ref alert_notifier),
+            ..
+        } = state
+        {
+            let rpc_impl = module::StatsRpcImpl {
+                shared: shared.to_owned(),
+                synchronizer: synchronizer.to_owned(),
+                alert_notifier: Arc::clone(alert_notifier),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.stats.update(inner_opt);
+    }
+
+    fn update_experiment(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            ..
+        } = state
+        {
+            let rpc_impl = module::ExperimentRpcImpl {
+                shared: shared.to_owned(),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.experiment.update(inner_opt);
+    }
+
+    fn update_test(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            shared: Some(ref shared),
+            network_controller: Some(ref network_controller),
+            chain_controller: Some(ref chain_controller),
+            ..
+        } = state
+        {
+            let rpc_impl = module::IntegrationTestRpcImpl {
+                shared: shared.to_owned(),
+                network_controller: network_controller.to_owned(),
+                chain: chain_controller.to_owned(),
+            };
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.test.update(inner_opt);
+    }
+
+    fn update_alert(&mut self, state: &RpcServerState) {
+        let inner_opt = if let RpcServerState {
+            network_controller: Some(ref network_controller),
+            alert_verifier: Some(ref alert_verifier),
+            alert_notifier: Some(ref alert_notifier),
+            ..
+        } = state
+        {
+            let rpc_impl = module::AlertRpcImpl::new(
+                Arc::clone(alert_verifier),
+                Arc::clone(alert_notifier),
+                network_controller.to_owned(),
+            );
+            Some(rpc_impl)
+        } else {
+            None
+        };
+        self.alert.update(inner_opt);
+    }
+}
+
+impl RpcServerController {
+    /// Create a new RPC server controller.
+    pub fn new(rpc_config: &RpcConfig, min_fee_rate: FeeRate, miner_enabled: bool) -> Self {
+        let state = RpcServerState::new(rpc_config, min_fee_rate, miner_enabled);
+        let server = None;
+        let manager = Default::default();
+        Self {
+            state,
+            server,
+            manager,
+        }
+    }
+
+    /// Start the RPC server.
+    pub fn start_server(&mut self) {
+        if self.server.is_none() {
+            let (server, manager) = self.state.start_server();
+            self.server.replace(server);
+            self.manager = manager;
+        }
+    }
+
+    /// Shutdown the RPC server.
+    pub fn stop_server(&mut self) {
+        let server = self.server.take();
+        drop(server);
+    }
+
+    /// Update `Shared` and related RPC modules.
+    pub fn update_shared(&mut self, v: Option<Shared>) -> &mut Self {
+        self.state.shared = v;
+        let config = &self.state.rpc_config;
+        if self.server.is_some()
+            && config.subscription_enable()
+            && (config.tcp_listen_address.is_some() || config.ws_listen_address.is_some())
+        {
+            // TODO how to enable subscription without restart the server?
+            self.stop_server();
+            self.start_server();
+        } else {
+            self.manager.update_chain(&self.state);
+            self.manager.update_pool(&self.state);
+            self.manager.update_miner(&self.state);
+            self.manager.update_stats(&self.state);
+            self.manager.update_experiment(&self.state);
+            self.manager.update_test(&self.state);
+        }
+        self
+    }
+
+    /// Update `ChainController` and related RPC modules.
+    pub fn update_chain_controller(&mut self, v: Option<ChainController>) -> &mut Self {
+        self.state.chain_controller = v;
+        self.manager.update_miner(&self.state);
+        self.manager.update_test(&self.state);
+        self
+    }
+
+    /// Update `NetworkController` and related RPC modules.
+    pub fn update_network_controller(&mut self, v: Option<NetworkController>) -> &mut Self {
+        self.state.network_controller = v;
+        self.manager.update_miner(&self.state);
+        self.manager.update_net(&self.state);
+        self.manager.update_test(&self.state);
+        self.manager.update_alert(&self.state);
+        self
+    }
+
+    /// Update `Synchronizer` and related RPC modules.
+    pub fn update_synchronizer(&mut self, v: Option<Synchronizer>) -> &mut Self {
+        self.state.synchronizer = v;
+        self.manager.update_stats(&self.state);
+        self
+    }
+
+    /// Update `SyncShared` and related RPC modules.
+    pub fn update_sync_shared(&mut self, v: Option<Arc<SyncShared>>) -> &mut Self {
+        self.state.sync_shared = v;
+        self.manager.update_pool(&self.state);
+        self.manager.update_net(&self.state);
+        self
+    }
+
+    /// Update `AlertNotifier` and related RPC modules.
+    pub fn update_alert_notifier(&mut self, v: Option<Arc<Mutex<AlertNotifier>>>) -> &mut Self {
+        self.state.alert_notifier = v;
+        self.manager.update_stats(&self.state);
+        self.manager.update_alert(&self.state);
+        self
+    }
+
+    /// Update `AlertVerifier` and related RPC modules.
+    pub fn update_alert_verifier(&mut self, v: Option<Arc<AlertVerifier>>) -> &mut Self {
+        self.state.alert_verifier = v;
+        self.manager.update_alert(&self.state);
+        self
+    }
+}

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -56,6 +56,8 @@ pub enum RPCError {
     ///
     /// Users have to edit the config file to fix the error.
     ConfigError = -7,
+    /// (-8): The RPC method is not ready.
+    NotReady = -8,
     /// (-101): The CKB local node failed to broadcast a message to its peers.
     P2PFailedToBroadcast = -101,
     /// (-200): Internal database error.
@@ -250,6 +252,14 @@ impl RPCError {
             "This RPC method is deprecated, it will be removed in future release. \
             Please check the related information in the CKB release notes and RPC document. \
             You may enable deprecated methods via adding `enable_deprecated_rpc = true` to the `[rpc]` section in ckb.toml.",
+        )
+    }
+
+    /// RPC error which indicates that the method is not ready.
+    pub fn rpc_method_is_not_ready() -> Error {
+        Self::custom(
+            RPCError::NotReady,
+            "This RPC method is not ready. Please try it later.",
         )
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 //! See [module](module/index.html) for the RPC methods documentation.
 
+pub(crate) mod controller;
 pub(crate) mod error;
 pub(crate) mod server;
 pub(crate) mod service_builder;
@@ -9,6 +10,7 @@ pub mod module;
 #[cfg(test)]
 mod test;
 
+pub use crate::controller::RpcServerController;
 pub use crate::error::RPCError;
 pub use crate::server::RpcServer;
 pub use crate::service_builder::ServiceBuilder;

--- a/rpc/src/module/alert.rs
+++ b/rpc/src/module/alert.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_jsonrpc_types::Alert;
 use ckb_logger::error;
@@ -90,7 +91,15 @@ impl AlertRpcImpl {
     }
 }
 
-impl AlertRpc for AlertRpcImpl {
+impl Pluginable for AlertRpcImpl {}
+
+impl AlertRpc for Plugin<AlertRpcImpl> {
+    fn send_alert(&self, alert: Alert) -> Result<()> {
+        is_ready!(self, send_alert(alert))
+    }
+}
+
+impl AlertRpcImpl {
     fn send_alert(&self, alert: Alert) -> Result<()> {
         let alert: packed::Alert = alert.into();
         let now_ms = faketime::unix_time_as_millis();

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
     BlockEconomicState, BlockNumber, BlockReward, BlockView, CellWithStatus, Consensus,
@@ -1243,7 +1244,113 @@ pub(crate) struct ChainRpcImpl {
 const DEFAULT_BLOCK_VERBOSITY_LEVEL: u32 = 2;
 const DEFAULT_HEADER_VERBOSITY_LEVEL: u32 = 1;
 
-impl ChainRpc for ChainRpcImpl {
+impl Pluginable for ChainRpcImpl {}
+
+impl ChainRpc for Plugin<ChainRpcImpl> {
+    fn get_block(
+        &self,
+        block_hash: H256,
+        verbosity: Option<Uint32>,
+    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+        is_ready!(self, get_block(block_hash, verbosity))
+    }
+
+    fn get_block_by_number(
+        &self,
+        block_number: BlockNumber,
+        verbosity: Option<Uint32>,
+    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+        is_ready!(self, get_block_by_number(block_number, verbosity))
+    }
+
+    fn get_header(
+        &self,
+        block_hash: H256,
+        verbosity: Option<Uint32>,
+    ) -> Result<Option<ResponseFormat<HeaderView, Header>>> {
+        is_ready!(self, get_header(block_hash, verbosity))
+    }
+
+    fn get_header_by_number(
+        &self,
+        block_number: BlockNumber,
+        verbosity: Option<Uint32>,
+    ) -> Result<Option<ResponseFormat<HeaderView, Header>>> {
+        is_ready!(self, get_header_by_number(block_number, verbosity))
+    }
+
+    fn get_transaction(&self, tx_hash: H256) -> Result<Option<TransactionWithStatus>> {
+        is_ready!(self, get_transaction(tx_hash))
+    }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> Result<Option<H256>> {
+        is_ready!(self, get_block_hash(block_number))
+    }
+
+    fn get_tip_header(
+        &self,
+        verbosity: Option<Uint32>,
+    ) -> Result<ResponseFormat<HeaderView, Header>> {
+        is_ready!(self, get_tip_header(verbosity))
+    }
+
+    fn get_current_epoch(&self) -> Result<EpochView> {
+        is_ready!(self, get_current_epoch())
+    }
+
+    fn get_epoch_by_number(&self, epoch_number: EpochNumber) -> Result<Option<EpochView>> {
+        is_ready!(self, get_epoch_by_number(epoch_number))
+    }
+
+    fn get_live_cell(&self, out_point: OutPoint, with_data: bool) -> Result<CellWithStatus> {
+        is_ready!(self, get_live_cell(out_point, with_data))
+    }
+
+    fn get_tip_block_number(&self) -> Result<BlockNumber> {
+        is_ready!(self, get_tip_block_number())
+    }
+
+    fn get_cellbase_output_capacity_details(
+        &self,
+        block_hash: H256,
+    ) -> Result<Option<BlockReward>> {
+        is_ready!(self, get_cellbase_output_capacity_details(block_hash))
+    }
+
+    fn get_block_economic_state(&self, block_hash: H256) -> Result<Option<BlockEconomicState>> {
+        is_ready!(self, get_block_economic_state(block_hash))
+    }
+
+    fn get_transaction_proof(
+        &self,
+        tx_hashes: Vec<H256>,
+        block_hash: Option<H256>,
+    ) -> Result<TransactionProof> {
+        is_ready!(self, get_transaction_proof(tx_hashes, block_hash))
+    }
+
+    fn verify_transaction_proof(&self, tx_proof: TransactionProof) -> Result<Vec<H256>> {
+        is_ready!(self, verify_transaction_proof(tx_proof))
+    }
+
+    fn get_fork_block(
+        &self,
+        block_hash: H256,
+        verbosity: Option<Uint32>,
+    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+        is_ready!(self, get_fork_block(block_hash, verbosity))
+    }
+
+    fn get_consensus(&self) -> Result<Consensus> {
+        is_ready!(self, get_consensus())
+    }
+
+    fn get_block_median_time(&self, block_hash: H256) -> Result<Option<Timestamp>> {
+        is_ready!(self, get_block_median_time(block_hash))
+    }
+}
+
+impl ChainRpcImpl {
     fn get_block(
         &self,
         block_hash: H256,

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_dao::DaoCalculator;
 use ckb_jsonrpc_types::{
@@ -285,7 +286,38 @@ pub(crate) struct ExperimentRpcImpl {
     pub shared: Shared,
 }
 
-impl ExperimentRpc for ExperimentRpcImpl {
+impl Pluginable for ExperimentRpcImpl {}
+
+impl ExperimentRpc for Plugin<ExperimentRpcImpl> {
+    fn compute_transaction_hash(&self, tx: Transaction) -> Result<H256> {
+        is_ready!(self, compute_transaction_hash(tx))
+    }
+
+    fn compute_script_hash(&self, script: Script) -> Result<H256> {
+        is_ready!(self, compute_script_hash(script))
+    }
+
+    fn dry_run_transaction(&self, tx: Transaction) -> Result<DryRunResult> {
+        is_ready!(self, dry_run_transaction(tx))
+    }
+
+    fn calculate_dao_maximum_withdraw(
+        &self,
+        out_point: OutPoint,
+        withdrawing_header_hash: H256,
+    ) -> Result<Capacity> {
+        is_ready!(
+            self,
+            calculate_dao_maximum_withdraw(out_point, withdrawing_header_hash)
+        )
+    }
+
+    fn estimate_fee_rate(&self, _expect_confirm_blocks: Uint64) -> Result<EstimateResult> {
+        is_ready!(self, estimate_fee_rate(_expect_confirm_blocks))
+    }
+}
+
+impl ExperimentRpcImpl {
     fn compute_transaction_hash(&self, tx: Transaction) -> Result<H256> {
         let tx: packed::Transaction = tx.into();
         Ok(tx.calc_tx_hash().unpack())

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_chain::chain::ChainController;
 use ckb_jsonrpc_types::{Block, BlockTemplate, Uint64, Version};
@@ -228,7 +229,27 @@ pub(crate) struct MinerRpcImpl {
     pub chain: ChainController,
 }
 
-impl MinerRpc for MinerRpcImpl {
+impl Pluginable for MinerRpcImpl {}
+
+impl MinerRpc for Plugin<MinerRpcImpl> {
+    fn get_block_template(
+        &self,
+        bytes_limit: Option<Uint64>,
+        proposals_limit: Option<Uint64>,
+        max_version: Option<Version>,
+    ) -> Result<BlockTemplate> {
+        is_ready!(
+            self,
+            get_block_template(bytes_limit, proposals_limit, max_version)
+        )
+    }
+
+    fn submit_block(&self, work_id: String, block: Block) -> Result<H256> {
+        is_ready!(self, submit_block(work_id, block))
+    }
+}
+
+impl MinerRpcImpl {
     fn get_block_template(
         &self,
         bytes_limit: Option<Uint64>,

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
     BannedAddr, LocalNode, LocalNodeProtocol, NodeAddress, PeerSyncState, RemoteNode,
@@ -536,7 +537,58 @@ pub(crate) struct NetRpcImpl {
     pub sync_shared: Arc<SyncShared>,
 }
 
-impl NetRpc for NetRpcImpl {
+impl Pluginable for NetRpcImpl {}
+
+impl NetRpc for Plugin<NetRpcImpl> {
+    fn local_node_info(&self) -> Result<LocalNode> {
+        is_ready!(self, local_node_info())
+    }
+
+    fn get_peers(&self) -> Result<Vec<RemoteNode>> {
+        is_ready!(self, get_peers())
+    }
+
+    fn get_banned_addresses(&self) -> Result<Vec<BannedAddr>> {
+        is_ready!(self, get_banned_addresses())
+    }
+
+    fn clear_banned_addresses(&self) -> Result<()> {
+        is_ready!(self, clear_banned_addresses())
+    }
+
+    fn set_ban(
+        &self,
+        address: String,
+        command: String,
+        ban_time: Option<Timestamp>,
+        absolute: Option<bool>,
+        reason: Option<String>,
+    ) -> Result<()> {
+        is_ready!(self, set_ban(address, command, ban_time, absolute, reason))
+    }
+
+    fn sync_state(&self) -> Result<SyncState> {
+        is_ready!(self, sync_state())
+    }
+
+    fn set_network_active(&self, state: bool) -> Result<()> {
+        is_ready!(self, set_network_active(state))
+    }
+
+    fn add_node(&self, peer_id: String, address: String) -> Result<()> {
+        is_ready!(self, add_node(peer_id, address))
+    }
+
+    fn remove_node(&self, peer_id: String) -> Result<()> {
+        is_ready!(self, remove_node(peer_id))
+    }
+
+    fn ping_peers(&self) -> Result<()> {
+        is_ready!(self, ping_peers())
+    }
+}
+
+impl NetRpcImpl {
     fn local_node_info(&self) -> Result<LocalNode> {
         Ok(LocalNode {
             version: self.network_controller.version().to_owned(),

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_jsonrpc_types::{OutputsValidator, RawTxPool, Transaction, TxPoolInfo};
@@ -237,7 +238,31 @@ impl PoolRpcImpl {
     }
 }
 
-impl PoolRpc for PoolRpcImpl {
+impl Pluginable for PoolRpcImpl {}
+
+impl PoolRpc for Plugin<PoolRpcImpl> {
+    fn send_transaction(
+        &self,
+        tx: Transaction,
+        outputs_validator: Option<OutputsValidator>,
+    ) -> Result<H256> {
+        is_ready!(self, send_transaction(tx, outputs_validator))
+    }
+
+    fn tx_pool_info(&self) -> Result<TxPoolInfo> {
+        is_ready!(self, tx_pool_info())
+    }
+
+    fn clear_tx_pool(&self) -> Result<()> {
+        is_ready!(self, clear_tx_pool())
+    }
+
+    fn get_raw_tx_pool(&self, verbose: Option<bool>) -> Result<RawTxPool> {
+        is_ready!(self, get_raw_tx_pool(verbose))
+    }
+}
+
+impl PoolRpcImpl {
     fn send_transaction(
         &self,
         tx: Transaction,

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use ckb_jsonrpc_types::{AlertMessage, ChainInfo, PeerState};
 use ckb_network_alert::notifier::Notifier as AlertNotifier;
 use ckb_shared::shared::Shared;
@@ -96,7 +97,19 @@ pub(crate) struct StatsRpcImpl {
     pub alert_notifier: Arc<Mutex<AlertNotifier>>,
 }
 
-impl StatsRpc for StatsRpcImpl {
+impl Pluginable for StatsRpcImpl {}
+
+impl StatsRpc for Plugin<StatsRpcImpl> {
+    fn get_blockchain_info(&self) -> Result<ChainInfo> {
+        is_ready!(self, get_blockchain_info())
+    }
+
+    fn get_peers_state(&self) -> Result<Vec<PeerState>> {
+        is_ready!(self, get_peers_state())
+    }
+}
+
+impl StatsRpcImpl {
     fn get_blockchain_info(&self) -> Result<ChainInfo> {
         let chain = self.synchronizer.shared.consensus().id.clone();
         let (tip_header, median_time) = {

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -1,3 +1,4 @@
+use super::{Plugin, Pluginable};
 use crate::error::RPCError;
 use ckb_app_config::BlockAssemblerConfig;
 use ckb_chain::chain::ChainController;
@@ -39,7 +40,34 @@ pub(crate) struct IntegrationTestRpcImpl {
     pub chain: ChainController,
 }
 
-impl IntegrationTestRpc for IntegrationTestRpcImpl {
+impl Pluginable for IntegrationTestRpcImpl {}
+
+impl IntegrationTestRpc for Plugin<IntegrationTestRpcImpl> {
+    fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Result<Option<H256>> {
+        is_ready!(self, process_block_without_verify(data, broadcast))
+    }
+
+    fn truncate(&self, target_tip_hash: H256) -> Result<()> {
+        is_ready!(self, truncate(target_tip_hash))
+    }
+
+    fn generate_block(
+        &self,
+        block_assembler_script: Option<Script>,
+        block_assembler_message: Option<JsonBytes>,
+    ) -> Result<H256> {
+        is_ready!(
+            self,
+            generate_block(block_assembler_script, block_assembler_message)
+        )
+    }
+
+    fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256> {
+        is_ready!(self, broadcast_transaction(transaction, cycles))
+    }
+}
+
+impl IntegrationTestRpcImpl {
     fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Result<Option<H256>> {
         let block: packed::Block = data.into();
         let block: Arc<core::BlockView> = Arc::new(block.into_view());

--- a/util/app-config/src/exit_code.rs
+++ b/util/app-config/src/exit_code.rs
@@ -14,6 +14,15 @@ pub enum ExitCode {
     Failure = 113,
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! exit_failure {
+    ($($token:tt)+) => {{
+        eprintln!($($token)+);
+        ExitCode::Failure
+    }};
+}
+
 impl ExitCode {
     /// Converts into signed 32-bit integer which can be used as the process exit status.
     pub fn into(self) -> i32 {


### PR DESCRIPTION
### Commits

- chore: add a macro to construct `ExitCode=Failure` more efficient
- feat(rpc): add a controller to support reload configurations

### Known Issues

- Update `Shared` after the RPC server started will restart the RPC server, since the subscription RPC couldn't be hot-plugged.

  https://github.com/nervosnetwork/ckb/blob/1b776c23a2ea6af335afb6e14ae1725c9dcf3cef/rpc/src/controller.rs#L404-L419