### PR TITLE
chore: panic if the database is corrupted

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -24,5 +24,10 @@ pub type Col = &'static str;
 pub type Result<T> = result::Result<T, Error>;
 
 fn internal_error<S: Display + Debug + Sync + Send + 'static>(reason: S) -> Error {
-    InternalErrorKind::Database.reason(reason).into()
+    let message = reason.to_string();
+    if message.starts_with("Corruption:") {
+        InternalErrorKind::Database.reason(message).into()
+    } else {
+        InternalErrorKind::DataCorrupted.reason(message).into()
+    }
 }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -10,6 +10,7 @@ mod relayer;
 mod status;
 mod synchronizer;
 mod types;
+mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -1,0 +1,36 @@
+use ckb_error::{Error as CKBError, ErrorKind, InternalError, InternalErrorKind};
+use failure::Error as FailureError;
+
+/// Returns whether the error's kind is `InternalErrorKind::Database`
+///
+/// ### Panic
+///
+/// Panic if the error kind is `InternalErrorKind::DataCorrupted`.
+/// If the database is corrupted, panic is better than handle it silently.
+pub(crate) fn is_ckb_db_error(error: &CKBError) -> bool {
+    if *error.kind() == ErrorKind::Internal {
+        let error_kind = error
+            .downcast_ref::<InternalError>()
+            .expect("error kind checked")
+            .kind();
+        if *error_kind == InternalErrorKind::DataCorrupted {
+            panic!("{}", error)
+        } else {
+            return *error_kind == InternalErrorKind::Database;
+        }
+    }
+    false
+}
+
+/// Returns whether the error's kind is `InternalErrorKind::Database`
+///
+/// ### Panic
+///
+/// Panic if the error kind is `InternalErrorKind::DataCorrupted`.
+/// If the database is corrupted, panic is better than handle it silently.
+pub(crate) fn is_failure_db_error(error: &FailureError) -> bool {
+    if let Some(ref error) = error.downcast_ref::<CKBError>() {
+        return is_ckb_db_error(error);
+    }
+    false
+}


### PR DESCRIPTION
Fix the issue posted by @doitian in https://github.com/nervosnetwork/ckb/issues/2855#issuecomment-884140994.

Since CI scripts in old `rc/v*` branches couldn't work, I ran tests in my laptop:
- Rustfmt, clippy, hashes test, bench test, unit tests and integration tests are passed.
- Cargo-deny and wasm test are failed.