### PR TITLE
chore: remove unnecessary field from `PeerState`

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -388,9 +388,8 @@ impl Synchronizer {
             if let Some(ref mut controller) = state.headers_sync_controller {
                 let better_tip_ts = better_tip_header.timestamp();
                 if let Some(is_timeout) = controller.is_timeout(better_tip_ts, now) {
-                    if is_timeout && !state.disconnect {
+                    if is_timeout {
                         eviction.push(*peer);
-                        state.disconnect = true;
                         continue;
                     }
                 } else {
@@ -439,7 +438,6 @@ impl Synchronizer {
                             }
                         } else {
                             eviction.push(*peer);
-                            state.disconnect = true;
                         }
                     } else {
                         state.chain_sync.sent_getheaders = true;

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -216,7 +216,6 @@ pub struct PeerState {
     pub headers_sync_controller: Option<HeadersSyncController>,
     pub peer_flags: PeerFlags,
     sync_connected: bool,
-    pub disconnect: bool,
     pub chain_sync: ChainSyncState,
     // The key is a `timeout`, means do not ask the tx before `timeout`.
     tx_ask_for_map: BTreeMap<Instant, Vec<Byte32>>,
@@ -238,7 +237,6 @@ impl PeerState {
             headers_sync_controller: None,
             peer_flags,
             sync_connected: false,
-            disconnect: false,
             chain_sync: ChainSyncState::default(),
             tx_ask_for_map: BTreeMap::default(),
             tx_ask_for_set: HashSet::new(),


### PR DESCRIPTION
`PeerState#disconnect` is only used in `Synchronizer#eviction`, it's unnecessary to use this field since we have added it to the eviction vec already.