### PR TITLE
ci: ckb service start failed on self runner,fix it

### DIFF
--- a/.github/workflows/smoking_test.yaml
+++ b/.github/workflows/smoking_test.yaml
@@ -30,6 +30,7 @@ jobs:
         rm -rf /tmp/ckb_*
     - name: Update ExecStart&StandardOutput
       run: |
+          sed -i  "s#User=.*#User=$USER#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
           sed -i  "s#ExecStart=.*#ExecStart=${{github.workspace}}/ckb run -C ${{github.workspace}}#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
           sed -i  "s#StandardOutput=.*#StandardOutput=file:${{github.workspace}}/data/logs/run.log#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
     - name: Init&Start ckb testnet with v0.35.0
@@ -69,6 +70,7 @@ jobs:
         cp ${CARGO_TARGET_DIR}/release/ckb ${{ github.workspace }}/ckb
     - name: Update ExecStart&StandardOutput
       run: |
+          sed -i  "s#User=.*#User=$USER#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
           sed -i  "s#ExecStart=.*#ExecStart=${{github.workspace}}/ckb run -C ${{github.workspace}}#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
           sed -i  "s#StandardOutput=.*#StandardOutput=file:${{github.workspace}}/data/logs/run.log#g" ${{ github.workspace }}/devtools/smoking_test/ckb.service
     - name: Regenerate testnet configuration
@@ -91,7 +93,7 @@ jobs:
       if: ${{ success() }}
       run: |
          rm -rf /tmp/data
-         rm -rf /tmp/ckb_*
+         rm -rf /tmp/ckb*
          sudo service ckb stop
          sudo systemctl disable ckb
          sudo systemctl daemon-reload


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

self-hosted runner has  different user name caused ckb service start failed, the smoking test failed. Change the `User` before start ckb service.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

