### PR TITLE
fix: temporary directories for database are dropped too soon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "ckb-store",
  "ckb-traits",
  "ckb-types",
+ "tempfile",
 ]
 
 [[package]]
@@ -1057,6 +1058,7 @@ dependencies = [
  "ckb-occupied-capacity",
  "ckb-store",
  "ckb-types",
+ "tempfile",
 ]
 
 [[package]]
@@ -1147,6 +1149,7 @@ dependencies = [
  "goblin 0.2.3",
  "proptest",
  "serde",
+ "tempfile",
  "tiny-keccak",
 ]
 
@@ -1220,6 +1223,7 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "lru",
+ "tempfile",
 ]
 
 [[package]]
@@ -1290,6 +1294,7 @@ dependencies = [
  "ckb-types",
  "faketime",
  "lazy_static",
+ "tempfile",
 ]
 
 [[package]]

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -187,9 +187,9 @@ fn test_transaction_spend_in_same_block() {
     );
 
     let epoch = mock_store
-        .0
+        .store()
         .get_block_epoch_index(&parent_hash4)
-        .and_then(|index| mock_store.0.get_epoch_ext(&index))
+        .and_then(|index| mock_store.store().get_epoch_ext(&index))
         .unwrap();
 
     assert_eq!(

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -149,8 +149,8 @@ pub(crate) fn calculate_reward(
 ) -> Capacity {
     let number = parent.number() + 1;
     let target_number = consensus.finalize_target(number).unwrap();
-    let target_hash = store.0.get_block_hash(target_number).unwrap();
-    let target = store.0.get_block_header(&target_hash).unwrap();
+    let target_hash = store.store().get_block_hash(target_number).unwrap();
+    let target = store.store().get_block_header(&target_hash).unwrap();
     let data_loader = store.store().as_data_provider();
     let calculator = DaoCalculator::new(consensus, &data_loader);
     calculator
@@ -338,7 +338,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.0.as_data_provider())
+            .next_epoch_ext(&parent, &store.store().as_data_provider())
             .unwrap()
             .epoch();
 
@@ -417,7 +417,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.0.as_data_provider())
+            .next_epoch_ext(&parent, &store.store().as_data_provider())
             .unwrap()
             .epoch();
 
@@ -441,7 +441,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.0.as_data_provider())
+            .next_epoch_ext(&parent, &store.store().as_data_provider())
             .unwrap()
             .epoch();
 
@@ -477,7 +477,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.0.as_data_provider())
+            .next_epoch_ext(&parent, &store.store().as_data_provider())
             .unwrap()
             .epoch();
 
@@ -547,7 +547,7 @@ pub fn dao_data(
     } else {
         rtxs.unwrap()
     };
-    let data_loader = store.0.as_data_provider();
+    let data_loader = store.store().as_data_provider();
     let calculator = DaoCalculator::new(consensus, &data_loader);
     calculator.dao_field(&rtxs, &parent).unwrap()
 }

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -15,4 +15,6 @@ ckb-error = { path = "../error", version = "= 0.102.0-pre" }
 libc = "0.2"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }
 ckb-db-schema = { path = "../db-schema", version = "= 0.102.0-pre" }
+
+[dev-dependencies]
 tempfile = "3.0"

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -99,11 +99,10 @@ impl RocksDB {
         Self::open_with_check(config, columns).unwrap_or_else(|err| panic!("{}", err))
     }
 
-    /// Open a temporary database with the default configuration and columns count.
-    pub fn open_tmp(columns: u32) -> Self {
-        let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
+    /// Open a database in the given directory with the default configuration and columns count.
+    pub fn open_in<P: AsRef<Path>>(path: P, columns: u32) -> Self {
         let config = DBConfig {
-            path: tmp_dir.path().to_path_buf(),
+            path: path.as_ref().to_path_buf(),
             ..Default::default()
         };
         Self::open_with_check(&config, columns).unwrap_or_else(|err| panic!("{}", err))

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -19,6 +19,8 @@ fs2 = "0.4.3"
 fail = "0.4"
 snap = "1"
 lru = "0.6.0"
+
+[dev-dependencies]
 tempfile = "3.0"
 
 [[test]]

--- a/freezer/src/freezer.rs
+++ b/freezer/src/freezer.rs
@@ -10,7 +10,7 @@ use ckb_util::Mutex;
 use fs2::FileExt;
 use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -74,9 +74,8 @@ impl Freezer {
     }
 
     /// Creates a freezer at temporary path
-    pub fn open_tmp() -> Result<Freezer, Error> {
-        let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
-        Self::open(tmp_dir.path().to_path_buf())
+    pub fn open_in<P: AsRef<Path>>(path: P) -> Result<Freezer, Error> {
+        Self::open(path.as_ref().to_path_buf())
     }
 
     /// Freeze background process that periodically checks the chain data for any

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -38,3 +38,4 @@ ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.102.0
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 ckb-crypto = { path = "../util/crypto", version = "= 0.102.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.102.0-pre" }
+tempfile = "3.0"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -19,3 +19,6 @@ ckb-error = { path = "../error", version = "= 0.102.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.102.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.102.0-pre" }
 ckb-freezer = { path = "../freezer", version = "= 0.102.0-pre" }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/store/src/tests/db.rs
+++ b/store/src/tests/db.rs
@@ -3,16 +3,14 @@ use ckb_db::RocksDB;
 use ckb_db_schema::{COLUMNS, COLUMN_BLOCK_HEADER};
 use ckb_freezer::Freezer;
 use ckb_types::{core::BlockExt, packed, prelude::*};
+use tempfile::TempDir;
 
 use crate::{db::ChainDB, store::ChainStore};
 
-fn setup_db(columns: u32) -> RocksDB {
-    RocksDB::open_tmp(columns)
-}
-
 #[test]
 fn save_and_get_block() {
-    let db = setup_db(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
     let consensus = ConsensusBuilder::default().build();
     let block = consensus.genesis_block();
@@ -26,7 +24,8 @@ fn save_and_get_block() {
 
 #[test]
 fn save_and_get_block_with_transactions() {
-    let db = setup_db(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
     let block = packed::Block::new_builder()
         .transactions(
@@ -47,7 +46,8 @@ fn save_and_get_block_with_transactions() {
 
 #[test]
 fn save_and_get_block_ext() {
-    let db = setup_db(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
     let consensus = ConsensusBuilder::default().build();
     let block = consensus.genesis_block();
@@ -69,7 +69,8 @@ fn save_and_get_block_ext() {
 
 #[test]
 fn index_store() {
-    let db = RocksDB::open_tmp(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
     let consensus = ConsensusBuilder::default().build();
     let block = consensus.genesis_block();
@@ -89,8 +90,10 @@ fn index_store() {
 
 #[test]
 fn freeze_blockv0() {
-    let db = RocksDB::open_tmp(COLUMNS);
-    let freezer = Freezer::open_tmp().expect("tmp freezer");
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let tmp_dir2 = TempDir::new().unwrap();
+    let freezer = Freezer::open_in(&tmp_dir2).expect("tmp freezer");
     let store = ChainDB::new_with_freezer(db, freezer.clone(), Default::default());
 
     let raw = packed::RawHeader::new_builder().number(1u64.pack()).build();
@@ -120,8 +123,10 @@ fn freeze_blockv0() {
 
 #[test]
 fn freeze_blockv1_with_extension() {
-    let db = RocksDB::open_tmp(COLUMNS);
-    let freezer = Freezer::open_tmp().expect("tmp freezer");
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let tmp_dir2 = TempDir::new().unwrap();
+    let freezer = Freezer::open_in(&tmp_dir2).expect("tmp freezer");
     let store = ChainDB::new_with_freezer(db, freezer.clone(), Default::default());
 
     let extension: packed::Bytes = vec![1u8; 96].pack();

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -20,3 +20,4 @@ ckb-traits = { path = "../../traits", version = "= 0.102.0-pre" }
 ckb-db = { path = "../../db", version = "= 0.102.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.102.0-pre" }
 ckb-store = { path = "../../store", version = "= 0.102.0-pre" }
+tempfile = "3.0"

--- a/util/dao/src/tests.rs
+++ b/util/dao/src/tests.rs
@@ -17,15 +17,17 @@ use ckb_types::{
     utilities::DIFF_TWO,
     U256,
 };
+use tempfile::TempDir;
 
 use crate::DaoCalculator;
 
-fn new_store() -> ChainDB {
-    ChainDB::new(RocksDB::open_tmp(COLUMNS), Default::default())
-}
-
-fn prepare_store(parent: &HeaderView, epoch_start: Option<BlockNumber>) -> (ChainDB, HeaderView) {
-    let store = new_store();
+fn prepare_store(
+    parent: &HeaderView,
+    epoch_start: Option<BlockNumber>,
+) -> (TempDir, ChainDB, HeaderView) {
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let store = ChainDB::new(db, Default::default());
     let txn = store.begin_transaction();
 
     let parent_block = BlockBuilder::default().header(parent.clone()).build();
@@ -51,7 +53,7 @@ fn prepare_store(parent: &HeaderView, epoch_start: Option<BlockNumber>) -> (Chai
 
     txn.commit().unwrap();
 
-    (store, parent.clone())
+    (tmp_dir, store, parent.clone())
 }
 
 #[test]
@@ -69,7 +71,7 @@ fn check_dao_data_calculation() {
         ))
         .build();
 
-    let (store, parent_header) = prepare_store(&parent_header, None);
+    let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
         .dao_field(&[], &parent_header)
         .unwrap();
@@ -100,7 +102,7 @@ fn check_initial_dao_data_calculation() {
         ))
         .build();
 
-    let (store, parent_header) = prepare_store(&parent_header, Some(0));
+    let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(0));
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
         .dao_field(&[], &parent_header)
         .unwrap();
@@ -131,7 +133,7 @@ fn check_first_epoch_block_dao_data_calculation() {
         ))
         .build();
 
-    let (store, parent_header) = prepare_store(&parent_header, Some(12340));
+    let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(12340));
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
         .dao_field(&[], &parent_header)
         .unwrap();
@@ -162,7 +164,7 @@ fn check_dao_data_calculation_overflows() {
         ))
         .build();
 
-    let (store, parent_header) = prepare_store(&parent_header, None);
+    let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
     let result =
         DaoCalculator::new(&consensus, &store.as_data_provider()).dao_field(&[], &parent_header);
     assert!(result
@@ -186,7 +188,7 @@ fn check_dao_data_calculation_with_transactions() {
         ))
         .build();
 
-    let (store, parent_header) = prepare_store(&parent_header, None);
+    let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
     let input_cell_data = Bytes::from("abcde");
     let input_cell = CellOutput::new_builder()
         .capacity(capacity_bytes!(10000).pack())
@@ -259,7 +261,9 @@ fn check_withdraw_calculation() {
         .build();
     let withdrawing_block = BlockBuilder::default().header(withdrawing_header).build();
 
-    let store = new_store();
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let store = ChainDB::new(db, Default::default());
     let txn = store.begin_transaction();
     txn.insert_block(&deposit_block).unwrap();
     txn.attach_block(&deposit_block).unwrap();
@@ -310,7 +314,9 @@ fn check_withdraw_calculation_overflows() {
         .build();
     let withdrawing_block = BlockBuilder::default().header(withdrawing_header).build();
 
-    let store = new_store();
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let store = ChainDB::new(db, Default::default());
     let txn = store.begin_transaction();
     txn.insert_block(&deposit_block).unwrap();
     txn.attach_block(&deposit_block).unwrap();

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -43,9 +43,9 @@ ckb-stop-handler = { path = "../stop-handler", version = "= 0.102.0-pre" }
 p2p = { version="0.4.0-alpha.1", package="tentacle" }
 num_cpus = "1.10"
 once_cell = "1.8.0"
+tempfile = "3.0"
 
 [dev-dependencies]
-tempfile = "3.0"
 faketime = "0.2.0"
 
 [features]

--- a/util/launcher/src/shared_builder.rs
+++ b/util/launcher/src/shared_builder.rs
@@ -33,6 +33,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use tempfile::TempDir;
 
 /// Shared builder for construct new shared.
 pub struct SharedBuilder {
@@ -136,19 +137,39 @@ impl SharedBuilder {
 
     /// Generates the SharedBuilder with temp db
     pub fn with_temp_db() -> Self {
-        use once_cell::unsync;
-        use std::borrow::Borrow;
+        use once_cell::{sync, unsync};
+        use std::{
+            borrow::Borrow,
+            sync::atomic::{AtomicUsize, Ordering},
+        };
 
         // once #[thread_local] is stable
         // #[thread_local]
         // static RUNTIME_HANDLE: unsync::OnceCell<...
 
         thread_local! {
+            static TMP_DIR: sync::OnceCell<TempDir> = sync::OnceCell::new();
             static RUNTIME_HANDLE: unsync::OnceCell<(Handle, StopHandler<()>)> = unsync::OnceCell::new();
         }
 
+        static DB_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        let db = {
+            let db_id = DB_COUNT.fetch_add(1, Ordering::SeqCst);
+            let db_base_dir = TMP_DIR.with(|tmp_dir| {
+                tmp_dir
+                    .borrow()
+                    .get_or_try_init(TempDir::new)
+                    .unwrap()
+                    .path()
+                    .to_path_buf()
+            });
+            let db_dir = db_base_dir.join(format!("db_{}", db_id));
+            RocksDB::open_in(db_dir, COLUMNS)
+        };
+
         RUNTIME_HANDLE.with(|runtime| SharedBuilder {
-            db: RocksDB::open_tmp(COLUMNS),
+            db,
             ancient_path: None,
             consensus: None,
             tx_pool_config: None,

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -20,3 +20,4 @@ ckb-error = { path = "../../error", version = "= 0.102.0-pre" }
 ckb-db = { path = "../../db", version = "= 0.102.0-pre" }
 ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.102.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.102.0-pre" }
+tempfile = "3.0"

--- a/util/reward-calculator/src/tests.rs
+++ b/util/reward-calculator/src/tests.rs
@@ -10,12 +10,14 @@ use ckb_types::{
 };
 use std::collections::HashSet;
 use std::iter::FromIterator;
+use tempfile::TempDir;
 
 use crate::RewardCalculator;
 
 #[test]
 fn get_proposal_ids_by_hash() {
-    let db = RocksDB::open_tmp(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
 
     let proposal1 = ProposalShortId::new([1; 10]);
@@ -59,7 +61,8 @@ fn get_proposal_ids_by_hash() {
 
 #[test]
 fn test_txs_fees() {
-    let db = RocksDB::open_tmp(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
 
     // Default PROPOSER_REWARD_RATIO is Ratio(4, 10)
@@ -117,7 +120,8 @@ fn test_txs_fees() {
 // target's earliest proposals: p4, p5, p6
 #[test]
 fn test_proposal_reward() {
-    let db = RocksDB::open_tmp(COLUMNS);
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
     let store = ChainDB::new(db, Default::default());
 
     let consensus = ConsensusBuilder::default()

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -19,3 +19,4 @@ lazy_static = "1.3.0"
 faketime = "0.2.0"
 ckb-resource = { path = "../../resource", version = "= 0.102.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.102.0-pre" }
+tempfile = "3.0"


### PR DESCRIPTION
### What problem does this PR solve?

- Local variables declared in a `let` statement are associated to the scope of the block that contains the `let` statement.

  When it goes out of the scope, the destructor will be called.

  Ref: https://doc.rust-lang.org/reference/destructors.html#scopes-of-local-variables

- So, after called `open_tmp(..)`, the local variable of `TempDir` will be destructed.

  - [`RocksDB::open_tmp(..)`](https://github.com/nervosnetwork/ckb/blob/defffe876ece415a78b90ee2dda086c02fa73774/db/src/db.rs#L103-L110)

  - [`Freezer::open_tmp(..)`](https://github.com/nervosnetwork/ckb/blob/defffe876ece415a78b90ee2dda086c02fa73774/freezer/src/freezer.rs#L77-L80)

- [`TempDir` will be removed when the variable was destructed](https://github.com/Stebalien/tempfile/blob/37e4bc0dab5b91bcf9fa8d449ded1cfe13148441/src/dir.rs#L393-L400).

- So, temporary directories for database will be removed before the database closed.

#### Impact

We only use these methods in unit tests.

### Check List

Tests

- Unit test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

