### PR TITLE
test: use grcov to generate coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ cobertura.xml
 
 # proptest
 **/proptest-regressions
+
+# generated coverage report files
+*.profraw
+lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ cobertura.xml
 
 # generated coverage report files
 *.profraw
-lcov.info
+lcov-unit-test.info
+lcov-integration-test.info


### PR DESCRIPTION
This PR changed the coverage report tool from tarpaulin to [grcov](https://github.com/mozilla/grcov), grcov is more simple to set up and it provides reporting for branches and calls count. Just run `make cov`, a `lcov-unit-test.info` file will be genearted in the root path. You can use some IDE [extension](https://github.com/ryanluker/vscode-coverage-gutters) to view the generated report, for example: 

![image](https://user-images.githubusercontent.com/8990/128995539-dbef3bc6-283f-40df-9781-46a225dfcbc5.png)
