### PR TITLE
fix(integration_test): fix RpcSetBan testcase failure on MacOS

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -505,6 +505,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RpcTruncate),
         Box::new(RpcTransactionProof),
         Box::new(RpcGetBlockMedianTime),
+        #[cfg(target_os = "linux")]
         Box::new(RpcSetBan),
         Box::new(SyncTooNewBlock),
         Box::new(RelayTooNewBlock),

--- a/test/src/specs/rpc/mod.rs
+++ b/test/src/specs/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod get_block_median_time;
 mod get_block_template;
 mod get_blockchain_info;
+#[cfg(target_os = "linux")]
 mod set_ban;
 mod submit_block;
 mod transaction_proof;
@@ -9,6 +10,7 @@ mod truncate;
 pub use get_block_median_time::*;
 pub use get_block_template::*;
 pub use get_blockchain_info::*;
+#[cfg(target_os = "linux")]
 pub use set_ban::*;
 pub use submit_block::*;
 pub use transaction_proof::*;

--- a/test/src/specs/rpc/set_ban.rs
+++ b/test/src/specs/rpc/set_ban.rs
@@ -6,9 +6,11 @@ use crate::{Node, Spec};
 
 pub struct RpcSetBan;
 
-impl Spec for RpcSetBan {
-    // crate::setup!(num_nodes: 3);
+const BAD_NODE_IP_1: &str = "127.0.0.2";
+const BAD_NODE_IP_2: &str = "127.0.1.1";
+const BAD_NODE_NETWORK: &str = "127.0.0.0/16";
 
+impl Spec for RpcSetBan {
     // node will ban the node with ip_address and ban the node within the ip/subnet
     fn run(&self, nodes: &mut Vec<Node>) {
         let node = &nodes[0];
@@ -21,7 +23,7 @@ impl Spec for RpcSetBan {
         assert_eq!(node.rpc_client().get_peers().len(), 2);
 
         node.rpc_client().set_ban(
-            "127.0.0.2".to_owned(),
+            BAD_NODE_IP_1.to_owned(),
             "insert".to_owned(),
             None,
             None,
@@ -30,7 +32,7 @@ impl Spec for RpcSetBan {
         assert_eq!(node.rpc_client().get_peers().len(), 1);
 
         node.rpc_client().set_ban(
-            "127.0.0.0/16".to_owned(),
+            BAD_NODE_NETWORK.to_owned(),
             "insert".to_owned(),
             None,
             None,
@@ -45,21 +47,21 @@ impl Spec for RpcSetBan {
 
         let mut banned_ip_node = Node::new(spec_name(self), "banned_ip_node");
         banned_ip_node.modify_app_config(|app_config| {
-            let rpc_port = find_available_port();
             let p2p_port = find_available_port();
-            app_config.rpc.listen_address = format!("127.0.0.2:{}", rpc_port);
             app_config.network.listen_addresses =
-                vec![format!("/ip4/127.0.0.2/tcp/{}", p2p_port).parse().unwrap()];
+                vec![format!("/ip4/{}/tcp/{}", BAD_NODE_IP_1, p2p_port)
+                    .parse()
+                    .unwrap()];
         });
         banned_ip_node.start();
 
         let mut banned_ipsubnet_node = Node::new(spec_name(self), "banned_ipsubnet_node");
         banned_ipsubnet_node.modify_app_config(|app_config| {
-            let rpc_port = find_available_port();
             let p2p_port = find_available_port();
-            app_config.rpc.listen_address = format!("127.0.1.1:{}", rpc_port);
             app_config.network.listen_addresses =
-                vec![format!("/ip4/127.0.1.1/tcp/{}", p2p_port).parse().unwrap()];
+                vec![format!("/ip4/{}/tcp/{}", BAD_NODE_IP_2, p2p_port)
+                    .parse()
+                    .unwrap()];
         });
         banned_ipsubnet_node.start();
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: fix RpcSetBan run failed on MacOS

### What is changed and how it works?

What's Changed:
conditional flag set for this testcase, only running on Linux/Ubuntu for now.
the testcase design will utility localhost different ip binding, but due to OS difference, 
MacOS doesn't support 127.0.x.x binding on localhost interface, the test result is negative.


- PR to update `owner/repo`:

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

