### PR TITLE
refactor(rpc): change struct from "TxPoolVerbosity" to "TxPoolEntries…

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -719,8 +719,8 @@ class RPCDoc(object):
         self.collect_type('ckb_jsonrpc_types/enum.PoolTransactionReject.html')
         # Referenced by RawTxPool
         self.collect_type('ckb_jsonrpc_types/struct.TxPoolIds.html')
-        self.collect_type('ckb_jsonrpc_types/struct.TxPoolVerbosity.html')
-        self.collect_type('ckb_jsonrpc_types/struct.TxVerbosity.html')
+        self.collect_type('ckb_jsonrpc_types/struct.TxPoolEntries.html')
+        self.collect_type('ckb_jsonrpc_types/struct.TxPoolEntry.html')
         self.types.sort(key=lambda t: t.name)
 
     def collect_type(self, path):

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -141,11 +141,11 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.51.0.
     * [Type `TransactionTemplate`](#type-transactiontemplate)
     * [Type `TransactionView`](#type-transactionview)
     * [Type `TransactionWithStatus`](#type-transactionwithstatus)
+    * [Type `TxPoolEntries`](#type-txpoolentries)
+    * [Type `TxPoolEntry`](#type-txpoolentry)
     * [Type `TxPoolIds`](#type-txpoolids)
     * [Type `TxPoolInfo`](#type-txpoolinfo)
-    * [Type `TxPoolVerbosity`](#type-txpoolverbosity)
     * [Type `TxStatus`](#type-txstatus)
-    * [Type `TxVerbosity`](#type-txverbosity)
     * [Type `U256`](#type-u256)
     * [Type `Uint128`](#type-uint128)
     * [Type `Uint32`](#type-uint32)
@@ -3993,7 +3993,7 @@ The ratio which numerator and denominator are both 256-bit unsigned integers.
 
 All transactions in tx-pool.
 
-`RawTxPool` is equivalent to [`TxPoolIds`](#type-txpoolids) `|` [`TxPoolVerbosity`](#type-txpoolverbosity).
+`RawTxPool` is equivalent to [`TxPoolIds`](#type-txpoolids) `|` [`TxPoolEntries`](#type-txpoolentries).
 
 ### Type `RemoteNode`
 
@@ -4378,6 +4378,40 @@ The JSON view of a transaction as well as its status.
 *   `tx_status`: [`TxStatus`](#type-txstatus) - The Transaction status.
 
 
+### Type `TxPoolEntries`
+
+Tx-pool entries object
+
+#### Fields
+
+`TxPoolEntries` is a JSON object with the following fields.
+
+*   `pending`: `{ [ key:` [`H256`](#type-h256) `]: ` [`TxPoolEntry`](#type-txpoolentry) `}` - Pending tx verbose info
+
+*   `proposed`: `{ [ key:` [`H256`](#type-h256) `]: ` [`TxPoolEntry`](#type-txpoolentry) `}` - Proposed tx verbose info
+
+
+### Type `TxPoolEntry`
+
+Transaction entry info
+
+#### Fields
+
+`TxPoolEntry` is a JSON object with the following fields.
+
+*   `cycles`: [`Uint64`](#type-uint64) - Consumed cycles.
+
+*   `size`: [`Uint64`](#type-uint64) - The transaction serialized size in block.
+
+*   `fee`: [`Capacity`](#type-capacity) - The transaction fee.
+
+*   `ancestors_size`: [`Uint64`](#type-uint64) - Size of in-tx-pool ancestor transactions
+
+*   `ancestors_cycles`: [`Uint64`](#type-uint64) - Cycles of in-tx-pool ancestor transactions
+
+*   `ancestors_count`: [`Uint64`](#type-uint64) - Number of in-tx-pool ancestor transactions
+
+
 ### Type `TxPoolIds`
 
 Array of transaction ids
@@ -4428,19 +4462,6 @@ Transaction pool information.
 *   `last_txs_updated_at`: [`Timestamp`](#type-timestamp) - Last updated time. This is the Unix timestamp in milliseconds.
 
 
-### Type `TxPoolVerbosity`
-
-Tx-pool verbose object
-
-#### Fields
-
-`TxPoolVerbosity` is a JSON object with the following fields.
-
-*   `pending`: `{ [ key:` [`H256`](#type-h256) `]: ` [`TxVerbosity`](#type-txverbosity) `}` - Pending tx verbose info
-
-*   `proposed`: `{ [ key:` [`H256`](#type-h256) `]: ` [`TxVerbosity`](#type-txverbosity) `}` - Proposed tx verbose info
-
-
 ### Type `TxStatus`
 
 Transaction status and the block hash if it is committed.
@@ -4452,27 +4473,6 @@ Transaction status and the block hash if it is committed.
 *   `status`: [`Status`](#type-status) - The transaction status, allowed values: "pending", "proposed" and "committed".
 
 *   `block_hash`: [`H256`](#type-h256) `|` `null` - The block hash of the block which has committed this transaction in the canonical chain.
-
-
-### Type `TxVerbosity`
-
-Transaction verbose info
-
-#### Fields
-
-`TxVerbosity` is a JSON object with the following fields.
-
-*   `cycles`: [`Uint64`](#type-uint64) - Consumed cycles.
-
-*   `size`: [`Uint64`](#type-uint64) - The transaction serialized size in block.
-
-*   `fee`: [`Capacity`](#type-capacity) - The transaction fee.
-
-*   `ancestors_size`: [`Uint64`](#type-uint64) - Size of in-tx-pool ancestor transactions
-
-*   `ancestors_cycles`: [`Uint64`](#type-uint64) - Cycles of in-tx-pool ancestor transactions
-
-*   `ancestors_count`: [`Uint64`](#type-uint64) - Number of in-tx-pool ancestor transactions
 
 
 ### Type `U256`

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -41,8 +41,8 @@ pub use self::net::{
     RemoteNodeProtocol, SyncState,
 };
 pub use self::pool::{
-    OutputsValidator, PoolTransactionEntry, PoolTransactionReject, RawTxPool, TxPoolIds,
-    TxPoolInfo, TxPoolVerbosity, TxVerbosity,
+    OutputsValidator, PoolTransactionEntry, PoolTransactionReject, RawTxPool, TxPoolEntries,
+    TxPoolEntry, TxPoolIds, TxPoolInfo,
 };
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::subscription::Topic;

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -103,9 +103,9 @@ impl From<CoreTxPoolIds> for TxPoolIds {
     }
 }
 
-/// Transaction verbose info
+/// Transaction entry info
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-pub struct TxVerbosity {
+pub struct TxPoolEntry {
     /// Consumed cycles.
     pub cycles: Uint64,
     /// The transaction serialized size in block.
@@ -120,9 +120,9 @@ pub struct TxVerbosity {
     pub ancestors_count: Uint64,
 }
 
-impl From<TxEntryInfo> for TxVerbosity {
+impl From<TxEntryInfo> for TxPoolEntry {
     fn from(info: TxEntryInfo) -> Self {
-        TxVerbosity {
+        TxPoolEntry {
             cycles: info.cycles.into(),
             size: info.size.into(),
             fee: info.fee.into(),
@@ -133,20 +133,20 @@ impl From<TxEntryInfo> for TxVerbosity {
     }
 }
 
-/// Tx-pool verbose object
+/// Tx-pool entries object
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct TxPoolVerbosity {
+pub struct TxPoolEntries {
     /// Pending tx verbose info
-    pub pending: HashMap<H256, TxVerbosity>,
+    pub pending: HashMap<H256, TxPoolEntry>,
     /// Proposed tx verbose info
-    pub proposed: HashMap<H256, TxVerbosity>,
+    pub proposed: HashMap<H256, TxPoolEntry>,
 }
 
-impl From<TxPoolEntryInfo> for TxPoolVerbosity {
+impl From<TxPoolEntryInfo> for TxPoolEntries {
     fn from(info: TxPoolEntryInfo) -> Self {
         let TxPoolEntryInfo { pending, proposed } = info;
 
-        TxPoolVerbosity {
+        TxPoolEntries {
             pending: pending
                 .into_iter()
                 .map(|(hash, entry)| (hash.unpack(), entry.into()))
@@ -161,17 +161,17 @@ impl From<TxPoolEntryInfo> for TxPoolVerbosity {
 
 /// All transactions in tx-pool.
 ///
-/// `RawTxPool` is equivalent to [`TxPoolIds`][] `|` [`TxPoolVerbosity`][].
+/// `RawTxPool` is equivalent to [`TxPoolIds`][] `|` [`TxPoolEntries`][].
 ///
 /// [`TxPoolIds`]: struct.TxPoolIds.html
-/// [`TxPoolVerbosity`]: struct.TxPoolVerbosity.html
+/// [`TxPoolEntries`]: struct.TxPoolEntries.html
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum RawTxPool {
     /// verbose = false
     Ids(TxPoolIds),
     /// verbose = true
-    Verbose(TxPoolVerbosity),
+    Verbose(TxPoolEntries),
 }
 
 /// TX reject message


### PR DESCRIPTION
Change "TxPoolVerbosity" to "TxPoolEntries", Change "TxVerbosity" to "TxPoolEntry"  
for clear expressed, avoid ambiguity 

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
the word "TxPoolVerbosity", and  "TxVerbosity" is ambiguous to used in the function/code
change them to "TxPoolEntries", and "TxPoolEntry", more clearly expressed. 


Problem Summary:

### What is changed and how it works?
change word in rpc/. and util/jsonrpc-types/.., run `make gen-rpc-doc` to update RPC readme

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch


Tests <!-- At least one of them must be included. -->

- No code (skip ci)
already make ci pass

Side effects

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

