### PR TITLE
refactor: use watch channel to notify resume state changes

### DIFF
--- a/tx-pool/src/error.rs
+++ b/tx-pool/src/error.rs
@@ -6,7 +6,9 @@ use ckb_error::{
     InternalError, InternalErrorKind, OtherError,
 };
 pub use ckb_types::core::tx_pool::Reject;
+use std::fmt;
 use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::watch::error::SendError;
 
 /// The error type for block assemble related
 #[derive(Error, Debug, PartialEq, Clone, Eq)]
@@ -42,6 +44,6 @@ pub(crate) fn handle_recv_error(error: RecvError) -> OtherError {
     OtherError::new(format!("RecvError {}", error))
 }
 
-pub(crate) fn handle_send_cmd_error<T>(error: ckb_channel::TrySendError<T>) -> OtherError {
-    OtherError::new(format!("send command fails: {}", error))
+pub(crate) fn handle_send_cmd_error<T: fmt::Debug>(error: SendError<T>) -> OtherError {
+    OtherError::new(format!("send command fails: {:?}", error))
 }

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -26,8 +26,8 @@ pub use crate::transaction_verifier::{
     TimeRelativeTransactionVerifier, TransactionVerifier,
 };
 pub use ckb_script::{
-    ScriptError, ScriptGroupType, TransactionState as ScriptVerifyState, TxVerifyEnv,
-    VerifyResult as ScriptVerifyResult,
+    ScriptError, ScriptGroupType, TransactionSnapshot, TransactionState as ScriptVerifyState,
+    TxVerifyEnv, VerifyResult as ScriptVerifyResult,
 };
 
 /// Maximum amount of time that a block timestamp is allowed to exceed the


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Signalling program state changes is good use cases for the watch channel, consumers only see the most recent value,  avoiding useless buffer overhead.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nervosnetwork/ckb/3346)
<!-- Reviewable:end -->
