### PR TITLE
fix(rpc): disconnect session of peers when invoke rpc set_ban

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1230,6 +1230,7 @@ impl NetworkController {
 
     /// Ban an ip
     pub fn ban(&self, address: IpNetwork, ban_until: u64, ban_reason: String) {
+        self.disconnect_peers_in_ip_range(address, &ban_reason);
         self.network_state
             .peer_store
             .lock()
@@ -1259,6 +1260,23 @@ impl NetworkController {
     pub fn ban_peer(&self, peer_index: PeerIndex, duration: Duration, reason: String) {
         self.network_state
             .ban_session(&self.p2p_control, peer_index, duration, reason);
+    }
+
+    /// disconnect peers with matched peer_ip or peer_ip_network, eg: 192.168.0.2 or 192.168.0.0/24
+    fn disconnect_peers_in_ip_range(&self, address: IpNetwork, reason: &str) {
+        self.network_state.with_peer_registry(|reg| {
+            reg.peers().iter().for_each(|(peer_index, peer)| {
+                if let Some(addr) = multiaddr_to_socketaddr(&peer.connected_addr) {
+                    if address.contains(addr.ip()) {
+                        let _ = disconnect_with_message(
+                            &self.p2p_control,
+                            *peer_index,
+                            &format!("Ban peer {}, reason: {}", addr.ip(), reason),
+                        );
+                    }
+                }
+            })
+        });
     }
 
     fn try_broadcast(

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -505,6 +505,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RpcTruncate),
         Box::new(RpcTransactionProof),
         Box::new(RpcGetBlockMedianTime),
+        Box::new(RpcSetBan),
         Box::new(SyncTooNewBlock),
         Box::new(RelayTooNewBlock),
         Box::new(LastCommonHeaderForPeerWithWorseChain),

--- a/test/src/specs/rpc/mod.rs
+++ b/test/src/specs/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod get_block_median_time;
 mod get_block_template;
 mod get_blockchain_info;
+mod set_ban;
 mod submit_block;
 mod transaction_proof;
 mod truncate;
@@ -8,6 +9,7 @@ mod truncate;
 pub use get_block_median_time::*;
 pub use get_block_template::*;
 pub use get_blockchain_info::*;
+pub use set_ban::*;
 pub use submit_block::*;
 pub use transaction_proof::*;
 pub use truncate::*;

--- a/test/src/specs/rpc/set_ban.rs
+++ b/test/src/specs/rpc/set_ban.rs
@@ -1,0 +1,68 @@
+use crate::node::{connect_all, waiting_for_sync};
+use crate::specs::spec_name;
+use crate::util::mining::out_ibd_mode;
+use crate::utils::find_available_port;
+use crate::{Node, Spec};
+
+pub struct RpcSetBan;
+
+impl Spec for RpcSetBan {
+    // crate::setup!(num_nodes: 3);
+
+    // node will ban the node with ip_address and ban the node within the ip/subnet
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node = &nodes[0];
+
+        out_ibd_mode(nodes);
+        connect_all(nodes);
+
+        waiting_for_sync(nodes);
+
+        assert_eq!(node.rpc_client().get_peers().len(), 2);
+
+        node.rpc_client().set_ban(
+            "127.0.0.2".to_owned(),
+            "insert".to_owned(),
+            None,
+            None,
+            Some("for_test".to_owned()),
+        );
+        assert_eq!(node.rpc_client().get_peers().len(), 1);
+
+        node.rpc_client().set_ban(
+            "127.0.0.0/16".to_owned(),
+            "insert".to_owned(),
+            None,
+            None,
+            Some("for_test".to_owned()),
+        );
+        assert_eq!(node.rpc_client().get_peers().len(), 0);
+    }
+
+    fn before_run(&self) -> Vec<Node> {
+        let mut node = Node::new(spec_name(self), "node");
+        node.start();
+
+        let mut banned_ip_node = Node::new(spec_name(self), "banned_ip_node");
+        banned_ip_node.modify_app_config(|app_config| {
+            let rpc_port = find_available_port();
+            let p2p_port = find_available_port();
+            app_config.rpc.listen_address = format!("127.0.0.2:{}", rpc_port);
+            app_config.network.listen_addresses =
+                vec![format!("/ip4/127.0.0.2/tcp/{}", p2p_port).parse().unwrap()];
+        });
+        banned_ip_node.start();
+
+        let mut banned_ipsubnet_node = Node::new(spec_name(self), "banned_ipsubnet_node");
+        banned_ipsubnet_node.modify_app_config(|app_config| {
+            let rpc_port = find_available_port();
+            let p2p_port = find_available_port();
+            app_config.rpc.listen_address = format!("127.0.1.1:{}", rpc_port);
+            app_config.network.listen_addresses =
+                vec![format!("/ip4/127.0.1.1/tcp/{}", p2p_port).parse().unwrap()];
+        });
+        banned_ipsubnet_node.start();
+
+        vec![node, banned_ip_node, banned_ipsubnet_node]
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

previous RPC `set_ban`(peer_ip, ... ) only adds peer into ckb inner ban_list, but doesn't disconnect the peer instantly.
the PR adds disconnect session operation when invoke RPC set_ban().

### What is changed and how it works?

What's Changed:
we add `disconnect session` into the process, to disconnect peers instantly.
RPC `set_ban` support user input single IP address, and IP/Subnet form. PR's code traverse connecting peers to check if match IP or within Subnet.  

- PR to update `owner/repo`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- IP address traversal match may be a concern of performance when node has lots of peer connection.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```
