### PR TITLE
chore(deps): bump crossbeam-deque from 0.8.0 to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",


### PR DESCRIPTION
### What problem does this PR solve?

Fix [RUSTSEC-2021-0093](https://rustsec.org/advisories/RUSTSEC-2021-0093).

Problem Summary:

> In the affected version of this crate, the result of the race condition is that one or more tasks in the worker queue can be popped twice instead of other tasks that are forgotten and never popped. If tasks are allocated on the heap, this can cause double free and a memory leak. If not, this still can cause a logical bug.
>
> Crates using `Stealer::steal`, `Stealer::steal_batch`, or `Stealer::steal_batch_and_pop` are affected by this issue.

### Release note

```release-note
None: Exclude this PR from the release note.
```

