### PR TITLE
chore: upgrade rust to 1.56.1 in docker builder

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -72,7 +72,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.51.0
+      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.56.1
       REL_PKG: x86_64-unknown-linux-gnu.tar.gz
 
   package-for-linux-aarch64:
@@ -158,7 +158,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.51.0
+      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.56.1
       REL_PKG: x86_64-unknown-centos-gnu.tar.gz
 
   package-for-mac:

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM nervos/ckb-docker-builder:bionic-rust-1.51.0 as ckb-docker-builder
+FROM nervos/ckb-docker-builder:bionic-rust-1.56.1 as ckb-docker-builder
 
 WORKDIR /ckb
 COPY ./ .


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: The docker build images used in CKB are outdated.

### What is changed and how it works?

What's Changed: Upgrade to the latest builder images with Rust 1.56.1

### Check List

Tests

- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

