### PR TITLE
feat(metrics): add metrics for fresh tx in compact block

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -505,6 +505,7 @@ impl Relayer {
                             )),
                     );
                 } else {
+                    metrics!(counter, "ckb.relay.transaction_short_id_collide", 1);
                     return ReconstructionResult::Collided;
                 }
             }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Add metrics for fresh tx in compact block process, indicating effect of transactions broadcasted over network.

### What is changed and how it works?

What's Changed:
- metrics of compact block reconstruction success/failure count
- metrics of fresh txs count when reconstruct fail and total txs count when reconstruct pass.
- add a metrics of txs collide(two different txs have the same short_id value)

### Related changes

- PR to update `owner/repo`:

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

