### PR TITLE
chore: output miner status

### DIFF
--- a/ckb-bin/src/subcommand/stats.rs
+++ b/ckb-bin/src/subcommand/stats.rs
@@ -3,11 +3,19 @@ use ckb_async_runtime::Handle;
 use ckb_launcher::SharedBuilder;
 use ckb_shared::Shared;
 use ckb_store::ChainStore;
-use ckb_types::core::BlockNumber;
+use ckb_types::{
+    core::{BlockNumber, ScriptHashType},
+    packed::CellbaseWitness,
+    prelude::*,
+};
+use std::cmp::max;
+use std::collections::HashMap;
+use std::convert::TryFrom;
 
 pub fn stats(args: StatsArgs, async_handle: Handle) -> Result<(), ExitCode> {
     let stats = Statics::build(args, async_handle)?;
     stats.print_uncle_rate()?;
+    stats.print_miner_statics()?;
     Ok(())
 }
 
@@ -61,6 +69,69 @@ impl Statics {
             block_nums,
             uncle_nums as f64 / block_nums as f64
         );
+        Ok(())
+    }
+
+    fn print_miner_statics(&self) -> Result<(), ExitCode> {
+        let store = self.shared.store();
+        let mut by_miner_script = HashMap::new();
+        let mut by_miner_message = HashMap::new();
+        // count maximum 1000 blocks
+        let from = max(self.to.saturating_sub(999), self.from);
+        for i in from..=self.to {
+            let cellbase = store
+                .get_block_hash(i)
+                .and_then(|hash| store.get_cellbase(&hash))
+                .ok_or(ExitCode::IO)?;
+            let cellbase_witness = cellbase
+                .witnesses()
+                .get(0)
+                .and_then(|witness| CellbaseWitness::from_slice(&witness.raw_data()).ok())
+                .expect("cellbase witness should be ok");
+            by_miner_script
+                .entry(cellbase_witness.lock())
+                .and_modify(|e| *e += 1)
+                .or_insert(1);
+            by_miner_message
+                .entry(cellbase_witness.message().raw_data())
+                .and_modify(|e| *e += 1)
+                .or_insert(1);
+        }
+        let total = self.to - from;
+
+        let mut by_miner_script_vec: Vec<_> = by_miner_script.into_iter().collect();
+        by_miner_script_vec.sort_by_key(|(_, v)| *v);
+        println!("by_miner_script:");
+        println!(
+            "{0: <10} | {1: <5} | {2: <40} | {3: <64} | {4: <9} ",
+            "percentage", "total", "args", "code_hash", "hash_type"
+        );
+        for (script, count) in by_miner_script_vec.iter().rev() {
+            println!(
+                "{0: <10} | {1: <5} | {2: <40x} | {3: <64x} | {4: <9?}",
+                format!("{:.1}%", 100.0 * (*count as f64) / (total as f64)),
+                count,
+                script.args().raw_data(),
+                script.code_hash(),
+                ScriptHashType::try_from(script.hash_type()).expect("checked script hash type"),
+            );
+        }
+
+        let mut by_miner_message_vec: Vec<_> = by_miner_message.into_iter().collect();
+        by_miner_message_vec.sort_by_key(|(_, v)| *v);
+        println!("by_miner_message:");
+        println!(
+            "{0: <10} | {1: <5} | {2: <50}",
+            "percentage", "total", "messages"
+        );
+        for (message, count) in by_miner_message_vec.iter().rev() {
+            println!(
+                "{0: <10} | {1: <5} | {2: <50?}",
+                format!("{:.1}%", 100.0 * (*count as f64) / (total as f64)),
+                count,
+                message,
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

outputs miner status in cli cmd

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
uncle_rate: 153507/5920421(0.025928392592351118)
by_miner_script:
percentage | total | args                                     | code_hash                                                        | hash_type 
35.9%      | 359   | dde7801c073dfb3464c7b1f05b806bb2bbb84e99 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
18.6%      | 186   | 7164f48d7a5bf2298166f8d81b81ea4e908e16ad | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
14.0%      | 140   | ba6caca0c7e893e412d67264c2eb2a1fc13c46fd | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
11.3%      | 113   | 4a336470564d07ca7059b7980481c2d59809d637 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
8.2%       | 82    | 23ca27e4b95f962e4dd6618fb5fd79cf70006597 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
5.2%       | 52    | 787725429829c280dbd225d8627fc88f57b0eaa5 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
2.3%       | 23    | ed99d08d751ae32df7fc6f3048b7cca56c3bfafa | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
1.6%       | 16    | a528f2b9a51118b193178db4cf2f3db92e7df323 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
1.2%       | 12    | 60cdc4aa67a4543f4246fba0cfcd55859c5d3ddd | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
0.9%       | 9     | 131d807770e13558a387ead6ddad83f77a99f4b8 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
0.8%       | 8     | 87c713e60afa56ca8711942fc57e9666d7474694 | 9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 | Type
by_miner_message:
percentage | total | messages                                          
35.9%      | 359   | b"0.101.1 (6d73bd2-dirty 2021-10-29) \0\0\0\0"
30.7%      | 307   | b"0.101.1 (fb1e5dd 2021-10-27)"
19.2%      | 192   | b""
8.2%       | 82    | b"\x124Vx\x90"
2.3%       | 23    | b"0.101.1 (fb1e5dd 2021-10-27) MinedByViaBTC"
2.1%       | 21    | b"0.101.1 (fb1e5dd 2021-10-27) BixinKelePool"
1.6%       | 16    | b"\0\0\0\0"
```

to avoid introducing bench32 dependencies, this PR only output miner scripts in hex format instead of address string, user may use the ckb-cli to get the address:

```
ckb-cli util key-info --lock-arg dde7801c073dfb3464c7b1f05b806bb2bbb84e99
address:
  mainnet: ckb1qyqdmeuqrsrnm7e5vnrmruzmsp4m9wacf6vsxasryq

```

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

