### PR TITLE
fix(tx_monitor): fix #3309, mismatch resolved_tx and completed_tx

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -844,8 +844,10 @@ impl ChainService {
 
                                         // log tx verification result for monitor node
                                         if log_enabled_target!("ckb_tx_monitor", Trace) {
+                                            // `cache_entries` already excludes cellbase tx, but `resolved` includes cellbase tx, skip it
+                                            // to make them aligned
                                             for (rtx, cycles) in
-                                                resolved.iter().zip(cache_entries.iter()).skip(1)
+                                                resolved.iter().skip(1).zip(cache_entries.iter())
                                             {
                                                 trace_target!(
                                                     "ckb_tx_monitor",


### PR DESCRIPTION
### What problem does this PR solve?
fix #3309, cycles mismatched when monitor tx verified result.

### What is changed and how it works?

mismatched between resolved(txs) and cache_entries(verified_result), because resolve(txs) includes cellbase_tx and cache_entries already exclude cellbase tx.


- PR to update `owner/repo`:

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  I will contact with Devops team member, help to verify it.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

