### PR TITLE
ci: Secrets cannot be used to condition job runs

### DIFF
--- a/.github/workflows/sync-mainnet.yml
+++ b/.github/workflows/sync-mainnet.yml
@@ -16,11 +16,6 @@ jobs:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
       GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-      PGHOST: ${{ secrets.PGHOST }}
-      PGPORT: ${{ secrets.PGPORT }}
-      PGUSER: ${{ secrets.PGUSER }}
-      PGPASSWORD: ${{ secrets.PGPASSWORD }}
-      PGDATABASE: ckbtest
       GITHUB_BRANCH: ${{ github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -47,10 +42,16 @@ jobs:
         if: ${{ failure() }}
         run: echo "GITHUB_RUN_STATE=1" >> $GITHUB_ENV
       - name: insert report to postgres
-        if: ${{ always() && secrets.PGHOST != "" }}
+        if: ${{ always() }}
         env:
           JOB_ID: "sync-mainnet-${{ github.repository }}-${{ github.ref_name }}-${{ steps.date.outputs.date }}-in-10h"
-        run: ./ckb-sync-mainnet/script/sync-mainnet.sh insert_report_to_postgres
+          PGHOST: ${{ secrets.PGHOST }}
+          PGPORT: ${{ secrets.PGPORT }}
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
+          PGDATABASE: ckbtest
+        run: |
+            [ -z "${{ secrets.PGHOST }}" ] || ./ckb-sync-mainnet/script/sync-mainnet.sh insert_report_to_postgres
       - name: Clean Up
         if: ${{ always() }}
         env:

--- a/.github/workflows/sync-mainnet.yml
+++ b/.github/workflows/sync-mainnet.yml
@@ -51,7 +51,7 @@ jobs:
           PGPASSWORD: ${{ secrets.PGPASSWORD }}
           PGDATABASE: ckbtest
         run: |
-            [ -z "${{ secrets.PGHOST }}" ] || ./ckb-sync-mainnet/script/sync-mainnet.sh insert_report_to_postgres
+            [ -z "${PGHOST}" ] || ./ckb-sync-mainnet/script/sync-mainnet.sh insert_report_to_postgres
       - name: Clean Up
         if: ${{ always() }}
         env:


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Sync-mainnet test failed since secrets cannot be used to condition job runs




### Check List <!--REMOVE the items that are not applicable-->

Tests 

- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

