### PR TITLE
doc: replace telegram badge with discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/badge/version-0.100.0--pre-orange.svg)](https://github.com/nervosnetwork/ckb/releases)
 [![Nervos Talk](https://img.shields.io/badge/discuss-on%20Nervos%20Talk-3CC68A.svg)](https://talk.nervos.org/t/where-to-discuss-ckb-and-how-to-ask-for-support/6024)
-[![Telegram Group](https://cdn.jsdelivr.net/gh/Patrolavia/telegram-badge@8fe3382b3fd3a1c533ba270e608035a27e430c2e/chat.svg)](https://t.me/nervosnetwork)
+[![Discord](https://img.shields.io/badge/chat-on%20Discord-7289DA.svg)](https://discord.gg/dBPuQ3qnXS)
 
 master | develop
 -------|----------


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Discord is the preferred chat tool for Nervos but the repo still links to Telegram.

### What is changed and how it works?

What's Changed:

Update the README badge. Remove the Telegram badge and add the Discord badge.

PREVIEW: [![Discord](https://img.shields.io/badge/chat-on%20Discord-7289DA.svg)](https://discord.gg/dBPuQ3qnXS)

### Check List

Tests

- No code (skip ci)

### Release note

```release-note
None: Exclude this PR from the release note.
```

