### PR TITLE
fix: resolve generate_block_with_template rpc error

### DIFF
--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -170,13 +170,10 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .expect("parent header should be stored");
         let mut seen_inputs = HashSet::new();
 
-        let txs: Vec<_> = block_template
-            .transactions
-            .iter()
-            .map(|tx_template| {
-                let transaction: packed::Transaction = tx_template.data.clone().into();
-                transaction.into_view()
-            })
+        let txs: Vec<_> = packed::Block::from(block_template.clone())
+            .transactions()
+            .into_iter()
+            .map(|tx| tx.into_view())
             .collect();
 
         let transactions_provider = TransactionsProvider::new(txs.as_slice().iter());

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -233,6 +233,13 @@ impl RpcClient {
             .pack()
     }
 
+    pub fn generate_block_with_template(&self, block_template: BlockTemplate) -> Byte32 {
+        self.inner()
+            .generate_block_with_template(block_template)
+            .expect("rpc call generate_block_with_template")
+            .pack()
+    }
+
     pub fn calculate_dao_maximum_withdraw(
         &self,
         out_point: OutPoint,
@@ -310,6 +317,7 @@ jsonrpc!(pub struct Inner {
     pub fn process_block_without_verify(&self, _data: Block, broadcast: bool) -> Option<H256>;
     pub fn truncate(&self, target_tip_hash: H256) -> ();
     pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
+    pub fn generate_block_with_template(&self, block_template: BlockTemplate) -> H256;
 
     pub fn calculate_dao_maximum_withdraw(&self, _out_point: OutPoint, _hash: H256) -> Capacity;
     pub fn get_cellbase_output_capacity_details(&self, _hash: H256) -> Option<BlockReward>;

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -2,8 +2,7 @@ use crate::node::waiting_for_sync;
 use crate::util::mining::mine;
 use crate::util::mining::out_ibd_mode;
 use crate::utils::{
-    build_block, build_compact_block, build_get_blocks, build_header, new_block_with_template,
-    now_ms, sleep, wait_until,
+    build_block, build_compact_block, build_get_blocks, build_header, now_ms, sleep, wait_until,
 };
 use crate::{Net, Node, Spec};
 use ckb_jsonrpc_types::ChainInfo;
@@ -368,8 +367,8 @@ impl Spec for RequestUnverifiedBlocks {
         let node2 = &nodes[2];
         out_ibd_mode(nodes);
 
-        let main_chain = build_forks(node1, &[0; 6]);
-        let fork_chain = build_forks(node2, &[1; 5]);
+        let main_chain = build_forks(node1, &[0; 16]);
+        let fork_chain = build_forks(node2, &[1; 15]);
         assert!(main_chain.len() > fork_chain.len());
 
         // Submit `main_chain` before `fork_chain`, to make `target_node` marks `fork_chain`
@@ -467,10 +466,8 @@ fn build_forks(node: &Node, offsets: &[u64]) -> Vec<BlockView> {
     for offset in offsets.iter() {
         let mut template = rpc_client.get_block_template(None, None, None);
         template.current_time = (template.current_time.value() + offset).into();
-        let block = new_block_with_template(template);
-        node.submit_block(&block);
-
-        blocks.push(block);
+        rpc_client.generate_block_with_template(template.clone());
+        blocks.push(packed::Block::from(template).into_view());
     }
     blocks
 }

--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -2,12 +2,11 @@ use crate::global::PORT_COUNTER;
 use crate::util::check::is_transaction_committed;
 use crate::util::mining::mine;
 use crate::{Node, TXOSet};
-use ckb_jsonrpc_types::BlockTemplate;
 use ckb_network::bytes::Bytes;
 use ckb_types::{
     core::{BlockNumber, BlockView, EpochNumber, HeaderView, TransactionView},
     packed::{
-        Block, BlockTransactions, Byte32, CompactBlock, GetBlocks, RelayMessage, RelayTransaction,
+        BlockTransactions, Byte32, CompactBlock, GetBlocks, RelayMessage, RelayTransaction,
         RelayTransactionHashes, RelayTransactions, SendBlock, SendHeaders, SyncMessage,
     },
     prelude::*,
@@ -125,13 +124,6 @@ pub fn build_relay_tx_hashes(hashes: &[Byte32]) -> Bytes {
         .build();
 
     RelayMessage::new_builder().set(content).build().as_bytes()
-}
-
-pub fn new_block_with_template(template: BlockTemplate) -> BlockView {
-    Block::from(template)
-        .as_advanced_builder()
-        .nonce(rand::random::<u128>().pack())
-        .build()
 }
 
 pub fn wait_until<F>(secs: u64, mut f: F) -> bool


### PR DESCRIPTION
fix a bug which is introduced by https://github.com/nervosnetwork/ckb/pull/2569: this rpc will fail after height 11 on a local dev chain. This PR changed an integration test also to utilize this rpc to make issue it's covered by testing.