### PR TITLE
ci: ci not run last job in the run_job list

### DIFF
--- a/.github/actions/ci_prologue/ci_prologue.sh
+++ b/.github/actions/ci_prologue/ci_prologue.sh
@@ -8,7 +8,7 @@ fun_run_os(){
   echo "$runs_on" | sed "s/\[//g" | sed "s/\]//g" | sed "s/,/\n/g" > runs_on.txt
   while read -r LINE;
   do
-    LINE=$(echo "$LINE" | sed -e 's/\r//g')
+    LINE="$(echo "$LINE" | tr -d '[:space:]')"
     echo "OS LINE is "$LINE
       if [[ $github_workflow_os == $LINE  ]];then
         os_skip="run"
@@ -24,7 +24,7 @@ fun_jobs(){
   echo "$job_list" | sed "s/\[//g" | sed "s/\]//g" | sed "s/,/\n/g" > job_run.txt
   while read -r LINE;
   do
-    LINE="ci_"$(echo "$LINE" | sed -e 's/\r//g')
+    LINE="ci_$(echo "$LINE" | tr -d '[:space:]')"
     if [[ $GITHUB_WORKFLOW == "$LINE"* ]];then
       echo "job_name is"$LINE
       echo $GITHUB_WORKFLOW
@@ -109,5 +109,3 @@ if [[ $GITHUB_EVENT_NAME == "pull_request" ]];then
     fi
   fi
 fi
-
-


### PR DESCRIPTION
### What problem does this PR solve?

CI not run last job in the runs_only list , since the  in the last job contains a space, fix it

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

