### PR TITLE
fix: the gauges for metrics present histograms

### DIFF
--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -68,9 +68,9 @@ macro_rules! metrics {
     };
     (gauge, $label:literal, $value:expr $(, $span_name:expr => $span_value:expr )* $(,)?) => {
         $crate::global_meter()
-            .i64_value_recorder($label)
+            .i64_up_down_counter($label)
             .init()
-            .record($value, &[$( $crate::internal::KeyValue::new($span_name, $span_value), )*]);
+            .add($value, &[$( $crate::internal::KeyValue::new($span_name, $span_value), )*]);
     };
     (timing, $label:literal, $duration:expr $(, $span_name:expr => $span_value:expr )* $(,)?) => {
         $crate::global_meter()


### PR DESCRIPTION
### What problem does this PR solve?

The gauges for metrics present histograms.

A gauge is a metric that can go up and down, arbitrarily, over time.

`UpDownCounter` in [Open Telemetry Instruments](https://docs.rs/opentelemetry/0.15.0/opentelemetry/metrics/struct.Meterhtml#instruments) is the most suitable.

### Check List

Tests

- Manual test

  Enable the metrics and see the result of `metrics!(gauge, "ckb.chain_tip", block.header().number() as i64);`.

  Before this PR,  it outputs:

  ```
  # HELP ckb_chain_tip ckb.chain_tip
  # TYPE ckb_chain_tip histogram
  ckb_chain_tip_bucket{le="0.5"} 0
  ckb_chain_tip_bucket{le="0.9"} 0
  ckb_chain_tip_bucket{le="0.99"} 0
  ckb_chain_tip_bucket{le="+Inf"} 167273
  ckb_chain_tip_sum 646402923007
  ckb_chain_tip_count 167273
  ```

  After this PR, it outputs:

  ```
  # HELP ckb_chain_tip ckb.chain_tip
  # TYPE ckb_chain_tip gauge
  ckb_chain_tip 4065100
  ```

### Release note

```release-note
None: Exclude this PR from the release note.
```