### PR TITLE
chore: update platform support tier

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -22,6 +22,7 @@ We ensure that these platforms will satisfy the following requirements:
 | --- | --- | --- |
 | Ubuntu 18.04 | x64 | ASM |
 | macOS | x64 | ASM |
+| Windows | x64 | ASM |
 
 The Tier 1 requires CPU to support at least SSE4.2, and AVX is recommended.
 
@@ -33,14 +34,11 @@ The official binary releases are also provided for the Tier 2 platforms.
 
 | OS | Arch | CKB VM Mode |
 | --- | --- | --- |
-| Windows \* | x64 | ASM |
 | Ubuntu 20.04 | x64 | ASM |
 | Debian Stretch | x64 | ASM |
 | Debian Buster | x64 | ASM |
 | Arch Linux | x64 | ASM |
 | CentOS 7 | x64 | ASM |
-
-\* The Rust code base uses RocksDB to store data, which has known issues in Windows.
 
 The Tier 2 requires CPU to support following instructions: call (MODE64), cmovbe (CMOV), xorps (SSE1), movq (SSE2). The provided binaries cannot run on the platforms without these instructions.
 


### PR DESCRIPTION
- chore: drop Ubuntu Xenial support
- chore: remove Windows experimental notice

### What problem does this PR solve?

Problem Summary: Platform tiers information is outdated.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

