### PR TITLE
chore: panic if the database is corrupted

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -138,7 +138,7 @@ impl RocksDB {
                         See https://github.com/facebook/rocksdb/wiki/RocksDB-Repairer for detail",
                         err_str
                     );
-                    Err(internal_error("DB corrupted"))
+                    Err(internal_error(err_str))
                 } else {
                     Err(internal_error(format!(
                         "failed to open the database: {}",

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -28,5 +28,10 @@ pub use rocksdb::{
 pub type Result<T> = result::Result<T, Error>;
 
 fn internal_error<S: fmt::Display>(reason: S) -> Error {
-    InternalErrorKind::Database.other(reason).into()
+    let message = reason.to_string();
+    if message.starts_with("Corruption:") {
+        InternalErrorKind::Database.other(message).into()
+    } else {
+        InternalErrorKind::DataCorrupted.other(message).into()
+    }
 }


### PR DESCRIPTION
Fix the issue posted by @doitian in https://github.com/nervosnetwork/ckb/issues/2855#issuecomment-884140994.

Since CI scripts in old `rc/v*` branches couldn't work, I ran tests in my laptop:
- Rustfmt, clippy, hashes test, wasm test, bench test, unit tests and integration tests are passed.
- Cargo-deny is failed.