### PR TITLE
feat(metrics): add metrics for ban and been_baned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "ckb-app-config",
  "ckb-hash",
  "ckb-logger",
+ "ckb-metrics",
  "ckb-spawn",
  "ckb-stop-handler",
  "ckb-types",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,6 +15,7 @@ ckb-util = { path = "../util", version = "= 0.104.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.104.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.104.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.104.0-pre" }
+ckb-metrics = {path = "../util/metrics", version = "= 0.104.0-pre"}
 tokio = { version = "1", features = ["sync", "macros"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures = "0.3"


### PR DESCRIPTION
### What problem does this PR solve?

Add metrics for network ban peer or  been banned, help to measure network partition.

### What is changed and how it works?

What's Changed:
ban peer operation ocurred at sync and tx_pool module, but callee function is at network module, network.rs
we add ban_peer and reason info. in metrics.

- PR to update `owner/repo`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]
- test manually

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```