### PR TITLE
chore(hardfork): size of the block extension field should be included in block size limit

### DIFF
--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -131,22 +131,40 @@ impl BlockAssembler {
         cellbase: Transaction,
         uncles: &[UncleBlockView],
         proposals: &HashSet<ProposalShortId>,
+        extension_opt: Option<packed::Bytes>,
     ) -> Result<usize, AnyError> {
         let empty_dao = packed::Byte32::default();
         let raw_header = packed::RawHeader::new_builder().dao(empty_dao).build();
         let header = packed::Header::new_builder().raw(raw_header).build();
-        let block = packed::Block::new_builder()
-            .header(header)
-            .transactions(vec![cellbase].pack())
-            .uncles(uncles.iter().map(|u| u.data()).pack())
-            .proposals(
-                proposals
-                    .iter()
-                    .map(ToOwned::to_owned)
-                    .collect::<Vec<_>>()
-                    .pack(),
-            )
-            .build();
+        let block = if let Some(extension) = extension_opt {
+            packed::BlockV1::new_builder()
+                .header(header)
+                .transactions(vec![cellbase].pack())
+                .uncles(uncles.iter().map(|u| u.data()).pack())
+                .proposals(
+                    proposals
+                        .iter()
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                        .pack(),
+                )
+                .extension(extension)
+                .build()
+                .as_v0()
+        } else {
+            packed::Block::new_builder()
+                .header(header)
+                .transactions(vec![cellbase].pack())
+                .uncles(uncles.iter().map(|u| u.data()).pack())
+                .proposals(
+                    proposals
+                        .iter()
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                        .pack(),
+                )
+                .build()
+        };
         let serialized_size = block.serialized_size_without_uncle_proposals();
         let bytes_limit = bytes_limit as usize;
         bytes_limit.checked_sub(serialized_size).ok_or_else(|| {

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -29,7 +29,7 @@ use ckb_types::{
         BlockView, Capacity, Cycle, EpochExt, HeaderView, ScriptHashType, TransactionView,
         UncleBlockView, Version,
     },
-    packed::{Byte32, CellbaseWitness, OutPoint, ProposalShortId, Script},
+    packed::{Byte32, Bytes, CellbaseWitness, OutPoint, ProposalShortId, Script},
     prelude::*,
 };
 use ckb_util::LinkedHashSet;
@@ -181,6 +181,7 @@ impl TxPoolService {
         max_block_cycles: Cycle,
         cellbase: &TransactionView,
         uncles: &[UncleBlockView],
+        extension_opt: Option<Bytes>,
     ) -> Result<(HashSet<ProposalShortId>, Vec<TxEntry>, u64), AnyError> {
         let guard = self.tx_pool.read().await;
         let uncle_proposals = uncles
@@ -194,6 +195,7 @@ impl TxPoolService {
             cellbase.data(),
             uncles,
             &proposals,
+            extension_opt,
         )?;
 
         let (entries, size, cycles) =
@@ -376,6 +378,7 @@ impl TxPoolService {
                     cycles_limit,
                     &cellbase,
                     &uncles,
+                    None,
                 )
                 .await?;
 

--- a/util/types/src/extension/serialized_size.rs
+++ b/util/types/src/extension/serialized_size.rs
@@ -95,30 +95,76 @@ mod tests {
         let uncle3 = packed::UncleBlock::new_builder()
             .proposals(proposals3)
             .build();
-        let mut empty_uncles = vec![
+        let empty_uncles = vec![
             uncle0.clone(),
             uncle0.clone(),
             uncle0.clone(),
             uncle0.clone(),
         ];
-        let mut uncles = vec![uncle0, uncle1, uncle2, uncle3];
-        loop {
-            let block_with_empty_uncles = packed::Block::new_builder()
-                .uncles(empty_uncles.clone().pack())
-                .build();
-            let block_with_uncles = packed::Block::new_builder()
-                .uncles(uncles.clone().pack())
-                .build();
-            let actual = block_with_uncles.serialized_size_without_uncle_proposals();
-            let actual_empty = block_with_empty_uncles.serialized_size_without_uncle_proposals();
-            let expected = block_with_empty_uncles.as_slice().len();
-            assert_eq!(actual, actual_empty);
-            assert_eq!(actual, expected);
-            if uncles.is_empty() {
-                break;
-            } else {
-                empty_uncles.pop();
-                uncles.pop();
+        let uncles = vec![uncle0, uncle1, uncle2, uncle3];
+        {
+            // without block extension
+            let mut empty_uncles = empty_uncles.clone();
+            let mut uncles = uncles.clone();
+            loop {
+                let block_with_empty_uncles = packed::Block::new_builder()
+                    .uncles(empty_uncles.clone().pack())
+                    .build();
+                let block_with_uncles = packed::Block::new_builder()
+                    .uncles(uncles.clone().pack())
+                    .build();
+                let actual = block_with_uncles.serialized_size_without_uncle_proposals();
+                let actual_empty =
+                    block_with_empty_uncles.serialized_size_without_uncle_proposals();
+                let expected = block_with_empty_uncles.as_slice().len();
+                assert_eq!(actual, actual_empty);
+                assert_eq!(actual, expected);
+                if uncles.is_empty() {
+                    break;
+                } else {
+                    empty_uncles.pop();
+                    uncles.pop();
+                }
+            }
+        }
+        {
+            // with block extension
+            let mut empty_uncles = empty_uncles;
+            let mut uncles = uncles;
+            let extensions: Vec<packed::Bytes> = vec![
+                vec![0u8].pack(),
+                vec![0u8; 24].pack(),
+                vec![0u8; 48].pack(),
+                vec![0u8; 72].pack(),
+                vec![0u8; 96].pack(),
+            ];
+            for extension in extensions {
+                loop {
+                    let block_with_empty_uncles_v1 = packed::BlockV1::new_builder()
+                        .uncles(empty_uncles.clone().pack())
+                        .extension(extension.clone())
+                        .build();
+                    let block_with_empty_uncles = block_with_empty_uncles_v1.as_v0();
+                    let block_with_uncles = packed::BlockV1::new_builder()
+                        .uncles(uncles.clone().pack())
+                        .extension(extension.clone())
+                        .build()
+                        .as_v0();
+                    let actual = block_with_uncles.serialized_size_without_uncle_proposals();
+                    let actual_empty =
+                        block_with_empty_uncles.serialized_size_without_uncle_proposals();
+                    let expected_v1 = block_with_empty_uncles_v1.as_slice().len();
+                    let expected = block_with_empty_uncles.as_slice().len();
+                    assert_eq!(actual, actual_empty);
+                    assert_eq!(actual, expected);
+                    assert_eq!(expected_v1, expected);
+                    if uncles.is_empty() {
+                        break;
+                    } else {
+                        empty_uncles.pop();
+                        uncles.pop();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR do?

- Add some code to count the size of the block extension field when package a block template.

  This code is meaningless currently, since there are no extension in block templates.
  The biggest significance of this code is to ensure that the logic is correct.

- Add tests for the feature: the size of the block extension field should be included in block size limit.

  See the discussion in https://github.com/nervosnetwork/rfcs/pull/224#issuecomment-896763326.

### Release note

```release-note
None
```

