### PR TITLE
fix: don't remove peer id on addr

### DIFF
--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -10,7 +11,7 @@ use p2p::{
     secio::PeerId,
     service::{SessionType, TargetProtocol},
     traits::ServiceProtocol,
-    utils::{is_reachable, multiaddr_to_socketaddr},
+    utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr},
     ProtocolId, SessionId,
 };
 
@@ -248,14 +249,8 @@ impl<T: Callback> ServiceProtocol for IdentifyProtocol<T> {
             .cloned()
             .collect();
 
-        let observed_addr = session
-            .address
-            .iter()
-            .filter(|proto| !matches!(proto, Protocol::P2P(_)))
-            .collect::<Multiaddr>();
-
         let identify = self.callback.identify();
-        let data = IdentifyMessage::new(listen_addrs, observed_addr, identify).encode();
+        let data = IdentifyMessage::new(listen_addrs, session.address.clone(), identify).encode();
         let _ = context.quick_send_message(data);
     }
 
@@ -471,7 +466,7 @@ impl Callback for IdentifyCallback {
     fn add_observed_addr(
         &mut self,
         peer_id: &PeerId,
-        addr: Multiaddr,
+        mut addr: Multiaddr,
         ty: SessionType,
     ) -> MisbehaveResult {
         debug!(
@@ -492,19 +487,27 @@ impl Callback for IdentifyCallback {
             return MisbehaveResult::Continue;
         }
 
+        if extract_peer_id(&addr).is_none() {
+            addr.push(Protocol::P2P(Cow::Borrowed(
+                self.network_state.local_peer_id().as_bytes(),
+            )))
+        }
+
+        let source_addr = addr.clone();
         let observed_addrs_iter = self
             .listen_addrs()
             .into_iter()
             .filter_map(|listen_addr| multiaddr_to_socketaddr(&listen_addr))
             .map(|socket_addr| {
                 addr.iter()
-                    .filter_map(|proto| match proto {
-                        Protocol::P2P(_) => None,
-                        Protocol::Tcp(_) => Some(Protocol::Tcp(socket_addr.port())),
-                        value => Some(value),
+                    .map(|proto| match proto {
+                        Protocol::Tcp(_) => Protocol::Tcp(socket_addr.port()),
+                        value => value,
                     })
                     .collect::<Multiaddr>()
-            });
+            })
+            .chain(::std::iter::once(source_addr));
+
         self.network_state.add_observed_addrs(observed_addrs_iter);
         // NOTE: for future usage
         MisbehaveResult::Continue


### PR DESCRIPTION
ref: #2565 

if no peer id on addr, it will always output an error log when trying to dial the observed addr:
```
error!("Do not dial addr without peer id, addr: {}", addr);
```