### PR TITLE
perf: skip fresh proposal id checking in TransactionHashes message

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -30,7 +30,7 @@ use p2p::{
     bytes::Bytes,
     context::{ServiceContext, SessionContext},
     error::{DialerErrorKind, HandshakeErrorKind, ProtocolHandleErrorKind, SendErrorKind},
-    multiaddr::{self, Multiaddr, Protocol},
+    multiaddr::{Multiaddr, Protocol},
     secio::{self, error::SecioError, PeerId},
     service::{ProtocolHandle, Service, ServiceError, ServiceEvent, TargetProtocol, TargetSession},
     traits::ServiceHandle,

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -847,7 +847,7 @@ impl<T: ExitHandler> NetworkService<T> {
                     let mut iter = addr.iter();
 
                     iter.find_map(|proto| {
-                        if let multiaddr::Protocol::Ws = proto {
+                        if let p2p::multiaddr::Protocol::Ws = proto {
                             Some(TransportType::Ws)
                         } else {
                             None

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -70,7 +70,7 @@ pub struct Shared {
     // async stop handle, only test will be assigned
     pub(crate) async_stop: Option<StopHandler<()>>,
     pub(crate) ibd_finished: Arc<AtomicBool>,
-    pub(crate) relay_tx_sender: Sender<(PeerIndex, Byte32)>,
+    pub(crate) relay_tx_sender: Sender<(Option<PeerIndex>, Byte32)>,
 }
 
 impl Shared {
@@ -425,13 +425,6 @@ impl Shared {
         } else {
             self.ibd_finished.store(true, Ordering::Relaxed);
             false
-        }
-    }
-
-    /// Send tx id to relay channel
-    pub fn relay_tx(&self, peer: PeerIndex, hash: Byte32) {
-        if let Err(e) = self.relay_tx_sender.send((peer, hash)) {
-            ckb_logger::error!("relay_tx error {}", e);
         }
     }
 }

--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -181,7 +181,7 @@ impl SharedBuilder {
 pub struct SharedPackage {
     table: Option<ProposalTable>,
     tx_pool_builder: Option<TxPoolServiceBuilder>,
-    relay_tx_receiver: Option<Receiver<(PeerIndex, Byte32)>>,
+    relay_tx_receiver: Option<Receiver<(Option<PeerIndex>, Byte32)>>,
 }
 
 impl SharedPackage {
@@ -196,7 +196,7 @@ impl SharedPackage {
     }
 
     /// Takes the relay_tx_receiver out of the package, leaving a None in its place.
-    pub fn take_relay_tx_receiver(&mut self) -> Receiver<(PeerIndex, Byte32)> {
+    pub fn take_relay_tx_receiver(&mut self) -> Receiver<(Option<PeerIndex>, Byte32)> {
         self.relay_tx_receiver
             .take()
             .expect("take relay_tx_receiver")

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -607,6 +607,7 @@ impl Relayer {
                                 .entry(*target)
                                 .or_insert_with(|| Vec::with_capacity(BUFFER_SIZE));
                             hashes.push(hash.clone());
+                            self.shared.state().mark_as_known_tx(hash.clone());
                         }
                     }
                 }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -591,11 +591,23 @@ impl Relayer {
             let mut known_txs = self.shared.state().known_txs();
             for (origin_peer, hash) in &tx_hashes {
                 for target in &connected_peers {
-                    if known_txs.insert(*target, hash.clone()) && (origin_peer != target) {
-                        let hashes = selected
-                            .entry(*target)
-                            .or_insert_with(|| Vec::with_capacity(BUFFER_SIZE));
-                        hashes.push(hash.clone());
+                    match origin_peer {
+                        Some(origin) => {
+                            // broadcast tx hash to all connected peers except origin peer
+                            if known_txs.insert(*target, hash.clone()) && (origin != target) {
+                                let hashes = selected
+                                    .entry(*target)
+                                    .or_insert_with(|| Vec::with_capacity(BUFFER_SIZE));
+                                hashes.push(hash.clone());
+                            }
+                        }
+                        None => {
+                            // since this tx is submitted through local rpc, it is assumed to be a new tx for all connected peers
+                            let hashes = selected
+                                .entry(*target)
+                                .or_insert_with(|| Vec::with_capacity(BUFFER_SIZE));
+                            hashes.push(hash.clone());
+                        }
                     }
                 }
             }

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1202,7 +1202,7 @@ impl SyncShared {
     pub fn new(
         shared: Shared,
         sync_config: SyncConfig,
-        tx_relay_receiver: Receiver<(PeerIndex, Byte32)>,
+        tx_relay_receiver: Receiver<(Option<PeerIndex>, Byte32)>,
     ) -> SyncShared {
         Self::with_tmpdir::<PathBuf>(shared, sync_config, None, tx_relay_receiver)
     }
@@ -1212,7 +1212,7 @@ impl SyncShared {
         shared: Shared,
         sync_config: SyncConfig,
         tmpdir: Option<P>,
-        tx_relay_receiver: Receiver<(PeerIndex, Byte32)>,
+        tx_relay_receiver: Receiver<(Option<PeerIndex>, Byte32)>,
     ) -> SyncShared
     where
         P: AsRef<Path>,
@@ -1504,7 +1504,7 @@ pub struct SyncState {
     inflight_blocks: RwLock<InflightBlocks>,
 
     /* cached for sending bulk */
-    tx_relay_receiver: Receiver<(PeerIndex, Byte32)>,
+    tx_relay_receiver: Receiver<(Option<PeerIndex>, Byte32)>,
     assume_valid_target: Mutex<Option<H256>>,
     min_chain_work: U256,
 }
@@ -1560,7 +1560,7 @@ impl SyncState {
         self.inflight_proposals.lock()
     }
 
-    pub fn take_relay_tx_hashes(&self, limit: usize) -> Vec<(PeerIndex, Byte32)> {
+    pub fn take_relay_tx_hashes(&self, limit: usize) -> Vec<(Option<PeerIndex>, Byte32)> {
         self.tx_relay_receiver.try_iter().take(limit).collect()
     }
 

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -428,14 +428,11 @@ impl TxPoolService {
         ret: &Result<CacheEntry, Reject>,
     ) {
         let tx_hash = tx.hash();
-        let is_remote = remote.is_some();
-
-        if is_remote {
-            let (declared_cycle, peer) = remote.unwrap();
-            match ret {
+        match remote {
+            Some((declared_cycle, peer)) => match ret {
                 Ok(verified) => {
                     if declared_cycle == verified.cycles {
-                        self.broadcast_tx(peer, tx_hash);
+                        self.broadcast_tx(Some(peer), tx_hash);
                         self.process_orphan_tx(&tx).await;
                     } else {
                         warn!(
@@ -458,9 +455,22 @@ impl TxPoolService {
                         self.ban_malformed(peer, format!("reject {}", reject));
                     }
                 }
+            },
+            None => {
+                match ret {
+                    Ok(_verified) => {
+                        self.broadcast_tx(None, tx_hash);
+                        self.process_orphan_tx(&tx).await;
+                    }
+                    Err(Reject::Duplicated(_)) => {
+                        // re-broadcast tx when it's duplicated and submitted through local rpc
+                        self.broadcast_tx(None, tx_hash);
+                    }
+                    Err(_err) => {
+                        // ignore
+                    }
+                }
             }
-        } else if ret.is_ok() {
-            self.process_orphan_tx(&tx).await;
         }
     }
 
@@ -492,7 +502,7 @@ impl TxPoolService {
                 match self._process_tx(orphan.tx.clone(), None).await {
                     Ok(_) => {
                         self.remove_orphan_tx(&orphan.tx.proposal_short_id()).await;
-                        self.broadcast_tx(orphan.peer, orphan.tx.hash());
+                        self.broadcast_tx(Some(orphan.peer), orphan.tx.hash());
                         orphan_queue.push_back(orphan.tx);
                     }
                     Err(reject) => {
@@ -515,7 +525,7 @@ impl TxPoolService {
             .any(|pt| snapshot.transaction_exists(&pt.tx_hash()))
     }
 
-    pub(crate) fn broadcast_tx(&self, origin: PeerIndex, tx_hash: Byte32) {
+    pub(crate) fn broadcast_tx(&self, origin: Option<PeerIndex>, tx_hash: Byte32) {
         if let Err(e) = self.tx_relay_sender.send((origin, tx_hash)) {
             error!("tx-pool broadcast_tx internal error {}", e);
         }

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -414,7 +414,7 @@ pub struct TxPoolServiceBuilder {
     pub(crate) receiver: mpsc::Receiver<Message>,
     pub(crate) signal_receiver: oneshot::Receiver<()>,
     pub(crate) handle: Handle,
-    pub(crate) tx_relay_sender: ckb_channel::Sender<(PeerIndex, Byte32)>,
+    pub(crate) tx_relay_sender: ckb_channel::Sender<(Option<PeerIndex>, Byte32)>,
 }
 
 impl TxPoolServiceBuilder {
@@ -426,7 +426,7 @@ impl TxPoolServiceBuilder {
         txs_verify_cache: Arc<RwLock<TxVerifyCache>>,
         snapshot_mgr: Arc<SnapshotMgr>,
         handle: &Handle,
-        tx_relay_sender: ckb_channel::Sender<(PeerIndex, Byte32)>,
+        tx_relay_sender: ckb_channel::Sender<(Option<PeerIndex>, Byte32)>,
     ) -> (TxPoolServiceBuilder, TxPoolController) {
         let (sender, receiver) = mpsc::channel(DEFAULT_CHANNEL_SIZE);
         let (signal_sender, signal_receiver) = oneshot::channel();
@@ -528,7 +528,7 @@ pub(crate) struct TxPoolService {
     pub(crate) callbacks: Arc<Callbacks>,
     pub(crate) snapshot_mgr: Arc<SnapshotMgr>,
     pub(crate) network: NetworkController,
-    pub(crate) tx_relay_sender: ckb_channel::Sender<(PeerIndex, Byte32)>,
+    pub(crate) tx_relay_sender: ckb_channel::Sender<(Option<PeerIndex>, Byte32)>,
 }
 
 impl TxPoolService {

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -288,7 +288,7 @@ impl Launcher {
         chain_controller: ChainController,
         exit_handler: &DefaultExitHandler,
         miner_enable: bool,
-        relay_tx_receiver: Receiver<(PeerIndex, Byte32)>,
+        relay_tx_receiver: Receiver<(Option<PeerIndex>, Byte32)>,
     ) -> (NetworkController, RpcServer) {
         let sync_shared = Arc::new(SyncShared::with_tmpdir(
             shared.clone(),


### PR DESCRIPTION
When the relay protocol receives tx hashes, the previous code has already checked if the transaction has been seen recently in the `tx_filter`:

https://github.com/nervosnetwork/ckb/blob/410023d97dcb23521bfe3d38ad542eefe0ec94c3/sync/src/relayer/transaction_hashes_process.rs#L53-L74

And when the proposal tx is received, it will update the `tx_filter` also:

https://github.com/nervosnetwork/ckb/blob/410023d97dcb23521bfe3d38ad542eefe0ec94c3/sync/src/relayer/block_proposal_process.rs#L53

it is redundant to check proposal tx hash again through tx-pool.

This PR removed this unnecessary checking and refactor the local submitted tx hash broadcasting also.