### PR TITLE
perf: use KeyedPriorityQueue to replace BTreeMap/HashSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "faux",
  "futures 0.3.12",
  "governor",
+ "keyed_priority_queue",
  "lru",
  "rand 0.7.3",
  "tempfile",
@@ -2838,9 +2839,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.0.2"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg 1.0.0",
+ "hashbrown 0.9.1",
+]
 
 [[package]]
 name = "indicatif"
@@ -3090,6 +3095,15 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "keyed_priority_queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a59df08c683d655315a5a674004a3da802743579069278fa07c37cf8a3e8d4"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3.0"
 faketime = "0.2.0"
 bitflags = "1.0"
 dashmap = "4.0"
+keyed_priority_queue = "0.3"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.43.0-pre" }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -549,14 +549,7 @@ impl Relayer {
             let tx_hashes = peer_state
                 .pop_ask_for_txs()
                 .into_iter()
-                .filter(|tx_hash| {
-                    let already_known = state.already_known_tx(&tx_hash);
-                    if already_known {
-                        // Remove tx_hash from `tx_ask_for_set`
-                        peer_state.remove_ask_for_tx(&tx_hash);
-                    }
-                    !already_known
-                })
+                .filter(|tx_hash| !state.already_known_tx(&tx_hash))
                 .take(MAX_RELAY_TXS_NUM_PER_BATCH)
                 .collect::<Vec<_>>();
 

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -543,16 +543,7 @@ impl Relayer {
 
     /// Ask for relay transaction by hash from all peers
     pub fn ask_for_txs(&self, nc: &dyn CKBProtocolContext) {
-        let state = self.shared().state();
-        for mut kv_pair in state.peers().state.iter_mut() {
-            let (peer, peer_state) = kv_pair.pair_mut();
-            let tx_hashes = peer_state
-                .pop_ask_for_txs()
-                .into_iter()
-                .filter(|tx_hash| !state.already_known_tx(&tx_hash))
-                .take(MAX_RELAY_TXS_NUM_PER_BATCH)
-                .collect::<Vec<_>>();
-
+        for (peer, mut tx_hashes) in self.shared().state().pop_ask_for_txs() {
             if !tx_hashes.is_empty() {
                 debug_target!(
                     crate::LOG_TARGET_RELAY,
@@ -560,11 +551,12 @@ impl Relayer {
                     tx_hashes.len(),
                     peer,
                 );
+                tx_hashes.truncate(MAX_RELAY_TXS_NUM_PER_BATCH);
                 let content = packed::GetRelayTransactions::new_builder()
                     .tx_hashes(tx_hashes.pack())
                     .build();
                 let message = packed::RelayMessage::new_builder().set(content).build();
-                let status = send_message_to(nc, *peer, &message);
+                let status = send_message_to(nc, peer, &message);
                 if !status.is_ok() {
                     ckb_logger::error!("break asking for transactions, status: {:?}", status);
                 }

--- a/sync/src/relayer/transactions_process.rs
+++ b/sync/src/relayer/transactions_process.rs
@@ -49,20 +49,7 @@ impl<'a> TransactionsProcess<'a> {
             return Status::ok();
         }
 
-        // Insert tx_hash into `already_known`
-        // Remove tx_hash from `inflight_transactions`
-        {
-            shared_state.mark_as_known_txs(txs.iter().map(|(tx, _)| tx.hash()));
-        }
-
-        // Remove tx_hash from `tx_ask_for_set`
-        {
-            if let Some(mut peer_state) = shared_state.peers().state.get_mut(&self.peer) {
-                for (tx, _) in txs.iter() {
-                    peer_state.remove_ask_for_tx(&tx.hash());
-                }
-            }
-        }
+        shared_state.mark_as_known_txs(txs.iter().map(|(tx, _)| tx.hash()));
 
         let tx_pool = self.relayer.shared.shared().tx_pool_controller().clone();
         let relayer = self.relayer.clone();

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -13,7 +13,7 @@ use ckb_constant::sync::{
     POW_INTERVAL, RETRY_ASK_TX_TIMEOUT_INCREASE, SUSPEND_SYNC_TIME,
 };
 use ckb_error::Error as CKBError;
-use ckb_logger::{debug, debug_target, error, trace};
+use ckb_logger::{debug, error, trace};
 use ckb_metrics::metrics;
 use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
@@ -50,7 +50,6 @@ const GET_HEADERS_CACHE_SIZE: usize = 10000;
 // TODO: Need discussed
 const GET_HEADERS_TIMEOUT: Duration = Duration::from_secs(15);
 const TX_FILTER_SIZE: usize = 50000;
-const TX_ASKED_SIZE: usize = TX_FILTER_SIZE;
 const ORPHAN_BLOCK_SIZE: usize = 1024;
 // 2 ** 13 < 6 * 1800 < 2 ** 14
 const ONE_DAY_BLOCK_NUMBER: u64 = 8192;
@@ -217,9 +216,6 @@ pub struct PeerState {
     pub peer_flags: PeerFlags,
     sync_connected: bool,
     pub chain_sync: ChainSyncState,
-    // The priority is ordering by timestamp (reversed), means do not ask the tx before this timestamp (timeout).
-    unknown_tx_hashes: KeyedPriorityQueue<Byte32, cmp::Reverse<Instant>>,
-
     // The best known block we know this peer has announced
     pub best_known_header: Option<HeaderView>,
     // The last block we both stored
@@ -237,7 +233,6 @@ impl PeerState {
             peer_flags,
             sync_connected: false,
             chain_sync: ChainSyncState::default(),
-            unknown_tx_hashes: KeyedPriorityQueue::default(),
             best_known_header: None,
             last_common_header: None,
             unknown_header_list: Vec::new(),
@@ -271,42 +266,6 @@ impl PeerState {
 
     pub(crate) fn stop_headers_sync(&mut self) {
         self.headers_sync_controller = None;
-    }
-
-    pub fn add_ask_for_tx(
-        &mut self,
-        tx_hash: Byte32,
-        last_ask_timeout: Option<Instant>,
-    ) -> Option<Instant> {
-        if self.unknown_tx_hashes.len() > MAX_UNKNOWN_TX_HASHES_SIZE {
-            debug_target!(
-                crate::LOG_TARGET_RELAY,
-                "this peer unknown_tx_hashes is full, ignore {}",
-                tx_hash
-            );
-            return None;
-        }
-        // Retry ask tx `RETRY_ASK_TX_TIMEOUT_INCREASE` later
-        //  NOTE: last_ask_timeout is some when other peer already asked for this tx_hash
-        let next_ask_timeout = last_ask_timeout
-            .map(|time| cmp::max(time + RETRY_ASK_TX_TIMEOUT_INCREASE, Instant::now()))
-            .unwrap_or_else(Instant::now);
-        self.unknown_tx_hashes
-            .push(tx_hash, cmp::Reverse(next_ask_timeout));
-        Some(next_ask_timeout)
-    }
-
-    pub fn pop_ask_for_txs(&mut self) -> Vec<Byte32> {
-        let mut all_txs = Vec::new();
-        let now = Instant::now();
-        while let Some((tx_hash, timeout)) = self.unknown_tx_hashes.pop() {
-            if timeout.0 >= now {
-                self.unknown_tx_hashes.push(tx_hash, timeout);
-                break;
-            }
-            all_txs.push(tx_hash);
-        }
-        all_txs
     }
 }
 
@@ -1198,13 +1157,13 @@ impl SyncShared {
             header_map,
             block_status_map: DashMap::new(),
             tx_filter: Mutex::new(Filter::new(TX_FILTER_SIZE)),
+            unknown_tx_hashes: Mutex::new(KeyedPriorityQueue::new()),
             peers: Peers::default(),
             known_txs: Mutex::new(KnownFilter::default()),
             pending_get_block_proposals: DashMap::new(),
             pending_compact_blocks: Mutex::new(HashMap::default()),
             orphan_block_pool: OrphanBlockPool::with_capacity(ORPHAN_BLOCK_SIZE),
             inflight_proposals: DashSet::new(),
-            inflight_transactions: Mutex::new(LruCache::new(TX_ASKED_SIZE)),
             inflight_blocks: RwLock::new(InflightBlocks::default()),
             pending_get_headers: RwLock::new(LruCache::new(GET_HEADERS_CACHE_SIZE)),
             tx_relay_receiver,
@@ -1440,6 +1399,60 @@ impl HeaderProvider for SyncShared {
     }
 }
 
+#[derive(Eq, PartialEq, Clone)]
+pub struct UnknownTxHashPriority {
+    request_time: Instant,
+    peers: Vec<PeerIndex>,
+    requested: bool,
+}
+
+impl UnknownTxHashPriority {
+    pub fn should_request(&self, now: Instant) -> bool {
+        self.next_request_at() < now
+    }
+
+    pub fn next_request_at(&self) -> Instant {
+        if self.requested {
+            self.request_time + RETRY_ASK_TX_TIMEOUT_INCREASE
+        } else {
+            self.request_time
+        }
+    }
+
+    pub fn next_request_peer(&mut self) -> Option<PeerIndex> {
+        if self.requested {
+            if self.peers.len() > 1 {
+                self.request_time = Instant::now();
+                self.peers.swap_remove(0);
+                self.peers.get(0).cloned()
+            } else {
+                None
+            }
+        } else {
+            self.requested = true;
+            self.peers.get(0).cloned()
+        }
+    }
+
+    pub fn push_peer(&mut self, peer_index: PeerIndex) {
+        self.peers.push(peer_index);
+    }
+}
+
+impl Ord for UnknownTxHashPriority {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.next_request_at()
+            .cmp(&other.next_request_at())
+            .reverse()
+    }
+}
+
+impl PartialOrd for UnknownTxHashPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub struct SyncState {
     n_sync_started: AtomicUsize,
     n_protected_outbound_peers: AtomicUsize,
@@ -1449,6 +1462,9 @@ pub struct SyncState {
     header_map: HeaderMap,
     block_status_map: DashMap<Byte32, BlockStatus>,
     tx_filter: Mutex<Filter<Byte32>>,
+
+    // The priority is ordering by timestamp (reversed), means do not ask the tx before this timestamp (timeout).
+    unknown_tx_hashes: Mutex<KeyedPriorityQueue<Byte32, UnknownTxHashPriority>>,
 
     /* Status relevant to peers */
     peers: Peers,
@@ -1462,7 +1478,6 @@ pub struct SyncState {
 
     /* In-flight items for which we request to peers, but not got the responses yet */
     inflight_proposals: DashSet<packed::ProposalShortId>,
-    inflight_transactions: Mutex<LruCache<Byte32, Instant>>,
     inflight_blocks: RwLock<InflightBlocks>,
 
     /* cached for sending bulk */
@@ -1504,10 +1519,6 @@ impl SyncState {
 
     pub fn pending_compact_blocks(&self) -> MutexGuard<PendingCompactBlockMap> {
         self.pending_compact_blocks.lock()
-    }
-
-    pub fn inflight_transactions(&self) -> MutexGuard<LruCache<Byte32, Instant>> {
-        self.inflight_transactions.lock()
     }
 
     pub fn read_inflight_blocks(&self) -> RwLockReadGuard<InflightBlocks> {
@@ -1572,17 +1583,69 @@ impl SyncState {
     // where T: Iterator<Item=Byte32>,
     // for<'a> &'a T: Iterator<Item=&'a Byte32>,
     pub fn mark_as_known_txs(&self, hashes: impl Iterator<Item = Byte32> + std::clone::Clone) {
-        {
-            let mut inflight_transactions = self.inflight_transactions.lock();
-            for hash in hashes.clone() {
-                inflight_transactions.pop(&hash);
-            }
-        }
-
+        let mut unknown_tx_hashes = self.unknown_tx_hashes.lock();
         let mut tx_filter = self.tx_filter.lock();
 
         for hash in hashes {
+            unknown_tx_hashes.remove(&hash);
             tx_filter.insert(hash);
+        }
+    }
+
+    pub fn pop_ask_for_txs(&self) -> HashMap<PeerIndex, Vec<Byte32>> {
+        let mut unknown_tx_hashes = self.unknown_tx_hashes.lock();
+        let mut result: HashMap<PeerIndex, Vec<Byte32>> = HashMap::new();
+        let now = Instant::now();
+
+        if !unknown_tx_hashes
+            .peek()
+            .map(|(_tx_hash, priority)| priority.should_request(now))
+            .unwrap_or_default()
+        {
+            return result;
+        }
+
+        while let Some((tx_hash, mut priority)) = unknown_tx_hashes.pop() {
+            if priority.should_request(now) {
+                if let Some(peer_index) = priority.next_request_peer() {
+                    result
+                        .entry(peer_index)
+                        .and_modify(|hashes| hashes.push(tx_hash.clone()))
+                        .or_insert_with(|| vec![tx_hash.clone()]);
+                    unknown_tx_hashes.push(tx_hash, priority);
+                }
+            } else {
+                unknown_tx_hashes.push(tx_hash, priority);
+                break;
+            }
+        }
+        result
+    }
+
+    pub fn add_ask_for_txs(&self, peer_index: PeerIndex, tx_hashes: Vec<Byte32>) {
+        let mut unknown_tx_hashes = self.unknown_tx_hashes.lock();
+        if unknown_tx_hashes.len() >= MAX_UNKNOWN_TX_HASHES_SIZE {
+            return;
+        }
+
+        for tx_hash in tx_hashes
+            .into_iter()
+            .take(MAX_UNKNOWN_TX_HASHES_SIZE - unknown_tx_hashes.len())
+        {
+            match unknown_tx_hashes.entry(tx_hash) {
+                keyed_priority_queue::Entry::Occupied(entry) => {
+                    let mut priority = entry.get_priority().clone();
+                    priority.push_peer(peer_index);
+                    entry.set_priority(priority);
+                }
+                keyed_priority_queue::Entry::Vacant(entry) => {
+                    entry.set_priority(UnknownTxHashPriority {
+                        request_time: Instant::now(),
+                        peers: vec![peer_index],
+                        requested: false,
+                    })
+                }
+            }
         }
     }
 
@@ -2017,8 +2080,7 @@ impl From<IBDState> for bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{HeaderView, PeerFlags, PeerState};
-    use ckb_constant::sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
+    use super::HeaderView;
     use ckb_types::{
         core::{BlockNumber, HeaderBuilder},
         packed::Byte32,
@@ -2026,11 +2088,7 @@ mod tests {
         U256,
     };
     use rand::{thread_rng, Rng};
-    use std::{
-        collections::{BTreeMap, HashMap},
-        thread::sleep,
-        time::{Duration, Instant},
-    };
+    use std::collections::{BTreeMap, HashMap};
 
     const SKIPLIST_LENGTH: u64 = 10_000;
 
@@ -2109,30 +2167,5 @@ mod tests {
             let found_0_header = a_to_b(from, 0, 120);
             assert_eq!(found_0_header.hash(), view_0.hash());
         }
-    }
-
-    #[test]
-    fn test_pop_ask_for_txs() {
-        let mut peer_state = PeerState::new(PeerFlags {
-            is_outbound: true,
-            is_protect: false,
-            is_whitelist: false,
-        });
-
-        let tx_hash_1 = Byte32::from_slice(&[0; 32]).unwrap();
-        peer_state.add_ask_for_tx(tx_hash_1.clone(), None);
-
-        let tx_hash_2 = Byte32::from_slice(&[1; 32]).unwrap();
-        let timeout = Instant::now() - RETRY_ASK_TX_TIMEOUT_INCREASE + Duration::from_secs(2);
-        peer_state.add_ask_for_tx(tx_hash_2.clone(), Some(timeout));
-
-        let mut tx_hashes = peer_state.pop_ask_for_txs();
-        assert_eq!(tx_hashes.pop().unwrap(), tx_hash_1);
-        assert!(tx_hashes.pop().is_none());
-
-        sleep(Duration::from_secs(3));
-        let mut tx_hashes = peer_state.pop_ask_for_txs();
-        assert_eq!(tx_hashes.pop().unwrap(), tx_hash_2);
-        assert!(tx_hashes.pop().is_none());
     }
 }


### PR DESCRIPTION
This PR optimized `tx_ask_for` related code, replace `tx_ask_for_map/tx_ask_for_set` with one `KeyedPriorityQueue`, avoids unnecessary hashset operation in `remove_ask_for_tx` and `pop_ask_for_txs` fn. 

And the memory layout is also optimized: 
1. the vec in `tx_ask_for_map` is removed.
2. `inflight_transactions` is removed.
3. `tx_ask_for` is traced in the global state (renamed to `unknown_tx_hashes`)