### PR TITLE
refactor: remove redudant `as_ref`

### DIFF
--- a/util/launcher/src/migrations/add_extra_data_hash.rs
+++ b/util/launcher/src/migrations/add_extra_data_hash.rs
@@ -35,7 +35,7 @@ impl Migration for AddExtraDataHash {
         while !next_key.is_empty() {
             let mut wb = db.new_write_batch();
             let mut cell_data_migration = |key: &[u8], value: &[u8]| -> Result<()> {
-                let data_hash = if !value.as_ref().is_empty() {
+                let data_hash = if !value.is_empty() {
                     let reader = packed::CellDataEntryReader::from_slice_should_be_ok(value);
                     reader.output_data_hash().as_slice()
                 } else {


### PR DESCRIPTION
The redudant `as_ref` also causes crates publish failure that the
compiler cannot resolve the type `T` in `AsRef<T>`.