### PR TITLE
chore(deps): enable hyper http1 for miner

### DIFF
--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -20,7 +20,7 @@ rand_distr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }
-hyper = "0.14"
+hyper = { version = "0.14", features = ["http1"] }
 hyper-tls = "0.5"
 futures = "0.3"
 lru = "0.6.0"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: `cargo publish` fails because hyper Client is available when enabling feature http1.

### What is changed and how it works?

What's Changed: Enable feature http1 for hyper in miner/Cargo.toml

- Already cherry-picked to rc/v0.100

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Run `cargo publish --dry-run` in sub-directory `miner`.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

