### PR TITLE
chore: fix instant panic on some case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "tempfile",
  "tentacle",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.0",
  "trust-dns-resolver",
 ]
 
@@ -1192,7 +1192,7 @@ version = "0.102.0-pre"
 dependencies = [
  "ckb-channel",
  "ckb-logger",
- "parking_lot",
+ "parking_lot 0.12.0",
  "tokio",
 ]
 
@@ -1352,7 +1352,7 @@ dependencies = [
  "ckb-fixed-hash",
  "linked-hash-map",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "regex",
 ]
 
@@ -2201,7 +2201,7 @@ dependencies = [
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
- "parking_lot",
+ "parking_lot 0.11.2",
  "quanta",
  "rand 0.8.5",
  "smallvec",
@@ -2222,7 +2222,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2580,7 +2580,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "net2",
- "parking_lot",
+ "parking_lot 0.11.2",
  "unicase",
 ]
 
@@ -2594,7 +2594,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "serde",
 ]
@@ -2613,7 +2613,7 @@ dependencies = [
  "log",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "unicase",
 ]
 
@@ -2626,7 +2626,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "tower-service",
 ]
 
@@ -2641,7 +2641,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "parity-ws",
- "parking_lot",
+ "parking_lot 0.11.2",
  "slab",
 ]
 
@@ -2829,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -3175,7 +3175,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -3184,15 +3194,28 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "backtrace",
  "cfg-if 1.0.0",
  "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "backtrace",
+ "cfg-if 1.0.0",
  "libc",
  "petgraph",
  "redox_syscall 0.2.10",
  "smallvec",
  "thread-id",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3376,7 +3399,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
  "thiserror",
 ]
@@ -4102,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a63aefa9353a0a482ddf8369d663c3190a2c13072a1c6d81889db9bf6628ba4"
+checksum = "3514445653a078dccffc4eefaf2bbbca6a1e6087e81cca24ca6757dacdedb437"
 dependencies = [
  "bytes 1.1.0",
  "futures",
@@ -4115,13 +4138,13 @@ dependencies = [
  "molecule",
  "nohash-hasher",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "tentacle-multiaddr",
  "tentacle-secio",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.0",
  "tokio-yamux",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4143,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4f18ad65a9ec344b1989bcacbaf01e3bf213de71a78d969f4efe3552a52625"
+checksum = "cd1b61199af018787e25f0d6674d5cd66c97ad9e34e8808d284ac0ad09132f2d"
 dependencies = [
  "bs58",
  "bytes 1.1.0",
@@ -4163,7 +4186,7 @@ dependencies = [
  "secp256k1",
  "sha2",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.0",
  "unsigned-varint",
  "x25519-dalek",
 ]
@@ -4305,19 +4328,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.4.4",
  "tokio-macros",
  "winapi 0.3.9",
 ]
@@ -4369,6 +4393,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-yamux"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,7 +4417,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -4454,7 +4492,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -4754,6 +4792,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/ckb-bin/src/subcommand/replay.rs
+++ b/ckb-bin/src/subcommand/replay.rs
@@ -74,7 +74,7 @@ fn profile(shared: Shared, mut chain: ChainService, from: Option<u64>, to: Optio
     println!("start profiling, re-process blocks {}..{}:", from, to);
     let now = std::time::Instant::now();
     let tx_count = process_range_block(&shared, &mut chain, from..=to);
-    let duration = now.elapsed();
+    let duration = std::time::Instant::now().saturating_duration_since(now);
     println!(
         "end profiling, duration {:?} txs {} tps {}",
         duration,

--- a/miner/src/worker/eaglesong_simple.rs
+++ b/miner/src/worker/eaglesong_simple.rs
@@ -96,7 +96,7 @@ impl Worker for EaglesongSimple {
                     self.solve(pow_hash, work, rng());
                     state_update_counter += 1;
 
-                    let elapsed = start.elapsed();
+                    let elapsed = Instant::now().saturating_duration_since(start);
                     if elapsed.as_millis() > STATE_UPDATE_DURATION_MILLIS {
                         let elapsed_nanos: f64 = (elapsed.as_secs() * 1_000_000_000
                             + u64::from(elapsed.subsec_nanos()))

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -16,7 +16,7 @@ ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.102.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.102.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.102.0-pre" }
 tokio = { version = "1", features = ["sync", "macros"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 futures = "0.3"
 faketime = "0.2.0"
 lazy_static = { version = "1.3.0", optional = true }
@@ -33,7 +33,7 @@ serde_json = "1.0"
 bloom-filters = "0.1"
 ckb-spawn = { path = "../util/spawn", version = "= 0.102.0-pre" }
 
-p2p = { version="=0.4.0-alpha.3", package="tentacle", features = ["upnp", "parking_lot"] }
+p2p = { version="=0.4.0-alpha.4", package="tentacle", features = ["upnp", "parking_lot"] }
 
 [features]
 with_sentry = ["sentry"]

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -343,7 +343,7 @@ impl NetworkState {
                 peer_id,
                 addr
             );
-            if dial_started.elapsed() > DIAL_HANG_TIMEOUT {
+            if Instant::now().saturating_duration_since(*dial_started) > DIAL_HANG_TIMEOUT {
                 #[cfg(feature = "with_sentry")]
                 with_scope(
                     |scope| scope.set_fingerprint(Some(&["ckb-network", "dialing-timeout"])),
@@ -1285,7 +1285,7 @@ impl NetworkController {
                     return Ok(());
                 }
                 Err(SendErrorKind::WouldBlock) => {
-                    if now.elapsed() > P2P_SEND_TIMEOUT {
+                    if Instant::now().saturating_duration_since(now) > P2P_SEND_TIMEOUT {
                         warn!("broadcast message to {} timeout", proto_id);
                         return Err(SendErrorKind::WouldBlock);
                     }

--- a/network/src/peer_registry.rs
+++ b/network/src/peer_registry.rs
@@ -145,13 +145,14 @@ impl PeerRegistry {
             &mut candidate_peers,
             EVICTION_PROTECT_PEERS,
             |peer1, peer2| {
+                let now = std::time::Instant::now();
                 let peer1_last_message = peer1
                     .last_ping_protocol_message_received_at
-                    .map(|t| t.elapsed().as_secs())
+                    .map(|t| now.saturating_duration_since(t).as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 let peer2_last_message = peer2
                     .last_ping_protocol_message_received_at
-                    .map(|t| t.elapsed().as_secs())
+                    .map(|t| now.saturating_duration_since(t).as_secs())
                     .unwrap_or_else(|| std::u64::MAX);
                 peer2_last_message.cmp(&peer1_last_message)
             },

--- a/network/src/protocols/discovery/state.rs
+++ b/network/src/protocols/discovery/state.rs
@@ -94,7 +94,7 @@ impl SessionState {
     pub(crate) fn check_timer(&mut self, now: Instant, interval: Duration) -> Option<&Multiaddr> {
         if self
             .last_announce
-            .map(|time| now - time > interval)
+            .map(|time| now.saturating_duration_since(time) > interval)
             .unwrap_or(true)
         {
             self.last_announce = Some(now);

--- a/network/src/protocols/ping.rs
+++ b/network/src/protocols/ping.rs
@@ -73,7 +73,7 @@ impl PingHandler {
         let now = Instant::now();
         self.network_state.with_peer_registry_mut(|reg| {
             if let Some(peer) = reg.get_peer_mut(id) {
-                peer.ping_rtt = Some(now.duration_since(last_ping));
+                peer.ping_rtt = Some(now.saturating_duration_since(last_ping));
                 peer.last_ping_protocol_message_received_at = Some(now);
             }
         });
@@ -115,7 +115,7 @@ impl PingHandler {
 }
 
 fn nonce(t: &Instant, start_time: Instant) -> u32 {
-    t.duration_since(start_time).as_secs() as u32
+    t.saturating_duration_since(start_time).as_secs() as u32
 }
 
 /// PingStatus of a peer
@@ -136,7 +136,7 @@ impl PingStatus {
 
     /// Time duration since we last send ping.
     fn elapsed(&self) -> Duration {
-        self.last_ping_sent_at.elapsed()
+        Instant::now().saturating_duration_since(self.last_ping_sent_at)
     }
 }
 

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -255,7 +255,7 @@ where
 {
     let start = Instant::now();
     let timeout = Duration::new(secs, 0);
-    while Instant::now().duration_since(start) <= timeout {
+    while Instant::now().saturating_duration_since(start) <= timeout {
         if f() {
             return true;
         }

--- a/network/src/services/protocol_type_checker.rs
+++ b/network/src/services/protocol_type_checker.rs
@@ -83,7 +83,7 @@ impl ProtocolTypeCheckerService {
             let now = Instant::now();
             for (session_id, peer) in reg.peers() {
                 // skip just connected peers
-                if now.duration_since(peer.connected_time) < TIMEOUT {
+                if now.saturating_duration_since(peer.connected_time) < TIMEOUT {
                     continue;
                 }
 

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -602,7 +602,10 @@ impl NetRpc for NetRpcImpl {
                         .map(|peer_id| peer_id.to_base58())
                         .unwrap_or_default(),
                     addresses: node_addresses,
-                    connected_duration: (peer.connected_time.elapsed().as_millis() as u64).into(),
+                    connected_duration: (std::time::Instant::now()
+                        .saturating_duration_since(peer.connected_time)
+                        .as_millis() as u64)
+                        .into(),
                     last_ping_duration: peer
                         .ping_rtt
                         .map(|duration| (duration.as_millis() as u64).into()),

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -801,7 +801,7 @@ impl CKBProtocolHandler for Relayer {
             "process message={}, peer={}, cost={:?}",
             msg.item_name(),
             peer_index,
-            start_time.elapsed(),
+            Instant::now().saturating_duration_since(start_time),
         );
     }
 
@@ -884,7 +884,7 @@ impl CKBProtocolHandler for Relayer {
             crate::LOG_TARGET_RELAY,
             "finished notify token={} cost={:?}",
             token,
-            start_time.elapsed()
+            Instant::now().saturating_duration_since(start_time)
         );
     }
 }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -750,7 +750,7 @@ impl CKBProtocolHandler for Synchronizer {
             "process message={}, peer={}, cost={:?}",
             msg.item_name(),
             peer_index,
-            start_time.elapsed(),
+            Instant::now().saturating_duration_since(start_time),
         );
     }
 
@@ -829,7 +829,7 @@ impl CKBProtocolHandler for Synchronizer {
             trace!(
                 "finished notify token={} cost={:?}",
                 token,
-                start_time.elapsed()
+                Instant::now().saturating_duration_since(start_time)
             );
         } else if token == NO_PEER_CHECK_TOKEN {
             debug!("no peers connected");

--- a/sync/src/tests/net_time_checker.rs
+++ b/sync/src/tests/net_time_checker.rs
@@ -161,7 +161,7 @@ where
 {
     let start = Instant::now();
     let timeout = Duration::new(secs, 0);
-    while Instant::now().duration_since(start) <= timeout {
+    while Instant::now().saturating_duration_since(start) <= timeout {
         if f() {
             return true;
         }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-parking_lot = "0.11"
+parking_lot = "0.12"
 linked-hash-map = "0.5"
 regex = "1.1.6"
 once_cell = "1.8.0"

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-parking_lot = "0.11"
+parking_lot = "0.12"
 ckb-logger = { path = "../logger", version = "= 0.102.0-pre" }
 tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
 ckb-channel = { path = "../channel", version = "= 0.102.0-pre" }


### PR DESCRIPTION
### What problem does this PR solve?

ref: https://github.com/rust-lang/rust/pull/89926

upgrade tokio/tentacle/parking_lot

tokio:
```
### Fixed

- time: prevent panicking in `sleep` with large durations ([#4495])
- time: eliminate potential panics in `Instant` arithmetic on platforms where
  `Instant::now` is not monotonic ([#4461])
- io: fix `DuplexStream` not participating in cooperative yielding ([#4478])
- rt: fix potential double panic when dropping a `JoinHandle` ([#4430])

### Changed

- update minimum supported Rust version to 1.49 ([#4457])
- update `parking_lot` dependency to v0.12.0 ([#4459])
- update `mio` dependency to v0.8 ([#4449])
- rt: remove an unnecessary lock in the blocking pool ([#4436])
- rt: remove an unnecessary enum in the basic scheduler ([#4462])
- time: use bit manipulation instead of modulo to improve performance ([#4480])
- net: use `std::future::Ready` instead of our own `Ready` future ([#4271])
- replace deprecated `atomic::spin_loop_hint` with `hint::spin_loop` ([#4491])
- fix miri failures in intrusive linked lists ([#4397]) 
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

