### PR TITLE
fix: mining blocking until specified tx confirm

### DIFF
--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -122,7 +122,7 @@ impl Spec for SpendSatoshiCell {
         node0
             .rpc_client()
             .send_transaction(transaction.data().into());
-        node0.mine_until_transactions_confirm();
+        node0.mine_until_transaction_confirm(&tx_hash);
         // cellbase occupied capacity minus satoshi cell
         let cellbase_used_capacity = Capacity::bytes(CELLBASE_USED_BYTES).unwrap();
         assert!(is_transaction_committed(node0, &transaction));

--- a/test/src/specs/dao/utils.rs
+++ b/test/src/specs/dao/utils.rs
@@ -6,11 +6,12 @@ use ckb_types::{core::TransactionView, packed::OutPoint};
 /// Send the given transaction and make it committed
 pub(crate) fn ensure_committed(node: &Node, transaction: &TransactionView) -> OutPoint {
     let closest = node.consensus().tx_proposal_window().closest();
+    let tx_hash = transaction.hash();
     node.rpc_client()
         .send_transaction(transaction.data().into());
-    node.mine_until_transactions_confirm_with_windows(closest);
+    node.mine_until_transaction_confirm_with_windows(&tx_hash, closest);
     assert!(is_transaction_committed(node, transaction));
-    OutPoint::new(transaction.hash(), 0)
+    OutPoint::new(tx_hash, 0)
 }
 
 /// A helper function keep the node growing until into the target EpochNumberWithFraction.

--- a/test/src/specs/hardfork/v2021/cell_deps.rs
+++ b/test/src/specs/hardfork/v2021/cell_deps.rs
@@ -388,7 +388,7 @@ impl<'a> CheckCellDepsTestRunner<'a> {
 
     fn submit_transaction_until_committed_to(node: &Node, tx: &TransactionView) {
         node.submit_transaction(tx);
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&tx.hash());
     }
 
     fn submit_transaction_until_committed(&self, tx: &TransactionView) {

--- a/test/src/specs/mining/basic.rs
+++ b/test/src/specs/mining/basic.rs
@@ -19,7 +19,7 @@ impl Spec for MiningBasic {
         let cells = gen_spendable(node, 1);
         let transaction = always_success_transaction(node, &cells[0]);
         node.submit_transaction(&transaction);
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&transaction.hash());
 
         let block3 = node.get_tip_block();
         assert_eq!(block3.get_commit_tx_ids(), transaction.get_commit_tx_ids());

--- a/test/src/specs/mining/fee.rs
+++ b/test/src/specs/mining/fee.rs
@@ -28,12 +28,13 @@ impl Spec for FeeOfTransaction {
         let cells = gen_spendable(node, 1);
         let transaction = always_success_transaction(node, &cells[0]);
         node.submit_transaction(&transaction);
+        let tx_hash = transaction.hash();
 
         let txs = vec![transaction];
         let closest = DEFAULT_TX_PROPOSAL_WINDOW.0;
         let number_to_propose = node.get_tip_block_number() + 1;
         let number_to_commit = number_to_propose + closest;
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&tx_hash);
         node.mine(2 * FINALIZATION_DELAY_LENGTH);
 
         assert_eq!(

--- a/test/src/specs/relay/get_block_proposal_process.rs
+++ b/test/src/specs/relay/get_block_proposal_process.rs
@@ -26,7 +26,7 @@ impl Spec for ProposalRespondSizelimit {
 
             proposal_ids.push(transaction.proposal_short_id());
 
-            node0.mine_until_transactions_confirm();
+            node0.mine_until_transaction_confirm(&transaction.hash());
 
             // spend all new cell
             cells = get_spendable(node0);

--- a/test/src/specs/rpc/transaction_proof.rs
+++ b/test/src/specs/rpc/transaction_proof.rs
@@ -8,9 +8,9 @@ impl Spec for RpcTransactionProof {
         let node0 = &nodes[0];
         node0.mine(DEFAULT_TX_PROPOSAL_WINDOW.1 + 2);
 
-        let tx_hash = node0.generate_transaction().unpack();
-        let tx_hashes = vec![tx_hash];
-        node0.mine_until_transactions_confirm();
+        let tx_hash = node0.generate_transaction();
+        node0.mine_until_transaction_confirm(&tx_hash);
+        let tx_hashes = vec![tx_hash.unpack()];
         let proof = node0
             .rpc_client()
             .inner()

--- a/test/src/specs/rpc/truncate.rs
+++ b/test/src/specs/rpc/truncate.rs
@@ -19,7 +19,7 @@ impl Spec for RpcTruncate {
         let to_truncate = node.get_block_by_number(truncate_number).hash();
 
         node.submit_transaction(tx1);
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&tx1.hash());
         node.submit_transaction(tx2);
 
         // tx1 is already committed on chain, tx2 is still in tx-pool.
@@ -70,7 +70,7 @@ impl Spec for RpcTruncate {
         // The chain can generate new blocks
         node.mine(3);
         node.submit_transaction(tx1);
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&tx1.hash());
         let cell1 = node
             .rpc_client()
             .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);

--- a/test/src/specs/tx_pool/collision.rs
+++ b/test/src/specs/tx_pool/collision.rs
@@ -131,7 +131,7 @@ impl Spec for SubmitConflict {
 
         let (txa, txb) = conflict_transactions(node);
         node.submit_transaction(&txa);
-        node.mine_until_transactions_confirm();
+        node.mine_until_transaction_confirm(&txa.hash());
         assert!(is_transaction_committed(node, &txa));
         assert_send_transaction_fail(
             node,

--- a/test/src/specs/tx_pool/pool_reconcile.rs
+++ b/test/src/specs/tx_pool/pool_reconcile.rs
@@ -18,7 +18,7 @@ impl Spec for PoolReconcile {
         let hash = node0.generate_transaction();
 
         info!("Generate 3 more blocks on node0");
-        node0.mine_until_transactions_confirm();
+        node0.mine_until_transaction_confirm(&hash);
 
         info!("Pool should be empty");
         assert!(node0

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -58,7 +58,7 @@ impl Spec for SendLargeCyclesTxInBlock {
             ret.is_some() && matches!(ret.unwrap().tx_status.status, Status::Pending)
         });
         assert!(result, "large cycles tx rejected by node0");
-        node0.mine_until_transactions_confirm();
+        node0.mine_until_transaction_confirm(&tx.hash());
         let block: BlockView = node0.get_tip_block();
         assert_eq!(block.transactions()[1], tx);
         node0.connect(node1);


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix integration tests that fail due to inaccurate assertions

### What is changed and how it works?

Add mine_until_transaction_confirm method to avoid interference when multiple transactions occur.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

