### PR TITLE
test: fix potential failure in integration test DeclaredWrongCyclesAndRelayAgain

### DIFF
--- a/test/src/specs/tx_pool/declared_wrong_cycles.rs
+++ b/test/src/specs/tx_pool/declared_wrong_cycles.rs
@@ -102,12 +102,13 @@ impl Spec for DeclaredWrongCyclesAndRelayAgain {
         // removing invalid tx hash from node0's known tx filer is async, wait 5 seconds to make sure it's removed
         sleep(5);
 
+        // connect node0 with node1, tx will be relayed from node1 to node0
+        node0.connect(node1);
+
         // relay tx to node1 with correct cycles
         net.connect(node1);
         relay_tx(&net, &node1, tx, ALWAYS_SUCCESS_SCRIPT_CYCLE);
 
-        // connect node0 with node1, tx will be relayed from node1 to node0
-        node0.connect(node1);
         let result = wait_until(5, || {
             let tx_pool_info = node0.get_tip_tx_pool_info();
             tx_pool_info.orphan.value() == 0 && tx_pool_info.pending.value() == 1


### PR DESCRIPTION
### What problem does this PR solve?

In the integration test `DeclaredWrongCyclesAndRelayAgain`:
- The controller relays a transaction `tx` to `node1` and we want to check `tx` in `node0`.
- But we connect `node0` with `node1` after `relay tx to node1`.
- So `node0` may miss the `RelayTransactionHashes` message.

#### Reproduce

- In my laptop, the original code has a 15% chance of failing, even I change the timeout of `wait_until` to `120`.

  https://github.com/nervosnetwork/ckb/blob/7b829beecf5b9d2646e0e13facdcf34516cc6f77/test/src/specs/tx_pool/declared_wrong_cycles.rs#L111

- When I insert `sleep(1)` before `node0.connect(node1);`, into the line 108 of the follow code:

  https://github.com/nervosnetwork/ckb/blob/7b829beecf5b9d2646e0e13facdcf34516cc6f77/test/src/specs/tx_pool/declared_wrong_cycles.rs#L106-L110

  The chance of failing becomes 100%.

### Check List

Tests

- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

