### PR TITLE
fix: ignore proposal window on vm version selection

### DIFF
--- a/script/src/ill_transaction_checker.rs
+++ b/script/src/ill_transaction_checker.rs
@@ -34,8 +34,7 @@ impl<'a> IllTransactionChecker<'a> {
 
     /// Checks whether the transaction is ill formed.
     pub fn check(&self) -> Result<(), ScriptError> {
-        let proposal_window = self.consensus.tx_proposal_window();
-        let epoch_number = self.tx_env.epoch_number(proposal_window);
+        let epoch_number = self.tx_env.current_epoch_number();
         let hardfork_switch = self.consensus.hardfork_switch();
         // Assume that after ckb2021 is activated, developers will only upload code for vm v1.
         if !hardfork_switch.is_vm_version_1_and_syscalls_2_enabled(epoch_number) {

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -399,8 +399,11 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
 
     /// Returns the version of the machine based on the script and the consensus rules.
     pub fn select_version(&self, script: &'a Script) -> Result<ScriptVersion, ScriptError> {
-        let proposal_window = self.consensus.tx_proposal_window();
-        let epoch_number = self.tx_env.epoch_number(proposal_window);
+        // If the proposal window is allowed to prejudge on the vm version,
+        // it will cause proposal tx to start a new vm in the blocks before hardfork,
+        // destroying the assumption that the transaction execution only uses the old vm
+        // before hardfork, leading to unexpected network splits.
+        let epoch_number = self.tx_env.current_epoch_number();
         let hardfork_switch = self.consensus.hardfork_switch();
         let is_vm_version_1_and_syscalls_2_enabled =
             hardfork_switch.is_vm_version_1_and_syscalls_2_enabled(epoch_number);

--- a/script/src/verify_env.rs
+++ b/script/src/verify_env.rs
@@ -117,4 +117,9 @@ impl TxVerifyEnv {
     pub fn epoch(&self) -> EpochNumberWithFraction {
         self.epoch
     }
+
+    /// Current epoch number without proposal window
+    pub fn current_epoch_number(&self) -> EpochNumber {
+        self.epoch.number()
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Transaction submission in the current epoch can only use the VM version based on the current epoch 

### Check List

Tests

- Integration test in other repo

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

