### PR TITLE
fix: shouldn't override the `log.file` after touch it

### DIFF
--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -297,7 +297,7 @@ impl CKBAppConfig {
         }
         if self.logger.log_to_file {
             mkdir(self.logger.log_dir.clone())?;
-            self.logger.file = touch(self.logger.log_dir.join(&self.logger.file))?;
+            touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
 
@@ -326,7 +326,7 @@ impl MinerAppConfig {
         self.logger.file = Path::new("miner.log").to_path_buf();
         if self.logger.log_to_file {
             mkdir(self.logger.log_dir.clone())?;
-            self.logger.file = touch(self.logger.log_dir.join(&self.logger.file))?;
+            touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
 


### PR DESCRIPTION
### What problem does this PR solve?

Since #2990, the log service will write logs into `log.dir + log.file`.
But the `log.file` is overridden to `log.dir + log.file` after `touch`.
Then the log service will write logs into `log.dir + log.dir + log.file`.

### Related changes

- Need to cherry-pick to the `rc/v0.100` release branch

### Check List

Tests

- Manual test

  - Test Case 1
    - `ckb init -C /tmp/ckb-dir`
    - `ckb run -C /tmp/ckb-dir`
    - `cat /tmp/ckb-dir/data/logs/run.log`
    - `ckb miner -C /tmp/ckb-dir`
    - `cat /tmp/ckb-dir/data/logs/miner.log`
  - Test Case 2
    - `cd /tmp`
    - `ckb init -C ckb-dir`
    - `ckb run -C ckb-dir`
    - `cat ckb-dir/data/logs/run.log`
    - `ckb miner -C ckb-dir`
    - `cat ckb-dir/data/logs/miner.log`
  - Test Case 3
    - `cd /tmp`
    - `ckb init -C ckb-dir`
    - `cd ckb-dir`
    - `ckb run -C .`
    - `cat data/logs/run.log`
    - `ckb miner -C .`
    - `cat data/logs/miner.log`

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

