### PR TITLE
chore: remove unnecessary struct `KnownFilter`

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -623,7 +623,6 @@ impl Relayer {
             .take_relay_tx_hashes(MAX_RELAY_TXS_NUM_PER_BATCH);
         let mut selected: HashMap<PeerIndex, Vec<Byte32>> = HashMap::default();
         {
-            let mut known_txs = self.shared.state().known_txs();
             for (origin_peer, is_ckb2021, hash) in &tx_hashes {
                 // must all fork or all no-fork
                 if ckb2021 != *is_ckb2021 {
@@ -634,7 +633,7 @@ impl Relayer {
                     match origin_peer {
                         Some(origin) => {
                             // broadcast tx hash to all connected peers except origin peer
-                            if known_txs.insert(*target, hash.clone()) && (origin != target) {
+                            if origin != target {
                                 let hashes = selected
                                     .entry(*target)
                                     .or_insert_with(|| Vec::with_capacity(BUFFER_SIZE));


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

remove unnecessary struct `KnownFilter`

### What is changed and how it works?

after https://github.com/nervosnetwork/ckb/pull/2634 , the tx hash is relayed by a channel sender with an original peer:

https://github.com/nervosnetwork/ckb/blob/26f930e6c83673e9bea019ff4622279bcdc701bd/tx-pool/src/process.rs#L807

and it will be broadcasted once, so the `KnownFilter` struct can be removed 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

