### PR TITLE
fix: fix pending compact block memory bloat on abnormal flow

### DIFF
--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -74,8 +74,8 @@ fn test_accept_block() {
         .uncles(vec![uncle.as_uncle().data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         block_transactions.as_reader(),
@@ -136,8 +136,8 @@ fn test_unknown_request() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         block_transactions.as_reader(),
@@ -200,8 +200,8 @@ fn test_invalid_transaction_root() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         block_transactions.as_reader(),
@@ -295,8 +295,8 @@ fn test_collision_and_send_missing_indexes() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         block_transactions.as_reader(),
@@ -338,8 +338,8 @@ fn test_collision_and_send_missing_indexes() {
         .transactions(vec![tx2.data(), tx3.data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         new_block_transactions.as_reader(),
@@ -402,8 +402,8 @@ fn test_missing() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
         block_transactions.as_reader(),

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -38,8 +38,8 @@ fn test_in_block_status_map() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -103,8 +103,8 @@ fn test_unknow_parent() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -156,8 +156,8 @@ fn test_accept_not_a_better_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -190,8 +190,8 @@ fn test_already_in_flight() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     // Already in flight
@@ -232,8 +232,8 @@ fn test_already_pending() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     // Already in pending
@@ -283,8 +283,8 @@ fn test_header_invalid() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -337,8 +337,8 @@ fn test_inflight_blocks_reach_limit() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
     // in_flight_blocks is full
@@ -399,8 +399,8 @@ fn test_send_missing_indexes() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -470,6 +470,19 @@ fn test_accept_block() {
         .uncle(uncle.as_uncle())
         .build();
 
+    let mock_block = BlockBuilder::default().number(4.pack()).build();
+    let mock_compact_block = CompactBlock::build_from_block(&mock_block, &Default::default());
+    {
+        let mut pending_compact_blocks = relayer.shared.state().pending_compact_blocks();
+        pending_compact_blocks.insert(
+            mock_block.header().hash(),
+            (
+                mock_compact_block,
+                HashMap::from_iter(vec![(1.into(), (vec![1], vec![0]))]),
+            ),
+        );
+    }
+
     let uncle_hash = uncle.hash();
     {
         let db_txn = relayer.shared().shared().store().begin_transaction();
@@ -484,8 +497,8 @@ fn test_accept_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -495,6 +508,9 @@ fn test_accept_block() {
         peer_index,
     );
     assert_eq!(compact_block_process.execute(), Status::ok(),);
+
+    let pending_compact_blocks = relayer.shared.state().pending_compact_blocks();
+    assert!(pending_compact_blocks.is_empty());
 }
 
 #[test]
@@ -516,8 +532,8 @@ fn test_ignore_a_too_old_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -552,8 +568,8 @@ fn test_invalid_transaction_root() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
     let compact_block_process = CompactBlockProcess::new(
@@ -627,8 +643,8 @@ fn test_collision() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocal_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocal_context);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
     let compact_block_process = CompactBlockProcess::new(


### PR DESCRIPTION
### What problem does this PR solve?

The cleanup of `pending_compact_blocks` is only in the process of the successful process([here](https://github.com/nervosnetwork/ckb/blob/92f1d8f69aa6b52e28a7164dc34dd62544531591/sync/src/relayer/block_transactions_process.rs#L122) or [here](https://github.com/nervosnetwork/ckb/blob/92f1d8f69aa6b52e28a7164dc34dd62544531591/sync/src/relayer/compact_block_process.rs#L207)). When the block is synchronized by the sync protocol first or the remote node does not respond, the cleanup process will not be executed, causing unexpected memory bloat.

The modification of this PR will depend on each successful compact block process. As long as there is one success, it will clean up all unexpected unsuccessful legacy issues. 

### Check List

Tests

- Unit test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

