### PR TITLE
test: add tests for logger-related crates after fix few negligible issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ name = "ckb-logger-config"
 version = "0.100.0-pre"
 dependencies = [
  "serde",
+ "toml",
 ]
 
 [[package]]
@@ -772,6 +773,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "ckb-channel",
+ "ckb-logger",
  "ckb-logger-config",
  "ckb-util",
  "env_logger",
@@ -779,6 +781,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sentry",
+ "tempfile",
 ]
 
 [[package]]

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -77,10 +77,19 @@ fn main() {
             ..Default::default()
         };
         if let Some(log_file) = log_file_opt {
-            if log_file.is_relative() {
-                logger_config.log_dir = current_dir();
-            }
-            logger_config.file = log_file;
+            let full_log_file = if log_file.is_relative() {
+                current_dir().join(log_file)
+            } else {
+                log_file
+            };
+            logger_config.file = full_log_file
+                .file_name()
+                .map(|name| Path::new(name).to_path_buf())
+                .unwrap_or_else(|| panic!("failed to get the filename for log_file"));
+            logger_config.log_dir = full_log_file
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| panic!("failed to get the parent path for log_file"));
             logger_config.log_to_file = true;
         } else {
             logger_config.log_to_file = false;

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -281,10 +281,7 @@ impl CKBAppConfig {
             self.tmp_dir = Some(self.data_dir.join("tmp"));
         }
         self.logger.log_dir = self.data_dir.join("logs");
-        self.logger.file = self
-            .logger
-            .log_dir
-            .join(subcommand_name.to_string() + ".log");
+        self.logger.file = Path::new(&(subcommand_name.to_string() + ".log")).to_path_buf();
 
         self.tx_pool.adjust(root_dir, &self.data_dir);
 
@@ -300,7 +297,7 @@ impl CKBAppConfig {
         }
         if self.logger.log_to_file {
             mkdir(self.logger.log_dir.clone())?;
-            self.logger.file = touch(self.logger.file)?;
+            self.logger.file = touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
 
@@ -326,10 +323,10 @@ impl MinerAppConfig {
 
         self.data_dir = mkdir(canonicalize_data_dir(self.data_dir, root_dir))?;
         self.logger.log_dir = self.data_dir.join("logs");
-        self.logger.file = self.logger.log_dir.join("miner.log");
+        self.logger.file = Path::new("miner.log").to_path_buf();
         if self.logger.log_to_file {
             mkdir(self.logger.log_dir.clone())?;
-            self.logger.file = touch(self.logger.file)?;
+            self.logger.file = touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
 

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+toml = "0.5"

--- a/util/logger-config/src/lib.rs
+++ b/util/logger-config/src/lib.rs
@@ -25,6 +25,7 @@ pub struct Config {
     /// [env_logger::Filter]: https://docs.rs/env_logger/*/env_logger/filter/struct.Filter.html
     pub filter: Option<String>,
     /// Colorize the output which was written into the stdout.
+    #[serde(default = "default_values::color")]
     pub color: bool,
     /// The log file of the main loggger.
     #[serde(skip)]
@@ -33,8 +34,10 @@ pub struct Config {
     #[serde(skip)]
     pub log_dir: PathBuf,
     /// Output the log records of the main logger into a file or not.
+    #[serde(default = "default_values::log_to_file")]
     pub log_to_file: bool,
     /// Output the log records of the main logger into the stdout or not.
+    #[serde(default = "default_values::log_to_stdout")]
     pub log_to_stdout: bool,
     /// An optional bool to control whether or not emit [Sentry Breadcrumbs].
     ///
@@ -64,13 +67,27 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             filter: None,
-            color: !cfg!(windows),
+            color: default_values::color(),
             file: Default::default(),
             log_dir: Default::default(),
-            log_to_file: false,
-            log_to_stdout: true,
+            log_to_file: default_values::log_to_file(),
+            log_to_stdout: default_values::log_to_stdout(),
             emit_sentry_breadcrumbs: None,
             extra: Default::default(),
         }
+    }
+}
+
+pub(crate) mod default_values {
+    pub(crate) const fn color() -> bool {
+        !cfg!(windows)
+    }
+
+    pub(crate) const fn log_to_file() -> bool {
+        false
+    }
+
+    pub(crate) const fn log_to_stdout() -> bool {
+        true
     }
 }

--- a/util/logger-config/src/lib.rs
+++ b/util/logger-config/src/lib.rs
@@ -8,6 +8,9 @@ use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// The whole CKB logger configuration.
 ///
 /// This struct is used to build [`Logger`].
@@ -15,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// Include configurations of the main logger and any number of extra loggers.
 ///
 /// [`Logger`]: ../ckb_logger_service/struct.Logger.html
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// An optional string which is used to build [env_logger::Filter] for the main logger.
@@ -55,7 +58,7 @@ pub struct Config {
 /// This struct is used to build [`ExtraLogger`].
 ///
 /// [`ExtraLogger`]: ../ckb_logger_service/struct.ExtraLogger.html
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExtraLoggerConfig {
     /// A string which is used to build [env_logger::Filter] for the extra logger.
     ///

--- a/util/logger-config/src/tests.rs
+++ b/util/logger-config/src/tests.rs
@@ -1,0 +1,35 @@
+use crate::{Config, ExtraLoggerConfig};
+
+fn update_extra_logger(config: &mut Config, name: &str, filter: &str) {
+    let value = ExtraLoggerConfig {
+        filter: filter.to_owned(),
+    };
+    config.extra.insert(name.to_owned(), value);
+}
+
+#[test]
+fn test_default_params() {
+    let config: Config = toml::from_str("").unwrap();
+    let expected = Config::default();
+    assert_eq!(config, expected);
+}
+
+#[test]
+fn test_extra_loggers() {
+    let config: Config = toml::from_str(
+        r#"
+            [extra.errors]
+            filter = "error"
+            [extra.ckb_trace]
+            filter = "off,ckb=trace"
+        "#,
+    )
+    .unwrap();
+    let expected = {
+        let mut config = Config::default();
+        update_extra_logger(&mut config, "errors", "error");
+        update_extra_logger(&mut config, "ckb_trace", "off,ckb=trace");
+        config
+    };
+    assert_eq!(config, expected);
+}

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -21,5 +21,9 @@ chrono = "0.4"
 backtrace = "0.3"
 sentry = { version = "0.23.0", optional = true, features = ["log"] }
 
+[dev-dependencies]
+ckb-logger = { path = "../logger", version = "= 0.100.0-pre" }
+tempfile = "3.0"
+
 [features]
 with_sentry = ["sentry"]

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -16,6 +16,9 @@ use std::{fs, panic, process, sync, thread};
 use ckb_logger_config::Config;
 use ckb_util::{strings, Mutex, RwLock};
 
+#[cfg(test)]
+mod tests;
+
 static CONTROL_HANDLE: OnceCell<ckb_channel::Sender<Message>> = OnceCell::new();
 static RE: OnceCell<regex::Regex> = OnceCell::new();
 
@@ -72,7 +75,7 @@ fn enable_ansi_support() {
 fn enable_ansi_support() {}
 
 // Parse crate name leniently in logger filter: convert "-" to "_".
-fn convert_compatible_crate_name(spec: &str) -> String {
+pub(crate) fn convert_compatible_crate_name(spec: &str) -> String {
     let mut parts = spec.splitn(2, '/');
     let first_part = parts.next();
     let last_part = parts.next();
@@ -90,27 +93,6 @@ fn convert_compatible_crate_name(spec: &str) -> String {
     } else {
         mods.join(",")
     }
-}
-
-#[test]
-fn test_convert_compatible_crate_name() {
-    let spec = "info,a-b=trace,c-d_e-f=warn,g-h-i=debug,jkl=trace/*[0-9]";
-    let expected = "info,a-b=trace,a_b=trace,c-d_e-f=warn,c_d_e_f=warn,g-h-i=debug,g_h_i=debug,jkl=trace/*[0-9]";
-    let result = convert_compatible_crate_name(&spec);
-    assert_eq!(&result, &expected);
-    let spec = "info,a-b=trace,c-d_e-f=warn,g-h-i=debug,jkl=trace";
-    let expected =
-        "info,a-b=trace,a_b=trace,c-d_e-f=warn,c_d_e_f=warn,g-h-i=debug,g_h_i=debug,jkl=trace";
-    let result = convert_compatible_crate_name(&spec);
-    assert_eq!(&result, &expected);
-    let spec = "info/*[0-9]";
-    let expected = "info/*[0-9]";
-    let result = convert_compatible_crate_name(&spec);
-    assert_eq!(&result, &expected);
-    let spec = "info";
-    let expected = "info";
-    let result = convert_compatible_crate_name(&spec);
-    assert_eq!(&result, &expected);
 }
 
 impl Logger {

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -132,13 +132,14 @@ impl Logger {
 
         let Config {
             color,
-            file: file_path,
+            file,
             log_dir,
             log_to_file,
             log_to_stdout,
             ..
         } = config;
         let mut main_logger = {
+            let file_path = log_dir.join(file);
             let file = if log_to_file {
                 match Self::open_log_file(&file_path) {
                     Err(err) => {

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -41,7 +41,6 @@ enum Message {
 /// When a CKB logger is created, a logging service will be started in a background thread.
 ///
 /// [log::Log]: https://docs.rs/log/*/log/trait.Log.html
-#[derive(Debug)]
 pub struct Logger {
     sender: ckb_channel::Sender<Message>,
     handle: Mutex<Option<thread::JoinHandle<()>>>,
@@ -51,7 +50,6 @@ pub struct Logger {
     extra_loggers: sync::Arc<RwLock<HashMap<String, ExtraLogger>>>,
 }
 
-#[derive(Debug)]
 struct MainLogger {
     file_path: PathBuf,
     file: Option<fs::File>,
@@ -60,7 +58,6 @@ struct MainLogger {
     color: bool,
 }
 
-#[derive(Debug)]
 struct ExtraLogger {
     filter: Filter,
 }
@@ -491,7 +488,6 @@ pub fn init_silent() -> Result<LoggerInitGuard, SetLoggerError> {
 /// The SilentLogger which implements [log::Log].
 ///
 /// Silent logger that does nothing.
-#[derive(Debug)]
 pub struct SilentLogger;
 
 impl Log for SilentLogger {

--- a/util/logger-service/src/tests.rs
+++ b/util/logger-service/src/tests.rs
@@ -1,0 +1,22 @@
+use crate::convert_compatible_crate_name;
+
+#[test]
+fn test_convert_compatible_crate_name() {
+    let spec = "info,a-b=trace,c-d_e-f=warn,g-h-i=debug,jkl=trace/*[0-9]";
+    let expected = "info,a-b=trace,a_b=trace,c-d_e-f=warn,c_d_e_f=warn,g-h-i=debug,g_h_i=debug,jkl=trace/*[0-9]";
+    let result = convert_compatible_crate_name(&spec);
+    assert_eq!(&result, &expected);
+    let spec = "info,a-b=trace,c-d_e-f=warn,g-h-i=debug,jkl=trace";
+    let expected =
+        "info,a-b=trace,a_b=trace,c-d_e-f=warn,c_d_e_f=warn,g-h-i=debug,g_h_i=debug,jkl=trace";
+    let result = convert_compatible_crate_name(&spec);
+    assert_eq!(&result, &expected);
+    let spec = "info/*[0-9]";
+    let expected = "info/*[0-9]";
+    let result = convert_compatible_crate_name(&spec);
+    assert_eq!(&result, &expected);
+    let spec = "info";
+    let expected = "info";
+    let result = convert_compatible_crate_name(&spec);
+    assert_eq!(&result, &expected);
+}

--- a/util/logger-service/tests/basic_features.rs
+++ b/util/logger-service/tests/basic_features.rs
@@ -1,0 +1,17 @@
+mod utils;
+
+#[test]
+fn basic_features() {
+    let (config, _tmp_dir) = utils::config_in_tempdir(|_| {});
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = "test basic features";
+    utils::do_tests(config, || {
+        utils::output_log_for_all_log_levels(line_content);
+    });
+
+    utils::test_if_log_file_exists(&log_file, true);
+
+    for level in utils::all_log_levels() {
+        assert!(utils::has_line_in_log_file(&log_file, *level, line_content));
+    }
+}

--- a/util/logger-service/tests/empty_filter.rs
+++ b/util/logger-service/tests/empty_filter.rs
@@ -1,0 +1,24 @@
+use ckb_logger::Level;
+
+mod utils;
+
+#[test]
+fn empty_filter() {
+    let (config, _tmp_dir) = utils::config_in_tempdir(|config| {
+        config.filter = None;
+    });
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = "test empty filter";
+    utils::do_tests(config, || {
+        utils::output_log_for_all_log_levels(line_content);
+    });
+
+    utils::test_if_log_file_exists(&log_file, true);
+
+    for level in utils::all_log_levels() {
+        assert_eq!(
+            *level <= Level::Error,
+            utils::has_line_in_log_file(&log_file, *level, line_content)
+        );
+    }
+}

--- a/util/logger-service/tests/env_filter.rs
+++ b/util/logger-service/tests/env_filter.rs
@@ -1,0 +1,25 @@
+use ckb_logger::Level;
+
+mod utils;
+
+#[test]
+fn env_filter() {
+    let (config, _tmp_dir) = utils::config_in_tempdir(|config| {
+        config.filter = None;
+    });
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = "test env filter";
+    let env_level = Level::Debug;
+    utils::do_tests_with_env(env_level.as_str(), config, || {
+        utils::output_log_for_all_log_levels(line_content);
+    });
+
+    utils::test_if_log_file_exists(&log_file, true);
+
+    for level in utils::all_log_levels() {
+        assert_eq!(
+            *level <= env_level,
+            utils::has_line_in_log_file(&log_file, *level, line_content)
+        );
+    }
+}

--- a/util/logger-service/tests/extra_loggers.rs
+++ b/util/logger-service/tests/extra_loggers.rs
@@ -1,0 +1,109 @@
+use ckb_logger::Level;
+use ckb_logger_service::Logger;
+
+mod utils;
+
+#[test]
+fn extra_loggers() {
+    let logger_name_turn_off = "turn_off";
+    let logger_name_no_log = "no_log";
+    let logger_name_warn = "warn";
+    let logger_name_updated = "updated";
+    let logger_name_removed = "removed";
+    let logger_name_inserted = "inserted";
+    let (config, _tmp_dir) = utils::config_in_tempdir(|config| {
+        utils::update_extra_logger(config, logger_name_turn_off, "trace");
+        utils::update_extra_logger(config, logger_name_no_log, "off");
+        utils::update_extra_logger(config, logger_name_warn, "warn");
+        utils::update_extra_logger(config, logger_name_updated, "trace");
+        utils::update_extra_logger(config, logger_name_removed, "trace");
+    });
+    let log_dir = config.log_dir.clone();
+    let line_content = "test extra loggers";
+    let new_level = Level::Info;
+    utils::do_tests(config, || {
+        Logger::update_extra_logger(logger_name_turn_off.to_owned(), "off".to_owned()).unwrap();
+        Logger::update_extra_logger(
+            logger_name_updated.to_owned(),
+            new_level.as_str().to_owned(),
+        )
+        .unwrap();
+        Logger::remove_extra_logger(logger_name_removed.to_owned()).unwrap();
+        Logger::update_extra_logger(
+            logger_name_inserted.to_owned(),
+            new_level.as_str().to_owned(),
+        )
+        .unwrap();
+        utils::apply_new_config();
+        utils::output_log_for_all_log_levels(line_content);
+    });
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_turn_off);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert!(!utils::has_line_in_log_file(
+                &log_file,
+                *level,
+                line_content
+            ),);
+        }
+    }
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_no_log);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert!(!utils::has_line_in_log_file(
+                &log_file,
+                *level,
+                line_content
+            ),);
+        }
+    }
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_warn);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert_eq!(
+                *level <= Level::Warn,
+                utils::has_line_in_log_file(&log_file, *level, line_content),
+            );
+        }
+    }
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_updated);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert_eq!(
+                *level <= new_level,
+                utils::has_line_in_log_file(&log_file, *level, line_content),
+            );
+        }
+    }
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_removed);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert!(!utils::has_line_in_log_file(
+                &log_file,
+                *level,
+                line_content
+            ),);
+        }
+    }
+
+    {
+        let log_file = utils::extra_logger_file(&log_dir, logger_name_inserted);
+        utils::test_if_log_file_exists(&log_file, true);
+        for level in utils::all_log_levels() {
+            assert_eq!(
+                *level <= new_level,
+                utils::has_line_in_log_file(&log_file, *level, line_content),
+            );
+        }
+    }
+}

--- a/util/logger-service/tests/has_panic_info.rs
+++ b/util/logger-service/tests/has_panic_info.rs
@@ -1,0 +1,44 @@
+use ckb_logger::Level;
+
+mod utils;
+
+#[test]
+fn has_panic_info() {
+    let (config, _tmp_dir) = utils::config_in_tempdir(|_| {});
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = "test has panic info";
+    let panic_message = "panic first";
+    let panic_line_content_1 = format!(r"thread 'unnamed' panicked at '{}':.*", panic_message);
+    let panic_line_content_2 = r"thread 'unnamed' panicked at 'panic second':.*";
+    utils::do_tests(config, || {
+        let _ = ::std::thread::spawn(move || {
+            panic!("{}", panic_message);
+        })
+        .join();
+        let _ = ::std::thread::spawn(move || {
+            panic!("panic second");
+        })
+        .join();
+        ckb_logger::error!("{}", line_content);
+    });
+
+    utils::test_if_log_file_exists(&log_file, true);
+
+    assert!(utils::has_line_in_log_file(
+        &log_file,
+        Level::Error,
+        &panic_line_content_1
+    ));
+
+    assert!(utils::has_line_in_log_file(
+        &log_file,
+        Level::Error,
+        &panic_line_content_2
+    ));
+
+    assert!(utils::has_line_in_log_file(
+        &log_file,
+        Level::Error,
+        &line_content
+    ));
+}

--- a/util/logger-service/tests/log_to_file_disabled.rs
+++ b/util/logger-service/tests/log_to_file_disabled.rs
@@ -1,0 +1,6 @@
+mod utils;
+
+#[test]
+fn log_to_file_disabled() {
+    utils::test_log_to_file(false);
+}

--- a/util/logger-service/tests/log_to_file_enabled.rs
+++ b/util/logger-service/tests/log_to_file_enabled.rs
@@ -1,0 +1,6 @@
+mod utils;
+
+#[test]
+fn log_to_file_enabled() {
+    utils::test_log_to_file(true);
+}

--- a/util/logger-service/tests/silent_logger.rs
+++ b/util/logger-service/tests/silent_logger.rs
@@ -1,0 +1,9 @@
+mod utils;
+
+#[test]
+fn silent_logger() {
+    let line_content = "test silent logger";
+    utils::do_tests_with_silent_logger(|| {
+        utils::output_log_for_all_log_levels(line_content);
+    });
+}

--- a/util/logger-service/tests/update_main_logger.rs
+++ b/util/logger-service/tests/update_main_logger.rs
@@ -1,0 +1,72 @@
+use ckb_logger::Level;
+use ckb_logger_service::Logger;
+
+mod utils;
+
+#[test]
+fn update_main_logger() {
+    let trace_filter = Level::Trace.as_str();
+    let (config, _tmp_dir) = utils::config_in_tempdir(|config| {
+        config.filter = Some(trace_filter.to_owned());
+        config.log_to_file = true;
+        config.log_to_stdout = false;
+    });
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content_1 = "test update main logger first";
+    let line_content_2 = "test update main logger second";
+    let line_content_3 = "test update main logger third";
+    let line_content_4 = "test update main logger fourth";
+    let new_level = Level::Info;
+    utils::do_tests(config, || {
+        utils::output_log_for_all_log_levels(line_content_1);
+
+        Logger::update_main_logger(
+            Some(new_level.as_str().to_owned()),
+            Some(true),
+            None,
+            Some(false),
+        )
+        .unwrap();
+        utils::apply_new_config();
+        utils::output_log_for_all_log_levels(line_content_2);
+
+        Logger::update_main_logger(Some(trace_filter.to_owned()), None, Some(false), None).unwrap();
+        utils::apply_new_config();
+        utils::output_log_for_all_log_levels(line_content_3);
+
+        Logger::update_main_logger(None, None, Some(true), None).unwrap();
+        utils::apply_new_config();
+        utils::output_log_for_all_log_levels(line_content_4);
+    });
+
+    for level in utils::all_log_levels() {
+        assert!(utils::has_line_in_log_file(
+            &log_file,
+            *level,
+            line_content_1
+        ),);
+    }
+
+    for level in utils::all_log_levels() {
+        assert_eq!(
+            *level <= new_level,
+            utils::has_line_in_log_file(&log_file, *level, line_content_2),
+        );
+    }
+
+    for level in utils::all_log_levels() {
+        assert!(!utils::has_line_in_log_file(
+            &log_file,
+            *level,
+            line_content_3
+        ),);
+    }
+
+    for level in utils::all_log_levels() {
+        assert!(utils::has_line_in_log_file(
+            &log_file,
+            *level,
+            line_content_4
+        ),);
+    }
+}

--- a/util/logger-service/tests/utils/mod.rs
+++ b/util/logger-service/tests/utils/mod.rs
@@ -1,0 +1,152 @@
+#![allow(dead_code)]
+
+use std::{
+    fs::OpenOptions,
+    io::{BufRead as _, BufReader},
+    path::{Path, PathBuf},
+};
+
+use ckb_logger::Level;
+use ckb_logger_config::{Config, ExtraLoggerConfig};
+use tempfile::TempDir;
+
+const DEFAULT_LOG_FILE: &str = "default.log";
+const DEFAULT_LOG_ENV: &str = "DEFAULT_LOG_ENV";
+const LOG_LEVELS: &[Level] = &[
+    Level::Trace,
+    Level::Debug,
+    Level::Info,
+    Level::Warn,
+    Level::Error,
+];
+const LOG_TIMESTAMP_REGEX: &str =
+    r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}([.]\d{1,3}) [+-]\d{2}:\d{2}";
+
+pub fn has_line_in_log_file(log_file: &Path, log_level: Level, content_pattern: &str) -> bool {
+    let full_line_pattern = format!(
+        r"^{} [^\s]+ {} [^\s]+  {}$",
+        LOG_TIMESTAMP_REGEX, log_level, content_pattern
+    );
+    let regex = regex::Regex::new(&full_line_pattern).unwrap();
+    let file = OpenOptions::new().read(true).open(log_file).unwrap();
+    for line in BufReader::new(file).lines() {
+        let line_str = line.unwrap();
+        if regex.is_match(&line_str) {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn test_if_log_file_exists(log_file: &Path, should_exist: bool) {
+    if should_exist {
+        assert!(
+            log_file.exists(),
+            "log file [{}] should exist",
+            log_file.display()
+        );
+    } else {
+        assert!(
+            !log_file.exists(),
+            "log file [{}] shouldn't exist",
+            log_file.display()
+        );
+    }
+}
+
+pub fn do_tests<F>(config: Config, func: F)
+where
+    F: Fn(),
+{
+    let guard = ckb_logger_service::init(None, config).unwrap();
+    func();
+    drop(guard);
+}
+
+pub fn do_tests_with_env<F>(env_filter: &str, config: Config, func: F)
+where
+    F: Fn(),
+{
+    std::env::set_var(DEFAULT_LOG_ENV, env_filter);
+    let guard = ckb_logger_service::init(Some(DEFAULT_LOG_ENV), config).unwrap();
+    func();
+    drop(guard);
+}
+
+pub fn do_tests_with_silent_logger<F>(func: F)
+where
+    F: Fn(),
+{
+    let guard = ckb_logger_service::init_silent().unwrap();
+    func();
+    drop(guard);
+}
+
+pub fn config_in_tempdir<F>(func: F) -> (Config, TempDir)
+where
+    F: Fn(&mut Config),
+{
+    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let mut config = Config {
+        filter: Some(Level::Trace.as_str().to_owned()),
+        file: Path::new(DEFAULT_LOG_FILE).to_path_buf(),
+        log_dir: tmp_dir.path().to_path_buf(),
+        log_to_file: true,
+        log_to_stdout: true,
+        ..Default::default()
+    };
+    func(&mut config);
+    (config, tmp_dir)
+}
+
+pub fn output_log_for_all_log_levels(log_message: &str) {
+    ckb_logger::error!("{}", log_message);
+    ckb_logger::warn!("{}", log_message);
+    ckb_logger::info!("{}", log_message);
+    ckb_logger::debug!("{}", log_message);
+    ckb_logger::trace!("{}", log_message);
+}
+
+pub fn all_log_levels() -> &'static [Level] {
+    LOG_LEVELS
+}
+
+pub fn update_extra_logger(config: &mut Config, name: &str, filter: &str) {
+    let value = ExtraLoggerConfig {
+        filter: filter.to_owned(),
+    };
+    config.extra.insert(name.to_owned(), value);
+}
+
+pub fn extra_logger_file(log_dir: &Path, logger_name: &str) -> PathBuf {
+    log_dir.join(format!("{}.log", logger_name))
+}
+
+pub fn apply_new_config() {
+    // waiting for the new configuration to be applied.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+}
+
+pub fn test_log_to_file(enabled: bool) {
+    let (config, _tmp_dir) = config_in_tempdir(|config| {
+        let file_name = format!("test_log_to_file_{}.log", enabled);
+        config.file = Path::new(&file_name).to_path_buf();
+        config.log_to_file = enabled;
+    });
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = format!("test log_to_file = {}", enabled);
+    do_tests(config, || {
+        ckb_logger::error!("{}", line_content);
+    });
+
+    test_if_log_file_exists(&log_file, enabled);
+
+    if enabled {
+        assert!(
+            has_line_in_log_file(&log_file, Level::Error, &line_content),
+            "line [{}] isn't found in the log [{}]",
+            line_content,
+            log_file.display()
+        );
+    }
+}

--- a/util/logger-service/tests/without_color.rs
+++ b/util/logger-service/tests/without_color.rs
@@ -1,0 +1,23 @@
+use ckb_logger::Level;
+
+mod utils;
+
+#[test]
+fn without_color() {
+    let (config, _tmp_dir) = utils::config_in_tempdir(|config| {
+        config.color = false;
+    });
+    let log_file = config.log_dir.join(config.file.as_path());
+    let line_content = "test without color";
+    utils::do_tests(config, || {
+        ckb_logger::error!("{}", line_content);
+    });
+
+    utils::test_if_log_file_exists(&log_file, true);
+
+    assert!(utils::has_line_in_log_file(
+        &log_file,
+        Level::Error,
+        line_content
+    ));
+}


### PR DESCRIPTION
### What problem does this PR solve?

- Fix few negligible logger-related issues:

  - fix: the default logger configuration doesn't have the default values

    `toml::from_str::<LoggerConfig>("").unwrap() != LoggerConfig::default()`

  - fix: cause ambiguity since log file could be irrelevant to the `log_dir`

    For example, if a user of crate `ckb-logger-service` set `logger.log_dir="/tmp/log_dir"` and `logger.file="run.log"` but run the binary under `/tmp/workdir`, he/she could NOT find the log file in `/tmp/log_dir`, because the log file is in `/tmp/workdir`.

    Changes:
    - Let the `logger.file` to be the main log file name.
    - Written the main log into `logger.log_dir.join(logger.file)`.

  _Only internal values are changed, doesn't affect the users of `ckb`._

- Minor changes:

  - remove useless `#[derive(Debug)]`
    - Two structs are private.
    - Another two don't have public constructor methods and their instances couldn't be got after initialized.
      _p.s. Maybe these two structs should be private too._

- Add tests for logger-related crates.

### Check List

Tests

- Unit test

Side effects

- Coverage of unit tests has been increased significantly:

  |          Directory          |            Lines Coverage            |        Functions Coverage        |
  |-----------------------------|--------------------------------------|----------------------------------|
  | ckb/util/logger-config/src  | `2/15 = 13.3%` -> `24/24 = 100%`     | `5/58 = 8.6%` -> `16/65 = 24.6%` |
  | ckb/util/logger-service/src | `32/364 = 8.8%` -> `318/345 = 92.2%` | `4/48 = 8.3%` -> `35/42 = 83.3%` |

### Release note

```release-note
None: Exclude this PR from the release note.
```

