### PR TITLE
ci: lock actions virtual environment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
           (
             github.event_name == 'pull_request_review' &&

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   create-release:
     name: Create release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   package-for-linux:
     name: package-for-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set Env
@@ -128,7 +128,7 @@ jobs:
 
   package-for-centos:
     name: package-for-centos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set Env
@@ -163,7 +163,7 @@ jobs:
 
   package-for-mac:
     name: package-for-mac
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Set Env
@@ -197,7 +197,7 @@ jobs:
 
   package-for-windows:
     name: package-for-windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - name: Install Dependencies
       run: |
@@ -255,7 +255,7 @@ jobs:
 
   Upload_File:
     name: Upload_Zip_File
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -306,7 +306,7 @@ jobs:
 
   Trigger_smoking_test:
     name: Trigger_smoking_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - Upload_File
     steps:

--- a/.github/workflows/scheduled_audit.yaml
+++ b/.github/workflows/scheduled_audit.yaml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: yangby-cryptape/cargo-audit-check-action@customized-for-ckb


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: Using `*-latest` environment is vulnerable to unexpected update.

For example, after GitHub upgrade windows-latest from windows-2019 to
windows-2022, yasm installed via scoop stops working, which leads to
failed CKB packaging.

https://github.com/nervosnetwork/ckb/runs/5343852953?check_suite_focus=true

### What is changed and how it works?

What's Changed: Stop using `*-latest` in all GitHub Actions workflows.

### Check List

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

