### PR TITLE
chore(deps): remove console 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
  "ckb-db-schema",
  "ckb-error",
  "ckb-logger",
- "console 0.15.0",
+ "console",
  "indicatif",
  "tempfile",
 ]
@@ -876,7 +876,7 @@ dependencies = [
  "ckb-pow",
  "ckb-stop-handler",
  "ckb-types",
- "console 0.13.0",
+ "console",
  "eaglesong",
  "futures",
  "hyper",
@@ -1462,22 +1462,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "console"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi 0.3.9",
- "winapi-util",
 ]
 
 [[package]]
@@ -2445,7 +2429,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console 0.15.0",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -27,7 +27,7 @@ lru = "0.7.1"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.102.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.102.0-pre" }
 indicatif = "0.16"
-console = "0.13.0"
+console = ">=0.9.1, <1.0.0"
 eaglesong = "0.1"
 base64 = "0.13.0"
 jsonrpc-core = "18.0"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: The build fails because of inconsistent console versions.

### What is changed and how it works?

What's Changed:

1. Use the same version requirements on console in `miner/Cargo.toml` as in `db-migration/Cargo.toml`.
2. Use `cargo update -p console:0.13.0` to remove the inconsistent version from the dependency tree.

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

