### PR TITLE
fix(hardfork): tx-pool clear statistical data before re-run all transactions

### DIFF
--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -564,6 +564,9 @@ impl TxPool {
         self.proposed.clear();
         txs.append(&mut self.gap.drain());
         txs.append(&mut self.pending.drain());
+        self.total_tx_size = 0;
+        self.total_tx_cycles = 0;
+        self.touch_last_txs_updated_at();
         txs
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

When tx-pool refreshes caches during hardfork, the statistical data should be cleared before re-run all transactions.

### Check List

Tests

- Unit test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

