### PR TITLE
chore: fix unaligned documentation which break highlighting for some editors

### DIFF
--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -101,16 +101,16 @@ pub const TYPE_ID_CODE_HASH: H256 = h256!("0x545950455f4944");
 /// 1) it is proposed at height h_p of the same chain, where w_close <= h_c − h_p <= w_far ;
 /// 2) it is in the commitment zone of the main chain block with height h_c ;
 ///
-///   ```text
-///   ProposalWindow (2, 10)
-///       propose
-///          \
-///           \
-///           13 14 [15 16 17 18 19 20 21 22 23]
-///                  \_______________________/
-///                               \
-///                             commit
-///  ```
+/// ```text
+/// ProposalWindow (2, 10)
+///     propose
+///        \
+///         \
+///         13 14 [15 16 17 18 19 20 21 22 23]
+///                \_______________________/
+///                             \
+///                           commit
+/// ```
 ///
 impl ProposalWindow {
     /// The w_close parameter


### PR DESCRIPTION
### Issue

The code block started at line 104 with 3 space but ended at line 113 with 1 space.

For some editors (with rust official plugins):
- No code highlighting.
- Couldn't fold code block.

### Affected

- [rust-lang/rust.vim for Vim](https://github.com/rust-lang/rust.vim/)
- [rust-lang/rust-mode for Emacs](https://github.com/rust-lang/rust-mode)