### PR TITLE
chore: upgrade blake2b and system-script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,11 +210,12 @@ checksum = "95916998c798756098a4eb1b3f2cd510659705a9817bf203d61abd30fbec3e7b"
 
 [[package]]
 name = "blake2b-rs"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e35e362830ef90ecea16f09b21b75d22d33a8562a679c74ab4f4fa49b4fcb87"
+checksum = "a89a8565807f21b913288968e391819e7f9b2f0f46c7b89549c051cccf3a2771"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]
@@ -1264,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7c2827ee5fe545ea15d52d0d3213c97db10e97a71eba302ff712ddb86c09c2"
+checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
 dependencies = [
  "blake2b-rs",
  "faster-hex",
@@ -1668,6 +1669,12 @@ dependencies = [
  "nix",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -23,7 +23,7 @@ ckb-hash = {path = "../util/hash", version = "= 0.100.0-pre"}
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.100.0-pre" }
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.100.0-pre" }
 ckb-dao = { path = "../util/dao", version = "= 0.100.0-pre" }
-ckb-system-scripts = { version = "= 0.5.3" }
+ckb-system-scripts = { version = "= 0.5.4" }
 lazy_static = "1.3.0"
 ckb-crypto = { path = "../util/crypto", version = "= 0.100.0-pre" }
 ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.100.0-pre" }

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -14,13 +14,13 @@ phf = "0.8.0"
 includedir = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
-ckb-system-scripts = { version = "= 0.5.3" }
+ckb-system-scripts = { version = "= 0.5.4" }
 
 [build-dependencies]
 includedir_codegen = "0.6.0"
 walkdir = "2.1.4"
 ckb-types = { path = "../util/types", version = "= 0.100.0-pre" }
-ckb-system-scripts = { version = "= 0.5.3" }
+ckb-system-scripts = { version = "= 0.5.4" }
 
 [dev-dependencies]
 # Lock tempfile so wasm-build-test will use getrandom 0.1.*

--- a/script/testdata/cpop_lock.c
+++ b/script/testdata/cpop_lock.c
@@ -5,7 +5,7 @@
  *    - `cpop(num0) == num 1`
  *  Compile Environment:
  *  - Toolchains: nervos/ckb-riscv-gnu-toolchain@sha256:7b168b4b109a0f741078a71b7c4dddaf1d283a5244608f7851f5714fbad273ba
- *  - Dependencies: Same as ckb-system-scripts v0.5.3.
+ *  - Dependencies: Same as ckb-system-scripts v0.5.4.
  *  - Commands:
  *    ```shell
  *    riscv64-unknown-elf-gcc -O3 -Ideps/molecule -I deps/secp256k1/src -I deps/secp256k1 -I c -I build \

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-blake2b-rs = "0.1.5"
+blake2b-rs = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 blake2b-ref = "0.2.0"


### PR DESCRIPTION
### What problem does this PR solve?

upgrade blake2b-rs make `ckb-hash` support no-std

### Check List 

Tests 

- No code (skip ci)

### Release note

```release-note
None: Exclude this PR from the release note.
```

