### PR TITLE
chore(deps): upgrade bit-vec to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,14 +167,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
 dependencies = [
- "bit-vec 0.6.3",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bit-vec"
@@ -1328,7 +1322,7 @@ dependencies = [
 name = "ckb-types"
 version = "0.102.0-pre"
 dependencies = [
- "bit-vec 0.5.1",
+ "bit-vec",
  "bitflags",
  "bytes 1.1.0",
  "ckb-channel",

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -18,7 +18,7 @@ merkle-cbt = "0.3"
 ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.102.0-pre" }
 ckb-hash = { path = "../hash", version = "= 0.102.0-pre" }
 ckb-channel = { path = "../channel", version = "= 0.102.0-pre" }
-bit-vec = "0.5.1"
+bit-vec = "0.6.3"
 ckb-error = { path = "../../error", version = "= 0.102.0-pre" }
 ckb-rational = { path = "../rational", version = "= 0.102.0-pre" }
 once_cell = "1.8.0"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: ckb-types depends on outdated version of bit-vec.

### What is changed and how it works?

What's Changed: Upgrade the version requirement of bit-vec in util/types/Cargo.toml

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

