### PR TITLE
refactor: refactor peer store

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -75,7 +75,7 @@ pub struct NetworkState {
     pending_observed_addrs: RwLock<HashSet<Multiaddr>>,
     local_private_key: secio::SecioKeyPair,
     local_peer_id: PeerId,
-    bootnodes: Vec<Multiaddr>,
+    pub(crate) bootnodes: Vec<Multiaddr>,
     pub(crate) config: NetworkConfig,
     pub(crate) active: AtomicBool,
     /// Node supported protocols
@@ -856,7 +856,8 @@ impl<T: ExitHandler> NetworkService<T> {
             .yamux_config(yamux_config)
             .forever(true)
             .max_connection_number(1024)
-            .set_send_buffer_size(config.max_send_buffer());
+            .set_send_buffer_size(config.max_send_buffer())
+            .timeout(Duration::from_secs(5));
 
         #[cfg(target_os = "linux")]
         let p2p_service = {

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -61,7 +61,7 @@ impl AddrManager {
                 // TODO remove this after fix the network tests.
                 let is_test_ip = ip.is_unspecified() || ip.is_loopback();
                 if (is_test_ip || is_unique_ip)
-                    && !addr_info.is_terrible(now_ms)
+                    && addr_info.is_connectable(now_ms)
                     && filter(&addr_info)
                 {
                     addr_infos.push(addr_info);

--- a/network/src/peer_store/mod.rs
+++ b/network/src/peer_store/mod.rs
@@ -24,6 +24,9 @@ pub(crate) const ADDR_COUNT_LIMIT: usize = 16384;
 const ADDR_TIMEOUT_MS: u64 = 7 * 24 * 3600 * 1000;
 /// The timeout that peer's address should be added to the feeler list again
 pub(crate) const ADDR_TRY_TIMEOUT_MS: u64 = 3 * 24 * 3600 * 1000;
+/// When obtaining the list of selectable nodes for identify,
+/// the node that has just been disconnected needs to be excluded
+pub(crate) const DIAL_INTERVAL: u64 = 15 * 1000;
 const ADDR_MAX_RETRIES: u32 = 3;
 const ADDR_MAX_FAILURES: u32 = 10;
 

--- a/network/src/peer_store/mod.rs
+++ b/network/src/peer_store/mod.rs
@@ -1,4 +1,12 @@
 //! Peer store manager
+//!
+//! This module implements a locally managed node information set, which is used for
+//! booting into the network when the node is started, real-time update detection/timing
+//! saving at runtime, and saving data when stopping
+//!
+//! The validity and screening speed of the data set are very important to the entire network,
+//! and the address information collected on the network cannot be blindly trusted
+
 pub mod addr_manager;
 pub mod ban_list;
 mod peer_store_db;
@@ -14,6 +22,8 @@ pub use peer_store_impl::PeerStore;
 pub(crate) const ADDR_COUNT_LIMIT: usize = 16384;
 /// Consider we never seen a peer if peer's last_connected_at beyond this timeout
 const ADDR_TIMEOUT_MS: u64 = 7 * 24 * 3600 * 1000;
+/// The timeout that peer's address should be added to the feeler list again
+pub(crate) const ADDR_TRY_TIMEOUT_MS: u64 = 3 * 24 * 3600 * 1000;
 const ADDR_MAX_RETRIES: u32 = 3;
 const ADDR_MAX_FAILURES: u32 = 10;
 

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -136,7 +136,8 @@ impl PeerStore {
                 extract_peer_id(&peer_addr.addr)
                     .map(|peer_id| !peers.contains_key(&peer_id))
                     .unwrap_or_default()
-                    && peer_addr.had_connected(addr_expired_ms)
+                    && peer_addr
+                        .connected(|t| t > addr_expired_ms && t <= now_ms.saturating_sub(15_000))
             })
     }
 
@@ -157,7 +158,7 @@ impl PeerStore {
                     .map(|peer_id| !peers.contains_key(&peer_id))
                     .unwrap_or_default()
                     && !peer_addr.tried_in_last_minute(now_ms)
-                    && !peer_addr.had_connected(addr_expired_ms)
+                    && !peer_addr.connected(|t| t >= addr_expired_ms)
             })
     }
 
@@ -175,7 +176,7 @@ impl PeerStore {
                 extract_peer_id(&peer_addr.addr)
                     .map(|peer_id| peers.contains_key(&peer_id))
                     .unwrap_or_default()
-                    || peer_addr.had_connected(addr_expired_ms)
+                    || peer_addr.connected(|t| t >= addr_expired_ms)
             })
     }
 

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -72,22 +72,22 @@ impl AddrInfo {
     }
 
     /// Whether terrible peer
-    pub fn is_terrible(&self, now_ms: u64) -> bool {
+    pub fn is_connectable(&self, now_ms: u64) -> bool {
         // do not remove addr tried in last minute
         if self.tried_in_last_minute(now_ms) {
-            return false;
+            return true;
         }
         // we give up if never connect to this addr
         if self.last_connected_at_ms == 0 && self.attempts_count >= ADDR_MAX_RETRIES {
-            return true;
+            return false;
         }
         // consider addr is terrible if failed too many times
         if now_ms.saturating_sub(self.last_connected_at_ms) > ADDR_TIMEOUT_MS
             && (self.attempts_count >= ADDR_MAX_FAILURES)
         {
-            return true;
+            return false;
         }
-        false
+        true
     }
 
     /// Try dail count

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -61,9 +61,9 @@ impl AddrInfo {
         }
     }
 
-    /// Whether already connected
-    pub fn had_connected(&self, expires_ms: u64) -> bool {
-        self.last_connected_at_ms > expires_ms
+    /// Connection information
+    pub fn connected<F: FnOnce(u64) -> bool>(&self, f: F) -> bool {
+        f(self.last_connected_at_ms)
     }
 
     /// Whether already try dail within a minute

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -71,7 +71,7 @@ impl AddrInfo {
         self.last_tried_at_ms >= now_ms.saturating_sub(60_000)
     }
 
-    /// Whether terrible peer
+    /// Whether connectable peer
     pub fn is_connectable(&self, now_ms: u64) -> bool {
         // do not remove addr tried in last minute
         if self.tried_in_last_minute(now_ms) {
@@ -81,7 +81,7 @@ impl AddrInfo {
         if self.last_connected_at_ms == 0 && self.attempts_count >= ADDR_MAX_RETRIES {
             return false;
         }
-        // consider addr is terrible if failed too many times
+        // consider addr is not connectable if failed too many times
         if now_ms.saturating_sub(self.last_connected_at_ms) > ADDR_TIMEOUT_MS
             && (self.attempts_count >= ADDR_MAX_FAILURES)
         {

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -12,7 +12,7 @@ use p2p::{
     service::{SessionType, TargetProtocol},
     traits::ServiceProtocol,
     utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr},
-    ProtocolId, SessionId,
+    SessionId,
 };
 
 mod protocol;
@@ -62,7 +62,7 @@ pub trait Callback: Clone + Send {
     // Register open protocol
     fn register(&self, context: &ProtocolContextMutRef, version: &str);
     // remove registered identify protocol
-    fn unregister(&self, id: SessionId, pid: ProtocolId);
+    fn unregister(&self, context: &ProtocolContextMutRef);
     /// Received custom message
     fn received_identify(
         &mut self,
@@ -261,8 +261,7 @@ impl<T: Callback> ServiceProtocol for IdentifyProtocol<T> {
                 .remove(&context.session.id)
                 .expect("RemoteInfo must exists");
             trace!("IdentifyProtocol disconnected from {:?}", info.peer_id);
-            self.callback
-                .unregister(context.session.id, context.proto_id)
+            self.callback.unregister(&context)
         }
     }
 
@@ -374,18 +373,37 @@ impl Callback for IdentifyCallback {
                 .mut_addr_manager()
                 .remove(&context.session.address);
         } else if context.session.ty.is_outbound() {
+            // why don't set inbound here?
+            // because inbound address can't feeler during staying connected
+            // and if set it to peer store, it will be broadcast to the entire network,
+            // but this is an unverified address
             self.network_state.with_peer_store_mut(|peer_store| {
                 peer_store.add_outbound_addr(context.session.address.clone());
             });
         }
     }
 
-    fn unregister(&self, id: SessionId, pid: ProtocolId) {
-        self.network_state.with_peer_registry_mut(|reg| {
-            let _ = reg.get_peer_mut(id).map(|peer| {
-                peer.protocols.remove(&pid);
+    fn unregister(&self, context: &ProtocolContextMutRef) {
+        let version = self
+            .network_state
+            .with_peer_registry_mut(|reg| {
+                reg.get_peer_mut(context.session.id)
+                    .map(|peer| peer.protocols.remove(&context.proto_id))
+            })
+            .flatten()
+            .map(|version| version != "2")
+            .unwrap_or_default();
+
+        if self.network_state.ckb2021.load(Ordering::SeqCst) && version {
+        } else if context.session.ty.is_outbound() {
+            // Due to the filtering strategy of the peer store, if the node is
+            // disconnected after a long connection is maintained for more than seven days,
+            // it is possible that the node will be accidentally evicted, so it is necessary
+            // to reset the information of the node when disconnected.
+            self.network_state.with_peer_store_mut(|peer_store| {
+                peer_store.add_outbound_addr(context.session.address.clone());
             });
-        });
+        }
     }
 
     fn identify(&mut self) -> &[u8] {

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -139,12 +139,12 @@ impl Future for OutboundPeerService {
             }
         }
         while self.interval.as_mut().unwrap().poll_tick(cx).is_ready() {
+            // keep whitelist peer on connected
+            self.try_dial_whitelist();
             // ensure feeler work at any time
             self.dial_feeler();
             // keep outbound peer is enough
             self.try_dial_peers();
-            // keep whitelist peer on connected
-            self.try_dial_whitelist();
             // try dial observed addrs
             self.try_dial_observed();
         }

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -70,7 +70,7 @@ fn test_attempt_ban() {
         .mut_addr_manager()
         .get_mut(&addr)
         .unwrap()
-        .last_connected_at_ms = faketime::unix_time_as_millis();
+        .mark_connected(faketime::unix_time_as_millis());
 
     faketime::write_millis(&faketime_file, 100_000).expect("write millis");
 
@@ -95,7 +95,7 @@ fn test_fetch_addrs_to_attempt() {
         .mut_addr_manager()
         .get_mut(&addr)
         .unwrap()
-        .last_connected_at_ms = faketime::unix_time_as_millis();
+        .mark_connected(faketime::unix_time_as_millis());
     faketime::write_millis(&faketime_file, 100_000).expect("write millis");
 
     assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 1);
@@ -153,7 +153,7 @@ fn test_fetch_addrs_to_attempt_in_last_minutes() {
         .mut_addr_manager()
         .get_mut(&addr)
         .unwrap()
-        .last_connected_at_ms = now;
+        .mark_connected(now);
     faketime::write_millis(&faketime_file, 200_000).expect("write millis");
 
     assert_eq!(peer_store.fetch_addrs_to_attempt(1).len(), 1);
@@ -224,7 +224,7 @@ fn test_fetch_random_addrs() {
         .mut_addr_manager()
         .get_mut(&addr3)
         .unwrap()
-        .last_connected_at_ms = 0;
+        .mark_connected(0);
     assert_eq!(peer_store.fetch_random_addrs(3).len(), 3);
     peer_store.remove_disconnected_peer(&addr3);
     assert_eq!(peer_store.fetch_random_addrs(3).len(), 2);

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -2,7 +2,7 @@ use super::random_addr;
 use crate::{
     extract_peer_id,
     multiaddr::Multiaddr,
-    peer_store::{PeerStore, Status, ADDR_COUNT_LIMIT},
+    peer_store::{PeerStore, Status, ADDR_COUNT_LIMIT, ADDR_TRY_TIMEOUT_MS},
     Behaviour, PeerId, SessionType,
 };
 
@@ -22,8 +22,9 @@ fn test_add_addr() {
     assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 0);
     let addr = random_addr();
     peer_store.add_addr(addr).unwrap();
-    assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 1);
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
     // we have not connected yet, so return 0
+    assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 0);
     assert_eq!(peer_store.fetch_random_addrs(2).len(), 0);
 }
 
@@ -59,6 +60,11 @@ fn test_attempt_ban() {
     let mut peer_store: PeerStore = Default::default();
     let addr = random_addr();
     peer_store.add_addr(addr.clone()).unwrap();
+    peer_store
+        .mut_addr_manager()
+        .get_mut(&addr)
+        .unwrap()
+        .last_connected_at_ms = faketime::unix_time_as_millis();
     assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 1);
     peer_store.ban_addr(&addr, 10_000, "no reason".into());
     assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 0);
@@ -70,9 +76,34 @@ fn test_fetch_addrs_to_attempt() {
     assert!(peer_store.fetch_addrs_to_attempt(1).is_empty());
     let addr = random_addr();
     peer_store.add_addr(addr.clone()).unwrap();
+    peer_store
+        .mut_addr_manager()
+        .get_mut(&addr)
+        .unwrap()
+        .last_connected_at_ms = faketime::unix_time_as_millis();
     assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 1);
     peer_store.add_connected_peer(addr, SessionType::Outbound);
     assert!(peer_store.fetch_addrs_to_attempt(1).is_empty());
+}
+
+#[cfg(not(disable_faketime))]
+#[test]
+fn test_fetch_addrs_to_attempt_or_feeler() {
+    let faketime_file = faketime::millis_tempfile(0).expect("create faketime file");
+    faketime::enable(&faketime_file);
+
+    faketime::write_millis(&faketime_file, 1).expect("write millis");
+
+    let mut peer_store: PeerStore = Default::default();
+    let addr = random_addr();
+    peer_store.add_outbound_addr(addr);
+    assert_eq!(peer_store.fetch_addrs_to_attempt(2).len(), 1);
+    assert!(peer_store.fetch_addrs_to_feeler(2).is_empty());
+
+    faketime::write_millis(&faketime_file, ADDR_TRY_TIMEOUT_MS + 1).expect("write millis");
+
+    assert!(peer_store.fetch_addrs_to_attempt(2).is_empty());
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
 }
 
 #[test]
@@ -89,6 +120,16 @@ fn test_fetch_addrs_to_attempt_in_last_minutes() {
     // after 60 seconds
     if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&addr) {
         paddr.mark_tried(now - 60_001);
+    }
+    assert!(peer_store.fetch_addrs_to_attempt(1).is_empty());
+    peer_store
+        .mut_addr_manager()
+        .get_mut(&addr)
+        .unwrap()
+        .last_connected_at_ms = now;
+    assert_eq!(peer_store.fetch_addrs_to_attempt(1).len(), 1);
+    if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&addr) {
+        paddr.mark_tried(now);
     }
     assert_eq!(peer_store.fetch_addrs_to_attempt(1).len(), 1);
 }
@@ -245,8 +286,7 @@ fn test_eviction() {
             .unwrap();
     peer_store.add_addr(new_peer_addr.clone()).unwrap();
     // check addrs
-    // peer store will evict peers from largest network group to low group
-    // the two evict_addrs should be evict, other addrs will remain in peer store
+    // peer store will evict all peers which are invalid
     assert!(peer_store.mut_addr_manager().get(&new_peer_addr).is_some());
     assert!(peer_store.mut_addr_manager().get(&evict_addr_2).is_none());
     assert!(peer_store.mut_addr_manager().get(&evict_addr).is_none());

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -271,13 +271,13 @@ fn test_eviction() {
         paddr.mark_tried(tried_ms);
         paddr.mark_tried(tried_ms);
         paddr.mark_tried(tried_ms);
-        assert!(paddr.is_terrible(now));
+        assert!(!paddr.is_connectable(now));
     }
     if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&evict_addr_2) {
         paddr.mark_tried(tried_ms);
         paddr.mark_tried(tried_ms);
         paddr.mark_tried(tried_ms);
-        assert!(paddr.is_terrible(now));
+        assert!(!paddr.is_connectable(now));
     }
     // should evict evict_addr and accept new_peer
     let new_peer_addr: Multiaddr =
@@ -290,4 +290,18 @@ fn test_eviction() {
     assert!(peer_store.mut_addr_manager().get(&new_peer_addr).is_some());
     assert!(peer_store.mut_addr_manager().get(&evict_addr_2).is_none());
     assert!(peer_store.mut_addr_manager().get(&evict_addr).is_none());
+
+    // In the absence of invalid nodes, too many nodes on the same network segment will be automatically evicted
+    let new_peer_addr: Multiaddr =
+        format!("/ip4/225.0.0.3/tcp/42/p2p/{}", PeerId::random().to_base58())
+            .parse()
+            .unwrap();
+    peer_store.add_addr(new_peer_addr.clone()).unwrap();
+    assert!(peer_store.mut_addr_manager().get(&new_peer_addr).is_some());
+    let new_peer_addr: Multiaddr =
+        format!("/ip4/225.0.0.3/tcp/42/p2p/{}", PeerId::random().to_base58())
+            .parse()
+            .unwrap();
+    peer_store.add_addr(new_peer_addr.clone()).unwrap();
+    assert!(peer_store.mut_addr_manager().get(&new_peer_addr).is_some());
 }


### PR DESCRIPTION
### What problem does this PR solve?

1. Peer store‘s detection and eviction efficiency is too low 
2. There is a certain conflict between the peer store obtaining available nodes and the nodes that need to be probed 
3. There is a problem with interval's choice of MissedTickBehavior
4.  When a node is disconnected, based on the peer store strategy, the node information may be lost 

### What is changed and how it works?

1. Made some adjustments to the peer store's strategy of randomly obtaining node information
```
| -- choose to identify --| --- choose to feeler --- | --      delete     -- |
| 1      | 2     | 3      | 4    | 5    | 6   | 7    | More than seven days  |
```
2. Made some adjustments to the use of interval:
- Removed the immediate execution behavior of dump peer store startup 
- Adjust interval default MissedTickBehavior to delay or skip 

3. The detection behavior is adjusted to not conflict with the behavior of completing outbound and will be executed permanently 
4. When no valid completion node can be found continuously, try to connect to boot node randomly 
5. Remove ban list from peer store
6. Evict connectable nodes by network segment 
7. Remove nodes that have been connected within 15s 

### Check List <!--REMOVE the items that are not applicable-->

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

