### PR TITLE
chore(deps): bump serde from 1.0.105 to 1.0.126

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,31 +9,13 @@ updates:
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
   ignore:
-  - dependency-name: serde
-    versions:
-    - "> 1.0.105, < 1.1"
   - dependency-name: ctrlc
     versions:
     - 3.1.9
-  - dependency-name: libc
-    versions:
-    - 0.2.88
-    - 0.2.89
-    - 0.2.91
-    - 0.2.92
-  - dependency-name: syn
-    versions:
-    - 1.0.63
   - dependency-name: futures
     versions:
     - 0.3.12
-  - dependency-name: serde_json
-    versions:
-    - 1.0.62
   - dependency-name: hyper
     versions:
     - 0.13.10
-  - dependency-name: lru
-    versions:
-    - 0.6.4
   rebase-strategy: disabled

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,9 +4448,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.105"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
@@ -4467,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.105"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
- Remove outdated versions from `.github/dependabot.yml`.
  We already use later versions for those crates. 
- Bump serde from 1.0.105 to 1.0.126.