### PR TITLE
config: activate ckb2021 in mainnet since epoch 5414

### DIFF
--- a/util/constant/src/hardfork/mainnet.rs
+++ b/util/constant/src/hardfork/mainnet.rs
@@ -1,6 +1,5 @@
 /// The Chain Specification name.
 pub const CHAIN_SPEC_NAME: &str = "ckb";
 
-// TODO ckb2021 Update the epoch number for mainnet.
-/// First epoch number for CKB v2021
-pub const CKB2021_START_EPOCH: u64 = u64::MAX;
+/// First epoch number for CKB v2021, at about 2022/05/10 1:00 UTC
+pub const CKB2021_START_EPOCH: u64 = 5414;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Activate ckb2021 in mainnet since epoch 5414

### Check List

Tests

- Unit test
- Integration test

Side effects

- Breaking backward compatibility: Nodes must upgrade to this version or above before 2020 May 10th.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

