### PR TITLE
feat(hardfork): reject vm1 lock script before hardfork started to keep compatible with old clients

### DIFF
--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -81,7 +81,7 @@ pub(crate) fn verify_rtx(
     let consensus = snapshot.consensus();
 
     if let Some(cached) = cache_entry {
-        TimeRelativeTransactionVerifier::new(&rtx, snapshot, tx_env)
+        TimeRelativeTransactionVerifier::new(&rtx, consensus, snapshot, tx_env)
             .verify()
             .map(|_| cached)
             .map_err(Reject::Verification)

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -1,6 +1,6 @@
 use ckb_constant::MAX_VM_VERSION;
 use ckb_error::OtherError;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 use crate::packed;
 
@@ -19,11 +19,11 @@ impl Default for ScriptHashType {
     }
 }
 
-impl TryFrom<packed::Byte> for ScriptHashType {
+impl TryFrom<u8> for ScriptHashType {
     type Error = OtherError;
 
-    fn try_from(v: packed::Byte) -> Result<Self, Self::Error> {
-        match Into::<u8>::into(v) {
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
             x if x % 2 == 0 => {
                 let vm_version = x / 2;
                 if vm_version > MAX_VM_VERSION {
@@ -38,6 +38,14 @@ impl TryFrom<packed::Byte> for ScriptHashType {
             1 => Ok(ScriptHashType::Type),
             _ => Err(OtherError::new(format!("Invalid script hash type {}", v))),
         }
+    }
+}
+
+impl TryFrom<packed::Byte> for ScriptHashType {
+    type Error = OtherError;
+
+    fn try_from(v: packed::Byte) -> Result<Self, Self::Error> {
+        Into::<u8>::into(v).try_into()
     }
 }
 

--- a/util/types/src/core/error.rs
+++ b/util/types/src/core/error.rs
@@ -167,6 +167,20 @@ pub enum TransactionError {
         /// The actual transaction size.
         actual: u64,
     },
+
+    /// The compatible error.
+    #[error("Compatible: the feature \"{feature}\" is used in current transaction but not enabled in current chain")]
+    Compatible {
+        /// The feature name.
+        feature: &'static str,
+    },
+
+    /// The internal error.
+    #[error("Internal: {description}, this error shouldn't happen, please report this bug to developers.")]
+    Internal {
+        /// The error description
+        description: String,
+    },
 }
 
 impl_error_conversion_with_kind!(TransactionError, ErrorKind::Transaction, Error);
@@ -186,7 +200,9 @@ impl TransactionError {
 
             TransactionError::Immature { .. }
             | TransactionError::CellbaseImmaturity { .. }
-            | TransactionError::MismatchedVersion { .. } => false,
+            | TransactionError::MismatchedVersion { .. }
+            | TransactionError::Compatible { .. }
+            | TransactionError::Internal { .. } => false,
         }
     }
 }

--- a/verification/contextual/src/contextual_block_verifier.rs
+++ b/verification/contextual/src/contextual_block_verifier.rs
@@ -383,16 +383,21 @@ impl<'a, CS: ChainStore<'a>> BlockTxsVerifier<'a, CS> {
                 let tx_hash = tx.transaction.hash();
                 let tx_env = TxVerifyEnv::new_commit(&self.header);
                 if let Some(cache_entry) = fetched_cache.get(&tx_hash) {
-                    TimeRelativeTransactionVerifier::new(&tx, self.context, &tx_env)
-                        .verify()
-                        .map_err(|error| {
-                            BlockTransactionsError {
-                                index: index as u32,
-                                error,
-                            }
-                            .into()
-                        })
-                        .map(|_| (tx_hash, *cache_entry))
+                    TimeRelativeTransactionVerifier::new(
+                        &tx,
+                        self.context.consensus,
+                        self.context,
+                        &tx_env,
+                    )
+                    .verify()
+                    .map_err(|error| {
+                        BlockTransactionsError {
+                            index: index as u32,
+                            error,
+                        }
+                        .into()
+                    })
+                    .map(|_| (tx_hash, *cache_entry))
                 } else {
                     ContextualTransactionVerifier::new(
                         &tx,

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -16,6 +16,7 @@ use ckb_types::{
     prelude::*,
 };
 use std::collections::HashSet;
+use std::convert::TryInto;
 
 /// The time-related TX verification
 ///
@@ -92,11 +93,13 @@ impl<'a> NonContextualTransactionVerifier<'a> {
 /// Context-dependent verification checks for transaction
 ///
 /// Contains:
+/// [`CompatibleVerifier`](./struct.CompatibleVerifier.html)
 /// [`TimeRelativeTransactionVerifier`](./struct.TimeRelativeTransactionVerifier.html)
 /// [`CapacityVerifier`](./struct.CapacityVerifier.html)
 /// [`ScriptVerifier`](./struct.ScriptVerifier.html)
 /// [`FeeCalculator`](./struct.FeeCalculator.html)
 pub struct ContextualTransactionVerifier<'a, DL> {
+    pub(crate) compatible: CompatibleVerifier<'a>,
     pub(crate) time_relative: TimeRelativeTransactionVerifier<'a, DL>,
     pub(crate) capacity: CapacityVerifier<'a>,
     pub(crate) script: ScriptVerifier<'a, DL>,
@@ -115,6 +118,7 @@ where
         tx_env: &'a TxVerifyEnv,
     ) -> Self {
         ContextualTransactionVerifier {
+            compatible: CompatibleVerifier::new(rtx, consensus, tx_env),
             time_relative: TimeRelativeTransactionVerifier::new(
                 &rtx,
                 consensus,
@@ -132,6 +136,7 @@ where
     /// skip script verify will result in the return value cycle always is zero
     pub fn verify(&self, max_cycles: Cycle, skip_script_verify: bool) -> Result<CacheEntry, Error> {
         let timer = Timer::start();
+        self.compatible.verify()?;
         self.time_relative.verify()?;
         self.capacity.verify()?;
         let cycles = if skip_script_verify {
@@ -323,6 +328,72 @@ impl<'a> EmptyVerifier<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+/// Check compatible between different versions CKB clients.
+///
+/// When a new client with hardfork features released, before the hardfork started, the old CKB
+/// clients will still be able to work.
+/// So, the new CKB client have to add several necessary checks to avoid fork attacks.
+///
+/// After hardfork, the old clients will be no longer available. Then we can delete all code in
+/// this verifier until next hardfork.
+pub struct CompatibleVerifier<'a> {
+    rtx: &'a ResolvedTransaction,
+    consensus: &'a Consensus,
+    tx_env: &'a TxVerifyEnv,
+}
+
+impl<'a> CompatibleVerifier<'a> {
+    pub fn new(
+        rtx: &'a ResolvedTransaction,
+        consensus: &'a Consensus,
+        tx_env: &'a TxVerifyEnv,
+    ) -> Self {
+        Self {
+            rtx,
+            consensus,
+            tx_env,
+        }
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        let proposal_window = self.consensus.tx_proposal_window();
+        let epoch_number = self.tx_env.epoch_number(proposal_window);
+        if !self
+            .consensus
+            .hardfork_switch()
+            .is_vm_version_1_and_syscalls_2_enabled(epoch_number)
+        {
+            for ht in self
+                .rtx
+                .transaction
+                .outputs()
+                .into_iter()
+                .map(|output| output.lock().hash_type())
+            {
+                let hash_type: ScriptHashType = ht.try_into().map_err(|_| {
+                    let val: u8 = ht.into();
+                    // This couldn't happen, because we already check it.
+                    TransactionError::Internal {
+                        description: format!("unknown hash type {:02x}", val),
+                    }
+                })?;
+                match hash_type {
+                    ScriptHashType::Data(vm_version) => {
+                        if vm_version > 0 {
+                            return Err(TransactionError::Compatible {
+                                feature: "VM Version 1",
+                            }
+                            .into());
+                        }
+                    }
+                    ScriptHashType::Type => {}
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
### Changes

- refactor: merge time relative verifiers in ContextualTransactionVerifier

  Before this commit:
  - `TimeRelativeTransactionVerifier = MaturityVerifier + SinceVerifier`
  - `ContextualTransactionVerifier = MaturityVerifier + SinceVerifier + OtherVerifiers`

  After this commit:
  - `TimeRelativeTransactionVerifier = MaturityVerifier + SinceVerifier`
  - `ContextualTransactionVerifier = TimeRelativeTransactionVerifier + OtherVerifiers`

- feat(hardfork): reject vm1 lock script before hardfork started to keep compatible with old clients

  Add `CompatibleVerifier` to `ContextualTransactionVerifier` to check compatible between different versions CKB clients.

  When a new client with hardfork features released, before the hardfork started, the old CKB clients will still be able to work.
  So, the new CKB client have to add several necessary checks to avoid fork attacks.

  After hardfork, the old clients will be no longer available. Then we can delete all code in that verifier until next hardfork.

  In current version, `CompatibleVerifier` only has one feature:
  - Reject vm1 lock script before hardfork started to keep compatible with old clients.