### PR TITLE
chore: ignore received compact block

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -97,6 +97,9 @@ impl<'a> CompactBlockProcess<'a> {
             state.may_set_best_known_header(self.peer, header_view);
 
             return StatusCode::CompactBlockAlreadyStored.with_context(block_hash);
+        } else if status.contains(BlockStatus::BLOCK_RECEIVED) {
+            // block already in orphan pool
+            return Status::ignored();
         } else if status.contains(BlockStatus::BLOCK_INVALID) {
             return StatusCode::BlockIsInvalid.with_context(block_hash);
         }

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -80,6 +80,23 @@ fn test_in_block_status_map() {
         compact_block_process.execute(),
         StatusCode::CompactBlockAlreadyStored.into(),
     );
+
+    let compact_block_process = CompactBlockProcess::new(
+        compact_block.as_reader(),
+        &relayer,
+        Arc::<MockProtocolContext>::clone(&nc),
+        peer_index,
+    );
+
+    // BLOCK_RECEIVED in block_status_map
+    {
+        relayer
+            .shared
+            .state()
+            .insert_block_status(block.header().hash(), BlockStatus::BLOCK_RECEIVED);
+    }
+
+    assert_eq!(compact_block_process.execute(), Status::ignored());
 }
 
 // send_getheaders_to_peer when UnknownParent


### PR DESCRIPTION
### What problem does this PR solve?

if block status is RECEIVED, it means block received and remain on orphan pool, the same block received afterwards does not need to be repeatedly inserted into the orphan pool 

### Check List 

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

