### PR TITLE
fix: fix peer store evict

### DIFF
--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -219,13 +219,19 @@ impl PeerStore {
                     .or_default()
                     .push(addr);
             }
+            let len = peers_by_network_group.len();
+            let mut peers = peers_by_network_group
+                .drain()
+                .map(|(_, v)| v)
+                .collect::<Vec<Vec<_>>>();
+
+            peers.sort_unstable_by_key(|k| std::cmp::Reverse(k.len()));
             let ban_score = self.score_config.ban_score;
-            // find the largest network group
-            peers_by_network_group
-                .values()
-                .max_by_key(|peers| peers.len())
-                .expect("largest network group")
-                .iter()
+            // evict nodes on the same network segment first
+            peers
+                .into_iter()
+                .take(len / 2)
+                .flatten()
                 .filter_map(move |addr| {
                     if addr.is_terrible(now_ms) || addr.score <= ban_score {
                         Some(addr.addr.clone())

--- a/util/app-config/src/configs/memory_tracker.rs
+++ b/util/app-config/src/configs/memory_tracker.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 /// Memory tracker config options.
-#[serde(deny_unknown_fields)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Tracking interval in seconds.
     pub interval: u64,


### PR DESCRIPTION
Originally, only the data in the largest group was considered, but now it is changed to traverse at least half of the groups 