### PR TITLE
doc(rpc): fix enum variant parsing

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -495,6 +495,8 @@ class EnumSchema(HTMLParser):
             if tag == 'div' and attrs == [("class", "docblock")]:
                 self.variant_parser = MarkdownParser(title_level=3)
                 self.variant_parser.indent_level = 4
+        else:
+            self.variant_parser.handle_starttag(tag, attrs)
 
     def handle_endtag(self, tag):
         if self.variant_parser is not None:
@@ -521,8 +523,11 @@ class EnumSchema(HTMLParser):
             file.write('*   ')
             out = io.StringIO()
             v.write(out)
-            file.write(out.getvalue().lstrip())
+            variant_doc = out.getvalue().lstrip()
+            file.write(variant_doc)
             file.write('\n')
+            if '\n' in variant_doc:
+                file.write('\n')
 
     # PoolTransactionReject
     def write_pool_transaction_reject(self, file):

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3420,7 +3420,15 @@ The dep cell type. Allowed values: "code" and "dep_group".
 `DepType` is equivalent to `"code" | "dep_group"`.
 
 *   Type "code".
+
+    Use the cell itself as the dep cell.
+
 *   Type "dep_group".
+
+    The cell is a dep group which members are cells. These members are used as dep cells instead of the group itself.
+
+    The dep group stores the array of `OutPoint`s serialized via molecule in the cell data. Each `OutPoint` points to one cell member.
+
 
 
 ### Type `DryRunResult`


### PR DESCRIPTION
The parser only accepts the first paragraph of the enum variant, because
`handle_starttag` is not forwarded to the underlying markdown parser.