### PR TITLE
chore: remove trailing semicolons in macro

### DIFF
--- a/util/types/src/core/hardfork.rs
+++ b/util/types/src/core/hardfork.rs
@@ -257,7 +257,7 @@ impl HardForkSwitchBuilder {
             ($feature:ident) => {
                 self.$feature.ok_or_else(|| {
                     concat!("The feature ", stringify!($feature), " isn't configured.").to_owned()
-                })?;
+                })?
             };
         }
         let rfc_0028 = try_find!(rfc_0028);


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

According to https://github.com/rust-lang/rust/issues/79813 says, a trailing semicolon in macros is useless.

### What is changed and how it works?

Just remove trailing semicolons in macro. This PR will not introduce any new behavior.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```