### PR TITLE
chore: better error messages for subcommand `list-hashes`

### DIFF
--- a/ckb-bin/src/subcommand/list_hashes.rs
+++ b/ckb-bin/src/subcommand/list_hashes.rs
@@ -154,6 +154,6 @@ pub fn list_hashes(root_dir: PathBuf, matches: &ArgMatches<'_>) -> Result<(), Ex
 }
 
 fn to_config_error(err: Box<dyn std::error::Error>) -> ExitCode {
-    eprintln!("{:?}", err);
+    eprintln!("ERROR: {}", err);
     ExitCode::Config
 }


### PR DESCRIPTION
Error messages is better than error structs names or error enumeration types names.

For example:
https://github.com/nervosnetwork/ckb/blob/b085099a7875ffccaa791406ac30311c1a37c7fd/ckb-bin/src/subcommand/list_hashes.rs#L120-L121
https://github.com/nervosnetwork/ckb/blob/b085099a7875ffccaa791406ac30311c1a37c7fd/spec/src/lib.rs#L422-L433
https://github.com/nervosnetwork/ckb/blob/b085099a7875ffccaa791406ac30311c1a37c7fd/spec/src/lib.rs#L404-L408