### PR TITLE
chore: only check PR title for semantic

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: We introduced [semantic](https://github.com/zeke/semantic-pull-requests) in CI recently. It requires the PR title or at least one commit follows the naming convention. Since we rely on PR to generate the change log, we really want to check the PR title only and require the title must follow the naming convention.

### What is changed and how it works?

What's Changed: Add a config file to ask semantic to always validate the PR title, and ignore the commits.

FYI: [configuration doc](https://github.com/zeke/semantic-pull-requests#configuration)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

