### PR TITLE
feat: Fix download scheduler

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -576,10 +576,15 @@ impl Synchronizer {
         };
 
         for peer in disconnect_list.iter() {
+            // It is not forbidden to evict protected nodes:
+            // - First of all, this node is not designated by the user for protection,
+            //   but is connected randomly. It does not represent the will of the user
+            // - Secondly, in the synchronization phase, the nodes with zero download tasks are
+            //   retained, apart from reducing the download efficiency, there is no benefit.
             if self
                 .peers()
                 .get_flag(*peer)
-                .map(|flag| flag.is_whitelist || flag.is_protect)
+                .map(|flag| flag.is_whitelist)
                 .unwrap_or(false)
             {
                 continue;

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -94,6 +94,7 @@ fn inflight_blocks_timeout() {
     let faketime_file = faketime::millis_tempfile(0).expect("create faketime file");
     faketime::enable(&faketime_file);
     let mut inflight_blocks = InflightBlocks::default();
+    inflight_blocks.protect_num = 0;
 
     assert!(inflight_blocks.insert(1.into(), (1, h256!("0x1").pack()).into()));
     assert!(inflight_blocks.insert(1.into(), (2, h256!("0x2").pack()).into()));
@@ -147,6 +148,7 @@ fn inflight_trace_number_state() {
     faketime::enable(&faketime_file);
 
     let mut inflight_blocks = InflightBlocks::default();
+    inflight_blocks.protect_num = 0;
 
     assert!(inflight_blocks.insert(1.into(), (1, h256!("0x1").pack()).into()));
     assert!(inflight_blocks.insert(2.into(), (2, h256!("0x2").pack()).into()));

--- a/test/src/specs/sync/get_blocks.rs
+++ b/test/src/specs/sync/get_blocks.rs
@@ -53,14 +53,14 @@ impl Spec for GetBlocksTimeout {
 
         let received = wait_get_blocks_point(&net, &node1, block_download_timeout_secs * 2, 1);
         assert!(
-            received.is_none(),
-            "Should not received GetBlocks anymore, the timeout could be any number."
+            received.is_some(),
+            "Should received GetBlocks anymore, the timeout could be any number."
         );
 
         let rpc_client = node1.rpc_client();
         let result = wait_until(10, || {
             let peers = rpc_client.get_peers();
-            peers.is_empty()
+            !peers.is_empty()
         });
         if !result {
             panic!("node1 must disconnect net");

--- a/test/src/specs/sync/get_blocks.rs
+++ b/test/src/specs/sync/get_blocks.rs
@@ -54,7 +54,7 @@ impl Spec for GetBlocksTimeout {
         let received = wait_get_blocks_point(&net, &node1, block_download_timeout_secs * 2, 1);
         assert!(
             received.is_some(),
-            "Should received GetBlocks anymore, the timeout could be any number."
+            "in the case of sparse connections, even if download times out, net should continue to receive GetBlock requests"
         );
 
         let rpc_client = node1.rpc_client();
@@ -63,7 +63,7 @@ impl Spec for GetBlocksTimeout {
             !peers.is_empty()
         });
         if !result {
-            panic!("node1 must disconnect net");
+            panic!("node1 must not disconnect net");
         }
     }
 }


### PR DESCRIPTION
1. disable penalty when download nodes are scarce
2. allow the protection node to be disconnected due to sync judgment