### PR TITLE
perf(replay): disable info output, improve replay speed

### DIFF
--- a/ckb-bin/src/subcommand/replay.rs
+++ b/ckb-bin/src/subcommand/replay.rs
@@ -4,6 +4,7 @@ use ckb_chain::chain::ChainService;
 use ckb_chain_iter::ChainIterator;
 use ckb_instrument::{ProgressBar, ProgressStyle};
 use ckb_launcher::SharedBuilder;
+use ckb_logger_service::Logger;
 use ckb_shared::Shared;
 use ckb_store::ChainStore;
 use ckb_verification_traits::Switch;
@@ -72,6 +73,9 @@ fn profile(shared: Shared, mut chain: ChainService, from: Option<u64>, to: Optio
     let to = to
         .map(|v| std::cmp::min(v, tip_number))
         .unwrap_or(tip_number);
+    // disable Info messages will improve performance
+    let _ = Logger::update_main_logger(Some("Error".to_owned()), Some(true), Some(true), None);
+
     process_range_block(&shared, &mut chain, 1..from);
     println!("start profiling, re-process blocks {}..{}:", from, to);
     let now = std::time::Instant::now();


### PR DESCRIPTION
raise default log level(Info) to Error when ckb replay profile, it'll reduce lots of messages output to
logfile and improve ckb replay profile speed, especially when replay with huge block range.

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

when ckb replay profile from 1 to tip(current 6 million height), disable normal Info output will reduce at least 10% time when replay takes; it also benefit after we add `ckb replay`  to daily SyncMainnet  procedure.
the code only temporarily dynamic raise logger level to Error when ckb replay run, that will not impact default ckb configuration.

### Related changes

- PR to update `owner/repo`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

