### PR TITLE
fix: fix the status marking problem of header sync

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -46,7 +46,7 @@ pub const NOT_IBD_BLOCK_FETCH_TOKEN: u64 = 2;
 pub const TIMEOUT_EVICTION_TOKEN: u64 = 3;
 pub const NO_PEER_CHECK_TOKEN: u64 = 255;
 
-const SYNC_NOTIFY_INTERVAL: Duration = Duration::from_millis(200);
+const SYNC_NOTIFY_INTERVAL: Duration = Duration::from_secs(1);
 const IBD_BLOCK_FETCH_INTERVAL: Duration = Duration::from_millis(40);
 const NOT_IBD_BLOCK_FETCH_INTERVAL: Duration = Duration::from_millis(200);
 
@@ -503,13 +503,11 @@ impl Synchronizer {
             }
             {
                 if let Some(mut peer_state) = self.peers().state.get_mut(&peer) {
-                    if !peer_state.sync_started() {
-                        peer_state.start_sync(HeadersSyncController::from_header(&tip));
-                        self.shared()
-                            .state()
-                            .n_sync_started()
-                            .fetch_add(1, Ordering::Release);
-                    }
+                    peer_state.start_sync(HeadersSyncController::from_header(&tip));
+                    self.shared()
+                        .state()
+                        .n_sync_started()
+                        .fetch_add(1, Ordering::Release);
                 }
             }
 
@@ -544,7 +542,7 @@ impl Synchronizer {
                             || state.peer_flags.is_whitelist
                             || state.peer_flags.is_protect
                     }
-                    IBDState::Out => state.sync_started(),
+                    IBDState::Out => state.started_or_tip_synced(),
                 }
             })
             .map(|kv_pair| *kv_pair.key())

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -490,6 +490,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(CellBeingCellDepThenSpentInSameBlockTestSubmitBlock),
         Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate),
         Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple),
+        Box::new(HeaderSyncCycle),
         // Test hard fork features
         Box::new(CheckAbsoluteEpochSince),
         Box::new(CheckRelativeEpochSince),


### PR DESCRIPTION
There has always been a problem with the header sync protocol. When only the sync protocol is enabled, there may be a relatively large delay in obtaining the latest block. This is caused by incorrect state marking. This PR introduces a new state. Try to fix this problem.

The action of header sync is not completed at one time. It needs to be updated in real-time during the entire connection process. It cannot be considered that this node is always at the highest just because it is synchronized to the highest one time. That is to say, the completed state of sync should be dynamically converted to need sync again. 

The `TipSynced` status indicates that this node has synchronized the headers and will try to synchronize again after 28s. At the same time, such a node can be used as the request object of `Getblocks`

`Suspend` and `TipSynced` are not exactly the same. Suspend thinks that the node may have some problems, such as being in the ibd state and suspending the sync request to it. Such a node cannot be used as the request object of the sync block, and it does not need to be based on the frequency of the block time to detection status 