### PR TITLE
fix: upgrade ckb-vm to fix snapshot behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc970484276d48edf06898acbff1de31ab393ef06cabdf44fbfa9dc955f7ce"
+checksum = "06b6f802b72e5ad5cc175a5441c9b0a193bd95e951ce2d2059fe8120e2be5ee5"
 dependencies = [
  "byteorder",
  "bytes 1.1.0",
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1196233775bb4a20804baf375aa0e1be48d08c54a3ee28efaa625d6652ee2e4f"
+checksum = "45af9be584526f91e1517739802d0ebf82eb8d14853c45128ce930144a171ddd"
 
 [[package]]
 name = "clang-sys"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -21,8 +21,8 @@ ckb-traits = { path = "../traits", version = "= 0.102.0-pre" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types", version = "= 0.102.0-pre"}
 ckb-hash = {path = "../util/hash", version = "= 0.102.0-pre"}
-ckb-vm-definitions = "0.20.0"
-ckb-vm = { version = "0.20.0", default-features = false }
+ckb-vm-definitions = "0.20.1"
+ckb-vm = { version = "0.20.1", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.102.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/script/src/syscalls/tests/vm_latest/syscalls_1.rs
+++ b/script/src/syscalls/tests/vm_latest/syscalls_1.rs
@@ -885,6 +885,7 @@ fn _test_load_cell_data_as_code(data: &[u8]) -> Result<(), TestCaseError> {
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -892,6 +893,7 @@ fn _test_load_cell_data_as_code(data: &[u8]) -> Result<(), TestCaseError> {
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     prop_assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
@@ -941,6 +943,7 @@ fn _test_load_cell_data(data: &[u8]) -> Result<(), TestCaseError> {
     let resolved_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -948,6 +951,7 @@ fn _test_load_cell_data(data: &[u8]) -> Result<(), TestCaseError> {
         &resolved_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     prop_assert!(load_code.ecall(&mut machine).is_ok());
@@ -1010,6 +1014,7 @@ fn test_load_overflowed_cell_data_as_code() {
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -1017,6 +1022,7 @@ fn test_load_overflowed_cell_data_as_code() {
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
@@ -1057,6 +1063,7 @@ fn _test_load_cell_data_on_freezed_memory(as_code: bool, data: &[u8]) -> Result<
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -1064,6 +1071,7 @@ fn _test_load_cell_data_on_freezed_memory(as_code: bool, data: &[u8]) -> Result<
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     prop_assert!(load_code.ecall(&mut machine).is_err());
@@ -1112,6 +1120,7 @@ fn test_load_code_unaligned_error() {
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -1119,6 +1128,7 @@ fn test_load_code_unaligned_error() {
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
@@ -1154,6 +1164,7 @@ fn test_load_code_slice_out_of_bound_error() {
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -1161,6 +1172,7 @@ fn test_load_code_slice_out_of_bound_error() {
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());
@@ -1199,6 +1211,7 @@ fn test_load_code_not_enough_space_error() {
     let resolved_cell_deps = vec![dep_cell];
     let group_inputs = vec![];
     let group_outputs = vec![];
+    let tracing_flags = Default::default();
     let mut load_code = LoadCellData::new(
         &data_loader,
         &outputs,
@@ -1206,6 +1219,7 @@ fn test_load_code_not_enough_space_error() {
         &resolved_cell_deps,
         &group_inputs,
         &group_outputs,
+        &tracing_flags,
     );
 
     assert!(machine.memory_mut().store_byte(addr, addr_size, 1).is_ok());

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -6,8 +6,9 @@ use ckb_types::{
 };
 use ckb_vm::{
     machine::{VERSION0, VERSION1},
+    memory::{FLAG_EXECUTABLE, FLAG_FREEZED},
     snapshot::{make_snapshot, Snapshot},
-    SupportMachine, ISA_B, ISA_IMC, ISA_MOP,
+    CoreMachine as _, Memory, SupportMachine, ISA_B, ISA_IMC, ISA_MOP, RISCV_PAGESIZE,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -230,6 +231,10 @@ pub struct TransactionState<'a> {
     pub current_cycles: Cycle,
     /// limit cycles
     pub limit_cycles: Cycle,
+    /// enable snapshot page dirty flags
+    pub enable_backup_page_flags: bool,
+    /// tracing data as code page index
+    pub flags_tracing: Vec<(u64, u64)>,
 }
 
 impl TransactionState<'_> {
@@ -270,11 +275,30 @@ impl TryFrom<TransactionState<'_>> for TransactionSnapshot {
             mut vm,
             current_cycles,
             limit_cycles,
+            enable_backup_page_flags,
+            flags_tracing,
         } = state;
 
         // we should not capture snapshot if load program failed by exceeded cycles
         let (snap, current_cycles) = if vm.program_loaded {
             let vm_cycles = vm.cycles();
+            // To be consistent with the mainnet, add this flag to enable this behavior after hardfork
+            if !enable_backup_page_flags {
+                for (addr, memory_size) in flags_tracing {
+                    let mut current_addr = addr;
+                    while current_addr < addr + memory_size {
+                        let page = current_addr / RISCV_PAGESIZE as u64;
+                        vm.machine
+                            .machine
+                            .memory_mut()
+                            .clear_flag(page, FLAG_EXECUTABLE | FLAG_FREEZED)
+                            .map_err(|e| {
+                                ScriptError::VMInternalError(format!("{:?}", e)).unknown_source()
+                            })?;
+                        current_addr += RISCV_PAGESIZE as u64;
+                    }
+                }
+            }
             (
                 Some(make_snapshot(&mut vm.machine.machine).map_err(|e| {
                     ScriptError::VMInternalError(format!("{:?}", e)).unknown_source()

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -129,6 +129,8 @@ pub struct TransactionScriptsVerifier<'a, DL> {
 
     lock_groups: HashMap<Byte32, ScriptGroup>,
     type_groups: HashMap<Byte32, ScriptGroup>,
+    // Vec<(addr, size)>, can be remove after hardfork
+    pub(crate) tracing_data_as_code_pages: RefCell<Vec<(u64, u64)>>,
 }
 
 impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, DL> {
@@ -228,6 +230,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                     debug!("script group: {} DEBUG OUTPUT: {}", hash, message);
                 },
             ),
+            tracing_data_as_code_pages: RefCell::new(Vec::new()),
         }
     }
 
@@ -326,6 +329,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             self.resolved_cell_deps(),
             group_inputs,
             group_outputs,
+            &self.tracing_data_as_code_pages,
         )
     }
 
@@ -479,6 +483,8 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             vm,
             current_cycles,
             limit_cycles,
+            enable_backup_page_flags: self.is_vm_version_1_and_syscalls_2_enabled(),
+            flags_tracing: self.tracing_data_as_code_pages.borrow().clone(),
         }
     }
 
@@ -656,6 +662,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
         vm.set_max_cycles(limit_cycles);
         match vm.machine.run() {
             Ok(code) => {
+                self.tracing_data_as_code_pages.borrow_mut().clear();
                 if code == 0 {
                     current_used = wrapping_cycles_add(current_used, vm.cycles(), &current_group)?;
                     cycles = wrapping_cycles_add(cycles, vm.cycles(), &current_group)?;
@@ -671,9 +678,10 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                     return Ok(VerifyResult::Suspended(state));
                 }
                 error => {
+                    self.tracing_data_as_code_pages.borrow_mut().clear();
                     return Err(ScriptError::VMInternalError(format!("{:?}", error))
                         .source(&current_group)
-                        .into())
+                        .into());
                 }
             },
         }
@@ -955,6 +963,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             .add_cycles_no_checking(transferred_byte_cycles(bytes))
             .map_err(map_vm_internal_error)?;
         let code = machine.run().map_err(map_vm_internal_error)?;
+        self.tracing_data_as_code_pages.borrow_mut().clear();
         if code == 0 {
             Ok(machine.machine.cycles())
         } else {
@@ -975,17 +984,16 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             _ => ScriptError::VMInternalError(format!("{:?}", error)),
         };
 
-        let program = self.extract_script(&script_group.script)?;
-        let bytes = machine
-            .load_program(&program, &[])
-            .map_err(map_vm_internal_error)?;
-
         // we should not capture snapshot if load program failed by exceeded cycles
         if let Some(sp) = snap {
             resume(&mut machine.machine, sp).map_err(map_vm_internal_error)?;
         } else {
+            let program = self.extract_script(&script_group.script)?;
+            let bytes = machine
+                .load_program(&program, &[])
+                .map_err(map_vm_internal_error)?;
             let load_ret = machine.machine.add_cycles(transferred_byte_cycles(bytes));
-            if matches!(load_ret, Err(error) if error == VMInternalError::InvalidCycles) {
+            if matches!(load_ret, Err(ref error) if error == &VMInternalError::InvalidCycles) {
                 return Ok(ChunkState::Suspended(ResumableMachine::new(machine, false)));
             }
             load_ret.map_err(|e| ScriptError::VMInternalError(format!("{:?}", e)))?;
@@ -993,6 +1001,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
 
         match machine.run() {
             Ok(code) => {
+                self.tracing_data_as_code_pages.borrow_mut().clear();
                 if code == 0 {
                     Ok(ChunkState::Completed(machine.machine.cycles()))
                 } else {
@@ -1003,7 +1012,10 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                 VMInternalError::InvalidCycles => {
                     Ok(ChunkState::Suspended(ResumableMachine::new(machine, true)))
                 }
-                _ => Err(ScriptError::VMInternalError(format!("{:?}", error))),
+                _ => {
+                    self.tracing_data_as_code_pages.borrow_mut().clear();
+                    Err(ScriptError::VMInternalError(format!("{:?}", error)))
+                }
             },
         }
     }

--- a/test/src/specs/hardfork/v2021/vm_b_extension.rs
+++ b/test/src/specs/hardfork/v2021/vm_b_extension.rs
@@ -204,9 +204,12 @@ impl ExpectedResult {
             ),
             Self::InvalidInstruction => Some(
                 "{\"code\":-302,\"message\":\"TransactionFailedToVerify: \
-                 Verification failed Script(TransactionScriptError { \
-                 source: Outputs[0].Type, \
-                 cause: VM Internal Error: InvalidInstruction(",
+                Verification failed Script(TransactionScriptError { \
+                source: Outputs[0].Type, \
+                cause: VM Internal Error: InvalidInstruction { pc: 65874, instruction: 1613306131 } })\",\
+                \"data\":\"Verification(Error { kind: Script, inner: TransactionScriptError { \
+                source: Outputs[0].Type, \
+                cause: VM Internal Error: InvalidInstruction { pc: 65874, instruction: 1613306131 } } })\"}",
             ),
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

chunk run with the snapshot unable to support the binary replacement behavior of exec, which will cause abnormal behavior after resume.

The upgraded VM supports backing up the current code(executable pages)  to the snapshot to fix the above problems. https://github.com/nervosnetwork/ckb-vm/pull/218

and https://github.com/nervosnetwork/ckb/pull/3176 should keep its behavior until hardfork activated

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

