### PR TITLE
docs(rpc): document that `send_transaction` will rebroadcast

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -2285,7 +2285,7 @@ RPC Module Pool for transaction memory pool.
     * `outputs_validator`: [`OutputsValidator`](#type-outputsvalidator) `|` `null`
 * result: [`H256`](#type-h256)
 
-Submits a new transaction into the transaction pool.
+Submits a new transaction into the transaction pool. If the transaction is already in the pool, rebroadcast it to peers.
 
 ##### Params
 

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 /// RPC Module Pool for transaction memory pool.
 #[rpc(server)]
 pub trait PoolRpc {
-    /// Submits a new transaction into the transaction pool.
+    /// Submits a new transaction into the transaction pool. If the transaction is already in the
+    /// pool, rebroadcast it to peers.
     ///
     /// ## Params
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: The RPC document does not mention that when the transaction is already in the pool, `send_transaction` will rebroadcast the transaction to peers.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

