### PR TITLE
feat: add RPC to return median fee rate

### DIFF
--- a/db-schema/src/lib.rs
+++ b/db-schema/src/lib.rs
@@ -3,7 +3,7 @@
 /// Column families alias type
 pub type Col = &'static str;
 /// Total column number
-pub const COLUMNS: u32 = 16;
+pub const COLUMNS: u32 = 17;
 /// Column store chain index
 pub const COLUMN_INDEX: Col = "0";
 /// Column store block's header
@@ -38,6 +38,8 @@ pub const COLUMN_NUMBER_HASH: Col = "13";
 pub const COLUMN_CELL_DATA_HASH: Col = "14";
 /// Column store block extension data
 pub const COLUMN_BLOCK_EXTENSION: Col = "15";
+/// Column store block's transaction cycle and size
+pub const COLUMN_BLOCK_TXS_STAT: Col = "16";
 
 /// META_TIP_HEADER_KEY tracks the latest known best block header
 pub const META_TIP_HEADER_KEY: &[u8] = b"TIP_HEADER";

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -50,6 +50,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.51.0.
         * [Method `get_fork_block`](#method-get_fork_block)
         * [Method `get_consensus`](#method-get_consensus)
         * [Method `get_block_median_time`](#method-get_block_median_time)
+        * [Method `get_median_fee_rate`](#method-get_median_fee_rate)
     * [Module Experiment](#module-experiment)
         * [Method `dry_run_transaction`](#method-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#method-calculate_dao_maximum_withdraw)
@@ -1369,6 +1370,51 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x5cd2b105"
+}
+```
+
+#### Method `get_median_fee_rate`
+* `get_median_fee_rate(blocks_to_scan, min_transactions)`
+    * `blocks_to_scan`: [`Uint32`](#type-uint32) `|` `null`
+    * `min_transactions`: [`Uint32`](#type-uint32) `|` `null`
+* result: [`Capacity`](#type-capacity)
+
+Returns the median fee rate in recent number of blocks specified by user.
+
+##### Params
+
+*   `blocks_to_scan` - the latest number (default and maximum blocks: 42) of blocks scanned to calculate median fee rate.
+
+*   `min_transactions` - minimal number of transactions(default: 42) should be included in the block.
+
+##### Returns
+
+*   `Result<Capacity>` - the median fee rate(in Shannons).
+
+Note: When there are less than `min_transactions` transactions in the last `blocks_to_scan` blocks, this RPC returns an error. Otherwise, it returns the median fee rate (in Shannons per vbyte).
+
+##### Examples
+
+Request
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "get_median_fee_rate",
+  "params": [
+        "0x2a", "0x1"
+  ]
+}
+```
+
+Response
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": "0x5a82bd636d98dd"
 }
 ```
 
@@ -2868,6 +2914,10 @@ Pool rejects a large package of chained transactions to avoid certain kinds of D
 (-1108): The transaction is rejected because it does not make sense in the context.
 
 For example, a cellbase transaction is not allowed in `send_transaction` RPC.
+
+### Error `ChainBlockTxStatsAreNotFound`
+
+(-1200): transaction statistics info(tx size, tx cycles, etc.) are not stored in db.
 
 
 ## RPC Types

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -108,6 +108,8 @@ pub enum RPCError {
     ///
     /// For example, a cellbase transaction is not allowed in `send_transaction` RPC.
     PoolRejectedMalformedTransaction = -1108,
+    /// (-1200): transaction statistics info(tx size, tx cycles, etc.) are not stored in db.
+    ChainBlockTxStatsAreNotFound = -1200,
 }
 
 impl RPCError {

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -673,6 +673,7 @@ fn mock_rpc_response(example: &RpcTestExample, response: &mut RpcTestResponse) {
         "subscribe" => replace_rpc_response::<Uint64>(example, response),
         "unsubscribe" => replace_rpc_response::<bool>(example, response),
         "send_transaction" => replace_rpc_response::<H256>(example, response),
+        "get_median_fee_rate" => replace_rpc_response::<Uint64>(example, response),
         "get_block_template" => {
             response.result["current_time"] = example.response.result["current_time"].clone()
         }

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -3,16 +3,16 @@ use crate::data_loader_wrapper::DataLoaderWrapper;
 use ckb_db::iter::{DBIter, Direction, IteratorMode};
 use ckb_db_schema::{
     Col, COLUMN_BLOCK_BODY, COLUMN_BLOCK_EPOCH, COLUMN_BLOCK_EXT, COLUMN_BLOCK_EXTENSION,
-    COLUMN_BLOCK_HEADER, COLUMN_BLOCK_PROPOSAL_IDS, COLUMN_BLOCK_UNCLE, COLUMN_CELL,
-    COLUMN_CELL_DATA, COLUMN_CELL_DATA_HASH, COLUMN_EPOCH, COLUMN_INDEX, COLUMN_META,
+    COLUMN_BLOCK_HEADER, COLUMN_BLOCK_PROPOSAL_IDS, COLUMN_BLOCK_TXS_STAT, COLUMN_BLOCK_UNCLE,
+    COLUMN_CELL, COLUMN_CELL_DATA, COLUMN_CELL_DATA_HASH, COLUMN_EPOCH, COLUMN_INDEX, COLUMN_META,
     COLUMN_TRANSACTION_INFO, COLUMN_UNCLES, META_CURRENT_EPOCH_KEY, META_TIP_HEADER_KEY,
 };
 use ckb_freezer::Freezer;
 use ckb_types::{
     bytes::Bytes,
     core::{
-        cell::CellMeta, BlockExt, BlockNumber, BlockView, EpochExt, EpochNumber, HeaderView,
-        TransactionInfo, TransactionView, UncleBlockVecView,
+        cell::CellMeta, BlockExt, BlockNumber, BlockTxStat, BlockView, EpochExt, EpochNumber,
+        HeaderView, TransactionInfo, TransactionView, UncleBlockVecView,
     },
     packed::{self, OutPoint},
     prelude::*,
@@ -536,6 +536,14 @@ pub trait ChainStore<'a>: Send + Sync + Sized {
             let reader = packed::HeaderViewReader::from_slice_should_be_ok(&slice.as_ref());
             reader.data().to_entity()
         })
+    }
+
+    /// get block tx statistic information, including tx_cycle and tx_size
+    fn get_block_tx_stat(&'a self, hash: &packed::Byte32) -> Option<BlockTxStat> {
+        self.get(COLUMN_BLOCK_TXS_STAT, hash.as_slice())
+            .map(|slice| {
+                packed::BlockTxStatReader::from_slice_should_be_ok(&slice.as_ref()).unpack()
+            })
     }
 }
 

--- a/store/src/transaction.rs
+++ b/store/src/transaction.rs
@@ -6,8 +6,8 @@ use ckb_db::{
 };
 use ckb_db_schema::{
     Col, COLUMN_BLOCK_BODY, COLUMN_BLOCK_EPOCH, COLUMN_BLOCK_EXT, COLUMN_BLOCK_EXTENSION,
-    COLUMN_BLOCK_HEADER, COLUMN_BLOCK_PROPOSAL_IDS, COLUMN_BLOCK_UNCLE, COLUMN_CELL,
-    COLUMN_CELL_DATA, COLUMN_CELL_DATA_HASH, COLUMN_EPOCH, COLUMN_INDEX, COLUMN_META,
+    COLUMN_BLOCK_HEADER, COLUMN_BLOCK_PROPOSAL_IDS, COLUMN_BLOCK_TXS_STAT, COLUMN_BLOCK_UNCLE,
+    COLUMN_CELL, COLUMN_CELL_DATA, COLUMN_CELL_DATA_HASH, COLUMN_EPOCH, COLUMN_INDEX, COLUMN_META,
     COLUMN_NUMBER_HASH, COLUMN_TRANSACTION_INFO, COLUMN_UNCLES, META_CURRENT_EPOCH_KEY,
     META_TIP_HEADER_KEY,
 };
@@ -16,7 +16,7 @@ use ckb_freezer::Freezer;
 use ckb_types::{
     core::{
         cell::{CellChecker, CellProvider, CellStatus},
-        BlockExt, BlockView, EpochExt, HeaderView,
+        BlockExt, BlockTxStat, BlockView, EpochExt, HeaderView,
     },
     packed::{self, OutPoint},
     prelude::*,
@@ -227,6 +227,19 @@ impl StoreTransaction {
             COLUMN_BLOCK_EXT,
             block_hash.as_slice(),
             ext.pack().as_slice(),
+        )
+    }
+
+    /// insert tx statistics into db
+    pub fn insert_block_tx_stat(
+        &self,
+        block_hash: &packed::Byte32,
+        txstat: &BlockTxStat,
+    ) -> Result<(), Error> {
+        self.insert_raw(
+            COLUMN_BLOCK_TXS_STAT,
+            block_hash.as_slice(),
+            txstat.pack().as_slice(),
         )
     }
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -493,6 +493,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RpcGetBlockchainInfo),
         Box::new(RpcTruncate),
         Box::new(RpcTransactionProof),
+        Box::new(RpcGetBlockMedianFeeRate::new()),
         Box::new(RpcGetBlockMedianTime),
         Box::new(SyncTooNewBlock),
         Box::new(RelayTooNewBlock),

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -178,6 +178,17 @@ impl RpcClient {
             .expect("rpc call get_block_median_time")
     }
 
+    pub fn get_median_fee_rate(
+        &self,
+        blocks_to_scan: Option<u64>,
+        min_transactions: Option<u64>,
+    ) -> Result<Capacity, AnyError> {
+        self.inner.get_median_fee_rate(
+            blocks_to_scan.map(|v| v.into()),
+            min_transactions.map(|v| v.into()),
+        )
+    }
+
     pub fn send_transaction(&self, tx: Transaction) -> Byte32 {
         self.send_transaction_result(tx)
             .expect("rpc call send_transaction")
@@ -313,6 +324,7 @@ jsonrpc!(pub struct Inner {
     pub fn submit_block(&self, _work_id: String, _data: Block) -> H256;
     pub fn get_blockchain_info(&self) -> ChainInfo;
     pub fn get_block_median_time(&self, block_hash: H256) -> Option<Timestamp>;
+    pub fn get_median_fee_rate(&self, blocks_to_scan: Option<Uint64>, min_transactions: Option<Uint64>) -> Capacity;
     pub fn dry_run_transaction(&self, _tx: Transaction) -> DryRunResult;
     pub fn send_transaction(&self, tx: Transaction, outputs_validator: Option<String>) -> H256;
     pub fn tx_pool_info(&self) -> TxPoolInfo;

--- a/test/src/specs/rpc/get_block_median_fee_rate.rs
+++ b/test/src/specs/rpc/get_block_median_fee_rate.rs
@@ -1,0 +1,179 @@
+use crate::{Node, Spec};
+// use crate::util::cell::gen_spendable;
+// use crate::util::transaction::always_success_transaction;
+use crate::util::mining::{mine, mine_until_out_bootstrap_period};
+use ckb_app_config::BlockAssemblerConfig;
+use ckb_crypto::secp::{Generator, Privkey};
+use ckb_hash::{blake2b_256, new_blake2b};
+use ckb_jsonrpc_types::JsonBytes;
+use ckb_resource::CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL;
+use ckb_test_chain_utils::type_lock_script_code_hash;
+use ckb_types::{
+    bytes::Bytes,
+    core::{Capacity, DepType, ScriptHashType, TransactionBuilder, TransactionView},
+    packed::{CellDep, CellInput, CellOutput, OutPoint, Script, WitnessArgs},
+    prelude::*,
+    H256,
+};
+
+const N_BLOCKS: u64 = 10;
+const N_TXS_PER_BLOCK: u64 = 10;
+const BASE_CAPACITY: usize = 0x16b969d00;
+
+pub struct RpcGetBlockMedianFeeRate {
+    privkey: Privkey,
+    lock_arg: Bytes,
+}
+
+impl RpcGetBlockMedianFeeRate {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let mut generator = Generator::new();
+        let privkey = generator.gen_privkey();
+        let pubkey_data = privkey.pubkey().expect("Get pubkey failed").serialize();
+        let lock_arg = Bytes::from(blake2b_256(&pubkey_data)[0..20].to_vec());
+        RpcGetBlockMedianFeeRate { privkey, lock_arg }
+    }
+}
+
+impl Spec for RpcGetBlockMedianFeeRate {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+        mine_until_out_bootstrap_period(node0);
+
+        let tip = node0.get_tip_block().number();
+
+        // mine enough blocks for valid input cell ready
+        let number_transactions = N_TXS_PER_BLOCK * N_BLOCKS;
+        mine(&node0, number_transactions);
+
+        // build enough txs
+        let txs = build_tx(
+            &node0,
+            &self.privkey,
+            self.lock_arg.clone(),
+            tip,
+            number_transactions,
+        );
+
+        // put N_TXS_PER_BLOCK txs into each block and commit N_BLOCKS blocks
+        for chunk in txs.chunks(N_TXS_PER_BLOCK as usize).into_iter() {
+            for tx in chunk {
+                node0
+                    .rpc_client()
+                    .send_transaction_result(tx.data().into())
+                    .expect("package large cycles tx");
+            }
+            mine(&node0, 1);
+        }
+
+        // test with user specific blocks_to_scan and transactions number
+        let result = node0.rpc_client().get_median_fee_rate(Some(10), Some(1));
+        assert!(result.is_ok());
+        // println!("result value:{}", result.unwrap().value());
+
+        // test with default
+        let result = node0.rpc_client().get_median_fee_rate(None, None);
+        assert!(result.is_ok());
+
+        // test with "not enough transactions in 1 block"
+        let result = node0
+            .rpc_client()
+            .get_median_fee_rate(Some(1), Some(N_TXS_PER_BLOCK + 1));
+        assert!(result.is_err());
+        // let err_msg = format!(
+        //     "InvalidParams: chain hasn't enough {} transactions in recent 1 blocks",
+        //     N_TXS_PER_BLOCK + 1
+        // );
+        // assert!(result.unwrap_err().to_string().contains(&err_msg));
+    }
+
+    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
+        let lock_arg = self.lock_arg.clone();
+        config.network.connect_outbound_interval_secs = 0;
+        config.tx_pool.max_tx_verify_cycles = 1_300u64;
+        let block_assembler = new_block_assembler_config(lock_arg, ScriptHashType::Type);
+        config.block_assembler = Some(block_assembler);
+    }
+}
+
+fn build_tx(
+    node: &Node,
+    privkey: &Privkey,
+    lock_arg: Bytes,
+    base_block_index: u64,
+    count: u64,
+) -> Vec<TransactionView> {
+    let mut tx_vec = Vec::with_capacity(count as usize);
+
+    for index in 0..count {
+        let secp_out_point = OutPoint::new(node.dep_group_tx_hash(), 0);
+        let lock = Script::new_builder()
+            .args(lock_arg.pack())
+            .code_hash(type_lock_script_code_hash().pack())
+            .hash_type(ScriptHashType::Type.into())
+            .build();
+        let cell_dep = CellDep::new_builder()
+            .out_point(secp_out_point)
+            .dep_type(DepType::DepGroup.into())
+            .build();
+        let input1 = {
+            // let block = node.get_tip_block();
+            let block = node.get_block_by_number(base_block_index + index as u64);
+            let cellbase_hash = block.transactions()[0].hash();
+            CellInput::new(OutPoint::new(cellbase_hash, 0), 0)
+        };
+        let output1 = CellOutput::new_builder()
+            // .capacity(capacity_bytes!(out_cell_capacity).pack())
+            .capacity(Capacity::shannons(BASE_CAPACITY as u64).pack())
+            .lock(lock)
+            .build();
+        let tx = TransactionBuilder::default()
+            .cell_dep(cell_dep)
+            .input(input1)
+            .output(output1)
+            .output_data(Default::default())
+            .build();
+        let tx_hash: H256 = tx.hash().unpack();
+        let witness = WitnessArgs::new_builder()
+            .lock(Some(Bytes::from(vec![0u8; 65])).pack())
+            .build();
+        let witness_len = witness.as_slice().len() as u64;
+        let message = {
+            let mut hasher = new_blake2b();
+            hasher.update(&tx_hash.as_bytes());
+            hasher.update(&witness_len.to_le_bytes());
+            hasher.update(&witness.as_slice());
+            let mut buf = [0u8; 32];
+            hasher.finalize(&mut buf);
+            H256::from(buf)
+        };
+        let sig = privkey.sign_recoverable(&message).expect("sign");
+        let witness = witness
+            .as_builder()
+            .lock(Some(Bytes::from(sig.serialize())).pack())
+            .build();
+        tx_vec.push(
+            tx.as_advanced_builder()
+                .witness(witness.as_bytes().pack())
+                .build(),
+        )
+    }
+    tx_vec
+}
+
+fn new_block_assembler_config(lock_arg: Bytes, hash_type: ScriptHashType) -> BlockAssemblerConfig {
+    let code_hash = if hash_type == ScriptHashType::Data {
+        CODE_HASH_SECP256K1_BLAKE160_SIGHASH_ALL.clone()
+    } else {
+        type_lock_script_code_hash()
+    };
+    BlockAssemblerConfig {
+        code_hash,
+        hash_type: hash_type.into(),
+        args: JsonBytes::from_bytes(lock_arg),
+        message: Default::default(),
+        use_binary_version_as_message_prefix: false,
+        binary_version: "TEST".to_string(),
+    }
+}

--- a/test/src/specs/rpc/mod.rs
+++ b/test/src/specs/rpc/mod.rs
@@ -1,3 +1,4 @@
+mod get_block_median_fee_rate;
 mod get_block_median_time;
 mod get_block_template;
 mod get_blockchain_info;
@@ -5,6 +6,7 @@ mod submit_block;
 mod transaction_proof;
 mod truncate;
 
+pub use get_block_median_fee_rate::*;
 pub use get_block_median_time::*;
 pub use get_block_template::*;
 pub use get_blockchain_info::*;

--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -26,6 +26,7 @@ impl Migrate {
         migrations.add_migration(Box::new(migrations::AddNumberHashMapping));
         migrations.add_migration(Box::new(migrations::AddExtraDataHash));
         migrations.add_migration(Box::new(migrations::AddBlockExtensionColumnFamily));
+        migrations.add_migration(Box::new(migrations::AddBlockTransactionStatistics));
 
         Migrate {
             migrations,

--- a/util/launcher/src/migrations/add_block_transaction_stat.rs
+++ b/util/launcher/src/migrations/add_block_transaction_stat.rs
@@ -1,0 +1,25 @@
+use ckb_db::{Result, RocksDB};
+use ckb_db_migration::{Migration, ProgressBar};
+use std::sync::Arc;
+
+pub struct AddBlockTransactionStatistics;
+
+const VERSION: &str = "20210918100000";
+
+impl Migration for AddBlockTransactionStatistics {
+    fn migrate(
+        &self,
+        db: RocksDB,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<RocksDB> {
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        VERSION
+    }
+
+    fn expensive(&self) -> bool {
+        false
+    }
+}

--- a/util/launcher/src/migrations/mod.rs
+++ b/util/launcher/src/migrations/mod.rs
@@ -1,10 +1,12 @@
 mod add_block_extension_cf;
+mod add_block_transaction_stat;
 mod add_extra_data_hash;
 mod add_number_hash_mapping;
 mod cell;
 mod table_to_struct;
 
 pub use add_block_extension_cf::AddBlockExtensionColumnFamily;
+pub use add_block_transaction_stat::AddBlockTransactionStatistics;
 pub use add_extra_data_hash::AddExtraDataHash;
 pub use add_number_hash_mapping::AddNumberHashMapping;
 pub use cell::CellMigration;

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -48,6 +48,11 @@ table BlockExt {
     verified:           BoolOpt,
 }
 
+table BlockTxStat {
+    txs_cycles:         Uint64Vec,
+    txs_size:           Uint64Vec,
+}
+
 struct EpochExt {
     previous_epoch_hash_rate:           Uint256,
     last_block_hash_in_previous_epoch:  Byte32,

--- a/util/types/src/conversion/storage.rs
+++ b/util/types/src/conversion/storage.rs
@@ -140,3 +140,22 @@ impl<'r> Unpack<core::TransactionInfo> for packed::TransactionInfoReader<'r> {
     }
 }
 impl_conversion_for_entity_unpack!(core::TransactionInfo, TransactionInfo);
+
+impl Pack<packed::BlockTxStat> for core::BlockTxStat {
+    fn pack(&self) -> packed::BlockTxStat {
+        packed::BlockTxStat::new_builder()
+            .txs_cycles((&self.txs_cycles[..]).pack())
+            .txs_size((&self.txs_size[..]).pack())
+            .build()
+    }
+}
+
+impl<'r> Unpack<core::BlockTxStat> for packed::BlockTxStatReader<'r> {
+    fn unpack(&self) -> core::BlockTxStat {
+        core::BlockTxStat {
+            txs_cycles: self.txs_cycles().unpack(),
+            txs_size: self.txs_size().unpack(),
+        }
+    }
+}
+impl_conversion_for_entity_unpack!(core::BlockTxStat, BlockTxStat);

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -26,6 +26,15 @@ pub struct BlockExt {
     pub txs_fees: Vec<Capacity>,
 }
 
+/// store transaction vbyte related info(cycles, size)
+#[derive(Clone, PartialEq, Default, Debug)]
+pub struct BlockTxStat {
+    /// transaction cycles
+    pub txs_cycles: Vec<u64>,
+    /// transaction size
+    pub txs_size: Vec<u64>,
+}
+
 /// TODO(doc): @quake
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct TransactionInfo {

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -29,7 +29,7 @@ mod transaction_meta;
 mod views;
 pub use advanced_builders::{BlockBuilder, HeaderBuilder, TransactionBuilder};
 pub use blockchain::{DepType, ScriptHashType};
-pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
+pub use extras::{BlockExt, BlockTxStat, EpochExt, EpochNumberWithFraction, TransactionInfo};
 pub use fee_rate::FeeRate;
 pub use reward::{BlockEconomicState, BlockIssuance, BlockReward, MinerReward};
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -3259,6 +3259,270 @@ impl molecule::prelude::Builder for BlockExtBuilder {
     }
 }
 #[derive(Clone)]
+pub struct BlockTxStat(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for BlockTxStat {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for BlockTxStat {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for BlockTxStat {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "txs_cycles", self.txs_cycles())?;
+        write!(f, ", {}: {}", "txs_size", self.txs_size())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for BlockTxStat {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            20, 0, 0, 0, 12, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        BlockTxStat::new_unchecked(v.into())
+    }
+}
+impl BlockTxStat {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn txs_cycles(&self) -> Uint64Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint64Vec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn txs_size(&self) -> Uint64Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Uint64Vec::new_unchecked(self.0.slice(start..end))
+        } else {
+            Uint64Vec::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> BlockTxStatReader<'r> {
+        BlockTxStatReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for BlockTxStat {
+    type Builder = BlockTxStatBuilder;
+    const NAME: &'static str = "BlockTxStat";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        BlockTxStat(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        BlockTxStatReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        BlockTxStatReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .txs_cycles(self.txs_cycles())
+            .txs_size(self.txs_size())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct BlockTxStatReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for BlockTxStatReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for BlockTxStatReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for BlockTxStatReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "txs_cycles", self.txs_cycles())?;
+        write!(f, ", {}: {}", "txs_size", self.txs_size())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> BlockTxStatReader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn txs_cycles(&self) -> Uint64VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint64VecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn txs_size(&self) -> Uint64VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Uint64VecReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Uint64VecReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for BlockTxStatReader<'r> {
+    type Entity = BlockTxStat;
+    const NAME: &'static str = "BlockTxStatReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        BlockTxStatReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Uint64VecReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Uint64VecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct BlockTxStatBuilder {
+    pub(crate) txs_cycles: Uint64Vec,
+    pub(crate) txs_size: Uint64Vec,
+}
+impl BlockTxStatBuilder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn txs_cycles(mut self, v: Uint64Vec) -> Self {
+        self.txs_cycles = v;
+        self
+    }
+    pub fn txs_size(mut self, v: Uint64Vec) -> Self {
+        self.txs_size = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for BlockTxStatBuilder {
+    type Entity = BlockTxStat;
+    const NAME: &'static str = "BlockTxStatBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.txs_cycles.as_slice().len()
+            + self.txs_size.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.txs_cycles.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.txs_size.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.txs_cycles.as_slice())?;
+        writer.write_all(self.txs_size.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        BlockTxStat::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct EpochExt(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for EpochExt {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {


### PR DESCRIPTION
add RPC to return median fee rate
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Add new rpc interface to fetch transaction median fee rate
user could specify blocks_to_scan and min_transactions_in_block parameter to filter blocks or use default setting.

Problem Summary:

### What is changed and how it works?

when new block is added,  also insert BlockTxStat, contains all transactions (exclude cellbase tx) cycle and tx_size information; 
we add new RPC to support scan number of latest blocks on chain, collect number of transactions; and calculate the median fee rate

What's Changed:

### Related changes

- db-schema


Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- db-schema change

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

