### PR TITLE
fix: miner panics since the future created by hyper 0.13 need tokio 0.2 runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio 1.7.0",
+ "tokio-compat-02",
 ]
 
 [[package]]
@@ -4836,6 +4837,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-compat-02"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite 0.2.4",
+ "tokio 0.2.25",
+ "tokio 1.7.0",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,6 +4859,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.7.0",
 ]
 
 [[package]]

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -33,3 +33,4 @@ eaglesong = "0.1"
 base64 = "0.13.0"
 jsonrpc-core = "17.1"
 tokio = { version = "1", features = ["sync"]  }
+tokio-compat-02 = "0.2"

--- a/miner/src/client.rs
+++ b/miner/src/client.rs
@@ -24,6 +24,7 @@ use std::convert::Into;
 use std::thread;
 use std::time;
 use tokio::sync::{mpsc, oneshot};
+use tokio_compat_02::FutureExt;
 
 type RpcRequest = (oneshot::Sender<Result<Bytes, RpcError>>, MethodCall);
 
@@ -68,6 +69,7 @@ impl Rpc {
                         }
                         let request = match client
                             .request(req)
+                            .compat()
                             .await
                             .map(|res|res.into_body())
                         {


### PR DESCRIPTION
The bug is that miner always panics, because the future created by hyper 0.13 needs tokio 0.2 runtime.

This bug is introduced since #2773 yesterday.
That PR removed the duplicate version of "hyper" and only kept one version of "hyper".

In fact, I had tested the miner for each commit in that PR, and everything was OK when I did tests.
To be honest, I don't know why this 100%-panic bug wasn't appeared yesterday.
I guess if it's because I didn't clear the "target" directory when I did tests.

This time, I cleared the "target" directory and re-compiled the executable file.
And I ran a dev-chain with 1 node and 4 miners in different speeds for 1 hours, no panics anymore.