### PR TITLE
chore: enable `update_base_for_deletes` in bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,3 +2,4 @@ status = [ "ci" ]
 
 timeout_sec = 7200
 delete_merged_branches = true
+update_base_for_deletes = true


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Say there are two PRs, PR 1 asks for merging branch pr/1 into develop, and PR 2 requests merging pr/2 into pr/1.

Because we have enabled `delete_merged_branches`, bors will delete branch pr/1 after PR 1 is merged, which deprecates PR 2.

### What is changed and how it works?

What's Changed:

Enable `update_base_for_deletes` in bors.

> If turned on, and if delete_merged_branches is also turned on, then when
> a pull request is merged and its base branch is about to be deleted, any
> other pull requests made against the base branch will be fixed up.
>
> -- https://bors.tech/documentation/#:~:text=update_base_for_deletes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
