### PR TITLE
ci: limit ci concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI workflow
 
+concurrency:
+  group: ci-${{ github.ref }}
+
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
When there are multiple ci workflows pendding for the same branch,
cancel old ones and only keep the last one.

See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
