### PR TITLE
chore(ci): install scoop as admin

### DIFF
--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -56,7 +56,8 @@ jobs:
     - name: install required tools
       if: ${{ needs.prologue.outputs.windows_runner_label == 'windows-2019' }}
       run: |
-        iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         scoop install git

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -60,7 +60,8 @@ jobs:
     - name: install required tools
       if: ${{ needs.prologue.outputs.windows_runner_label == 'windows-2019' }}
       run: |
-        iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         scoop install git

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -56,7 +56,8 @@ jobs:
     - name: install required tools
       if: ${{ needs.prologue.outputs.windows_runner_label == 'windows-2019' }}
       run: |
-        iex (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         scoop install git

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,8 @@ jobs:
     - name: Install Dependencies
       run: |
         Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
         scoop install llvm yasm
         echo ("GIT_TAG_NAME=" + $env:GITHUB_REF.replace('refs/heads/pkg/', '')) >> $env:GITHUB_ENV
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Scoop no longer supports installation as admin by default.

### What is changed and how it works?

What's Changed: Use two-steps installation as suggested by the Scoop README.

https://github.com/ScoopInstaller/Install#for-admin

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

