### PR TITLE
build: enable build-id when build ckb with debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,15 +122,15 @@ build-for-profiling: ## Build binary with for profiling.
 
 .PHONY: prod
 prod: ## Build binary for production release.
-	RUSTFLAGS="--cfg disable_faketime" cargo build ${VERBOSE} --release --features "with_sentry,with_dns_seeding"
+	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" cargo build ${VERBOSE} --release --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod-docker
 prod-docker:
-	RUSTFLAGS="--cfg disable_faketime --cfg docker" cargo build --verbose --release --features "with_sentry,with_dns_seeding"
+	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime --cfg docker" cargo build --verbose --release --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod-test
 prod-test:
-	RUSTFLAGS="--cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" cargo test ${VERBOSE} --all -- --nocapture
+	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" cargo test ${VERBOSE} --all -- --nocapture
 
 .PHONY: prod-with-debug
 prod-with-debug:

--- a/devtools/release/make-with-debug-symbols
+++ b/devtools/release/make-with-debug-symbols
@@ -11,9 +11,11 @@ case "$OSTYPE" in
             exit 1
         fi
         SED=gsed
+        NEW_RUSTFLAGS="${RUSTFLAGS:-}"
         ;;
     *)
         SED=sed
+        NEW_RUSTFLAGS="${RUSTFLAGS:-} -C link-args=-Wl,--build-id"
         ;;
 esac
 
@@ -25,7 +27,7 @@ trap restore_manifest_file EXIT
 
 function main() {
     ${SED} -i "/\[profile.release\]/adebug = true" Cargo.toml
-    make "$@"
+    RUSTFLAGS="${NEW_RUSTFLAGS}" make "$@"
 }
 
 main "$@"


### PR DESCRIPTION
### What problem does this PR solve?

If we want to debug with **detached** debug information, there are two methods (with `gdb`):

- The `.gnu_debuglink` section.

  The executable contains a debug link that specifies the name of the separate debug info file. 

  The separate debug file's name is usually `executable.debug`.

- The `.note.gnu.build-id` section.

  The executable contains a build ID, a unique bit string that is also present in the corresponding debug info file.

So, if the ckb binary has the `.note.gnu.build-id` section, even we have lots ckb binaries with different versions,
the tools, such as `gdb`, still can find the matched symbols file.

More technical details can be found in this manual [Debugging Information in Separate Files].

Postscript:
 
- Why we have to detach debug information?

  Currently, the file of ckb debug symbols is about `730 MiB` and the ckb binary is about `34 MiB`.

- Why doesn't use [`cargo:rustc-flags=FLAGS`] in `build.rs`?

  Because the `rustc-flags` instruction only allows the `-l` and `-L` flags.

- Why don't support macOS?

  Because the `ld` (BSD version) in macOS doesn't support `--build-id`.

[Debugging Information in Separate Files]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
[`cargo:rustc-flags=FLAGS`]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-flagsflags

### Check List

Tests

- Manual test

  - No `build-id`:
    - `make prod`
    - `objdump -j .note.gnu.build-id -s target/release/ckb`

  - Should have `build-id`.
    - `make prod-with-debug`
    - `objdump -j .note.gnu.build-id -s target/release/ckb`

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

