### PR TITLE
feat(fork): Activate ckb2021 in testnet since epoch 3113

### DIFF
--- a/util/constant/src/hardfork/testnet.rs
+++ b/util/constant/src/hardfork/testnet.rs
@@ -1,6 +1,5 @@
 /// The Chain Specification name.
 pub const CHAIN_SPEC_NAME: &str = "ckb_testnet";
 
-// TODO ckb2021 Update the epoch number for testnet.
-/// First epoch number for CKB v2021
-pub const CKB2021_START_EPOCH: u64 = u64::MAX;
+/// First epoch number for CKB v2021, at about 2021/10/24 3:15 UTC.
+pub const CKB2021_START_EPOCH: u64 = 3113;


### PR DESCRIPTION
### What is changed and how it works?

Proposal: Activate ckb2021 in testnet since epoch 3113, which is around 2021/10/24 3:15 UTC

### Related changes

After the activation, nodes running v0.101.0 and above are not compatible with nodes running old versions in the testnet.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Breaking backward compatibility: Not compatible with old versions in the testnet after the activation.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

