### PR TITLE
refactor: remove impl cell_provider on store

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -735,8 +735,7 @@ impl ChainService {
                     };
 
                     let resolved = {
-                        let txn_cell_provider = txn.cell_provider();
-                        let cell_provider = OverlayCellProvider::new(&block_cp, &txn_cell_provider);
+                        let cell_provider = OverlayCellProvider::new(&block_cp, txn);
                         transactions
                             .iter()
                             .cloned()

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -115,6 +115,7 @@ fn test_genesis_transaction_spend() {
     assert_eq!(
         shared
             .snapshot()
+            .as_ref()
             .cell(&OutPoint::new(genesis_tx_hash, 0), false),
         CellStatus::Unknown
     );
@@ -142,6 +143,7 @@ fn test_transaction_spend_in_same_block() {
         assert_eq!(
             shared
                 .snapshot()
+                .as_ref()
                 .cell(&OutPoint::new(hash.to_owned().to_owned(), 0), false),
             CellStatus::Unknown
         );
@@ -171,12 +173,16 @@ fn test_transaction_spend_in_same_block() {
     assert_eq!(
         shared
             .snapshot()
+            .as_ref()
             .cell(&OutPoint::new(last_cellbase_hash, 0), false),
         CellStatus::Unknown
     );
 
     assert_eq!(
-        shared.snapshot().cell(&OutPoint::new(tx1_hash, 0), false),
+        shared
+            .snapshot()
+            .as_ref()
+            .cell(&OutPoint::new(tx1_hash, 0), false),
         CellStatus::Unknown
     );
 
@@ -189,6 +195,7 @@ fn test_transaction_spend_in_same_block() {
     assert_eq!(
         shared
             .snapshot()
+            .as_ref()
             .cell(&OutPoint::new(tx2_hash.clone(), 0), false),
         CellStatus::live_cell(CellMeta {
             cell_output: tx2_output,
@@ -375,7 +382,7 @@ fn test_genesis_transaction_fetch() {
     let (_chain_controller, shared, _parent) = start_chain(Some(consensus));
 
     let out_point = OutPoint::new(root_hash, 0);
-    let state = shared.snapshot().cell(&out_point, false);
+    let state = shared.snapshot().as_ref().cell(&out_point, false);
     assert!(state.is_live());
 }
 

--- a/chain/src/tests/cell.rs
+++ b/chain/src/tests/cell.rs
@@ -138,7 +138,7 @@ fn test_block_cells_update() {
     db_txn.attach_block(&block).unwrap();
 
     attach_block_cell(&db_txn, &block).unwrap();
-    let txn_cell_provider = db_txn.cell_provider();
+    let txn_cell_provider = &db_txn;
 
     // ensure tx0-2 outputs is spent after attach_block_cell
     for tx in block.transactions()[1..4].iter() {

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -5,7 +5,6 @@ use ckb_build_info::Version;
 use ckb_launcher::Launcher;
 use ckb_logger::info;
 use ckb_network::{DefaultExitHandler, ExitHandler};
-use ckb_store::ChainStore;
 use ckb_types::core::cell::setup_system_cell_cache;
 
 pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), ExitCode> {
@@ -26,7 +25,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     setup_system_cell_cache(
         shared.consensus().genesis_block(),
-        &shared.store().cell_provider(),
+        shared.snapshot().as_ref(),
     )
     .expect("SYSTEM_CELL cache init once");
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1406,7 +1406,11 @@ impl ChainRpc for ChainRpcImpl {
     }
 
     fn get_live_cell(&self, out_point: OutPoint, with_data: bool) -> Result<CellWithStatus> {
-        let cell_status = self.shared.snapshot().cell(&out_point.into(), with_data);
+        let cell_status = self
+            .shared
+            .snapshot()
+            .as_ref()
+            .cell(&out_point.into(), with_data);
         Ok(cell_status.into())
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In principle，we should only impl cell_provider on snapshot, not the store directly.

### What is changed and how it works?

Remove impl cell_provider on store

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```