### PR TITLE
feat: remove invalid header dep tx for reorg

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -396,6 +396,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(GetRawTxPool),
         Box::new(PoolReconcile),
         Box::new(PoolResurrect),
+        Box::new(InvalidHeaderDep),
         #[cfg(not(target_os = "windows"))]
         Box::new(PoolPersisted),
         Box::new(TransactionRelayBasic),

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -8,7 +8,7 @@ use ckb_types::{
         error::OutPointError,
         TransactionView,
     },
-    packed::{CellOutput, OutPoint, ProposalShortId},
+    packed::{Byte32, CellOutput, OutPoint, ProposalShortId},
     prelude::*,
 };
 use std::collections::{HashMap, HashSet};
@@ -24,6 +24,8 @@ pub(crate) struct Edges {
     pub(crate) inputs: HashMap<OutPoint, ProposalShortId>,
     /// dep-set<txid> map represent in-pool tx's deps
     pub(crate) deps: HashMap<OutPoint, HashSet<ProposalShortId>>,
+    /// dep-set<txid-headers> map represent in-pool tx's header deps
+    pub(crate) header_deps: HashMap<ProposalShortId, Vec<Byte32>>,
 }
 
 impl Edges {
@@ -93,6 +95,7 @@ impl Edges {
         self.outputs.clear();
         self.inputs.clear();
         self.deps.clear();
+        self.header_deps.clear();
     }
 }
 
@@ -199,6 +202,8 @@ impl ProposedPool {
                 self.edges.remove_output(&o);
                 // self.edges.remove_deps(&o);
             }
+
+            self.edges.header_deps.remove(&entry.proposal_short_id());
         }
         removed_entries
     }
@@ -210,7 +215,6 @@ impl ProposedPool {
     ) -> Option<TxEntry> {
         let outputs = tx.output_pts();
         let inputs = tx.input_pts_iter();
-        // TODO: handle header deps
         let id = tx.proposal_short_id();
 
         if let Some(entry) = self.inner.remove_entry(&id) {
@@ -231,6 +235,8 @@ impl ProposedPool {
             for d in related_out_points {
                 self.edges.delete_txid_by_dep(&d, &id);
             }
+
+            self.edges.header_deps.remove(&id);
 
             return Some(entry);
         }
@@ -267,16 +273,20 @@ impl ProposedPool {
             self.edges.insert_output(o);
         }
 
+        // record header_deps
+        let header_deps = entry.transaction().header_deps();
+        if !header_deps.is_empty() {
+            self.edges
+                .header_deps
+                .insert(tx_short_id, header_deps.into_iter().collect());
+        }
+
         self.inner.add_entry(entry)
     }
 
-    pub(crate) fn resolve_conflict(
-        &mut self,
-        tx: &TransactionView,
-    ) -> (Vec<ConflictEntry>, Vec<ConflictEntry>) {
+    pub(crate) fn resolve_conflict(&mut self, tx: &TransactionView) -> Vec<ConflictEntry> {
         let inputs = tx.input_pts_iter();
-        let mut input_conflict = Vec::new();
-        let mut deps_consumed = Vec::new();
+        let mut conflicts = Vec::new();
 
         for i in inputs {
             if let Some(id) = self.edges.remove_input(&i) {
@@ -284,7 +294,7 @@ impl ProposedPool {
                 if !entries.is_empty() {
                     let reject = Reject::Resolve(OutPointError::Dead(i.clone()));
                     let rejects = iter::repeat(reject).take(entries.len());
-                    input_conflict.extend(entries.into_iter().zip(rejects));
+                    conflicts.extend(entries.into_iter().zip(rejects));
                 }
             }
 
@@ -295,12 +305,42 @@ impl ProposedPool {
                     if !entries.is_empty() {
                         let reject = Reject::Resolve(OutPointError::Dead(i.clone()));
                         let rejects = iter::repeat(reject).take(entries.len());
-                        deps_consumed.extend(entries.into_iter().zip(rejects));
+                        conflicts.extend(entries.into_iter().zip(rejects));
                     }
                 }
             }
         }
-        (input_conflict, deps_consumed)
+
+        conflicts
+    }
+
+    pub(crate) fn resolve_conflict_header_dep(
+        &mut self,
+        headers: &HashSet<Byte32>,
+    ) -> Vec<ConflictEntry> {
+        let mut conflicts = Vec::new();
+
+        // invalid header deps
+        let mut invalid_header_ids = Vec::new();
+        for (tx_id, deps) in self.edges.header_deps.iter() {
+            for hash in deps {
+                if headers.contains(hash) {
+                    invalid_header_ids.push((hash.clone(), tx_id.clone()));
+                    break;
+                }
+            }
+        }
+
+        for (blk_hash, id) in invalid_header_ids {
+            let entries = self.remove_entry_and_descendants(&id);
+            if !entries.is_empty() {
+                let reject = Reject::Resolve(OutPointError::InvalidHeader(blk_hash));
+                let rejects = iter::repeat(reject).take(entries.len());
+                conflicts.extend(entries.into_iter().zip(rejects));
+            }
+        }
+
+        conflicts
     }
 
     /// sorted by ancestor score from higher to lower

--- a/tx-pool/src/component/tests/util.rs
+++ b/tx-pool/src/component/tests/util.rs
@@ -50,3 +50,24 @@ pub(crate) fn build_tx_with_dep(
         .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
         .build()
 }
+
+pub(crate) fn build_tx_with_header_dep(
+    inputs: Vec<(&Byte32, u32)>,
+    header_deps: Vec<Byte32>,
+    outputs_len: usize,
+) -> TransactionView {
+    TransactionBuilder::default()
+        .inputs(
+            inputs
+                .into_iter()
+                .map(|(txid, index)| CellInput::new(OutPoint::new(txid.to_owned(), index), 0)),
+        )
+        .set_header_deps(header_deps)
+        .outputs((0..outputs_len).map(|i| {
+            CellOutput::new_builder()
+                .capacity(Capacity::bytes(i + 1).unwrap().pack())
+                .build()
+        }))
+        .outputs_data((0..outputs_len).map(|_| Bytes::new().pack()))
+        .build()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Previously, transaction is not wiped immediately after tip changed, header dep becomes invalid, this may lead header-dep transaction stuck in tx-pool, but to be rare in practice.

### What is changed and how it works?

Remove invalid header-dep transaction after tip changed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

