### PR TITLE
chore(deps): bump lru from 0.6.6 to 0.7.1 to fix RUSTSEC-2021-0130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+checksum = "469898e909a1774d844793b347135a0cd344ca2f69d082013ecb8061a2229a3a"
 dependencies = [
  "hashbrown 0.11.2",
 ]

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -18,7 +18,7 @@ ckb-metrics = { path = "../util/metrics", version = "= 0.102.0-pre" }
 fs2 = "0.4.3"
 fail = "0.4"
 snap = "1"
-lru = "0.6.0"
+lru = "0.7.1"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -23,7 +23,7 @@ ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.102.0-pre" 
 hyper = { version = "0.14", features = ["http1"] }
 hyper-tls = "0.5"
 futures = "0.3"
-lru = "0.6.0"
+lru = "0.7.1"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.102.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.102.0-pre" }
 indicatif = "0.16"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-types = { path = "../util/types", version = "= 0.102.0-pre" }
 ckb-db = { path = "../db", version = "= 0.102.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.102.0-pre" }
-lru = "0.6.0"
+lru = "0.7.1"
 ckb-traits = { path = "../traits", version = "= 0.102.0-pre" }
 ckb-util = { path = "../util", version = "= 0.102.0-pre" }
 ckb-error = { path = "../error", version = "= 0.102.0-pre" }

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -28,7 +28,7 @@ ckb-error = {path = "../error", version = "= 0.102.0-pre"}
 ckb-tx-pool = { path = "../tx-pool", version = "= 0.102.0-pre" }
 sentry = { version = "0.23.0", optional = true }
 ckb-constant = { path = "../util/constant", version = "= 0.102.0-pre" }
-lru = "0.6.0"
+lru = "0.7.1"
 futures = "0.3"
 governor = "0.3.1"
 tempfile = "3.0"

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -15,7 +15,7 @@ ckb-types = { path = "../util/types", version = "= 0.102.0-pre" }
 ckb-logger = {path = "../util/logger", version = "= 0.102.0-pre"}
 ckb-verification = { path = "../verification", version = "= 0.102.0-pre" }
 faketime = "0.2"
-lru = "0.6.0"
+lru = "0.7.1"
 ckb-dao = { path = "../util/dao", version = "= 0.102.0-pre" }
 ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.102.0-pre" }
 ckb-store = { path = "../store", version = "= 0.102.0-pre" }

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -19,7 +19,7 @@ ckb-logger = { path = "../logger", version = "= 0.102.0-pre"}
 ckb-app-config = { path = "../app-config", version = "= 0.102.0-pre" }
 ckb-error = { path = "../../error", version = "= 0.102.0-pre" }
 faketime = "0.2.0"
-lru = "0.6"
+lru = "0.7.1"
 semver = "1.0"
 
 [dev-dependencies]

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -13,7 +13,7 @@ ckb-types = { path = "../util/types", version = "= 0.102.0-pre" }
 ckb-script = { path = "../script", version = "= 0.102.0-pre" }
 ckb-pow = { path = "../pow", version = "= 0.102.0-pre" }
 faketime = "0.2.0"
-lru = "0.6.0"
+lru = "0.7.1"
 ckb-traits = { path = "../traits", version = "= 0.102.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.102.0-pre" }
 ckb-dao = { path = "../util/dao", version = "= 0.102.0-pre" }


### PR DESCRIPTION
### What problem does this PR solve?

Fix #3249: [RUSTSEC-2021-0130] Use after free in lru crate.

### What is changed and how it works?

- bump lru from 0.6.6 to 0.7.1.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

[RUSTSEC-2021-0130]: https://rustsec.org/advisories/RUSTSEC-2021-0130.html
