### PR TITLE
fix pending leak

### DIFF
--- a/tx-pool/src/component/tests/pending.rs
+++ b/tx-pool/src/component/tests/pending.rs
@@ -21,6 +21,9 @@ fn test_basic() {
     assert!(queue.contains_key(&tx1.proposal_short_id()));
     assert!(queue.contains_key(&tx2.proposal_short_id()));
 
+    assert_eq!(queue.inputs_len(), 4);
+    assert_eq!(queue.outputs_len(), 4);
+
     assert_eq!(queue.get(&tx1.proposal_short_id()).unwrap(), &entry1);
     assert_eq!(queue.get_tx(&tx2.proposal_short_id()).unwrap(), &tx2);
 
@@ -112,6 +115,10 @@ fn test_resolve_conflict_header_dep() {
     assert!(queue.add_entry(entry.clone()));
     assert!(queue.add_entry(entry1.clone()));
 
+    assert_eq!(queue.inputs_len(), 3);
+    assert_eq!(queue.header_deps_len(), 1);
+    assert_eq!(queue.outputs_len(), 2);
+
     let mut headers = HashSet::new();
     headers.insert(header);
 
@@ -190,6 +197,10 @@ fn test_fill_proposals() {
     assert!(queue.add_entry(entry1));
     assert!(queue.add_entry(entry2));
     assert!(queue.add_entry(entry3));
+
+    assert_eq!(queue.inputs_len(), 5);
+    assert_eq!(queue.deps_len(), 1);
+    assert_eq!(queue.outputs_len(), 7);
 
     let id1 = tx1.proposal_short_id();
     let id2 = tx2.proposal_short_id();


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

fix memory leak introduce from https://github.com/nervosnetwork/ckb/pull/3264

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

```
failures:

---- component::tests::pending::test_basic stdout ----
thread 'component::tests::pending::test_basic' panicked at 'assertion failed: `(left == right)`
  left: `8`,
 right: `4`', tx-pool/src/component/tests/pending.rs:26:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- component::tests::pending::test_fill_proposals stdout ----
thread 'component::tests::pending::test_fill_proposals' panicked at 'assertion failed: `(left == right)`
  left: `13`,
 right: `7`', tx-pool/src/component/tests/pending.rs:204:5

---- component::tests::pending::test_resolve_conflict_header_dep stdout ----
thread 'component::tests::pending::test_resolve_conflict_header_dep' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `2`', tx-pool/src/component/tests/pending.rs:121:5
```

failures:
    component::tests::pending::test_basic
    component::tests::pending::test_fill_proposals
    component::tests::pending::test_resolve_conflict_header_dep

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

