### PR TITLE
test(hardfork): refactor and add more testcases for cell deps

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -492,16 +492,13 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple),
         Box::new(HeaderSyncCycle),
         // Test hard fork features
+        Box::new(CheckCellDeps),
         Box::new(CheckAbsoluteEpochSince),
         Box::new(CheckRelativeEpochSince),
         Box::new(CheckBlockExtension),
         Box::new(CheckVmVersion),
         Box::new(CheckVmBExtension),
         Box::new(ImmatureHeaderDeps),
-        Box::new(DuplicateCellDepsForDataHashTypeLockScript),
-        Box::new(DuplicateCellDepsForDataHashTypeTypeScript),
-        Box::new(DuplicateCellDepsForTypeHashTypeLockScript),
-        Box::new(DuplicateCellDepsForTypeHashTypeTypeScript),
     ];
     specs.shuffle(&mut thread_rng());
     specs

--- a/test/src/specs/hardfork/v2021/mod.rs
+++ b/test/src/specs/hardfork/v2021/mod.rs
@@ -5,10 +5,7 @@ mod since;
 mod vm_b_extension;
 mod vm_version;
 
-pub use cell_deps::{
-    DuplicateCellDepsForDataHashTypeLockScript, DuplicateCellDepsForDataHashTypeTypeScript,
-    DuplicateCellDepsForTypeHashTypeLockScript, DuplicateCellDepsForTypeHashTypeTypeScript,
-};
+pub use cell_deps::CheckCellDeps;
 pub use extension::CheckBlockExtension;
 pub use header_deps::ImmatureHeaderDeps;
 pub use since::{CheckAbsoluteEpochSince, CheckRelativeEpochSince};

--- a/test/src/util/check.rs
+++ b/test/src/util/check.rs
@@ -52,6 +52,18 @@ pub fn assert_epoch_should_less_than(node: &Node, number: u64, index: u64, lengt
     );
 }
 
+pub fn assert_epoch_should_greater_than(node: &Node, number: u64, index: u64, length: u64) {
+    let tip_header: HeaderView = node.rpc_client().get_tip_header().into();
+    let tip_epoch = tip_header.epoch();
+    let target_epoch = EpochNumberWithFraction::new(number, index, length);
+    assert!(
+        tip_epoch > target_epoch,
+        "current tip epoch is {}, but expect epoch greater than {}",
+        tip_epoch,
+        target_epoch
+    );
+}
+
 pub fn assert_submit_block_fail(node: &Node, block: &BlockView, message: &str) {
     let result = node
         .rpc_client()


### PR DESCRIPTION
The old test specs have `18+18+34+34 = 104` testcases in total.

Current test spec has `4*19*(2*2*2+1) = 684` testcases:
- 4 Chain Status:
  - CKB v2019, far away from the start of v2021.
  - CKB v2019, the last block in v2019 (boundary test).
  - CKB v2021, the first block in v2021(boundary test).
  - CKB v2021, far away from the start of v2021.
- 19 Cell Deps Cases.
  The details can be found in comments.
- 3 Cell Status: where is the cell whose scripts requires the cell deps?
  - The script is in an input cell.
  - The script is in an output cell.
  - No cell requires those cell deps.
- 2 Script Type
  - Lock script.
  - Type script.
- 2 Script Hash Type
  - Data hash-type.
  - Type hash-type.