### PR TITLE
refactor: redesign sync orphan_block_pool and add bench.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "ckb-resource",
  "ckb-shared",
  "ckb-store",
+ "ckb-sync",
  "ckb-system-scripts",
  "ckb-test-chain-utils",
  "ckb-types",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -33,6 +33,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }
 ckb-network = { path = "../network", version = "= 0.100.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
+ckb-sync = { path = "../sync", version = "= 0.100.0-pre" }
 tempfile = "3.0"
 
 [[bench]]

--- a/benches/benches/bench_main.rs
+++ b/benches/benches/bench_main.rs
@@ -8,4 +8,5 @@ criterion_main! {
     benchmarks::secp_2in2out::process_block,
     benchmarks::overall::overall,
     benchmarks::resolve::resolve,
+    benchmarks::orphan_block_pool::orphan_block_pool,
 }

--- a/benches/benches/benchmarks/mod.rs
+++ b/benches/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub mod always_success;
+pub mod orphan_block_pool;
 pub mod overall;
 pub mod resolve;
 pub mod secp_2in2out;

--- a/benches/benches/benchmarks/orphan_block_pool.rs
+++ b/benches/benches/benchmarks/orphan_block_pool.rs
@@ -1,0 +1,90 @@
+use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
+
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
+use ckb_sync::orphan_block_pool::OrphanBlockPool;
+use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
+use ckb_types::prelude::*;
+
+#[cfg(not(feature = "ci"))]
+const SIZE: usize = 1024 * 8;
+
+#[cfg(feature = "ci")]
+const SIZE: usize = 512;
+
+const CHUNK_SIZE: usize = 256;
+
+pub fn setup_chain(
+    block_num: usize,
+) -> (OrphanBlockPool, Vec<ckb_types::core::BlockView>, Consensus) {
+    let consensus = ConsensusBuilder::default().build();
+    let mut blocks = Vec::new();
+    let mut parent = consensus.genesis_block().header();
+    let pool = OrphanBlockPool::with_capacity(block_num);
+    for _ in 0..block_num {
+        let new_block = gen_block(&parent);
+        blocks.push(new_block.clone());
+        parent = new_block.header();
+    }
+    (pool, blocks, consensus)
+}
+
+fn gen_block(parent_header: &HeaderView) -> BlockView {
+    let since_the_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    BlockBuilder::default()
+        .parent_hash(parent_header.hash())
+        .timestamp(since_the_epoch.pack())
+        .number((parent_header.number() + 1).pack())
+        .nonce((parent_header.nonce() + 1).pack())
+        .build()
+}
+
+fn test_sync(pool: &OrphanBlockPool, blocks: &[ckb_types::core::BlockView], consensus: &Consensus) {
+    let mut rng = thread_rng();
+    let mut heads_index = vec![];
+
+    for (index, _) in blocks.chunks(CHUNK_SIZE).enumerate() {
+        let start = CHUNK_SIZE * index;
+        let end = CHUNK_SIZE * (index + 1) - 1;
+        let mut v: Vec<usize> = (start + 1..=end).collect();
+        v.shuffle(&mut rng);
+        for seq in v.iter() {
+            let block = blocks.get(*seq).expect("seq wrong?");
+            pool.insert(block.clone()).expect("insert error");
+        }
+        heads_index.push(start);
+    }
+
+    // index 0 doesn't in the orphan pool, so do nothing
+    pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
+
+    for index in heads_index {
+        pool.insert(blocks[index].clone()).expect("insert error");
+        pool.remove_blocks_by_parent(&blocks[index].hash());
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("orphan_block_pool");
+
+    group.bench_with_input(BenchmarkId::new("remove", SIZE), &SIZE, |b, n_blocks| {
+        b.iter_batched(
+            || setup_chain(*n_blocks),
+            |(pool, blocks, consensus)| {
+                test_sync(&pool, &blocks, &consensus);
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+criterion_group!(
+    name = orphan_block_pool;
+    config = Criterion::default().sample_size(10);
+    targets = bench
+);

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -5,7 +5,8 @@
 
 mod block_status;
 mod net_time_checker;
-mod orphan_block_pool;
+/// orphan_block_pool module
+pub mod orphan_block_pool;
 mod relayer;
 mod status;
 mod synchronizer;

--- a/sync/src/orphan_block_pool.rs
+++ b/sync/src/orphan_block_pool.rs
@@ -1,151 +1,325 @@
-use ckb_logger::debug;
+use std::collections::{HashMap, VecDeque};
+use std::ops::Deref;
+
+use ckb_error::{Error, InternalErrorKind};
+use ckb_types::prelude::ShouldBeOk;
 use ckb_types::{core, packed};
-use ckb_util::{parking_lot::RwLock, shrink_to_fit};
-use std::collections::{HashMap, HashSet, VecDeque};
+use ckb_util::parking_lot::RwLock;
+use ckb_util::shrink_to_fit;
 
+/// alias name
 pub type ParentHash = packed::Byte32;
+/// alias name
+pub type Hash = packed::Byte32;
+
 const SHRINK_THRESHOLD: usize = 100;
+const MAX_SUB_NODES_UPDATE_IN_ROOTOF: usize = 16;
 
-#[derive(Default)]
-struct InnerPool {
-    // Group by blocks in the pool by the parent hash.
-    blocks: HashMap<ParentHash, HashMap<packed::Byte32, core::BlockView>>,
-    // The map tells the parent hash when given the hash of a block in the pool.
-    //
-    // The block is in the orphan pool if and only if the block hash exists as a key in this map.
-    parents: HashMap<packed::Byte32, ParentHash>,
-    // Leaders are blocks not in the orphan pool but having at least a child in the pool.
-    leaders: HashSet<ParentHash>,
-}
-
-impl InnerPool {
-    fn with_capacity(capacity: usize) -> Self {
-        InnerPool {
-            blocks: HashMap::with_capacity(capacity),
-            parents: HashMap::new(),
-            leaders: HashSet::new(),
-        }
-    }
-
-    fn insert(&mut self, block: core::BlockView) {
-        let hash = block.header().hash();
-        let parent_hash = block.data().header().raw().parent_hash();
-        self.blocks
-            .entry(parent_hash.clone())
-            .or_insert_with(HashMap::default)
-            .insert(hash.clone(), block);
-        // Out-of-order insertion needs to be deduplicated
-        self.leaders.remove(&hash);
-        // It is a possible optimization to make the judgment in advance,
-        // because the parent of the block must not be equal to its own hash,
-        // so we can judge first, which may reduce one arc clone
-        if !self.parents.contains_key(&parent_hash) {
-            // Block referenced by `parent_hash` is not in the pool,
-            // and it has at least one child, the new inserted block, so add it to leaders.
-            self.leaders.insert(parent_hash.clone());
-        }
-        self.parents.insert(hash, parent_hash);
-    }
-
-    pub fn remove_blocks_by_parent(&mut self, parent_hash: &ParentHash) -> Vec<core::BlockView> {
-        // try remove leaders first
-        if !self.leaders.remove(parent_hash) {
-            return Vec::new();
-        }
-
-        let mut queue: VecDeque<packed::Byte32> = VecDeque::new();
-        queue.push_back(parent_hash.to_owned());
-
-        let mut removed: Vec<core::BlockView> = Vec::new();
-        while let Some(parent_hash) = queue.pop_front() {
-            if let Some(orphaned) = self.blocks.remove(&parent_hash) {
-                let (hashes, blocks): (Vec<_>, Vec<_>) = orphaned.into_iter().unzip();
-                for hash in hashes.iter() {
-                    self.parents.remove(hash);
-                }
-                queue.extend(hashes);
-                removed.extend(blocks);
-            }
-        }
-
-        debug!("orphan pool pop chain len: {}", removed.len());
-        debug_assert_ne!(
-            removed.len(),
-            0,
-            "orphan pool removed list must not be zero"
-        );
-
-        shrink_to_fit!(self.blocks, SHRINK_THRESHOLD);
-        shrink_to_fit!(self.parents, SHRINK_THRESHOLD);
-        shrink_to_fit!(self.leaders, SHRINK_THRESHOLD);
-        removed
-    }
-
-    pub fn get_block(&self, hash: &packed::Byte32) -> Option<core::BlockView> {
-        self.parents.get(hash).and_then(|parent_hash| {
-            self.blocks
-                .get(&parent_hash)
-                .and_then(|blocks| blocks.get(hash).cloned())
-        })
-    }
-}
-
-// NOTE: Never use `LruCache` as container. We have to ensure synchronizing between
-// orphan_block_pool and block_status_map, but `LruCache` would prune old items implicitly.
-// RwLock ensures the consistency between maps. Using multiple concurrent maps does not work here.
-#[derive(Default)]
+/// RwLock of wrapper for OrphanBlockPool
 pub struct OrphanBlockPool {
-    inner: RwLock<InnerPool>,
+    inner: RwLock<InnerOrphanBlockPool>,
 }
 
 impl OrphanBlockPool {
+    ///  init orphan block pool, reserve maps with specific capacity
     pub fn with_capacity(capacity: usize) -> Self {
         OrphanBlockPool {
-            inner: RwLock::new(InnerPool::with_capacity(capacity)),
+            inner: RwLock::new(InnerOrphanBlockPool::with_capacity(capacity)),
+        }
+    }
+    /// insert the orphan block into pool
+    ///
+    /// Return Ok() normally
+    ///
+    /// Return Error when inner data not sync
+    pub fn insert(&self, block: core::BlockView) -> Result<(), Error> {
+        self.inner.write().insert(block)
+    }
+    /// return vector of sub-node blocks beneath to the root hash
+    ///
+    /// return None if none beneath the root
+    pub fn remove_blocks_by_parent(&self, root: &Hash) -> Vec<core::BlockView> {
+        self.inner
+            .write()
+            .remove_blocks_by_parent(root)
+            .unwrap_or_default()
+    }
+    /// return block stored in pool
+    ///
+    /// return None if not found in pool
+    pub fn get_block(&self, hash: &Hash) -> Option<core::BlockView> {
+        self.inner.read().get_block(hash)
+    }
+    /// is trees map is empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_trees_empty()
+    }
+    /// the leaders count in trees
+    pub fn len(&self) -> usize {
+        self.inner.read().trees_len()
+    }
+
+    /// get leaders(key) in trees
+    pub fn get_leaders(&self) -> Vec<Hash> {
+        self.inner.read().get_leaders()
+    }
+
+    #[allow(dead_code)]
+    /// debug tool to get length of trees
+    fn trees_len(&self) -> usize {
+        self.inner.read().trees_len()
+    }
+    #[allow(dead_code)]
+    /// debug tool to get length of rootof
+    fn root_of_len(&self) -> usize {
+        self.inner.read().rootof_len()
+    }
+}
+
+struct InnerOrphanBlockPool {
+    // store root and sub-node block
+    trees: HashMap<ParentHash, VecDeque<(Hash, core::BlockView)>>,
+    // CP(child-parent) relationship between sub-nodes
+    root_of: HashMap<Hash, ParentHash>,
+}
+
+fn internal_error(reason: String) -> Error {
+    InternalErrorKind::System.other(reason).into()
+}
+
+impl InnerOrphanBlockPool {
+    fn with_capacity(capacity: usize) -> Self {
+        InnerOrphanBlockPool {
+            trees: HashMap::with_capacity(capacity),
+            root_of: HashMap::new(),
         }
     }
 
-    /// Insert orphaned block, for which we have already requested its parent block
-    pub fn insert(&self, block: core::BlockView) {
-        self.inner.write().insert(block);
+    /// root_of table contains direct child-parent relationship
+    ///
+    /// but we need to find the root recursively when given any child
+    ///
+    /// Return hash of the root hash
+    fn find_root(&self, hash: &Hash) -> Hash {
+        let mut p = hash.clone();
+        loop {
+            if let Some(v) = self.root_of.get(&p) {
+                p = v.clone();
+            } else {
+                return p;
+            }
+        }
     }
 
-    pub fn remove_blocks_by_parent(&self, parent_hash: &ParentHash) -> Vec<core::BlockView> {
-        self.inner.write().remove_blocks_by_parent(parent_hash)
+    /// update specific sub-node's parent to root(hash)
+    /// if sub-nodes' count less than LIMIT, we update their parent
+    ///
+    /// params:
+    ///
+    /// key: which tree's sub-nodes needs be be upgrade (in trees)
+    ///
+    /// root: update root
+    fn update_root_in_rootof(&mut self, key: &Hash, root: &Hash) {
+        let tree = self.trees.get(key).should_be_ok();
+        if tree.iter().size_hint().0 < MAX_SUB_NODES_UPDATE_IN_ROOTOF {
+            for (hash, _) in tree.iter() {
+                *self.root_of.get_mut(hash).unwrap() = root.clone();
+            }
+        }
     }
 
-    pub fn get_block(&self, hash: &packed::Byte32) -> Option<core::BlockView> {
-        self.inner.read().get_block(hash)
+    /// insert node block into orphan block pool
+    ///
+    /// there are 4 cases related with character of insert node
+    ///
+    /// 1. add leaf node
+    ///
+    /// 2. add separated root node
+    ///
+    /// 3. join two trees
+    ///
+    /// 4. update root
+    ///
+    /// params: block - block inserted
+    ///
+    /// Returns OK if none error occurs
+    ///
+    /// Returns Error or Panic if internal data not sync
+    fn insert(&mut self, block: core::BlockView) -> Result<(), Error> {
+        let hash = block.header().hash();
+        let parent_hash = block.data().header().raw().parent_hash();
+
+        // ignore duplicated block
+        if self.root_of.contains_key(&hash) {
+            return Ok(());
+        }
+
+        if self.root_of.contains_key(&parent_hash) {
+            if self.trees.contains_key(&hash) {
+                // case3: join two trees
+                self.join_two_trees(hash, parent_hash, block);
+            } else if !self.root_of.contains_key(&hash) {
+                // case1: add leaf node
+                self.add_leaf_node(hash, parent_hash, block);
+            } else {
+                return Err(internal_error(String::from(
+                    "insert node inner state error!",
+                )));
+            }
+        } else if self.trees.contains_key(&hash) {
+            // case4: update root
+            self.update_root(hash, parent_hash, block);
+        } else if !self.trees.contains_key(&hash) && !self.trees.contains_key(&parent_hash) {
+            // case2: add separated root node, add new entry in root_of and trees
+            self.add_separated_root_node(hash, parent_hash, block);
+        } else if !self.trees.contains_key(&hash) && self.trees.contains_key(&parent_hash) {
+            // that means duplicate block occurs, for now we can't tell which is valid
+            // so we append that block at end of deque
+            self.trees
+                .get_mut(&parent_hash)
+                .should_be_ok()
+                .push_back((hash, block));
+        } else {
+            return Err(internal_error(String::from(
+                "insert node inner state error!",
+            )));
+        }
+
+        Ok(())
     }
 
-    pub fn len(&self) -> usize {
-        self.inner.read().parents.len()
+    /// Note: without input check, this function only used in insert()
+    fn join_two_trees(&mut self, hash: Hash, parent_hash: ParentHash, block: core::BlockView) {
+        let root = self.find_root(&parent_hash);
+        // update root_of
+        self.root_of.insert(hash.clone(), parent_hash);
+        self.update_root_in_rootof(&hash, &root);
+
+        let mut new_vec = VecDeque::new();
+        let tree2 = self.trees.get_mut(&hash).should_be_ok();
+        new_vec.push_front((hash.clone(), block));
+        new_vec.append(tree2);
+        let tree1 = self.trees.get_mut(&root).should_be_ok();
+        tree1.append(&mut new_vec);
+
+        self.trees.remove(&hash);
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    /// Note: without input check, this function only used in insert()
+    fn add_leaf_node(&mut self, hash: Hash, parent_hash: ParentHash, block: core::BlockView) {
+        let root = self.find_root(&parent_hash);
+        if let Some(deq) = self.trees.get_mut(&root) {
+            self.root_of.insert(hash.clone(), root.clone());
+            deq.push_back((hash, block));
+        } else {
+            // TODO: re-construct record in trees instead of panic
+            panic!("find the root in root_of, but trees lack of root record!");
+        }
     }
 
-    pub fn clone_leaders(&self) -> Vec<ParentHash> {
-        self.inner.read().leaders.iter().cloned().collect()
+    /// Note: without input check, this function only used in insert()
+    fn update_root(&mut self, hash: Hash, parent_hash: ParentHash, block: core::BlockView) {
+        self.root_of.insert(hash.clone(), parent_hash.clone());
+        self.update_root_in_rootof(&hash, &parent_hash);
+        let mut v = VecDeque::new();
+        v.append(self.trees.get_mut(&hash).unwrap());
+        self.trees.remove(&hash);
+        v.push_front((hash, block));
+        self.trees.insert(parent_hash, v);
     }
 
-    #[cfg(test)]
-    fn leaders_len(&self) -> usize {
-        self.inner.read().leaders.len()
+    /// Note: without input check, this function only used in insert()
+    fn add_separated_root_node(
+        &mut self,
+        hash: Hash,
+        parent_hash: ParentHash,
+        block: core::BlockView,
+    ) {
+        self.root_of.insert(hash.clone(), parent_hash.clone());
+        let mut v = VecDeque::new();
+        v.push_back((hash, block));
+        self.trees.insert(parent_hash, v);
+    }
+
+    /// collect all blocks of sub-nodes via input root-node hash
+    /// remove all sub-nodes info in trees and root_of
+    ///
+    /// params: parent_hash: root node hash
+    ///
+    /// Returns Some(Vec) all sub-nodes' blocks
+    ///
+    /// Return None if input root-node hash not exists in trees(not real root node?)
+    fn remove_blocks_by_parent(&mut self, root: &Hash) -> Option<Vec<core::BlockView>> {
+        if let Some(v) = self.trees.get_mut(root) {
+            let mut vec = Vec::with_capacity(v.len());
+            for (hash, block) in v.iter() {
+                vec.push(block.clone());
+                self.root_of.remove(hash);
+            }
+
+            self.trees.remove(root);
+            shrink_to_fit!(self.trees, SHRINK_THRESHOLD);
+            shrink_to_fit!(self.root_of, SHRINK_THRESHOLD);
+            Some(vec)
+        } else {
+            None
+        }
+    }
+
+    /// get block by input node hash
+    ///
+    /// params: hash - node hash
+    ///
+    /// Returns Some(block) if the node is found
+    ///
+    /// Returns None if the node is not found
+    fn get_block(&self, hash: &Hash) -> Option<core::BlockView> {
+        self.root_of.get(hash).and_then(|relationship| {
+            let parent_hash = self.find_root(relationship);
+            self.trees.get(&parent_hash).and_then(|v| {
+                for (h, b) in v.iter() {
+                    if *h.deref() == (*hash) {
+                        return Some(b.clone());
+                    }
+                }
+                None
+            })
+        })
+    }
+
+    /// get leaders(key) from trees
+    pub fn get_leaders(&self) -> Vec<Hash> {
+        let mut result = vec![];
+        for key in self.trees.keys() {
+            result.push(key.clone());
+        }
+        result
+    }
+
+    fn trees_len(&self) -> usize {
+        self.trees.len()
+    }
+    fn rootof_len(&self) -> usize {
+        self.root_of.len()
+    }
+    fn is_trees_empty(&self) -> bool {
+        self.trees.is_empty()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::OrphanBlockPool;
-    use ckb_chain_spec::consensus::ConsensusBuilder;
-    use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
-    use ckb_types::prelude::*;
-    use faketime::unix_time_as_millis;
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::thread;
+
+    use faketime::unix_time_as_millis;
+
+    use ckb_chain_spec::consensus::ConsensusBuilder;
+    use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
+    use ckb_types::prelude::*;
+
+    use super::OrphanBlockPool;
 
     fn gen_block(parent_header: &HeaderView) -> BlockView {
         BlockBuilder::default()
@@ -157,6 +331,7 @@ mod tests {
     }
 
     #[test]
+    /// generate 200 blocks, and get all blocks by input genesis block.
     fn test_remove_blocks_by_parent() {
         let consensus = ConsensusBuilder::default().build();
         let block_number = 200;
@@ -166,7 +341,7 @@ mod tests {
         for _ in 1..block_number {
             let new_block = gen_block(&parent);
             blocks.push(new_block.clone());
-            pool.insert(new_block.clone());
+            pool.insert(new_block.clone()).expect("insert error");
             parent = new_block.header();
         }
 
@@ -177,6 +352,31 @@ mod tests {
     }
 
     #[test]
+    /// generate 2 blocks(valid and invalid), their parents all are genesis.
+    /// test if get both blocks retrieved by input genesis block.
+    fn test_duplicated_blocks() {
+        let consensus = ConsensusBuilder::default().build();
+        let parent = consensus.genesis_block().header();
+        let pool = OrphanBlockPool::with_capacity(200);
+
+        let valid_block = gen_block(&parent);
+        pool.insert(valid_block).expect("insert error");
+
+        let invalid_block = BlockBuilder::default()
+            .parent_hash(parent.hash())
+            .timestamp(unix_time_as_millis().pack())
+            .number((1000).pack())
+            .nonce((parent.nonce() + 1).pack())
+            .build();
+
+        pool.insert(invalid_block).expect("insert error");
+
+        let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
+        assert_eq!(orphan.len(), 2);
+    }
+
+    #[test]
+    /// generate 1024 blocks and do remove and insert concurrently
     fn test_remove_blocks_by_parent_and_get_block_should_not_deadlock() {
         let consensus = ConsensusBuilder::default().build();
         let pool = OrphanBlockPool::with_capacity(1024);
@@ -184,7 +384,7 @@ mod tests {
         let mut hashes = Vec::new();
         for _ in 1..1024 {
             let new_block = gen_block(&header);
-            pool.insert(new_block.clone());
+            pool.insert(new_block.clone()).expect("insert error");
             header = new_block.header();
             hashes.push(header.hash());
         }
@@ -204,7 +404,8 @@ mod tests {
     }
 
     #[test]
-    fn test_leaders() {
+    ///generate 19 blocks(0..=18) and put 4 blocks in leader, 15 blocks in pool
+    fn test_trees() {
         let consensus = ConsensusBuilder::default().build();
         let block_number = 20;
         let mut blocks = Vec::new();
@@ -215,46 +416,48 @@ mod tests {
             blocks.push(new_block.clone());
             parent = new_block.header();
             if i % 5 != 0 {
-                pool.insert(new_block.clone());
+                pool.insert(new_block.clone()).expect("insert error");
             }
         }
 
-        assert_eq!(pool.len(), 15);
-        assert_eq!(pool.leaders_len(), 4);
+        assert_eq!(pool.trees_len(), 4);
+        assert_eq!(pool.root_of_len(), 15);
 
-        pool.insert(blocks[5].clone());
-        assert_eq!(pool.len(), 16);
-        assert_eq!(pool.leaders_len(), 3);
+        assert!(pool.insert(blocks[5].clone()).is_ok());
+        assert_eq!(pool.root_of_len(), 16);
+        assert_eq!(pool.trees_len(), 3);
 
-        pool.insert(blocks[10].clone());
-        assert_eq!(pool.len(), 17);
-        assert_eq!(pool.leaders_len(), 2);
+        assert!(pool.insert(blocks[10].clone()).is_ok());
+        assert_eq!(pool.root_of_len(), 17);
+        assert_eq!(pool.trees_len(), 2);
 
-        // index 0 doesn't in the orphan pool, so do nothing
-        let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
-        assert!(orphan.is_empty());
-        assert_eq!(pool.len(), 17);
-        assert_eq!(pool.leaders_len(), 2);
+        // block 0 doesn't in the pool, so do nothing
+        assert_eq!(
+            pool.remove_blocks_by_parent(&consensus.genesis_block().hash())
+                .len(),
+            0
+        );
+        assert_eq!(pool.root_of_len(), 17);
+        assert_eq!(pool.trees_len(), 2);
 
-        pool.insert(blocks[0].clone());
-        assert_eq!(pool.len(), 18);
-        assert_eq!(pool.leaders_len(), 2);
+        assert!(pool.insert(blocks[0].clone()).is_ok());
+        assert_eq!(pool.root_of_len(), 18);
+        assert_eq!(pool.trees_len(), 2);
 
-        let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
-        assert_eq!(pool.len(), 3);
-        assert_eq!(pool.leaders_len(), 1);
+        assert_eq!(
+            pool.remove_blocks_by_parent(&consensus.genesis_block().hash())
+                .len(),
+            15
+        );
+        assert_eq!(pool.root_of_len(), 3);
+        assert_eq!(pool.trees_len(), 1);
 
-        pool.insert(blocks[15].clone());
-        assert_eq!(pool.len(), 4);
-        assert_eq!(pool.leaders_len(), 1);
+        assert!(pool.insert(blocks[15].clone()).is_ok());
+        assert_eq!(pool.root_of_len(), 4);
+        assert_eq!(pool.trees_len(), 1);
 
-        let orphan_1 = pool.remove_blocks_by_parent(&blocks[14].hash());
-
-        let orphan_set: HashSet<BlockView> =
-            orphan.into_iter().chain(orphan_1.into_iter()).collect();
-        let blocks_set: HashSet<BlockView> = blocks.into_iter().collect();
-        assert_eq!(orphan_set, blocks_set);
-        assert_eq!(pool.len(), 0);
-        assert_eq!(pool.leaders_len(), 0);
+        assert_eq!(pool.remove_blocks_by_parent(&blocks[14].hash()).len(), 4);
+        assert_eq!(pool.root_of_len(), 0);
+        assert_eq!(pool.trees_len(), 0);
     }
 }


### PR DESCRIPTION
[sync]: refactor orphan block pool and add benchmark

### What problem does this PR solve?
resign data structure, reduce 3 maps to 2 maps, make interface not expose inner map.

Problem Summary:

### What is changed and how it works?
redesign datastruct and invent two maps:   
trees  --  keep leader and its sub-node blocks
root_of --  keep all child-parent relationship

What's Changed:

### Related changes
sync/types/mod.rs  and relayer   -- where to use orphan block pool  

Tests <!-- At least one of them must be included. -->

- Unit test
- Benchmark

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

