### PR TITLE
feat: port to aarch64, and provide official binary when release

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -75,6 +75,57 @@ jobs:
       BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.51.0
       REL_PKG: x86_64-unknown-linux-gnu.tar.gz
 
+  package-for-linux-aarch64:
+    name: package-for-linux-aarch64
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Env
+      run: |
+        export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
+        echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
+    - name: Add rust target
+      run: rustup target add aarch64-unknown-linux-gnu
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+    - name: Build CKB and Package CKB
+      env:
+        LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+        QINIU_ACCESS_KEY: ${{ secrets.QINIU_ACCESS_KEY }}
+        QINIU_SECRET_KEY: ${{ secrets.QINIU_SECRET_KEY }}
+        GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
+        SKIP_CKB_CLI: true
+      run: |
+        export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
+        export TOP_DIR=$(pwd)
+        curl -LO https://www.openssl.org/source/openssl-1.1.1.tar.gz
+        tar -xzf openssl-1.1.1.tar.gz
+        cd openssl-1.1.1
+        CC=aarch64-linux-gnu-gcc ./Configure linux-aarch64 shared
+        CC=aarch64-linux-gnu-gcc make
+        cd ..
+        export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-1.1.1
+        export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-1.1.1/include
+        PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release
+        gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
+        gpg --import devtools/ci/signer.asc
+        devtools/ci/package.sh target/aarch64-unknown-linux-gnu/release/ckb
+        mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
+        mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
+        devtools/ci/qput-7z "releases/ckb_${GIT_TAG_NAME}_aarch64-unknown-linux-gnu"
+    - name: upload-zip-file
+      uses: actions/upload-artifact@v2
+      with:
+        name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
+        path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
+    - name: upload-asc-file
+      uses: actions/upload-artifact@v2
+      with:
+        name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
+        path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
+    env:
+      REL_PKG: aarch64-unknown-linux-gnu.tar.gz
+
   package-for-centos:
     name: package-for-centos
     runs-on: ubuntu-latest
@@ -209,12 +260,14 @@ jobs:
       matrix:
         include:
           - REL_PKG: x86_64-unknown-linux-gnu.tar.gz
+          - REL_PKG: aarch64-unknown-linux-gnu.tar.gz
           - REL_PKG: x86_64-unknown-centos-gnu.tar.gz
           - REL_PKG: x86_64-apple-darwin.zip
           - REL_PKG: x86_64-pc-windows-msvc.zip
     needs:
       - create-release
       - package-for-linux
+      - package-for-linux-aarch64
       - package-for-mac
       - package-for-windows
       - package-for-centos

--- a/devtools/ci/package.sh
+++ b/devtools/ci/package.sh
@@ -24,13 +24,15 @@ cp -R devtools/init "releases/$PKG_NAME"
 cp -R docs "releases/$PKG_NAME"
 cp rpc/README.md "releases/$PKG_NAME/docs/rpc.md"
 
-curl -LO "https://github.com/nervosnetwork/ckb-cli/releases/download/${CKB_CLI_VERSION}/ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
-if [ "${REL_PKG##*.}" = "zip" ]; then
-  unzip "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
-else
-  tar -xzf "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+if [ ! "${SKIP_CKB_CLI:-false}" == "true" ]; then
+  curl -LO "https://github.com/nervosnetwork/ckb-cli/releases/download/${CKB_CLI_VERSION}/ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+  if [ "${REL_PKG##*.}" = "zip" ]; then
+    unzip "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+  else
+    tar -xzf "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+  fi
+  mv "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG%%.*}/ckb-cli" "releases/$PKG_NAME/ckb-cli"
 fi
-mv "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG%%.*}/ckb-cli" "releases/$PKG_NAME/ckb-cli"
 
 pushd releases
 if [ "${REL_PKG#*.}" = "tar.gz" ]; then

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -39,8 +39,13 @@ The official binary releases are also provided for the Tier 2 platforms.
 | Debian Buster | x64 | ASM |
 | Arch Linux | x64 | ASM |
 | CentOS 7 | x64 | ASM |
+| Ubuntu 20.04 | AArch64 | ASM |
+
+> \* AArch64 support is experimental.
 
 The Tier 2 requires CPU to support following instructions: call (MODE64), cmovbe (CMOV), xorps (SSE1), movq (SSE2). The provided binaries cannot run on the platforms without these instructions.
+
+Since this is early days of the AArch64 port, you might experience quirks or slowdowns, we are still working on optimizing the AArch64 port.
 
 ## Tier 3
 

--- a/script/build.rs
+++ b/script/build.rs
@@ -7,10 +7,16 @@ fn main() {
     let is_windows = target_family == "windows";
     let is_unix = target_family == "unix";
     let is_x86_64 = target_arch == "x86_64";
-    let can_enable_asm = is_x86_64 && (is_windows || is_unix);
+    let is_aarch64 = target_arch == "aarch64";
+    let x64_asm = is_x86_64 && (is_windows || is_unix);
+    let aarch64_asm = is_aarch64 && is_unix;
+    let can_enable_asm = x64_asm || aarch64_asm;
 
     if cfg!(feature = "asm") && (!can_enable_asm) {
-        panic!("asm feature can only be enabled on x86_64 Linux, macOS and Windows platforms!");
+        panic!(
+            "ASM feature is not available for target {} on {}!",
+            target_arch, target_family
+        );
     }
 
     if cfg!(any(feature = "asm", feature = "detect-asm")) && can_enable_asm {


### PR DESCRIPTION
### What problem does this PR solve?

Port CKB to aarch64, and provide official binary when release.

Note: No `ckb-cli` for AArch64 port.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

