### PR TITLE
chore: tweak tx_pool default persisted path

### DIFF
--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -283,7 +283,8 @@ impl CKBAppConfig {
         self.logger.log_dir = self.data_dir.join("logs");
         self.logger.file = Path::new(&(subcommand_name.to_string() + ".log")).to_path_buf();
 
-        self.tx_pool.adjust(root_dir, &self.data_dir);
+        let tx_pool_path = mkdir(self.data_dir.join("tx_pool"))?;
+        self.tx_pool.adjust(root_dir, tx_pool_path);
 
         if subcommand_name == cli::CMD_RESET_DATA {
             return Ok(self);

--- a/util/app-config/src/configs/tx_pool.rs
+++ b/util/app-config/src/configs/tx_pool.rs
@@ -59,14 +59,20 @@ impl TxPoolConfig {
     ///
     /// If `self.path` is relative, convert them to absolute path using
     /// `root_dir` as current working directory.
-    pub fn adjust<P: AsRef<Path>>(&mut self, root_dir: &Path, data_dir: P) {
-        if self.persisted_data.to_str().is_none() || self.persisted_data.to_str() == Some("") {
-            self.persisted_data = data_dir
-                .as_ref()
-                .to_path_buf()
-                .join("tx_pool_persisted_data");
-        } else if self.persisted_data.is_relative() {
-            self.persisted_data = root_dir.to_path_buf().join(&self.persisted_data)
-        }
+    pub fn adjust<P: AsRef<Path>>(&mut self, root_dir: &Path, tx_pool_dir: P) {
+        _adjust(
+            root_dir,
+            tx_pool_dir.as_ref(),
+            &mut self.persisted_data,
+            "persisted_data",
+        );
+    }
+}
+
+fn _adjust(root_dir: &Path, tx_pool_dir: &Path, target: &mut PathBuf, sub: &str) {
+    if target.to_str().is_none() || target.to_str() == Some("") {
+        *target = tx_pool_dir.to_path_buf().join(sub);
+    } else if target.is_relative() {
+        *target = root_dir.to_path_buf().join(&target)
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Currently, the tx_pool default persistent path is  `data/tx_pool_persisted_data`, we will have more other data that need persistent.

### What is changed and how it works?

Proposal: tweak default data/tx_pool_persisted_data -> data/tx_pool/persisted_data.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
`PoolPersisted` covered


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```