### PR TITLE
feat: observe listen port occupancy

### DIFF
--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -19,8 +19,8 @@ use ckb_channel::Receiver;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_logger::info;
 use ckb_network::{
-    CKBProtocol, DefaultExitHandler, NetworkController, NetworkService, NetworkState,
-    SupportProtocols,
+    observe_listen_port_occupancy, CKBProtocol, DefaultExitHandler, NetworkController,
+    NetworkService, NetworkState, SupportProtocols,
 };
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_proposal_table::ProposalTable;
@@ -190,6 +190,10 @@ impl Launcher {
         &self,
         block_assembler_config: Option<BlockAssemblerConfig>,
     ) -> Result<(Shared, SharedPackage), ExitCode> {
+        self.async_handle.block_on(observe_listen_port_occupancy(
+            &self.args.config.network.listen_addresses,
+        ))?;
+
         let shared_builder = SharedBuilder::new(
             &self.args.config.bin_name,
             self.args.config.root_dir.as_path(),


### PR DESCRIPTION
### What problem does this PR solve?

Since the port reuse function of ckb is enabled by default on Linux, starting two ckb nodes will not report an error explicitly, after this PR will automatically exit the second ckb node 

### Check List

Tests

Manual test:
1. start 2 ckb nodes with the same net port
2. the second one will stop with an error
```
2021-12-13 17:21:31.585 +08:00 main INFO ckb_bin::helper  raise_fd_limit newly-increased limit: 524288                                 
2021-12-13 17:21:34.235 +08:00 main INFO ckb_bin::subcommand::run  ckb version: 0.102.0-pre (1595009-dirty 2021-12-13)                 
2021-12-13 17:21:34.236 +08:00 main INFO ckb_launcher  Miner is disabled, edit ckb.toml to enable it                                   
IO Error: Os { code: 98, kind: AddrInUse, message: "Address already in use" }                                                          
2021-12-13 17:21:34.236 +08:00 main INFO ckb_stop_handler  StopHandler(GT) send signal
```

### Release note 

```release-note
Title Only: Include only the PR title in the release note.
```

