### PR TITLE
chore(hardfork): reject block extension from JSON-RPC temporarily

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3106,7 +3106,7 @@ Miners optional pick transactions and then assemble the final block.
 
 *   `extension`: [`JsonBytes`](#type-jsonbytes) `|` `null` - The extension for the new block.
 
-    This field is optional. It a reserved field, please leave it blank. More details can be found in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md).
+    This field is optional. It's a reserved field, please leave it blank. More details can be found in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md).
 
 
 ### Type `BlockView`

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1607,6 +1607,7 @@ Response
     "cycles_limit": "0xd09dc300",
     "dao": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000",
     "epoch": "0x7080019000001",
+    "extension": null,
     "number": "0x401",
     "parent_hash": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
     "proposals": ["0xa0ef4eb5f4ceeb08a4c8"],
@@ -3102,6 +3103,10 @@ Miners optional pick transactions and then assemble the final block.
     *   `U_i`, bytes 24 to 31
 
     See RFC [Deposit and Withdraw in Nervos DAO](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md#calculation).
+
+*   `extension`: [`JsonBytes`](#type-jsonbytes) `|` `null` - The extension for the new block.
+
+    This field is optional. It a reserved field, please leave it blank. More details can be found in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md).
 
 
 ### Type `BlockView`

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -7,6 +7,7 @@ use crate::{
     calculate_block_reward, OUTPUT_INDEX_DAO, OUTPUT_INDEX_SECP256K1_BLAKE160_MULTISIG_ALL,
     OUTPUT_INDEX_SECP256K1_BLAKE160_SIGHASH_ALL,
 };
+use ckb_constant::hardfork::{mainnet, testnet};
 use ckb_dao_utils::genesis_dao_data_with_satoshi_gift;
 use ckb_pow::{Pow, PowEngine};
 use ckb_rational::RationalU256;
@@ -930,6 +931,14 @@ impl Consensus {
     /// Returns the hardfork switch.
     pub fn hardfork_switch(&self) -> &HardForkSwitch {
         &self.hardfork_switch
+    }
+
+    /// If the CKB block chain specification is for an public chain.
+    pub fn is_public_chain(&self) -> bool {
+        matches!(
+            self.id.as_str(),
+            mainnet::CHAIN_SPEC_NAME | testnet::CHAIN_SPEC_NAME
+        )
     }
 }
 

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -227,6 +227,7 @@ impl TxPoolService {
         uncles: Vec<UncleBlockView>,
         bytes_limit: u64,
         version: Version,
+        extension: Option<Bytes>,
     ) -> Result<BlockTemplate, AnyError> {
         let consensus = snapshot.consensus();
         let tip_header = snapshot.tip_header();
@@ -303,7 +304,7 @@ impl TxPoolService {
             cellbase: BlockAssembler::transform_cellbase(&cellbase, None),
             work_id: work_id.into(),
             dao: dao.into(),
-            extension: None,
+            extension: extension.map(Into::into),
         })
     }
 
@@ -371,6 +372,8 @@ impl TxPoolService {
                 .prepare_block_template_uncles(&snapshot, &block_assembler)
                 .await;
 
+            let extension = None;
+
             let (proposals, entries, txs_updated_at) = self
                 .package_txs_for_block_template(
                     bytes_limit,
@@ -378,7 +381,7 @@ impl TxPoolService {
                     cycles_limit,
                     &cellbase,
                     &uncles,
-                    None,
+                    extension.clone(),
                 )
                 .await?;
 
@@ -394,6 +397,7 @@ impl TxPoolService {
                 uncles,
                 bytes_limit,
                 version,
+                extension,
             )?;
 
             self.update_block_template_cache(

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -86,7 +86,7 @@ pub struct BlockTemplate {
     pub dao: Byte32,
     /// The extension for the new block.
     ///
-    /// This field is optional. It a reserved field, please leave it blank.
+    /// This field is optional. It's a reserved field, please leave it blank.
     /// More details can be found in [CKB RFC 0031].
     ///
     /// [CKB RFC 0031]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -87,8 +87,10 @@ pub struct BlockTemplate {
     /// The extension for the new block.
     ///
     /// This field is optional. It a reserved field, please leave it blank.
-    #[doc(hidden)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// More details can be found in [CKB RFC 0031].
+    ///
+    /// [CKB RFC 0031]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md
+    #[serde(default)]
     pub extension: Option<JsonBytes>,
 }
 

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -859,7 +859,7 @@ pub struct Block {
     pub proposals: Vec<ProposalShortId>,
     /// The extension in the block body.
     ///
-    /// This field is optional. It a reserved field, please leave it blank.
+    /// This field is optional. It's a reserved field, please leave it blank.
     #[doc(hidden)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension: Option<JsonBytes>,
@@ -878,7 +878,7 @@ pub struct BlockView {
     pub proposals: Vec<ProposalShortId>,
     /// The extension in the block body.
     ///
-    /// This field is optional. It a reserved field, please leave it blank.
+    /// This field is optional. It's a reserved field, please leave it blank.
     #[doc(hidden)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension: Option<JsonBytes>,


### PR DESCRIPTION
### What problem does this PR solve?

- The RPC method `get_block_template` should always return the extension field and the value should always be `null`.

- Reject blocks which are submitted from JSON-RPC and have the extension field, for both mainnet and testnet.

- Allow extension fields for development and tests, since we have a lot of tests base on this feature.

### Check List

Tests

- Manual test

  - Update the code of CKB to set the CKB v2021 hardfork epoch to be `0` for both mainnet and testnet.

    https://github.com/nervosnetwork/ckb/blob/cc792ca745014fe0976d442227984cc689cdf7c0/util/constant/src/hardfork/mainnet.rs#L5-L6
    https://github.com/nervosnetwork/ckb/blob/cc792ca745014fe0976d442227984cc689cdf7c0/util/constant/src/hardfork/testnet.rs#L5-L6

  - Replace the `extension` in block template as follow:

    ```rust
    let extension = {
        let bytes: Bytes = snapshot.tip_hash().as_bytes().pack();
        Some(bytes)
    };
    ```

  - Build an executable file: `make prod`.

  - Initialize a develop chain: `target/release/ckb init --chain -C dev`.

  - Check 1

    - Run both `ckb run` and `ckb miner` for the develop chain, **things should go well**.

  - Check 2

    - Remove all chain data: `rm -rf dev/data`.

    - Update `dev/specs/dev.toml` to change the chain name to `ckb` or `ckb_testnet`.

      https://github.com/nervosnetwork/ckb/blob/cc792ca745014fe0976d442227984cc689cdf7c0/resource/specs/dev.toml#L1

    - Run both `ckb run` and `ckb miner` for the develop chain, **the chain will reject all blocks from the miner**.

### Release note

```release-note
None: Exclude this PR from the release note.
```

