### PR TITLE
chore: upgrade deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,9 +1985,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2000,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2010,15 +2010,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2028,17 +2028,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -2046,18 +2045,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-timer"
@@ -2067,9 +2063,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2080,8 +2076,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -2479,9 +2473,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "ipnetwork"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
 ]
@@ -3347,18 +3341,6 @@ checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 dependencies = [
  "toml",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -29,7 +29,7 @@ secp256k1 = {version = "0.19", features = ["recovery"], optional = true }
 trust-dns-resolver = { version = "0.20", optional = true }
 snap = "1"
 ckb-types = { path = "../util/types", version = "= 0.102.0-pre" }
-ipnetwork = "0.14"
+ipnetwork = "0.18"
 serde_json = "1.0"
 bloom-filters = "0.1"
 ckb-spawn = { path = "../util/spawn", version = "= 0.102.0-pre" }


### PR DESCRIPTION
### What problem does this PR solve?

ipnetwork 0.14 -> 0.18

There is no security fix, only partially optimized code

https://github.com/achanda/ipnetwork/compare/v0.14.0...v0.18.0

futures 0.3.12 -> 0.3.18
```
# 0.3.18 - 2021-11-23

* Fix unusable `Sink` implementation on `stream::Scan` (#2499)
* Make `task::noop_waker_ref` available without `std` feature (#2505)
* Add async `LineWriter` (#2477)
* Remove dependency on `proc-macro-hack`. This raises MSRV of utility crates to 1.45. (#2520)

# 0.3.17 - 2021-08-30

* Use `FuturesOrdered` in `join_all` (#2412)
* Add `{future, stream}::poll_immediate` (#2452)
* Add `stream_select!` macro (#2262)
* Implement `Default` for `OptionFuture` (#2471)
* Add `Peekable::{peek_mut, poll_peek_mut}` (#2488)
* Add `BufReader::seek_relative` (#2489)

# 0.3.16 - 2021-07-23

* Add `TryStreamExt::try_chunks` (#2438)
* Add `StreamExt::{all, any}` (#2460)
* Add `stream::select_with_strategy` (#2450)
* Update to new `io_slice_advance` interface (#2454)

# 0.3.15 - 2021-05-11

* Use `#[proc_macro]` at Rust 1.45+ to fix an issue where proc macros don't work with rust-analyzer (#2407)
* Support targets that do not have atomic CAS on stable Rust (#2400)
* futures-test: Add async `#[test]` function attribute (#2409)
* Add `stream::abortable` (#2410)
* Add `FuturesUnordered::clear` (#2415)
* Implement `IntoIterator` for `FuturesUnordered` (#2423)
* Implement `Send` and `Sync` for `FuturesUnordered` iterators (#2416)
* Make `FuturesUnordered::iter_pin_ref` public (#2423)
* Add `SelectAll::clear` (#2430)
* Add `SelectAll::{iter, iter_mut}` (#2428)
* Implement `IntoIterator` for `SelectAll` (#2428)
* Implement `Clone` for `WeakShared` (#2396)

# 0.3.14 - 2021-04-10

* Add `future::SelectAll::into_inner` (#2363)
* Allow calling `UnboundedReceiver::try_next` after `None` (#2369)
* Reexport non-Ext traits from the root of `futures_util` (#2377)
* Add `AsyncSeekExt::stream_position` (#2380)
* Add `stream::Peekable::{next_if, next_if_eq}` (#2379)

# 0.3.13 - 2021-02-23

* Mitigated starvation issues in `FuturesUnordered` (#2333)
* Fixed race with dropping `mpsc::Receiver` (#2304)
* Added `Shared::{strong_count, weak_count}` (#2346)
* Added `no_std` support for `task::noop_waker_ref` (#2332)
* Implemented `Stream::size_hint` for `Either` (#2325)
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

