### PR TITLE
chore: override toolchain in coverage workflow

### DIFF
--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -13,10 +13,11 @@ jobs:
     if: |
         github.repository_owner == 'nervosnetwork'
     steps:
-      - name: install nightly
-        run: |
-          rustup toolchain list | { grep 'nightly' || rustup install nightly; }
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
       - name: unit coverage
         run: make cov
       - name: integration cov

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/vendor"]
 	path = test/vendor
 	url = https://github.com/nervosnetwork/ckb-tests.git
+	shallow = true


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: Coverage CI failed because that grcov could not find the executable `llvm-profdata` in the toolchain 1.51.0.

https://github.com/nervosnetwork/ckb/runs/3377259782?check_suite_focus=true#step:4:1946

It's surprised that grcov exit with status code 0 event it fails to find the llvm-profdata executable.

### What is changed and how it works?

What's Changed: Override toolchain to nightly in CI.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

