### PR TITLE
feat: retain candidate uncle until next epoch

### DIFF
--- a/tx-pool/src/block_assembler/candidate_uncles.rs
+++ b/tx-pool/src/block_assembler/candidate_uncles.rs
@@ -64,7 +64,7 @@ impl CandidateUncles {
         self.map.values().flat_map(HashSet::iter)
     }
 
-    pub fn remove(&mut self, uncle: &UncleBlockView) -> bool {
+    pub fn remove_by_number(&mut self, uncle: &UncleBlockView) -> bool {
         let number: BlockNumber = uncle.header().number();
 
         if let Entry::Occupied(mut entry) = self.map.entry(number) {

--- a/tx-pool/src/block_assembler/candidate_uncles.rs
+++ b/tx-pool/src/block_assembler/candidate_uncles.rs
@@ -11,12 +11,14 @@ const MAX_PER_HEIGHT: usize = 10;
 #[cfg(test)]
 pub(crate) const MAX_PER_HEIGHT: usize = 2;
 
+/// Candidate uncles container
 pub struct CandidateUncles {
     pub(crate) map: BTreeMap<BlockNumber, HashSet<UncleBlockView>>,
     count: usize,
 }
 
 impl CandidateUncles {
+    /// Construct new candidate uncles container
     pub fn new() -> CandidateUncles {
         CandidateUncles {
             map: BTreeMap::new(),
@@ -24,6 +26,9 @@ impl CandidateUncles {
         }
     }
 
+    /// insert new candidate uncles
+    /// If the map did not have this value present, true is returned.
+    /// If the map did have this value present, false is returned.
     pub fn insert(&mut self, uncle: UncleBlockView) -> bool {
         let number: BlockNumber = uncle.header().number();
         if self.count >= MAX_CANDIDATE_UNCLES {
@@ -49,21 +54,38 @@ impl CandidateUncles {
         }
     }
 
-    #[cfg(test)]
+    /// Returns the number of elements in the container.
     pub fn len(&self) -> usize {
         self.count
     }
 
+    /// Returns true if the container contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     #[cfg(test)]
+    /// Removing all values.
     pub fn clear(&mut self) {
         self.map.clear();
         self.count = 0;
     }
 
+    /// Returns true if the container contains a value.
+    pub fn contains(&self, uncle: &UncleBlockView) -> bool {
+        let number: BlockNumber = uncle.header().number();
+        self.map
+            .get(&number)
+            .map(|set| set.contains(uncle))
+            .unwrap_or(false)
+    }
+
+    /// Gets an iterator over the values of the map, in order by block_number.
     pub fn values(&self) -> impl Iterator<Item = &UncleBlockView> {
         self.map.values().flat_map(HashSet::iter)
     }
 
+    /// Removes uncles from the container by specified uncle's number
     pub fn remove_by_number(&mut self, uncle: &UncleBlockView) -> bool {
         let number: BlockNumber = uncle.header().number();
 
@@ -78,5 +100,11 @@ impl CandidateUncles {
             }
         }
         false
+    }
+}
+
+impl Default for CandidateUncles {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -1,3 +1,5 @@
+//! Generate a new block
+
 mod candidate_uncles;
 
 #[cfg(test)]
@@ -31,26 +33,31 @@ use tokio::task::block_in_place;
 const BLOCK_TEMPLATE_TIMEOUT: u64 = 3000;
 const TEMPLATE_CACHE_SIZE: usize = 10;
 
-pub struct TemplateCache {
-    pub time: u64,
-    pub uncles_updated_at: u64,
-    pub txs_updated_at: u64,
-    pub template: BlockTemplate,
+pub(crate) struct TemplateCache {
+    pub(crate) time: u64,
+    pub(crate) uncles_updated_at: u64,
+    pub(crate) txs_updated_at: u64,
+    pub(crate) template: BlockTemplate,
 }
 
 impl TemplateCache {
-    pub fn is_outdate(&self, current_time: u64) -> bool {
+    pub(crate) fn is_outdate(&self, current_time: u64) -> bool {
         current_time.saturating_sub(self.time) > BLOCK_TEMPLATE_TIMEOUT
     }
 
-    pub fn is_modified(&self, last_uncles_updated_at: u64, last_txs_updated_at: u64) -> bool {
+    pub(crate) fn is_modified(
+        &self,
+        last_uncles_updated_at: u64,
+        last_txs_updated_at: u64,
+    ) -> bool {
         last_uncles_updated_at != self.uncles_updated_at
             || last_txs_updated_at != self.txs_updated_at
     }
 }
 
-pub type BlockTemplateCacheKey = (Byte32, Cycle, u64, Version);
+pub(crate) type BlockTemplateCacheKey = (Byte32, Cycle, u64, Version);
 
+/// Block generator
 #[derive(Clone)]
 pub struct BlockAssembler {
     pub(crate) config: Arc<BlockAssemblerConfig>,
@@ -61,6 +68,7 @@ pub struct BlockAssembler {
 }
 
 impl BlockAssembler {
+    /// Construct new block generator
     pub fn new(config: BlockAssemblerConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -214,12 +222,13 @@ impl BlockAssembler {
         Ok(tx)
     }
 
+    /// Get uncles from snapshot and current states.
     // A block B1 is considered to be the uncle of another block B2 if all of the following conditions are met:
     // (1) they are in the same epoch, sharing the same difficulty;
     // (2) height(B2) > height(B1);
     // (3) B1's parent is either B2's ancestor or embedded in B2 or its ancestors as an uncle;
     // and (4) B2 is the first block in its chain to refer to B1.
-    pub(crate) fn prepare_uncles(
+    pub fn prepare_uncles(
         snapshot: &Snapshot,
         candidate_number: BlockNumber,
         current_epoch_ext: &EpochExt,

--- a/tx-pool/src/block_assembler/tests.rs
+++ b/tx-pool/src/block_assembler/tests.rs
@@ -17,7 +17,7 @@ fn test_candidate_uncles_basic() {
     assert!(!candidate_uncles.insert(block.clone()));
     assert_eq!(candidate_uncles.len(), 1);
 
-    assert!(candidate_uncles.remove(&block));
+    assert!(candidate_uncles.remove_by_number(&block));
     assert_eq!(candidate_uncles.len(), 0);
     assert_eq!(candidate_uncles.map.len(), 0);
 }

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -1,7 +1,7 @@
 //! CKB Tx-pool stores transactions,
 //! design for CKB [Two-Step-Transaction-Confirmation](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0020-ckb-consensus-protocol/0020-ckb-consensus-protocol.md#Two-Step-Transaction-Confirmation) mechanism
 
-mod block_assembler;
+pub mod block_assembler;
 mod callback;
 mod chunk_process;
 mod component;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:  Now, candidate uncles will be clear immediately once we checked it's invalid, but this is variable and temporary, we should keep candidate until next epoch.

### What is changed and how it works?

Proposal: retain candidate uncle until next epoch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

