### PR TITLE
fix: block-template test

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -359,10 +359,19 @@ fn test_package_basic() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // 300 size best scored txs
-    let block_template = shared
+    let mut block_template = shared
         .get_block_template(Some(300 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
+
+    // wait tx-pool sync with chain
+    while block_template.transactions.is_empty() {
+        block_template = shared
+            .get_block_template(Some(300 + *BASIC_BLOCK_SIZE), None, None)
+            .unwrap()
+            .unwrap()
+    }
+
     check_txs(
         &block_template,
         vec![&tx2_1, &tx2_2, &tx2_3],
@@ -499,10 +508,19 @@ fn test_package_multi_best_scores() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // 250 size best scored txs
-    let block_template = shared
+    let mut block_template = shared
         .get_block_template(Some(250 + *BASIC_BLOCK_SIZE), None, None)
         .unwrap()
         .unwrap();
+
+    // wait tx-pool sync with chain
+    while block_template.transactions.is_empty() {
+        block_template = shared
+            .get_block_template(Some(250 + *BASIC_BLOCK_SIZE), None, None)
+            .unwrap()
+            .unwrap()
+    }
+
     check_txs(
         &block_template,
         vec![&tx1, &tx2, &tx3],
@@ -604,10 +622,19 @@ fn test_package_low_fee_decendants() {
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // best scored txs
-    let block_template = shared
+    let mut block_template = shared
         .get_block_template(None, None, None)
         .unwrap()
         .unwrap();
+
+    // wait tx-pool sync with chain
+    while block_template.transactions.is_empty() {
+        block_template = shared
+            .get_block_template(None, None, None)
+            .unwrap()
+            .unwrap()
+    }
+
     check_txs(
         &block_template,
         vec![&tx1, &tx2, &tx3, &tx4, &tx5],


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: 
Since https://github.com/nervosnetwork/ckb/pull/2984, if tx-pool does not sync with chain yet, a blank template will return by request.  this may lead to some block-template tests failed randomly.

### What is changed and how it works?

What's Changed:  Make block-template tests block on status sync.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

