### PR TITLE
chore: downgrade futures version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,9 +1986,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",


### PR DESCRIPTION
### What problem does this PR solve?

ref https://github.com/rust-lang/futures-rs/issues/2529, 0.3.18 has been yank

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

