### PR TITLE
ci: fix cargo deny installation

### DIFF
--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -51,7 +51,7 @@ ci_integration_tests*)
     ;;
   ci_cargo_deny*)
     echo "ci_security_audit_licenses"
-    cargo deny --version || cargo install cargo-deny --locked
+    cargo deny --version || cargo +stable install cargo-deny --locked
     make security-audit
     make check-crates
     make check-licenses


### PR DESCRIPTION
### What problem does this PR solve?

The minimum supported rust version for `cargo-deny` (`=1.53.0`, [since it upgrade spdx](https://github.com/EmbarkStudios/cargo-deny/commit/b0fc7c440bea0fb39dc6aea921094e4ea15b6887)) is greater the rust version we locked in `rust-toolchain` (`=1.51.0`).

We could just use the latest stable version of rust (`=1.56.0`, at present) to install `cargo-deny`.

### Check List

Tests

- No code ci-runs-only: [ cargo_deny ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

