### PR TITLE
refactor(relay): remove obsolete min_fee_rate, max_tx_verify_cycles from relayer

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -80,10 +80,7 @@ impl Relayer {
     /// Init relay protocol handle
     ///
     /// This is a runtime relay protocol shared state, and any relay messages will be processed and forwarded by it
-    pub fn new(
-        chain: ChainController,
-        shared: Arc<SyncShared>,
-    ) -> Self {
+    pub fn new(chain: ChainController, shared: Arc<SyncShared>) -> Self {
         // setup a rate limiter keyed by peer and message type that lets through 30 requests per second
         // current max rps is 10 (ASK_FOR_TXS_TOKEN / TX_PROPOSAL_TOKEN), 30 is a flexible hard cap with buffer
         let quota = governor::Quota::per_second(std::num::NonZeroU32::new(30).unwrap());

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -34,7 +34,7 @@ use ckb_network::{
 };
 use ckb_tx_pool::service::TxVerificationResult;
 use ckb_types::{
-    core::{self, BlockView, Cycle, FeeRate},
+    core::{self, BlockView},
     packed::{self, Byte32, ProposalShortId},
     prelude::*,
 };
@@ -72,8 +72,6 @@ pub enum ReconstructionResult {
 pub struct Relayer {
     chain: ChainController,
     pub(crate) shared: Arc<SyncShared>,
-    pub(crate) min_fee_rate: FeeRate,
-    pub(crate) max_tx_verify_cycles: Cycle,
     rate_limiter: Arc<Mutex<RateLimiter<(PeerIndex, u32)>>>,
     v2: bool,
 }
@@ -82,14 +80,9 @@ impl Relayer {
     /// Init relay protocol handle
     ///
     /// This is a runtime relay protocol shared state, and any relay messages will be processed and forwarded by it
-    ///
-    /// min_fee_rate: Default transaction fee unit, can be modified by configuration file
-    /// max_tx_verify_cycles: Maximum transaction consumption allowed by default, can be modified by configuration file
     pub fn new(
         chain: ChainController,
         shared: Arc<SyncShared>,
-        min_fee_rate: FeeRate,
-        max_tx_verify_cycles: Cycle,
     ) -> Self {
         // setup a rate limiter keyed by peer and message type that lets through 30 requests per second
         // current max rps is 10 (ASK_FOR_TXS_TOKEN / TX_PROPOSAL_TOKEN), 30 is a flexible hard cap with buffer
@@ -98,8 +91,6 @@ impl Relayer {
         Relayer {
             chain,
             shared,
-            min_fee_rate,
-            max_tx_verify_cycles,
             rate_limiter,
             v2: false,
         }

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -15,7 +15,7 @@ use ckb_types::prelude::*;
 use ckb_types::{
     bytes::Bytes,
     core::{
-        capacity_bytes, BlockBuilder, BlockNumber, Capacity, EpochNumberWithFraction, FeeRate,
+        capacity_bytes, BlockBuilder, BlockNumber, Capacity, EpochNumberWithFraction,
         HeaderBuilder, HeaderView, TransactionBuilder, TransactionView,
     },
     packed::{
@@ -201,10 +201,7 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
         pack.take_relay_tx_receiver(),
     ));
     (
-        Relayer::new(
-            chain_controller,
-            sync_shared,
-        ),
+        Relayer::new(chain_controller, sync_shared),
         always_success_out_point,
     )
 }

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -204,8 +204,6 @@ pub(crate) fn build_chain(tip: BlockNumber) -> (Relayer, OutPoint) {
         Relayer::new(
             chain_controller,
             sync_shared,
-            FeeRate::zero(),
-            std::u64::MAX,
         ),
         always_success_out_point,
     )

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -276,10 +276,7 @@ impl Launcher {
         let support_protocols = &self.args.config.network.support_protocols;
 
         if support_protocols.contains(&SupportProtocol::Relay) {
-            let relayer = Relayer::new(
-                chain_controller.clone(),
-                Arc::clone(&sync_shared),
-            );
+            let relayer = Relayer::new(chain_controller.clone(), Arc::clone(&sync_shared));
 
             protocols.push(CKBProtocol::new_with_support_protocol(
                 SupportProtocols::RelayV2,

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -279,8 +279,6 @@ impl Launcher {
             let relayer = Relayer::new(
                 chain_controller.clone(),
                 Arc::clone(&sync_shared),
-                self.args.config.tx_pool.min_fee_rate,
-                self.args.config.tx_pool.max_tx_verify_cycles,
             );
 
             protocols.push(CKBProtocol::new_with_support_protocol(


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

remove obsolete min_fee_rate, max_tx_verify_cycles from relayer

### What is changed and how it works?

these 2 parts' function are already implemented in tx pool,  and these 2 fields in relay not working for now

### Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Side effects

None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

