### PR TITLE
perf: shortcut return proposal reward when target_proposals is empty

### DIFF
--- a/util/reward-calculator/src/lib.rs
+++ b/util/reward-calculator/src/lib.rs
@@ -211,7 +211,7 @@ impl<'a, CS: ChainStore<'a>> RewardCalculator<'a, CS> {
             }
         }
 
-        while index.number() > competing_commit_start {
+        while index.number() > competing_commit_start && !target_proposals.is_empty() {
             index = store
                 .get_block_header(&index.data().raw().parent_hash())
                 .expect("header stored");


### PR DESCRIPTION
This PR will reduce the rocksdb query especially `get_block_txs_hashes` in the `committed_idx_proc`, which is a slow query according to profiler result.