### PR TITLE
fix: don't use cache if tx-pool does re-org process during hardfork

### DIFF
--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -1017,7 +1017,11 @@ impl TxPoolService {
         }
         let retain: Vec<TransactionView> = detached.difference(&attached).cloned().collect();
 
-        let fetched_cache = self.fetch_txs_verify_cache(retain.iter()).await;
+        let fetched_cache = if hardfork_during_detach || hardfork_during_attach {
+            HashMap::new()
+        } else {
+            self.fetch_txs_verify_cache(retain.iter()).await
+        };
 
         {
             let txs_opt = {


### PR DESCRIPTION
### What problem does this PR solve?

- If the re-org process is running during hardfork, the whole caches for transactions will be cleared.

  https://github.com/nervosnetwork/ckb/blob/033c6f951f2ec5f7d2876d1d83778a2a5b147753/tx-pool/src/process.rs#L1027-L1031

- But the cache for re-add detached transactions is fetched before doing re-org process.

  https://github.com/nervosnetwork/ckb/blob/033c6f951f2ec5f7d2876d1d83778a2a5b147753/tx-pool/src/process.rs#L1018-L1020

- So the cache for re-add detached transactions will be obsolete.

  https://github.com/nervosnetwork/ckb/blob/033c6f951f2ec5f7d2876d1d83778a2a5b147753/tx-pool/src/process.rs#L1048

### What is changed and how it works?

If tx-pool is doing re-org process during hardfork, returns an empty `HashMap` as the cache.

### Check List

Tests

- This feature doesn't have its own tests, but it has already be tested in other integration tests.

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```