### PR TITLE
fix: fix 3307

### DIFF
--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -150,20 +150,21 @@ impl<'a> ServiceBuilder<'a> {
         network_controller: NetworkController,
         chain: ChainController,
     ) -> Self {
-        // IntegrationTest only on Dummy PoW chain
-        assert_eq!(
-            shared.consensus().pow,
-            Pow::Dummy,
-            "Only run integration test on Dummy PoW chain"
-        );
-
         let rpc_methods = IntegrationTestRpcImpl {
-            shared,
+            shared: shared.clone(),
             network_controller,
             chain,
         }
         .to_delegate();
+
         if self.config.integration_test_enable() {
+            // IntegrationTest only on Dummy PoW chain
+            assert_eq!(
+                shared.consensus().pow,
+                Pow::Dummy,
+                "Only run integration test on Dummy PoW chain"
+            );
+
             self.add_methods(rpc_methods);
         } else {
             self.update_disabled_methods("IntegrationTest", rpc_methods);


### PR DESCRIPTION
fix #3307, check PoW Dummy after integration test is enabled

### What problem does this PR solve?

fix #3307, move PoW Dummy check after integration_test_enable()
otherwise, normal node(without Integration test) also run pow dummy check.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

