### PR TITLE
fix typo for hash_type note

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4917,7 +4917,7 @@ Refer to the section [Code Locating](https://github.com/nervosnetwork/rfcs/blob/
 
 *   Type “data” matches script code via cell data hash, and run the script code in v0 CKB VM.
 *   Type “type” matches script code via cell type script hash.
-*   Type “data” matches script code via cell data hash, and run the script code in v1 CKB VM.
+*   Type “data1” matches script code via cell data hash, and run the script code in v1 CKB VM.
 
 
 ### Type `SerializedBlock`

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -21,7 +21,7 @@ pub enum ScriptHashType {
     Data = 0,
     /// Type "type" matches script code via cell type script hash.
     Type = 1,
-    /// Type "data" matches script code via cell data hash, and run the script code in v1 CKB VM.
+    /// Type "data1" matches script code via cell data hash, and run the script code in v1 CKB VM.
     Data1 = 2,
 }
 

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -9,7 +9,7 @@ pub enum ScriptHashType {
     Data = 0,
     /// Type "type" matches script code via cell type script hash.
     Type = 1,
-    /// Type "data" matches script code via cell data hash, and run the script code in v1 CKB VM.
+    /// Type "data1" matches script code via cell data hash, and run the script code in v1 CKB VM.
     Data1 = 2,
 }
 


### PR DESCRIPTION
Fix a typo for `rpc/README.md`