### PR TITLE
chore: replace dashmap with rwlock on orphan pool

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1300,7 +1300,10 @@ impl SyncShared {
 
     /// Try to find blocks from the orphan block pool that may no longer be orphan
     pub fn try_search_orphan_pool(&self, chain: &ChainController) {
-        for hash in self.state.orphan_pool().clone_leaders() {
+        let leaders = self.state.orphan_pool().clone_leaders();
+        debug!("orphan pool leader parents hash len: {}", leaders.len());
+
+        for hash in leaders {
             if self.state.orphan_pool().is_empty() {
                 break;
             }


### PR DESCRIPTION
### What problem does this PR solve?

Replace dashmap with rwlock on the orphan pool, ensure overall consistency 

### What is changed and how it works?

What's Changed:

### Related changes

Replace dashmap with rwlock on the orphan pool

Tests

- Unit test

### Release note

```release-note
None
```

