### PR TITLE
chore: use rust-toolchain to override toolchain

### DIFF
--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-          override: true
+      - name: overwrite toolchain
+        # It's easier to clean than `rustup override`
+        run: echo nightly > rust-toolchain
       - name: unit coverage
         run: make cov
       - name: integration cov


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: `rustup override` will affect following jobs in self runners.

### What is changed and how it works?

What's Changed: Use `rust-toolchain` file to override the toolchain instead.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code (skip ci)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

