### PR TITLE
chore: remove unnecessary timer

### DIFF
--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -146,7 +146,7 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
                                 state.remote_addr.change_to_listen();
                             }
 
-                            let max = ::std::cmp::max(MAX_ADDR_TO_SEND, count as usize);
+                            let max = ::std::cmp::min(MAX_ADDR_TO_SEND, count as usize);
                             if items.len() > max {
                                 items = items
                                     .choose_multiple(&mut rand::thread_rng(), max)

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -243,8 +243,6 @@ impl ServiceProtocol for CKBHandler {
             network_state: Arc::clone(&self.network_state),
             p2p_control: context.control().to_owned(),
         };
-        nc.set_notify(Duration::from_secs(6), std::u64::MAX)
-            .expect("set_notify at init should be ok");
         self.handler.init(Arc::new(nc));
     }
 
@@ -324,17 +322,12 @@ impl ServiceProtocol for CKBHandler {
         if !self.network_state.is_active() {
             return;
         }
-
-        if token == std::u64::MAX {
-            trace!("protocol handler heart beat {}", self.proto_id);
-        } else {
-            let nc = DefaultCKBProtocolContext {
-                proto_id: self.proto_id,
-                network_state: Arc::clone(&self.network_state),
-                p2p_control: context.control().to_owned(),
-            };
-            self.handler.notify(Arc::new(nc), token);
-        }
+        let nc = DefaultCKBProtocolContext {
+            proto_id: self.proto_id,
+            network_state: Arc::clone(&self.network_state),
+            p2p_control: context.control().to_owned(),
+        };
+        self.handler.notify(Arc::new(nc), token);
     }
 
     fn poll(


### PR DESCRIPTION
### What problem does this PR solve?

After more than two years of operation, I am sure that the stability of Tentacle’s notify can be guaranteed. This PR removes this unnecessary timer 

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

