### PR TITLE
chore: remove inflight block struct's compact's record

### DIFF
--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -64,6 +64,7 @@ fn test_accept_block() {
                     (peer_index, (vec![1], vec![0])),
                     (other_peer_index, (vec![1], vec![])),
                 ]),
+                faketime::unix_time_as_millis(),
             ),
         );
     }
@@ -126,6 +127,7 @@ fn test_unknown_request() {
             (
                 compact_block,
                 HashMap::from_iter(vec![(foo_peer_index, (vec![1], vec![]))]),
+                faketime::unix_time_as_millis(),
             ),
         );
     }
@@ -190,6 +192,7 @@ fn test_invalid_transaction_root() {
             (
                 compact_block,
                 HashMap::from_iter(vec![(peer_index, (vec![1], vec![]))]),
+                faketime::unix_time_as_millis(),
             ),
         );
     }
@@ -285,6 +288,7 @@ fn test_collision_and_send_missing_indexes() {
             (
                 compact_block,
                 vec![(peer_index, (vec![1], vec![]))].into_iter().collect(),
+                faketime::unix_time_as_millis(),
             ),
         );
     }
@@ -392,6 +396,7 @@ fn test_missing() {
             (
                 compact_block,
                 HashMap::from_iter(vec![(peer_index, (vec![1], vec![]))]),
+                faketime::unix_time_as_millis(),
             ),
         );
     }

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -1,7 +1,6 @@
 use crate::block_status::BlockStatus;
 use crate::relayer::compact_block_process::CompactBlockProcess;
 use crate::relayer::tests::helper::{build_chain, new_header_builder, MockProtocolContext};
-use crate::types::InflightBlocks;
 use crate::{Status, StatusCode};
 use ckb_network::{PeerIndex, SupportProtocols};
 use ckb_store::ChainStore;
@@ -170,98 +169,6 @@ fn test_accept_not_a_better_block() {
 }
 
 #[test]
-fn test_already_in_flight() {
-    let (relayer, _) = build_chain(5);
-    let parent = {
-        let active_chain = relayer.shared.active_chain();
-        active_chain.tip_header()
-    };
-
-    // Better block
-    let header = new_header_builder(relayer.shared.shared(), &parent).build();
-
-    // Better block
-    let block = BlockBuilder::default()
-        .header(header)
-        .transaction(TransactionBuilder::default().build())
-        .build();
-
-    let mut prefilled_transactions_indexes = HashSet::new();
-    prefilled_transactions_indexes.insert(0);
-    let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
-
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocol_context);
-    let peer_index: PeerIndex = 1.into();
-
-    // Already in flight
-    let mut in_flight_blocks = InflightBlocks::default();
-    in_flight_blocks.compact_reconstruct(peer_index, block.header().hash());
-    *relayer.shared.state().write_inflight_blocks() = in_flight_blocks;
-
-    let compact_block_process = CompactBlockProcess::new(
-        compact_block.as_reader(),
-        &relayer,
-        Arc::<MockProtocolContext>::clone(&nc),
-        peer_index,
-    );
-
-    assert_eq!(
-        compact_block_process.execute(),
-        StatusCode::CompactBlockIsAlreadyInFlight.into(),
-    );
-}
-
-#[test]
-fn test_already_pending() {
-    let (relayer, _) = build_chain(5);
-    let parent = {
-        let active_chain = relayer.shared.active_chain();
-        active_chain.tip_header()
-    };
-
-    // Better block
-    let header = new_header_builder(relayer.shared.shared(), &parent).build();
-
-    let block = BlockBuilder::default()
-        .header(header)
-        .transaction(TransactionBuilder::default().build())
-        .build();
-
-    let mut prefilled_transactions_indexes = HashSet::new();
-    prefilled_transactions_indexes.insert(0);
-    let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
-
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocol_context);
-    let peer_index: PeerIndex = 1.into();
-
-    // Already in pending
-    {
-        let mut pending_compact_blocks = relayer.shared.state().pending_compact_blocks();
-        pending_compact_blocks.insert(
-            compact_block.header().into_view().hash(),
-            (
-                compact_block.clone(),
-                HashMap::from_iter(vec![(1.into(), (vec![0], vec![]))]),
-            ),
-        );
-    }
-
-    let compact_block_process = CompactBlockProcess::new(
-        compact_block.as_reader(),
-        &relayer,
-        Arc::<MockProtocolContext>::clone(&nc),
-        peer_index,
-    );
-
-    assert_eq!(
-        compact_block_process.execute(),
-        StatusCode::CompactBlockIsAlreadyPending.into(),
-    );
-}
-
-#[test]
 fn test_header_invalid() {
     let (relayer, _) = build_chain(5);
     let parent = {
@@ -304,62 +211,6 @@ fn test_header_invalid() {
             .active_chain()
             .get_block_status(&block.header().hash()),
         BlockStatus::BLOCK_INVALID
-    );
-}
-
-#[test]
-fn test_inflight_blocks_reach_limit() {
-    let (relayer, _) = build_chain(5);
-    let parent = {
-        let active_chain = relayer.shared.active_chain();
-        active_chain.tip_header()
-    };
-
-    let header = new_header_builder(relayer.shared.shared(), &parent).build();
-
-    // Better block including one missing transaction
-    let block = BlockBuilder::default()
-        .header(header)
-        .transaction(TransactionBuilder::default().build())
-        .transaction(
-            TransactionBuilder::default()
-                .output(
-                    CellOutputBuilder::default()
-                        .capacity(Capacity::bytes(1).unwrap().pack())
-                        .build(),
-                )
-                .output_data(Bytes::new().pack())
-                .build(),
-        )
-        .build();
-
-    let mut prefilled_transactions_indexes = HashSet::new();
-    prefilled_transactions_indexes.insert(0);
-    let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
-
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
-    let nc = Arc::new(mock_protocol_context);
-    let peer_index: PeerIndex = 100.into();
-
-    // in_flight_blocks is full
-    {
-        let mut in_flight_blocks = InflightBlocks::default();
-        for i in 0..=2 {
-            in_flight_blocks.compact_reconstruct(i.into(), block.header().hash());
-        }
-        *relayer.shared.state().write_inflight_blocks() = in_flight_blocks;
-    }
-
-    let compact_block_process = CompactBlockProcess::new(
-        compact_block.as_reader(),
-        &relayer,
-        Arc::<MockProtocolContext>::clone(&nc),
-        peer_index,
-    );
-
-    assert_eq!(
-        compact_block_process.execute(),
-        StatusCode::BlocksInFlightReachLimit.into(),
     );
 }
 
@@ -480,6 +331,7 @@ fn test_accept_block() {
             (
                 mock_compact_block_1,
                 HashMap::from_iter(vec![(1.into(), (vec![1], vec![0]))]),
+                faketime::unix_time_as_millis(),
             ),
         );
 
@@ -488,6 +340,7 @@ fn test_accept_block() {
             (
                 mock_compact_block_2,
                 HashMap::from_iter(vec![(1.into(), (vec![1], vec![0]))]),
+                faketime::unix_time_as_millis(),
             ),
         );
     }

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -1,6 +1,5 @@
 use crate::types::{BlockNumberAndHash, InflightBlocks};
 use ckb_constant::sync::BLOCK_DOWNLOAD_TIMEOUT;
-use ckb_network::PeerIndex;
 use ckb_types::h256;
 use ckb_types::prelude::*;
 use std::collections::HashSet;
@@ -198,88 +197,4 @@ fn inflight_trace_number_state() {
 
     assert_eq!(inflight_blocks.peer_can_fetch_count(3.into()), 8);
     assert_eq!(inflight_blocks.peer_can_fetch_count(4.into()), 8);
-}
-
-#[cfg(not(disable_faketime))]
-#[test]
-fn inflight_with_compact() {
-    let faketime_file = faketime::millis_tempfile(0).expect("create faketime file");
-    faketime::enable(&faketime_file);
-
-    let mut inflight_blocks = InflightBlocks::default();
-    inflight_blocks.protect_num = 0;
-
-    assert!(inflight_blocks.compact_reconstruct(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.compact_reconstruct(2.into(), h256!("0x1").pack()));
-    assert!(!inflight_blocks.compact_reconstruct(3.into(), h256!("0x1").pack()));
-
-    // try sync, but can't, mark this block a deadline
-    assert!(!inflight_blocks.insert(3.into(), (1, h256!("0x1").pack()).into()));
-    assert_eq!(inflight_blocks.total_inflight_count(), 0);
-
-    assert_eq!(
-        inflight_blocks
-            .inflight_compact_by_block(&h256!("0x1").pack())
-            .unwrap()
-            .clone()
-            .into_iter()
-            .collect::<HashSet<PeerIndex>>(),
-        HashSet::from_iter(vec![1.into(), 2.into()])
-    );
-
-    faketime::write_millis(&faketime_file, 3000).expect("write millis");
-
-    let list = inflight_blocks.prune(1);
-
-    assert_eq!(list.len(), 0);
-
-    assert!(inflight_blocks
-        .inflight_compact_by_block(&h256!("0x1").pack())
-        .is_none());
-
-    // remove compact by `remove_compact_by_peer`
-
-    assert!(inflight_blocks.compact_reconstruct(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.compact_reconstruct(2.into(), h256!("0x1").pack()));
-
-    inflight_blocks.remove_compact_by_peer(1.into(), &h256!("0x1").pack());
-
-    assert_eq!(
-        inflight_blocks
-            .inflight_compact_by_block(&h256!("0x1").pack())
-            .unwrap()
-            .clone()
-            .into_iter()
-            .collect::<HashSet<PeerIndex>>(),
-        HashSet::from_iter(vec![2.into()])
-    );
-
-    inflight_blocks.remove_compact_by_peer(2.into(), &h256!("0x1").pack());
-
-    assert!(inflight_blocks
-        .inflight_compact_by_block(&h256!("0x1").pack())
-        .is_none());
-
-    // remove compact by `remove_by_peer`
-
-    assert!(inflight_blocks.compact_reconstruct(1.into(), h256!("0x1").pack()));
-    assert!(inflight_blocks.compact_reconstruct(2.into(), h256!("0x1").pack()));
-
-    inflight_blocks.remove_by_peer(1.into());
-
-    assert_eq!(
-        inflight_blocks
-            .inflight_compact_by_block(&h256!("0x1").pack())
-            .unwrap()
-            .clone()
-            .into_iter()
-            .collect::<HashSet<PeerIndex>>(),
-        HashSet::from_iter(vec![2.into()])
-    );
-
-    inflight_blocks.remove_by_peer(2.into());
-
-    assert!(inflight_blocks
-        .inflight_compact_by_block(&h256!("0x1").pack())
-        .is_none());
 }


### PR DESCRIPTION
### What problem does this PR solve?

Currently, there is a record of `pending_compact_block` in `SyncState`, and a record of `pending_compact` in `InflightBlock`. The record in `InflightBlock` limits the `BlockTransaction` request to only two remote nodes at the same time. 

This is repetitive recording work, and because of the limitation, the construction work with n-2 data is completely wasted.

This change removes the internal records of `InflightBlock` and turns on the request limit of `BlockTransaction` .

The remaining question is, do we need to keep the limit on the number of requests? 

### Check List

Tests

- Unit test

### Release note

```release-note
None: Exclude this PR from the release note.
```

