### PR TITLE
ci: use new skip ci command in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ Tests <!-- At least one of them must be included. -->
 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
-- No code (skip ci)
+- No code ci-runs-only: [ quick_checks,linters ]
 
 Side effects
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Our GitHub Actions workflows does not recognize the skip ci command in the PR template.

### What is changed and how it works?

What's Changed: use `ci-runs-only: [ quick_checks,linters ]` in the PR template

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

