### PR TITLE
chore: protect node in ibd should also disconnnected

### DIFF
--- a/sync/src/synchronizer/in_ibd_process.rs
+++ b/sync/src/synchronizer/in_ibd_process.rs
@@ -26,20 +26,13 @@ impl<'a> InIBDProcess<'a> {
         info!("getheader with ibd peer {:?}", self.peer);
         if let Some(mut kv_pair) = self.synchronizer.peers().state.get_mut(&self.peer) {
             let state = kv_pair.value_mut();
-            // Don't assume that the peer is sync_started.
-            // It is possible that a not-sync-started peer sends us `InIBD` messages:
-            //   - Malicious behavior
-            //   - Peer sends multiple `InIBD` messages
-            if !state.sync_started() {
-                return Status::ignored();
-            }
 
             // The node itself needs to ensure the validity of the outbound connection.
             //
-            // If outbound is an ibd node(non-whitelist, non-protect), it should be disconnected automatically.
+            // If outbound is an ibd node(non-whitelist), it should be disconnected automatically.
             // If inbound is an ibd node, just mark the node does not pass header sync authentication.
             if state.peer_flags.is_outbound {
-                if state.peer_flags.is_whitelist || state.peer_flags.is_protect {
+                if state.peer_flags.is_whitelist {
                     self.synchronizer.shared().state().suspend_sync(state);
                 } else if let Err(err) = self.nc.disconnect(self.peer, "outbound in ibd") {
                     return StatusCode::Network

--- a/test/src/specs/alert/alert_propagation.rs
+++ b/test/src/specs/alert/alert_propagation.rs
@@ -1,5 +1,6 @@
 use super::new_alert_config;
 use crate::node::connect_all;
+use crate::util::mining::out_ibd_mode;
 use crate::utils::wait_until;
 use crate::{Node, Spec};
 use ckb_app_config::{CKBAppConfig, NetworkAlertConfig, RpcModule};
@@ -33,6 +34,7 @@ impl Spec for AlertPropagation {
     //    2. cancel previous alert via node0; all nodes should receive the alert;
     //    3. resend the first alert, all nodes should ignore the alert.
     fn run(&self, nodes: &mut Vec<Node>) {
+        out_ibd_mode(nodes);
         connect_all(nodes);
 
         let node0 = &nodes[0];

--- a/test/src/specs/p2p/discovery.rs
+++ b/test/src/specs/p2p/discovery.rs
@@ -1,3 +1,4 @@
+use crate::util::mining::out_ibd_mode;
 use crate::utils::wait_until;
 use crate::{Node, Spec};
 
@@ -7,6 +8,7 @@ impl Spec for Discovery {
     crate::setup!(num_nodes: 3);
 
     fn run(&self, nodes: &mut Vec<Node>) {
+        out_ibd_mode(nodes);
         for i in 0..nodes.len() - 1 {
             nodes[i].connect(&nodes[i + 1]);
         }

--- a/test/src/specs/p2p/whitelist.rs
+++ b/test/src/specs/p2p/whitelist.rs
@@ -1,4 +1,4 @@
-use crate::util::mining::mine;
+use crate::util::mining::{mine, out_ibd_mode};
 use crate::utils::{sleep, wait_until};
 use crate::{Node, Spec};
 
@@ -21,6 +21,7 @@ impl Spec for WhitelistOnSessionLimit {
     fn run(&self, nodes: &mut Vec<Node>) {
         info!("Running whitelist on session limit");
 
+        out_ibd_mode(nodes);
         // with no whitelist
         let node4 = nodes.pop().unwrap();
         let node3 = nodes.pop().unwrap();

--- a/test/src/specs/sync/ibd_process.rs
+++ b/test/src/specs/sync/ibd_process.rs
@@ -6,7 +6,7 @@ use ckb_logger::info;
 pub struct IBDProcess;
 
 impl Spec for IBDProcess {
-    crate::setup!(num_nodes: 7);
+    crate::setup!(num_nodes: 3);
 
     fn run(&self, nodes: &mut Vec<Node>) {
         info!("Running IBD process");
@@ -14,76 +14,55 @@ impl Spec for IBDProcess {
         let node0 = &nodes[0];
         let node1 = &nodes[1];
         let node2 = &nodes[2];
-        let node3 = &nodes[3];
-        let node4 = &nodes[4];
-        let node5 = &nodes[5];
-        let node6 = &nodes[6];
 
-        node0.connect(node1);
-        node0.connect(node2);
-        node0.connect(node3);
-        node0.connect(node4);
         // The node's outbound connection does not retain the peer which in the ibd state
         mine(node0, 1);
         // will never connect
-        node0.connect_uncheck(node5);
-        node0.connect_uncheck(node6);
+        node0.connect_uncheck(node1);
+        node0.connect_uncheck(node2);
 
         sleep(5);
 
         let rpc_client0 = node0.rpc_client();
-        let is_connect_peer_num_eq_4 = wait_until(10, || {
+        let is_connect_peer_num_eq_0 = wait_until(10, || {
             let peers = rpc_client0.get_peers();
-            peers.len() == 4
+            peers.is_empty()
         });
 
-        if !is_connect_peer_num_eq_4 {
+        if !is_connect_peer_num_eq_0 {
             panic!("refuse to connect fail");
         }
 
         // IBD only with outbound/whitelist node
         let rpc_client1 = node1.rpc_client();
         let rpc_client2 = node2.rpc_client();
-        let rpc_client3 = node3.rpc_client();
-        let rpc_client4 = node4.rpc_client();
-        let rpc_client5 = node5.rpc_client();
-        let rpc_client6 = node6.rpc_client();
 
         let is_nodes_ibd_sync = wait_until(10, || {
             let header1 = rpc_client1.get_tip_header();
             let header2 = rpc_client2.get_tip_header();
-            let header3 = rpc_client3.get_tip_header();
-            let header4 = rpc_client4.get_tip_header();
-            let header5 = rpc_client5.get_tip_header();
-            let header6 = rpc_client6.get_tip_header();
 
-            header1.inner.number.value() == 0
-                && header1 == header6
-                && header1 == header5
-                && header1 == header4
-                && header1 == header3
-                && header1 == header2
+            header1.inner.number.value() == 0 && header1 == header2
         });
 
-        assert!(is_nodes_ibd_sync, "node 1-6 must not sync with node0");
+        assert!(is_nodes_ibd_sync, "node 1-2 must not sync with node0");
 
-        node5.connect(node0);
-        node6.connect(node0);
+        node1.connect(node0);
+        node2.connect(node0);
 
         let is_node_sync = wait_until(10, || {
-            let header5 = rpc_client5.get_tip_header();
-            let header6 = rpc_client6.get_tip_header();
-            header5 == header6 && header5.inner.number.value() == 1
+            let header1 = rpc_client1.get_tip_header();
+            let header2 = rpc_client2.get_tip_header();
+            header1 == header2 && header1.inner.number.value() == 1
         });
 
-        assert!(is_node_sync, "node 5-6 must sync with node0");
+        assert!(is_node_sync, "node 1-2 must sync with node0");
     }
 }
 
 pub struct IBDProcessWithWhiteList;
 
 impl Spec for IBDProcessWithWhiteList {
-    crate::setup!(num_nodes: 7);
+    crate::setup!(num_nodes: 3);
 
     fn run(&self, nodes: &mut Vec<Node>) {
         info!("Running IBD process with whitelist");
@@ -92,9 +71,9 @@ impl Spec for IBDProcessWithWhiteList {
             nodes[0].stop();
 
             // whitelist will be connected on outbound on node start
-            let node6_address = nodes[6].p2p_address();
+            let node2_address = nodes[2].p2p_address();
             nodes[0].modify_app_config(move |config| {
-                config.network.whitelist_peers = vec![node6_address.parse().unwrap()];
+                config.network.whitelist_peers = vec![node2_address.parse().unwrap()];
             });
             nodes[0].start();
         }
@@ -102,36 +81,27 @@ impl Spec for IBDProcessWithWhiteList {
         let node0 = &nodes[0];
         let node1 = &nodes[1];
         let node2 = &nodes[2];
-        let node3 = &nodes[3];
-        let node4 = &nodes[4];
-        let node5 = &nodes[5];
-        let node6 = &nodes[6];
-
-        node0.connect(node1);
-        node0.connect(node2);
-        node0.connect(node3);
-        node0.connect(node4);
 
         // will never connect, protect node default is 4, see
         // https://github.com/nervosnetwork/ckb/blob/da8897dbc8382293bdf8fadea380a0b79c1efa92/sync/src/lib.rs#L57
-        node0.connect_uncheck(node5);
+        node0.connect_uncheck(node1);
 
         let rpc_client0 = node0.rpc_client();
-        let is_connect_peer_num_eq_5 = wait_until(10, || {
+        let is_connect_peer_num_eq_1 = wait_until(10, || {
             let peers = rpc_client0.get_peers();
-            peers.len() == 5
+            peers.len() == 1
         });
 
-        if !is_connect_peer_num_eq_5 {
+        if !is_connect_peer_num_eq_1 {
             panic!("refuse to connect fail");
         }
 
         // After the whitelist is disconnected, it will always try to reconnect.
         // In order to ensure that the node6 has already generated two blocks when reconnecting,
         // it must be in the connected state, and then disconnected.
-        mine(node6, 2);
+        mine(node2, 2);
 
-        let generate_res = wait_until(10, || nodes[6].get_tip_block_number() == 2);
+        let generate_res = wait_until(10, || nodes[2].get_tip_block_number() == 2);
 
         if !generate_res {
             panic!("node6 can't generate blocks to 2");
@@ -139,40 +109,29 @@ impl Spec for IBDProcessWithWhiteList {
 
         // Although the disconnection of the whitelist is automatically reconnected for node0,
         // the disconnect operation is still needed here to instantly refresh the state of node6 in node0.
-        node6.disconnect(node0);
+        node2.disconnect(node0);
 
         // Make sure node0 re-connect with node6
-        node0.connect(node6);
+        node0.connect(node2);
 
         // IBD only with outbound/whitelist node
         let rpc_client1 = node1.rpc_client();
         let rpc_client2 = node2.rpc_client();
-        let rpc_client3 = node3.rpc_client();
-        let rpc_client4 = node4.rpc_client();
-        let rpc_client5 = node5.rpc_client();
-        let rpc_client6 = node6.rpc_client();
 
         let is_nodes_ibd_sync = wait_until(10, || {
             let header0 = rpc_client0.get_tip_header();
             let header1 = rpc_client1.get_tip_header();
             let header2 = rpc_client2.get_tip_header();
-            let header3 = rpc_client3.get_tip_header();
-            let header4 = rpc_client4.get_tip_header();
-            let header5 = rpc_client5.get_tip_header();
-            let header6 = rpc_client6.get_tip_header();
 
             header1.inner.number.value() == 0
-                && header1 == header5
-                && header1 == header4
-                && header1 == header3
                 && header1 == header2
-                && header6.inner.number.value() == 2
-                && header0 == header6
+                && header2.inner.number.value() == 2
+                && header0 == header2
         });
 
         assert!(
             is_nodes_ibd_sync,
-            "node 1-5 must not sync with node0, node 6 must sync with node0"
+            "node 1 must not sync with node0, node2 must sync with node0"
         );
     }
 }

--- a/test/src/specs/tx_pool/txs_relay_order.rs
+++ b/test/src/specs/tx_pool/txs_relay_order.rs
@@ -16,8 +16,8 @@ impl Spec for TxsRelayOrder {
     crate::setup!(num_nodes: 2);
 
     fn run(&self, nodes: &mut Vec<Node>) {
-        connect_all(nodes);
         out_ibd_mode(nodes);
+        connect_all(nodes);
 
         let node0 = &nodes[0];
         let node1 = &nodes[1];


### PR DESCRIPTION
### What problem does this PR solve?

1. `suspend_sync` has determined if it is in sync start state
2. Errors sent behavior in outbound should be disconnected unless they are whitelisted
3. The protect node is randomly generated and should be disconnected if it is in ibd state, otherwise the sync data source is inherently missing

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

