### PR TITLE
chore: remove unsafe reader to array unpack fn

### DIFF
--- a/util/jsonrpc-types/src/proposal_short_id.rs
+++ b/util/jsonrpc-types/src/proposal_short_id.rs
@@ -26,7 +26,11 @@ impl ProposalShortId {
 
 impl From<packed::ProposalShortId> for ProposalShortId {
     fn from(core: packed::ProposalShortId) -> ProposalShortId {
-        ProposalShortId::new(core.unpack())
+        ProposalShortId::new(
+            core.as_slice()
+                .try_into()
+                .expect("checked in packed::ProposalShortId"),
+        )
     }
 }
 

--- a/util/types/src/conversion/blockchain.rs
+++ b/util/types/src/conversion/blockchain.rs
@@ -51,28 +51,12 @@ impl Pack<packed::Byte32> for [u8; 32] {
     }
 }
 
-impl<'r> Unpack<[u8; 32]> for packed::Byte32Reader<'r> {
-    fn unpack(&self) -> [u8; 32] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 32];
-        unsafe { *ptr }
-    }
-}
-impl_conversion_for_entity_unpack!([u8; 32], Byte32);
-
 impl Pack<packed::ProposalShortId> for [u8; 10] {
     fn pack(&self) -> packed::ProposalShortId {
         packed::ProposalShortId::from_slice(&self[..])
             .expect("impossible: fail to pack to ProposalShortId")
     }
 }
-
-impl<'r> Unpack<[u8; 10]> for packed::ProposalShortIdReader<'r> {
-    fn unpack(&self) -> [u8; 10] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 10];
-        unsafe { *ptr }
-    }
-}
-impl_conversion_for_entity_unpack!([u8; 10], ProposalShortId);
 
 impl Pack<packed::Bytes> for Bytes {
     fn pack(&self) -> packed::Bytes {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Please refer to https://github.com/nervosnetwork/godwoken/pull/629, I think unpack a reader to array is quite rare, we should always unpack to new type, for example: `H256([u8; 32]) or ProposalId([u8;10])`. 

And in ckb current code, there are only one place to unpack the `ProposalIdReader` to [u8;10], which can be simply replaced by `try_into`, so I proposal this PR to remove these two unsafe fn.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nervosnetwork/ckb/3353)
<!-- Reviewable:end -->
