### PR TITLE
feat: run sync-mainnet.yml on self-hosted runner

### DIFF
--- a/.github/workflows/sync-mainnet.yml
+++ b/.github/workflows/sync-mainnet.yml
@@ -1,0 +1,32 @@
+name: Sync Mainnet
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  sync-mainnet:
+    runs-on: [ self-hosted, linux ]
+    if: ${{ github.repository_owner == 'nervosnetwork' }}
+    timeout-minutes: 1200
+    env:
+      AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: nervosnetwork/ckb-integration-test
+      - name: Get Current Date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Start
+        timeout-minutes: 1200
+        env:
+          JOB_ID: "sync-mainnet-${{ steps.date.outputs.date }}-in-10h"
+        run: ./ckb-sync-mainnet/script/sync-mainnet.sh run
+      - name: Clean Up
+        if: ${{ always() }}
+        env:
+          JOB_ID: "sync-mainnet-${{ steps.date.outputs.date }}-in-10h"
+        run: ./ckb-sync-mainnet/script/sync-mainnet.sh clean


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed: This PR adds a new GitHub Actions workflow sync-mainnet.yml. sync-mainnet.yml runs [CKB Sync Mainnet Test](https://github.com/nervosnetwork/ckb-integration-test/tree/main/ckb-sync-mainnet) on a self-hosted runner.

The reason for running this workflow on a self-hosted runner could be found from the below references:
    - https://github.community/t/one-job-stuck-for-6-hrs-and-failed/165249
    - https://github.community/t/is-that-possible-to-run-job-which-takes-more-than-6-hours-on-self-hosted-runner/17121/4

### Related changes

- https://github.com/nervosnetwork/ckb-integration-test/pull/50
- https://github.com/nervosnetwork/ckb-integration-test/pull/32

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

