### PR TITLE
fix(ckb cli) add h256 validator for --assume-valid-target and ba-code-hash

### DIFF
--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -180,7 +180,7 @@ fn run<'help>() -> Command<'help> {
         Arg::new(ARG_ASSUME_VALID_TARGET)
             .long(ARG_ASSUME_VALID_TARGET)
             .takes_value(true)
-            .validator(is_hex)
+            .validator(is_h256)
             .help("This parameter specifies the hash of a block. \
             When the height does not reach this block's height, the execution of the script will be disabled, \
             that is, skip verifying the script content. \
@@ -417,7 +417,7 @@ fn init<'help>() -> Command<'help> {
             Arg::new(ARG_BA_CODE_HASH)
                 .long(ARG_BA_CODE_HASH)
                 .value_name("code_hash")
-                .validator(is_hex)
+                .validator(is_h256)
                 .takes_value(true)
                 .help(
                     "Sets code_hash in [block_assembler] \
@@ -524,5 +524,13 @@ fn is_hex(hex: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("Must 0x-prefixed hexadecimal string".to_string())
+    }
+}
+
+fn is_h256(hex: &str) -> Result<(), String> {
+    if hex.len() != 66 {
+        Err("Must be 0x-prefixed hexadecimal string and string length is 66".to_owned())
+    } else {
+        is_hex(hex)
     }
 }


### PR DESCRIPTION
fix(ckb cli) add h256 validator for --assume-valid-target and ba-code-hash

### What problem does this PR solve?

- add H256 validator for `ckb init --ba-code-hash` and `ckb run --assume-valid-target` replace naive is_hex check.
- add related 1 testcase

### What is changed and how it works?

now cli report error at parsing phase, prompt invalid h256 message, instead of running error.

### Related changes

- PR to update `owner/repo`:

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

