### PR TITLE
chore(hardfork): bump db migrate version for the new column family of block extension data

### DIFF
--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -24,6 +24,7 @@ impl Migrate {
         migrations.add_migration(Box::new(migrations::CellMigration));
         migrations.add_migration(Box::new(migrations::AddNumberHashMapping));
         migrations.add_migration(Box::new(migrations::AddExtraDataHash));
+        migrations.add_migration(Box::new(migrations::AddBlockExtensionColumnFamily));
 
         Migrate {
             migrations,

--- a/util/launcher/src/migrations/add_block_extension_cf.rs
+++ b/util/launcher/src/migrations/add_block_extension_cf.rs
@@ -1,0 +1,25 @@
+use ckb_db::{Result, RocksDB};
+use ckb_db_migration::{Migration, ProgressBar};
+use std::sync::Arc;
+
+pub struct AddBlockExtensionColumnFamily;
+
+const VERSION: &str = "20210727100000";
+
+impl Migration for AddBlockExtensionColumnFamily {
+    fn migrate(
+        &self,
+        db: RocksDB,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<RocksDB> {
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        VERSION
+    }
+
+    fn expensive(&self) -> bool {
+        false
+    }
+}

--- a/util/launcher/src/migrations/mod.rs
+++ b/util/launcher/src/migrations/mod.rs
@@ -1,8 +1,10 @@
+mod add_block_extension_cf;
 mod add_extra_data_hash;
 mod add_number_hash_mapping;
 mod cell;
 mod table_to_struct;
 
+pub use add_block_extension_cf::AddBlockExtensionColumnFamily;
 pub use add_extra_data_hash::AddExtraDataHash;
 pub use add_number_hash_mapping::AddNumberHashMapping;
 pub use cell::CellMigration;


### PR DESCRIPTION
This PR is useless, unless the PR #2877 was backported to branch "rc/v0.43".