### PR TITLE
chore: move sentry scope

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -620,16 +620,6 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
             }
             ServiceError::ProtocolHandleError { proto_id, error } => {
                 debug!("ProtocolHandleError: {:?}, proto_id: {}", error, proto_id);
-                #[cfg(feature = "with_sentry")]
-                with_scope(
-                    |scope| scope.set_fingerprint(Some(&["ckb-network", "p2p-service-error"])),
-                    || {
-                        capture_message(
-                            &format!("ProtocolHandleError: {:?}, proto_id: {}", error, proto_id),
-                            Level::Warning,
-                        )
-                    },
-                );
 
                 if let ProtocolHandleErrorKind::AbnormallyClosed(opt_session_id) = error {
                     if let Some(id) = opt_session_id {
@@ -640,6 +630,16 @@ impl<T: ExitHandler> ServiceHandle for EventHandler<T> {
                             format!("protocol {} panic when process peer message", proto_id),
                         );
                     }
+                    #[cfg(feature = "with_sentry")]
+                    with_scope(
+                        |scope| scope.set_fingerprint(Some(&["ckb-network", "p2p-service-error"])),
+                        || {
+                            capture_message(
+                                &format!("ProtocolHandleError: AbnormallyClosed, proto_id: {:?}, session id: {:?}", opt_session_id, opt_session_id),
+                                Level::Warning,
+                            )
+                        },
+                    );
                     self.exit_handler.notify_exit();
                 }
             }


### PR DESCRIPTION
### What problem does this PR solve?

`ProtocolHandleErrorKind::Block(None)` just mention user there may be something blocking the event process, but nothing is wrong, always it just needs to wait for the process, except deadlock.

`ProtocolHandleErrorKind::AbnormallyClosed` is a terrible error for any protocol, it means there has one protocol handle abnormally closed, usually something wrong for panic

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

