### PR TITLE
docs: fix missing links and deprecated descriptions

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -1,10 +1,10 @@
 //! CKB chain service.
 //!
-//! [ChainService] background base on database, handle block importing,
-//! the [ChainController] is responsible for receive the request and returning response
+//! [`ChainService`] background base on database, handle block importing,
+//! the [`ChainController`] is responsible for receive the request and returning response
 //!
-//! [ChainService](chain/struct.ChainService.html)
-//! [ChainController](chain/struct.ChainController.html)
+//! [`ChainService`]: chain/struct.ChainService.html
+//! [`ChainController`]: chain/struct.ChainController.html
 
 pub mod chain;
 #[cfg(test)]

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -3,7 +3,7 @@
 //! By default, when simply running CKB, CKB will connect to the official public Nervos network.
 //!
 //! In order to run a chain different to the official public one,
-//! with a config file specifying chain = "path" under [ckb].
+//! with a config file specifying `spec = { file = "<the-path-of-spec-file>" }` under `[chain]`.
 //!
 
 // Because the limitation of toml library,

--- a/util/dao/utils/src/error.rs
+++ b/util/dao/utils/src/error.rs
@@ -11,9 +11,9 @@ pub enum DaoError {
 
     /// When withdraws from NervosDAO, it requires the deposited header and withdrawing header to help calculating interest.
     /// This error occurs at [withdrawing phase 2] for the below cases:
-    ///   - The [`HeaderDeps`] does not include the withdrawing block hash. The withdrawing block hash
+    ///   - The `HeaderDeps` does not include the withdrawing block hash. The withdrawing block hash
     ///     indicates the block which packages the target transaction at [withdrawing phase 1].
-    ///   - The [`HeaderDeps`] does not include the deposited block hash. The deposited block hash
+    ///   - The `HeaderDeps` does not include the deposited block hash. The deposited block hash
     ///     indicates the block which packages the target transaction at [deposit phase]. Please see
     ///     [withdrawing phase 2] for more details.
     ///

--- a/util/instrument/src/lib.rs
+++ b/util/instrument/src/lib.rs
@@ -2,10 +2,8 @@
 //!
 //! Instruments for ckb for working with `Export`, `Import`
 //!
-//! - [Export](instrument::export::Export) provide block data
-//!   export function.
-//! - [Import](instrument::import::Import) import block data which
-//!   export from `Export`.
+//! - [`Export`] provides block data export function.
+//! - [`Import`] imports block data which export from `Export`.
 
 mod export;
 mod import;

--- a/util/runtime/src/lib.rs
+++ b/util/runtime/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Handle {
 
 impl Handle {
     /// Enter the runtime context. This allows you to construct types that must
-    /// have an executor available on creation such as [`Delay`] or [`TcpStream`].
+    /// have an executor available on creation such as [`tokio::time::Sleep`] or [`tokio::net::TcpStream`].
     /// It will also allow you to call methods such as [`tokio::spawn`].
     pub fn enter<F, R>(&self, f: F) -> R
     where


### PR DESCRIPTION
Fix errors when execture `RUSTDOCFLAGS='-D warnings' cargo doc --all --no-deps`.

p.s. Maybe we should add a CI check?