### PR TITLE
chore: add aarch64 build workflow to CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,6 @@
 name = "Nervos Core Dev"
 email = "dev@nervos.org"
 edition = "2018"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -1,0 +1,58 @@
+name: ci_aarch64_build_ubuntu
+concurrency:
+  group: ci_aarch64_build_ubuntu-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches:
+      - master
+      - develop
+      - trying
+      - staging
+      - 'rc/*'
+
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTFLAGS: -D warnings
+jobs:
+  prologue:
+    name: prologue
+    runs-on: ubuntu-20.04
+    outputs:
+      os_skip: ${{ steps.prologue.outputs.os_skip }}
+      job_skip: ${{ steps.prologue.outputs.job_skip }}
+      linux_runner_label: ${{ steps.prologue.outputs.linux_runner_label }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: prologue
+      id: prologue
+      uses: ./.github/actions/ci_prologue
+      with:
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        COMMIT_MESSAGE: "${{github.event.head_commit.message}}"
+        PR_COMMONS_BODY: "${{ github.event.pull_request.body }}"
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        LABELS: "${{ toJson(github.event.pull_request.labels.*.name) }}"
+        GITHUB_REPOSITORY: ${{ github.repositoty }}
+        GITHUB_WORKFLOW: ${{ github.workflow }}
+  ci_aarch64_build_ubuntu:
+    name: ci_aarch64_build_ubuntu
+    needs: prologue
+    runs-on: ${{ needs.prologue.outputs.linux_runner_label }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: ci_aarch64_build_ubuntu
+      run: |
+        if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
+            devtools/ci/ci_main.sh
+        else
+          echo "skip job"
+          exit 0
+        fi
+    env:
+      RUNNER_LABEL: ${{ needs.prologue.outputs.runner_label }}
+

--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -49,6 +49,25 @@ ci_integration_tests*)
     rustup target add wasm32-unknown-unknown
     make wasm-build-test
     ;;
+  ci_aarch64_build*)
+    echo "ci_aarch64_build"
+    sudo apt-get install -y gcc-multilib
+    sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu clang
+    rustup target add aarch64-unknown-linux-gnu
+    curl -LO https://www.openssl.org/source/openssl-1.1.1.tar.gz
+    tar -xvzf openssl-1.1.1.tar.gz
+    cd openssl-1.1.1
+    CC=aarch64-linux-gnu-gcc ./Configure linux-aarch64 shared
+    CC=aarch64-linux-gnu-gcc make
+    cd ..
+    export TOP
+    export OPENSSL_LIB_DIR=$(pwd)/openssl-1.1.1
+    export OPENSSL_INCLUDE_DIR=$(pwd)/openssl-1.1.1/include
+    export PKG_CONFIG_ALLOW_CROSS=1
+    export CC=gcc
+    export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+    cargo build --target=aarch64-unknown-linux-gnu
+    ;;
   ci_cargo_deny*)
     echo "ci_security_audit_licenses"
     cargo deny --version || cargo +stable install cargo-deny --locked


### PR DESCRIPTION
Now that aarch64 build has been tested for a while, I propose we include
aarch64 build workflow as part of the CI process

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Add aarch64 build as part of the CI workflow

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ aarch64_build_ubuntu, quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

