### PR TITLE
ci: enabled github-hosted ci for forked repositories and support control them with commit messages or pr comments

### DIFF
--- a/.github/workflows/basic-checks.yaml
+++ b/.github/workflows/basic-checks.yaml
@@ -1,0 +1,250 @@
+name: Basic Checks
+
+on:
+  repository_dispatch:
+    types: [ basic-checks ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTFLAGS: -D warnings
+
+jobs:
+
+  bootstrap:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  clippy:
+    name: Clippy
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+          components: clippy
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/
+          key: ${{ runner.os }}-clippy-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-clippy-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-clippy-
+      - run: make clippy
+
+  bench-test:
+    name: Compile Benches
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/
+          key: ${{ runner.os }}-bench-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-bench-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-bench-
+      - run: make bench-test
+
+  check-docs:
+    name: Check Docs
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/doc
+          key: ${{ runner.os }}-doc-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-doc-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-doc-
+      - env:
+          RUSTDOCFLAGS: -D warnings
+        run: |
+          rm -f doc/ckb_rpc/module/*.html
+          cargo doc --all --no-deps
+          python ./devtools/doc/rpc.py > rpc/README.md;
+          git diff --exit-code rpc/README.md
+
+  check-codes:
+    name: Check Generated Codes
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions/cache@v2
+        id: restore-moleculec
+        with:
+          path: |
+            ~/.cargo/bin/moleculec
+            ~/.cargo/bin/moleculec-rust
+          key: ${{ runner.os }}-moleculec-v${{ github.event.client_payload.env.molc_version }}
+      - if: steps.restore-moleculec.outputs.cache-hit != 'true'
+        run: cargo install moleculec --locked
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+          components: rustfmt
+      - run: |
+          make gen
+          git diff --exit-code util/types/src/generated/
+
+  lint-deps:
+    name: Lint Dependencies
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - id: cache-key
+        run: echo "::set-output name=yyyymm::$(/bin/date -u '+%Y%m')"
+      - uses: actions/cache@v2
+        id: restore-cargo-deny
+        with:
+          path: ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-cargo-deny-${{ steps.cache-key.outputs.yyyymm }}
+      - if: steps.restore-cargo-deny.outputs.cache-hit != 'true'
+        run: cargo install cargo-deny --locked
+      - run: |
+          cargo deny --version
+          make security-audit
+          make check-crates
+          make check-licenses
+
+  wasm32-build:
+    name: WASM32 Build
+    needs: [ bootstrap ]
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - run: |
+          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/llvm.gpg add -
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+          sudo apt update --yes
+          sudo apt upgrade --yes
+          sudo apt install --yes clang-8
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+          target: wasm32-unknown-unknown
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-wasm32-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-wasm32-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-wasm32-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: wasm-build-test/target/
+          key: ${{ runner.os }}-wasm32-build-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-wasm32-build-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-wasm32-build-
+      - run: make wasm-build-test
+
+  finally:
+    name: Finally
+    needs: [ clippy, bench-test, check-docs, check-codes, lint-deps, wasm32-build ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
+        run: exit 1
+      - uses: actions/github-script@v4
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  trigger-next-checks:
+    name: Trigger Next Checks
+    needs: [ finally ]
+    if: ${{ github.event.client_payload.env.trigger_next_checks }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: unit-tests-checks
+          client-payload: ${{ toJSON(github.event.client_payload) }}

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -1,0 +1,158 @@
+name: Build Checks
+
+on:
+  repository_dispatch:
+    types: [ build-checks ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTFLAGS: -D warnings
+
+jobs:
+
+  bootstrap:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  build:
+    name: Build
+    needs: [ bootstrap ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ github.event.client_payload.env.os_matrix }}
+      fail-fast: true
+      max-parallel: 10
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - if: ${{ runner.os == 'Windows' }}
+        id: cache-key
+        shell: bash
+        run: echo "::set-output name=yyyymm::$(/bin/date -u '+%Y%m')"
+      - if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@v2
+        id: restore-scoop
+        with:
+          path: ~/scoop
+          key: ${{ runner.os }}-scoop-${{ steps.cache-key.outputs.yyyymm }}
+      - if: ${{ runner.os == 'Windows' && steps.restore-scoop.outputs.cache-hit != 'true' }}
+        run: iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          scoop install git
+          scoop bucket add extras
+          scoop install llvm yasm
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/
+          key: ${{ runner.os }}-build-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-build-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-build-
+      - run: make prod
+      - run: git diff --exit-code Cargo.lock
+      - uses: actions/cache@v2
+        if: ${{ runner.os != 'Windows' }}
+        with:
+          path: target/release/ckb
+          key: ${{ runner.os }}-executable-${{ github.event.client_payload.github.sha }}
+      - uses: actions/cache@v2
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          path: target/release/ckb.exe
+          key: ${{ runner.os }}-executable-${{ github.event.client_payload.github.sha }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ runner.os != 'Windows' }}
+        with:
+          name: Release (${{ runner.os }}, ${{ matrix.os }})
+          path: target/release/ckb
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          name: Release (${{ runner.os }}, ${{ matrix.os }})
+          path: target/release/ckb.exe
+          if-no-files-found: error
+
+  check-hashes:
+    name: Check Hashes
+    needs: [ build ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions/cache@v2
+        with:
+          path: target/release/ckb
+          key: ${{ runner.os }}-executable-${{ github.event.client_payload.github.sha }}
+      - run: target/release/ckb list-hashes -b > docs/hashes.toml
+      - run: git diff --exit-code docs/hashes.toml
+
+  finally:
+    name: Finally
+    needs: [ build, check-hashes ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
+        run: exit 1
+      - uses: actions/github-script@v4
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  trigger-next-checks:
+    name: Trigger Next Checks
+    needs: [ finally ]
+    if: ${{ github.event.client_payload.env.trigger_next_checks }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: integration-tests-checks
+          client-payload: ${{ toJSON(github.event.client_payload) }}

--- a/.github/workflows/execute-command.yaml
+++ b/.github/workflows/execute-command.yaml
@@ -1,0 +1,36 @@
+name: Execute Command
+
+on:
+  repository_dispatch:
+    types: [ execute-command ]
+
+env:
+  linux_os: ubuntu-20.04
+  os_matrix: '[ "ubuntu-20.04", "macos-10.15", "windows-2019" ]'
+  rust_toolchain: 1.51.0
+  molc_version: 0.7.1
+  trigger_next_checks: false
+
+jobs:
+
+  execute-command:
+    name: Execute Provided Command
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
+          client-payload: |
+            {
+              "github": {
+                "sha": "${{ github.event.client_payload.slash_command.args.named.github_sha }}"
+              },
+              "env": {
+                "linux_os": "${{ env.linux_os }}",
+                "os_matrix": ${{ env.os_matrix }},
+                "rust_toolchain": "${{ env.rust_toolchain }}",
+                "molc_version": "${{ env.molc_version }}",
+                "trigger_next_checks": ${{ env.trigger_next_checks }}
+              }
+            }

--- a/.github/workflows/integration-tests-checks.yaml
+++ b/.github/workflows/integration-tests-checks.yaml
@@ -1,0 +1,137 @@
+name: Integration Tests Checks
+
+on:
+  repository_dispatch:
+    types: [ integration-tests-checks ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTFLAGS: -D warnings
+
+jobs:
+
+  bootstrap:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  integration-tests:
+    name: Integration Tests
+    needs: [ bootstrap ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ github.event.client_payload.env.os_matrix }}
+      fail-fast: true
+      max-parallel: 10
+    env:
+      RUST_LOG: info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
+      CKB_TEST_SEC_COEFFICIENT: 5
+      CKB_TEST_ARGS: -c 4 --no-report --no-fail-fast
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - if: ${{ runner.os == 'Windows' }}
+        id: cache-key
+        shell: bash
+        run: echo "::set-output name=yyyymm::$(/bin/date -u '+%Y%m')"
+      - if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@v2
+        id: restore-scoop
+        with:
+          path: ~/scoop
+          key: ${{ runner.os }}-scoop-${{ steps.cache-key.outputs.yyyymm }}
+      - if: ${{ runner.os == 'Windows' && steps.restore-scoop.outputs.cache-hit != 'true' }}
+        run: iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          scoop install git
+          scoop bucket add extras
+          scoop install llvm yasm
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/
+          key: ${{ runner.os }}-build-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-build-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-build-
+      - uses: actions/cache@v2
+        if: ${{ runner.os != 'Windows' }}
+        with:
+          path: target/release/ckb
+          key: ${{ runner.os }}-executable-${{ github.event.client_payload.github.sha }}
+      - uses: actions/cache@v2
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          path: target/release/ckb.exe
+          key: ${{ runner.os }}-executable-${{ github.event.client_payload.github.sha }}
+      - run: |
+          make submodule-init
+          make setup-ckb-test
+      - if: ${{ runner.os != 'Windows' }}
+        run: |
+          cd test
+          cargo run -- --bin target/release/ckb --log-file target/integration.log ${{ env.CKB_TEST_ARGS }}
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          cd test
+          cargo run -- --bin target/release/ckb.exe --log-file target/integration.log ${{ env.CKB_TEST_ARGS }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Integration Logs (${{ runner.os }}, ${{ matrix.os }})
+          path: target/integration.log
+          if-no-files-found: error
+
+  finally:
+    name: Finally
+    needs: [ integration-tests ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
+        run: exit 1
+      - uses: actions/github-script@v4
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })

--- a/.github/workflows/nocompile-checks.yaml
+++ b/.github/workflows/nocompile-checks.yaml
@@ -1,0 +1,91 @@
+name: No Compile Checks
+
+on:
+  repository_dispatch:
+    types: [ no-compile-checks ]
+
+jobs:
+
+  bootstrap:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  rustfmt:
+    name: Rustfmt
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+          components: rustfmt
+      - run: make fmt
+
+  check-style:
+    name: Check Coding Style
+    needs: [ bootstrap ]
+    runs-on: ${{ github.event.client_payload.env.linux_os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - run: |
+          make check-cargotoml
+          make check-whitespaces
+          devtools/ci/check-cyclic-dependencies.py
+
+  finally:
+    name: Finally
+    needs: [ rustfmt, check-style ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
+        run: exit 1
+      - uses: actions/github-script@v4
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  trigger-next-checks:
+    name: Trigger Next Checks
+    needs: [ finally ]
+    if: ${{ github.event.client_payload.env.trigger_next_checks }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: basic-checks
+          client-payload: ${{ toJSON(github.event.client_payload) }}
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: build-checks
+          client-payload: ${{ toJSON(github.event.client_payload) }}

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -1,0 +1,71 @@
+name: Preflight Checks
+
+on:
+  push:
+
+env:
+  linux_os: ubuntu-20.04
+  os_matrix: '[ "ubuntu-20.04", "macos-10.15", "windows-2019" ]'
+  rust_toolchain: 1.51.0
+  molc_version: 0.7.1
+  trigger_next_checks: true
+
+jobs:
+
+  if-workflow-is-required:
+    name: Check If Workflow is Required
+    if: |
+      (github.repository_owner != 'nervosnetwork'
+          && ! contains(github.event.head_commit.message, 'disable github-hosted ci'))
+      || contains(github.event.head_commit.message, 'enable github-hosted ci')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Succeeded
+        run: exit 0
+
+  trigger-required-checks:
+    name: Trigger Required Checks
+    needs: [ if-workflow-is-required ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: no-compile-checks
+          client-payload: |
+            {
+              "github": {
+                "sha": "${{ github.sha }}"
+              },
+              "env": {
+                "linux_os": "${{ env.linux_os }}",
+                "os_matrix": ${{ env.os_matrix }},
+                "rust_toolchain": "${{ env.rust_toolchain }}",
+                "molc_version": "${{ env.molc_version }}",
+                "trigger_next_checks": ${{ env.trigger_next_checks }}
+              }
+            }
+      - uses: actions/github-script@v4.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })

--- a/.github/workflows/slash-command.yaml
+++ b/.github/workflows/slash-command.yaml
@@ -1,0 +1,29 @@
+name: Slash Command
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+
+  slash-command:
+    name: Trigger Execute Command
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        id: pull_request_payload
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            return github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            })
+      - uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          commands: execute
+          issue-type: pull-request
+          static-args: |
+            github_sha=${{ toJSON(fromJson(steps.pull_request_payload.outputs.result).data.head.sha) }}

--- a/.github/workflows/unit-tests-checks.yaml
+++ b/.github/workflows/unit-tests-checks.yaml
@@ -1,0 +1,111 @@
+name: Unit Tests Checks
+
+on:
+  repository_dispatch:
+    types: [ unit-tests-checks ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTFLAGS: -D warnings
+
+jobs:
+
+  bootstrap:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: 'pending',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })
+
+  unit-tests:
+    name: Unit Tests
+    needs: [ bootstrap ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ github.event.client_payload.env.os_matrix }}
+      fail-fast: true
+      max-parallel: 10
+    env:
+      ImageOS:  ${{ matrix.os }}
+      BUILD_BUILDID: ${{ github.event.client_payload.github.sha }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.github.sha }}
+      - if: ${{ runner.os == 'Windows' }}
+        id: cache-key
+        shell: bash
+        run: echo "::set-output name=yyyymm::$(/bin/date -u '+%Y%m')"
+      - if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@v2
+        id: restore-scoop
+        with:
+          path: ~/scoop
+          key: ${{ runner.os }}-scoop-${{ steps.cache-key.outputs.yyyymm }}
+      - if: ${{ runner.os == 'Windows' && steps.restore-scoop.outputs.cache-hit != 'true' }}
+        run: iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - if: ${{ runner.os == 'Windows' }}
+        run: |
+          scoop install git
+          scoop bucket add extras
+          scoop install llvm yasm
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ github.event.client_payload.env.rust_toolchain }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        with:
+          path: target/
+          key: ${{ runner.os }}-unit-tests-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+               ${{ runner.os }}-unit-tests-${{ hashFiles('rust-toolchain') }}-
+               ${{ runner.os }}-unit-tests-
+      - run: make test
+
+  finally:
+    name: Finally
+    needs: [ unit-tests ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
+        run: exit 1
+      - uses: actions/github-script@v4
+        if: ${{ always() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              state: '${{ job.status }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: '${{ github.workflow }}',
+              sha: '${{ github.event.client_payload.github.sha }}',
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -74,14 +74,32 @@ function run-test {
   cargo test @Verbose --all -- --nocapture
 }
 
-function run-integration {
+function run-submodule-init {
   git submodule update --init
+}
+
+function run-setup-ckb-test {
   cp -Fo Cargo.lock test/Cargo.lock
   rm -Re -Fo -ErrorAction SilentlyContinue test/target
 
-  cargo build --features deadlock_detection
   New-Item -ItemType Junction -Path test/target -Value "$($env:CARGO_TARGET_DIR ?? "$(pwd)/target")"
+}
 
+function run-integration-release {
+  run-submodule-init
+  run-setup-ckb-test
+  run-prod
+  run-integration-directly
+}
+
+function run-integration {
+  run-submodule-init
+  run-setup-ckb-test
+  cargo build --features deadlock_detection
+  run-integration-directly
+}
+
+function run-integration-directly {
   pushd test
 
   Set-Env RUST_BACKTRACE 1


### PR DESCRIPTION
### Requires

- A Personal Access Token `REPO_ACCESS_TOKEN`:

  - For **public** repository, the `public_repo` permission is enough.

  - For **private** repository, the whole `repo` permission is required.

- These Actions only work when the scripts are already in default branch.

  For example, default branch in `nervosnetwork/ckb` is `develop` branch.

### Purposes & Features

I want to show a coding-pattern of GitHub Actions:

- We can have only one trigger.

  For example, we don't have to use a lot of cron jobs.
  We only need one, and dispatch to other workflow if the condition was satisfied.

  And we can put all conditions in this trigger action.

- We can split a big workflow into several small workflows.

  If any workflow is failed, we can just re-run that failed workflow, not all.

- With the Action [Slash Command Dispatch], we can run or re-run any workflow in PR with a comment.

  We don't have to write "comment-to-execute" feature for each workflows if we use this coding-pattern for all workflows.

  For example:
  - Comment `/execute basic-checks` will execute the `basic-checks` workflow.
  - Comment `/execute unit-tests-checks` will execute the `unit-tests-checks` workflow.

  [Slash Command Dispatch]: https://github.com/marketplace/actions/slash-command-dispatch

Other features:
- Enable GitHub Actions that **require GitHub-hosted runners** for the forked repositories as default.
- Allow disabling or enabling the GitHub-hosted CI tests for any branches in any repositories.
  - If the HEAD commit message contains `enable github-hosted ci`, the GitHub-hosted CI tests will **be required**.
  - If the HEAD commit message contains `disable github-hosted ci`, the GitHub-hosted CI tests will **be skipped**.

### Default Workflows

In the follow flowchart, each node is a workflow and it has two cost time:
- 1st is the time cost without cache;
- 2nd is the time cost with cache.
- So only 50 minutes real time (not total time) for each commit to run all checks.

```
                                                Preflight Checks ---------------> Check If Workflow is Required
                                                    (39s, 32s)
                                                        |                
                                                        V                   |---> Rustfmt
                                                No Compile Checks ----------+                          |-> Check Cargo.toml
                                                  (3m20s, 2m54s)            |---> Check Coding Styles -+-> Check Whitespaces
                                                        |                                              |-> Check Cyclic Dependencies
       Clippy                <-|                        V
       Compile               <-+            |-----------+-----------|
(New!) Check Documents       <-+----+       |                       |
(New!) Check Generated Codes <-+    |       V                       V                     |---> Build in ubuntu 20.04
       Lint Dependencies     <-+    |-- Basic Checks            Build Checks -------------+---> Build in macOS 10.15
       WASM32 Build          <-|        (26m39s, 18m32s)        (31m25s, 20m32s)          |---> Build in windows-2019
                                            |                       |
                                            |                       | (Use the binary from previous workflow)
                                            |                       |
  Unit Tests in ubuntu 20.04 <-|            V                       V                     |--> Integration Tests in ubuntu 20.04
  Unit Tests in macOS 10.15  <-+------- Unit Tests Checks       Integration Tests Checks -+--> Integration Tests in macOS 10.15
  Unit Tests in windows-2019 <-|        (27m49s, 19m26s)        (28m43s, 23m55s)          |--> Integration Tests in windows-2019
```