### PR TITLE
ci: add a scheduled audit workflow

### DIFF
--- a/.github/workflows/scheduled_audit.yaml
+++ b/.github/workflows/scheduled_audit.yaml
@@ -1,0 +1,12 @@
+name: Security Audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: yangby-cryptape/cargo-audit-check-action@customized-for-ckb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What problem does this PR solve?

At present, CKB only checks security vulnerabilities when some one submits a pull request.

If no one submit a pull request, we couldn't know whether CKB has security vulnerabilities or not.

This PR add a scheduled audit workflow to check security vulnerabilities daily.
So we could know any security vulnerability in 24 hours after it became public.

Ref: https://github.com/actions-rs/audit-check#scheduled-audit

### Check List

Tests

- No code (skip ci)

### Release note

```release-note
None: Exclude this PR from the release note.
```

