### PR TITLE
feat: add `ckb doctor` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bugreport"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c"
+dependencies = [
+ "git-version",
+ "shell-escape",
+ "sys-info",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +484,7 @@ version = "0.100.0-pre"
 dependencies = [
  "atty",
  "base64",
+ "bugreport",
  "ckb-app-config",
  "ckb-async-runtime",
  "ckb-build-info",
@@ -503,6 +515,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_plain",
+ "sysinfo",
  "tempfile",
  "toml",
 ]
@@ -1781,6 +1794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "eaglesong"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2150,28 @@ name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+
+[[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "glob"
@@ -4036,6 +4077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,6 +4197,32 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fcecee49339531cf6bd84ecf3ed94f9c8ef4a7e700f2a1cac9cc1ca485383a"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -43,6 +43,8 @@ rayon = "1.0"
 sentry = { version = "0.23.0", optional = true }
 atty = "0.2"
 fdlimit = "0.2.1"
+bugreport = "0.4.1"
+sysinfo = "0.19.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
         cli::CMD_RESET_DATA => subcommand::reset_data(setup.reset_data(&matches)?),
         cli::CMD_MIGRATE => subcommand::migrate(setup.migrate(&matches)?),
         cli::CMD_DB_REPAIR => subcommand::db_repair(setup.db_repair(&matches)?),
+        cli::CMD_DOCTOR => subcommand::doctor(setup.doctor(&matches)?),
         _ => unreachable!(),
     };
 

--- a/ckb-bin/src/subcommand/doctor.rs
+++ b/ckb-bin/src/subcommand/doctor.rs
@@ -1,0 +1,245 @@
+use std::path::Path;
+
+use bugreport::{bugreport, collector::*, format::Markdown};
+use sysinfo::{NetworkExt, System, SystemExt};
+
+use ckb_app_config::{DoctorArgs, ExitCode};
+use ckb_chain_spec::ChainSpec;
+
+struct Environment {
+    ckb_version: String,
+    os_info: String,
+    compile_info: String,
+    disk_info: String,
+    cpu_info: String,
+    mem_info: String,
+    kernel_info: String,
+    cfg_content: Vec<String>,
+}
+
+/// strip "abc" from "abc\n\n1234", return "1234"
+fn strip_title(content: &str) -> &str {
+    //if match, pass '\n\n'; or head of content
+    let pass_title = content.find("\n\n").map_or(0, |i| i + 2);
+    content.split_at(pass_title).1.trim()
+}
+
+/// make content(list in markdown) into level-2 list
+fn make_level2_list(content: &str) -> String {
+    let mut new_string = content.replacen('\n', "\n  ", 9);
+    new_string.insert_str(0, "  ");
+    new_string
+}
+
+impl Environment {
+    fn create() -> Self {
+        let ckb_version = String::from(strip_title(
+            &bugreport!()
+                .info(SoftwareVersion::default())
+                .format::<Markdown>(),
+        ));
+        let compile_info = make_level2_list(strip_title(
+            &bugreport!()
+                .info(CompileTimeInformation::default())
+                .format::<Markdown>(),
+        ));
+
+        let mut sys = System::new_all();
+        sys.refresh_all();
+
+        let os_info: String = [
+            sys.name().unwrap_or_else(|| String::from("UNKNOWN")),
+            sys.os_version().unwrap_or_else(|| String::from("UNKNOWN")),
+        ]
+        .join(" ");
+
+        let mut disk_info = String::new();
+        for disk in sys.disks() {
+            disk_info.push_str(&format!("{:?}\n", disk));
+        }
+
+        let mut network_info = String::new();
+        for (interface_name, data) in sys.networks() {
+            network_info.push_str(&format!(
+                "{}: {}/{} B\n",
+                interface_name,
+                data.received(),
+                data.transmitted()
+            ));
+        }
+
+        let mut cpu_info = String::new();
+        for component in sys.components() {
+            cpu_info.push_str(&format!("{:?}\n", component));
+        }
+
+        let mut mem_info = String::new();
+        mem_info.push_str(&format!("total memory: {} KB\n", sys.total_memory()));
+        mem_info.push_str(&format!("used memory : {} KB\n", sys.used_memory()));
+        mem_info.push_str(&format!("total swap  : {} KB\n", sys.total_swap()));
+        mem_info.push_str(&format!("used swap   : {} KB\n", sys.used_swap()));
+
+        let cfg_content = vec![String::from(strip_title(
+            &bugreport!()
+                .info(FileContent::new("ckb.toml", Path::new("./ckb.toml")))
+                .format::<Markdown>(),
+        ))];
+
+        let kernel_info = sys
+            .kernel_version()
+            .unwrap_or_else(|| String::from("UNKNOWN"));
+
+        Self {
+            os_info,
+            ckb_version,
+            compile_info,
+            disk_info,
+            cpu_info,
+            kernel_info,
+            mem_info,
+            cfg_content,
+        }
+    }
+}
+
+/// transfer to normal chain name
+fn chain_name(chain: String) -> &'static str {
+    match chain.as_str() {
+        "ckb" => "mainnet",
+        "ckb_dev" => "dev",
+        "ckb_testnet" => "testnet",
+        "ckb_staging" => "staging",
+        _ => "unknown",
+    }
+}
+
+fn make_github_issue(chain: ChainSpec, environment: Environment) -> String {
+    let body = format!(
+"
+## Bug Report
+
+<details><summary>Bug Report Guideline</summary>
+
+### What is a Useful Bug Report
+
+Useful bug reports are ones that get bugs fixed. A useful bug report is...
+
+1. Reproducible - If an engineer can't see it or conclusively prove that it exists, the engineer will probably stamp it WORKSFORME or INVALID, and move on to the next bug.
+2. Specific - The quicker the engineer can trace down the issue to a specific problem, the more likely it'll be fixed expediently.
+
+So the goals of a bug report are to:
+
+- Pinpoint the bug
+- Explain it to the developer
+
+Your job is to figure out exactly what the problem is.
+
+### Bug Reporting General Guidelines
+
+- Avoid duplicates: Search before you file!
+- Always test the latest available build.
+- One bug per report.
+- State useful facts, not opinions or complaints.
+- Flag security/privacy vulnerabilities as non-public.
+
+</details>
+
+### Status Update
+
+- **Severity**: P1 / P2 / P3
+- **Priority**: Now / Later
+- **Happened at**: <!-- when the bug happened -->
+- **Assigned to**:
+- **Reported by**:
+- **Status**: Investigating / Root Cause Located
+
+### Current Behavior
+<!-- A clear and concise description of the behavior. -->
+
+### Expected Behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Steps to reproduce
+<!-- How you encounter the bug? Can you reproduce it now and summarize the steps? -->
+
+### Possible Solution
+<!-- Only if you have suggestions on a fix for the bug -->
+
+### Reduced Test Case
+<!-- The goal of test case is to pinpoint the bug. A Reduced Test Case rips out everything in the page that is not required to reproduce the bug. Also try variations on the test case to find related situations that also trigger the bug. -->
+
+### Environment Setup and Configuration
+<!--
+Please also include the environment setup and configuration information, such as OS, system build and platform etc.
+-->
+
+- **CKB version**: {}
+- **Chain**: {}
+- **Installation**: [GitHub Release, Built from source]
+- **Operating system**: {}
+- **CompileInfo**:
+{}
+- **Kernel**: {}
+
+<details><summary>More System Info</summary>
+
+- cpus:
+{}
+- memory:
+{}
+- disks:
+{}
+
+</details>
+
+#### Existing Environment for Debug
+
+- How to login.
+- How to locate related information.
+- What need to do to restore the environment after investigation
+
+### Additional context/Screenshots
+<!-- Add any other context about the problem here. If applicable, add screenshots to help explain. -->
+
+#### Config files
+
+<details><summary>ckb.toml</summary>
+
+{}
+
+</details>
+
+<!-- Add ckb-miner.toml if the bug is related to the miner -->",
+        environment.ckb_version,
+        chain_name(chain.name),
+        environment.os_info,
+        &environment.compile_info,
+        &environment.kernel_info ,
+        &environment.cpu_info,
+        &environment.mem_info,
+        &environment.disk_info,
+        &environment.cfg_content.get(0).unwrap(),
+    );
+
+    body
+}
+
+pub fn doctor(args: DoctorArgs) -> Result<(), ExitCode> {
+    let chain = args.chain;
+    if args.gen_report.is_some() {
+        // generate report
+        let mut report_file = std::env::current_dir()?;
+        report_file.push("bug_report.md");
+
+        let environment = Environment::create();
+        let bug_content = make_github_issue(chain, environment);
+        std::fs::write(&report_file, bug_content)?;
+        println!("...Save BugReport to {:?}", &report_file);
+        println!(
+            "If user want to submit a new issue, please paste below link to web browser, and fill in BugReport content\
+        \n\nhttps://github.com/nervosnetwork/ckb/issues/new?template=Bug_report.md&labels=t%3Abug\n"
+        );
+    }
+
+    Ok(())
+}

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -1,4 +1,5 @@
 mod db_repair;
+mod doctor;
 mod export;
 mod import;
 mod init;
@@ -12,6 +13,7 @@ mod run;
 mod stats;
 
 pub use self::db_repair::db_repair;
+pub use self::doctor::doctor;
 pub use self::export::export;
 pub use self::import::import;
 pub use self::init::init;

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -1,5 +1,6 @@
 use crate::{CKBAppConfig, MemoryTrackerConfig, MinerConfig};
 use ckb_chain_spec::consensus::Consensus;
+use ckb_chain_spec::ChainSpec;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_pow::PowEngine;
 use ckb_types::packed::Byte32;
@@ -188,6 +189,14 @@ pub struct MigrateArgs {
 pub struct RepairArgs {
     /// Parsed `ckb.toml`.
     pub config: Box<CKBAppConfig>,
+}
+
+/// Parsed command line arguments for `ckb doctor`.
+pub struct DoctorArgs {
+    /// The parsed `ckb.toml.`
+    pub chain: ChainSpec,
+    /// Parsed `doctor --gen_report`
+    pub gen_report: Option<bool>,
 }
 
 impl CustomizeSpec {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -33,6 +33,8 @@ pub const CMD_FROM_SECRET: &str = "from-secret";
 pub const CMD_MIGRATE: &str = "migrate";
 /// Subcommand `db-repair`.
 pub const CMD_DB_REPAIR: &str = "db-repair";
+/// Subcommand `doctor`.
+pub const CMD_DOCTOR: &str = "doctor";
 
 /// Command line argument `--config-dir`.
 pub const ARG_CONFIG_DIR: &str = "config-dir";
@@ -110,6 +112,8 @@ pub const ARG_OVERWRITE_CHAIN_SPEC: &str = "overwrite-spec";
 pub const ARG_ASSUME_VALID_TARGET: &str = "assume-valid-target";
 /// Command line argument `--check`.
 pub const ARG_MIGRATE_CHECK: &str = "check";
+/// Command line argument `--bug_report_path`.
+pub const ARG_GEN_BUG_REPORT: &str = "gen_report";
 
 /// Command line arguments group `ba` for block assembler.
 const GROUP_BA: &str = "ba";
@@ -141,6 +145,7 @@ pub(crate) fn basic_app<'b>() -> App<'static, 'b> {
         .subcommand(peer_id())
         .subcommand(migrate())
         .subcommand(db_repair())
+        .subcommand(doctor())
 }
 
 /// Parse the command line arguments by supplying the version information.
@@ -355,6 +360,20 @@ fn migrate() -> App<'static, 'static> {
 
 fn db_repair() -> App<'static, 'static> {
     SubCommand::with_name(CMD_DB_REPAIR).about("Try repair ckb database")
+}
+
+fn doctor() -> App<'static, 'static> {
+    SubCommand::with_name(CMD_DOCTOR)
+        .about(
+            "ckb generate bug report\n\
+             Example:\n\
+             ckb doctor --gen_report",
+        )
+        .arg(
+            Arg::with_name(ARG_GEN_BUG_REPORT)
+                .long(ARG_GEN_BUG_REPORT)
+                .help("generate bug report template."),
+        )
 }
 
 fn list_hashes() -> App<'static, 'static> {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -15,8 +15,8 @@ pub use app_config::{
     AppConfig, CKBAppConfig, ChainConfig, LogConfig, MetricsConfig, MinerAppConfig,
 };
 pub use args::{
-    ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, RepairArgs, ReplayArgs,
-    ResetDataArgs, RunArgs, StatsArgs,
+    DoctorArgs, ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, RepairArgs,
+    ReplayArgs, ResetDataArgs, RunArgs, StatsArgs,
 };
 pub use configs::*;
 pub use exit_code::ExitCode;
@@ -123,6 +123,14 @@ impl Setup {
         let config = self.config.into_ckb()?;
 
         Ok(RepairArgs { config })
+    }
+
+    /// `doctor` subcommand
+    pub fn doctor(self, matches: &ArgMatches<'_>) -> Result<DoctorArgs, ExitCode> {
+        let chain = self.chain_spec()?;
+        let gen_report = matches.is_present(cli::ARG_GEN_BUG_REPORT).then(|| true);
+
+        Ok(DoctorArgs { chain, gen_report })
     }
 
     /// Executes `ckb miner`.


### PR DESCRIPTION
add `ckb doctor` subcommand, support ckb diagnostic and generate bug report function

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

add `ckb doctor` subcommand,  support ~~ckb diagnostic(under construction) or~~ generate bug report(based on bug_report.md)

Problem Summary:

add subcommand
`ckb doctor --gen_report` to generate bug report content and issue commit link.

gen_report: generate bug report template(based on bug_report.md template), pre-filled generated info(as ckb version, os, ...) and  save report to local file,  prompt user with issue link. 
(user could paste url to browser and fill in bug report content to complete issue commit) 

pre-filled information is by bug_report crate and sys_info crate


What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

