### PR TITLE
fix: don't panic when the database is created by a higher version executable binary

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -1566,11 +1566,7 @@ mod tests {
             let peer_state = peers.state.read();
             // Protected peer 0 still in sync state
             assert_eq!(
-                peers
-                    .state
-                    .get(&sync_protected_peer)
-                    .unwrap()
-                    .sync_started(),
+                peer_state.get(&sync_protected_peer).unwrap().sync_started(),
                 true
             );
             assert_eq!(
@@ -1663,11 +1659,7 @@ mod tests {
             let peer_state = peers.state.read();
             // Protected peer 0 chain_sync timeout
             assert_eq!(
-                peers
-                    .state
-                    .get(&sync_protected_peer)
-                    .unwrap()
-                    .sync_started(),
+                peer_state.get(&sync_protected_peer).unwrap().sync_started(),
                 false
             );
             assert_eq!(

--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -5,6 +5,7 @@ use ckb_db::{ReadOnlyDB, RocksDB};
 use ckb_db_migration::{DefaultMigration, Migrations};
 use ckb_db_schema::{COLUMNS, COLUMN_META};
 use ckb_error::Error;
+use std::cmp::Ordering;
 use std::path::PathBuf;
 
 const INIT_DB_VERSION: &str = "20191127135521";
@@ -37,8 +38,15 @@ impl Migrate {
         ReadOnlyDB::open_cf(&self.path, vec![COLUMN_META])
     }
 
-    /// Return true if migration is required
-    pub fn check(&self, db: &ReadOnlyDB) -> bool {
+    /// Check if database's version is matched with the executable binary version.
+    ///
+    /// Returns
+    /// - Less: The database version is less than the matched version of the executable binary.
+    ///   Requires migration.
+    /// - Equal: The database version is matched with the executable binary version.
+    /// - Greater: The database version is greater than the matched version of the executable binary.
+    ///   Requires upgrade the executable binary.
+    pub fn check(&self, db: &ReadOnlyDB) -> Ordering {
         self.migrations.check(&db)
     }
 


### PR DESCRIPTION
#### Summary

Backport 1st commit in #2877 to branch "rc/v0.43".

Why no 2nd commit: because there is no fast migrations before "v0.100.0".

#### How to test this feature?
- Build ckb v0.100.0 with the patch #2878.
- Build ckb v0.43.1 with this patch.
- Use patched ckb v0.43.1 to initialize a work directory.
- Run patched ckb v0.100.0 on the previous work directory several minutes.
- Run patched ckb v0.43.1 on the previous work directory to check the error message.
p.s. I did this test in my laptop before pull request.

#### CI Tests

Since CI scripts in old `rc/v*` branches couldn't work, I ran tests in my laptop:
- Rustfmt, clippy, hashes test, wasm test, bench test, unit tests and integration tests are passed.
- Cargo-deny is failed.

