### PR TITLE
refactor(hardfork): verify the epoch in since more strictly

### DIFF
--- a/test/src/specs/hardfork/v2021/since.rs
+++ b/test/src/specs/hardfork/v2021/since.rs
@@ -34,8 +34,20 @@ impl Spec for CheckAbsoluteEpochSince {
             assert_send_transaction_fail(node, &tx, ERROR_IMMATURE);
         }
         {
-            info!("CKB v2019, since absolute epoch failed");
+            info!("CKB v2019, since absolute epoch ok");
             let tx = create_tx_since_absolute_epoch(node, 1, 2);
+            let res = node.rpc_client().send_transaction_result(tx.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
+        {
+            info!("CKB v2019, since absolute epoch ok (index=length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 1, 0, 0);
+            let res = node.rpc_client().send_transaction_result(tx.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
+        {
+            info!("CKB v2019, since absolute epoch ok (index>length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 1, 1, 0);
             let res = node.rpc_client().send_transaction_result(tx.data().into());
             assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
         }
@@ -70,8 +82,13 @@ impl Spec for CheckAbsoluteEpochSince {
             assert_send_transaction_fail(node, &tx, ERROR_INVALID_SINCE);
         }
         {
-            info!("CKB v2021, since absolute epoch ok (boundary)");
-            let tx = create_tx_since_absolute_epoch(node, 2, 0);
+            info!("CKB v2021, since absolute epoch failed (boundary, index>length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 2, 1, 0);
+            assert_send_transaction_fail(node, &tx, ERROR_INVALID_SINCE);
+        }
+        {
+            info!("CKB v2021, since absolute epoch ok (boundary, index=length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 2, 0, 0);
             let res = node.rpc_client().send_transaction_result(tx.data().into());
             assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
         }
@@ -92,8 +109,20 @@ impl Spec for CheckAbsoluteEpochSince {
             assert_send_transaction_fail(node, &tx, ERROR_INVALID_SINCE);
         }
         {
+            info!("CKB v2021, since absolute epoch failed (index>length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 3, 1, 0);
+            assert_send_transaction_fail(node, &tx, ERROR_INVALID_SINCE);
+        }
+        {
+            info!("CKB v2021, since absolute epoch failed (index=length=0)");
+            let tx = create_tx_since_absolute_epoch_with_length(node, 3, 0, 0);
+            let res = node.rpc_client().send_transaction_result(tx.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
+        mine(&node, 1);
+        {
             info!("CKB v2021, since absolute epoch ok");
-            let tx = create_tx_since_absolute_epoch(node, 3, 0);
+            let tx = create_tx_since_absolute_epoch(node, 3, 1);
             let res = node.rpc_client().send_transaction_result(tx.data().into());
             assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
         }
@@ -140,9 +169,25 @@ impl Spec for CheckRelativeEpochSince {
         }
         assert_epoch_should_be(node, 3, epoch_length - 4, epoch_length);
         {
+            info!("CKB v2019, since relative epoch ok (index=length=0)");
+            let tx = create_tx_since_relative_epoch_with_length(node, 1, 0, 0);
+            mine(&node, epoch_length);
+            let res = node.rpc_client().send_transaction_result(tx.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
+        {
+            info!("CKB v2019, since relative epoch ok (index>length=0)");
+            let tx = create_tx_since_relative_epoch_with_length(node, 1, 1, 0);
+            mine(&node, epoch_length);
+            let res = node.rpc_client().send_transaction_result(tx.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
+        assert_epoch_should_be(node, 5, epoch_length - 4, epoch_length);
+        {
             let tx1 = create_tx_since_relative_epoch(node, 0, epoch_length);
             mine(&node, 1);
             let tx2 = create_tx_since_relative_epoch(node, 0, epoch_length);
+            let tx3 = create_tx_since_relative_epoch_with_length(node, 1, 1, 0);
             mine(&node, epoch_length - 2);
 
             info!("CKB v2019, since relative epoch failed (boundary, malformed)");
@@ -152,21 +197,28 @@ impl Spec for CheckRelativeEpochSince {
             let res = node.rpc_client().send_transaction_result(tx1.data().into());
             assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
 
-            info!("CKB v2021, since relative epoch failed (boundary, malformed)");
+            info!("CKB v2019, since relative epoch failed (boundary, malformed)");
             assert_send_transaction_fail(node, &tx2, ERROR_IMMATURE);
 
+            info!("CKB v2019, since relative epoch failed (boundary, index>length=0)");
+            assert_send_transaction_fail(node, &tx3, ERROR_IMMATURE);
+
             mine(&node, 1);
-            info!("CKB v2021, since relative epoch failed (boundary, malformed)");
+
+            info!("CKB v2019, since relative epoch failed (boundary, malformed)");
             assert_send_transaction_fail(node, &tx2, ERROR_INVALID_SINCE);
 
+            info!("CKB v2019, since relative epoch failed (boundary, index>length=0)");
+            assert_send_transaction_fail(node, &tx3, ERROR_INVALID_SINCE);
+
             info!("CKB v2019, since relative epoch transaction will be committed (boundary, malformed)");
-            assert_epoch_should_be(node, 4, epoch_length - 3, epoch_length);
+            assert_epoch_should_be(node, 6, epoch_length - 3, epoch_length);
             assert!(check::is_transaction_pending(node, &tx1));
             mine(&node, 1);
             assert!(check::is_transaction_proposed(node, &tx1));
             mine(&node, 1);
             assert!(check::is_transaction_committed(node, &tx1));
-            assert_epoch_should_be(node, 4, epoch_length - 1, epoch_length);
+            assert_epoch_should_be(node, 6, epoch_length - 1, epoch_length);
         }
         {
             info!("CKB v2021, since relative epoch failed (malformed)");
@@ -177,29 +229,58 @@ impl Spec for CheckRelativeEpochSince {
             info!("CKB v2021, since relative epoch failed (malformed)");
             assert_send_transaction_fail(node, &tx, ERROR_INVALID_SINCE);
         }
+        {
+            let tx1 = create_tx_since_relative_epoch_with_length(node, 1, 1, 0);
+            let tx2 = create_tx_since_relative_epoch_with_length(node, 1, 0, 0);
+
+            mine(&node, epoch_length);
+
+            info!("CKB v2021, since relative epoch failed (index>length=0)");
+            assert_send_transaction_fail(node, &tx1, ERROR_INVALID_SINCE);
+
+            info!("CKB v2021, since relative epoch ok (index=length=0)");
+            let res = node.rpc_client().send_transaction_result(tx2.data().into());
+            assert!(res.is_ok(), "result: {:?}", res.unwrap_err());
+        }
     }
 
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
         if let Some(mut switch) = spec.params.hardfork.as_mut() {
-            switch.rfc_pr_0223 = Some(5);
+            switch.rfc_pr_0223 = Some(7);
         }
     }
 }
 
-fn create_tx_since_absolute_epoch(node: &Node, number: u64, index: u64) -> TransactionView {
-    let epoch_length = GENESIS_EPOCH_LENGTH;
-    let epoch = EpochNumberWithFraction::new(number, index, epoch_length);
+fn create_tx_since_absolute_epoch_with_length(
+    node: &Node,
+    number: u64,
+    index: u64,
+    length: u64,
+) -> TransactionView {
+    let epoch = EpochNumberWithFraction::new_unchecked(number, index, length);
     let since = since_from_absolute_epoch_number(epoch);
     let cellbase = node.get_tip_block().transactions()[0].clone();
     node.new_transaction_with_since(cellbase.hash(), since)
 }
 
-fn create_tx_since_relative_epoch(node: &Node, number: u64, index: u64) -> TransactionView {
-    let epoch_length = GENESIS_EPOCH_LENGTH;
-    let epoch = EpochNumberWithFraction::new(number, index, epoch_length);
+fn create_tx_since_relative_epoch_with_length(
+    node: &Node,
+    number: u64,
+    index: u64,
+    length: u64,
+) -> TransactionView {
+    let epoch = EpochNumberWithFraction::new_unchecked(number, index, length);
     let since = since_from_relative_epoch_number(epoch);
     let cellbase = node.get_tip_block().transactions()[0].clone();
     node.new_transaction_with_since(cellbase.hash(), since)
+}
+
+fn create_tx_since_absolute_epoch(node: &Node, number: u64, index: u64) -> TransactionView {
+    create_tx_since_absolute_epoch_with_length(node, number, index, GENESIS_EPOCH_LENGTH)
+}
+
+fn create_tx_since_relative_epoch(node: &Node, number: u64, index: u64) -> TransactionView {
+    create_tx_since_relative_epoch_with_length(node, number, index, GENESIS_EPOCH_LENGTH)
 }

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -507,4 +507,11 @@ impl EpochNumberWithFraction {
     pub fn is_well_formed(self) -> bool {
         self.length() > 0 && self.length() > self.index()
     }
+
+    /// Check the data format as an increment.
+    ///
+    /// The epoch index should be less than the epoch length or both of them are zero.
+    pub fn is_well_formed_increment(self) -> bool {
+        self.length() > self.index() || (self.length() == 0 && self.index() == 0)
+    }
 }


### PR DESCRIPTION
### Before Hardfork

- When the length of since absolute (or relative) epoch is zero:
  - The `epoch_index` will be considered as `0`.
  - The `epoch_length` will be considered as `1`.

  https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/verification/src/transaction_verifier.rs#L544-L547
  https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/util/types/src/core/extras.rs#L452-L459

- Since relative epoch uses rational number operations but since absolute epoch doesn't.

  https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/verification/src/transaction_verifier.rs#L657-L662
  https://github.com/nervosnetwork/ckb/blob/85bf46065cc91e75980c9ee82925af77c524964d/verification/src/transaction_verifier.rs#L610-L612

### After Hardfork

- A transaction with since absolute (or relative) epoch is valid only if `epoch_index` is less than `epoch_length` or both `epoch_index` and `epoch_length` are zero.
- Using rational number operations for both since absolute epoch and since relative epoch.