### PR TITLE
doc: resolve todos for ckb2021

### DIFF
--- a/script/src/ill_transaction_checker.rs
+++ b/script/src/ill_transaction_checker.rs
@@ -33,8 +33,9 @@ impl<'a> IllTransactionChecker<'a> {
         let proposal_window = self.consensus.tx_proposal_window();
         let epoch_number = self.tx_env.epoch_number(proposal_window);
         let hardfork_switch = self.consensus.hardfork_switch();
-        // TODO ckb2021 require-confirmation We couldn't known if user run the code in vm v0 or vm v1.
+        // Assume that after ckb2021 is activated, developers will only upload code for vm v1.
         if !hardfork_switch.is_vm_version_1_and_syscalls_2_enabled(epoch_number) {
+            // IllTransactionChecker is only for vm v0
             for (i, data) in self.tx.outputs_data().into_iter().enumerate() {
                 IllScriptChecker::new(&data.raw_data(), i).check()?;
             }

--- a/test/src/specs/hardfork/v2021/vm_version.rs
+++ b/test/src/specs/hardfork/v2021/vm_version.rs
@@ -16,7 +16,6 @@ use ckb_types::{
 };
 use std::fmt;
 
-// TODO ckb2021 how to test malformed hash type?
 const RPC_MAX_VM_VERSION: u8 = 1;
 const MAX_VM_VERSION: u8 = 1;
 

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -642,7 +642,6 @@ pub struct Header {
     ///
     /// It is all zeros when `proposals` is empty, or the hash on all the bytes concatenated together.
     pub proposals_hash: H256,
-    // TODO ckb2021 Update the rfc number and fix the link, after the proposal is merged.
     /// The hash on `uncles` and extension in the block body.
     ///
     /// The uncles hash is all zeros when `uncles` is empty, or the hash on all the uncle header hashes concatenated together.


### PR DESCRIPTION
* `IllTransactionChecker`: added comments
* `TODO ckb2021 how to test malformed hash type?`: recorded in backlog
* `// TODO ckb2021 Update the rfc number and fix the link, after the proposal is merged.`: already updated.

There are two todos remaining for testnet and mainnet activation.