### PR TITLE
fix: fix identify disconnect

### DIFF
--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -407,7 +407,9 @@ impl Callback for IdentifyCallback {
             // it is possible that the node will be accidentally evicted, so it is necessary
             // to reset the information of the node when disconnected.
             self.network_state.with_peer_store_mut(|peer_store| {
-                peer_store.add_outbound_addr(context.session.address.clone());
+                if !peer_store.is_addr_banned(&context.session.address) {
+                    peer_store.add_outbound_addr(context.session.address.clone());
+                }
             });
         }
     }

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -312,8 +312,16 @@ fn test_identify_behavior() {
     wait_connect_state(&node1, 1);
     wait_connect_state(&node2, 0);
 
+    if !wait_until(10, || {
+        node1.network_state.with_peer_store_mut(|peer_store| {
+            peer_store.is_addr_banned(&node2.listen_addr)
+                && peer_store.addr_manager().get(&node2.listen_addr).is_none()
+        })
+    }) {
+        panic!("identify can't ban not same net")
+    }
+
     let sessions = node3.connected_sessions();
-    assert_eq!(sessions.len(), 1);
 
     if !wait_until(10, || node3.connected_protocols(sessions[0]).len() == 4) {
         panic!("identify can't open other protocols")


### PR DESCRIPTION
### What problem does this PR solve?

fix https://github.com/nervosnetwork/ckb/runs/3673717980#step:4:1915 this ci fail

1. assert fail because the assert is wrong here, the `registered` behavior is before `received`, and the `discovery` in the test is broadcast every second. It is impossible to determine whether the node3 is just in the process of trying to connect when asserting. It can also be changed to `wait_connect_state(&node3, 1)`, but I don’t think it’s necessary, it’s no problem to delete it directly 
2. When identify is closed, we should first check whether the current node information is banned and then insert the peer store, otherwise, the banned address may be spread 

### Check List

Tests

- Unit test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

