### PR TITLE
refactor: verify the epoch in block headers explicitly

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -101,7 +101,7 @@ fn gen_block(parent_header: &HeaderView, nonce: u128, epoch: &EpochExt) -> Block
         .parent_hash(parent_header.hash())
         .timestamp((parent_header.timestamp() + 10).pack())
         .number(number.pack())
-        .epoch(epoch.number().pack())
+        .epoch(epoch.number_with_fraction(number).pack())
         .compact_target(epoch.compact_target().pack())
         .nonce(nonce.pack())
         .dao(dao)

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -69,7 +69,14 @@ impl StatsRpc for StatsRpcImpl {
             );
             (tip_header, median_time)
         };
-        let epoch = tip_header.epoch();
+        let epoch = if tip_header.is_genesis() {
+            self.shared
+                .consensus()
+                .genesis_epoch_ext()
+                .number_with_fraction(0)
+        } else {
+            tip_header.epoch()
+        };
         let difficulty = tip_header.difficulty();
         let is_initial_block_download = self.shared.is_initial_block_download();
         let alerts: Vec<AlertMessage> = {

--- a/rpc/src/test.rs
+++ b/rpc/src/test.rs
@@ -56,6 +56,7 @@ fn always_success_consensus() -> Consensus {
     let genesis = BlockBuilder::default()
         .timestamp(GENESIS_TIMESTAMP.pack())
         .compact_target(GENESIS_TARGET.pack())
+        .epoch(EpochNumberWithFraction::new_unchecked(0, 0, 0).pack())
         .dao(dao)
         .transaction(always_success_tx)
         .build();

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -178,6 +178,7 @@ impl Default for ConsensusBuilder {
 
         let genesis_block = BlockBuilder::default()
             .compact_target(DIFF_TWO.pack())
+            .epoch(EpochNumberWithFraction::new_unchecked(0, 0, 0).pack())
             .dao(dao)
             .transaction(cellbase)
             .build();

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -564,6 +564,7 @@ impl ChainSpec {
             .timestamp(self.genesis.timestamp.pack())
             .compact_target(self.genesis.compact_target.pack())
             .extra_hash(self.genesis.uncles_hash.pack())
+            .epoch(EpochNumberWithFraction::new_unchecked(0, 0, 0).pack())
             .dao(dao)
             .nonce(u128::from_le_bytes(self.genesis.nonce.to_le_bytes()).pack())
             .transaction(cellbase_transaction)

--- a/test/src/specs/rpc/get_blockchain_info.rs
+++ b/test/src/specs/rpc/get_blockchain_info.rs
@@ -34,9 +34,9 @@ impl Spec for RpcGetBlockchainInfo {
             genesis_blockchain_info.epoch.epoch_index()
         );
         assert_eq!(
-            1,
+            0,
             genesis_blockchain_info.epoch.epoch_length(),
-            "Epoch length of genesis block should be 1, but got {}",
+            "Epoch length of genesis block should be 0, but got {}",
             genesis_blockchain_info.epoch.epoch_length()
         );
         check_median_time(genesis_blockchain_info, node0);

--- a/test/src/specs/rpc/get_blockchain_info.rs
+++ b/test/src/specs/rpc/get_blockchain_info.rs
@@ -34,9 +34,9 @@ impl Spec for RpcGetBlockchainInfo {
             genesis_blockchain_info.epoch.epoch_index()
         );
         assert_eq!(
-            0,
+            1000,
             genesis_blockchain_info.epoch.epoch_length(),
-            "Epoch length of genesis block should be 0, but got {}",
+            "Epoch length of genesis block should be 1000, but got {}",
             genesis_blockchain_info.epoch.epoch_length()
         );
         check_median_time(genesis_blockchain_info, node0);

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -104,7 +104,7 @@ impl Pack<packed::Uint64> for core::EpochNumberWithFraction {
 
 impl<'r> Unpack<core::EpochNumberWithFraction> for packed::Uint64Reader<'r> {
     fn unpack(&self) -> core::EpochNumberWithFraction {
-        core::EpochNumberWithFraction::from_full_value(self.unpack())
+        core::EpochNumberWithFraction::from_full_value_unchecked(self.unpack())
     }
 }
 impl_conversion_for_entity_unpack!(core::EpochNumberWithFraction, Uint64);

--- a/util/types/src/core/advanced_builders.rs
+++ b/util/types/src/core/advanced_builders.rs
@@ -95,7 +95,7 @@ impl ::std::default::Default for HeaderBuilder {
             proposals_hash: Default::default(),
             compact_target: DIFF_TWO.pack(),
             extra_hash: Default::default(),
-            epoch: Default::default(),
+            epoch: core::EpochNumberWithFraction::new(0, 0, 1).pack(),
             dao: Default::default(),
             nonce: Default::default(),
         }
@@ -278,6 +278,14 @@ impl HeaderBuilder {
         debug_assert!(
             Unpack::<u32>::unpack(&compact_target) > 0,
             "[HeaderBuilder] compact_target should greater than zero"
+        );
+        debug_assert!(
+            Unpack::<core::BlockNumber>::unpack(&number) == 0
+                || Unpack::<core::EpochNumberWithFraction>::unpack(&epoch).is_well_formed(),
+            "[HeaderBuilder] epoch {:x} should be well formed, \
+            unless it's in the genesis block (number: {:x})",
+            epoch,
+            number
         );
         let raw = packed::RawHeader::new_builder()
             .version(version)

--- a/verification/contextual/src/tests/contextual_block_verifier.rs
+++ b/verification/contextual/src/tests/contextual_block_verifier.rs
@@ -11,7 +11,8 @@ use ckb_types::{
     bytes::Bytes,
     core::{
         capacity_bytes, cell::ResolvedTransaction, BlockBuilder, BlockNumber, BlockView, Capacity,
-        EpochExt, HeaderBuilder, HeaderView, TransactionBuilder, TransactionView, UncleBlockView,
+        EpochExt, EpochNumberWithFraction, HeaderBuilder, HeaderView, TransactionBuilder,
+        TransactionView, UncleBlockView,
     },
     packed::{Byte32, CellDep, CellInput, CellOutputBuilder, OutPoint, ProposalShortId, Script},
     prelude::*,
@@ -159,7 +160,8 @@ pub fn test_should_have_no_output_in_cellbase_no_finalization_target() {
 
 #[test]
 fn test_epoch_number() {
-    let block = BlockBuilder::default().epoch(2u64.pack()).build();
+    let actual_epoch = EpochNumberWithFraction::new(2, 0, 1);
+    let block = BlockBuilder::default().epoch(actual_epoch.pack()).build();
     let mut epoch = EpochExt::default();
     epoch.set_length(1);
 

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -2,7 +2,10 @@ use ckb_error::{def_error_base_on_kind, prelude::*, Error};
 use ckb_types::{core::Version, packed::Byte32};
 use derive_more::Display;
 
-pub use ckb_types::core::error::{TransactionError, TransactionErrorSource};
+pub use ckb_types::core::{
+    error::{TransactionError, TransactionErrorSource},
+    EpochNumberWithFraction,
+};
 
 /// A list specifying categories of ckb header error.
 ///
@@ -312,6 +315,22 @@ pub struct NumberError {
 /// Errors due to the fact that the block epoch is not expected.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum EpochError {
+    /// The format of header epoch is malformed.
+    #[error("Malformed(value: {value:#})")]
+    Malformed {
+        /// The malformed header epoch.
+        value: EpochNumberWithFraction,
+    },
+
+    /// The header epoch is not continuous.
+    #[error("NonContinuous(current: {current:#}, parent: {parent:#})")]
+    NonContinuous {
+        /// The current header epoch.
+        current: EpochNumberWithFraction,
+        /// The parent header epoch.
+        parent: EpochNumberWithFraction,
+    },
+
     /// The compact-target of block epoch is unexpected.
     #[error("TargetMismatch(expected: {expected:x}, actual: {actual:x})")]
     TargetMismatch {

--- a/verification/src/tests/genesis_verifier.rs
+++ b/verification/src/tests/genesis_verifier.rs
@@ -1,7 +1,7 @@
 use crate::{genesis_verifier::GenesisVerifier, NumberError, UnknownParentError};
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_error::assert_error_eq;
-use ckb_types::prelude::*;
+use ckb_types::{core::EpochNumberWithFraction, prelude::*};
 use ckb_verification_traits::Verifier;
 
 #[test]
@@ -10,6 +10,7 @@ pub fn test_genesis_non_zero_number() {
     let genesis_block = genesis_block
         .as_advanced_builder()
         .number(42.pack())
+        .epoch(EpochNumberWithFraction::from_full_value(0).pack())
         .build();
     let consensus = ConsensusBuilder::default()
         .genesis_block(genesis_block)


### PR DESCRIPTION
### Issue

The data of epoch in bytes is not same as the `EpochNumberWithFraction`.

https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/util/types/src/conversion/blockchain.rs#L105-L110
https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/util/types/src/core/extras.rs#L452-L459

It cause a few unintended consequences.
For example, the RPC return `"0x"` as the epoch of genesis block, but the integration tests checks if its length is `1`.

And we couldn't convert it back with the same value.
```rust
let original = Uint64::default();
let epoch: EpochNumberWithFraction = original.unpack();
let result: Uint64 = epoch.pack();
assert_eq!(result, original); // failed!
```

### Changes

- When convert a series of bytes to an `EpochNumberWithFraction`, don't change its value.

- Add an `EpochVerifier` to `HeaderVerifier`:
  - Check if the epoch is well formed.
  - Check if the epoch is continuous.
  So we can reject those blocks which have invalid epochs earlier.

- If an `EpochNumberWithFraction`'s full value is `0`, returns `RationalU256::zero()` when calling `to_rational()`.
  Because the full value of a genesis block' epoch is `0`.