### PR TITLE
fix: resolve inflight proposals memory bloat issue

### DIFF
--- a/sync/src/relayer/block_proposal_process.rs
+++ b/sync/src/relayer/block_proposal_process.rs
@@ -16,6 +16,12 @@ impl<'a> BlockProposalProcess<'a> {
     pub fn execute(self) -> Status {
         let shared = self.relayer.shared();
         let sync_state = shared.state();
+        sync_state.clear_expired_inflight_proposals(
+            shared
+                .active_chain()
+                .tip_number()
+                .saturating_sub(shared.consensus().tx_proposal_window().farthest()),
+        );
         {
             let block_proposals = self.message;
             let limit = shared.consensus().max_block_proposals_limit()

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -112,7 +112,11 @@ impl<'a> BlockTransactionsProcess<'a> {
                     self.relayer.request_proposal_txs(
                         self.nc.as_ref(),
                         self.peer,
-                        block_hash.clone(),
+                        (
+                            compact_block.header().into_view().number(),
+                            block_hash.clone(),
+                        )
+                            .into(),
                         proposals,
                     );
                 }

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -189,7 +189,7 @@ impl<'a> CompactBlockProcess<'a> {
                 self.relayer.request_proposal_txs(
                     self.nc.as_ref(),
                     self.peer,
-                    block_hash.clone(),
+                    (header.number(), block_hash.clone()).into(),
                     proposals,
                 );
             }

--- a/sync/src/relayer/tests/block_proposal_process.rs
+++ b/sync/src/relayer/tests/block_proposal_process.rs
@@ -53,7 +53,10 @@ fn test_ok() {
 
     // Before asked proposals
     {
-        relayer.shared.state().insert_inflight_proposals(proposals);
+        relayer
+            .shared
+            .state()
+            .insert_inflight_proposals(proposals, 1);
     }
 
     let content = packed::BlockProposal::new_builder()
@@ -65,4 +68,30 @@ fn test_ok() {
 
     let known = relayer.shared.state().already_known_tx(&transaction.hash());
     assert_eq!(known, true);
+}
+
+#[test]
+fn test_clear_expired_inflight_proposals() {
+    // mark the inflight proposals as block number 2, the default farthest proposal window is 10, it will be expired and ignored
+    let (relayer, always_success_out_point) = build_chain(13);
+    let transaction = new_transaction(&relayer, 1, &always_success_out_point);
+    let transactions = vec![transaction];
+    let proposals: Vec<ProposalShortId> = transactions
+        .iter()
+        .map(|tx| tx.proposal_short_id())
+        .collect();
+
+    {
+        relayer
+            .shared
+            .state()
+            .insert_inflight_proposals(proposals, 2);
+    }
+
+    let content = packed::BlockProposal::new_builder()
+        .transactions(transactions.into_iter().map(|tx| tx.data()).pack())
+        .build();
+
+    let process = BlockProposalProcess::new(content.as_reader(), &relayer);
+    assert_eq!(process.execute(), Status::ignored());
 }

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -92,8 +92,7 @@ fn test_accept_block() {
     assert!(relayer
         .shared
         .state()
-        .inflight_proposals()
-        .contains(&tx3.proposal_short_id()));
+        .contains_inflight_proposal(&tx3.proposal_short_id()));
 }
 
 #[test]

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -413,8 +413,7 @@ fn test_send_missing_indexes() {
     assert!(!relayer
         .shared
         .state()
-        .inflight_proposals()
-        .contains(&proposal_id));
+        .contains_inflight_proposal(&proposal_id));
     assert_eq!(
         compact_block_process.execute(),
         StatusCode::CompactBlockRequiresFreshTransactions.into()
@@ -435,8 +434,7 @@ fn test_send_missing_indexes() {
     assert!(relayer
         .shared
         .state()
-        .inflight_proposals()
-        .contains(&proposal_id));
+        .contains_inflight_proposal(&proposal_id));
 
     let content = packed::GetBlockProposal::new_builder()
         .block_hash(block.header().hash())
@@ -641,8 +639,7 @@ fn test_collision() {
     assert!(!relayer
         .shared
         .state()
-        .inflight_proposals()
-        .contains(&proposal_id));
+        .contains_inflight_proposal(&proposal_id));
     assert_eq!(
         compact_block_process.execute(),
         StatusCode::CompactBlockMeetsShortIdsCollision.into(),

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -19,6 +19,7 @@ use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_traits::HeaderProvider;
+use ckb_types::packed::ProposalShortId;
 use ckb_types::{
     core::{self, BlockNumber, EpochExt},
     packed::{self, Byte32},
@@ -27,7 +28,7 @@ use ckb_types::{
 };
 use ckb_util::{shrink_to_fit, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use ckb_verification_traits::Switch;
-use dashmap::{DashMap, DashSet};
+use dashmap::{self, DashMap};
 use faketime::unix_time_as_millis;
 use keyed_priority_queue::{self, KeyedPriorityQueue};
 use lru::LruCache;
@@ -1226,7 +1227,7 @@ impl SyncShared {
             pending_get_block_proposals: DashMap::new(),
             pending_compact_blocks: Mutex::new(HashMap::default()),
             orphan_block_pool: OrphanBlockPool::with_capacity(ORPHAN_BLOCK_SIZE),
-            inflight_proposals: DashSet::new(),
+            inflight_proposals: DashMap::new(),
             inflight_blocks: RwLock::new(InflightBlocks::default()),
             pending_get_headers: RwLock::new(LruCache::new(GET_HEADERS_CACHE_SIZE)),
             tx_relay_receiver,
@@ -1566,7 +1567,7 @@ pub struct SyncState {
     orphan_block_pool: OrphanBlockPool,
 
     /* In-flight items for which we request to peers, but not got the responses yet */
-    inflight_proposals: DashSet<packed::ProposalShortId>,
+    inflight_proposals: DashMap<packed::ProposalShortId, BlockNumber>,
     inflight_blocks: RwLock<InflightBlocks>,
 
     /* cached for sending bulk */
@@ -1616,10 +1617,6 @@ impl SyncState {
 
     pub fn write_inflight_blocks(&self) -> RwLockWriteGuard<InflightBlocks> {
         self.inflight_blocks.write()
-    }
-
-    pub fn inflight_proposals(&self) -> &DashSet<packed::ProposalShortId> {
-        &self.inflight_proposals
     }
 
     pub fn take_relay_tx_hashes(&self, limit: usize) -> Vec<(Option<PeerIndex>, bool, Byte32)> {
@@ -1778,9 +1775,26 @@ impl SyncState {
         }
     }
 
-    pub fn insert_inflight_proposals(&self, ids: Vec<packed::ProposalShortId>) -> Vec<bool> {
+    pub fn insert_inflight_proposals(
+        &self,
+        ids: Vec<packed::ProposalShortId>,
+        block_number: BlockNumber,
+    ) -> Vec<bool> {
         ids.into_iter()
-            .map(|id| self.inflight_proposals.insert(id))
+            .map(|id| match self.inflight_proposals.entry(id) {
+                dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
+                    if *occupied.get() < block_number {
+                        occupied.insert(block_number);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                    vacant.insert(block_number);
+                    true
+                }
+            })
             .collect()
     }
 
@@ -1788,6 +1802,15 @@ impl SyncState {
         ids.iter()
             .map(|id| self.inflight_proposals.remove(id).is_some())
             .collect()
+    }
+
+    pub fn clear_expired_inflight_proposals(&self, keep_min_block_number: BlockNumber) {
+        self.inflight_proposals
+            .retain(|_, block_number| *block_number >= keep_min_block_number);
+    }
+
+    pub fn contains_inflight_proposal(&self, proposal_id: &ProposalShortId) -> bool {
+        self.inflight_proposals.contains_key(proposal_id)
     }
 
     pub fn insert_orphan_block(&self, block: core::BlockView) {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

the `inflight_proposals` field of `SyncState` struct is never cleared.

### What is changed and how it works?

change the `inflight_proposals` to map and clear expired data when processing the `BlockProposals` message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

