### PR TITLE
feat(verification): log tx verification result for monitor

### DIFF
--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -18,7 +18,8 @@ use ckb_chain_spec::consensus::MAX_BLOCK_PROPOSALS_LIMIT;
 use ckb_dao::DaoCalculator;
 use ckb_error::{AnyError, InternalErrorKind};
 use ckb_jsonrpc_types::BlockTemplate;
-use ckb_logger::{debug, error, info};
+use ckb_logger::Level::Trace;
+use ckb_logger::{debug, error, info, log_enabled_target, trace_target};
 use ckb_network::PeerIndex;
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
@@ -728,6 +729,18 @@ impl TxPoolService {
                 .hardfork_switch
                 .is_vm_version_1_and_syscalls_2_enabled(epoch)
         };
+
+        // log tx verification result for monitor node
+        if log_enabled_target!("ckb_tx_monitor", Trace) {
+            if let Ok(c) = ret {
+                trace_target!(
+                    "ckb_tx_monitor",
+                    r#"{{"tx_hash":"{:#x}","cycles":{}}}"#,
+                    tx_hash,
+                    c.cycles
+                );
+            }
+        }
 
         match remote {
             Some((declared_cycle, peer)) => match ret {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: log transaction verified result for monitor node to inspect transaction including cycles, vm...

### What is changed and how it works?

What's Changed: 
- add checkpoint to log transaction verified result in chain and tx-pool 
- add `ckb_tx_monitor` log target to log tx verification result to logfile
- combined with config in ckb.toml to store JSON format tx verification log messages in separate output file.

### Related changes

- PR to update `owner/repo`:


Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
add  
  > [logger.extra.ckb_tx_monitor]
  > filter = "off,ckb_tx_monitor=trace"
     
    after logger section in ckb.toml
 
Side effects

- None (transaction log message output only when logger.extra configured)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

