### PR TITLE
feat: update ckb-vm to 0.20.0-rc5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.20.0-rc4"
+version = "0.20.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b21d09396c2dff735e9a70d83f21bf4408fb92b2f8eb665da0d3777c10710f3"
+checksum = "60dcf786d3e6424be300a84b65a35bafc8344de5350fa96500ed9f6cc370865f"
 dependencies = [
  "byteorder",
  "bytes 1.1.0",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.20.0-rc4"
+version = "0.20.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65f45b2bb6bac4e298f3672318a80dca970264759fc2a3339cdcc13b30bc9c9"
+checksum = "deb44cd2753aaeb2dc8a3df7b293ddfc3cbaaf8232d819650c0fc365cacda34f"
 
 [[package]]
 name = "clap"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -21,8 +21,8 @@ ckb-traits = { path = "../traits", version = "= 0.100.0-pre" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types", version = "= 0.100.0-pre"}
 ckb-hash = {path = "../util/hash", version = "= 0.100.0-pre"}
-ckb-vm-definitions = "0.20.0-rc4"
-ckb-vm = { version = "0.20.0-rc4", default-features = false }
+ckb-vm-definitions = "0.20.0-rc5"
+ckb-vm = { version = "0.20.0-rc5", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.100.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Contains a bug fix, see release notes below:

https://github.com/nervosnetwork/ckb-vm/releases/tag/0.20.0-rc5