### PR TITLE
fix: session close also should remove feeler dialing flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ integration: submodule-init setup-ckb-test ## Run integration tests in "test" di
 
 .PHONY: integration-release
 integration-release: submodule-init setup-ckb-test prod
-	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh --release -- --bin ${CARGO_TARGET_DIR}/release/ckb ${CKB_TEST_ARGS}
+	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ${CARGO_TARGET_DIR}/release/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-cov
 integration-cov: cov-install-tools submodule-init setup-ckb-test ## Run integration tests and genearte coverage report.


### PR DESCRIPTION
### What problem does this PR solve?

dial command will reject by dialing feeler or session keep online
https://github.com/nervosnetwork/ckb/blob/5b44843b0053ca8eee23249c38eaca3308bceb64/network/src/network.rs#L332-L334

dialing feeler flag will remove on feeler disconnected
https://github.com/nervosnetwork/ckb/blob/5b44843b0053ca8eee23249c38eaca3308bceb64/network/src/protocols/feeler.rs#L47-L51

But if the remote side turns off the protocol before local has opened it, the local's dialing feeler flag will not be cleared, also, this node can no longer be dial

why has such a delay on open protocol?

outbound: request open -> wait remote response -> open protocol
inbound: wait request -> send back response and open the protocol

There is a slight difference in the opening time of the two sides

### Check List

Tests 

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```