### PR TITLE
fix: genesis dep groups should supports relative file path

### DIFF
--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -453,9 +453,19 @@ impl ChainSpec {
 
         let mut spec: ChainSpec = toml::from_slice(&config_bytes)?;
         if let Some(parent) = resource.parent() {
-            for r in spec.genesis.system_cells.iter_mut() {
-                r.file.absolutize(parent)
-            }
+            spec.genesis
+                .system_cells
+                .iter_mut()
+                .for_each(|system_cell| system_cell.file.absolutize(parent));
+            spec.genesis
+                .dep_groups
+                .iter_mut()
+                .for_each(|dep_group_resource| {
+                    dep_group_resource
+                        .files
+                        .iter_mut()
+                        .for_each(|resource| resource.absolutize(parent))
+                });
         }
         // leverage serialize for sanitizing
         spec.hash = packed::Byte32::new(blake2b_256(&toml::to_vec(&spec)?));


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
When running ckb dev chain locally, user may put some custom scripts into the genesis block for development convenience, however, currently only `system_cells` supports relative paths, while `dep_groups` does not.

works:
```
[[genesis.system_cells]]
file = { file = "../compiled_binary/always_failure" }
create_type_id = true
capacity = 100_000_0000_0000
```

not working:
```
[[genesis.dep_groups]]
name = "always"
files = [
  { file = "../compiled_binary/always_success" },
  { file = "../compiled_binary/always_failure" },
]
```

this PR resolved this issue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
./ckb init -c dev
edit dev.toml # add two script to dep_groups
mkdir compiled_binary
cp ckb/test/template/specs/cells/always_success compiled_binary
cp ckb/test/template/specs/cells/always_failure compiled_binary
./ckb run
```

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

