### PR TITLE
chore: remove lru cache from get_cellbase fn

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -138,7 +138,6 @@ cell_data_cache_size       = 128
 block_proposals_cache_size = 30
 block_tx_hashes_cache_size = 30
 block_uncles_cache_size    = 30
-cellbase_cache_size        = 30
 
 # [notifier]
 # # Execute command when the new tip block changes, first arg is block hash.

--- a/store/src/cache.rs
+++ b/store/src/cache.rs
@@ -1,7 +1,7 @@
 use ckb_app_config::StoreConfig;
 use ckb_types::{
     bytes::Bytes,
-    core::{HeaderView, TransactionView, UncleBlockVecView},
+    core::{HeaderView, UncleBlockVecView},
     packed::{self, Byte32, ProposalShortIdVec},
 };
 use ckb_util::Mutex;
@@ -23,8 +23,6 @@ pub struct StoreCache {
     pub block_uncles: Mutex<LruCache<Byte32, UncleBlockVecView>>,
     /// The cache of block extension sections.
     pub block_extensions: Mutex<LruCache<Byte32, Option<packed::Bytes>>>,
-    /// TODO(doc): @quake
-    pub cellbase: Mutex<LruCache<Byte32, TransactionView>>,
 }
 
 impl Default for StoreCache {
@@ -44,7 +42,6 @@ impl StoreCache {
             block_tx_hashes: Mutex::new(LruCache::new(config.block_tx_hashes_cache_size)),
             block_uncles: Mutex::new(LruCache::new(config.block_uncles_cache_size)),
             block_extensions: Mutex::new(LruCache::new(config.block_extensions_cache_size)),
-            cellbase: Mutex::new(LruCache::new(config.cellbase_cache_size)),
         }
     }
 }

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -480,26 +480,13 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
     /// Gets cellbase by block hash
     fn get_cellbase(&'a self, hash: &packed::Byte32) -> Option<TransactionView> {
-        if let Some(cache) = self.cache() {
-            if let Some(data) = cache.cellbase.lock().get(hash) {
-                return Some(data.clone());
-            }
-        };
         let key = packed::TransactionKey::new_builder()
             .block_hash(hash.to_owned())
             .build();
-        let ret = self.get(COLUMN_BLOCK_BODY, key.as_slice()).map(|slice| {
+        self.get(COLUMN_BLOCK_BODY, key.as_slice()).map(|slice| {
             let reader = packed::TransactionViewReader::from_slice_should_be_ok(&slice.as_ref());
             Unpack::<TransactionView>::unpack(&reader)
-        });
-        if let Some(cache) = self.cache() {
-            ret.map(|data| {
-                cache.cellbase.lock().put(hash.clone(), data.clone());
-                data
-            })
-        } else {
-            ret
-        }
+        })
     }
 
     /// TODO(doc): @quake

--- a/test/template/ckb.toml
+++ b/test/template/ckb.toml
@@ -92,7 +92,6 @@ cell_data_cache_size       = 128
 block_proposals_cache_size = 30
 block_tx_hashes_cache_size = 30
 block_uncles_cache_size    = 30
-cellbase_cache_size        = 30
 
 # [notifier]
 # # Execute command when the new tip block changes, first arg is block hash.

--- a/util/app-config/src/configs/store.rs
+++ b/util/app-config/src/configs/store.rs
@@ -16,8 +16,6 @@ pub struct Config {
     /// The maximum number of blocks which extension section is cached.
     #[serde(default = "default_block_extensions_cache_size")]
     pub block_extensions_cache_size: usize,
-    /// The maximum number of blocks which cellbase transaction is cached.
-    pub cellbase_cache_size: usize,
     /// whether enable freezer
     #[serde(default = "default_freezer_enable")]
     pub freezer_enable: bool,
@@ -40,7 +38,6 @@ impl Default for Config {
             block_tx_hashes_cache_size: 30,
             block_uncles_cache_size: 30,
             block_extensions_cache_size: default_block_extensions_cache_size(),
-            cellbase_cache_size: 30,
             freezer_enable: false,
         }
     }


### PR DESCRIPTION
The cellbase's cache hit ratio was found to be zero in testing the cache efficiency of store layer (running an ibd sync on mainnet), it's only used in `RewardVerifier` and `BlockAssembler`.

For `RewardVerifier`, it will only be called once for each block, it can never hit the cache, while for `BlockAssembler`, since there is a block template cache already, there is no need to overlay this cache, and the `get_cellbase` actually hits rocksdb's own cache quite well, so I don't see the need to introduce additional overhead.

please note that `cellbase_cache_size` is removed from configuration file, however, old version configuration file is compatible with this change since we ignore unknown conf fields.