### PR TITLE
feat: add github action "terraform"

### DIFF
--- a/.github/actions/terraform/Dockerfile
+++ b/.github/actions/terraform/Dockerfile
@@ -1,0 +1,9 @@
+FROM hashicorp/terraform:0.15.0
+
+RUN apk add bash
+
+COPY main.sh    /terraform/main.sh
+COPY apply.sh   /terraform/apply.sh
+COPY cleanup.sh /terraform/cleanup.sh
+
+ENTRYPOINT [ "/terraform/main.sh" ]

--- a/.github/actions/terraform/README.md
+++ b/.github/actions/terraform/README.md
@@ -1,0 +1,47 @@
+# Terraform
+
+Suppose you have a job that applies AWS resources, runs your tests on these resources, and finally, destroys them whatever succeeded, failed or aborted. You can do this safely by writing Terraform configuration files and passing the directory path.
+
+This action use [`post`](https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/docs/adrs/0361-wrapper-action.md) keyword to ensure that clean work always be done.
+
+# Usage
+
+<!-- start usage -->
+```yaml
+- uses: ./.github/actions/terraform
+  with:
+    # Required, directory path to Terraform configuration files
+    terraform_dir: /path/to/terraform/configuration/directory
+```
+<!-- end usage -->
+
+# Examples
+
+```yaml
+# Generate a random SSH key pair to access instances, such as Ansible, via SSH
+- run: ssh-keygen -N "" -f ${{ env.PRIVATE_KEY_PATH }}
+
+- name: Apply Resources
+  uses: ./.github/actions/terraform
+  env:
+    # You may declare Terraform variables in `variables.tf`.
+    #
+    # Setting declared variables as environment variables is a common practice.
+    #
+    # [Learn more about Terraform variables](https://www.terraform.io/docs/language/values/variables.html#environment-variables)
+    TF_VAR_access_key:       ${{ secrets.AWS_ACCESS_KEY }}
+    TF_VAR_secret_key:       ${{ secrets.AWS_SECRET_KEY }}
+    TF_VAR_private_key_path: ${{ env.PRIVATE_KEY_PATH }}
+    TF_VAR_public_key_path:  ${{ env.PUBLIC_KEY_PATH }}
+    TF_VAR_instance_type:    t3.micro
+  with:
+    terraform_dir: /path/to/terraform/configuration/directory
+
+- name: Output
+  working-directory: /path/to/terraform/configuration/directory
+  run: |
+    terraform output -raw "<ansible inventory defined as Terraform output>" >> /path/to/ansible/inventory-file
+
+# Ansible-playbook do tests
+- run: ansible-playbook playbook.yml -i /path/to/ansible/inventory-file ...
+```

--- a/.github/actions/terraform/action.yml
+++ b/.github/actions/terraform/action.yml
@@ -1,0 +1,14 @@
+name: 'Terraform'
+
+description: 'Apply Terraform defined Infrastructures on-demand, destroy at job end'
+
+inputs:
+  terraform_dir:
+    description: 'Directory path to Terraform configuration files'
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  entrypoint:      '/terraform/apply.sh'
+  post-entrypoint: '/terraform/cleanup.sh'

--- a/.github/actions/terraform/apply.sh
+++ b/.github/actions/terraform/apply.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Call by action `entrypoint`
+
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+${SCRIPT_PATH}/main.sh apply

--- a/.github/actions/terraform/cleanup.sh
+++ b/.github/actions/terraform/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Call by action `post_entrypoint`
+
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+${SCRIPT_PATH}/main.sh cleanup

--- a/.github/actions/terraform/main.sh
+++ b/.github/actions/terraform/main.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Path to location of terraform files
+TERRAFORM_DIR=${INPUT_TERRAFORM_DIR:-${TERRAFORM_DIR}}
+
+function apply_infrastructure () {
+    cd ${TERRAFORM_DIR}
+    terraform init
+    terraform plan
+    terraform apply -auto-approve
+}
+
+function cleanup_infrastructure () {
+    cd ${TERRAFORM_DIR}
+    terraform init
+    terraform destroy -auto-approve
+}
+
+function cleanup_terraform_footprint () {
+    rm -rf ${TERRAFORM_DIR}/.terraform
+    rm -rf ${TERRAFORM_DIR}/terraform.tfstate
+}
+
+function main () {
+    [ $1 ] || { echo "Wrong usage"; exit 1; }
+
+    local command="${1}"
+    shift 1
+    case ${command} in
+        apply )
+            apply_infrastructure
+            ;;
+        cleanup )
+            cleanup_infrastructure
+            cleanup_terraform_footprint
+            ;;
+        * )
+            echo "Wrong usage"; exit 1;
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Action desctiption: [action-terraform](https://github.com/keroro520/ckb/blob/action-terraform/.github/actions/terraform/README.md)


CI tests "benchmark" and "sync-mainnet" apply AWS instances on-demand. I created a docker action using the Github Action `post` keyword to ensure that the applied instances must be destroyed.