### PR TITLE
chore: sort integration tests duration

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -617,7 +617,7 @@ fn print_results(mut test_results: Vec<TestResult>) {
     println!("{}", "-".repeat(20));
     println!("{:50} | {:10} | {:10}", "TEST", "STATUS", "DURATION");
 
-    test_results.sort_by(|a, b| a.status.cmp(&b.status));
+    test_results.sort_by(|a, b| (&a.status, a.duration).cmp(&(&b.status, b.duration)));
 
     for result in test_results.iter() {
         println!(


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

sort integration test results by duration, help us to optimize the long execution time test.

### What is changed and how it works?

on my pc, outputs:

```
TEST                                               | STATUS     | DURATION  
HandlingDescendantsOfProposed                      | Passed     | 7 s       
DuplicatedTransaction                              | Passed     | 7 s       
CyclesLimit                                        | Passed     | 7 s       
CheckAbsoluteEpochSince                            | Passed     | 7 s       
SubmitConflict                                     | Passed     | 7 s       
ConflictInProposed                                 | Passed     | 7 s       
ImmatureHeaderDeps                                 | Passed     | 7 s       
SizeLimit                                          | Passed     | 7 s       
send_secp_tx_use_dep_group_data_hash               | Passed     | 7 s       
SendLowFeeRateTx                                   | Passed     | 7 s       
DeclaredWrongCyclesChunk                           | Passed     | 7 s       
SendTxChain                                        | Passed     | 7 s       
RpcTransactionProof                                | Passed     | 7 s       
send_defected_binary_reject_known_bugs             | Passed     | 7 s       
send_multisig_secp_tx_use_dep_group_data_hash      | Passed     | 7 s       
ProposeOutOfOrder                                  | Passed     | 7 s       
DeclaredWrongCycles                                | Passed     | 7 s       
AvoidDuplicatedProposalsWithUncles                 | Passed     | 7 s       
SubmitTransactionWhenItsParentInProposed           | Passed     | 7 s       
MiningBasic                                        | Passed     | 7 s       
ConflictInPending                                  | Passed     | 8 s       
BootstrapCellbase                                  | Passed     | 8 s       
send_defected_binary_do_not_reject_known_bugs      | Passed     | 8 s       
FeeOfTransaction                                   | Passed     | 8 s       
NotifyLargeCyclesTx                                | Passed     | 8 s       
TransactionHashCollisionDifferentWitnessHashes     | Passed     | 8 s       
DepentTxInSameBlock                                | Passed     | 8 s       
CompactBlockEmpty                                  | Passed     | 8 s       
OrphanTxRejected                                   | Passed     | 8 s       
RelayInvalidTransaction                            | Passed     | 8 s       
TemplateTxSelect                                   | Passed     | 8 s       
SpendSatoshiCell                                   | Passed     | 8 s       
CellBeingCellDepThenSpentInSameBlockTestSubmitBlock | Passed     | 8 s       
send_secp_tx_use_dep_group_type_hash               | Passed     | 8 s       
ConflictInGap                                      | Passed     | 8 s       
CompactBlockPrefilled                              | Passed     | 8 s       
OrphanTxAccepted                                   | Passed     | 8 s       
CheckRelativeEpochSince                            | Passed     | 9 s       
SubmitTransactionWhenItsParentInGap                | Passed     | 9 s       
DAOVerify                                          | Passed     | 9 s       
CellBeingSpentThenCellDepInSameBlockTestSubmitBlock | Passed     | 9 s       
RpcTruncate                                        | Passed     | 9 s       
GetRawTxPool                                       | Passed     | 9 s       
TemplateSizeLimit                                  | Passed     | 9 s       
CheckTypical2In2OutTx                              | Passed     | 9 s       
send_multisig_secp_tx_use_dep_group_type_hash      | Passed     | 9 s       
ProposalExpireRuleForCommittingAndExpiredAtOneTime | Passed     | 9 s       
BlockTemplates                                     | Passed     | 9 s       
ProposeTransactionButParentNot                     | Passed     | 9 s       
DifferentTxsWithSameInput                          | Passed     | 9 s       
ProposeDuplicated                                  | Passed     | 9 s       
CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate | Passed     | 9 s       
HandlingDescendantsOfCommitted                     | Passed     | 9 s       
CompactBlockMissingNotFreshTxs                     | Passed     | 10 s      
LastCommonHeaderForPeerWithWorseChain              | Passed     | 10 s      
RelayWithWrongTx                                   | Passed     | 10 s      
RpcGetBlockMedianTime                              | Passed     | 10 s      
LoadProgramFailedTx                                | Passed     | 10 s      
MalformedMessage                                   | Passed     | 10 s      
CheckVmBExtension                                  | Passed     | 10 s      
PoolPersisted                                      | Passed     | 12 s      
ValidSince                                         | Passed     | 12 s      
DAOWithSatoshiCellOccupied                         | Passed     | 13 s      
MissingUncleRequest                                | Passed     | 13 s      
WithdrawDAOWithOverflowCapacity                    | Passed     | 14 s      
WithdrawDAO                                        | Passed     | 14 s      
TransactionRelayLowFeeRate                         | Passed     | 15 s      
BlockSyncWithUncle                                 | Passed     | 15 s      
PackUnclesIntoEpochStarting                        | Passed     | 15 s      
ForkedTransaction                                  | Passed     | 15 s      
ReorgHandleProposals                               | Passed     | 16 s      
ForksContainSameUncle                              | Passed     | 16 s      
UncleInheritFromForkUncle                          | Passed     | 17 s      
SendLargeCyclesTxToRelay                           | Passed     | 17 s      
CheckVmVersion                                     | Passed     | 17 s      
RpcGetBlockTemplate                                | Passed     | 17 s      
BlockTransactionsRelayParentOfOrphanBlock          | Passed     | 17 s      
PoolResurrect                                      | Passed     | 17 s      
ProposeButNotCommit                                | Passed     | 17 s      
UncleInheritFromForkBlock                          | Passed     | 17 s      
CompactBlockRelayParentOfOrphanBlock               | Passed     | 18 s      
RpcGetBlockchainInfo                               | Passed     | 18 s      
Disconnect                                         | Passed     | 18 s      
CompactBlockEmptyParentUnknown                     | Passed     | 18 s      
InvalidHeaderDep                                   | Passed     | 18 s      
BlockSyncNonAncestorBestBlocks                     | Passed     | 18 s      
CompactBlockRelayLessThenSharedBestKnown           | Passed     | 18 s      
BlockSyncFromOne                                   | Passed     | 18 s      
SendLargeCyclesTxInBlock                           | Passed     | 19 s      
PoolReconcile                                      | Passed     | 19 s      
ReferenceHeaderMaturity                            | Passed     | 19 s      
BlockSyncRelayerCollaboration                      | Passed     | 20 s      
InvalidLocatorSize                                 | Passed     | 20 s      
ChainFork1                                         | Passed     | 20 s      
TransactionRelayEmptyPeers                         | Passed     | 20 s      
BlockSyncDuplicatedAndReconnect                    | Passed     | 21 s      
RpcSubmitBlock                                     | Passed     | 23 s      
BlockSyncOrphanBlocks                              | Passed     | 23 s      
AlertPropagation                                   | Passed     | 25 s      
Discovery                                          | Passed     | 27 s      
MalformedMessageWithWhitelist                      | Passed     | 27 s      
TxsRelayOrder                                      | Passed     | 27 s      
TransactionRelayBasic                              | Passed     | 28 s      
ChainFork5                                         | Passed     | 29 s      
ChainFork4                                         | Passed     | 30 s      
ChainFork3                                         | Passed     | 31 s      
CheckBlockExtension                                | Passed     | 31 s      
InboundMinedDuringSync                             | Passed     | 33 s      
InboundSync                                        | Passed     | 34 s      
BlockSyncForks                                     | Passed     | 34 s      
ChainFork2                                         | Passed     | 34 s      
ChainFork7                                         | Passed     | 35 s      
CompactBlockMissingFreshTxs                        | Passed     | 35 s      
ChainFork6                                         | Passed     | 35 s      
ForkContainsInvalidBlock                           | Passed     | 35 s      
LongForks                                          | Passed     | 36 s      
RequestUnverifiedBlocks                            | Passed     | 37 s      
OutboundSync                                       | Passed     | 37 s      
HeaderSyncCycle                                    | Passed     | 37 s      
OutboundMinedDuringSync                            | Passed     | 38 s      
ChainContainsInvalidBlock                          | Passed     | 38 s      
CompactBlockLoseGetBlockTransactions               | Passed     | 40 s      
ForksContainSameTransactions                       | Passed     | 41 s      
RelayTooNewBlock                                   | Passed     | 42 s      
FeeOfMaxBlockProposalsLimit                        | Passed     | 43 s      
SyncTooNewBlock                                    | Passed     | 46 s      
GetBlocksTimeout                                   | Passed     | 48 s      
WhitelistOnSessionLimit                            | Passed     | 56 s      
SyncTimeout                                        | Passed     | 64 s      
IBDProcess                                         | Passed     | 64 s      
CheckCellDeps                                      | Passed     | 66 s      
TransactionRelayTimeout                            | Passed     | 69 s      
CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplateMultiple | Passed     | 85 s      
FeeOfMultipleMaxBlockProposalsLimit                | Passed     | 116 s     
Total elapsed time: 695.579242782s
```

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

