### PR TITLE
fix(hardfork): built-in miner shouldn't ignore the extension field in block templates

### DIFF
--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -123,7 +123,11 @@ impl Miner {
                 .raw(raw_header)
                 .nonce(nonce.pack())
                 .build();
-            let block = work.block.as_builder().header(header).build().into_view();
+            let block = work
+                .block
+                .as_advanced_builder()
+                .header(header.into_view())
+                .build();
             let block_hash = block.hash();
             if self.stderr_is_tty {
                 debug!("Found! #{} {:#x}", block.number(), block_hash);

--- a/util/types/src/core/advanced_builders.rs
+++ b/util/types/src/core/advanced_builders.rs
@@ -524,6 +524,7 @@ impl packed::Block {
                     .collect::<Vec<_>>(),
             )
             .proposals(self.proposals().into_iter().collect::<Vec<_>>())
+            .extension(self.extension())
     }
 }
 


### PR DESCRIPTION
### Issue

The built-in miner will ignore the extension field in block templates.

### Reason

When call `as_builder()` to convert a `Block` to a `BlockBuilder`, all extra fields will be ignored, because the generated code of `BlockBuilder` couldn't know any about extra fields.

And the extension field is an extra field on the molecule-serialized `struct Block`, it will be ignored, too.

### Solution

We already have the advanced `Block` builder, which is not generated.

The `as_advanced_builder` will handle the extension field.

### How to reproduce the issue and test the solution?

- Set the `extension` in the [`TxPoolService::build_block_template(..)`](https://github.com/nervosnetwork/ckb/blob/fb27f98b699768f6723b11b904abeacf8fae093a/tx-pool/src/process.rs#L305) to the follow value:
    ```rust
    let extension = if candidate_number % 2 == 0 {
        let bytes: Bytes = format!("block number = {}", candidate_number).as_bytes().pack();
        Some(bytes.into())
    } else {
        None
    };
    ```

- Start a dev chain with [`func = "Eaglesong"`](https://github.com/nervosnetwork/ckb/blob/fb27f98b699768f6723b11b904abeacf8fae093a/resource/specs/dev.toml#L107) and run a built-in miner.

- Check the extension field in all blocks.