### PR TITLE
bump to 0.100.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "ckb"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-bin",
  "ckb-build-info",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-app-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-build-info",
  "ckb-chain-spec",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-async-runtime"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-logger",
  "ckb-spawn",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-benches"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-chain",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-bin"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "atty",
  "base64",
@@ -503,11 +503,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-build-info"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 
 [[package]]
 name = "ckb-chain"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-iter"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-store",
  "ckb-types",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-spec"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-constant",
  "ckb-crypto",
@@ -566,18 +566,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "crossbeam-channel 0.3.9",
 ]
 
 [[package]]
 name = "ckb-constant"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 
 [[package]]
 name = "ckb-crypto"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-db"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-db-schema",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-db-migration"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-db",
@@ -640,11 +640,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-db-schema"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 
 [[package]]
 name = "ckb-error"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "faster-hex",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-freezer"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-error",
  "ckb-logger",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-instrument"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-chain",
  "ckb-chain-iter",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-types",
  "faster-hex",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-launcher"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -780,21 +780,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ckb-logger-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-logger-service"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ansi_term 0.12.1",
  "backtrace",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-memory-tracker"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-db",
  "ckb-logger",
@@ -824,14 +824,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-metrics"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "ckb-metrics-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "log",
  "serde",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-metrics-service"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-async-runtime",
  "ckb-metrics-config",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-migration-template"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "quote",
  "syn",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-miner"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "base64",
  "ckb-app-config",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-multisig"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-crypto",
  "ckb-error",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-network"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "bloom-filters",
  "bs58",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-network-alert"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-crypto",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-notify"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-channel",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -992,14 +992,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-pow"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-proposal-table"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-chain-spec",
  "ckb-logger",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "numext-fixed-uint",
  "proptest",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-resource"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-reward-calculator"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rpc"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-chain",
@@ -1126,14 +1126,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-rust-unstable-port"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "is_sorted",
 ]
 
 [[package]]
 name = "ckb-script"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-shared"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "arc-swap",
  "ckb-async-runtime",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-snapshot"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "arc-swap",
  "ckb-chain-spec",
@@ -1290,11 +1290,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-spawn"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 
 [[package]]
 name = "ckb-stop-handler"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-channel",
  "ckb-logger",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-store"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-sync"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "bitflags",
  "ckb-app-config",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-test-chain-utils"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao-utils",
@@ -1388,14 +1388,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-tx-pool"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-types"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "bit-vec",
  "bitflags",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-util"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-fixed-hash",
  "linked-hash-map",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification-contextual"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "ckb-async-runtime",
  "ckb-chain",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification-traits"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 dependencies = [
  "bitflags",
  "ckb-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,11 +11,11 @@ repository = "https://github.com/nervosnetwork/ckb"
 resolver = "2"
 
 [build-dependencies]
-ckb-build-info = { path = "util/build-info", version = "= 0.44.0-pre" }
+ckb-build-info = { path = "util/build-info", version = "= 0.100.0-pre" }
 
 [dependencies]
-ckb-build-info = { path = "util/build-info", version = "= 0.44.0-pre" }
-ckb-bin = { path = "ckb-bin", version = "= 0.44.0-pre" }
+ckb-build-info = { path = "util/build-info", version = "= 0.100.0-pre" }
+ckb-bin = { path = "ckb-bin", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Nervos CKB](https://www.nervos.org/) - The Common Knowledge Base
 
-[![Version](https://img.shields.io/badge/version-0.44.0--pre-orange.svg)](https://github.com/nervosnetwork/ckb/releases)
+[![Version](https://img.shields.io/badge/version-0.100.0--pre-orange.svg)](https://github.com/nervosnetwork/ckb/releases)
 [![Telegram Group](https://cdn.jsdelivr.net/gh/Patrolavia/telegram-badge@8fe3382b3fd3a1c533ba270e608035a27e430c2e/chat.svg)](https://t.me/nervosnetwork)
 [![Nervos Talk](https://img.shields.io/badge/discuss-on%20Nervos%20Talk-3CC68A.svg)](https://talk.nervos.org/)
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-benches"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -13,26 +13,26 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dev-dependencies]
 criterion = "0.3"
-ckb-chain = { path = "../chain", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
+ckb-chain = { path = "../chain", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../shared", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
 rand = "0.7"
-ckb-hash = {path = "../util/hash", version = "= 0.44.0-pre"}
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
+ckb-hash = {path = "../util/hash", version = "= 0.100.0-pre"}
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
 ckb-system-scripts = { version = "= 0.5.2" }
 lazy_static = "1.3.0"
-ckb-crypto = { path = "../util/crypto", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-launcher = { path = "../util/launcher", version = "= 0.44.0-pre" }
+ckb-crypto = { path = "../util/crypto", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../verification/traits", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
 tempfile = "3.0"
 
 [[bench]]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,32 +9,32 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
-ckb-verification-contextual = { path = "../verification/contextual", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-metrics = { path = "../util/metrics", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../shared", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
+ckb-verification-contextual = { path = "../verification/contextual", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../verification/traits", version = "= 0.100.0-pre" }
 faketime = "0.2.0"
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
-ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-rust-unstable-port = { path = "../util/rust-unstable-port", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
+ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-rust-unstable-port = { path = "../util/rust-unstable-port", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
 faux = { version = "^0.1", optional = true }
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-launcher = { path = "../util/launcher", version = "= 0.44.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
 lazy_static = "1.4"
 tempfile = "3.0"
 

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-bin"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -13,30 +13,30 @@ clap = { version = "2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_plain = "0.3.0"
 toml = "0.5"
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.44.0-pre" }
-ckb-metrics-service = { path = "../util/metrics-service", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-chain-spec = {path = "../spec", version = "= 0.44.0-pre"}
-ckb-miner = { path = "../miner", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre"}
-ckb-resource = { path = "../resource", version = "= 0.44.0-pre"}
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-logger-service = { path = "../util/logger-service", version = "= 0.100.0-pre" }
+ckb-metrics-service = { path = "../util/metrics-service", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-chain = { path = "../chain", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../shared", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-chain-spec = {path = "../spec", version = "= 0.100.0-pre"}
+ckb-miner = { path = "../miner", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre"}
+ckb-resource = { path = "../resource", version = "= 0.100.0-pre"}
 ctrlc = { version = "3.1", features = ["termination"] }
-ckb-instrument = { path = "../util/instrument", version = "= 0.44.0-pre", features = ["progress_bar"] }
-ckb-build-info = { path = "../util/build-info", version = "= 0.44.0-pre" }
-ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.44.0-pre" }
-ckb-chain-iter = { path = "../util/chain-iter", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.44.0-pre" }
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-launcher = { path = "../util/launcher", version = "= 0.44.0-pre" }
+ckb-instrument = { path = "../util/instrument", version = "= 0.100.0-pre", features = ["progress_bar"] }
+ckb-build-info = { path = "../util/build-info", version = "= 0.100.0-pre" }
+ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.100.0-pre" }
+ckb-chain-iter = { path = "../util/chain-iter", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../verification/traits", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../util/runtime", version = "= 0.100.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
 base64 = "0.13.0"
 tempfile = "3.0"
 rayon = "1.0"

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-migration"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,13 +11,13 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.44.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../db-schema", version = "= 0.100.0-pre" }
 indicatif = "0.16"
 console = ">=0.9.1, <1.0.0"
 
 [dev-dependencies]
 tempfile = "3.0"
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }

--- a/db-schema/Cargo.toml
+++ b/db-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-schema"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,10 +9,10 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
 libc = "0.2"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.0", features = ["snappy"] }
-ckb-db-schema = { path = "../db-schema", version = "= 0.44.0-pre" }
+ckb-db-schema = { path = "../db-schema", version = "= 0.100.0-pre" }
 tempfile = "3.0"

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-error"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,5 +11,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 thiserror = "1.0.22"
 anyhow = "1.0.34"
-ckb-occupied-capacity = { path = "../util/occupied-capacity", version = "= 0.44.0-pre" }
+ckb-occupied-capacity = { path = "../util/occupied-capacity", version = "= 0.100.0-pre" }
 derive_more = { version = "0.99.0", default-features = false, features = ["display"] }

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-freezer"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -10,11 +10,11 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-metrics = { path = "../util/metrics", version = "= 0.100.0-pre" }
 fs2 = "0.4.3"
 fail = "0.4"
 snap = "1"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-miner"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,24 +9,24 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.44.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-hash = { path = "../util/hash", version = "= 0.100.0-pre" }
+ckb-pow = { path = "../pow", version = "= 0.100.0-pre" }
 rand = "0.7"
 rand_distr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
 hyper = "0.13"
 hyper-tls = "0.4"
 futures = "0.3"
 lru = "0.6.0"
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../util/runtime", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
 indicatif = "0.16"
 console = "0.13.0"
 eaglesong = "0.1"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,10 +11,10 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
 tokio = { version = "1", features = ["sync", "macros"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 futures = "0.3"
@@ -24,15 +24,15 @@ lazy_static = { version = "1.3.0", optional = true }
 bs58 = { version = "0.3.0", optional = true }
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
 faster-hex = { version = "0.6", optional = true }
-ckb-hash = {path = "../util/hash", version = "= 0.44.0-pre"}
+ckb-hash = {path = "../util/hash", version = "= 0.100.0-pre"}
 secp256k1 = {version = "0.19", features = ["recovery"], optional = true }
 trust-dns-resolver = { version = "0.19", optional = true }
 snap = "1"
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
 ipnetwork = "0.14"
 serde_json = "1.0"
 bloom-filters = "0.1"
-ckb-spawn = { path = "../util/spawn", version = "= 0.44.0-pre" }
+ckb-spawn = { path = "../util/spawn", version = "= 0.100.0-pre" }
 
 [features]
 with_sentry = ["sentry"]

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-notify"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,10 +9,10 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-app-config  = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-app-config  = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
 
 [dev-dependencies]

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-pow"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -10,8 +10,8 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 byteorder = "1.3.1"
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.44.0-pre"}
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-hash = { path = "../util/hash", version = "= 0.100.0-pre"}
 serde = { version = "1.0", features = ["derive"] }
 eaglesong = "0.1"
 log = "0.4"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-resource"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -15,11 +15,11 @@ includedir = "0.5.0"
 # Lock tempfile so wasm-build-test will use getrandom 0.1.*
 tempfile = "=3.1.0"
 serde = { version = "1.0", features = ["derive"] }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
 ckb-system-scripts = { version = "= 0.5.2" }
 
 [build-dependencies]
 includedir_codegen = "0.5.0"
 walkdir = "2.1.4"
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
 ckb-system-scripts = { version = "= 0.5.2" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rpc"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,20 +9,20 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-notify = { path = "../notify", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-sync = { path = "../sync", version = "= 0.44.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre"}
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.44.0-pre"}
-ckb-network-alert = { path = "../util/network-alert", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.44.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-notify = { path = "../notify", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../shared", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-sync = { path = "../sync", version = "= 0.100.0-pre" }
+ckb-chain = { path = "../chain", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre"}
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-logger-service = { path = "../util/logger-service", version = "= 0.100.0-pre"}
+ckb-network-alert = { path = "../util/network-alert", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.100.0-pre" }
 jsonrpc-core = "17.1"
 jsonrpc-derive = "17.1"
 jsonrpc-http-server = "17.1"
@@ -32,24 +32,24 @@ jsonrpc-server-utils = "17.1"
 jsonrpc-pubsub = "17.1"
 serde_json = "1.0"
 num_cpus = "1.10"
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../verification/traits", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
 faketime = "0.2.0"
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.44.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.44.0-pre" }
-ckb-script = { path = "../script", version = "= 0.44.0-pre" }
-ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.44.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.100.0-pre" }
+ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }
+ckb-script = { path = "../script", version = "= 0.100.0-pre" }
+ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
-ckb-launcher = { path = "../util/launcher", version = "= 0.44.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
+ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
 tempfile = "3.0"
 pretty_assertions = "0.6.1"
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3562,7 +3562,7 @@ Refer to RFC [CKB Block Structure](https://github.com/nervosnetwork/rfcs/blob/ma
 
     ### Notice
 
-    This field is renamed from `uncles_hash` since 0.44.0. More details can be found in [CKB RFC 224](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0224-variable-length-header-field/0224-variable-length-header-field.md).
+    This field is renamed from `uncles_hash` since 0.100.0. More details can be found in [CKB RFC 224](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0224-variable-length-header-field/0224-variable-length-header-field.md).
 
 *   `dao`: [`Byte32`](#type-byte32) - DAO fields.
 

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-script"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -17,24 +17,24 @@ detect-asm = ["ckb-vm/detect-asm"]
 logging = ["ckb-logger"]
 
 [dependencies]
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
 byteorder = "1.3.1"
-ckb-types = {path = "../util/types", version = "= 0.44.0-pre"}
-ckb-hash = {path = "../util/hash", version = "= 0.44.0-pre"}
+ckb-types = {path = "../util/types", version = "= 0.100.0-pre"}
+ckb-hash = {path = "../util/hash", version = "= 0.100.0-pre"}
 ckb-vm-definitions = "0.20.0-rc1"
 ckb-vm = { version = "0.20.0-rc1", default-features = false }
 faster-hex = "0.6"
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre", optional = true }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
 goblin = "0.2"
 
 [dev-dependencies]
 proptest = "0.9"
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
 tiny-keccak = { version = "2.0", features = ["sha3"] }
-ckb-crypto = { path = "../util/crypto", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.44.0-pre" }
+ckb-crypto = { path = "../util/crypto", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../db-schema", version = "= 0.100.0-pre" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-shared"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,22 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.100.0-pre" }
 arc-swap = "0.4"
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-snapshot = { path = "../util/snapshot", version = "= 0.44.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.44.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
-ckb-notify = { path = "../notify", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.44.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-snapshot = { path = "../util/snapshot", version = "= 0.100.0-pre" }
+ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
+ckb-notify = { path = "../notify", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../db-schema", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../util/runtime", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.100.0-pre" }
 p2p = { version="0.4.0-alpha.1", package="tentacle" }
 faketime = "0.2.0"

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-spec"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,14 +11,14 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
-ckb-constant = { path = "../util/constant", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.44.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-rational = { path = "../util/rational", version = "= 0.44.0-pre" }
-ckb-crypto = { path = "../util/crypto", version = "= 0.44.0-pre"}
-ckb-hash = { path = "../util/hash", version = "= 0.44.0-pre"}
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-pow = { path = "../pow", version = "= 0.100.0-pre" }
+ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-rational = { path = "../util/rational", version = "= 0.100.0-pre" }
+ckb-crypto = { path = "../util/crypto", version = "= 0.100.0-pre"}
+ckb-hash = { path = "../util/hash", version = "= 0.100.0-pre"}
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-store"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,13 +9,13 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
 lru = "0.6.0"
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.44.0-pre" }
-ckb-freezer = { path = "../freezer", version = "= 0.44.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../db-schema", version = "= 0.100.0-pre" }
+ckb-freezer = { path = "../freezer", version = "= 0.100.0-pre" }

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sync"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,25 +9,25 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain = { path = "../chain", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-db = { path = "../db", version = "= 0.44.0-pre" }
-ckb-app-config = {path = "../util/app-config", version = "= 0.44.0-pre"}
-ckb-types = {path = "../util/types", version = "= 0.44.0-pre"}
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-logger = {path = "../util/logger", version = "= 0.44.0-pre"}
-ckb-metrics = {path = "../util/metrics", version = "= 0.44.0-pre"}
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
-ckb-error = {path = "../error", version = "= 0.44.0-pre"}
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.44.0-pre" }
+ckb-chain = { path = "../chain", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../shared", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-db = { path = "../db", version = "= 0.100.0-pre" }
+ckb-app-config = {path = "../util/app-config", version = "= 0.100.0-pre"}
+ckb-types = {path = "../util/types", version = "= 0.100.0-pre"}
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-logger = {path = "../util/logger", version = "= 0.100.0-pre"}
+ckb-metrics = {path = "../util/metrics", version = "= 0.100.0-pre"}
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../verification/traits", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
+ckb-error = {path = "../error", version = "= 0.100.0-pre"}
+ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
-ckb-constant = { path = "../util/constant", version = "= 0.44.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.100.0-pre" }
 lru = "0.6.0"
 futures = "0.3"
 governor = "0.3.1"
@@ -38,12 +38,12 @@ dashmap = "4.0"
 keyed_priority_queue = "0.3"
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
 rand = "0.7"
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.44.0-pre", features = ["mock"] }
-ckb-launcher = { path = "../util/launcher", version = "= 0.44.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-chain = { path = "../chain", version = "= 0.100.0-pre", features = ["mock"] }
+ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
 faux = "^0.1"
 
 [features]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-test"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,25 +11,25 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 clap = { version = "2" }
 toml = "0.5.0"
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-crypto = { path = "../util/crypto", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.44.0-pre" }
-ckb-logger-config = { path = "../util/logger-config", version = "= 0.44.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.44.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-hash = { path = "../util/hash", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-crypto = { path = "../util/crypto", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
+ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../util/runtime", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre" }
+ckb-logger-config = { path = "../util/logger-config", version = "= 0.100.0-pre" }
+ckb-logger-service = { path = "../util/logger-service", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
+ckb-constant = { path = "../util/constant", version = "= 0.100.0-pre" }
 tempfile = "3.0"
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
 rand = "0.7"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-traits"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-tx-pool"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,26 +11,26 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-logger = {path = "../util/logger", version = "= 0.44.0-pre"}
-ckb-verification = { path = "../verification", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-logger = {path = "../util/logger", version = "= 0.100.0-pre"}
+ckb-verification = { path = "../verification", version = "= 0.100.0-pre" }
 faketime = "0.2"
 lru = "0.6.0"
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.44.0-pre" }
-ckb-store = { path = "../store", version = "= 0.44.0-pre" }
-ckb-util = { path = "../util", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-snapshot = { path = "../util/snapshot", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
+ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.100.0-pre" }
+ckb-store = { path = "../store", version = "= 0.100.0-pre" }
+ckb-util = { path = "../util", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-snapshot = { path = "../util/snapshot", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
 tokio = { version = "1", features = ["sync"] }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.44.0-pre" }
-ckb-network = { path = "../network", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
+ckb-async-runtime = { path = "../util/runtime", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
+ckb-network = { path = "../network", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../util/channel", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
 sentry = { package = "ckb-sentry", version = "0.21.0", optional = true }
 
 [features]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-util"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -14,7 +14,7 @@ linked-hash-map = "0.5"
 regex = "1.1.6"
 
 [dev-dependencies]
-ckb-fixed-hash = { path = "fixed-hash", version = "= 0.44.0-pre" }
+ckb-fixed-hash = { path = "fixed-hash", version = "= 0.100.0-pre" }
 
 [features]
 deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-app-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -15,15 +15,15 @@ serde_plain = "0.3.0"
 serde_json = "1.0"
 toml = "0.5"
 path-clean = "0.1.0"
-ckb-logger = { path = "../../util/logger", version = "= 0.44.0-pre" }
-ckb-logger-config = { path = "../../util/logger-config", version = "= 0.44.0-pre" }
-ckb-metrics-config = { path = "../../util/metrics-config", version = "= 0.44.0-pre" }
-ckb-chain-spec = {path = "../../spec", version = "= 0.44.0-pre"}
-ckb-jsonrpc-types = {path = "../jsonrpc-types", version = "= 0.44.0-pre"}
-ckb-pow = { path = "../../pow", version = "= 0.44.0-pre" }
-ckb-resource = { path = "../../resource", version = "= 0.44.0-pre"}
-ckb-build-info = { path = "../build-info", version = "= 0.44.0-pre" }
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../../util/logger", version = "= 0.100.0-pre" }
+ckb-logger-config = { path = "../../util/logger-config", version = "= 0.100.0-pre" }
+ckb-metrics-config = { path = "../../util/metrics-config", version = "= 0.100.0-pre" }
+ckb-chain-spec = {path = "../../spec", version = "= 0.100.0-pre"}
+ckb-jsonrpc-types = {path = "../jsonrpc-types", version = "= 0.100.0-pre"}
+ckb-pow = { path = "../../pow", version = "= 0.100.0-pre" }
+ckb-resource = { path = "../../resource", version = "= 0.100.0-pre"}
+ckb-build-info = { path = "../build-info", version = "= 0.100.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
 secio = { version="0.5.0", package="tentacle-secio" }
 multiaddr = { version="0.3.0", package="tentacle-multiaddr" }
 rand = "0.7"

--- a/util/app-config/src/legacy/mod.rs
+++ b/util/app-config/src/legacy/mod.rs
@@ -174,10 +174,15 @@ impl CKBAppConfig {
     pub(crate) fn deprecated_fields(&self) -> Vec<DeprecatedField> {
         let mut v = Vec::new();
         deprecate!(self, v, indexer, "0.40.0");
-        deprecate!(self, v, store.cellbase_cache_size, "0.44.0");
-        deprecate!(self, v, tx_pool.max_verify_cache_size, "0.44.0");
-        deprecate!(self, v, tx_pool.max_conflict_cache_size, "0.44.0");
-        deprecate!(self, v, tx_pool.max_committed_txs_hash_cache_size, "0.44.0");
+        deprecate!(self, v, store.cellbase_cache_size, "0.100.0");
+        deprecate!(self, v, tx_pool.max_verify_cache_size, "0.100.0");
+        deprecate!(self, v, tx_pool.max_conflict_cache_size, "0.100.0");
+        deprecate!(
+            self,
+            v,
+            tx_pool.max_committed_txs_hash_cache_size,
+            "0.100.0"
+        );
         v
     }
 }

--- a/util/build-info/Cargo.toml
+++ b/util/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-build-info"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-iter"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,5 +11,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-channel"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/constant/Cargo.toml
+++ b/util/constant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-constant"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-crypto"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.44.0-pre" }
+ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.100.0-pre" }
 lazy_static = "1.3"
 secp256k1 = { version = "0.19", features = ["recovery"], optional = true }
 thiserror = "1.0.22"

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -10,13 +10,13 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 byteorder = "1.3.1"
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "./utils", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "./utils", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../../traits", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao-utils"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -10,5 +10,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 byteorder = "1.3.1"
-ckb-types = { path = "../../types", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../../error", version = "= 0.44.0-pre" }
+ckb-types = { path = "../../types", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../../error", version = "= 0.100.0-pre" }

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fee-estimator"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -11,6 +11,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
 serde = { version = "1.0", features = ["derive"] }

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash-core = { path = "core", version = "= 0.44.0-pre" }
-ckb-fixed-hash-macros = { path = "macros", version = "= 0.44.0-pre" }
+ckb-fixed-hash-core = { path = "core", version = "= 0.100.0-pre" }
+ckb-fixed-hash-macros = { path = "macros", version = "= 0.100.0-pre" }

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-core"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-macros"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-ckb-fixed-hash-core = { path = "../core", version = "= 0.44.0-pre" }
+ckb-fixed-hash-core = { path = "../core", version = "= 0.100.0-pre" }
 quote = "1.0"
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-hash"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-instrument"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-chain = { path = "../../chain", version = "= 0.44.0-pre" }
-ckb-chain-iter = { path = "../chain-iter", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-chain = { path = "../../chain", version = "= 0.100.0-pre" }
+ckb-chain-iter = { path = "../chain-iter", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../../shared", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.100.0-pre" }
 serde_json = "1.0"
 indicatif = { version = "0.16", optional = true }
 

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-jsonrpc-types"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 faster-hex = "0.6"

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -651,7 +651,7 @@ pub struct Header {
     ///
     /// # Notice
     ///
-    /// This field is renamed from `uncles_hash` since 0.44.0.
+    /// This field is renamed from `uncles_hash` since 0.100.0.
     /// More details can be found in [CKB RFC 224].
     ///
     /// [CKB RFC 224]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0224-variable-length-header-field/0224-variable-length-header-field.md

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-launcher"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,35 +11,35 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
-ckb-migration-template = { path = "migration-template", version = "= 0.44.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.44.0-pre" }
-ckb-db-migration = { path = "../../db-migration", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
-ckb-build-info = { path = "../build-info", version = "= 0.44.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-chain = { path = "../../chain", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.44.0-pre" }
-ckb-network = { path = "../../network", version = "= 0.44.0-pre"}
-ckb-rpc = { path = "../../rpc", version = "= 0.44.0-pre"}
-ckb-resource = { path = "../../resource", version = "= 0.44.0-pre"}
-ckb-network-alert = { path = "../network-alert", version = "= 0.44.0-pre" }
-ckb-sync = { path = "../../sync", version = "= 0.44.0-pre"}
-ckb-verification = { path = "../../verification", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../../verification/traits", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.44.0-pre" }
-ckb-proposal-table = { path = "../proposal-table", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-freezer = { path = "../../freezer", version = "= 0.44.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.44.0-pre" }
-ckb-snapshot = { path = "../snapshot", version = "= 0.44.0-pre" }
-ckb-tx-pool = { path = "../../tx-pool", version = "= 0.44.0-pre" }
-ckb-stop-handler = { path = "../stop-handler", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
+ckb-migration-template = { path = "migration-template", version = "= 0.100.0-pre" }
+ckb-app-config = { path = "../app-config", version = "= 0.100.0-pre" }
+ckb-db-migration = { path = "../../db-migration", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
+ckb-build-info = { path = "../build-info", version = "= 0.100.0-pre" }
+ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-chain = { path = "../../chain", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../../shared", version = "= 0.100.0-pre" }
+ckb-network = { path = "../../network", version = "= 0.100.0-pre"}
+ckb-rpc = { path = "../../rpc", version = "= 0.100.0-pre"}
+ckb-resource = { path = "../../resource", version = "= 0.100.0-pre"}
+ckb-network-alert = { path = "../network-alert", version = "= 0.100.0-pre" }
+ckb-sync = { path = "../../sync", version = "= 0.100.0-pre"}
+ckb-verification = { path = "../../verification", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../../verification/traits", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../runtime", version = "= 0.100.0-pre" }
+ckb-proposal-table = { path = "../proposal-table", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../channel", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-freezer = { path = "../../freezer", version = "= 0.100.0-pre" }
+ckb-notify = { path = "../../notify", version = "= 0.100.0-pre" }
+ckb-snapshot = { path = "../snapshot", version = "= 0.100.0-pre" }
+ckb-tx-pool = { path = "../../tx-pool", version = "= 0.100.0-pre" }
+ckb-stop-handler = { path = "../stop-handler", version = "= 0.100.0-pre" }
 p2p = { version="0.4.0-alpha.1", package="tentacle" }
 num_cpus = "1.10"
 once_cell = "1.8.0"

--- a/util/launcher/migration-template/Cargo.toml
+++ b/util/launcher/migration-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-migration-template"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-service"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-util = { path = "..", version = "= 0.44.0-pre" }
-ckb-logger-config = { path = "../logger-config", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.44.0-pre" }
+ckb-util = { path = "..", version = "= 0.100.0-pre" }
+ckb-logger-config = { path = "../logger-config", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../channel", version = "= 0.100.0-pre" }
 ansi_term = "0.12"
 log = "0.4"
 env_logger = "0.6"

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-memory-tracker"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-metrics = { path = "../metrics", version = "= 0.44.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-metrics = { path = "../metrics", version = "= 0.100.0-pre" }
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 heim = { version = "0.0.11", default-features=false, features = ["process"] }

--- a/util/metrics-config/Cargo.toml
+++ b/util/metrics-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-config"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-service"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"
@@ -9,8 +9,8 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-metrics-config = { path = "../metrics-config", version = "= 0.44.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.44.0-pre" }
-ckb-util = { path = "..", version = "= 0.44.0-pre" }
+ckb-metrics-config = { path = "../metrics-config", version = "= 0.100.0-pre" }
+ckb-async-runtime = { path = "../runtime", version = "= 0.100.0-pre" }
+ckb-util = { path = "..", version = "= 0.100.0-pre" }
 metrics-runtime = { package = "ckb-metrics-runtime", version = "0.13.1" }
 metrics-core = "0.5.2"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2018"

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-multisig"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-crypto = { path = "../crypto", version = "= 0.44.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-crypto = { path = "../crypto", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
 rand = "0.7"

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network-alert"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-multisig = { path = "../multisig", version = "= 0.44.0-pre" }
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-util = { path = "..", version = "= 0.44.0-pre" }
-ckb-network = { path = "../../network", version = "= 0.44.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.44.0-pre"}
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre"}
-ckb-app-config = { path = "../app-config", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
+ckb-multisig = { path = "../multisig", version = "= 0.100.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-util = { path = "..", version = "= 0.100.0-pre" }
+ckb-network = { path = "../../network", version = "= 0.100.0-pre" }
+ckb-notify = { path = "../../notify", version = "= 0.100.0-pre"}
+ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre"}
+ckb-app-config = { path = "../app-config", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
 faketime = "0.2.0"
 lru = "0.6"
 semver = "0.9"
 
 [dev-dependencies]
-ckb-crypto = { path = "../crypto", version = "= 0.44.0-pre" }
+ckb-crypto = { path = "../crypto", version = "= 0.100.0-pre" }

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-occupied-capacity-macros = { path = "macros", version = "= 0.44.0-pre" }
-ckb-occupied-capacity-core = { path = "core", version = "= 0.44.0-pre" }
+ckb-occupied-capacity-macros = { path = "macros", version = "= 0.100.0-pre" }
+ckb-occupied-capacity-core = { path = "core", version = "= 0.100.0-pre" }

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-core"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-macros"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 syn = "1.0"
-ckb-occupied-capacity-core = { path = "../core", version = "= 0.44.0-pre" }
+ckb-occupied-capacity-core = { path = "../core", version = "= 0.100.0-pre" }

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-proposal-table"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -10,6 +10,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rational"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-reward-calculator"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,14 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
-ckb-dao = { path = "../dao", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-chain-spec = {path = "../../spec", version = "= 0.44.0-pre"}
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }
+ckb-dao = { path = "../dao", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-chain-spec = {path = "../../spec", version = "= 0.100.0-pre"}
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
-ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.44.0-pre" }
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
+ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-async-runtime"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -10,6 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-ckb-stop-handler = { path = "../stop-handler", version = "= 0.44.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
-ckb-spawn = {  path = "../spawn", version = "= 0.44.0-pre" }
+ckb-stop-handler = { path = "../stop-handler", version = "= 0.100.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+ckb-spawn = {  path = "../spawn", version = "= 0.100.0-pre" }

--- a/util/rust-unstable-port/Cargo.toml
+++ b/util/rust-unstable-port/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rust-unstable-port"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-snapshot"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -11,14 +11,14 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
-ckb-proposal-table = { path = "../proposal-table", version = "= 0.44.0-pre" }
+ckb-types = { path = "../types", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../../traits", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
+ckb-proposal-table = { path = "../proposal-table", version = "= 0.100.0-pre" }
 arc-swap = "0.4"
-ckb-reward-calculator = { path = "../reward-calculator", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.44.0-pre" }
-ckb-freezer = { path = "../../freezer", version = "= 0.44.0-pre" }
+ckb-reward-calculator = { path = "../reward-calculator", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }
+ckb-freezer = { path = "../../freezer", version = "= 0.100.0-pre" }

--- a/util/spawn/Cargo.toml
+++ b/util/spawn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-spawn"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-stop-handler"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -10,6 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 parking_lot = "0.11"
-ckb-logger = { path = "../logger", version = "= 0.44.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
 tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
-ckb-channel = { path = "../channel", version = "= 0.44.0-pre" }
+ckb-channel = { path = "../channel", version = "= 0.100.0-pre" }

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-test-chain-utils"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,13 +9,13 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = {path = "../types", version = "= 0.44.0-pre"}
-ckb-db = { path = "../../db", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../dao/utils", version = "= 0.44.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.44.0-pre" }
+ckb-types = {path = "../types", version = "= 0.100.0-pre"}
+ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../dao/utils", version = "= 0.100.0-pre" }
+ckb-traits = { path = "../../traits", version = "= 0.100.0-pre" }
 lazy_static = "1.3.0"
 faketime = "0.2.0"
-ckb-resource = { path = "../../resource", version = "= 0.44.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.44.0-pre" }
+ckb-resource = { path = "../../resource", version = "= 0.100.0-pre" }
+ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-types"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -11,16 +11,16 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 bitflags = "1.0"
 molecule = "=0.7.1"
-ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.44.0-pre" }
+ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.100.0-pre" }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 bytes = { version="1", features = ["serde"] }
 merkle-cbt = "0.3"
-ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.44.0-pre" }
-ckb-hash = { path = "../hash", version = "= 0.44.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.44.0-pre" }
+ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.100.0-pre" }
+ckb-hash = { path = "../hash", version = "= 0.100.0-pre" }
+ckb-channel = { path = "../channel", version = "= 0.100.0-pre" }
 bit-vec = "0.5.1"
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
-ckb-rational = { path = "../rational", version = "= 0.44.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
+ckb-rational = { path = "../rational", version = "= 0.100.0-pre" }
 once_cell = "1.8.0"
 derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
 

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,20 +9,20 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-script = { path = "../script", version = "= 0.44.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.44.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-script = { path = "../script", version = "= 0.100.0-pre" }
+ckb-pow = { path = "../pow", version = "= 0.100.0-pre" }
 faketime = "0.2.0"
 lru = "0.6.0"
-ckb-traits = { path = "../traits", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.44.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.44.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.44.0-pre" }
-ckb-error = { path = "../error", version = "= 0.44.0-pre" }
+ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
+ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
+ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
+ckb-error = { path = "../error", version = "= 0.100.0-pre" }
 derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
-ckb-verification-traits = { path = "./traits", version = "= 0.44.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.44.0-pre" }
+ckb-verification-traits = { path = "./traits", version = "= 0.100.0-pre" }
+ckb-metrics = { path = "../util/metrics", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.44.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.44.0-pre" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
+ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-contextual"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,25 +9,25 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../../util/types", version = "= 0.44.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.44.0-pre" }
+ckb-types = { path = "../../util/types", version = "= 0.100.0-pre" }
+ckb-store = { path = "../../store", version = "= 0.100.0-pre" }
 faketime = "0.2.0"
 rayon = "1.0"
-ckb-traits = { path = "../../traits", version = "= 0.44.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.44.0-pre" }
-ckb-dao = { path = "../../util/dao", version = "= 0.44.0-pre" }
-ckb-logger = {path = "../../util/logger", version = "= 0.44.0-pre"}
-ckb-reward-calculator= { path = "../../util/reward-calculator", version = "= 0.44.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
+ckb-traits = { path = "../../traits", version = "= 0.100.0-pre" }
+ckb-chain-spec = { path = "../../spec", version = "= 0.100.0-pre" }
+ckb-dao = { path = "../../util/dao", version = "= 0.100.0-pre" }
+ckb-logger = {path = "../../util/logger", version = "= 0.100.0-pre"}
+ckb-reward-calculator= { path = "../../util/reward-calculator", version = "= 0.100.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
 tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
-ckb-async-runtime = { path = "../../util/runtime", version = "= 0.44.0-pre" }
-ckb-verification-traits = { path = "../traits", version = "= 0.44.0-pre" }
-ckb-verification = { path = "..", version = "= 0.44.0-pre" }
-ckb-metrics = { path = "../../util/metrics", version = "= 0.44.0-pre" }
+ckb-async-runtime = { path = "../../util/runtime", version = "= 0.100.0-pre" }
+ckb-verification-traits = { path = "../traits", version = "= 0.100.0-pre" }
+ckb-verification = { path = "..", version = "= 0.100.0-pre" }
+ckb-metrics = { path = "../../util/metrics", version = "= 0.100.0-pre" }
 
 [dev-dependencies]
-ckb-chain = { path = "../../chain", version = "= 0.44.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.44.0-pre" }
-ckb-launcher = { path = "../../util/launcher", version = "= 0.44.0-pre" }
-ckb-test-chain-utils = { path = "../../util/test-chain-utils", version = "= 0.44.0-pre" }
+ckb-chain = { path = "../../chain", version = "= 0.100.0-pre" }
+ckb-shared = { path = "../../shared", version = "= 0.100.0-pre" }
+ckb-launcher = { path = "../../util/launcher", version = "= 0.100.0-pre" }
+ckb-test-chain-utils = { path = "../../util/test-chain-utils", version = "= 0.100.0-pre" }
 rand = "0.7"

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-traits"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -10,4 +10,4 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 bitflags = "1.0"
-ckb-error = { path = "../../error", version = "= 0.44.0-pre" }
+ckb-error = { path = "../../error", version = "= 0.100.0-pre" }

--- a/wasm-build-test/Cargo.toml
+++ b/wasm-build-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-wasm-test"
-version = "0.44.0-pre"
+version = "0.100.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -9,8 +9,8 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.44.0-pre" }
-ckb-script = { path = "../script", version = "= 0.44.0-pre", default-features = false, features = [] }
+ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
+ckb-script = { path = "../script", version = "= 0.100.0-pre", default-features = false, features = [] }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Make the next version stand out since it requires hard fork to deploy.

See commit 56e61f0b419bec6ce29ff77fa1d2bd6f709539e2 for changes not in `Cargo.toml` files.