### PR TITLE
ci: use llvm/current in LIBCLANG_PATH

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -207,7 +207,7 @@ jobs:
         echo ("GIT_TAG_NAME=" + $env:GITHUB_REF.replace('refs/heads/pkg/', '')) >> $env:GITHUB_ENV
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "LIBCLANG_PATH=$env:USERPROFILE\scoop\apps\llvm\13.0.0\bin" >> $env:GITHUB_ENV
+        echo "LIBCLANG_PATH=$env:USERPROFILE\scoop\apps\llvm\current\bin" >> $env:GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Build
       run: |


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: LLVM has upgraded to 13.0.1, which breaks the package workflows because the build script cannot find libclang via the environment variable LIBCLANG_PATH

### What is changed and how it works?

What's Changed: Use `$env:USERPROFILE\scoop\apps\llvm\current\bin` instead.

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

