### PR TITLE
fix: chunk process cycle calculation

### DIFF
--- a/script/src/verify/tests/ckb_latest/features_since_v2019.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2019.rs
@@ -1,19 +1,13 @@
 use byteorder::{ByteOrder, LittleEndian};
-use ckb_chain_spec::consensus::{TWO_IN_TWO_OUT_BYTES, TWO_IN_TWO_OUT_CYCLES, TYPE_ID_CODE_HASH};
-use ckb_crypto::secp::{Generator, Privkey};
+use ckb_chain_spec::consensus::{TWO_IN_TWO_OUT_CYCLES, TYPE_ID_CODE_HASH};
+use ckb_crypto::secp::Privkey;
 use ckb_error::assert_error_eq;
 use ckb_hash::{blake2b_256, new_blake2b};
-use ckb_test_chain_utils::{
-    always_success_cell, ckb_testnet_consensus, secp256k1_blake160_sighash_cell,
-    secp256k1_data_cell, type_lock_script_code_hash,
-};
+use ckb_test_chain_utils::always_success_cell;
 use ckb_types::{
-    core::{
-        capacity_bytes, cell::CellMetaBuilder, Capacity, DepType, ScriptHashType,
-        TransactionBuilder,
-    },
+    core::{capacity_bytes, cell::CellMetaBuilder, Capacity, ScriptHashType, TransactionBuilder},
     h256,
-    packed::{CellDep, CellInput, CellOutputBuilder, OutPoint, Script, WitnessArgs},
+    packed::{CellDep, CellInput, CellOutputBuilder, OutPoint, Script},
     H256,
 };
 use std::io::Read;
@@ -1115,144 +1109,7 @@ fn check_type_id_one_in_two_out() {
 fn check_typical_secp256k1_blake160_2_in_2_out_tx() {
     let script_version = SCRIPT_VERSION;
 
-    let consensus = ckb_testnet_consensus();
-    let dep_group_tx_hash = consensus.genesis_block().transactions()[1].hash();
-    let secp_out_point = OutPoint::new(dep_group_tx_hash, 0);
-
-    let cell_dep = CellDep::new_builder()
-        .out_point(secp_out_point)
-        .dep_type(DepType::DepGroup.into())
-        .build();
-
-    let input1 = CellInput::new(OutPoint::new(h256!("0x1234").pack(), 0), 0);
-    let input2 = CellInput::new(OutPoint::new(h256!("0x1111").pack(), 0), 0);
-
-    let mut generator = Generator::non_crypto_safe_prng(42);
-    let privkey = generator.gen_privkey();
-    let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
-    let lock_arg = Bytes::from((&blake2b_256(&pubkey_data)[0..20]).to_owned());
-    let privkey2 = generator.gen_privkey();
-    let pubkey_data2 = privkey2.pubkey().expect("Get pubkey failed").serialize();
-    let lock_arg2 = Bytes::from((&blake2b_256(&pubkey_data2)[0..20]).to_owned());
-
-    let lock = Script::new_builder()
-        .args(lock_arg.pack())
-        .code_hash(type_lock_script_code_hash().pack())
-        .hash_type(ScriptHashType::Type.into())
-        .build();
-
-    let lock2 = Script::new_builder()
-        .args(lock_arg2.pack())
-        .code_hash(type_lock_script_code_hash().pack())
-        .hash_type(ScriptHashType::Type.into())
-        .build();
-
-    let output1 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock.clone())
-        .build();
-    let output2 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock2.clone())
-        .build();
-    let tx = TransactionBuilder::default()
-        .cell_dep(cell_dep)
-        .input(input1.clone())
-        .input(input2.clone())
-        .output(output1)
-        .output(output2)
-        .output_data(Default::default())
-        .output_data(Default::default())
-        .build();
-
-    let tx_hash: H256 = tx.hash().unpack();
-    // sign input1
-    let witness = {
-        WitnessArgs::new_builder()
-            .lock(Some(Bytes::from(vec![0u8; 65])).pack())
-            .build()
-    };
-    let witness_len: u64 = witness.as_bytes().len() as u64;
-    let mut hasher = new_blake2b();
-    hasher.update(tx_hash.as_bytes());
-    hasher.update(&witness_len.to_le_bytes());
-    hasher.update(&witness.as_bytes());
-    let message = {
-        let mut buf = [0u8; 32];
-        hasher.finalize(&mut buf);
-        H256::from(buf)
-    };
-    let sig = privkey.sign_recoverable(&message).expect("sign");
-    let witness = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(sig.serialize())).pack())
-        .build();
-    // sign input2
-    let witness2 = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(vec![0u8; 65])).pack())
-        .build();
-    let witness2_len: u64 = witness2.as_bytes().len() as u64;
-    let mut hasher = new_blake2b();
-    hasher.update(tx_hash.as_bytes());
-    hasher.update(&witness2_len.to_le_bytes());
-    hasher.update(&witness2.as_bytes());
-    let message2 = {
-        let mut buf = [0u8; 32];
-        hasher.finalize(&mut buf);
-        H256::from(buf)
-    };
-    let sig2 = privkey2.sign_recoverable(&message2).expect("sign");
-    let witness2 = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(sig2.serialize())).pack())
-        .build();
-    let tx = tx
-        .as_advanced_builder()
-        .witness(witness.as_bytes().pack())
-        .witness(witness2.as_bytes().pack())
-        .build();
-
-    let serialized_size = tx.data().as_slice().len() as u64;
-
-    assert_eq!(
-        serialized_size, TWO_IN_TWO_OUT_BYTES,
-        "2 in 2 out tx serialized size changed, PLEASE UPDATE consensus"
-    );
-
-    let (secp256k1_blake160_cell, secp256k1_blake160_cell_data) =
-        secp256k1_blake160_sighash_cell(consensus.clone());
-
-    let (secp256k1_data_cell, secp256k1_data_cell_data) = secp256k1_data_cell(consensus);
-
-    let input_cell1 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock)
-        .build();
-
-    let resolved_input_cell1 = CellMetaBuilder::from_cell_output(input_cell1, Default::default())
-        .out_point(input1.previous_output())
-        .build();
-
-    let input_cell2 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock2)
-        .build();
-
-    let resolved_input_cell2 = CellMetaBuilder::from_cell_output(input_cell2, Default::default())
-        .out_point(input2.previous_output())
-        .build();
-
-    let resolved_secp256k1_blake160_cell =
-        CellMetaBuilder::from_cell_output(secp256k1_blake160_cell, secp256k1_blake160_cell_data)
-            .build();
-
-    let resolved_secp_data_cell =
-        CellMetaBuilder::from_cell_output(secp256k1_data_cell, secp256k1_data_cell_data).build();
-
-    let rtx = ResolvedTransaction {
-        transaction: tx,
-        resolved_cell_deps: vec![resolved_secp256k1_blake160_cell, resolved_secp_data_cell],
-        resolved_inputs: vec![resolved_input_cell1, resolved_input_cell2],
-        resolved_dep_groups: vec![],
-    };
+    let rtx = random_2_in_2_out_rtx();
 
     let max_cycles = TWO_IN_TWO_OUT_CYCLES;
     let verifier = TransactionScriptsVerifierWithEnv::new();

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -1,21 +1,14 @@
-use ckb_chain_spec::consensus::{TWO_IN_TWO_OUT_BYTES, TWO_IN_TWO_OUT_CYCLES, TYPE_ID_CODE_HASH};
-use ckb_crypto::secp::Generator;
+use ckb_chain_spec::consensus::{TWO_IN_TWO_OUT_CYCLES, TYPE_ID_CODE_HASH};
 use ckb_error::assert_error_eq;
-use ckb_hash::{blake2b_256, new_blake2b};
-use ckb_test_chain_utils::{
-    always_success_cell, ckb_testnet_consensus, secp256k1_blake160_sighash_cell,
-    secp256k1_data_cell, type_lock_script_code_hash,
-};
+use ckb_test_chain_utils::always_success_cell;
 use ckb_types::{
-    core::{
-        capacity_bytes, cell::CellMetaBuilder, Capacity, DepType, ScriptHashType,
-        TransactionBuilder,
-    },
+    core::{capacity_bytes, cell::CellMetaBuilder, Capacity, ScriptHashType, TransactionBuilder},
     h256,
-    packed::{self, CellDep, CellInput, CellOutputBuilder, OutPoint, Script, WitnessArgs},
+    packed::{self, CellDep, CellInput, CellOutputBuilder, OutPoint, Script},
     H256,
 };
 use ckb_vm::Error as VmError;
+use std::convert::TryInto;
 use std::path::Path;
 
 use super::SCRIPT_VERSION;
@@ -348,144 +341,7 @@ fn check_type_id_one_in_one_out_chunk() {
 fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_chunk() {
     let script_version = SCRIPT_VERSION;
 
-    let consensus = ckb_testnet_consensus();
-    let dep_group_tx_hash = consensus.genesis_block().transactions()[1].hash();
-    let secp_out_point = OutPoint::new(dep_group_tx_hash, 0);
-
-    let cell_dep = CellDep::new_builder()
-        .out_point(secp_out_point)
-        .dep_type(DepType::DepGroup.into())
-        .build();
-
-    let input1 = CellInput::new(OutPoint::new(h256!("0x1234").pack(), 0), 0);
-    let input2 = CellInput::new(OutPoint::new(h256!("0x1111").pack(), 0), 0);
-
-    let mut generator = Generator::non_crypto_safe_prng(42);
-    let privkey = generator.gen_privkey();
-    let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
-    let lock_arg = Bytes::from((&blake2b_256(&pubkey_data)[0..20]).to_owned());
-    let privkey2 = generator.gen_privkey();
-    let pubkey_data2 = privkey2.pubkey().expect("Get pubkey failed").serialize();
-    let lock_arg2 = Bytes::from((&blake2b_256(&pubkey_data2)[0..20]).to_owned());
-
-    let lock = Script::new_builder()
-        .args(lock_arg.pack())
-        .code_hash(type_lock_script_code_hash().pack())
-        .hash_type(ScriptHashType::Type.into())
-        .build();
-
-    let lock2 = Script::new_builder()
-        .args(lock_arg2.pack())
-        .code_hash(type_lock_script_code_hash().pack())
-        .hash_type(ScriptHashType::Type.into())
-        .build();
-
-    let output1 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock.clone())
-        .build();
-    let output2 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock2.clone())
-        .build();
-    let tx = TransactionBuilder::default()
-        .cell_dep(cell_dep)
-        .input(input1.clone())
-        .input(input2.clone())
-        .output(output1)
-        .output(output2)
-        .output_data(Default::default())
-        .output_data(Default::default())
-        .build();
-
-    let tx_hash: H256 = tx.hash().unpack();
-    // sign input1
-    let witness = {
-        WitnessArgs::new_builder()
-            .lock(Some(Bytes::from(vec![0u8; 65])).pack())
-            .build()
-    };
-    let witness_len: u64 = witness.as_bytes().len() as u64;
-    let mut hasher = new_blake2b();
-    hasher.update(tx_hash.as_bytes());
-    hasher.update(&witness_len.to_le_bytes());
-    hasher.update(&witness.as_bytes());
-    let message = {
-        let mut buf = [0u8; 32];
-        hasher.finalize(&mut buf);
-        H256::from(buf)
-    };
-    let sig = privkey.sign_recoverable(&message).expect("sign");
-    let witness = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(sig.serialize())).pack())
-        .build();
-    // sign input2
-    let witness2 = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(vec![0u8; 65])).pack())
-        .build();
-    let witness2_len: u64 = witness2.as_bytes().len() as u64;
-    let mut hasher = new_blake2b();
-    hasher.update(tx_hash.as_bytes());
-    hasher.update(&witness2_len.to_le_bytes());
-    hasher.update(&witness2.as_bytes());
-    let message2 = {
-        let mut buf = [0u8; 32];
-        hasher.finalize(&mut buf);
-        H256::from(buf)
-    };
-    let sig2 = privkey2.sign_recoverable(&message2).expect("sign");
-    let witness2 = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(sig2.serialize())).pack())
-        .build();
-    let tx = tx
-        .as_advanced_builder()
-        .witness(witness.as_bytes().pack())
-        .witness(witness2.as_bytes().pack())
-        .build();
-
-    let serialized_size = tx.data().as_slice().len() as u64;
-
-    assert_eq!(
-        serialized_size, TWO_IN_TWO_OUT_BYTES,
-        "2 in 2 out tx serialized size changed, PLEASE UPDATE consensus"
-    );
-
-    let (secp256k1_blake160_cell, secp256k1_blake160_cell_data) =
-        secp256k1_blake160_sighash_cell(consensus.clone());
-
-    let (secp256k1_data_cell, secp256k1_data_cell_data) = secp256k1_data_cell(consensus);
-
-    let input_cell1 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock)
-        .build();
-
-    let resolved_input_cell1 = CellMetaBuilder::from_cell_output(input_cell1, Default::default())
-        .out_point(input1.previous_output())
-        .build();
-
-    let input_cell2 = CellOutput::new_builder()
-        .capacity(capacity_bytes!(100).pack())
-        .lock(lock2)
-        .build();
-
-    let resolved_input_cell2 = CellMetaBuilder::from_cell_output(input_cell2, Default::default())
-        .out_point(input2.previous_output())
-        .build();
-
-    let resolved_secp256k1_blake160_cell =
-        CellMetaBuilder::from_cell_output(secp256k1_blake160_cell, secp256k1_blake160_cell_data)
-            .build();
-
-    let resolved_secp_data_cell =
-        CellMetaBuilder::from_cell_output(secp256k1_data_cell, secp256k1_data_cell_data).build();
-
-    let rtx = ResolvedTransaction {
-        transaction: tx,
-        resolved_cell_deps: vec![resolved_secp256k1_blake160_cell, resolved_secp_data_cell],
-        resolved_inputs: vec![resolved_input_cell1, resolved_input_cell2],
-        resolved_dep_groups: vec![],
-    };
+    let rtx = random_2_in_2_out_rtx();
 
     let mut cycles = 0;
     let verifier = TransactionScriptsVerifierWithEnv::new();
@@ -533,6 +389,127 @@ fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_chunk() {
                 break;
             }
         }
+
+        verifier.verify(TWO_IN_TWO_OUT_CYCLES)
+    });
+
+    let cycles_once = result.unwrap();
+    assert!(cycles <= TWO_IN_TWO_OUT_CYCLES);
+    assert!(cycles >= TWO_IN_TWO_OUT_CYCLES - CYCLE_BOUND);
+    assert_eq!(cycles, cycles_once);
+}
+
+#[test]
+fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap() {
+    let script_version = SCRIPT_VERSION;
+
+    let rtx = random_2_in_2_out_rtx();
+    let mut cycles = 0;
+    let verifier = TransactionScriptsVerifierWithEnv::new();
+    let result = verifier.verify_map(script_version, &rtx, |verifier| {
+        let mut init_snap: Option<TransactionSnapshot> = None;
+
+        if let VerifyResult::Suspended(state) = verifier
+            .resumable_verify(TWO_IN_TWO_OUT_CYCLES / 10)
+            .unwrap()
+        {
+            init_snap = Some(state.try_into().unwrap());
+        }
+
+        loop {
+            match verifier
+                .resume_from_snap(&init_snap.take().unwrap(), TWO_IN_TWO_OUT_CYCLES / 10)
+                .unwrap()
+            {
+                VerifyResult::Suspended(state) => init_snap = Some(state.try_into().unwrap()),
+                VerifyResult::Completed(cycle) => {
+                    cycles = cycle;
+                    break;
+                }
+            }
+        }
+
+        verifier.verify(TWO_IN_TWO_OUT_CYCLES)
+    });
+
+    let cycles_once = result.unwrap();
+    assert!(cycles <= TWO_IN_TWO_OUT_CYCLES);
+    assert!(cycles >= TWO_IN_TWO_OUT_CYCLES - CYCLE_BOUND);
+    assert_eq!(cycles, cycles_once);
+}
+
+#[test]
+fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_state() {
+    let script_version = SCRIPT_VERSION;
+
+    let rtx = random_2_in_2_out_rtx();
+    let mut cycles = 0;
+    let verifier = TransactionScriptsVerifierWithEnv::new();
+    let result = verifier.verify_map(script_version, &rtx, |verifier| {
+        let mut init_state: Option<TransactionState<'_>> = None;
+
+        if let VerifyResult::Suspended(state) = verifier
+            .resumable_verify(TWO_IN_TWO_OUT_CYCLES / 10)
+            .unwrap()
+        {
+            init_state = Some(state);
+        }
+
+        loop {
+            let max = init_state.as_ref().unwrap().current_cycles + TWO_IN_TWO_OUT_CYCLES / 10;
+            match verifier
+                .resume_from_state(init_state.take().unwrap(), max)
+                .unwrap()
+            {
+                VerifyResult::Suspended(state) => init_state = Some(state),
+                VerifyResult::Completed(cycle) => {
+                    cycles = cycle;
+                    break;
+                }
+            }
+        }
+
+        verifier.verify(TWO_IN_TWO_OUT_CYCLES)
+    });
+
+    let cycles_once = result.unwrap();
+    assert!(cycles <= TWO_IN_TWO_OUT_CYCLES);
+    assert!(cycles >= TWO_IN_TWO_OUT_CYCLES - CYCLE_BOUND);
+    assert_eq!(cycles, cycles_once);
+}
+
+#[test]
+fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_complete() {
+    let script_version = SCRIPT_VERSION;
+
+    let rtx = random_2_in_2_out_rtx();
+    let mut cycles = 0;
+    let verifier = TransactionScriptsVerifierWithEnv::new();
+    let result = verifier.verify_map(script_version, &rtx, |verifier| {
+        let mut init_snap: Option<TransactionSnapshot> = None;
+
+        if let VerifyResult::Suspended(state) = verifier
+            .resumable_verify(TWO_IN_TWO_OUT_CYCLES / 10)
+            .unwrap()
+        {
+            init_snap = Some(state.try_into().unwrap());
+        }
+
+        for _ in 0..6 {
+            match verifier
+                .resume_from_snap(&init_snap.take().unwrap(), TWO_IN_TWO_OUT_CYCLES / 10)
+                .unwrap()
+            {
+                VerifyResult::Suspended(state) => init_snap = Some(state.try_into().unwrap()),
+                VerifyResult::Completed(_) => {
+                    unreachable!()
+                }
+            }
+        }
+
+        cycles = verifier
+            .complete(&init_snap.take().unwrap(), TWO_IN_TWO_OUT_CYCLES)
+            .unwrap();
 
         verifier.verify(TWO_IN_TWO_OUT_CYCLES)
     });

--- a/tx-pool/src/chunk_process.rs
+++ b/tx-pool/src/chunk_process.rs
@@ -214,15 +214,6 @@ impl TxChunkProcess {
                     return Err(Reject::Verification(error));
                 }
 
-                // next_limit_cycles
-                // let remain = max_cycles - self.current_cycles;
-                // let next_limit = self.limit_cycles + step_cycles;
-
-                // if next_limit < remain {
-                //     (next_limit, false)
-                // } else {
-                //     (remain, true)
-                // }
                 let (limit_cycles, last) = state.next_limit_cycles(MIN_STEP_CYCLE, max_cycles);
                 last_step = last;
                 script_verifier.resume_from_state(state, limit_cycles)


### PR DESCRIPTION
### What problem does this PR solve?

Tx chunk process cycles calculation error:
1. all suspended branches lack the cycle calculation process
https://github.com/nervosnetwork/ckb/blob/39c8cee51018931e4be8c90d776071faf42647c0/script/src/verify.rs#L508-L517
2. `resume_from_state` use incoming VM, It needs to avoid repeated calculation of cycles that already exists 
https://github.com/nervosnetwork/ckb/blob/39c8cee51018931e4be8c90d776071faf42647c0/script/src/verify.rs#L654-L655
3. `next_limit_cycles` on `TransactionSnapshot` or `TransactionState` must less than or equal to `step_cycles`
4. `resume_from_state` use incoming VM，reset max cycles must be greater than old max cycle
https://github.com/nervosnetwork/ckb/blob/39c8cee51018931e4be8c90d776071faf42647c0/script/src/verify.rs#L650

### What is changed and how it works?

Rewrite the cycles calculation process in the entire verification process 

### Check List

Tests

- Unit test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

