### PR TITLE
Replace `get_cellbase_output_capacity_details` with `get_block_economic_state` in test

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1077,7 +1077,7 @@ Because of the delay, this RPC returns null if the block rewards are not finaliz
 
 ##### Returns
 
-If the block with the hash `block_hash` is in the [canonical chain](#canonical-chain) and its rewards have been finalized, return the block rewards analysis for this block.
+If the block with the hash `block_hash` is in the [canonical chain](#canonical-chain) and its rewards have been finalized, return the block rewards analysis for this block. A special case is that the return value for genesis block is null.
 
 ##### Examples
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -892,7 +892,8 @@ pub trait ChainRpc {
     /// ## Returns
     ///
     /// If the block with the hash `block_hash` is in the [canonical chain](#canonical-chain) and
-    /// its rewards have been finalized, return the block rewards analysis for this block.
+    /// its rewards have been finalized, return the block rewards analysis for this block. A special
+    /// case is that the return value for genesis block is null.
     ///
     /// ## Examples
     ///

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -5,10 +5,10 @@ mod error;
 
 use ckb_error::AnyError;
 use ckb_jsonrpc_types::{
-    Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockReward, BlockTemplate,
-    BlockView, Capacity, CellWithStatus, ChainInfo, Cycle, DryRunResult, EpochNumber, EpochView,
-    EstimateResult, HeaderView, JsonBytes, LocalNode, OutPoint, RemoteNode, Script, Timestamp,
-    Transaction, TransactionProof, TransactionWithStatus, TxPoolInfo, Uint64, Version,
+    Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockTemplate, BlockView, Capacity,
+    CellWithStatus, ChainInfo, Cycle, DryRunResult, EpochNumber, EpochView, EstimateResult,
+    HeaderView, JsonBytes, LocalNode, OutPoint, RemoteNode, Script, Timestamp, Transaction,
+    TransactionProof, TransactionWithStatus, TxPoolInfo, Uint64, Version,
 };
 use ckb_types::core::{
     BlockNumber as CoreBlockNumber, Capacity as CoreCapacity, EpochNumber as CoreEpochNumber,
@@ -244,12 +244,6 @@ impl RpcClient {
             .into()
     }
 
-    pub fn get_cellbase_output_capacity_details(&self, hash: Byte32) -> Option<BlockReward> {
-        self.inner()
-            .get_cellbase_output_capacity_details(hash.unpack())
-            .expect("rpc call get_cellbase_output_capacity_details")
-    }
-
     pub fn get_block_economic_state(&self, hash: Byte32) -> Option<BlockEconomicState> {
         self.inner()
             .get_block_economic_state(hash.unpack())
@@ -312,7 +306,6 @@ jsonrpc!(pub struct Inner {
     pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
 
     pub fn calculate_dao_maximum_withdraw(&self, _out_point: OutPoint, _hash: H256) -> Capacity;
-    pub fn get_cellbase_output_capacity_details(&self, _hash: H256) -> Option<BlockReward>;
     pub fn get_block_economic_state(&self, _hash: H256) -> Option<BlockEconomicState>;
     pub fn get_transaction_proof(&self, tx_hashes: Vec<H256>, block_hash: Option<H256>) -> TransactionProof;
     pub fn verify_transaction_proof(&self, tx_proof: TransactionProof) -> Vec<H256>;

--- a/test/src/specs/mining/fee.rs
+++ b/test/src/specs/mining/fee.rs
@@ -47,7 +47,7 @@ impl Spec for FeeOfTransaction {
             txs.get_commit_tx_ids()
         );
 
-        assert_chain_rewards(node);
+        check_fee(node);
     }
 }
 
@@ -100,7 +100,7 @@ impl Spec for FeeOfMaxBlockProposalsLimit {
         );
         assert!(txs.iter().all(|tx| is_transaction_committed(node, tx)));
 
-        assert_chain_rewards(node);
+        check_fee(node);
     }
 }
 
@@ -156,7 +156,7 @@ impl Spec for FeeOfMultipleMaxBlockProposalsLimit {
         mine(node, 2 * FINALIZATION_DELAY_LENGTH);
 
         assert!(txs.iter().all(|tx| is_transaction_committed(node, tx)));
-        assert_chain_rewards(node);
+        check_fee(node);
     }
 }
 
@@ -237,6 +237,6 @@ impl Spec for ProposeDuplicated {
         mine(node, 2 * FINALIZATION_DELAY_LENGTH);
 
         assert!(txs.iter().all(|tx| is_transaction_committed(node, tx)));
-        assert_chain_rewards(node);
+        check_fee(node);
     }
 }


### PR DESCRIPTION
[`get_cellbase_output_capacity_details`](https://github.com/nervosnetwork/ckb/tree/80da25593086cf99723ae350f20e8ae43d965aa6/rpc#method-get_cellbase_output_capacity_details) will be deprecated soon and [`get_block_economic_state`](https://github.com/nervosnetwork/ckb/tree/80da25593086cf99723ae350f20e8ae43d965aa6/rpc#method-get_block_economic_state) is the alternative.
In this PR, I replace `get_cellbase_output_capacity_details` with `get_block_economic_state` and do some refactory in integration test.