### PR TITLE
fix: fix pending compact retain

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -206,10 +206,16 @@ impl<'a> CompactBlockProcess<'a> {
             match ret {
                 ReconstructionResult::Block(block) => {
                     pending_compact_blocks.remove(&block_hash);
-                    // remove all pending request below this block number
+                    // remove all pending request below this block epoch
+                    //
+                    // use epoch as the judgment condition because we accept
+                    // all block in current epoch as uncle block
                     pending_compact_blocks.retain(|_, (v, _)| {
-                        Unpack::<core::BlockNumber>::unpack(&v.header().as_reader().raw().number())
-                            >= block.number()
+                        Unpack::<core::EpochNumberWithFraction>::unpack(
+                            &v.header().as_reader().raw().epoch(),
+                        )
+                        .number()
+                            >= block.epoch().number()
                     });
                     shrink_to_fit!(pending_compact_blocks, 20);
                     self.relayer

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -468,14 +468,25 @@ fn test_accept_block() {
         .uncle(uncle.as_uncle())
         .build();
 
-    let mock_block = BlockBuilder::default().number(4.pack()).build();
-    let mock_compact_block = CompactBlock::build_from_block(&mock_block, &Default::default());
+    let mock_block_1 = BlockBuilder::default().number(4.pack()).build();
+    let mock_compact_block_1 = CompactBlock::build_from_block(&mock_block_1, &Default::default());
+
+    let mock_block_2 = block.as_advanced_builder().number(7.pack()).build();
+    let mock_compact_block_2 = CompactBlock::build_from_block(&mock_block_2, &Default::default());
     {
         let mut pending_compact_blocks = relayer.shared.state().pending_compact_blocks();
         pending_compact_blocks.insert(
-            mock_block.header().hash(),
+            mock_block_1.header().hash(),
             (
-                mock_compact_block,
+                mock_compact_block_1,
+                HashMap::from_iter(vec![(1.into(), (vec![1], vec![0]))]),
+            ),
+        );
+
+        pending_compact_blocks.insert(
+            mock_block_2.header().hash(),
+            (
+                mock_compact_block_2,
                 HashMap::from_iter(vec![(1.into(), (vec![1], vec![0]))]),
             ),
         );
@@ -508,7 +519,12 @@ fn test_accept_block() {
     assert_eq!(compact_block_process.execute(), Status::ok(),);
 
     let pending_compact_blocks = relayer.shared.state().pending_compact_blocks();
-    assert!(pending_compact_blocks.is_empty());
+    assert!(pending_compact_blocks
+        .get(&mock_block_1.header().hash())
+        .is_none());
+    assert!(pending_compact_blocks
+        .get(&mock_block_2.header().hash())
+        .is_some());
 }
 
 #[test]

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -1,7 +1,7 @@
 use crate::{Relayer, SyncShared};
 use ckb_app_config::NetworkConfig;
 use ckb_chain::chain::ChainService;
-use ckb_chain_spec::consensus::ConsensusBuilder;
+use ckb_chain_spec::consensus::{build_genesis_epoch_ext, ConsensusBuilder};
 use ckb_launcher::SharedBuilder;
 use ckb_network::{
     bytes::Bytes as P2pBytes, Behaviour, CKBProtocolContext, DefaultExitHandler, Error,
@@ -142,8 +142,15 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
             .compact_target(difficulty_to_compact(U256::from(1000u64)).pack())
             .transaction(always_success_tx)
             .build();
-        let consensus = ConsensusBuilder::default()
-            .genesis_block(genesis)
+        let epoch_ext = build_genesis_epoch_ext(
+            Capacity::shannons(191_780_821_917_808),
+            0x20800000,
+            // genesis epoch length change to 1
+            1,
+            4 * 60 * 60,
+            (1, 40),
+        );
+        let consensus = ConsensusBuilder::new(genesis, epoch_ext)
             .cellbase_maturity(EpochNumberWithFraction::new(0, 0, 1))
             .build();
         SharedBuilder::with_temp_db()


### PR DESCRIPTION
### What problem does this PR solve?

Issue introduced in #3110

Block number cannot be used as the judgment condition here, but epoch number should be used because any block of the current epoch can be accepted as uncle, and the practice of using block number as the judgment condition will not be able to broadcast and accept some uncle records, resulting in an abnormal uncle rate 

### Check List

Tests

- Unit test

### Release note

```release-note
None: Exclude this PR from the release note.
```

