### PR TITLE
chore: format shell files using shfmt

### DIFF
--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -6,204 +6,207 @@ SRC_ROOT=.
 ERRCNT=0
 
 case "$OSTYPE" in
-    darwin*)
-        if ! type gsed &> /dev/null || ! type ggrep &> /dev/null; then
-            echo "GNU sed and grep not found! You can install via Homebrew" >&2
-            echo >&2
-            echo "    brew install grep gnu-sed" >&2
-            exit 1
-        fi
+  darwin*)
+    if ! type gsed &>/dev/null || ! type ggrep &>/dev/null; then
+      echo "GNU sed and grep not found! You can install via Homebrew" >&2
+      echo >&2
+      echo "    brew install grep gnu-sed" >&2
+      exit 1
+    fi
 
-        SED=gsed
-        GREP=ggrep
-        ;;
-    *)
-        SED=sed
-        GREP=grep
-        ;;
+    SED=gsed
+    GREP=ggrep
+    ;;
+  *)
+    SED=sed
+    GREP=grep
+    ;;
 esac
 
 function check_package_name() {
-    local regex_to_cut_pkgname='s/^\[\(package\)\]\nname\(\|[ ]\+\)=\(\|[ ]\+\)"\(.\+\)"/\4/p'
-    for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
-        local pkgname=$(${SED} -n -e N -e "${regex_to_cut_pkgname}" "${cargo_toml}")
-        if [ -z "${pkgname}" ]; then
-            printf "Error: No package name in <%s>\n" "${cargo_toml}"
-            ERRCNT=$((ERRCNT + 1))
-        elif [[ "${pkgname}" =~ ^ckb- ]] || [ "${pkgname}" = "ckb" ]; then
-            :
-        else
-            printf "Error: Package name in <%s> is not with prefix 'ckb-' (actual: '%s')\n" \
-                "${cargo_toml}" "${pkgname}"
-            ERRCNT=$((ERRCNT + 1))
-        fi
-    done
+  local regex_to_cut_pkgname='s/^\[\(package\)\]\nname\(\|[ ]\+\)=\(\|[ ]\+\)"\(.\+\)"/\4/p'
+  for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
+    local pkgname=$(${SED} -n -e N -e "${regex_to_cut_pkgname}" "${cargo_toml}")
+    if [ -z "${pkgname}" ]; then
+      printf "Error: No package name in <%s>\n" "${cargo_toml}"
+      ERRCNT=$((ERRCNT + 1))
+    elif [[ "${pkgname}" =~ ^ckb- ]] || [ "${pkgname}" = "ckb" ]; then
+      :
+    else
+      printf "Error: Package name in <%s> is not with prefix 'ckb-' (actual: '%s')\n" \
+        "${cargo_toml}" "${pkgname}"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+  done
 }
 
 function check_version() {
-    local regex_to_cut_version='s/^version = "\(.*\)"$/\1/p'
-    local expected=$(${SED} -n "${regex_to_cut_version}" "${SRC_ROOT}/Cargo.toml")
-    for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
-        local tmp=$(${SED} -n "${regex_to_cut_version}" "${cargo_toml}")
-        if [ "${expected}" != "${tmp}" ]; then
-            printf "Error: Version in <%s> is not right (expect: '%s', actual: '%s')\n" \
-                "${cargo_toml}" "${expected}" "${tmp}"
-            ERRCNT=$((ERRCNT + 1))
-        fi
+  local regex_to_cut_version='s/^version = "\(.*\)"$/\1/p'
+  local expected=$(${SED} -n "${regex_to_cut_version}" "${SRC_ROOT}/Cargo.toml")
+  for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
+    local tmp=$(${SED} -n "${regex_to_cut_version}" "${cargo_toml}")
+    if [ "${expected}" != "${tmp}" ]; then
+      printf "Error: Version in <%s> is not right (expect: '%s', actual: '%s')\n" \
+        "${cargo_toml}" "${expected}" "${tmp}"
+      ERRCNT=$((ERRCNT + 1))
+    fi
 
-        if grep -n -H '{.*path\s*=\s*' $cargo_toml | grep -F -v 'version = "= '"$expected"'"'; then
-          printf "Error: Local depedencies in <%s> must specify version \"= %s\"\n" \
-              "${cargo_toml}" "${expected}"
-          ERRCNT=$((ERRCNT + 1))
-        fi
-    done
+    if grep -n -H '{.*path\s*=\s*' $cargo_toml | grep -F -v 'version = "= '"$expected"'"'; then
+      printf "Error: Local depedencies in <%s> must specify version \"= %s\"\n" \
+        "${cargo_toml}" "${expected}"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+  done
 }
 
 function check_license() {
-    local regex_to_cut_license='s/^license = "\(.*\)"$/\1/p'
-    local expected=$(${SED} -n "${regex_to_cut_license}" "${SRC_ROOT}/Cargo.toml")
-    for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
-        local tmp=$(${SED} -n "${regex_to_cut_license}" "${cargo_toml}")
-        if [ "${expected}" != "${tmp}" ]; then
-            printf "Error: License in <%s> is not right (expect: '%s', actual: '%s')\n" \
-                "${cargo_toml}" "${expected}" "${tmp}"
-            ERRCNT=$((ERRCNT + 1))
-        fi
-    done
+  local regex_to_cut_license='s/^license = "\(.*\)"$/\1/p'
+  local expected=$(${SED} -n "${regex_to_cut_license}" "${SRC_ROOT}/Cargo.toml")
+  for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
+    local tmp=$(${SED} -n "${regex_to_cut_license}" "${cargo_toml}")
+    if [ "${expected}" != "${tmp}" ]; then
+      printf "Error: License in <%s> is not right (expect: '%s', actual: '%s')\n" \
+        "${cargo_toml}" "${expected}" "${tmp}"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+  done
 }
 
 function check_cargo_publish() {
-    for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
-        if ! grep -q '^description =' "${cargo_toml}"; then
-            echo "Error: Require description in <${cargo_toml}>"
-            ERRCNT=$((ERRCNT + 1))
-        fi
-        if ! grep -q '^homepage =' "${cargo_toml}"; then
-            echo "Error: Require homepage in <${cargo_toml}>"
-            ERRCNT=$((ERRCNT + 1))
-        fi
-        if ! grep -q '^repository =' "${cargo_toml}"; then
-            echo "Error: Require repository in <${cargo_toml}>"
-            ERRCNT=$((ERRCNT + 1))
-        fi
-    done
+  for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
+    if ! grep -q '^description =' "${cargo_toml}"; then
+      echo "Error: Require description in <${cargo_toml}>"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+    if ! grep -q '^homepage =' "${cargo_toml}"; then
+      echo "Error: Require homepage in <${cargo_toml}>"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+    if ! grep -q '^repository =' "${cargo_toml}"; then
+      echo "Error: Require repository in <${cargo_toml}>"
+      ERRCNT=$((ERRCNT + 1))
+    fi
+  done
 }
 
 function search_crate() {
-    local crate="$1"
-    local source="$2"
-    local tmpcnt=0
-    local depcnt=0
-    local grepopts="-rh"
-    tmpcnt=$({\
-        ${GREP} ${grepopts} "\(^\| \)extern crate ${crate}\(::\|;\| as \)" "${source}" \
-            || true; }\
-        | wc -l)
-    depcnt=$((depcnt + tmpcnt))
-    tmpcnt=$({\
-        ${GREP} ${grepopts} "\(^\| \)use ${crate}\(::\|;\| as \)" "${source}" \
-            || true; }\
-        | wc -l)
-    depcnt=$((depcnt + tmpcnt))
-    tmpcnt=$({\
-        ${GREP} ${grepopts} "\(^\|[ (<]\)\(::\|\)${crate}::" "${source}" \
-            || true; }\
-        | wc -l)
-    depcnt=$((depcnt + tmpcnt))
-    printf "${depcnt}"
+  local crate="$1"
+  local source="$2"
+  local tmpcnt=0
+  local depcnt=0
+  local grepopts="-rh"
+  tmpcnt=$({
+    ${GREP} ${grepopts} "\(^\| \)extern crate ${crate}\(::\|;\| as \)" "${source}" ||
+      true
+  } |
+    wc -l)
+  depcnt=$((depcnt + tmpcnt))
+  tmpcnt=$({
+    ${GREP} ${grepopts} "\(^\| \)use ${crate}\(::\|;\| as \)" "${source}" ||
+      true
+  } |
+    wc -l)
+  depcnt=$((depcnt + tmpcnt))
+  tmpcnt=$({
+    ${GREP} ${grepopts} "\(^\|[ (<]\)\(::\|\)${crate}::" "${source}" ||
+      true
+  } |
+    wc -l)
+  depcnt=$((depcnt + tmpcnt))
+  printf "${depcnt}"
 }
 
 function check_dependencies_for() {
-    local deptype="$1"
-    for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
-        local pkgroot=$(dirname "${cargo_toml}")
-        for dependency_original in $(${SED} -n "/^\[${deptype}\]/,/^\[/p" "${cargo_toml}" \
-                | { ${GREP} -v "^\(\[\|[ ]*$\|[ ]*#\)" || true; } \
-                | ${SED} -n "s/\([^ =]*\).*/\1/p"); do
-            local dependency=$(printf "${dependency_original}" | tr '-' '_')
-            local tmpcnt=0
-            local depcnt=0
-            local srcdir=
-            local buildrs=
-            case "${deptype}" in
-                "dependencies" | "dev-dependencies")
-                    srcdir="${pkgroot}/src"
-                    if [ ! -d "${srcdir}" ]; then
-                        srcdir="${pkgroot}"
-                    fi
-                    tmpcnt=$(search_crate "${dependency}" "${srcdir}")
-                    depcnt=$((depcnt + tmpcnt))
-                    ;;
-                "build-dependencies")
-                    buildrs="${pkgroot}/build.rs"
-                    tmpcnt=$(search_crate "${dependency}" "${buildrs}")
-                    depcnt=$((depcnt + tmpcnt))
-                    ;;
-                *)
-                    :
-                    ;;
-            esac
-            if [ "${deptype}" = "dev-dependencies" ]; then
-                for subdir in "tests" "benches" "examples"; do
-                    srcdir="${pkgroot}/${subdir}"
-                    if [ -d "${srcdir}" ]; then
-                        tmpcnt=$(search_crate "${dependency}" "${srcdir}")
-                        depcnt=$((depcnt + tmpcnt))
-                    fi
-                done
-            fi
-            if [ "${depcnt}" -eq 0 ]; then
-                case "${dependency}" in
-                    phf)
-                        # We cann't handle these crates.
-                        printf "Warn: [%s::%s] in <%s>\n" \
-                            "${deptype}" "${dependency}" "${pkgroot}"
-                        ;;
-                    tokio_yamux)
-                        if [ "$(basename "$pkgroot")" != "network" ]; then
-                            printf "Error: [%s::%s] in <%s>\n" \
-                                "${deptype}" "${dependency}" "${pkgroot}"
-                            ERRCNT=$((ERRCNT + 1))
-                        else
-                            printf "Warn: [%s::%s] locked in <%s>\n" \
-                                "${deptype}" "${dependency}" "${pkgroot}"
-                        fi
-                        ;;
-                    *)
-                        printf "Error: [%s::%s] in <%s>\n" \
-                            "${deptype}" "${dependency}" "${pkgroot}"
-                        ERRCNT=$((ERRCNT + 1))
-                        ;;
-                esac
-            fi
-            if [ "${deptype}" = "dev-dependencies" ]; then
-                tmpcnt=$(${GREP} -c "^${dependency_original}[^a-zA-Z0-9=_-]*=" "${cargo_toml}")
-                if [ "${tmpcnt}" -gt 1 ]; then
-                    printf "Warn: [%s::%s] in <%s>, twice\n" \
-                        "${deptype}" "${dependency}" "${pkgroot}"
-                fi
-            fi
+  local deptype="$1"
+  for cargo_toml in $(find "${SRC_ROOT}" -type f -name "Cargo.toml" -not -path '*/target/*'); do
+    local pkgroot=$(dirname "${cargo_toml}")
+    for dependency_original in $(${SED} -n "/^\[${deptype}\]/,/^\[/p" "${cargo_toml}" |
+      { ${GREP} -v "^\(\[\|[ ]*$\|[ ]*#\)" || true; } |
+      ${SED} -n "s/\([^ =]*\).*/\1/p"); do
+      local dependency=$(printf "${dependency_original}" | tr '-' '_')
+      local tmpcnt=0
+      local depcnt=0
+      local srcdir=
+      local buildrs=
+      case "${deptype}" in
+        "dependencies" | "dev-dependencies")
+          srcdir="${pkgroot}/src"
+          if [ ! -d "${srcdir}" ]; then
+            srcdir="${pkgroot}"
+          fi
+          tmpcnt=$(search_crate "${dependency}" "${srcdir}")
+          depcnt=$((depcnt + tmpcnt))
+          ;;
+        "build-dependencies")
+          buildrs="${pkgroot}/build.rs"
+          tmpcnt=$(search_crate "${dependency}" "${buildrs}")
+          depcnt=$((depcnt + tmpcnt))
+          ;;
+        *)
+          :
+          ;;
+      esac
+      if [ "${deptype}" = "dev-dependencies" ]; then
+        for subdir in "tests" "benches" "examples"; do
+          srcdir="${pkgroot}/${subdir}"
+          if [ -d "${srcdir}" ]; then
+            tmpcnt=$(search_crate "${dependency}" "${srcdir}")
+            depcnt=$((depcnt + tmpcnt))
+          fi
         done
+      fi
+      if [ "${depcnt}" -eq 0 ]; then
+        case "${dependency}" in
+          phf)
+            # We cann't handle these crates.
+            printf "Warn: [%s::%s] in <%s>\n" \
+              "${deptype}" "${dependency}" "${pkgroot}"
+            ;;
+          tokio_yamux)
+            if [ "$(basename "$pkgroot")" != "network" ]; then
+              printf "Error: [%s::%s] in <%s>\n" \
+                "${deptype}" "${dependency}" "${pkgroot}"
+              ERRCNT=$((ERRCNT + 1))
+            else
+              printf "Warn: [%s::%s] locked in <%s>\n" \
+                "${deptype}" "${dependency}" "${pkgroot}"
+            fi
+            ;;
+          *)
+            printf "Error: [%s::%s] in <%s>\n" \
+              "${deptype}" "${dependency}" "${pkgroot}"
+            ERRCNT=$((ERRCNT + 1))
+            ;;
+        esac
+      fi
+      if [ "${deptype}" = "dev-dependencies" ]; then
+        tmpcnt=$(${GREP} -c "^${dependency_original}[^a-zA-Z0-9=_-]*=" "${cargo_toml}")
+        if [ "${tmpcnt}" -gt 1 ]; then
+          printf "Warn: [%s::%s] in <%s>, twice\n" \
+            "${deptype}" "${dependency}" "${pkgroot}"
+        fi
+      fi
     done
+  done
 }
 
 function check_dependencies() {
-    check_dependencies_for "dependencies"
-    check_dependencies_for "build-dependencies"
-    check_dependencies_for "dev-dependencies"
+  check_dependencies_for "dependencies"
+  check_dependencies_for "build-dependencies"
+  check_dependencies_for "dev-dependencies"
 }
 
 function main() {
-    echo "[BEGIN] Checking Cargo.toml ..."
-    check_package_name
-    check_version
-    check_license
-    check_cargo_publish
-    check_dependencies
-    echo "[ END ] Found ${ERRCNT} errors."
-    if [ "${ERRCNT}" -ne 0 ]; then
-        exit 1
-    fi
+  echo "[BEGIN] Checking Cargo.toml ..."
+  check_package_name
+  check_version
+  check_license
+  check_cargo_publish
+  check_dependencies
+  echo "[ END ] Found ${ERRCNT} errors."
+  if [ "${ERRCNT}" -ne 0 ]; then
+    exit 1
+  fi
 }
 
 main "$@"

--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 set -euo pipefail
-is_self_runner=`echo $RUNNER_LABEL | awk -F '-' '{print $1}'`
+is_self_runner=$(echo $RUNNER_LABEL | awk -F '-' '{print $1}')
 clean_threshold=40000
-available_space=`df -m "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}'`
-if [[ $is_self_runner == "self" ]];then
+available_space=$(df -m "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
+if [[ $is_self_runner == "self" ]]; then
   export CARGO_TARGET_DIR="$GITHUB_WORKSPACE/../target"
   export RUSTC_WRAPPER='sccache'
   export SCCACHE_CACHE_SIZE='20G'
   #clean space when disk full
   if [[ $available_space -lt $clean_threshold ]]; then
-          echo "Run clean command"
-          cargo clean --target-dir "${CARGO_TARGET_DIR}" || true
+    echo "Run clean command"
+    cargo clean --target-dir "${CARGO_TARGET_DIR}" || true
   fi
 fi
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$GITHUB_WORKSPACE/target"}
 case $GITHUB_WORKFLOW in
   ci_linters*)
     echo "ci_linters"
-    cargo fmt --version ||  rustup component add rustfmt
-    cargo clippy --version ||  rustup component add clippy
+    cargo fmt --version || rustup component add rustfmt
+    cargo clippy --version || rustup component add clippy
     make fmt
     make clippy
     git diff --exit-code Cargo.lock
@@ -31,14 +31,14 @@ case $GITHUB_WORKFLOW in
     echo "ci_benchmarks_test"
     make bench-test
     ;;
-ci_integration_tests*)
+  ci_integration_tests*)
     echo "ci_integration_test"
-    github_workflow_os=`echo $GITHUB_WORKFLOW | awk -F '_' '{print $NF}'`
+    github_workflow_os=$(echo $GITHUB_WORKFLOW | awk -F '_' '{print $NF}')
     export BUILD_BUILDID=$GITHUB_RUN_ID
     export ImageOS=$RUNNER_OS
     export BINARY_NAME=${BINARY_NAME:-"ckb"}
-    if [[ $github_workflow_os == 'windows' ]];then
-       BINARY_NAME="ckb.exe"
+    if [[ $github_workflow_os == 'windows' ]]; then
+      BINARY_NAME="ckb.exe"
     fi
     make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
     ;;

--- a/devtools/release/publish-crates.sh
+++ b/devtools/release/publish-crates.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 [ -n "${DEBUG:-}" ] && set -x || true
 
-CRATES="$(cat Cargo.toml| sed -n -e '0, /^members/d' -e '/^\]$/, $d' -e 's/.*["'\'']\(.*\)["'\''].*/\1/p')"
+CRATES="$(cat Cargo.toml | sed -n -e '0, /^members/d' -e '/^\]$/, $d' -e 's/.*["'\'']\(.*\)["'\''].*/\1/p')"
 RUST_VERSION="$(cat rust-toolchain)"
 
 retry_cargo_publish() {
@@ -50,15 +50,15 @@ generate_readme() {
   CRATE_DESCRIPTION="$(sed -n -e '/^description\s*=\s*"""/,/^"""/p' -e 's/description\s*=\s*"\([^"].*\)"$/\1/p' Cargo.toml | grep -v '"""$')"
   CRATE_NAME="$(sed -n -e 's/name\s*=\s*"\([^"].*\)"$/\1/p' Cargo.toml)"
 
-  echo "# $CRATE_NAME" > README.md
-  echo >> README.md
-  echo "This crate is a component of [ckb](https://github.com/nervosnetwork/ckb)." >> README.md
-  echo >> README.md
-  echo "$CRATE_DESCRIPTION" >> README.md
-  echo >> README.md
-  echo '## Minimum Supported Rust Version policy (MSRV)' >> README.md
-  echo >> README.md
-  echo "This crate's minimum supported rustc version is $RUST_VERSION" >> README.md
+  echo "# $CRATE_NAME" >README.md
+  echo >>README.md
+  echo "This crate is a component of [ckb](https://github.com/nervosnetwork/ckb)." >>README.md
+  echo >>README.md
+  echo "$CRATE_DESCRIPTION" >>README.md
+  echo >>README.md
+  echo '## Minimum Supported Rust Version policy (MSRV)' >>README.md
+  echo >>README.md
+  echo "This crate's minimum supported rustc version is $RUST_VERSION" >>README.md
 }
 
 cp -f Cargo.lock Cargo.lock.bak
@@ -72,7 +72,7 @@ fi
 
 for crate_dir in $CRATES; do
   case "$crate_dir" in
-    benches | util/test-chain-utils )
+    benches | util/test-chain-utils)
       # ignore
       ;;
     *)

--- a/devtools/smoking_test/check-migrate.sh
+++ b/devtools/smoking_test/check-migrate.sh
@@ -12,9 +12,8 @@ if [ ${EXIT_CODE} == 0 ]; then
   echo "migrate exit code is "${EXIT_CODE}
   if [ ${EXIT_CODE} != 0 ]; then
     echo "migrate faile,please try again"
-    exit ${EXIT_CODE};
+    exit ${EXIT_CODE}
   else
     echo "DB migrate done"
   fi
 fi
-

--- a/devtools/smoking_test/tip_block_growth_check.sh
+++ b/devtools/smoking_test/tip_block_growth_check.sh
@@ -4,29 +4,29 @@ set -euo pipefail
 
 set -e
 function get_tip_block_number() {
-    tip_block_json=` echo '{
+  tip_block_json=$(echo '{
         "id": 2,
         "jsonrpc": "2.0",
         "method": "get_tip_block_number",
         "params": [
         ]
-    }' \
-    | tr -d '\n' \
-    | curl -H 'content-type: application/json' -d @- \
-    http://127.0.0.1:8114 `
+      }' |
+    tr -d '\n' |
+    curl -H 'content-type: application/json' -d @- \
+      http://127.0.0.1:8114)
 
-   TIP_BLOCK_NUMBER=`echo $tip_block_json | jq --raw-output '.result'`
-   TIP_BLOCK_NUMBER=$(printf %d $TIP_BLOCK_NUMBER)
-   echo $TIP_BLOCK_NUMBER
+  TIP_BLOCK_NUMBER=$(echo $tip_block_json | jq --raw-output '.result')
+  TIP_BLOCK_NUMBER=$(printf %d $TIP_BLOCK_NUMBER)
+  echo $TIP_BLOCK_NUMBER
 }
 sleep 60 #waiting for ckb start
-FIRST_TIP_BLOCK_NUMBER=`get_tip_block_number`
+FIRST_TIP_BLOCK_NUMBER=$(get_tip_block_number)
 echo "Fsirt tip block number is "$FIRST_TIP_BLOCK_NUMBER
 sleep 600
-SECOND_TIP_BLOCK_NUMBER=`get_tip_block_number`
+SECOND_TIP_BLOCK_NUMBER=$(get_tip_block_number)
 echo "Second tip block number is "$SECOND_TIP_BLOCK_NUMBER
 
 if [ $FIRST_TIP_BLOCK_NUMBER == $SECOND_TIP_BLOCK_NUMBER ]; then
-   echo "Tip block number No update in 10mins"
-   exit 1
+  echo "Tip block number No update in 10mins"
+  exit 1
 fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 set -e
 set -u
@@ -18,18 +17,18 @@ set +e
 test_id=$(date +"%Y%m%d-%H%M%S")
 test_tmp_dir=${CKB_INTEGRATION_TEST_TMP:-$(pwd)/target/ckb-test/${test_id}}
 export CKB_INTEGRATION_TEST_TMP="${test_tmp_dir}"
-echo "CKB_INTEGRATION_TEST_TMP=$CKB_INTEGRATION_TEST_TMP" >> $GITHUB_ENV
+echo "CKB_INTEGRATION_TEST_TMP=$CKB_INTEGRATION_TEST_TMP" >>$GITHUB_ENV
 mkdir -p "${test_tmp_dir}"
 test_log_file="${test_tmp_dir}/integration.log"
 
 export CKB_INTEGRATION_FAILURE_FILE="${test_tmp_dir}/integration.failure"
-echo "Unknown integration error" > "$CKB_INTEGRATION_FAILURE_FILE"
+echo "Unknown integration error" >"$CKB_INTEGRATION_FAILURE_FILE"
 cargo run "$@" 2>&1 | tee "${test_log_file}"
 EXIT_CODE="${PIPESTATUS[0]}"
 set -e
 
 if [ "$EXIT_CODE" != 0 ] && [ "${TRAVIS_REPO_SLUG:-nervosnetwork/ckb}" = "nervosnetwork/ckb" ]; then
-  if ! command -v sentry-cli &> /dev/null; then
+  if ! command -v sentry-cli &>/dev/null; then
     curl -sL https://sentry.io/get-cli/ | bash
   fi
   export SENTRY_DSN="https://15373165fbf2439b99ba46684dfbcb12@sentry.nervos.org/7"
@@ -41,8 +40,8 @@ if [ "$EXIT_CODE" != 0 ] && [ "${TRAVIS_REPO_SLUG:-nervosnetwork/ckb}" = "nervos
         CKB_BIN="$2"
         break
         ;;
-      *)
-        ;;
+      *) ;;
+
     esac
     shift
   done
@@ -63,7 +62,7 @@ send "bye\r"
 EOF
     cd -
   fi
-# upload github actions log if test failed
+  # upload github actions log if test failed
   if [ -n "${BUILD_BUILDID:-}" ] && [ -n "${LOGBAK_SERVER:-}" ]; then
     upload_id="github-actions-${test_id}-${BUILD_BUILDID:-0}-${ImageOS:-unknown}"
     cd "${test_tmp_dir}"/..


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: The shell files are not consistent in format.

### What is changed and how it works?

What's Changed:

Format all the shell files using `shfmt` with following options:

- `-ci`: Indent case
- `-i 2`: 2-spaces indentation

Example to format the file `test/run.sh`

```
shfmt -ci -i 2 -w test/run.sh
```

See more details about `shfmt` in https://github.com/mvdan/sh

### Check List

Tests

- Unit test

### Release note

```release-note
None: Exclude this PR from the release note.
```

