### PR TITLE
test(orphan pool): add orphan block pool benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "ckb-resource",
  "ckb-shared",
  "ckb-store",
+ "ckb-sync",
  "ckb-system-scripts",
  "ckb-test-chain-utils",
  "ckb-types",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -33,6 +33,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.100.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.100.0-pre" }
 ckb-network = { path = "../network", version = "= 0.100.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.100.0-pre" }
+ckb-sync = { path = "../sync", version = "= 0.100.0-pre" }
 tempfile = "3.0"
 
 [[bench]]

--- a/benches/benches/bench_main.rs
+++ b/benches/benches/bench_main.rs
@@ -8,4 +8,5 @@ criterion_main! {
     benchmarks::secp_2in2out::process_block,
     benchmarks::overall::overall,
     benchmarks::resolve::resolve,
+    benchmarks::orphan_block_pool::orphan_block_pool,
 }

--- a/benches/benches/benchmarks/mod.rs
+++ b/benches/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub mod always_success;
+pub mod orphan_block_pool;
 pub mod overall;
 pub mod resolve;
 pub mod secp_2in2out;

--- a/benches/benches/benchmarks/orphan_block_pool.rs
+++ b/benches/benches/benchmarks/orphan_block_pool.rs
@@ -1,0 +1,88 @@
+use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
+
+use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
+use ckb_sync::orphan_block_pool::OrphanBlockPool;
+use ckb_types::core::{BlockBuilder, BlockView, HeaderView};
+use ckb_types::prelude::*;
+
+#[cfg(not(feature = "ci"))]
+const BLOCKS_CNT: usize = 500 * CHUNK_SIZE;
+
+#[cfg(feature = "ci")]
+const BLOCKS_CNT: usize = CHUNK_SIZE;
+
+const CHUNK_SIZE: usize = 2048;
+
+/// test orphan block pool data structure and operation performance, focus on insert and remove
+pub fn setup_chain(
+    block_num: usize,
+) -> (OrphanBlockPool, Vec<ckb_types::core::BlockView>, Consensus) {
+    let consensus = ConsensusBuilder::default().build();
+    let mut blocks = Vec::new();
+    let mut parent = consensus.genesis_block().header();
+    let pool = OrphanBlockPool::with_capacity(block_num);
+    for _ in 0..block_num {
+        let new_block = gen_block(&parent);
+        blocks.push(new_block.clone());
+        parent = new_block.header();
+    }
+    (pool, blocks, consensus)
+}
+
+fn gen_block(parent_header: &HeaderView) -> BlockView {
+    BlockBuilder::default()
+        .parent_hash(parent_header.hash())
+        .number((parent_header.number() + 1).pack())
+        .build()
+}
+
+/// 1000K blocks, divide into 500 groups, each group with 2048 blocks.
+/// in each group, we shuffle the order of blocks and insert all blocks into pool except the 1st block of the group,
+/// then call remove_blocks_by_parent to claim all blocks in the group.
+fn test_sync(pool: &OrphanBlockPool, blocks: &[ckb_types::core::BlockView], consensus: &Consensus) {
+    let mut rng = thread_rng();
+    let mut heads_index = vec![];
+
+    for (index, _) in blocks.chunks(CHUNK_SIZE).enumerate() {
+        let start = CHUNK_SIZE * index;
+        let end = CHUNK_SIZE * (index + 1) - 1;
+        let mut v: Vec<usize> = (start + 1..=end).collect();
+        v.shuffle(&mut rng);
+        for seq in v.iter() {
+            let block = blocks.get(*seq).expect("seq wrong?");
+            pool.insert(block.clone());
+        }
+        heads_index.push(start);
+    }
+
+    for index in heads_index {
+        pool.remove_blocks_by_parent(&blocks[index].hash());
+    }
+    pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("orphan_block_pool");
+
+    group.bench_with_input(
+        BenchmarkId::new("insert_remove", BLOCKS_CNT),
+        &BLOCKS_CNT,
+        |b, n_blocks| {
+            b.iter_batched(
+                || setup_chain(*n_blocks),
+                |(pool, blocks, consensus)| {
+                    test_sync(&pool, &blocks, &consensus);
+                },
+                BatchSize::PerIteration,
+            )
+        },
+    );
+}
+
+criterion_group!(
+    name = orphan_block_pool;
+    config = Criterion::default().sample_size(10);
+    targets = bench
+);

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -5,7 +5,8 @@
 
 mod block_status;
 pub(crate) mod net_time_checker;
-pub(crate) mod orphan_block_pool;
+#[doc(hidden)]
+pub mod orphan_block_pool;
 mod relayer;
 mod status;
 mod synchronizer;


### PR DESCRIPTION
### What problem does this PR solve?

add seperated benchmark, tes orphan block pool data structure and operation performance.
related Issue Number: #2960  benchmark  <!-- REMOVE this line if no issue to close -->

benchmark design:
building chain with 1000K blocks, divide into 500 groups, each group with 2048 blocks.
in each group, we shuffle the order of blocks and insert all blocks into pool except the 1st block of the group, 
then call `remove_blocks_by_parent(1st block)` to claim all blocks in the group.
repeat above procedure 500 times and calculate the time.
 
benchmark steps:

- cd  benches
- cargo bench orphan_block_pool
```
   ............
   orphan_block_pool/remove/1024000
                              time: [3.5374 s  3.5907 s 3.6260 s]   <----data varies depends on testing machine
```
### What is changed and how it works?

Add benchmark for orphan block pool, only measure data structure and api performance.
benchmark provides measuring tool for alternative design. 

### Related changes

- None


Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

