### PR TITLE
chore: update publish-crates.sh to support yanking

### DIFF
--- a/devtools/release/publish-crates.sh
+++ b/devtools/release/publish-crates.sh
@@ -64,6 +64,7 @@ generate_readme() {
 cp -f Cargo.lock Cargo.lock.bak
 
 PUBLISH_FROM="${CKB_PUBLISH_FROM:-}"
+YANK="${CKB_YANK:-}"
 SKIP=false
 if [ -n "$PUBLISH_FROM" ]; then
   SKIP=true
@@ -80,6 +81,11 @@ for crate_dir in $CRATES; do
       fi
       if [ "$SKIP" = true ]; then
         echo "=> skip $crate_dir"
+      elif [ -n "$YANK" ]; then
+        echo "=> yank $crate_dir"
+        pushd "$crate_dir"
+        cargo yank --vers "$YANK"
+        popd
       else
         echo "=> publish $crate_dir"
         pushd "$crate_dir"
@@ -94,5 +100,10 @@ for crate_dir in $CRATES; do
       ;;
   esac
 done
-retry_cargo_publish "$@"
-mv -f Cargo.lock.bak Cargo.lock
+
+if [ -n "$YANK" ]; then
+  cargo yank --vers "$YANK"
+else
+  retry_cargo_publish "$@"
+  mv -f Cargo.lock.bak Cargo.lock
+fi


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: There's no tool to yank a specific version of all the crates.

### What is changed and how it works?

What's Changed:

```
CKB_YANK=0.100.0-rc3 devtools/release/publish-crates.sh
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

