### PR TITLE
fix: InvalidHeaderDep wait_for_tx_pool

### DIFF
--- a/test/src/specs/tx_pool/pool_resurrect.rs
+++ b/test/src/specs/tx_pool/pool_resurrect.rs
@@ -91,6 +91,8 @@ impl Spec for InvalidHeaderDep {
         node0.connect(node1);
         waiting_for_sync(nodes);
 
+        node0.wait_for_tx_pool();
+
         info!("invalid header dep tx should be removed");
         node0.assert_tx_pool_size(1, 0);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

integration-test InvalidHeaderDep random failed.

### What is changed and how it works?

What's Changed: wait tx-pool state sync with chain.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

