### PR TITLE
fix(hardfork): should always check the extension field when reconstruct blocks

### DIFF
--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -514,14 +514,27 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
 
         let uncles = self.get_block_uncles(hash)?;
         let proposals = self.get_block_proposal_txs_ids(hash)?;
-        Some(
+        let extension_opt = self.get_block_extension(hash);
+
+        let block = if let Some(extension) = extension_opt {
+            packed::BlockV1::new_builder()
+                .header(header)
+                .uncles(uncles.data())
+                .transactions(transactions)
+                .proposals(proposals)
+                .extension(extension)
+                .build()
+                .as_v0()
+        } else {
             packed::Block::new_builder()
                 .header(header)
                 .uncles(uncles.data())
                 .transactions(transactions)
                 .proposals(proposals)
-                .build(),
-        )
+                .build()
+        };
+
+        Some(block)
     }
 
     /// TODO(doc): @quake

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -477,13 +477,24 @@ impl Relayer {
                 .into_iter()
                 .collect::<Option<Vec<_>>>()
                 .expect("missing checked, should not fail");
-            let block = packed::Block::new_builder()
-                .header(compact_block.header())
-                .uncles(uncles.pack())
-                .transactions(txs.into_iter().map(|tx| tx.data()).pack())
-                .proposals(compact_block.proposals())
-                .build()
-                .into_view();
+            let block = if let Some(extension) = compact_block.extension() {
+                packed::BlockV1::new_builder()
+                    .header(compact_block.header())
+                    .uncles(uncles.pack())
+                    .transactions(txs.into_iter().map(|tx| tx.data()).pack())
+                    .proposals(compact_block.proposals())
+                    .extension(extension)
+                    .build()
+                    .as_v0()
+            } else {
+                packed::Block::new_builder()
+                    .header(compact_block.header())
+                    .uncles(uncles.pack())
+                    .transactions(txs.into_iter().map(|tx| tx.data()).pack())
+                    .proposals(compact_block.proposals())
+                    .build()
+            }
+            .into_view();
 
             debug_target!(
                 crate::LOG_TARGET_RELAY,


### PR DESCRIPTION
### What problem does this PR solve?

Forget the extension fields when reconstruct blocks.

Only the relay protocol is broken, the sync protocol works well, so the chain works well.

The only things could be observed is that there are uncles in logs, but no real uncles in blocks.

### What is changed and how it works?

I checked all `Block::new_builder(..)`, and found 2 locations.

### Release note

This bug is not in  `version < 0.100`, so no release note is needed for the next release (`v0.100.0`).

```release-note
None
```