### PR TITLE
refactor: let verifiers know the real tip number and tx status

### DIFF
--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -359,7 +359,7 @@ impl TxPool {
         self.check_rtx_from_pending_and_proposed(&rtx)?;
         let snapshot = self.snapshot();
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let tx_phase = TransactionVerificationPhase::Gap;
+        let tx_phase = TransactionVerificationPhase::Proposed(0);
         let verified = verify_rtx(snapshot, &rtx, tx_phase, cache_entry, max_cycles)?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);
@@ -380,7 +380,7 @@ impl TxPool {
         self.check_rtx_from_proposed(&rtx)?;
         let snapshot = self.snapshot();
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let tx_phase = TransactionVerificationPhase::Proposed;
+        let tx_phase = TransactionVerificationPhase::Proposed(1);
         let verified = verify_rtx(snapshot, &rtx, tx_phase, cache_entry, max_cycles)?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -18,7 +18,7 @@ use ckb_types::{
     },
     packed::{Byte32, OutPoint, ProposalShortId},
 };
-use ckb_verification::cache::CacheEntry;
+use ckb_verification::{cache::CacheEntry, TransactionVerificationPhase};
 use faketime::unix_time_as_millis;
 use lru::LruCache;
 use std::collections::HashSet;
@@ -359,7 +359,8 @@ impl TxPool {
         self.check_rtx_from_pending_and_proposed(&rtx)?;
         let snapshot = self.snapshot();
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let verified = verify_rtx(snapshot, &rtx, cache_entry, max_cycles)?;
+        let tx_phase = TransactionVerificationPhase::Gap;
+        let verified = verify_rtx(snapshot, &rtx, tx_phase, cache_entry, max_cycles)?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);
         let tx_hash = entry.transaction().hash();
@@ -379,7 +380,8 @@ impl TxPool {
         self.check_rtx_from_proposed(&rtx)?;
         let snapshot = self.snapshot();
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let verified = verify_rtx(snapshot, &rtx, cache_entry, max_cycles)?;
+        let tx_phase = TransactionVerificationPhase::Proposed;
+        let verified = verify_rtx(snapshot, &rtx, tx_phase, cache_entry, max_cycles)?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);
         let tx_hash = entry.transaction().hash();

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -60,8 +60,8 @@ impl From<TxStatus> for TransactionVerificationPhase {
     fn from(status: TxStatus) -> Self {
         match status {
             TxStatus::Fresh => Self::Submitted,
-            TxStatus::Gap => Self::Gap,
-            TxStatus::Proposed => Self::Proposed,
+            TxStatus::Gap => Self::Proposed(0),
+            TxStatus::Proposed => Self::Proposed(1),
         }
     }
 }

--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -7,7 +7,7 @@ use ckb_store::ChainStore;
 use ckb_types::core::{cell::ResolvedTransaction, Capacity, Cycle, TransactionView};
 use ckb_verification::{
     cache::CacheEntry, ContextualTransactionVerifier, NonContextualTransactionVerifier,
-    TimeRelativeTransactionVerifier,
+    TimeRelativeTransactionVerifier, TransactionVerificationPhase,
 };
 use tokio::task::block_in_place;
 
@@ -74,6 +74,7 @@ pub(crate) fn non_contextual_verify(
 pub(crate) fn verify_rtx(
     snapshot: &Snapshot,
     rtx: &ResolvedTransaction,
+    tx_phase: TransactionVerificationPhase,
     cache_entry: Option<CacheEntry>,
     max_tx_verify_cycles: Cycle,
 ) -> Result<CacheEntry, Reject> {
@@ -86,9 +87,10 @@ pub(crate) fn verify_rtx(
         TimeRelativeTransactionVerifier::new(
             &rtx,
             snapshot,
-            tip_number + 1,
+            tip_number,
             epoch,
             tip_header.hash(),
+            tx_phase,
             consensus,
         )
         .verify()
@@ -98,9 +100,10 @@ pub(crate) fn verify_rtx(
         block_in_place(|| {
             ContextualTransactionVerifier::new(
                 &rtx,
-                tip_number + 1,
+                tip_number,
                 epoch,
                 tip_header.hash(),
+                tx_phase,
                 consensus,
                 &snapshot.as_data_provider(),
             )

--- a/verification/contextual/src/contextual_block_verifier.rs
+++ b/verification/contextual/src/contextual_block_verifier.rs
@@ -23,7 +23,7 @@ use ckb_verification::{
     BlockErrorKind, CellbaseError, CommitError, ContextualTransactionVerifier,
     TimeRelativeTransactionVerifier, UnknownParentError,
 };
-use ckb_verification::{BlockTransactionsError, EpochError};
+use ckb_verification::{BlockTransactionsError, EpochError, TransactionVerificationPhase};
 use ckb_verification_traits::Switch;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::collections::{HashMap, HashSet};
@@ -375,6 +375,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
             .enumerate()
             .map(|(index, tx)| {
                 let tx_hash = tx.transaction.hash();
+                let tx_phase = TransactionVerificationPhase::Committed;
                 if let Some(cache_entry) = fetched_cache.get(&tx_hash) {
                     TimeRelativeTransactionVerifier::new(
                         &tx,
@@ -382,6 +383,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         self.block_number,
                         self.epoch_number_with_fraction,
                         self.parent_hash.clone(),
+                        tx_phase,
                         self.context.consensus,
                     )
                     .verify()
@@ -399,6 +401,7 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                         self.block_number,
                         self.epoch_number_with_fraction,
                         self.parent_hash.clone(),
+                        tx_phase,
                         self.context.consensus,
                         &self.context.store.as_data_provider(),
                     )

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -22,7 +22,8 @@ pub use crate::genesis_verifier::GenesisVerifier;
 pub use crate::header_verifier::HeaderVerifier;
 pub use crate::transaction_verifier::{
     ContextualTransactionVerifier, NonContextualTransactionVerifier, ScriptVerifier, Since,
-    SinceMetric, TimeRelativeTransactionVerifier, TransactionVerifier,
+    SinceMetric, TimeRelativeTransactionVerifier, TransactionVerificationPhase,
+    TransactionVerifier,
 };
 
 /// Maximum amount of time that a block timestamp is allowed to exceed the

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -4,7 +4,7 @@ use super::super::transaction_verifier::{
 };
 use crate::error::TransactionErrorSource;
 use crate::TransactionError;
-use ckb_chain_spec::{build_genesis_type_id_script, OUTPUT_INDEX_DAO};
+use ckb_chain_spec::{build_genesis_type_id_script, consensus::ProposalWindow, OUTPUT_INDEX_DAO};
 use ckb_error::{assert_error_eq, Error};
 use ckb_test_chain_utils::{MockMedianTime, MOCK_MEDIAN_TIME_COUNT};
 use ckb_traits::HeaderProvider;
@@ -395,6 +395,7 @@ fn verify_since<'a, DL: HeaderProvider>(
     SinceVerifier::new(
         rtx,
         data_loader,
+        ProposalWindow(2, 10),
         block_number,
         EpochNumberWithFraction::new(epoch_number, 0, 10),
         parent_hash.as_ref().to_owned(),
@@ -503,6 +504,7 @@ fn test_fraction_epoch_since_verify() {
     let result = SinceVerifier::new(
         &rtx,
         &median_time_context,
+        ProposalWindow(2, 10),
         block_number,
         EpochNumberWithFraction::new(16, 1, 10),
         parent_hash.as_ref().to_owned(),
@@ -515,6 +517,7 @@ fn test_fraction_epoch_since_verify() {
     let result = SinceVerifier::new(
         &rtx,
         &median_time_context,
+        ProposalWindow(2, 10),
         block_number,
         EpochNumberWithFraction::new(16, 5, 10),
         parent_hash.as_ref().to_owned(),

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -1,6 +1,6 @@
 use super::super::transaction_verifier::{
     CapacityVerifier, DuplicateDepsVerifier, EmptyVerifier, MaturityVerifier, OutputsDataVerifier,
-    Since, SinceVerifier, SizeVerifier, VersionVerifier,
+    Since, SinceVerifier, SizeVerifier, TransactionVerificationPhase, VersionVerifier,
 };
 use crate::error::TransactionErrorSource;
 use crate::TransactionError;
@@ -397,8 +397,9 @@ fn verify_since<'a, DL: HeaderProvider>(
         data_loader,
         block_number,
         EpochNumberWithFraction::new(epoch_number, 0, 10),
-        11,
         parent_hash.as_ref().to_owned(),
+        TransactionVerificationPhase::Committed,
+        11,
     )
     .verify()
 }
@@ -504,8 +505,9 @@ fn test_fraction_epoch_since_verify() {
         &median_time_context,
         block_number,
         EpochNumberWithFraction::new(16, 1, 10),
-        MOCK_MEDIAN_TIME_COUNT,
         parent_hash.as_ref().to_owned(),
+        TransactionVerificationPhase::Committed,
+        MOCK_MEDIAN_TIME_COUNT,
     )
     .verify();
     assert_error_eq!(result.unwrap_err(), TransactionError::Immature { index: 0 });
@@ -515,8 +517,9 @@ fn test_fraction_epoch_since_verify() {
         &median_time_context,
         block_number,
         EpochNumberWithFraction::new(16, 5, 10),
-        MOCK_MEDIAN_TIME_COUNT,
         parent_hash.as_ref().to_owned(),
+        TransactionVerificationPhase::Committed,
+        MOCK_MEDIAN_TIME_COUNT,
     )
     .verify();
     assert!(result.is_ok());


### PR DESCRIPTION
### Purpose

In the latest version, we hard-code `tip_number + 1` as the block number for verification.

For example:
https://github.com/nervosnetwork/ckb/blob/dd9040f207364a039fdbe5fa9a21510c26b67b8f/tx-pool/src/util.rs#L86-L93
https://github.com/nervosnetwork/ckb/blob/dd9040f207364a039fdbe5fa9a21510c26b67b8f/tx-pool/src/util.rs#L99-L106

There are several defects:

- The tip header hash doesn't correspond to the tip block number.

- The epoch number doesn't correspond to the tip block number.

- For hard fork at a particular epoch, the script verifier have to know the exact epoch number.

  But epoch number couldn't add a number directly, since a epoch length is depend on the whole previous epoch information.

  So, the best way, I think, is to pass the real epoch number to all verifiers and tell those verifiers the minimum block latency.

  Then, I think the block number should be checked with same logic.

### Further

The `MaturityVerifier` and `SinceVerifier` with epoch numbers could be optimized, too.