### PR TITLE
chore: check if the corresponding tx hash has already been requested before processing the tx relay message

### DIFF
--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -3,7 +3,7 @@ use ckb_app_config::BlockAssemblerConfig;
 use ckb_chain::chain::ChainController;
 use ckb_dao::DaoCalculator;
 use ckb_jsonrpc_types::{
-    AsEpochNumberWithFraction, Block, BlockTemplate, Byte32, Cycle, JsonBytes, Script, Transaction,
+    AsEpochNumberWithFraction, Block, BlockTemplate, Byte32, JsonBytes, Script, Transaction,
 };
 use ckb_logger::error;
 use ckb_network::{NetworkController, SupportProtocols};
@@ -46,9 +46,6 @@ pub trait IntegrationTestRpc {
 
     #[rpc(name = "notify_transaction")]
     fn notify_transaction(&self, transaction: Transaction) -> Result<H256>;
-
-    #[rpc(name = "broadcast_transaction")]
-    fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256>;
 
     #[rpc(name = "generate_block_with_template")]
     fn generate_block_with_template(&self, block_template: BlockTemplate) -> Result<H256>;
@@ -148,32 +145,6 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
 
         self.process_and_announce_block(block_template.into())
-    }
-
-    fn broadcast_transaction(&self, transaction: Transaction, cycles: Cycle) -> Result<H256> {
-        let tx: packed::Transaction = transaction.into();
-        let hash = tx.calc_tx_hash();
-        let relay_tx = packed::RelayTransaction::new_builder()
-            .cycles(cycles.value().pack())
-            .transaction(tx)
-            .build();
-        let relay_txs = packed::RelayTransactions::new_builder()
-            .transactions(vec![relay_tx].pack())
-            .build();
-        let message = packed::RelayMessage::new_builder().set(relay_txs).build();
-
-        if let Err(err) = self
-            .network_controller
-            .broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
-        {
-            error!("Broadcast transaction failed: {:?}", err);
-            Err(RPCError::custom_with_error(
-                RPCError::P2PFailedToBroadcast,
-                err,
-            ))
-        } else {
-            Ok(hash.unpack())
-        }
     }
 
     fn notify_transaction(&self, tx: Transaction) -> Result<H256> {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1518,6 +1518,14 @@ impl UnknownTxHashPriority {
     pub fn push_peer(&mut self, peer_index: PeerIndex) {
         self.peers.push(peer_index);
     }
+
+    pub fn requesting_peer(&self) -> Option<PeerIndex> {
+        if self.requested {
+            self.peers.get(0).cloned()
+        } else {
+            None
+        }
+    }
 }
 
 impl Ord for UnknownTxHashPriority {
@@ -1749,6 +1757,12 @@ impl SyncState {
 
     pub fn tx_filter(&self) -> MutexGuard<Filter<Byte32>> {
         self.tx_filter.lock()
+    }
+
+    pub fn unknown_tx_hashes(
+        &self,
+    ) -> MutexGuard<KeyedPriorityQueue<Byte32, UnknownTxHashPriority>> {
+        self.unknown_tx_hashes.lock()
     }
 
     // Return true when the block is that we have requested and received first time.

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -6,7 +6,7 @@ mod error;
 use ckb_error::AnyError;
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockTemplate, BlockView, Capacity,
-    CellWithStatus, ChainInfo, Cycle, DryRunResult, EpochNumber, EpochView, HeaderView, JsonBytes,
+    CellWithStatus, ChainInfo, DryRunResult, EpochNumber, EpochView, HeaderView, JsonBytes,
     LocalNode, OutPoint, RawTxPool, RemoteNode, Script, Timestamp, Transaction, TransactionProof,
     TransactionWithStatus, TxPoolInfo, Uint32, Uint64, Version,
 };
@@ -212,10 +212,6 @@ impl RpcClient {
             .expect("rpc call dry_run_transaction")
     }
 
-    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> Result<H256, AnyError> {
-        self.inner.broadcast_transaction(tx, cycles)
-    }
-
     pub fn send_alert(&self, alert: Alert) {
         self.inner.send_alert(alert).expect("rpc call send_alert")
     }
@@ -348,7 +344,6 @@ jsonrpc!(pub struct Inner {
     pub fn get_block_economic_state(&self, _hash: H256) -> Option<BlockEconomicState>;
     pub fn get_transaction_proof(&self, tx_hashes: Vec<H256>, block_hash: Option<H256>) -> TransactionProof;
     pub fn verify_transaction_proof(&self, tx_proof: TransactionProof) -> Vec<H256>;
-    pub fn broadcast_transaction(&self, tx: Transaction, cycles: Cycle) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
     pub fn tx_pool_ready(&self) -> bool;
 });


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

By design we should check that the corresponding tx hash has been requested before processing the relay transaction message, but the current code misses this check, this PR resolved this issue.

### What is changed and how it works?

Check the `unknown_tx_hashes` structure before processing the message to see if the corresponding tx hash has already been requested.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

This PR removed `broadcast_transaction` rpc from the `IntegrationTest` module, other integration tests that rely on this rpc need to be adapted accordingly, please refer to the related change of test code in this PR.


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

