### PR TITLE
fix: return None when get git commit info failed

### DIFF
--- a/util/build-info/src/lib.rs
+++ b/util/build-info/src/lib.rs
@@ -115,6 +115,7 @@ pub fn get_commit_describe() -> Option<String> {
         ])
         .output()
         .ok()
+        .filter(|output| output.status.success())
         .and_then(|r| {
             String::from_utf8(r.stdout)
                 .ok()
@@ -131,6 +132,7 @@ pub fn get_commit_date() -> Option<String> {
         .args(&["log", "-1", "--date=iso", "--pretty=format:%cd"])
         .output()
         .ok()
+        .filter(|output| output.status.success())
         .and_then(|r| {
             String::from_utf8(r.stdout)
                 .ok()


### PR DESCRIPTION


### What problem does this PR solve?

Return `None` when execute `git` command to get commit information failed.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

