### PR TITLE
feat: increase yamux window size

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -849,6 +849,7 @@ impl<T: ExitHandler> NetworkService<T> {
         let mut service_builder = ServiceBuilder::default();
         let yamux_config = YamuxConfig {
             max_stream_count: protocol_metas.len(),
+            max_stream_window_size: 1024 * 1024,
             ..Default::default()
         };
         for meta in protocol_metas.into_iter() {


### PR DESCRIPTION
### What problem does this PR solve?

Increase the window size of yamux to improve bandwidth utilization.

By default, the window size of yamux is 256kb, but the maximum size of a block of ckb is 500k+, which means that the message needs to be sent and received twice + 2 window update messages to complete 

Side effects

- Memory usage may increase 

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

