### PR TITLE
feat: script group consistent execution order

### DIFF
--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -2,7 +2,7 @@ use crate::ScriptError;
 use ckb_error::Error;
 use ckb_types::{
     core::{Cycle, ScriptHashType},
-    packed::{Byte32, Script},
+    packed::Script,
 };
 use ckb_vm::{
     machine::{VERSION0, VERSION1},
@@ -206,10 +206,8 @@ impl fmt::Display for ScriptGroupType {
 /// Struct specifies which script has verified so far.
 /// Snapshot is lifetime free, but capture snapshot need heavy memory copy
 pub struct TransactionSnapshot {
-    /// current suspended script
-    pub current: (ScriptGroupType, Byte32),
-    /// remain script groups to verify
-    pub remain: Vec<(ScriptGroupType, Byte32)>,
+    /// current suspended script index
+    pub current: usize,
     /// vm snapshot
     pub snap: Option<(Snapshot, Cycle)>,
     /// current consumed cycle
@@ -221,10 +219,8 @@ pub struct TransactionSnapshot {
 /// Struct specifies which script has verified so far.
 /// State lifetime bound with vm machine.
 pub struct TransactionState<'a> {
-    /// current suspended script
-    pub current: (ScriptGroupType, Byte32),
-    /// remain script groups to verify
-    pub remain: Vec<(ScriptGroupType, Byte32)>,
+    /// current suspended script index
+    pub current: usize,
     /// vm state
     pub vm: ResumableMachine<'a>,
     /// current consumed cycle
@@ -271,7 +267,6 @@ impl TryFrom<TransactionState<'_>> for TransactionSnapshot {
     fn try_from(state: TransactionState<'_>) -> Result<Self, Self::Error> {
         let TransactionState {
             current,
-            remain,
             mut vm,
             current_cycles,
             limit_cycles,
@@ -314,7 +309,6 @@ impl TryFrom<TransactionState<'_>> for TransactionSnapshot {
 
         Ok(TransactionSnapshot {
             current,
-            remain,
             snap,
             current_cycles,
             limit_cycles,
@@ -335,7 +329,6 @@ impl std::fmt::Debug for TransactionSnapshot {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("TransactionSnapshot")
             .field("current", &self.current)
-            .field("remain", &self.remain)
             .field("current_cycles", &self.current_cycles)
             .field("limit_cycles", &self.limit_cycles)
             .finish()
@@ -346,7 +339,6 @@ impl std::fmt::Debug for TransactionState<'_> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("TransactionState")
             .field("current", &self.current)
-            .field("remain", &self.remain)
             .field("current_cycles", &self.current_cycles)
             .field("limit_cycles", &self.limit_cycles)
             .finish()

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -42,7 +42,7 @@ use ckb_vm::machine::asm::AsmMachine;
 use ckb_vm::TraceMachine;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 
 #[cfg(test)]
@@ -129,8 +129,8 @@ pub struct TransactionScriptsVerifier<'a, DL> {
     binaries_by_data_hash: HashMap<Byte32, LazyData>,
     binaries_by_type_hash: HashMap<Byte32, Binaries>,
 
-    lock_groups: HashMap<Byte32, ScriptGroup>,
-    type_groups: HashMap<Byte32, ScriptGroup>,
+    lock_groups: BTreeMap<Byte32, ScriptGroup>,
+    type_groups: BTreeMap<Byte32, ScriptGroup>,
     // Vec<(addr, size)>, can be remove after hardfork
     pub(crate) tracing_data_as_code_pages: RefCell<Vec<(u64, u64)>>,
 
@@ -192,8 +192,8 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             }
         }
 
-        let mut lock_groups = HashMap::default();
-        let mut type_groups = HashMap::default();
+        let mut lock_groups = BTreeMap::default();
+        let mut type_groups = BTreeMap::default();
         for (i, cell_meta) in resolved_inputs.iter().enumerate() {
             // here we are only pre-processing the data, verify method validates
             // each input has correct script setup.

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -497,7 +497,7 @@ fn check_type_id_one_in_one_out_chunk() {
     let verifier = TransactionScriptsVerifierWithEnv::new();
 
     verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut groups: Vec<_> = verifier.groups().collect();
+        let mut groups: Vec<_> = verifier.groups_with_type().collect();
         let mut tmp: Option<ResumableMachine<'_>> = None;
 
         loop {
@@ -558,7 +558,7 @@ fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_chunk() {
     let mut cycles = 0;
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut groups: Vec<_> = verifier.groups().collect();
+        let mut groups: Vec<_> = verifier.groups_with_type().collect();
         let mut tmp: Option<ResumableMachine<'_>> = None;
 
         loop {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Normally, transaction script group execution is not order sensitivity, but consistent execution order may help prevent potential unexpected inconsistent bug

### What is changed and how it works?

Proposal:  make script group with consistent order

What's Changed:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

