### PR TITLE
fix: don't panic when the database is created by a higher version executable binary

### DIFF
--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -5,6 +5,7 @@ use ckb_db::{ReadOnlyDB, RocksDB};
 use ckb_db_migration::{DefaultMigration, Migrations};
 use ckb_db_schema::{COLUMNS, COLUMN_META};
 use ckb_error::Error;
+use std::cmp::Ordering;
 use std::path::PathBuf;
 
 const INIT_DB_VERSION: &str = "20191127135521";
@@ -37,8 +38,15 @@ impl Migrate {
         ReadOnlyDB::open_cf(&self.path, vec![COLUMN_META])
     }
 
-    /// Return true if migration is required
-    pub fn check(&self, db: &ReadOnlyDB) -> bool {
+    /// Check if database's version is matched with the executable binary version.
+    ///
+    /// Returns
+    /// - Less: The database version is less than the matched version of the executable binary.
+    ///   Requires migration.
+    /// - Equal: The database version is matched with the executable binary version.
+    /// - Greater: The database version is greater than the matched version of the executable binary.
+    ///   Requires upgrade the executable binary.
+    pub fn check(&self, db: &ReadOnlyDB) -> Ordering {
         self.migrations.check(&db)
     }
 

--- a/util/launcher/src/shared_builder.rs
+++ b/util/launcher/src/shared_builder.rs
@@ -27,6 +27,7 @@ use ckb_types::core::HeaderView;
 use ckb_types::packed::Byte32;
 use ckb_verification::cache::init_cache;
 use p2p::SessionId as PeerIndex;
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -51,43 +52,48 @@ pub fn open_or_create_db(
 ) -> Result<RocksDB, ExitCode> {
     let migrate = Migrate::new(&config.path);
 
-    let mut db_exist = false;
+    let read_only_db = migrate.open_read_only_db().map_err(|e| {
+        eprintln!("migrate error {}", e);
+        ExitCode::Failure
+    })?;
 
-    // migration prompt
-    {
-        let read_only_db = migrate.open_read_only_db().map_err(|e| {
-            eprintln!("migrate error {}", e);
-            ExitCode::Failure
-        })?;
-
-        if let Some(db) = read_only_db {
-            db_exist = true;
-
-            if migrate.require_expensive(&db) {
+    if let Some(db) = read_only_db {
+        match migrate.check(&db) {
+            Ordering::Greater => {
                 eprintln!(
-                    "For optimal performance, CKB wants to migrate the data into new format.\n\
-                    You can use the old version CKB if you don't want to do the migration.\n\
-                    We strongly recommended you to use the latest stable version of CKB, \
-                    since the old versions may have unfixed vulnerabilities.\n\
-                    Run `\"{}\" migrate -C \"{}\"` and confirm by typing \"YES\" to migrate the data.\n\
-                    We strongly recommend that you backup the data directory before migration.",
-                    bin_name,
-                    root_dir.display()
+                    "The database is created by a higher version CKB executable binary, \n\
+                     so that the current CKB executable binary couldn't open this database.\n\
+                     Please download the latest CKB executable binary."
                 );
-                return Err(ExitCode::Failure);
+                Err(ExitCode::Failure)
+            }
+            Ordering::Equal => Ok(RocksDB::open(config, COLUMNS)),
+            Ordering::Less => {
+                if migrate.require_expensive(&db) {
+                    eprintln!(
+                        "For optimal performance, CKB wants to migrate the data into new format.\n\
+                        You can use the old version CKB if you don't want to do the migration.\n\
+                        We strongly recommended you to use the latest stable version of CKB, \
+                        since the old versions may have unfixed vulnerabilities.\n\
+                        Run `\"{}\" migrate -C \"{}\"` and confirm by typing \"YES\" to migrate the data.\n\
+                        We strongly recommend that you backup the data directory before migration.",
+                        bin_name,
+                        root_dir.display()
+                    );
+                    Err(ExitCode::Failure)
+                } else {
+                    Ok(RocksDB::open(config, COLUMNS))
+                }
             }
         }
-    }
-
-    let db = RocksDB::open(config, COLUMNS);
-    if !db_exist {
+    } else {
+        let db = RocksDB::open(config, COLUMNS);
         migrate.init_db_version(&db).map_err(|e| {
             eprintln!("migrate init_db_version error {}", e);
             ExitCode::Failure
         })?;
+        Ok(db)
     }
-
-    Ok(db)
 }
 
 impl SharedBuilder {


### PR DESCRIPTION
### Commits

- fix: don't panic when the database is created by a higher version executable binary

- fix: the sub-command `run` shouldn't skip the fast migrations

  This bug doesn't affect any old versions because there is no fast migrations in old versions.

  Ref: [What are fast migrations?](https://github.com/nervosnetwork/ckb/pull/2571#issuecomment-781775665).