### PR TITLE
chore: limit number of unknown transactions per peer

### DIFF
--- a/sync/src/relayer/transaction_hashes_process.rs
+++ b/sync/src/relayer/transaction_hashes_process.rs
@@ -45,8 +45,6 @@ impl<'a> TransactionHashesProcess<'a> {
                 .collect()
         };
 
-        state.add_ask_for_txs(self.peer, tx_hashes);
-
-        Status::ok()
+        state.add_ask_for_txs(self.peer, tx_hashes)
     }
 }

--- a/sync/src/status.rs
+++ b/sync/src/status.rs
@@ -101,6 +101,8 @@ pub enum StatusCode {
     GetHeadersMissCommonAncestors = 414,
     /// Headers verified failed
     HeadersIsInvalid = 415,
+    /// Too many unknown transactions
+    TooManyUnknownTransactions = 416,
 
     ///////////////////////////////////
     //      Warning 5xx              //

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -402,6 +402,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(PoolPersisted),
         Box::new(TransactionRelayBasic),
         Box::new(TransactionRelayLowFeeRate),
+        Box::new(TooManyUnknownTransactions),
         // TODO failed on poor CI server
         // Box::new(TransactionRelayMultiple),
         Box::new(RelayInvalidTransaction),

--- a/test/src/specs/relay/mod.rs
+++ b/test/src/specs/relay/mod.rs
@@ -2,6 +2,7 @@ mod block_relay;
 mod compact_block;
 mod get_block_proposal_process;
 mod get_block_transactions_process;
+mod too_many_unknown_transactions;
 mod transaction_relay;
 mod transaction_relay_low_fee_rate;
 
@@ -9,5 +10,6 @@ pub use block_relay::*;
 pub use compact_block::*;
 pub use get_block_proposal_process::ProposalRespondSizelimit;
 pub use get_block_transactions_process::*;
+pub use too_many_unknown_transactions::TooManyUnknownTransactions;
 pub use transaction_relay::*;
 pub use transaction_relay_low_fee_rate::TransactionRelayLowFeeRate;

--- a/test/src/specs/relay/too_many_unknown_transactions.rs
+++ b/test/src/specs/relay/too_many_unknown_transactions.rs
@@ -1,0 +1,47 @@
+use crate::util::cell::gen_spendable;
+use crate::util::transaction::always_success_transaction;
+use crate::utils::{build_relay_tx_hashes, since_from_absolute_timestamp, wait_until};
+use crate::{Net, Node, Spec};
+use ckb_constant::sync::{MAX_RELAY_TXS_NUM_PER_BATCH, MAX_UNKNOWN_TX_HASHES_SIZE_PER_PEER};
+use ckb_network::SupportProtocols;
+use ckb_types::packed::CellInput;
+
+pub struct TooManyUnknownTransactions;
+
+impl Spec for TooManyUnknownTransactions {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+        let mut net = Net::new(
+            self.name(),
+            node0.consensus(),
+            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+        );
+        net.connect(node0);
+
+        // Send `MAX_UNKNOWN_TX_HASHES_SIZE_PER_PEER` transactions with a same input
+        let input = gen_spendable(node0, 1)[0].to_owned();
+        let tx_template = always_success_transaction(node0, &input);
+        let txs = {
+            (0..MAX_UNKNOWN_TX_HASHES_SIZE_PER_PEER).map(|i| {
+                let since = since_from_absolute_timestamp(i as u64);
+                tx_template
+                    .as_advanced_builder()
+                    .set_inputs(vec![CellInput::new(input.out_point.clone(), since)])
+                    .build()
+            })
+        };
+        let tx_hashes = txs.map(|tx| tx.hash()).collect::<Vec<_>>();
+        assert!(MAX_RELAY_TXS_NUM_PER_BATCH >= tx_hashes.len());
+        net.send(
+            node0,
+            SupportProtocols::Relay,
+            build_relay_tx_hashes(&tx_hashes),
+        );
+
+        let banned = wait_until(60, || node0.rpc_client().get_banned_addresses().len() == 1);
+        assert!(
+            banned,
+            "NetController should be banned cause TooManyUnknownTransactions"
+        );
+    }
+}

--- a/util/constant/src/sync.rs
+++ b/util/constant/src/sync.rs
@@ -63,3 +63,10 @@ pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
 /// Default ban time for sync useless
 // 10 minutes, peer have no common ancestor block
 pub const SYNC_USELESS_BAN_TIME: Duration = Duration::from_secs(10 * 60);
+
+/// The maximum number transaction hashes inside a `RelayTransactionHashes` message
+pub const MAX_RELAY_TXS_NUM_PER_BATCH: usize = 32767;
+/// The soft limit to the number of unknown transactions
+pub const MAX_UNKNOWN_TX_HASHES_SIZE: usize = 50000;
+/// The soft limit to the number of unknown transactions per peer
+pub const MAX_UNKNOWN_TX_HASHES_SIZE_PER_PEER: usize = MAX_RELAY_TXS_NUM_PER_BATCH;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

A peer is allowed to send too many transactions hash but doesn't respond with the transaction entities.

### What is changed and how it works?

What's Changed:

Ban peer which sends too many unknown transactions hash.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

