### PR TITLE
fix: fix dummy miner solve

### DIFF
--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -145,7 +145,7 @@ impl Miner {
         let parent_hash = block.parent_hash();
 
         if self.legacy_work.contains(&parent_hash) {
-            info!(
+            debug!(
                 "uncle {} pow_hash: {:#x}, header: {}",
                 block.number(),
                 pow_hash,
@@ -154,7 +154,7 @@ impl Miner {
             self.notify_workers(WorkerMessage::Start);
             return;
         } else {
-            info!(
+            debug!(
                 "block {} pow_hash: {:#x}, header: {}",
                 block.number(),
                 pow_hash,

--- a/miner/src/worker/dummy.rs
+++ b/miner/src/worker/dummy.rs
@@ -105,17 +105,13 @@ impl Dummy {
 
 impl Worker for Dummy {
     fn run<G: FnMut() -> u128>(&mut self, mut rng: G, _progress_bar: ProgressBar) {
-        let mut current = self.pow_work.clone();
         loop {
             self.poll_worker_message();
-            if current.as_ref().map(|a| &a.0) != self.pow_work.as_ref().map(|a| &a.0) && self.start
-            {
+            if self.start {
                 if let Some((pow_hash, work)) = self.pow_work.clone() {
                     self.solve(pow_hash, work, rng());
                 }
             }
-
-            current = self.pow_work.clone();
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

It is a mix of several problems here:

1. Timed poll is turned on from off on dummy miner
2. There is a consistency problem with the deletion judgment because of the background poll, that is, when self start = false, it will also update current, resulting in the previous judgment becoming false when start becomes true
3. Poll new block template will not be updated in this case because of the same work id, i.e., it is not possible to remove the judgment error caused by 2 through poll template

The actual effect is that there is a thread in the miner that keeps on looping but does not work

### Check List

Tests

- Manual test (add detailed scripts or steps below)
 init with dev chain, mining it, it will not be stuck

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

