### PR TITLE
feat: add network protocol config

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -18,7 +18,7 @@ use crate::services::{
     protocol_type_checker::ProtocolTypeCheckerService,
 };
 use crate::{Behaviour, CKBProtocol, Peer, PeerIndex, ProtocolId, ServiceControl};
-use ckb_app_config::NetworkConfig;
+use ckb_app_config::{NetworkConfig, SupportProtocol};
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_spawn::Spawn;
 use ckb_stop_handler::{SignalSender, StopHandler};
@@ -740,7 +740,7 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
 pub struct NetworkService<T> {
     p2p_service: Service<EventHandler<T>>,
     network_state: Arc<NetworkState>,
-    ping_controller: Sender<()>,
+    ping_controller: Option<Sender<()>>,
     // Background services
     bg_services: Vec<Pin<Box<dyn Future<Output = ()> + 'static + Send>>>,
     version: String,
@@ -757,65 +757,82 @@ impl<T: ExitHandler> NetworkService<T> {
         exit_handler: T,
     ) -> Self {
         let config = &network_state.config;
-        // == Build special protocols
-
-        // TODO: how to deny banned node to open those protocols?
-        // Ping protocol
-        let ping_interval = Duration::from_secs(config.ping_interval_secs);
-        let ping_timeout = Duration::from_secs(config.ping_timeout_secs);
-
-        let ping_network_state = Arc::clone(&network_state);
-        let (ping_handler, ping_controller) =
-            PingHandler::new(ping_interval, ping_timeout, ping_network_state);
-        let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(ping_handler))
-        });
-
-        // Discovery protocol
-        let addr_mgr = DiscoveryAddressManager {
-            network_state: Arc::clone(&network_state),
-            discovery_local_address: config.discovery_local_address,
-        };
-        let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(
-                addr_mgr,
-                config
-                    .discovery_announce_check_interval_secs
-                    .map(Duration::from_secs),
-            )))
-        });
-
-        // Identify protocol
-        let identify_callback =
-            IdentifyCallback::new(Arc::clone(&network_state), name, version.clone());
-        let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(IdentifyProtocol::new(identify_callback)))
-        });
-
-        // Feeler protocol
-        let feeler_meta = SupportProtocols::Feeler.build_meta_with_service_handle({
-            let network_state = Arc::clone(&network_state);
-            move || ProtocolHandle::Callback(Box::new(Feeler::new(Arc::clone(&network_state))))
-        });
-
-        let disconnect_message_state = Arc::clone(&network_state);
-        let disconnect_message_meta = SupportProtocols::DisconnectMessage
-            .build_meta_with_service_handle(move || {
-                ProtocolHandle::Callback(Box::new(DisconnectMessageProtocol::new(
-                    disconnect_message_state,
-                )))
-            });
-
         // == Build p2p service struct
         let mut protocol_metas = protocols
             .into_iter()
             .map(CKBProtocol::build)
             .collect::<Vec<_>>();
-        protocol_metas.push(feeler_meta);
-        protocol_metas.push(disconnect_message_meta);
-        protocol_metas.push(ping_meta);
-        protocol_metas.push(disc_meta);
+
+        // == Build special protocols
+
+        // Identify is a core protocol, user cannot disable it via config
+        let identify_callback =
+            IdentifyCallback::new(Arc::clone(&network_state), name, version.clone());
+        let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
+            ProtocolHandle::Callback(Box::new(IdentifyProtocol::new(identify_callback)))
+        });
         protocol_metas.push(identify_meta);
+
+        // Ping protocol
+        let ping_controller = if config.support_protocols.contains(&SupportProtocol::Ping) {
+            let ping_interval = Duration::from_secs(config.ping_interval_secs);
+            let ping_timeout = Duration::from_secs(config.ping_timeout_secs);
+
+            let ping_network_state = Arc::clone(&network_state);
+            let (ping_handler, ping_controller) =
+                PingHandler::new(ping_interval, ping_timeout, ping_network_state);
+            let ping_meta = SupportProtocols::Ping.build_meta_with_service_handle(move || {
+                ProtocolHandle::Callback(Box::new(ping_handler))
+            });
+            protocol_metas.push(ping_meta);
+            Some(ping_controller)
+        } else {
+            None
+        };
+
+        // Discovery protocol
+        if config
+            .support_protocols
+            .contains(&SupportProtocol::Discovery)
+        {
+            let addr_mgr = DiscoveryAddressManager {
+                network_state: Arc::clone(&network_state),
+                discovery_local_address: config.discovery_local_address,
+            };
+            let disc_meta = SupportProtocols::Discovery.build_meta_with_service_handle(move || {
+                ProtocolHandle::Callback(Box::new(DiscoveryProtocol::new(
+                    addr_mgr,
+                    config
+                        .discovery_announce_check_interval_secs
+                        .map(Duration::from_secs),
+                )))
+            });
+            protocol_metas.push(disc_meta);
+        }
+
+        // Feeler protocol
+        if config.support_protocols.contains(&SupportProtocol::Feeler) {
+            let feeler_meta = SupportProtocols::Feeler.build_meta_with_service_handle({
+                let network_state = Arc::clone(&network_state);
+                move || ProtocolHandle::Callback(Box::new(Feeler::new(Arc::clone(&network_state))))
+            });
+            protocol_metas.push(feeler_meta);
+        }
+
+        // DisconnectMessage protocol
+        if config
+            .support_protocols
+            .contains(&SupportProtocol::DisconnectMessage)
+        {
+            let disconnect_message_state = Arc::clone(&network_state);
+            let disconnect_message_meta = SupportProtocols::DisconnectMessage
+                .build_meta_with_service_handle(move || {
+                    ProtocolHandle::Callback(Box::new(DisconnectMessageProtocol::new(
+                        disconnect_message_state,
+                    )))
+                });
+            protocol_metas.push(disconnect_message_meta);
+        }
 
         let mut service_builder = ServiceBuilder::default();
         let yamux_config = YamuxConfig {
@@ -1115,7 +1132,7 @@ pub struct NetworkController {
     version: String,
     network_state: Arc<NetworkState>,
     p2p_control: ServiceControl,
-    ping_controller: Sender<()>,
+    ping_controller: Option<Sender<()>>,
     stop: StopHandler<()>,
 }
 
@@ -1301,8 +1318,9 @@ impl NetworkController {
 
     /// Try ping all connected peers
     pub fn ping_peers(&self) {
-        let mut ping_controller = self.ping_controller.clone();
-        let _ignore = ping_controller.try_send(());
+        if let Some(mut ping_controller) = self.ping_controller.clone() {
+            let _ignore = ping_controller.try_send(());
+        }
     }
 }
 

--- a/util/app-config/src/configs/mod.rs
+++ b/util/app-config/src/configs/mod.rs
@@ -14,7 +14,7 @@ pub use miner::{
     ClientConfig as MinerClientConfig, Config as MinerConfig, DummyConfig, EaglesongSimpleConfig,
     ExtraHashFunction, WorkerConfig as MinerWorkerConfig,
 };
-pub use network::{Config as NetworkConfig, HeaderMapConfig, SyncConfig};
+pub use network::{Config as NetworkConfig, HeaderMapConfig, SupportProtocol, SyncConfig};
 pub use network_alert::Config as NetworkAlertConfig;
 pub use notify::Config as NotifyConfig;
 pub use rpc::{Config as RpcConfig, Module as RpcModule};

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -71,6 +71,9 @@ pub struct Config {
     /// `bootnodes`.
     #[serde(default)]
     pub bootnode_mode: bool,
+    /// Supported protocols list
+    #[serde(default = "default_support_all_protocols")]
+    pub support_protocols: Vec<SupportProtocol>,
     /// Max send buffer size in bytes.
     pub max_send_buffer: Option<usize>,
     /// Network use reuse port or not
@@ -115,6 +118,34 @@ impl Default for HeaderMapConfig {
             backend_close_threshold: 20_000,
         }
     }
+}
+
+#[derive(Clone, Debug, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum SupportProtocol {
+    Ping,
+    Discovery,
+    Identify,
+    Feeler,
+    DisconnectMessage,
+    Sync,
+    Relay,
+    Time,
+    Alert,
+}
+
+fn default_support_all_protocols() -> Vec<SupportProtocol> {
+    vec![
+        SupportProtocol::Ping,
+        SupportProtocol::Discovery,
+        SupportProtocol::Identify,
+        SupportProtocol::Feeler,
+        SupportProtocol::DisconnectMessage,
+        SupportProtocol::Sync,
+        SupportProtocol::Relay,
+        SupportProtocol::Time,
+        SupportProtocol::Alert,
+    ]
 }
 
 pub(crate) fn generate_random_key() -> [u8; 32] {

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -9,7 +9,7 @@ pub mod migrate;
 mod migrations;
 mod shared_builder;
 
-use ckb_app_config::{BlockAssemblerConfig, ExitCode, RunArgs};
+use ckb_app_config::{BlockAssemblerConfig, ExitCode, RunArgs, SupportProtocol};
 use ckb_async_runtime::Handle;
 use ckb_build_info::Version;
 use ckb_chain::chain::{ChainController, ChainService};
@@ -257,15 +257,49 @@ impl Launcher {
                 .map(|t| NetworkState::ckb2021(t, fork_enable))
                 .expect("Init network state failed"),
         );
-        let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
 
-        let relayer = Relayer::new(
-            chain_controller.clone(),
-            Arc::clone(&sync_shared),
-            self.args.config.tx_pool.min_fee_rate,
-            self.args.config.tx_pool.max_tx_verify_cycles,
-        );
-        let net_timer = NetTimeProtocol::default();
+        // Sync is a core protocol, user cannot disable it via config
+        let synchronizer = Synchronizer::new(chain_controller.clone(), Arc::clone(&sync_shared));
+        let mut protocols = vec![CKBProtocol::new_with_support_protocol(
+            SupportProtocols::Sync,
+            Box::new(synchronizer),
+            Arc::clone(&network_state),
+        )];
+
+        let support_protocols = &self.args.config.network.support_protocols;
+
+        if support_protocols.contains(&SupportProtocol::Relay) {
+            let relayer = Relayer::new(
+                chain_controller.clone(),
+                Arc::clone(&sync_shared),
+                self.args.config.tx_pool.min_fee_rate,
+                self.args.config.tx_pool.max_tx_verify_cycles,
+            );
+
+            protocols.push(CKBProtocol::new_with_support_protocol(
+                SupportProtocols::RelayV2,
+                Box::new(relayer.clone().v2()),
+                Arc::clone(&network_state),
+            ));
+
+            if !fork_enable {
+                protocols.push(CKBProtocol::new_with_support_protocol(
+                    SupportProtocols::Relay,
+                    Box::new(relayer),
+                    Arc::clone(&network_state),
+                ))
+            }
+        }
+
+        if support_protocols.contains(&SupportProtocol::Time) {
+            let net_timer = NetTimeProtocol::default();
+            protocols.push(CKBProtocol::new_with_support_protocol(
+                SupportProtocols::Time,
+                Box::new(net_timer),
+                Arc::clone(&network_state),
+            ));
+        }
+
         let alert_signature_config = self.args.config.alert_signature.clone().unwrap_or_default();
         let alert_relayer = AlertRelayer::new(
             self.version.to_string(),
@@ -275,36 +309,12 @@ impl Launcher {
 
         let alert_notifier = Arc::clone(alert_relayer.notifier());
         let alert_verifier = Arc::clone(alert_relayer.verifier());
-
-        let mut protocols = vec![
-            CKBProtocol::new_with_support_protocol(
-                SupportProtocols::Sync,
-                Box::new(synchronizer),
-                Arc::clone(&network_state),
-            ),
-            CKBProtocol::new_with_support_protocol(
-                SupportProtocols::RelayV2,
-                Box::new(relayer.clone().v2()),
-                Arc::clone(&network_state),
-            ),
-            CKBProtocol::new_with_support_protocol(
-                SupportProtocols::Time,
-                Box::new(net_timer),
-                Arc::clone(&network_state),
-            ),
-            CKBProtocol::new_with_support_protocol(
+        if support_protocols.contains(&SupportProtocol::Alert) {
+            protocols.push(CKBProtocol::new_with_support_protocol(
                 SupportProtocols::Alert,
                 Box::new(alert_relayer),
                 Arc::clone(&network_state),
-            ),
-        ];
-
-        if !fork_enable {
-            protocols.push(CKBProtocol::new_with_support_protocol(
-                SupportProtocols::Relay,
-                Box::new(relayer),
-                Arc::clone(&network_state),
-            ))
+            ));
         }
 
         let required_protocol_ids = vec![SupportProtocols::Sync.protocol_id()];


### PR DESCRIPTION
This feature is designed for testing and use of ckb-network crate by third party code, allows user to customize network protocols, for example, only open sync protocol in full node:

```
support_protocols = ["Sync"]
```