### PR TITLE
fix: tx-pool snapshot consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.8"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "34a23efe54373080cf871532e2d01076be41c4c896d32ef63af1b2dded924b03"
 
 [[package]]
 name = "async-trait"
@@ -4170,11 +4170,10 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -31,7 +31,7 @@ faux = { version = "^0.1", optional = true }
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }
+ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre", features = ["internal"] }
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
 ckb-network = { path = "../network", version = "= 0.100.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }

--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -55,9 +55,8 @@ fn start_chain(consensus: Option<Consensus>) -> (ChainController, Shared) {
 lazy_static! {
     static ref BASIC_BLOCK_SIZE: u64 = {
         let (_chain_controller, shared) = start_chain(None);
-        let tx_pool = shared.tx_pool_controller();
 
-        let block_template = tx_pool
+        let block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap();
@@ -70,9 +69,8 @@ lazy_static! {
 #[test]
 fn test_get_block_template() {
     let (_chain_controller, shared) = start_chain(None);
-    let tx_pool = shared.tx_pool_controller();
 
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -147,14 +145,13 @@ fn test_block_template_timestamp() {
     chain_controller
         .internal_process_block(Arc::new(block.clone()), Switch::DISABLE_ALL)
         .unwrap();
-    let tx_pool = shared.tx_pool_controller();
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
     while (Into::<u64>::into(block_template.number)) != 2 {
-        block_template = tx_pool
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -168,9 +165,8 @@ fn test_block_template_timestamp() {
 #[test]
 fn test_block_template_message() {
     let (_chain_controller, shared) = start_chain(None);
-    let tx_pool = shared.tx_pool_controller();
 
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -216,15 +212,13 @@ fn test_prepare_uncles() {
         .internal_process_block(Arc::new(block1_1.clone()), Switch::DISABLE_ALL)
         .unwrap();
 
-    let tx_pool = shared.tx_pool_controller();
-
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
     // block number 3, epoch 0
     while (Into::<u64>::into(block_template.number)) != 3 || block_template.uncles.is_empty() {
-        block_template = tx_pool
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -242,12 +236,12 @@ fn test_prepare_uncles() {
         .internal_process_block(Arc::new(block2_1.clone()), Switch::DISABLE_ALL)
         .unwrap();
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
     while (Into::<u64>::into(block_template.number)) != 4 {
-        block_template = tx_pool
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -266,12 +260,12 @@ fn test_prepare_uncles() {
         .internal_process_block(Arc::new(block3_1), Switch::DISABLE_ALL)
         .unwrap();
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
     while (Into::<u64>::into(block_template.number)) != 5 {
-        block_template = tx_pool
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -365,7 +359,7 @@ fn test_package_basic() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // 300 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(300 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -376,7 +370,7 @@ fn test_package_basic() {
     );
 
     // 400 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(400 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -387,7 +381,7 @@ fn test_package_basic() {
     );
 
     // 500 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(500 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -398,7 +392,7 @@ fn test_package_basic() {
     );
 
     // 600 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(600 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -409,7 +403,7 @@ fn test_package_basic() {
     );
 
     // 700 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(700 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -420,7 +414,7 @@ fn test_package_basic() {
     );
 
     // 800 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(800 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -431,14 +425,14 @@ fn test_package_basic() {
     );
 
     // none package txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(30 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
     check_txs(&block_template, vec![], "none package txs");
 
     // best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -505,7 +499,7 @@ fn test_package_multi_best_scores() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // 250 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(250 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -516,7 +510,7 @@ fn test_package_multi_best_scores() {
     );
 
     // 400 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(400 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -527,7 +521,7 @@ fn test_package_multi_best_scores() {
     );
 
     // 500 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(500 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -538,7 +532,7 @@ fn test_package_multi_best_scores() {
     );
 
     // 900 size best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(900 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
@@ -549,14 +543,14 @@ fn test_package_multi_best_scores() {
     );
 
     // none package txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(Some(30 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
     check_txs(&block_template, vec![], "none package txs");
 
     // best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -610,7 +604,7 @@ fn test_package_low_fee_decendants() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // best scored txs
-    let block_template = tx_pool
+    let block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();

--- a/chain/src/tests/dep_cell.rs
+++ b/chain/src/tests/dep_cell.rs
@@ -126,7 +126,7 @@ fn test_package_txs_with_deps() {
 
     let txs = vec![tx1, tx2, tx3, tx4];
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -134,7 +134,7 @@ fn test_package_txs_with_deps() {
     // proposal txs
     {
         while (Into::<u64>::into(block_template.number)) != 1 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -157,7 +157,7 @@ fn test_package_txs_with_deps() {
     // skip gap
     {
         while (Into::<u64>::into(block_template.number)) != 2 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -182,8 +182,9 @@ fn test_package_txs_with_deps() {
     }
 
     // get block template with txs
-    while (Into::<u64>::into(block_template.number)) != 3 {
-        block_template = tx_pool
+    while (Into::<u64>::into(block_template.number)) != 3 && block_template.transactions.len() != 5
+    {
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -191,7 +192,6 @@ fn test_package_txs_with_deps() {
 
     let block: Block = block_template.into();
     let block = block.as_advanced_builder().build();
-    assert_eq!(block.transactions().len(), 5);
 
     for (index, tx) in block.transactions().iter().skip(1).enumerate() {
         assert_eq!(tx.proposal_short_id(), txs[index].proposal_short_id());
@@ -270,7 +270,7 @@ fn test_package_txs_with_deps_unstable_sort() {
 
     let txs = vec![tx1, tx2, tx3.clone(), tx4, tx5, tx6.clone()];
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -278,7 +278,7 @@ fn test_package_txs_with_deps_unstable_sort() {
     // proposal txs
     {
         while (Into::<u64>::into(block_template.number)) != 1 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -301,7 +301,7 @@ fn test_package_txs_with_deps_unstable_sort() {
     // skip gap
     {
         while (Into::<u64>::into(block_template.number)) != 2 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -326,8 +326,9 @@ fn test_package_txs_with_deps_unstable_sort() {
     }
 
     // get block template with txs
-    while (Into::<u64>::into(block_template.number)) != 3 {
-        block_template = tx_pool
+    while (Into::<u64>::into(block_template.number)) != 3 && block_template.transactions.len() != 7
+    {
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -335,7 +336,6 @@ fn test_package_txs_with_deps_unstable_sort() {
 
     let block: Block = block_template.into();
     let block = block.as_advanced_builder().build();
-    assert_eq!(block.transactions().len(), 7);
 
     let in_blocks = block.transactions();
     assert_eq!(tx3.proposal_short_id(), in_blocks[3].proposal_short_id());
@@ -409,7 +409,7 @@ fn test_package_txs_with_deps2() {
 
     let txs = vec![tx1, tx2, tx3, tx4, tx5, tx6];
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -417,7 +417,7 @@ fn test_package_txs_with_deps2() {
     // proposal txs
     {
         while (Into::<u64>::into(block_template.number)) != 1 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -440,7 +440,7 @@ fn test_package_txs_with_deps2() {
     // skip gap
     {
         while (Into::<u64>::into(block_template.number)) != 2 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -465,8 +465,9 @@ fn test_package_txs_with_deps2() {
     }
 
     // get block template with txs
-    while (Into::<u64>::into(block_template.number)) != 3 {
-        block_template = tx_pool
+    while (Into::<u64>::into(block_template.number)) != 3 && block_template.transactions.len() != 7
+    {
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -474,7 +475,6 @@ fn test_package_txs_with_deps2() {
 
     let block: Block = block_template.into();
     let block = block.as_advanced_builder().build();
-    assert_eq!(block.transactions().len(), 7);
 
     for (index, tx) in block.transactions().iter().skip(1).enumerate() {
         assert_eq!(tx.proposal_short_id(), txs[index].proposal_short_id());
@@ -541,7 +541,7 @@ fn test_package_txs_with_deps_priority() {
         assert!(ret.is_ok(), "submit {} {:?}", tx.proposal_short_id(), ret);
     }
 
-    let mut block_template = tx_pool
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
@@ -549,7 +549,7 @@ fn test_package_txs_with_deps_priority() {
     // proposal txs
     {
         while (Into::<u64>::into(block_template.number)) != 1 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -565,7 +565,7 @@ fn test_package_txs_with_deps_priority() {
     // skip gap
     {
         while (Into::<u64>::into(block_template.number)) != 2 {
-            block_template = tx_pool
+            block_template = shared
                 .get_block_template(None, None, None)
                 .unwrap()
                 .unwrap()
@@ -584,8 +584,9 @@ fn test_package_txs_with_deps_priority() {
     }
 
     // get block template with txs
-    while (Into::<u64>::into(block_template.number)) != 3 {
-        block_template = tx_pool
+    while (Into::<u64>::into(block_template.number)) != 3 && block_template.transactions.len() != 2
+    {
+        block_template = shared
             .get_block_template(None, None, None)
             .unwrap()
             .unwrap()
@@ -593,7 +594,6 @@ fn test_package_txs_with_deps_priority() {
 
     let block: Block = block_template.into();
     let block = block.as_advanced_builder().build();
-    assert_eq!(block.transactions().len(), 2);
     // tx1 will be discard
     assert_eq!(block.transactions()[1], tx2);
 }

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -246,9 +246,7 @@ impl MinerRpc for MinerRpcImpl {
             None => None,
         };
 
-        let tx_pool = self.shared.tx_pool_controller();
-
-        tx_pool
+        self.shared
             .get_block_template(bytes_limit, proposals_limit, max_version.map(Into::into))
             .map_err(|err| {
                 error!("send get_block_template request error {}", err);

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -127,6 +127,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
         block_assembler_message: Option<JsonBytes>,
     ) -> Result<H256> {
         let tx_pool = self.shared.tx_pool_controller();
+        let snapshot = Arc::clone(&self.shared.snapshot());
         let block_assembler_config = block_assembler_script.map(|script| BlockAssemblerConfig {
             code_hash: script.code_hash,
             hash_type: script.hash_type,
@@ -140,6 +141,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
                 None,
                 None,
                 None,
+                snapshot,
                 block_assembler_config,
             )
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,7 @@ ckb-chain-spec = { path = "../spec", version = "= 0.100.0-pre" }
 ckb-store = { path = "../store", version = "= 0.100.0-pre" }
 ckb-db = { path = "../db", version = "= 0.100.0-pre" }
 ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.100.0-pre" }
-arc-swap = "0.4"
+arc-swap = "1.3"
 ckb-error = { path = "../error", version = "= 0.100.0-pre" }
 ckb-snapshot = { path = "../util/snapshot", version = "= 0.100.0-pre" }
 ckb-tx-pool = { path = "../tx-pool", version = "= 0.100.0-pre" }

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -9,14 +9,14 @@ use ckb_constant::store::TX_INDEX_UPPER_BOUND;
 use ckb_constant::sync::MAX_TIP_AGE;
 use ckb_db::{Direction, IteratorMode};
 use ckb_db_schema::{COLUMN_BLOCK_BODY, COLUMN_NUMBER_HASH};
-use ckb_error::Error;
+use ckb_error::{AnyError, Error};
 use ckb_notify::NotifyController;
 use ckb_proposal_table::ProposalView;
 use ckb_stop_handler::{SignalSender, StopHandler};
 use ckb_store::{ChainDB, ChainStore};
-use ckb_tx_pool::{TokioRwLock, TxPoolController};
+use ckb_tx_pool::{BlockTemplate, TokioRwLock, TxPoolController};
 use ckb_types::{
-    core::{service, BlockNumber, EpochExt, EpochNumber, HeaderView},
+    core::{service, BlockNumber, EpochExt, EpochNumber, HeaderView, Version},
     packed::{self, Byte32},
     prelude::*,
     U256,
@@ -353,5 +353,21 @@ impl Shared {
             self.ibd_finished.store(true, Ordering::Relaxed);
             false
         }
+    }
+
+    /// Generate and return block_template
+    pub fn get_block_template(
+        &self,
+        bytes_limit: Option<u64>,
+        proposals_limit: Option<u64>,
+        max_version: Option<Version>,
+    ) -> Result<Result<BlockTemplate, AnyError>, AnyError> {
+        let snapshot = Arc::clone(&self.snapshot());
+        self.tx_pool_controller().get_block_template(
+            bytes_limit,
+            proposals_limit,
+            max_version.map(Into::into),
+            snapshot,
+        )
     }
 }

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -35,4 +35,5 @@ sentry = { version = "0.23.0", optional = true }
 
 [features]
 default = []
+internal = []
 with_sentry = ["sentry"]

--- a/tx-pool/src/chunk_process.rs
+++ b/tx-pool/src/chunk_process.rs
@@ -1,9 +1,11 @@
 use crate::component::chunk::Entry;
 use crate::component::entry::TxEntry;
+use crate::try_or_return_with_snapshot;
 use crate::{error::Reject, service::TxPoolService};
 use ckb_async_runtime::Handle;
 use ckb_channel::{select, Receiver};
 use ckb_error::Error;
+use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_traits::{CellDataProvider, HeaderProvider};
 use ckb_types::{core::Cycle, packed::Byte32};
@@ -99,26 +101,32 @@ impl TxChunkProcess {
     }
 
     fn process(&mut self, entry: Entry) -> Stop {
-        self.process_inner(entry.clone()).unwrap_or_else(|e| {
-            self.handle
-                .block_on(self.service.after_process(entry.tx, entry.remote, &Err(e)));
+        let (ret, snapshot) = self.process_inner(entry.clone());
+        ret.unwrap_or_else(|e| {
+            self.handle.block_on(self.service.after_process(
+                entry.tx,
+                entry.remote,
+                &snapshot,
+                &Err(e),
+            ));
             self.handle.block_on(self.remove_front());
             false
         })
     }
 
-    fn process_inner(&mut self, entry: Entry) -> Result<Stop, Reject> {
+    fn process_inner(&mut self, entry: Entry) -> (Result<Stop, Reject>, Arc<Snapshot>) {
         let Entry { tx, remote } = entry;
         let tx_hash = tx.hash();
 
-        let (tip_hash, snapshot, rtx, status, fee, tx_size) =
-            self.handle.block_on(self.service.pre_check(tx.clone()))?;
+        let (ret, snapshot) = self.handle.block_on(self.service.pre_check(&tx));
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
+
         let cached = self
             .handle
             .block_on(self.service.fetch_tx_verify_cache(&tx_hash));
 
         let tip_header = snapshot.tip_header();
-        let consensus = snapshot.consensus();
+        let consensus = snapshot.cloned_consensus();
 
         let tx_env = TxVerifyEnv::new_submit(tip_header);
         let mut init_snap = None;
@@ -126,25 +134,31 @@ impl TxChunkProcess {
         if let Some(ref cached) = cached {
             match cached {
                 CacheEntry::Completed(completed) => {
-                    let completed = TimeRelativeTransactionVerifier::new(
+                    let ret = TimeRelativeTransactionVerifier::new(
                         &rtx,
-                        consensus,
+                        &consensus,
                         snapshot.as_ref(),
                         &tx_env,
                     )
                     .verify()
                     .map(|_| *completed)
-                    .map_err(Reject::Verification)?;
+                    .map_err(Reject::Verification);
+                    let completed = try_or_return_with_snapshot!(ret, snapshot);
 
                     let entry = TxEntry::new(rtx, completed.cycles, fee, tx_size);
-                    self.handle.block_on(
+                    let (ret, submit_snapshot) = self.handle.block_on(
                         self.service
                             .submit_entry(completed, tip_hash, entry, status),
-                    )?;
-                    self.handle
-                        .block_on(self.service.after_process(tx, remote, &Ok(completed)));
+                    );
+                    try_or_return_with_snapshot!(ret, submit_snapshot);
+                    self.handle.block_on(self.service.after_process(
+                        tx,
+                        remote,
+                        &submit_snapshot,
+                        &Ok(completed),
+                    ));
                     self.handle.block_on(self.remove_front());
-                    return Ok(false);
+                    return (Ok(false), submit_snapshot);
                 }
                 CacheEntry::Suspended(suspended) => {
                     init_snap = Some(Arc::clone(&suspended.snap));
@@ -152,12 +166,18 @@ impl TxChunkProcess {
             }
         }
 
-        let data_loader = snapshot.as_data_provider();
-        let fee =
-            ContextualWithoutScriptTransactionVerifier::new(&rtx, consensus, &data_loader, &tx_env)
-                .verify()
-                .map_err(Reject::Verification)?;
-        let script_verifier = ScriptVerifier::new(&rtx, consensus, &data_loader, &tx_env);
+        let cloned_snapshot = Arc::clone(&snapshot);
+        let data_loader = cloned_snapshot.as_data_provider();
+        let ret = ContextualWithoutScriptTransactionVerifier::new(
+            &rtx,
+            &consensus,
+            &data_loader,
+            &tx_env,
+        )
+        .verify()
+        .map_err(Reject::Verification);
+        let fee = try_or_return_with_snapshot!(ret, snapshot);
+        let script_verifier = ScriptVerifier::new(&rtx, &consensus, &data_loader, &tx_env);
         let mut tmp_state: Option<ScriptVerifyState> = None;
 
         let max_cycles = if let Some((declared_cycle, _peer)) = remote {
@@ -173,7 +193,8 @@ impl TxChunkProcess {
                     Command::Suspend => {
                         let state = tmp_state.take();
                         if let Some(state) = state {
-                            let snap = state.try_into().map_err(Reject::Verification)?;
+                            let ret = state.try_into().map_err(Reject::Verification);
+                            let snap = try_or_return_with_snapshot!(ret, snapshot);
                             let txs_verify_cache = Arc::clone(&self.service.txs_verify_cache);
                             self.handle.block_on(async move {
                                 let mut guard = txs_verify_cache.write().await;
@@ -181,10 +202,10 @@ impl TxChunkProcess {
                             })
                         }
                         self.p_state = ProcessState::Interrupt;
-                        return Ok(false);
+                        return (Ok(false), snapshot);
                     }
                     Command::Stop => {
-                        return Ok(true);
+                        return (Ok(true), snapshot);
                     }
                     Command::Continue => {
                         self.p_state = ProcessState::Normal;
@@ -197,7 +218,7 @@ impl TxChunkProcess {
                 if snap.current_cycles > max_cycles {
                     let error =
                         exceeded_maximum_cycles_error(&script_verifier, max_cycles, &snap.current);
-                    return Err(Reject::Verification(error));
+                    return (Err(Reject::Verification(error)), snapshot);
                 }
 
                 let (limit_cycles, last) = snap.next_limit_cycles(MIN_STEP_CYCLE, max_cycles);
@@ -211,7 +232,7 @@ impl TxChunkProcess {
                 if state.current_cycles > max_cycles {
                     let error =
                         exceeded_maximum_cycles_error(&script_verifier, max_cycles, &state.current);
-                    return Err(Reject::Verification(error));
+                    return (Err(Reject::Verification(error)), snapshot);
                 }
 
                 // next_limit_cycles
@@ -229,7 +250,9 @@ impl TxChunkProcess {
             } else {
                 script_verifier.resumable_verify(MIN_STEP_CYCLE)
             }
-            .map_err(Reject::Verification)?;
+            .map_err(Reject::Verification);
+
+            let ret = try_or_return_with_snapshot!(ret, snapshot);
 
             match ret {
                 ScriptVerifyResult::Completed(cycles) => {
@@ -242,7 +265,7 @@ impl TxChunkProcess {
                             max_cycles,
                             &state.current,
                         );
-                        return Err(Reject::Verification(error));
+                        return (Err(Reject::Verification(error)), snapshot);
                     }
                     tmp_state = Some(state);
                 }
@@ -250,12 +273,18 @@ impl TxChunkProcess {
         };
 
         let entry = TxEntry::new(rtx.clone(), completed.cycles, fee, tx_size);
-        self.handle.block_on(
+        let (ret, submit_snapshot) = self.handle.block_on(
             self.service
                 .submit_entry(completed, tip_hash, entry, status),
-        )?;
-        self.handle
-            .block_on(self.service.after_process(tx, remote, &Ok(completed)));
+        );
+        try_or_return_with_snapshot!(ret, snapshot);
+
+        self.handle.block_on(self.service.after_process(
+            tx,
+            remote,
+            &submit_snapshot,
+            &Ok(completed),
+        ));
 
         self.handle.block_on(self.remove_front());
 
@@ -265,7 +294,7 @@ impl TxChunkProcess {
             guard.put(tx_hash, CacheEntry::Completed(completed));
         });
 
-        Ok(false)
+        (Ok(false), submit_snapshot)
     }
 }
 

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -12,6 +12,7 @@ mod process;
 pub mod service;
 mod util;
 
+pub use ckb_jsonrpc_types::BlockTemplate;
 pub use component::entry::TxEntry;
 pub use pool::TxPool;
 pub use process::PlugTarget;

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -7,6 +7,7 @@ use crate::component::orphan::Entry as OrphanEntry;
 use crate::error::Reject;
 use crate::pool::TxPool;
 use crate::service::TxPoolService;
+use crate::try_or_return_with_snapshot;
 use crate::util::{
     check_tx_cycle_limit, check_tx_fee, check_tx_size_limit, check_txid_collision,
     is_missing_input, non_contextual_verify, verify_rtx,
@@ -436,19 +437,23 @@ impl TxPoolService {
         pre_resolve_tip: Byte32,
         entry: TxEntry,
         mut status: TxStatus,
-    ) -> Result<(), Reject> {
-        let mut tx_pool = self.tx_pool.write().await;
+    ) -> (Result<(), Reject>, Arc<Snapshot>) {
+        let (ret, snapshot) = self
+            .with_tx_pool_write_lock(move |tx_pool, snapshot| {
+                check_tx_cycle_limit(&tx_pool, verified.cycles)?;
 
-        check_tx_cycle_limit(&tx_pool, verified.cycles)?;
+                if pre_resolve_tip != snapshot.tip_hash() {
+                    // destructuring assignments are not currently supported
+                    status = check_rtx(&tx_pool, &snapshot, &entry.rtx)?;
+                }
 
-        let snapshot = tx_pool.snapshot();
-        // if tip changed, resolve again
-        if pre_resolve_tip != snapshot.tip_hash() {
-            // destructuring assignments are not currently supported
-            status = check_rtx(&tx_pool, snapshot, &entry.rtx)?;
-        }
+                _submit_entry(tx_pool, status, entry.clone(), &self.callbacks)?;
 
-        _submit_entry(&mut tx_pool, status, entry, &self.callbacks)
+                Ok(())
+            })
+            .await;
+
+        (ret, snapshot)
     }
 
     pub(crate) async fn orphan_contains(&self, tx: &TransactionView) -> bool {
@@ -461,26 +466,67 @@ impl TxPoolService {
         chunk.contains_key(&tx.proposal_short_id())
     }
 
-    pub(crate) async fn pre_check(&self, tx: TransactionView) -> Result<PreCheckedTx, Reject> {
-        // Acquire read lock for cheap check
+    pub(crate) async fn with_tx_pool_read_lock<U, F: FnMut(&TxPool, &Snapshot) -> U>(
+        &self,
+        mut f: F,
+    ) -> (U, Arc<Snapshot>) {
         let tx_pool = self.tx_pool.read().await;
         let snapshot = tx_pool.cloned_snapshot();
-        let tip_hash = snapshot.tip_hash();
 
+        let ret = f(&tx_pool, &snapshot);
+        (ret, snapshot)
+    }
+
+    pub(crate) async fn with_tx_pool_write_lock<U, F: FnMut(&mut TxPool, &Snapshot) -> U>(
+        &self,
+        mut f: F,
+    ) -> (U, Arc<Snapshot>) {
+        let mut tx_pool = self.tx_pool.write().await;
+        let snapshot = tx_pool.cloned_snapshot();
+
+        let ret = f(&mut tx_pool, &snapshot);
+        (ret, snapshot)
+    }
+
+    pub(crate) async fn pre_check(
+        &self,
+        tx: &TransactionView,
+    ) -> (Result<PreCheckedTx, Reject>, Arc<Snapshot>) {
+        // Acquire read lock for cheap check
         let tx_size = tx.data().serialized_size_in_block();
 
-        // reject if pool reach size limit
-        // TODO: tx evict strategy
-        check_tx_size_limit(&tx_pool, tx_size)?;
+        let (ret, snapshot) = self
+            .with_tx_pool_read_lock(|tx_pool, snapshot| {
+                let tip_hash = snapshot.tip_hash();
+                check_tx_size_limit(&tx_pool, tx_size)?;
 
-        // reject collision id
-        check_txid_collision(&tx_pool, &tx)?;
+                check_txid_collision(&tx_pool, &tx)?;
 
-        let (rtx, status) = resolve_tx(&tx_pool, &snapshot, tx)?;
+                let (rtx, status) = resolve_tx(&tx_pool, &snapshot, tx.clone())?;
 
-        let fee = check_tx_fee(&tx_pool, &snapshot, &rtx, tx_size)?;
+                let fee = check_tx_fee(&tx_pool, &snapshot, &rtx, tx_size)?;
 
-        Ok((tip_hash, snapshot, rtx, status, fee, tx_size))
+                Ok((tip_hash, rtx, status, fee, tx_size))
+            })
+            .await;
+
+        (ret, snapshot)
+    }
+
+    pub(crate) fn non_contextual_verify(
+        &self,
+        tx: &TransactionView,
+        remote: Option<(Cycle, PeerIndex)>,
+    ) -> Result<(), Reject> {
+        if let Err(reject) = non_contextual_verify(&self.consensus, tx) {
+            if reject.is_malformed_tx() {
+                if let Some(remote) = remote {
+                    self.ban_malformed(remote.1, format!("reject {}", reject));
+                }
+            }
+            return Err(reject);
+        }
+        Ok(())
     }
 
     pub(crate) async fn enqueue_remote_chunk_tx(
@@ -489,29 +535,33 @@ impl TxPoolService {
         remote: (Cycle, PeerIndex),
     ) -> Result<(), Reject> {
         // non contextual verify first
-        if let Err(reject) = non_contextual_verify(&self.consensus, &tx) {
-            if reject.is_malformed_tx() {
-                self.ban_malformed(remote.1, format!("reject {}", reject));
-            }
-            return Err(reject);
-        }
+        self.non_contextual_verify(&tx, Some(remote))?;
         self.chunk.write().await.add_remote_tx(tx, remote);
         Ok(())
     }
 
     pub(crate) async fn resumeble_process_tx(&self, tx: TransactionView) -> Result<(), Reject> {
         let limit_cycles = self.tx_pool_config.max_tx_verify_cycles;
-        let ret = self._resumeble_process_tx(tx.clone(), limit_cycles).await;
+        // non contextual verify first
+        self.non_contextual_verify(&tx, None)?;
+
+        if self.chunk_contains(&tx).await || self.orphan_contains(&tx).await {
+            return Err(Reject::Duplicated(tx.hash()));
+        }
+
+        let (ret, snapshot) = self._resumeble_process_tx(tx.clone(), limit_cycles).await;
 
         match ret {
             Ok(processed) => {
                 if let ProcessResult::Completed(completed) = processed {
-                    self.after_process(tx, None, &Ok(completed)).await;
+                    self.after_process(tx, None, &snapshot, &Ok(completed))
+                        .await;
                 }
                 Ok(())
             }
             Err(e) => {
-                self.after_process(tx, None, &Err(e.clone())).await;
+                self.after_process(tx, None, &snapshot, &Err(e.clone()))
+                    .await;
                 Err(e)
             }
         }
@@ -522,9 +572,16 @@ impl TxPoolService {
         tx: TransactionView,
         remote: Option<(Cycle, PeerIndex)>,
     ) -> Result<Completed, Reject> {
-        let ret = self._process_tx(tx.clone(), remote.map(|r| r.0)).await;
+        // non contextual verify first
+        self.non_contextual_verify(&tx, remote)?;
 
-        self.after_process(tx, remote, &ret).await;
+        if self.chunk_contains(&tx).await || self.orphan_contains(&tx).await {
+            return Err(Reject::Duplicated(tx.hash()));
+        }
+
+        let (ret, snapshot) = self._process_tx(tx.clone(), remote.map(|r| r.0)).await;
+
+        self.after_process(tx, remote, &snapshot, &ret).await;
 
         ret
     }
@@ -533,13 +590,14 @@ impl TxPoolService {
         &self,
         tx: TransactionView,
         remote: Option<(Cycle, PeerIndex)>,
+        snapshot: &Snapshot,
         ret: &Result<Completed, Reject>,
     ) {
         let tx_hash = tx.hash();
         // The network protocol is switched after tx-pool confirms the cache,
         // there will be no problem with the current state as the choice of the broadcast protocol.
         let with_vm_2021 = {
-            let epoch = self.snapshot().tip_header().epoch().number();
+            let epoch = snapshot.tip_header().epoch().number();
             self.consensus
                 .hardfork_switch
                 .is_vm_version_1_and_syscalls_2_enabled(epoch)
@@ -566,7 +624,7 @@ impl TxPoolService {
                     }
                 }
                 Err(reject) => {
-                    if is_missing_input(&reject) && self.all_inputs_is_unknown(&tx) {
+                    if is_missing_input(&reject) && all_inputs_is_unknown(snapshot, &tx) {
                         self.add_orphan(tx, peer, declared_cycle).await;
                     } else if reject.is_malformed_tx() {
                         self.ban_malformed(peer, format!("reject {}", reject));
@@ -632,14 +690,15 @@ impl TxPoolService {
                         .await
                         .add_remote_tx(orphan.tx, (orphan.cycle, orphan.peer));
                 } else {
-                    match self._process_tx(orphan.tx.clone(), None).await {
+                    let (ret, snapshot) = self._process_tx(orphan.tx.clone(), None).await;
+                    let with_vm_2021 = {
+                        let epoch = snapshot.tip_header().epoch().number();
+                        self.consensus
+                            .hardfork_switch
+                            .is_vm_version_1_and_syscalls_2_enabled(epoch)
+                    };
+                    match ret {
                         Ok(_) => {
-                            let with_vm_2021 = {
-                                let epoch = self.snapshot().tip_header().epoch().number();
-                                self.consensus
-                                    .hardfork_switch
-                                    .is_vm_version_1_and_syscalls_2_enabled(epoch)
-                            };
                             self.remove_orphan_tx(&orphan.tx.proposal_short_id()).await;
                             self.broadcast_tx(Some(orphan.peer), orphan.tx.hash(), with_vm_2021);
                             orphan_queue.push_back(orphan.tx);
@@ -657,12 +716,6 @@ impl TxPoolService {
                 }
             }
         }
-    }
-
-    pub(crate) fn all_inputs_is_unknown(&self, tx: &TransactionView) -> bool {
-        let snapshot = self.snapshot();
-        !tx.input_pts_iter()
-            .any(|pt| snapshot.transaction_exists(&pt.tx_hash()))
     }
 
     pub(crate) fn broadcast_tx(
@@ -705,16 +758,12 @@ impl TxPoolService {
         &self,
         tx: TransactionView,
         limit_cycles: Cycle,
-    ) -> Result<ProcessResult, Reject> {
+    ) -> (Result<ProcessResult, Reject>, Arc<Snapshot>) {
         let tx_hash = tx.hash();
-        // non contextual verify first
-        non_contextual_verify(&self.consensus, &tx)?;
 
-        if self.chunk_contains(&tx).await || self.orphan_contains(&tx).await {
-            return Err(Reject::Duplicated(tx.hash()));
-        }
+        let (ret, snapshot) = self.pre_check(&tx).await;
 
-        let (tip_hash, snapshot, rtx, status, fee, tx_size) = self.pre_check(tx).await?;
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
 
         let cached = self.fetch_tx_verify_cache(&tx_hash).await;
         let tip_header = snapshot.tip_header();
@@ -723,18 +772,19 @@ impl TxPoolService {
         let completed = if let Some(ref entry) = cached {
             match entry {
                 CacheEntry::Completed(completed) => {
-                    TimeRelativeTransactionVerifier::new(
+                    let ret = TimeRelativeTransactionVerifier::new(
                         &rtx,
                         &self.consensus,
                         snapshot.as_ref(),
                         &tx_env,
                     )
                     .verify()
-                    .map_err(Reject::Verification)?;
+                    .map_err(Reject::Verification);
+                    try_or_return_with_snapshot!(ret, snapshot);
                     *completed
                 }
                 CacheEntry::Suspended(_) => {
-                    return Ok(ProcessResult::Suspended);
+                    return (Ok(ProcessResult::Suspended), snapshot);
                 }
             }
         } else {
@@ -742,7 +792,7 @@ impl TxPoolService {
             let data_provider = snapshot.as_data_provider();
             let is_chunk_full = !self.is_chunk_full().await;
 
-            let entry = block_in_place(|| {
+            let ret = block_in_place(|| {
                 let verifier =
                     ContextualTransactionVerifier::new(&rtx, consensus, &data_provider, &tx_env);
 
@@ -764,13 +814,16 @@ impl TxPoolService {
                         }
                     }
                 }
-            })?;
+            });
 
+            let entry = try_or_return_with_snapshot!(ret, snapshot);
             match entry {
                 cached @ CacheEntry::Suspended(_) => {
-                    self.enqueue_suspended_tx(rtx.transaction.clone(), cached)
-                        .await?;
-                    return Ok(ProcessResult::Suspended);
+                    let ret = self
+                        .enqueue_suspended_tx(rtx.transaction.clone(), cached)
+                        .await;
+                    try_or_return_with_snapshot!(ret, snapshot);
+                    return (Ok(ProcessResult::Suspended), snapshot);
                 }
                 CacheEntry::Completed(completed) => completed,
             }
@@ -778,8 +831,8 @@ impl TxPoolService {
 
         let entry = TxEntry::new(rtx, completed.cycles, fee, tx_size);
 
-        self.submit_entry(completed, tip_hash, entry, status)
-            .await?;
+        let (ret, submit_snapshot) = self.submit_entry(completed, tip_hash, entry, status).await;
+        try_or_return_with_snapshot!(ret, submit_snapshot);
 
         if cached.is_none() {
             // update cache
@@ -790,7 +843,7 @@ impl TxPoolService {
             });
         }
 
-        Ok(ProcessResult::Completed(completed))
+        (Ok(ProcessResult::Completed(completed)), submit_snapshot)
     }
 
     pub(crate) async fn is_chunk_full(&self) -> bool {
@@ -815,27 +868,25 @@ impl TxPoolService {
         &self,
         tx: TransactionView,
         max_cycles: Option<Cycle>,
-    ) -> Result<Completed, Reject> {
+    ) -> (Result<Completed, Reject>, Arc<Snapshot>) {
         let tx_hash = tx.hash();
 
-        // non contextual verify first
-        non_contextual_verify(&self.consensus, &tx)?;
+        let (ret, snapshot) = self.pre_check(&tx).await;
 
-        if self.chunk_contains(&tx).await || self.orphan_contains(&tx).await {
-            return Err(Reject::Duplicated(tx.hash()));
-        }
-
-        let (tip_hash, snapshot, rtx, status, fee, tx_size) = self.pre_check(tx).await?;
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
 
         let verify_cache = self.fetch_tx_verify_cache(&tx_hash).await;
         let max_cycles = max_cycles.unwrap_or_else(|| self.consensus.max_block_cycles());
         let tip_header = snapshot.tip_header();
         let tx_env = status.with_env(tip_header);
-        let verified = verify_rtx(&snapshot, &rtx, &tx_env, &verify_cache, max_cycles)?;
+        let verified_ret = verify_rtx(&snapshot, &rtx, &tx_env, &verify_cache, max_cycles);
+
+        let verified = try_or_return_with_snapshot!(verified_ret, snapshot);
 
         let entry = TxEntry::new(rtx, verified.cycles, fee, tx_size);
 
-        self.submit_entry(verified, tip_hash, entry, status).await?;
+        let (ret, submit_snapshot) = self.submit_entry(verified, tip_hash, entry, status).await;
+        try_or_return_with_snapshot!(ret, submit_snapshot);
 
         if verify_cache.is_none() {
             // update cache
@@ -846,7 +897,7 @@ impl TxPoolService {
             });
         }
 
-        Ok(verified)
+        (Ok(verified), submit_snapshot)
     }
 
     pub(crate) async fn update_tx_pool_for_reorg(
@@ -976,7 +1027,8 @@ impl TxPoolService {
         let mut count = 0usize;
         for tx in txs {
             let tx_hash = tx.hash();
-            if let Err(err) = self._process_tx(tx, None).await {
+            let (ret, _) = self._process_tx(tx, None).await;
+            if let Err(err) = ret {
                 error!("failed to process {:#x}, error: {:?}", tx_hash, err);
                 count += 1;
             }
@@ -1001,14 +1053,7 @@ impl TxPoolService {
     }
 }
 
-type PreCheckedTx = (
-    Byte32,
-    Arc<Snapshot>,
-    ResolvedTransaction,
-    TxStatus,
-    Capacity,
-    usize,
-);
+type PreCheckedTx = (Byte32, ResolvedTransaction, TxStatus, Capacity, usize);
 
 type ResolveResult = Result<(ResolvedTransaction, TxStatus), Reject>;
 
@@ -1219,4 +1264,9 @@ fn check_if_hardfork_during_blocks(
                 .any(|hardfork_epoch| epoch_first < hardfork_epoch && hardfork_epoch <= epoch_next)
         }
     }
+}
+
+pub fn all_inputs_is_unknown(snapshot: &Snapshot, tx: &TransactionView) -> bool {
+    !tx.input_pts_iter()
+        .any(|pt| snapshot.transaction_exists(&pt.tx_hash()))
 }

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -131,6 +131,12 @@ impl TxPoolController {
         self.started.load(Ordering::Relaxed)
     }
 
+    /// Set tx-pool service started, should only used for test
+    #[cfg(feature = "internal")]
+    pub fn set_service_started(&self, v: bool) {
+        self.started.store(v, Ordering::Relaxed);
+    }
+
     /// Return reference of tokio runtime handle
     pub fn handle(&self) -> &Handle {
         &self.handle

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -16,7 +16,7 @@ use ckb_jsonrpc_types::BlockTemplate;
 use ckb_logger::error;
 use ckb_logger::info;
 use ckb_network::{NetworkController, PeerIndex};
-use ckb_snapshot::{Snapshot, SnapshotMgr};
+use ckb_snapshot::Snapshot;
 use ckb_stop_handler::{SignalSender, StopHandler, WATCH_INIT};
 use ckb_types::{
     core::{
@@ -67,6 +67,7 @@ type BlockTemplateArgs = (
     Option<u64>,
     Option<u64>,
     Option<Version>,
+    Arc<Snapshot>,
     Option<BlockAssemblerConfig>,
 );
 
@@ -141,11 +142,13 @@ impl TxPoolController {
         bytes_limit: Option<u64>,
         proposals_limit: Option<u64>,
         max_version: Option<Version>,
+        snapshot: Arc<Snapshot>,
     ) -> Result<BlockTemplateResult, AnyError> {
         self.get_block_template_with_block_assembler_config(
             bytes_limit,
             proposals_limit,
             max_version,
+            snapshot,
             None,
         )
     }
@@ -156,6 +159,7 @@ impl TxPoolController {
         bytes_limit: Option<u64>,
         proposals_limit: Option<u64>,
         max_version: Option<Version>,
+        snapshot: Arc<Snapshot>,
         block_assembler_config: Option<BlockAssemblerConfig>,
     ) -> Result<BlockTemplateResult, AnyError> {
         let (responder, response) = oneshot::channel();
@@ -164,6 +168,7 @@ impl TxPoolController {
                 bytes_limit,
                 proposals_limit,
                 max_version,
+                snapshot,
                 block_assembler_config,
             ),
             responder,
@@ -466,7 +471,6 @@ pub struct TxPoolServiceBuilder {
     pub(crate) snapshot: Arc<Snapshot>,
     pub(crate) block_assembler: Option<BlockAssembler>,
     pub(crate) txs_verify_cache: Arc<RwLock<TxVerificationCache>>,
-    pub(crate) snapshot_mgr: Arc<SnapshotMgr>,
     pub(crate) callbacks: Callbacks,
     pub(crate) receiver: mpsc::Receiver<Message>,
     pub(crate) reorg_receiver: mpsc::Receiver<Notify<ChainReorgArgs>>,
@@ -485,7 +489,6 @@ impl TxPoolServiceBuilder {
         snapshot: Arc<Snapshot>,
         block_assembler_config: Option<BlockAssemblerConfig>,
         txs_verify_cache: Arc<RwLock<TxVerificationCache>>,
-        snapshot_mgr: Arc<SnapshotMgr>,
         handle: &Handle,
         tx_relay_sender: ckb_channel::Sender<(Option<PeerIndex>, bool, Byte32)>,
     ) -> (TxPoolServiceBuilder, TxPoolController) {
@@ -514,7 +517,6 @@ impl TxPoolServiceBuilder {
             snapshot,
             block_assembler: block_assembler_config.map(BlockAssembler::new),
             txs_verify_cache,
-            snapshot_mgr,
             callbacks: Callbacks::new(),
             receiver,
             reorg_receiver,
@@ -574,7 +576,6 @@ impl TxPoolServiceBuilder {
             orphan: Arc::new(RwLock::new(OrphanPool::new())),
             block_assembler: self.block_assembler,
             txs_verify_cache: self.txs_verify_cache,
-            snapshot_mgr: self.snapshot_mgr,
             callbacks: Arc::new(self.callbacks),
             tx_relay_sender: self.tx_relay_sender,
             chunk: self.chunk,
@@ -650,16 +651,9 @@ pub(crate) struct TxPoolService {
     pub(crate) txs_verify_cache: Arc<RwLock<TxVerificationCache>>,
     pub(crate) last_txs_updated_at: Arc<AtomicU64>,
     pub(crate) callbacks: Arc<Callbacks>,
-    pub(crate) snapshot_mgr: Arc<SnapshotMgr>,
     pub(crate) network: NetworkController,
     pub(crate) tx_relay_sender: ckb_channel::Sender<(Option<PeerIndex>, bool, Byte32)>,
     pub(crate) chunk: Arc<RwLock<ChunkQueue>>,
-}
-
-impl TxPoolService {
-    pub(crate) fn snapshot(&self) -> Arc<Snapshot> {
-        Arc::clone(&self.snapshot_mgr.load())
-    }
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -673,13 +667,14 @@ async fn process(mut service: TxPoolService, message: Message) {
         }
         Message::BlockTemplate(Request {
             responder,
-            arguments: (bytes_limit, proposals_limit, max_version, block_assembler_config),
+            arguments: (bytes_limit, proposals_limit, max_version, snapshot, block_assembler_config),
         }) => {
             let block_template_result = service
                 .get_block_template(
                     bytes_limit,
                     proposals_limit,
                     max_version,
+                    snapshot,
                     block_assembler_config,
                 )
                 .await;

--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -112,6 +112,17 @@ pub(crate) fn verify_rtx(
     }
 }
 
+pub(crate) fn time_relative_verify(
+    snapshot: &Snapshot,
+    rtx: &ResolvedTransaction,
+    tx_env: &TxVerifyEnv,
+) -> Result<(), Reject> {
+    let consensus = snapshot.consensus();
+    TimeRelativeTransactionVerifier::new(rtx, consensus, snapshot, tx_env)
+        .verify()
+        .map_err(Reject::Verification)
+}
+
 pub(crate) fn is_missing_input(reject: &Reject) -> bool {
     matches!(reject, Reject::Resolve(out_point_err) if out_point_err.is_unknown())
 }

--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -115,3 +115,19 @@ pub(crate) fn verify_rtx(
 pub(crate) fn is_missing_input(reject: &Reject) -> bool {
     matches!(reject, Reject::Resolve(out_point_err) if out_point_err.is_unknown())
 }
+
+/// Unwraps a result or propagates its error with snapshot.
+#[macro_export]
+macro_rules! try_or_return_with_snapshot {
+    ($expr:expr, $snapshot:expr) => {
+        match $expr {
+            core::result::Result::Ok(val) => val,
+            core::result::Result::Err(err) => {
+                return (
+                    core::result::Result::Err(core::convert::From::from(err)),
+                    $snapshot,
+                );
+            }
+        }
+    };
+}

--- a/util/launcher/src/shared_builder.rs
+++ b/util/launcher/src/shared_builder.rs
@@ -322,7 +322,6 @@ impl SharedBuilder {
             Arc::clone(&snapshot),
             block_assembler_config,
             Arc::clone(&txs_verify_cache),
-            Arc::clone(&snapshot_mgr),
             &async_handle,
             sender.clone(),
         );

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -18,7 +18,7 @@ ckb-db = { path = "../../db", version = "= 0.100.0-pre" }
 ckb-traits = { path = "../../traits", version = "= 0.100.0-pre" }
 ckb-error = { path = "../../error", version = "= 0.100.0-pre" }
 ckb-proposal-table = { path = "../proposal-table", version = "= 0.100.0-pre" }
-arc-swap = "0.4"
+arc-swap = "1.3"
 ckb-reward-calculator = { path = "../reward-calculator", version = "= 0.100.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.100.0-pre" }
 ckb-freezer = { path = "../../freezer", version = "= 0.100.0-pre" }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Previously, tx-pool has a potential issue, some code gets snapshots directly from the `ArcSwap` container, which means those snapshots represent the newest chain, it may be inconsistent with tx-pool owned snapshot.

### What is changed and how it works?

Remove interface that can get snapshot from swap container.
https://github.com/nervosnetwork/ckb/pull/2984/files#diff-fb91da4f07a6ef121b8913771dd0cf067853b6a3b41eaa96fd242881b71b5f32L659-L664


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
 https://github.com/nervosnetwork/ckb/pull/2984/files#diff-6dd28380157411935dbe8b390f7a324dc57b8a8654f9276cb83e2cfca8df36f4R618-R641

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

