### PR TITLE
build: skip re-link ckb-bin when no code was changed, to make a better dev experience

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,8 +10,15 @@ fn rerun_if_changed(path_str: &str) -> bool {
         || path.starts_with("docs")
         || path.starts_with("test")
         || path.starts_with(".github")
+        || path.ends_with("tests.rs")
     {
         return false;
+    }
+
+    for ancestor in path.ancestors() {
+        if ancestor.ends_with("tests") {
+            return false;
+        }
     }
 
     !matches!(

--- a/build.rs
+++ b/build.rs
@@ -46,14 +46,26 @@ fn main() {
         );
 
         println!("cargo:rerun-if-changed=build.rs");
-        println!("cargo:rerun-if-changed=.git/HEAD");
 
-        let head = std::fs::read_to_string(".git/HEAD").unwrap_or_default();
-        if head.starts_with("ref: ") {
-            let path_str = format!(".git/{}", head[5..].trim());
-            let path = Path::new(&path_str);
-            if path.exists() {
-                println!("cargo:rerun-if-changed={}", path_str);
+        let git_head = std::process::Command::new("git")
+            .args(&["rev-parse", "--git-dir"])
+            .output()
+            .ok()
+            .and_then(|r| String::from_utf8(r.stdout).ok())
+            .and_then(|s| s.lines().next().map(ToOwned::to_owned))
+            .map(|ref s| Path::new(s).to_path_buf())
+            .unwrap_or_else(|| Path::new(".git").to_path_buf())
+            .join("HEAD");
+        if git_head.exists() {
+            println!("cargo:rerun-if-changed={}", git_head.display());
+
+            let head = std::fs::read_to_string(&git_head).unwrap_or_default();
+            if head.starts_with("ref: ") {
+                let path_str = format!(".git/{}", head[5..].trim());
+                let path = Path::new(&path_str);
+                if path.exists() {
+                    println!("cargo:rerun-if-changed={}", path_str);
+                }
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

The binary of `ckb` will be re-linked when any of follow conditions was satisfied:

- Any test-related code was changed.

- No `.git/HEAD` file but under `git` vcs. For example, in a [`Git Worktree`].

About 4.5 seconds will be spent for waiting linking `ckb-bin`, with an intel i9 laptop CPU and mounted-RAM as the disk.
It wastes me a lot of time every day, even I'm just writing tests.

Tests

- Manual test

  - Run `make prod`, then run `echo "who cares this file" > freezer/tests/failpoints.rs`, at last run `make prod` again.

    - Without the commits in this PR, the `ckb-bin` will be linked twice.
    - With the commits in this PR, the `ckb-bin` will be linked only once.

  - Run `make prod` twice in a [`Git Worktree`].

    - Without the commits in this PR, the `ckb-bin` will be linked twice.
    - With the commits in this PR, the `ckb-bin` will be linked only once.
      - Then `touch "$(git rev-parse --git-dir)/HEAD"` and run `make prod` again.
        The `ckb-bin` will be linked again. 

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

[`Git Worktree`]: https://git-scm.com/docs/git-worktree
