### PR TITLE
deps: fix crates publish

### DIFF
--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -15,4 +15,4 @@ ckb-async-runtime = { path = "../runtime", version = "= 0.100.0-pre" }
 ckb-util = { path = "..", version = "= 0.100.0-pre" }
 opentelemetry-prometheus = "0.8"
 prometheus = "0.12"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["http1", "tcp", "server"] }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: In a Rust workspace, features of dependencies are merged. But when publishing crates, cargo only uses the features list in the current crate Cargo.toml

### What is changed and how it works?

What's Changed:

- Enable feature `server`, `tcp`, and `http1` for `hyper` in `ckb-metrics-service` (introduced by [jsonrpc-http-server](https://github.com/paritytech/jsonrpc/blob/dc6b8ede1e86feb32a2bbe4770628ee3788b3f4d/http/Cargo.toml#L15)).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Run `cargo publish --dry-run` in directory `util/metrics-service`.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

