### PR TITLE
doc: annotate migration since version

### DIFF
--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -21,11 +21,11 @@ impl Migrate {
     pub fn new<P: Into<PathBuf>>(path: P) -> Self {
         let mut migrations = Migrations::default();
         migrations.add_migration(Box::new(DefaultMigration::new(INIT_DB_VERSION)));
-        migrations.add_migration(Box::new(migrations::ChangeMoleculeTableToStruct));
-        migrations.add_migration(Box::new(migrations::CellMigration));
-        migrations.add_migration(Box::new(migrations::AddNumberHashMapping));
-        migrations.add_migration(Box::new(migrations::AddExtraDataHash));
-        migrations.add_migration(Box::new(migrations::AddBlockExtensionColumnFamily));
+        migrations.add_migration(Box::new(migrations::ChangeMoleculeTableToStruct)); // since v0.35.0
+        migrations.add_migration(Box::new(migrations::CellMigration)); // since v0.37.0
+        migrations.add_migration(Box::new(migrations::AddNumberHashMapping)); // since v0.40.0
+        migrations.add_migration(Box::new(migrations::AddExtraDataHash)); // since v0.43.0
+        migrations.add_migration(Box::new(migrations::AddBlockExtensionColumnFamily)); // since v0.100.0
 
         Migrate {
             migrations,


### PR DESCRIPTION
It tells us which migrations will run from a specific version.

### What problem does this PR solve?

Problem Summary: It's hard to tell which migrations will run when upgrading from a specific version.

### What is changed and how it works?

Annotate the first version which introduced the migration. From the annotation it's easy to see which migrations will run from a specific version.

### Check List

Tests

- No code (skip ci)

### Release note

```release-note
None: Exclude this PR from the release note.
```

