### PR TITLE
feat: case-insensitive hex

### DIFF
--- a/util/jsonrpc-types/src/uints.rs
+++ b/util/jsonrpc-types/src/uints.rs
@@ -73,18 +73,9 @@ impl<T: Uint> JsonUintVisitor<T> {
             )));
         }
 
-        let number = T::from_str_radix(&value[2..], 16)
+        T::from_str_radix(&value[2..], 16)
             .map(JsonUint)
-            .map_err(|e| Error::custom(format!("Invalid {} {}: {}", T::NAME, value, e)))?;
-        if number.to_string() != value {
-            return Err(Error::custom(format!(
-                "Invalid {} {}: only digits and lowercase are allowed",
-                T::NAME,
-                value,
-            )));
-        }
-
-        Ok(number)
+            .map_err(|e| Error::custom(format!("Invalid {} {}: {}", T::NAME, value, e)))
     }
 }
 
@@ -240,14 +231,7 @@ mod tests {
                     let cases = vec![r#""0xFF""#, r#""0xfF""#];
                     for s in cases {
                         let ret: Result<$name, _> = serde_json::from_str(s);
-                        assert!(ret.is_err(), ret);
-
-                        let err = ret.unwrap_err();
-                        assert!(
-                            err.to_string()
-                                .contains("only digits and lowercase are allowed"),
-                            err,
-                        );
+                        assert!(ret.is_ok());
                     }
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Previously, uppercase hex format have been unintentionally forbiden. 

Many language such [java](https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1) 
> each letter used as a hexadecimal digit may be uppercase or lowercase.

specify hexadecimal is not case-sensitive.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

