### PR TITLE
test: fix potential failure in integration test CheckVmVersion

### DIFF
--- a/test/src/specs/hardfork/v2021/vm_version.rs
+++ b/test/src/specs/hardfork/v2021/vm_version.rs
@@ -80,7 +80,9 @@ impl Spec for CheckVmVersion {
             info!("Test Sync:");
             let (rpc_client0, rpc_client1) = (node.rpc_client(), node1.rpc_client());
 
-            let ret = wait_until(20, || {
+            // The GetHeaders will be sent every 15s.
+            // When reach tip, the GetHeaders will be paused 28s.
+            let ret = wait_until(60, || {
                 let header0 = rpc_client0.get_tip_header();
                 let header1 = rpc_client1.get_tip_header();
                 header0 == header1


### PR DESCRIPTION
### What problem does this PR solve?

In the integration test `CheckVmVersion`, the timeout is too short, so it may causes potential failures.

- The GetHeaders will be sent every `15` seconds.
  https://github.com/nervosnetwork/ckb/blob/b9bbb505a74e9f05829e5a87439a5bd18d248a2b/sync/src/types/mod.rs#L53

- When reach tip, the GetHeaders will be paused `28` seconds.
  https://github.com/nervosnetwork/ckb/blob/b9bbb505a74e9f05829e5a87439a5bd18d248a2b/sync/src/types/mod.rs#L105-L109

So, `20` seconds are not enough. A suggestion from @driftluo is be greater than `28 * 2` seconds (for the worst case), here I round up it to `1` minute.

### Check List

Tests

- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```