### PR TITLE
chore: upgrade yamux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dae0498310f69c7cc0cfe16bc32c118bfd89e6aa49997386bd7f3135c36506"
+checksum = "f84d50536696bbb75958c07cbc687429898325081eeed6cf915de3bed50f6a75"
 dependencies = [
  "bytes 1.1.0",
  "futures",


### PR DESCRIPTION
### What problem does this PR solve?

In the default configuration, it has no effect, but we can enable the adjustment of window size after hardfork

```
## yamux 0.3.1-0.3.3 secio 0.5.1

yamux 0.3.2: edition 2018 
yamux 0.3.3 and 0.3.1: edition 2021

### Bug Fix

- Fix yamux window update(#340)
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

