### PR TITLE
refactor(rpc): change 'connected_duration' duration unit to milliseconds

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4082,7 +4082,7 @@ A remote node connects to the local node via the P2P network. It is often called
 
     If the connection is established by the local node, `is_outbound` is true.
 
-*   `connected_duration`: [`Uint64`](#type-uint64) - Elapsed time in seconds since the remote node is connected.
+*   `connected_duration`: [`Uint64`](#type-uint64) - Elapsed time in milliseconds since the remote node is connected.
 
 *   `last_ping_duration`: [`Uint64`](#type-uint64) `|` `null` - Elapsed time in milliseconds since receiving the ping response from this remote node.
 

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -602,7 +602,7 @@ impl NetRpc for NetRpcImpl {
                         .map(|peer_id| peer_id.to_base58())
                         .unwrap_or_default(),
                     addresses: node_addresses,
-                    connected_duration: peer.connected_time.elapsed().as_secs().into(),
+                    connected_duration: (peer.connected_time.elapsed().as_millis() as u64).into(),
                     last_ping_duration: peer
                         .ping_rtt
                         .map(|duration| (duration.as_millis() as u64).into()),

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -160,7 +160,7 @@ pub struct RemoteNode {
     ///
     /// If the connection is established by the local node, `is_outbound` is true.
     pub is_outbound: bool,
-    /// Elapsed time in seconds since the remote node is connected.
+    /// Elapsed time in milliseconds since the remote node is connected.
     pub connected_duration: Uint64,
     /// Elapsed time in milliseconds since receiving the ping response from this remote node.
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

make duration unit consistent in `get_peers` RPC 

Problem Summary:

### What is changed and how it works?

Proposal: in 'get_peer' RPC, connected_duration uses secs but last_ping_duration uses millis,  we need to change connected_duration uses millis.

What's Changed: 

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- rpc client should change 'connected_duration' duration unit from 'second' to 'millisecond' when `get_peers` RPC is used.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
**BREAKING RPC**. Change field `connected_duration` time unit from seconds to **milliseconds** in `get_peers` RPC to make time unit  used  consistently in `get_peers` , RPC clients are suggested to modify time quantity correspond with this change.
```
