### PR TITLE
build: customize `opt-level` to avoid building some crates twice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,12 @@ members = [
 [profile.release]
 overflow-checks = true
 
+[profile.release.build-override]
+opt-level = 3
+
+[profile.bench.build-override]
+opt-level = 3
+
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 jemallocator = { version = "0.3.0", features = ["unprefixed_malloc_on_supported_platforms"] }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -42,3 +42,9 @@ jsonrpc-core = "17.1"
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
+[profile.release.build-override]
+opt-level = 3
+
+[profile.bench.build-override]
+opt-level = 3


### PR DESCRIPTION
### Purpose

Since "Cargo PR-8500" merged, as "Cargo Issue-8502" said: "if a crate will also be built as a runtime dependency, that would result in Cargo building it twice, once with opt-level 0 and once with opt-level 3."

So, in this PR I customize the `opt-level` to the default values, to make sure each crates only be compiled once.

### Results

When `make prod`  for `v0.42.0`:
- This PR can reduce the number of compiled dependencies 9.56%  (`596 -> 544`).
- This PR can reduce the size of target directory 14.2% (`1_813_100 bytes -> 1_587_780 bytes`).
- Save total compile time.

**Notice: the size of final binary won't be chaneged.**

### References

- [Cargo PR-8500: Build host dependencies with opt-level 0 by default](https://github.com/rust-lang/cargo/pull/8500)
- [Cargo Issue-8502: Support opt-level ranges to avoid building twice with different opt-level values](https://github.com/rust-lang/cargo/issues/8502)
- [Cargo Reference / Default profiles](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles)