### PR TITLE
feat: add workflow "Sync-Mainnet"

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,102 @@
+name: Sync-Mainnet
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  build_ckb:
+    name: Build CKB
+    runs-on: [ self-hosted, Linux, X64, building ]
+    if: |
+      contains(github.event.review.body, '#sync-mainnet') &&
+      contains(fromJson('[ "janx", "doitian", "quake", "xxuejie", "zhangsoledad", "jjyr", "TheWaWaR", "driftluo", "keroro520", "yangby-cryptape", "liya2017" ]'), github.actor)
+
+    env:
+      CARGO_TARGET_DIR: "${{ github.workspace }}/../target"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build CKB
+        run: |
+          make build
+          cd ${{ env.CARGO_TARGET_DIR }}/release
+          tar cfJ ckb.tar.xz ckb
+          mv ckb.tar.xz ${{ github.workspace }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ckb.tar.xz
+          path: ckb.tar.xz
+
+  sync:
+    name: Sync
+    runs-on: [ self-hosted, Linux, X64, operating ]
+    needs: [ build_ckb ]
+    env:
+      TERRAFORM_DIR:     ${{ github.workspace }}/.github/workflows/sync/terraform
+      ANSIBLE_DIR:       ${{ github.workspace }}/.github/workflows/sync/ansible
+      ANSIBLE_INVENTORY: ${{ github.workspace }}/.github/workflows/sync/ansible/inventory.yml
+      PRIVATE_KEY_PATH:  ${{ github.workspace }}/id_rsa
+      PUBLIC_KEY_PATH:   ${{ github.workspace }}/id_rsa.pub
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare - Download CKB Tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: ckb.tar.xz
+
+      # Prepare
+      - name: Prepare - Generate Random SSH Key
+        run: ssh-keygen -N "" -f ${{ env.PRIVATE_KEY_PATH }}
+      - name: Prepare - Apply Resources Based on Terraform Files
+        uses: ./.github/actions/terraform
+        env:
+          # Environment variables used inside terraform/variables.tf
+          TF_VAR_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          TF_VAR_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          TF_VAR_prefix: sync-${{ github.repository }}-${{ github.run_id }}
+          TF_VAR_instance_type: c5.xlarge
+          TF_VAR_private_key_path: ${{ env.PRIVATE_KEY_PATH }}
+          TF_VAR_public_key_path: ${{ env.PUBLIC_KEY_PATH }}
+        with:
+          terraform_dir: ${{ env.TERRAFORM_DIR }}
+      - name: Prepare - Output Ansible Inventory Based on Terraform State
+        working-directory: ${{ env.TERRAFORM_DIR }}
+        run: |
+          terraform output | grep -v EOT > ${{ env.ANSIBLE_INVENTORY }}
+          terraform output | grep -v EOT
+
+      # Run
+      - name: Run Ansible Playbook
+        shell: bash
+        working-directory: ${{ env.ANSIBLE_DIR }}
+        env:
+          QINIU_ACCESS_KEY:         ${{ secrets.QINIU_ACCESS_KEY }}
+          QINIU_SECRET_KEY:         ${{ secrets.QINIU_SECRET_KEY }}
+          ANSIBLE_PRIVATE_KEY_FILE: ${{ env.PRIVATE_KEY_PATH }}
+        run: |
+          ansible-galaxy install --roles-path roles --role-file requirements.yml
+
+          ansible-playbook playbook.yml \
+            -e 'ckb_local_source=${{ github.workspace  }}/ckb.tar.xz' \
+            -t ckb_install,ckb_configure
+          ansible-playbook playbook.yml -t ckb_restart
+          ansible-playbook playbook.yml -t wait_ckb_synchronization
+          ansible-playbook playbook.yml -t fetch_ckb_logfiles
+          # Will produce report.yml within ANSIBLE_DIR
+          ansible-playbook playbook.yml -t process_result
+
+      - name: Post Run - Construct Report
+        run: |
+          echo 'SYNC_MAINNET_REPORT<<EOF' >> $GITHUB_ENV
+          cat ${ANSIBLE_DIR}/report.yml   >> $GITHUB_ENV
+          echo 'EOF'                      >> $GITHUB_ENV
+      - name: Post Run - Comment Report
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Sync-Mainnet Report**: https://www.github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ```yaml
+            ${{ env.SYNC_MAINNET_REPORT }}
+            ```


### PR DESCRIPTION
This PR adds a Github Actions workflow, "Sync-Mainnet".

In this workflow,
it applies AWS resources based on [Terraform configuration files #2712](https://github.com/nervosnetwork/ckb/pull/2712),
executes tests via [Ansible playbook #2713](https://github.com/nervosnetwork/ckb/pull/2713).