### PR TITLE
chore: let a constructor for script error to be public so as to write tests

### DIFF
--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -97,7 +97,8 @@ impl fmt::Display for TransactionScriptError {
 }
 
 impl ScriptError {
-    pub(crate) fn validation_failure(script: &Script, exit_code: i8) -> ScriptError {
+    /// Creates a script error originated the script and its exit code.
+    pub fn validation_failure(script: &Script, exit_code: i8) -> ScriptError {
         let url_path = match ScriptHashType::try_from(script.hash_type()).expect("checked data") {
             ScriptHashType::Data | ScriptHashType::Data1 => {
                 format!("by-data-hash/{:x}", script.code_hash())


### PR DESCRIPTION
Original issue was posted by @mohanson: he wanted to `assert` script errors but he didn't find any API.