### PR TITLE
doc: use community contributed site for script error codes

### DIFF
--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -521,7 +521,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
         if code == 0 {
             Ok(machine.machine.cycles())
         } else {
-            Err(ScriptError::ValidationFailure(code))
+            Err(ScriptError::validation_failure(&script_group.script, code))
         }
     }
 }
@@ -551,7 +551,7 @@ mod tests {
     use faster_hex::hex_encode;
 
     use ckb_chain_spec::consensus::{
-        ConsensusBuilder, TWO_IN_TWO_OUT_BYTES, TWO_IN_TWO_OUT_CYCLES,
+        ConsensusBuilder, TWO_IN_TWO_OUT_BYTES, TWO_IN_TWO_OUT_CYCLES, TYPE_ID_CODE_HASH,
     };
     use ckb_error::assert_error_eq;
     use ckb_test_chain_utils::{
@@ -572,6 +572,10 @@ mod tests {
         sha3.update(s.as_ref());
         sha3.finalize(&mut output);
         output
+    }
+
+    fn type_id_validation_failure(exit_code: i8) -> ScriptError {
+        ScriptError::ValidationFailure(format!("by-type-hash/{}", TYPE_ID_CODE_HASH), exit_code)
     }
 
     // NOTE: `verify` binary is outdated and most related unit tests are testing `script` crate functions
@@ -965,7 +969,7 @@ mod tests {
 
         let output = CellOutputBuilder::default()
             .capacity(capacity_bytes!(100).pack())
-            .lock(script)
+            .lock(script.clone())
             .build();
         let dummy_cell = CellMetaBuilder::from_cell_output(output, Bytes::new())
             .transaction_info(default_transaction_info())
@@ -990,7 +994,8 @@ mod tests {
 
         assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
-            ScriptError::ValidationFailure(-1).input_lock_script(0),
+            ScriptError::ValidationFailure(format!("by-data-hash/{:x}", script.code_hash()), -1)
+                .input_lock_script(0),
         );
     }
 
@@ -1176,7 +1181,7 @@ mod tests {
             .hash_type(ScriptHashType::Data.into())
             .build();
         let output = CellOutputBuilder::default()
-            .type_(Some(script).pack())
+            .type_(Some(script.clone()).pack())
             .build();
 
         let dep_out_point = OutPoint::new(h256!("0x123").pack(), 8);
@@ -1217,7 +1222,8 @@ mod tests {
 
         assert_error_eq!(
             verifier.verify(100_000_000).unwrap_err(),
-            ScriptError::ValidationFailure(-1).output_type_script(0),
+            ScriptError::ValidationFailure(format!("by-data-hash/{:x}", script.code_hash()), -1)
+                .output_type_script(0),
         );
     }
 
@@ -1644,7 +1650,7 @@ mod tests {
 
         assert_error_eq!(
             verifier.verify(1_001_000).unwrap_err(),
-            ScriptError::ValidationFailure(-3).output_type_script(0),
+            type_id_validation_failure(-3).output_type_script(0),
         );
     }
 
@@ -1729,7 +1735,7 @@ mod tests {
 
         assert_error_eq!(
             verifier.verify(1_001_000).unwrap_err(),
-            ScriptError::ValidationFailure(-1).output_type_script(0),
+            type_id_validation_failure(-1).output_type_script(0),
         );
     }
 
@@ -1803,7 +1809,7 @@ mod tests {
 
         assert_error_eq!(
             verifier.verify(TYPE_ID_CYCLES * 2).unwrap_err(),
-            ScriptError::ValidationFailure(-2).input_type_script(0),
+            type_id_validation_failure(-2).input_type_script(0),
         );
     }
 


### PR DESCRIPTION
Before the error message only link to the error codes for the system
scripts. This commit links to a page organized by script hash type and
code hash. The community can contribute the error codes pages for
various scripts in https://github.com/nervosnetwork/ckb-script-error-codes

See the example page for the built-in `TYPE_ID` script:

https://nervosnetwork.github.io/ckb-script-error-codes/by-type-hash/00000000000000000000000000000000000000000000000000545950455f4944.html#-3
