### PR TITLE
refactor: move state flag to `HeadersSyncState` enum

### DIFF
--- a/sync/src/synchronizer/in_ibd_process.rs
+++ b/sync/src/synchronizer/in_ibd_process.rs
@@ -30,7 +30,7 @@ impl<'a> InIBDProcess<'a> {
             // It is possible that a not-sync-started peer sends us `InIBD` messages:
             //   - Malicious behavior
             //   - Peer sends multiple `InIBD` messages
-            if !state.sync_started {
+            if !state.sync_started() {
                 return Status::ignored();
             }
 

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -76,7 +76,48 @@ pub struct ChainSyncState {
     pub work_header: Option<core::HeaderView>,
     pub total_difficulty: Option<U256>,
     pub sent_getheaders: bool,
-    pub not_sync_until: Option<u64>,
+    headers_sync_state: HeadersSyncState,
+}
+
+impl ChainSyncState {
+    fn can_start_sync(&self, now: u64) -> bool {
+        match self.headers_sync_state {
+            HeadersSyncState::Initialized => false,
+            HeadersSyncState::SyncProtocolConnected => true,
+            HeadersSyncState::Started => false,
+            HeadersSyncState::Suspend(until) => until < now,
+        }
+    }
+
+    fn connected(&mut self) {
+        self.headers_sync_state = HeadersSyncState::SyncProtocolConnected;
+    }
+
+    fn start(&mut self) {
+        self.headers_sync_state = HeadersSyncState::Started
+    }
+
+    fn suspend(&mut self, until: u64) {
+        self.headers_sync_state = HeadersSyncState::Suspend(until)
+    }
+
+    fn started(&self) -> bool {
+        matches!(self.headers_sync_state, HeadersSyncState::Started)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum HeadersSyncState {
+    Initialized,
+    SyncProtocolConnected,
+    Started,
+    Suspend(u64), // suspend headers sync until this timestamp (milliseconds since unix epoch)
+}
+
+impl Default for HeadersSyncState {
+    fn default() -> Self {
+        HeadersSyncState::Initialized
+    }
 }
 
 #[derive(Clone, Default, Debug, Copy)]
@@ -211,11 +252,8 @@ impl HeadersSyncController {
 
 #[derive(Clone, Default, Debug)]
 pub struct PeerState {
-    // only use on header sync
-    pub sync_started: bool,
     pub headers_sync_controller: Option<HeadersSyncController>,
     pub peer_flags: PeerFlags,
-    sync_connected: bool,
     pub chain_sync: ChainSyncState,
     // The key is a `timeout`, means do not ask the tx before `timeout`.
     tx_ask_for_map: BTreeMap<Instant, Vec<Byte32>>,
@@ -233,10 +271,8 @@ pub struct PeerState {
 impl PeerState {
     pub fn new(peer_flags: PeerFlags) -> PeerState {
         PeerState {
-            sync_started: false,
             headers_sync_controller: None,
             peer_flags,
-            sync_connected: false,
             chain_sync: ChainSyncState::default(),
             tx_ask_for_map: BTreeMap::default(),
             tx_ask_for_set: HashSet::new(),
@@ -246,29 +282,29 @@ impl PeerState {
         }
     }
 
-    pub fn can_sync(&self, now: u64, ibd: bool) -> bool {
+    pub fn can_start_sync(&self, now: u64, ibd: bool) -> bool {
         // only sync with protect/whitelist peer in IBD
-        self.sync_connected
-            && ((self.peer_flags.is_protect || self.peer_flags.is_whitelist) || !ibd)
-            && !self.sync_started
-            && self
-                .chain_sync
-                .not_sync_until
-                .map(|ts| ts < now)
-                .unwrap_or(true)
+        ((self.peer_flags.is_protect || self.peer_flags.is_whitelist) || !ibd)
+            && self.chain_sync.can_start_sync(now)
     }
 
     pub fn start_sync(&mut self, headers_sync_controller: HeadersSyncController) {
-        self.sync_started = true;
-        self.chain_sync.not_sync_until = None;
+        self.chain_sync.start();
         self.headers_sync_controller = Some(headers_sync_controller);
     }
 
     pub fn suspend_sync(&mut self, suspend_time: u64) {
         let now = unix_time_as_millis();
-        self.sync_started = false;
-        self.chain_sync.not_sync_until = Some(now + suspend_time);
+        self.chain_sync.suspend(now + suspend_time);
         self.stop_headers_sync();
+    }
+
+    pub(crate) fn sync_started(&self) -> bool {
+        self.chain_sync.started()
+    }
+
+    pub(crate) fn sync_connected(&mut self) {
+        self.chain_sync.connected()
     }
 
     pub(crate) fn stop_headers_sync(&mut self) {
@@ -876,11 +912,11 @@ impl Peers {
             .entry(peer)
             .and_modify(|state| {
                 state.peer_flags = peer_flags;
-                state.sync_connected = true;
+                state.sync_connected();
             })
             .or_insert_with(|| {
                 let mut state = PeerState::new(peer_flags);
-                state.sync_connected = true;
+                state.sync_connected();
                 state
             });
     }


### PR DESCRIPTION
We are using 3 fields `sync_started` / `sync_connected` / `not_sync_until` in the headers sync process, this PR refactored them to a state machine enum `HeadersSyncState`