### PR TITLE
feat(app_config): add new item "tx_block_stat_enable" in ckb.toml chain section

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1,6 +1,7 @@
 //! CKB chain service.
 #![allow(missing_docs)]
 
+use ckb_app_config::ChainConfig;
 use ckb_channel::{self as channel, select, Sender};
 use ckb_error::{Error, InternalErrorKind};
 use ckb_logger::{self, debug, error, info, log_enabled, trace, warn};
@@ -185,6 +186,8 @@ impl GlobalIndex {
 pub struct ChainService {
     shared: Shared,
     proposal_table: ProposalTable,
+    #[allow(dead_code)]
+    chain_config: Option<ChainConfig>,
 }
 
 impl ChainService {
@@ -193,6 +196,19 @@ impl ChainService {
         ChainService {
             shared,
             proposal_table,
+            chain_config: None,
+        }
+    }
+
+    pub fn new_with_config(
+        shared: Shared,
+        proposal_table: ProposalTable,
+        chain_config: Option<ChainConfig>,
+    ) -> ChainService {
+        ChainService {
+            shared,
+            proposal_table,
+            chain_config,
         }
     }
 
@@ -687,6 +703,14 @@ impl ChainService {
         self.find_fork_until_latest_common(fork, &mut index);
 
         is_sorted_assert(fork);
+    }
+
+    #[allow(dead_code)]
+    fn is_tx_block_stat_enabled(&self) -> bool {
+        if let Some(chain_cfg) = &self.chain_config {
+            return chain_cfg.tx_block_stat_enable;
+        }
+        false
     }
 
     // we found new best_block

--- a/ckb-bin/src/subcommand/import.rs
+++ b/ckb-bin/src/subcommand/import.rs
@@ -5,6 +5,7 @@ use ckb_instrument::Import;
 use ckb_launcher::SharedBuilder;
 
 pub fn import(args: ImportArgs, async_handle: Handle) -> Result<(), ExitCode> {
+    let chain_cfg = args.config.chain.clone();
     let builder = SharedBuilder::new(
         &args.config.bin_name,
         args.config.root_dir.as_path(),
@@ -14,7 +15,8 @@ pub fn import(args: ImportArgs, async_handle: Handle) -> Result<(), ExitCode> {
     )?;
     let (shared, mut pack) = builder.consensus(args.consensus).build()?;
 
-    let chain_service = ChainService::new(shared, pack.take_proposal_table());
+    let chain_service =
+        ChainService::new_with_config(shared, pack.take_proposal_table(), Some(chain_cfg));
     let chain_controller = chain_service.start::<&str>(Some("ImportChainService"));
 
     // manual drop tx_pool_builder and relay_tx_receiver

--- a/ckb-bin/src/subcommand/replay.rs
+++ b/ckb-bin/src/subcommand/replay.rs
@@ -10,6 +10,7 @@ use ckb_verification_traits::Switch;
 use std::sync::Arc;
 
 pub fn replay(args: ReplayArgs, async_handle: Handle) -> Result<(), ExitCode> {
+    let chain_cfg = args.config.chain.clone();
     let shared_builder = SharedBuilder::new(
         &args.config.bin_name,
         args.config.root_dir.as_path(),
@@ -48,7 +49,8 @@ pub fn replay(args: ReplayArgs, async_handle: Handle) -> Result<(), ExitCode> {
             .consensus(args.consensus)
             .tx_pool_config(args.config.tx_pool)
             .build()?;
-        let chain = ChainService::new(tmp_shared, pack.take_proposal_table());
+        let chain =
+            ChainService::new_with_config(tmp_shared, pack.take_proposal_table(), Some(chain_cfg));
 
         if let Some((from, to)) = args.profile {
             profile(shared, chain, from, to);

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -41,7 +41,9 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     launcher.check_assume_valid_target(&shared);
 
-    let chain_controller = launcher.start_chain_service(&shared, pack.take_proposal_table());
+    let chain_cfg = launcher.args.config.chain.clone();
+    let chain_controller =
+        launcher.start_chain_service(&shared, pack.take_proposal_table(), chain_cfg);
 
     let (network_controller, rpc_server) = launcher.start_network_and_rpc(
         &shared,

--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -8,6 +8,7 @@
 data_dir = "data"
 
 [chain]
+tx_block_stat_enable = false
 # Choose the kind of chains to run, possible values:
 # - { file = "specs/dev.toml" }
 # - { bundled = "specs/testnet.toml" }

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -8,6 +8,7 @@
 data_dir = "data"
 
 [chain]
+tx_block_stat_enable = false
 # Choose the kind of chains to run, possible values:
 # - { file = "specs/dev.toml" }
 # - { bundled = "specs/testnet.toml" }

--- a/test/template/ckb.toml
+++ b/test/template/ckb.toml
@@ -7,6 +7,7 @@ data_dir = "data"
 # - { file = "specs/dev.toml" }
 # - { bundled = "specs/testnet.toml" }
 # - { bundled = "specs/mainnet.toml" }
+tx_block_stat_enable = false
 spec = { file = "specs/integration.toml" }
 
 [logger]

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -131,6 +131,9 @@ pub struct MinerAppConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChainConfig {
+    #[serde(default)]
+    /// Specifies if transaction_block_statistics(tx_size, tx_cycles) feature is enabled
+    pub tx_block_stat_enable: bool,
     /// Specifies the chain spec.
     pub spec: Resource,
 }
@@ -301,6 +304,7 @@ impl CKBAppConfig {
             touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
+        self.chain.tx_block_stat_enable = false;
 
         Ok(self)
     }
@@ -330,6 +334,7 @@ impl MinerAppConfig {
             touch(self.logger.log_dir.join(&self.logger.file))?;
         }
         self.chain.spec.absolutize(root_dir);
+        self.chain.tx_block_stat_enable = true;
 
         Ok(self)
     }

--- a/util/app-config/src/exit_code.rs
+++ b/util/app-config/src/exit_code.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::str::ParseBoolError;
 
 /// Uses 0, 64 - 113 as exit code.
 #[repr(i32)]
@@ -46,5 +47,12 @@ impl From<clap::Error> for ExitCode {
     fn from(err: clap::Error) -> ExitCode {
         eprintln!("Args Error: {:?}", err);
         ExitCode::Cli
+    }
+}
+
+impl From<ParseBoolError> for ExitCode {
+    fn from(err: ParseBoolError) -> ExitCode {
+        eprintln!("Config Error: {:?}", err);
+        ExitCode::Config
     }
 }

--- a/util/app-config/src/legacy/chain.rs
+++ b/util/app-config/src/legacy/chain.rs
@@ -1,0 +1,46 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ChainConfig {
+    #[serde(default = "default_tx_block_stat_enable")]
+    tx_block_stat_enable: bool,
+    #[serde(default = "default_spec")]
+    spec: Resource,
+}
+
+const fn default_spec() -> Resource {
+    Resource::default()
+}
+
+const fn default_tx_block_stat_enable() -> bool {
+    false
+}
+
+impl Default for crate::ChainConfig {
+    fn default() -> Self {
+        ChainConfig::default().into()
+    }
+}
+
+impl Default for ChainConfig {
+    fn default() -> Self {
+        Self {
+            spec: default_spec(),
+            tx_block_stat_enable: default_tx_block_stat_enable(),
+        }
+    }
+}
+
+impl From<ChainConfig> for crate::ChainConfig {
+    fn from(input: ChainConfig) -> Self {
+        let ChainConfig {
+            spec,
+            tx_block_stat_enable,
+        } = input;
+        Self {
+            spec,
+            tx_block_stat_enable,
+        }
+    }
+}

--- a/util/app-config/src/tests/app_config.rs
+++ b/util/app-config/src/tests/app_config.rs
@@ -48,6 +48,7 @@ fn test_export_dev_config_files() {
             ckb_config.chain.spec,
             Resource::file_system(dir.path().join("specs").join("dev.toml"))
         );
+        assert_eq!(ckb_config.chain.tx_block_stat_enable, false);
         assert_eq!(
             ckb_config.network.listen_addresses,
             vec!["/ip4/0.0.0.0/tcp/8000".parse().unwrap()]
@@ -98,6 +99,7 @@ fn test_log_to_stdout_only() {
             .unwrap_or_else(|err| std::panic::panic_any(err));
         assert_eq!(ckb_config.logger.log_to_file, false);
         assert_eq!(ckb_config.logger.log_to_stdout, true);
+        assert_eq!(ckb_config.chain.tx_block_stat_enable, false);
     }
     {
         Resource::bundled_miner_config()
@@ -141,6 +143,7 @@ fn test_export_testnet_config_files() {
             ckb_config.chain.spec,
             Resource::bundled("specs/testnet.toml".to_string())
         );
+        assert_eq!(ckb_config.chain.tx_block_stat_enable, false);
         assert_eq!(
             ckb_config.network.listen_addresses,
             vec!["/ip4/0.0.0.0/tcp/8000".parse().unwrap()]
@@ -193,6 +196,7 @@ fn test_export_integration_config_files() {
             ckb_config.chain.spec,
             Resource::file_system(dir.path().join("specs").join("integration.toml"))
         );
+        assert_eq!(ckb_config.chain.tx_block_stat_enable, false);
         assert_eq!(
             ckb_config.network.listen_addresses,
             vec!["/ip4/0.0.0.0/tcp/8000".parse().unwrap()]
@@ -245,6 +249,7 @@ fn test_export_dev_config_files_assembly() {
             ckb_config.chain.spec,
             Resource::file_system(dir.path().join("specs").join("dev.toml"))
         );
+        assert_eq!(ckb_config.chain.tx_block_stat_enable, false);
         assert_eq!(
             ckb_config.network.listen_addresses,
             vec!["/ip4/0.0.0.0/tcp/8000".parse().unwrap()]

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -9,6 +9,7 @@ pub mod migrate;
 mod migrations;
 mod shared_builder;
 
+use ckb_app_config::ChainConfig;
 use ckb_app_config::{BlockAssemblerConfig, ExitCode, RunArgs, SupportProtocol};
 use ckb_async_runtime::Handle;
 use ckb_build_info::Version;
@@ -223,8 +224,13 @@ impl Launcher {
     }
 
     /// Start chain service, return ChainController
-    pub fn start_chain_service(&self, shared: &Shared, table: ProposalTable) -> ChainController {
-        let chain_service = ChainService::new(shared.clone(), table);
+    pub fn start_chain_service(
+        &self,
+        shared: &Shared,
+        table: ProposalTable,
+        chain_cfg: ChainConfig,
+    ) -> ChainController {
+        let chain_service = ChainService::new_with_config(shared.clone(), table, Some(chain_cfg));
         let chain_controller = chain_service.start(Some("ChainService"));
         info!("chain genesis hash: {:#x}", shared.genesis_hash());
         chain_controller


### PR DESCRIPTION
add new config item "tx_block_stat_enable" in ckb.toml [chain] section, as a feature to support tx
median fee rate.


<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: as a feature to support "tx median fee rate"(https://github.com/nervosnetwork/ckb/pull/3000)

### What is changed and how it works?

What's Changed: 

- we add a config item"tx_block_stat_enable" in ckb.toml, default value is false;
- if user use legacy ckb.toml(without this item), also get default value(false) effect; 
- if user config it to true, "tx_median_fee_rate" rpc will work and transactions' info, such as tx_size, tx_cylces will be insert to db, and rpc "get_median_fee_rate" will return effective value.
- for implementation, we add this config item in Chain Config, and pass it as parameter to invented function "ChainService::new_with_config(...)",  in order to pass config information to ChainService. (we keep the orginal function "ChainService::new(...)" instead, avoid much code modification, especial test code) 

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

- User need to add "tx_block_stat_enable" item in ckb.toml and set it to true, before RPC "get_median_fee_rate" works. 

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

