### PR TITLE
fix: Fix miner

### DIFF
--- a/miner/src/client.rs
+++ b/miner/src/client.rs
@@ -4,9 +4,12 @@ use ckb_async_runtime::Handle;
 use ckb_channel::Sender;
 use ckb_error::AnyError;
 use ckb_jsonrpc_types::{Block as JsonBlock, BlockTemplate};
-use ckb_logger::{debug, error, warn};
+use ckb_logger::{debug, error};
 use ckb_stop_handler::{SignalSender, StopHandler};
-use ckb_types::{packed::Block, H256};
+use ckb_types::{
+    packed::{Block, Byte32},
+    H256,
+};
 use futures::prelude::*;
 use hyper::{
     body::{to_bytes, Bytes},
@@ -47,6 +50,7 @@ impl Rpc {
 
         let https = hyper_tls::HttpsConnector::new();
         let client = HttpClient::builder().build(https);
+        let loop_handle = handle.clone();
         handle.spawn(async move {
             loop {
                 tokio::select! {
@@ -63,17 +67,20 @@ impl Rpc {
                             req.headers_mut()
                                 .append(hyper::header::AUTHORIZATION, value);
                         }
-                        let request = match client
-                            .request(req)
-                            .await
-                            .map(|res|res.into_body())
-                        {
-                            Ok(body) => to_bytes(body).await.map_err(RpcError::Http),
-                            Err(err) => Err(RpcError::Http(err)),
-                        };
-                        if sender.send(request).is_err() {
-                            break;
-                        }
+                        let client = client.clone();
+                        loop_handle.spawn(async move {
+                            let request = match client
+                                .request(req)
+                                .await
+                                .map(|res|res.into_body())
+                            {
+                                Ok(body) => to_bytes(body).await.map_err(RpcError::Http),
+                                Err(err) => Err(RpcError::Http(err)),
+                            };
+                            if sender.send(request).is_err() {
+                                error!("rpc response send back error")
+                            }
+                        });
                     },
                     _ = &mut stop_rx => break,
                     else => break
@@ -87,7 +94,11 @@ impl Rpc {
         }
     }
 
-    pub async fn request(&self, method: String, params: Vec<Value>) -> Result<Output, RpcError> {
+    pub fn request(
+        &self,
+        method: String,
+        params: Vec<Value>,
+    ) -> impl Future<Output = Result<Output, RpcError>> {
         let (tx, rev) = oneshot::channel();
 
         let call = MethodCall {
@@ -98,13 +109,17 @@ impl Rpc {
         };
 
         let req = (tx, call);
-        self.sender
-            .send(req)
-            .map_err(|_| RpcError::SendError)
-            .await?;
-        rev.map_err(|_| RpcError::Canceled)
-            .await?
-            .and_then(|chunk| serde_json::from_slice(&chunk).map_err(RpcError::Json))
+        let sender = self.sender.clone();
+        async move {
+            sender
+                .clone()
+                .send(req)
+                .map_err(|_| RpcError::SendError)
+                .await?;
+            rev.map_err(|_| RpcError::Canceled)
+                .await?
+                .and_then(|chunk| serde_json::from_slice(&chunk).map_err(RpcError::Json))
+        }
     }
 }
 
@@ -114,13 +129,18 @@ impl Drop for Rpc {
     }
 }
 
+pub enum Works {
+    New(Work),
+    FailSubmit(Byte32),
+}
+
 /// TODO(doc): @quake
 #[derive(Debug, Clone)]
 pub struct Client {
     /// TODO(doc): @quake
     pub current_work_id: Option<u64>,
     /// TODO(doc): @quake
-    pub new_work_tx: Sender<Work>,
+    pub new_work_tx: Sender<Works>,
     /// TODO(doc): @quake
     pub config: MinerClientConfig,
     /// TODO(doc): @quake
@@ -130,7 +150,7 @@ pub struct Client {
 
 impl Client {
     /// TODO(doc): @quake
-    pub fn new(new_work_tx: Sender<Work>, config: MinerClientConfig, handle: Handle) -> Client {
+    pub fn new(new_work_tx: Sender<Works>, config: MinerClientConfig, handle: Handle) -> Client {
         let uri: Uri = config.rpc_url.parse().expect("valid rpc url");
 
         Client {
@@ -142,35 +162,36 @@ impl Client {
         }
     }
 
-    async fn send_submit_block_request(
+    fn send_submit_block_request(
         &self,
         work_id: &str,
         block: Block,
-    ) -> Result<Output, RpcError> {
+    ) -> impl Future<Output = Result<Output, RpcError>> + 'static + Send {
         let block: JsonBlock = block.into();
         let method = "submit_block".to_owned();
         let params = vec![json!(work_id), json!(block)];
 
-        self.rpc.request(method, params).await
+        self.rpc.clone().request(method, params)
     }
 
     /// TODO(doc): @quake
-    pub fn submit_block(&self, work_id: &str, block: Block) {
+    pub fn submit_block(&self, work_id: &str, block: Block) -> Result<(), RpcError> {
+        let parent = block.header().raw().parent_hash();
         let future = self
             .send_submit_block_request(work_id, block)
-            .and_then(parse_response);
+            .and_then(parse_response::<H256>);
+
         if self.config.block_on_submit {
-            let ret: Result<Option<H256>, RpcError> = self.handle.block_on(future);
-            match ret {
-                Ok(hash) => {
-                    if hash.is_none() {
-                        warn!("submit_block failed");
-                    }
-                }
-                Err(e) => {
+            self.handle.block_on(future).map(|_| ())
+        } else {
+            let sender = self.new_work_tx.clone();
+            self.handle.spawn(async move {
+                if let Err(e) = future.await {
                     error!("rpc call submit_block error: {:?}", e);
+                    sender.send(Works::FailSubmit(parent)).unwrap()
                 }
-            }
+            });
+            Ok(())
         }
     }
 
@@ -227,7 +248,7 @@ impl Client {
 
     fn notify_new_work(&self, block_template: BlockTemplate) -> Result<(), AnyError> {
         let work: Work = block_template.into();
-        self.new_work_tx.send(work)?;
+        self.new_work_tx.send(Works::New(work))?;
         Ok(())
     }
 }

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -23,14 +23,14 @@ pub struct Miner {
     pub pow: Arc<dyn PowEngine>,
     /// TODO(doc): @quake
     pub client: Client,
-    /// TODO(doc): @quake
-    pub works: LruCache<Byte32, Work>,
+    /// Tasks's parent's hash that have already been submitted
+    pub legacy_work: LruCache<Byte32, ()>,
     /// TODO(doc): @quake
     pub worker_controllers: Vec<WorkerController>,
     /// TODO(doc): @quake
     pub work_rx: Receiver<Work>,
     /// TODO(doc): @quake
-    pub nonce_rx: Receiver<(Byte32, u128)>,
+    pub nonce_rx: Receiver<(Byte32, Work, u128)>,
     /// TODO(doc): @quake
     pub pb: ProgressBar,
     /// TODO(doc): @quake
@@ -68,7 +68,7 @@ impl Miner {
         });
 
         Miner {
-            works: LruCache::new(WORK_CACHE_SIZE),
+            legacy_work: LruCache::new(WORK_CACHE_SIZE),
             nonces_found: 0,
             pow,
             client,
@@ -82,17 +82,12 @@ impl Miner {
     }
 
     /// TODO(doc): @quake
-    // remove `allow` tag when https://github.com/crossbeam-rs/crossbeam/issues/404 is solved
-    #[allow(clippy::zero_ptr, clippy::drop_copy)]
     pub fn run(&mut self) {
         loop {
             select! {
                 recv(self.work_rx) -> msg => match msg {
                     Ok(work) => {
-                        let pow_hash= work.block.header().calc_pow_hash();
-                        let (target, _,) = compact_to_target(work.block.header().raw().compact_target().unpack());
-                        self.works.put(pow_hash.clone(), work);
-                        self.notify_workers(WorkerMessage::NewWork{pow_hash, target});
+                        self.submit_work(work);
                     },
                     _ => {
                         error!("work_rx closed");
@@ -100,8 +95,8 @@ impl Miner {
                     },
                 },
                 recv(self.nonce_rx) -> msg => match msg {
-                    Ok((pow_hash, nonce)) => {
-                        self.submit_nonce(pow_hash, nonce);
+                    Ok((pow_hash, work, nonce)) => {
+                        self.submit_nonce(pow_hash, work, nonce);
                         if self.limit != 0 && self.nonces_found >= self.limit {
                             break;
                         }
@@ -115,43 +110,76 @@ impl Miner {
         }
     }
 
-    fn submit_nonce(&mut self, pow_hash: Byte32, nonce: u128) {
-        if let Some(work) = self.works.get(&pow_hash).cloned() {
-            self.notify_workers(WorkerMessage::Stop);
-            let raw_header = work.block.header().raw();
-            let header = Header::new_builder()
-                .raw(raw_header)
-                .nonce(nonce.pack())
-                .build();
-            let block = work
-                .block
-                .as_advanced_builder()
-                .header(header.into_view())
-                .build();
-            let block_hash = block.hash();
-            if self.stderr_is_tty {
-                debug!("Found! #{} {:#x}", block.number(), block_hash);
-            } else {
-                info!("Found! #{} {:#x}", block.number(), block_hash);
-            }
+    fn submit_work(&mut self, work: Work) {
+        let parent_hash = work.block.header().into_view().parent_hash();
+        if !self.legacy_work.contains(&parent_hash) {
+            let pow_hash = work.block.header().calc_pow_hash();
+            let (target, _) =
+                compact_to_target(work.block.header().raw().compact_target().unpack());
+            self.notify_workers(WorkerMessage::NewWork {
+                pow_hash,
+                work,
+                target,
+            });
+        }
+    }
 
-            // submit block and poll new work
-            {
-                self.client
-                    .submit_block(&work.work_id.to_string(), block.data());
-                self.client.try_update_block_template();
-                self.notify_workers(WorkerMessage::Start);
-            }
+    fn submit_nonce(&mut self, pow_hash: Byte32, work: Work, nonce: u128) {
+        self.notify_workers(WorkerMessage::Stop);
+        let raw_header = work.block.header().raw();
+        let header = Header::new_builder()
+            .raw(raw_header)
+            .nonce(nonce.pack())
+            .build();
+        let block = work
+            .block
+            .as_advanced_builder()
+            .header(header.into_view())
+            .build();
+        let block_hash = block.hash();
+        let parent_hash = block.parent_hash();
 
-            // draw progress bar
-            {
-                self.nonces_found += 1;
-                self.pb
-                    .println(format!("Found! #{} {:#x}", block.number(), block_hash));
-                self.pb
-                    .set_message(format!("Total nonces found: {:>3}", self.nonces_found));
-                self.pb.inc(1);
-            }
+        if self.legacy_work.contains(&parent_hash) {
+            info!(
+                "uncle {} pow_hash: {:#x}, header: {}",
+                block.number(),
+                pow_hash,
+                block.header()
+            );
+            self.notify_workers(WorkerMessage::Start);
+            return;
+        } else {
+            info!(
+                "block {} pow_hash: {:#x}, header: {}",
+                block.number(),
+                pow_hash,
+                block.header()
+            );
+        }
+
+        self.legacy_work.put(parent_hash, ());
+        if self.stderr_is_tty {
+            debug!("Found! #{} {:#x}", block.number(), block_hash);
+        } else {
+            info!("Found! #{} {:#x}", block.number(), block_hash);
+        }
+
+        // submit block and poll new work
+        {
+            self.client
+                .submit_block(&work.work_id.to_string(), block.data());
+            self.client.try_update_block_template();
+            self.notify_workers(WorkerMessage::Start);
+        }
+
+        // draw progress bar
+        {
+            self.nonces_found += 1;
+            self.pb
+                .println(format!("Found! #{} {:#x}", block.number(), block_hash));
+            self.pb
+                .set_message(format!("Total nonces found: {:>3}", self.nonces_found));
+            self.pb.inc(1);
         }
     }
 

--- a/miner/src/worker/mod.rs
+++ b/miner/src/worker/mod.rs
@@ -1,6 +1,7 @@
 mod dummy;
 mod eaglesong_simple;
 
+use crate::Work;
 use ckb_app_config::MinerWorkerConfig;
 use ckb_channel::{unbounded, Sender};
 use ckb_logger::error;
@@ -18,7 +19,11 @@ use std::thread;
 pub enum WorkerMessage {
     Stop,
     Start,
-    NewWork { pow_hash: Byte32, target: U256 },
+    NewWork {
+        pow_hash: Byte32,
+        work: Work,
+        target: U256,
+    },
 }
 
 pub struct WorkerController {
@@ -61,7 +66,7 @@ const PROGRESS_BAR_TEMPLATE: &str = "{prefix:.bold.dim} {spinner:.green} [{elaps
 pub fn start_worker(
     pow: Arc<dyn PowEngine>,
     config: &MinerWorkerConfig,
-    nonce_tx: Sender<(Byte32, u128)>,
+    nonce_tx: Sender<(Byte32, Work, u128)>,
     mp: &MultiProgress,
 ) -> WorkerController {
     match config {

--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -51,9 +51,7 @@ rpc_url = "http://127.0.0.1:8114/" # {{
 block_on_submit = true
 
 # block template polling interval in milliseconds
-poll_interval = 1000 # {{
-# dev => poll_interval = 1_000_000_000_000
-# }}
+poll_interval = 1000
 
 [[miner.workers]]
 worker_type = "EaglesongSimple" # {{


### PR DESCRIPTION
### What problem does this PR solve?

1. In the case that the poll interval is small enough, the miner may work on unknown work, which is equivalent to doing useless work(work cache is 32, the channel is unbound, worker get new work just one loop one get)
2. Assuming that miner must be submitted successfully 
3. Miner will submit uncle block 
4. If `block_on_submit` is false, the miner will not submit the block

### Tests

- setup a dev node(test for Dummy)，use miner subcommand for it
- setup a staging node(test for Eaglesong)，use miner subcommand for it
- change `block_on_submit` to false，and `poll_interval` = 200, old miner can't work, the new one works well
- old miner may have uncle block submit, the new one doesn't

### Related changes

Rewritten part of the miner logic 

### Release note

```release-note
None
```

