### PR TITLE
feat: remove old version peer from peer store on fork

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -670,7 +670,7 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
                     match self.network_state.accept_peer(&session_context) {
                         Ok(Some(evicted_peer)) => {
                             debug!(
-                                "evict peer (disonnect it), {} => {}",
+                                "evict peer (disconnect it), {} => {}",
                                 evicted_peer.session_id, evicted_peer.connected_addr,
                             );
                             if let Err(err) = disconnect_with_message(

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -108,7 +108,7 @@ impl PeerRegistry {
                 return Err(PeerError::ReachMaxOutboundLimit.into());
             }
         }
-        peer_store.add_connected_peer(remote_addr.clone(), session_type)?;
+        peer_store.add_connected_peer(remote_addr.clone(), session_type);
         let peer = Peer::new(session_id, session_type, remote_addr, is_whitelist);
         self.peers.insert(session_id, peer);
         Ok(evicted_peer)


### PR DESCRIPTION
1. Remove the behavior of joining the peer store when the session is established, and now only operate the peer store after the identify or feeler is successfully established 
2. After the fork switch, the non-latest version of the node information will be slowly cleaned up, and no longer added to the peer store 
3. Remove unnecessary runtime judgment `RefCell` 