### PR TITLE
Upload logfile in github actions when integation failed and remove allow-failure jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,6 @@ jobs:
           - os: win-runner
             script_run: devtools/windows/make test
             CI: true
-            ImageOS: 'windows-2019'
-            BUILD_BUILDID: ${{ github.sha }}
     needs: Security_Audit_Licenses
     steps:
     - uses: actions/checkout@v2
@@ -42,8 +40,6 @@ jobs:
       run: ${{ matrix.script_run }}
     env:
       CI: ${{ matrix.CI }}
-      SENTRY_DSN: ${{ matrix.SENTRY_DSN }}
-      ImageOS:  ${{ matrix.ImageOS }}
 
   Integration_Test:
     runs-on: ${{ matrix.os }}
@@ -57,16 +53,23 @@ jobs:
             script_run: make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
           - os: win-runner
             script_run: devtools/windows/make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
-            CI: true
             SENTRY_DSN: "https://15373165fbf2439b99ba46684dfbcb12@sentry.nervos.org/7"
     needs: Security_Audit_Licenses
     steps:
     - uses: actions/checkout@v2
     - name: Integration_Test
       run: ${{ matrix.script_run }}
+    - name: Post Run - Upload integration Result when failed
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}_integration.log
+        path: ${{ env.CKB_INTEGRATION_TEST_TMP }}/integration.log
     env:
-      CI: ${{ matrix.CI }}
+      CI: true
       SENTRY_DSN: ${{ matrix.SENTRY_DSN }}
+      ImageOS: ${{matrix.os}}
+      BUILD_BUILDID: ${{ github.run_id }}
 
   Benchmarks_Test:
     runs-on: ${{ matrix.os }}
@@ -150,47 +153,6 @@ jobs:
         make security-audit
         make check-crates
         make check-licenses
-
-  Cyclic_dev_dependencies:
-    if: |
-      contains(fromJson('[ "refs/heads/master", "refs/heads/trying","refs/heads/staging", "refs/heads/staging2" ]'), github.ref)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [Linux-runner, mac-runner]
-    needs: Security_Audit_Licenses
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v2
-    - name: Cyclic_dev_dependencies
-      run: |
-        devtools/ci/check-cyclic-dependencies.py --dev
-
-  Latest_Linters:
-    if: |
-      contains(fromJson('[ "refs/heads/master", "refs/heads/trying","refs/heads/staging", "refs/heads/staging2" ]'), github.ref)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [Linux-runner, mac-runner]
-        include:
-          - os: Linux-runner
-            script_run: rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu &&  rustup component add clippy --toolchain stable-x86_64-unknown-linux-gnu
-          - os:  mac-runner
-            script_run: rustup component add rustfmt-preview && rustup component add clippy-preview
-    needs: Cyclic_dev_dependencies
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pre install
-      run: ${{ matrix.script_run }}
-    - name: Latest_Linters
-      run: |
-        mv rust-toolchain rust-toolchain.bak
-        echo "stable" > rust-toolchain
-        make fmt
-        make clippy
-        mv rust-toolchain.bak rust-toolchain
 
   ci-success:
     name: ci

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -95,7 +95,7 @@ function run-integration {
     Set-Env CKB_INTEGRATION_FAILURE_FILE "$env:CKB_INTEGRATION_TEST_TMP/integration.failure"
   }
   New-Item -Path "$env:CKB_INTEGRATION_TEST_TMP" -Type Directory -ErrorAction SilentlyContinue
-
+  echo ("CKB_INTEGRATION_TEST_TMP=" +$env:CKB_INTEGRATION_TEST_TMP) >> $env:GITHUB_ENV
   $ckb_bin="target/debug/ckb"
   $logfile="$env:CKB_INTEGRATION_TEST_TMP/integration.log"
   $ckb_release=$(iex "$ckb_bin --version")


### PR DESCRIPTION
This PR contains 2 tips:

1.Upload integration files in  github actions and remove usless variables from UnitTest job
2. Remove jobs `Cyclic_dev_dependencies` & `Latest_Linters` from CI