### PR TITLE
feat: remove conflict pending for reorg

### DIFF
--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -2,23 +2,33 @@ use crate::component::entry::TxEntry;
 use ckb_types::{
     core::{
         cell::{CellChecker, CellMetaBuilder, CellProvider, CellStatus},
+        error::OutPointError,
+        tx_pool::Reject,
         TransactionView,
     },
     packed::{OutPoint, ProposalShortId},
     prelude::*,
 };
 use ckb_util::{LinkedHashMap, LinkedHashMapEntries};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+type ConflictEntry = (TxEntry, Reject);
 
 #[derive(Debug, Clone)]
 pub(crate) struct PendingQueue {
     inner: LinkedHashMap<ProposalShortId, TxEntry>,
+    /// dep-set<txid> map represent in-pool tx's deps
+    deps: HashMap<OutPoint, HashSet<ProposalShortId>>,
+    /// input-txid map represent in-pool tx's inputs
+    inputs: HashMap<OutPoint, ProposalShortId>,
 }
 
 impl PendingQueue {
     pub(crate) fn new() -> Self {
         PendingQueue {
             inner: Default::default(),
+            deps: Default::default(),
+            inputs: Default::default(),
         }
     }
 
@@ -26,8 +36,57 @@ impl PendingQueue {
         self.inner.len()
     }
 
-    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> Option<TxEntry> {
-        self.inner.insert(entry.proposal_short_id(), entry)
+    pub(crate) fn add_entry(&mut self, entry: TxEntry) -> bool {
+        let inputs = entry.transaction().input_pts_iter();
+        let tx_short_id = entry.proposal_short_id();
+
+        if self.inner.contains_key(&tx_short_id) {
+            return false;
+        }
+
+        for i in inputs {
+            self.inputs.insert(i.to_owned(), tx_short_id.clone());
+        }
+
+        // record dep-txid
+        for d in entry.related_dep_out_points() {
+            self.deps
+                .entry(d.to_owned())
+                .or_default()
+                .insert(tx_short_id.clone());
+        }
+
+        self.inner.insert(tx_short_id, entry);
+        true
+    }
+
+    pub(crate) fn resolve_conflict(
+        &mut self,
+        tx: &TransactionView,
+    ) -> (Vec<ConflictEntry>, Vec<ConflictEntry>) {
+        let inputs = tx.input_pts_iter();
+        let mut input_conflict = Vec::new();
+        let mut deps_consumed = Vec::new();
+
+        for i in inputs {
+            if let Some(id) = self.inputs.remove(&i) {
+                if let Some(entry) = self.remove_entry(&id) {
+                    let reject = Reject::Resolve(OutPointError::Dead(i.clone()));
+                    input_conflict.push((entry, reject));
+                }
+            }
+
+            // deps consumed
+            if let Some(x) = self.deps.remove(&i) {
+                for id in x {
+                    if let Some(entry) = self.remove_entry(&id) {
+                        let reject = Reject::Resolve(OutPointError::Dead(i.clone()));
+                        deps_consumed.push((entry, reject));
+                    }
+                }
+            }
+        }
+        (input_conflict, deps_consumed)
     }
 
     pub(crate) fn contains_key(&self, id: &ProposalShortId) -> bool {
@@ -46,8 +105,84 @@ impl PendingQueue {
         self.inner.get(id).map(|entry| entry.transaction())
     }
 
+    pub(crate) fn remove_committed_tx(
+        &mut self,
+        tx: &TransactionView,
+        related_out_points: &[OutPoint],
+    ) -> Option<TxEntry> {
+        let inputs = tx.input_pts_iter();
+        let id = tx.proposal_short_id();
+
+        if let Some(entry) = self.inner.remove(&id) {
+            for i in inputs {
+                self.inputs.remove(&i);
+            }
+
+            for d in related_out_points {
+                let mut empty = false;
+                if let Some(x) = self.deps.get_mut(d) {
+                    x.remove(&id);
+                    empty = x.is_empty();
+                }
+
+                if empty {
+                    self.deps.remove(d);
+                }
+            }
+
+            return Some(entry);
+        }
+        None
+    }
+
     pub(crate) fn remove_entry(&mut self, id: &ProposalShortId) -> Option<TxEntry> {
-        self.inner.remove(id)
+        let removed = self.inner.remove(id);
+
+        if let Some(ref entry) = removed {
+            self.remove_entry_relation(entry);
+        }
+
+        removed
+    }
+
+    pub(crate) fn remove_entry_relation(&mut self, entry: &TxEntry) {
+        let inputs = entry.transaction().input_pts_iter();
+        let tx_short_id = entry.proposal_short_id();
+
+        for i in inputs {
+            self.inputs.remove(&i);
+        }
+
+        // remove dep
+        for d in entry.related_dep_out_points() {
+            let mut empty = false;
+            if let Some(x) = self.deps.get_mut(d) {
+                x.remove(&tx_short_id);
+                empty = x.is_empty();
+            }
+
+            if empty {
+                self.deps.remove(d);
+            }
+        }
+    }
+
+    pub(crate) fn remove_entries_by_filter<P: FnMut(&ProposalShortId, &TxEntry) -> bool>(
+        &mut self,
+        mut predicate: P,
+    ) -> Vec<TxEntry> {
+        let entries = self.entries();
+        let mut removed = Vec::new();
+        for entry in entries {
+            if predicate(entry.key(), entry.get()) {
+                removed.push(entry.remove());
+            }
+        }
+        for entry in &removed {
+            self.remove_entry_relation(&entry);
+        }
+
+        removed
     }
 
     pub fn entries(&mut self) -> LinkedHashMapEntries<ProposalShortId, TxEntry> {
@@ -78,6 +213,8 @@ impl PendingQueue {
             .map(|entry| entry.transaction().clone())
             .collect::<Vec<_>>();
         self.inner.clear();
+        self.deps.clear();
+        self.inputs.clear();
         txs
     }
 }

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -16,11 +16,11 @@ type ConflictEntry = (TxEntry, Reject);
 
 #[derive(Debug, Clone)]
 pub(crate) struct PendingQueue {
-    inner: LinkedHashMap<ProposalShortId, TxEntry>,
+    pub(crate) inner: LinkedHashMap<ProposalShortId, TxEntry>,
     /// dep-set<txid> map represent in-pool tx's deps
-    deps: HashMap<OutPoint, HashSet<ProposalShortId>>,
+    pub(crate) deps: HashMap<OutPoint, HashSet<ProposalShortId>>,
     /// input-txid map represent in-pool tx's inputs
-    inputs: HashMap<OutPoint, ProposalShortId>,
+    pub(crate) inputs: HashMap<OutPoint, ProposalShortId>,
 }
 
 impl PendingQueue {

--- a/tx-pool/src/component/tests/mod.rs
+++ b/tx-pool/src/component/tests/mod.rs
@@ -1,3 +1,5 @@
 mod chunk;
 mod container;
+mod pending;
 mod proposed;
+mod util;

--- a/tx-pool/src/component/tests/pending.rs
+++ b/tx-pool/src/component/tests/pending.rs
@@ -1,0 +1,169 @@
+use crate::component::tests::util::{
+    build_tx, build_tx_with_dep, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE,
+};
+use crate::component::{entry::TxEntry, pending::PendingQueue};
+use ckb_types::{h256, packed::Byte32, prelude::*};
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+#[test]
+fn test_basic() {
+    let mut queue = PendingQueue::new();
+    let tx1 = build_tx(vec![(&Byte32::zero(), 1), (&Byte32::zero(), 2)], 1);
+    let tx2 = build_tx(
+        vec![(&h256!("0x2").pack(), 1), (&h256!("0x3").pack(), 2)],
+        3,
+    );
+    let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry2 = TxEntry::dummy_resolve(tx2.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    assert!(queue.add_entry(entry1.clone()));
+    assert!(queue.add_entry(entry2));
+    assert!(queue.size() == 2);
+    assert!(queue.contains_key(&tx1.proposal_short_id()));
+    assert!(queue.contains_key(&tx2.proposal_short_id()));
+
+    assert_eq!(queue.get(&tx1.proposal_short_id()).unwrap(), &entry1);
+    assert_eq!(queue.get_tx(&tx2.proposal_short_id()).unwrap(), &tx2);
+
+    let txs = queue.drain();
+    assert!(queue.inner.is_empty());
+    assert!(queue.deps.is_empty());
+    assert!(queue.inputs.is_empty());
+    assert_eq!(txs, vec![tx1, tx2]);
+}
+
+#[test]
+fn test_resolve_conflict() {
+    let mut queue = PendingQueue::new();
+    let tx1 = build_tx(vec![(&Byte32::zero(), 1), (&h256!("0x1").pack(), 1)], 1);
+    let tx2 = build_tx(
+        vec![(&h256!("0x2").pack(), 1), (&h256!("0x3").pack(), 1)],
+        3,
+    );
+    let tx3 = build_tx_with_dep(
+        vec![(&h256!("0x4").pack(), 1)],
+        vec![(&h256!("0x5").pack(), 1)],
+        3,
+    );
+    let tx4 = build_tx(
+        vec![(&h256!("0x2").pack(), 1), (&h256!("0x1").pack(), 1)],
+        3,
+    );
+    let tx5 = build_tx(vec![(&h256!("0x5").pack(), 1)], 3);
+
+    let entry1 = TxEntry::dummy_resolve(tx1, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry2 = TxEntry::dummy_resolve(tx2, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry3 = TxEntry::dummy_resolve(tx3, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    assert!(queue.add_entry(entry1.clone()));
+    assert!(queue.add_entry(entry2.clone()));
+    assert!(queue.add_entry(entry3.clone()));
+
+    let (input_conflict, deps_consumed) = queue.resolve_conflict(&tx4);
+    assert!(deps_consumed.is_empty());
+    assert_eq!(
+        input_conflict
+            .into_iter()
+            .map(|i| i.0)
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![entry1, entry2])
+    );
+
+    let (input_conflict, deps_consumed) = queue.resolve_conflict(&tx5);
+    assert!(input_conflict.is_empty());
+    assert_eq!(
+        deps_consumed
+            .into_iter()
+            .map(|i| i.0)
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![entry3])
+    );
+}
+
+#[test]
+fn test_remove_committed_tx() {
+    let mut queue = PendingQueue::new();
+    let tx1 = build_tx(vec![(&Byte32::zero(), 1), (&h256!("0x1").pack(), 1)], 1);
+    let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    assert!(queue.add_entry(entry1.clone()));
+
+    let related_dep: Vec<_> = entry1.related_dep_out_points().cloned().collect();
+
+    let removed = queue.remove_committed_tx(&tx1, &related_dep);
+    assert_eq!(removed, Some(entry1));
+    assert!(queue.inner.is_empty());
+    assert!(queue.deps.is_empty());
+    assert!(queue.inputs.is_empty());
+}
+
+#[test]
+fn test_remove_entries_by_filter() {
+    let mut queue = PendingQueue::new();
+    let tx1 = build_tx(vec![(&Byte32::zero(), 1), (&h256!("0x1").pack(), 1)], 1);
+    let tx2 = build_tx(
+        vec![(&h256!("0x2").pack(), 1), (&h256!("0x3").pack(), 1)],
+        3,
+    );
+    let tx3 = build_tx_with_dep(
+        vec![(&h256!("0x4").pack(), 1)],
+        vec![(&h256!("0x5").pack(), 1)],
+        3,
+    );
+    let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry2 = TxEntry::dummy_resolve(tx2.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry3 = TxEntry::dummy_resolve(tx3.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    assert!(queue.add_entry(entry1));
+    assert!(queue.add_entry(entry2));
+    assert!(queue.add_entry(entry3));
+
+    queue.remove_entries_by_filter(|id, _tx_entry| id == &tx1.proposal_short_id());
+
+    assert!(!queue.contains_key(&tx1.proposal_short_id()));
+    assert!(queue.contains_key(&tx2.proposal_short_id()));
+    assert!(queue.contains_key(&tx3.proposal_short_id()));
+}
+
+#[test]
+fn test_fill_proposals() {
+    let mut queue = PendingQueue::new();
+    let tx1 = build_tx(vec![(&Byte32::zero(), 1), (&h256!("0x1").pack(), 1)], 1);
+    let tx2 = build_tx(
+        vec![(&h256!("0x2").pack(), 1), (&h256!("0x3").pack(), 1)],
+        3,
+    );
+    let tx3 = build_tx_with_dep(
+        vec![(&h256!("0x4").pack(), 1)],
+        vec![(&h256!("0x5").pack(), 1)],
+        3,
+    );
+    let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry2 = TxEntry::dummy_resolve(tx2.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    let entry3 = TxEntry::dummy_resolve(tx3.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
+    assert!(queue.add_entry(entry1));
+    assert!(queue.add_entry(entry2));
+    assert!(queue.add_entry(entry3));
+
+    let id1 = tx1.proposal_short_id();
+    let id2 = tx2.proposal_short_id();
+    let id3 = tx3.proposal_short_id();
+
+    let mut ret = HashSet::new();
+    queue.fill_proposals(10, &HashSet::new(), &mut ret);
+    assert_eq!(
+        ret,
+        HashSet::from_iter(vec![id1.clone(), id2.clone(), id3.clone()])
+    );
+
+    let mut ret = HashSet::new();
+    queue.fill_proposals(1, &HashSet::new(), &mut ret);
+    assert_eq!(ret, HashSet::from_iter(vec![id1.clone()]));
+
+    let mut ret = HashSet::new();
+    queue.fill_proposals(2, &HashSet::new(), &mut ret);
+    assert_eq!(ret, HashSet::from_iter(vec![id1.clone(), id2.clone()]));
+
+    let mut ret = HashSet::new();
+    let mut exclusion = HashSet::new();
+    exclusion.insert(id2);
+    queue.fill_proposals(2, &exclusion, &mut ret);
+    assert_eq!(ret, HashSet::from_iter(vec![id1, id3]));
+}

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -1,37 +1,17 @@
+use crate::component::tests::util::{
+    build_tx, DEFAULT_MAX_ANCESTORS_SIZE, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE,
+};
+use crate::component::{entry::TxEntry, proposed::ProposedPool};
 use ckb_types::{
     bytes::Bytes,
     core::{
         cell::{get_related_dep_out_points, CellMeta, ResolvedTransaction},
-        Capacity, Cycle, DepType, TransactionBuilder, TransactionView,
+        Capacity, DepType, TransactionBuilder, TransactionView,
     },
     h256,
     packed::{Byte32, CellDep, CellInput, CellOutput, OutPoint},
     prelude::*,
 };
-
-use crate::component::{entry::TxEntry, proposed::ProposedPool};
-
-const DEFAULT_MAX_ANCESTORS_SIZE: usize = 25;
-
-fn build_tx(inputs: Vec<(&Byte32, u32)>, outputs_len: usize) -> TransactionView {
-    TransactionBuilder::default()
-        .inputs(
-            inputs
-                .into_iter()
-                .map(|(txid, index)| CellInput::new(OutPoint::new(txid.to_owned(), index), 0)),
-        )
-        .outputs((0..outputs_len).map(|i| {
-            CellOutput::new_builder()
-                .capacity(Capacity::bytes(i + 1).unwrap().pack())
-                .build()
-        }))
-        .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
-        .build()
-}
-
-const MOCK_CYCLES: Cycle = 0;
-const MOCK_FEE: Capacity = Capacity::zero();
-const MOCK_SIZE: usize = 0;
 
 fn dummy_resolve<F: Fn(&OutPoint) -> Option<Bytes>>(
     tx: TransactionView,

--- a/tx-pool/src/component/tests/util.rs
+++ b/tx-pool/src/component/tests/util.rs
@@ -1,0 +1,52 @@
+use ckb_types::{
+    bytes::Bytes,
+    core::{Capacity, Cycle, TransactionBuilder, TransactionView},
+    packed::{Byte32, CellDep, CellInput, CellOutput, OutPoint},
+    prelude::*,
+};
+
+pub(crate) const DEFAULT_MAX_ANCESTORS_SIZE: usize = 25;
+pub(crate) const MOCK_CYCLES: Cycle = 0;
+pub(crate) const MOCK_FEE: Capacity = Capacity::zero();
+pub(crate) const MOCK_SIZE: usize = 0;
+
+pub(crate) fn build_tx(inputs: Vec<(&Byte32, u32)>, outputs_len: usize) -> TransactionView {
+    TransactionBuilder::default()
+        .inputs(
+            inputs
+                .into_iter()
+                .map(|(txid, index)| CellInput::new(OutPoint::new(txid.to_owned(), index), 0)),
+        )
+        .outputs((0..outputs_len).map(|i| {
+            CellOutput::new_builder()
+                .capacity(Capacity::bytes(i + 1).unwrap().pack())
+                .build()
+        }))
+        .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
+        .build()
+}
+
+pub(crate) fn build_tx_with_dep(
+    inputs: Vec<(&Byte32, u32)>,
+    deps: Vec<(&Byte32, u32)>,
+    outputs_len: usize,
+) -> TransactionView {
+    TransactionBuilder::default()
+        .inputs(
+            inputs
+                .into_iter()
+                .map(|(txid, index)| CellInput::new(OutPoint::new(txid.to_owned(), index), 0)),
+        )
+        .cell_deps(deps.into_iter().map(|(txid, index)| {
+            CellDep::new_builder()
+                .out_point(OutPoint::new(txid.to_owned(), index))
+                .build()
+        }))
+        .outputs((0..outputs_len).map(|i| {
+            CellOutput::new_builder()
+                .capacity(Capacity::bytes(i + 1).unwrap().pack())
+                .build()
+        }))
+        .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
+        .build()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Previously, some conflict pending transactions may not be clean immediately, this does not affect the correctness，but will make developers who rely on `get_transaction` get confused.

### What is changed and how it works?

Now, conflict pending transactions will be clean immediately after the new best block is committed.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
   tx-pool/src/component/tests/pending.rs
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

