### PR TITLE
feat: remove compatibility codes from the network

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -82,8 +82,6 @@ pub struct NetworkState {
     /// Node supported protocols
     /// fields: ProtocolId, Protocol Name, Supported Versions
     pub(crate) protocols: RwLock<Vec<(ProtocolId, String, Vec<String>)>>,
-
-    pub(crate) ckb2021: AtomicBool,
 }
 
 impl NetworkState {
@@ -134,14 +132,7 @@ impl NetworkState {
             local_peer_id,
             active: AtomicBool::new(true),
             protocols: RwLock::new(Vec::new()),
-            ckb2021: AtomicBool::new(false),
         })
-    }
-
-    /// fork flag
-    pub fn ckb2021(self, init: bool) -> Self {
-        self.ckb2021.store(init, Ordering::SeqCst);
-        self
     }
 
     pub(crate) fn report_session(
@@ -1165,16 +1156,6 @@ pub struct NetworkController {
 }
 
 impl NetworkController {
-    /// set ckb2021 start
-    pub fn init_ckb2021(&self) {
-        self.network_state.ckb2021.store(true, Ordering::SeqCst);
-    }
-
-    /// get ckb2021 flag
-    pub fn load_ckb2021(&self) -> bool {
-        self.network_state.ckb2021.load(Ordering::SeqCst)
-    }
-
     /// Node listen address list
     pub fn public_urls(&self, max_urls: usize) -> Vec<(String, u8)> {
         self.network_state.public_urls(max_urls)

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -78,10 +78,8 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
         self.addr_mgr
             .register(session.id, context.proto_id, version);
 
-        self.sessions.insert(
-            session.id,
-            SessionState::new(context, &self.addr_mgr, version == "2"),
-        );
+        self.sessions
+            .insert(session.id, SessionState::new(context, &self.addr_mgr));
     }
 
     fn disconnected(&mut self, context: ProtocolContextMutRef) {
@@ -107,13 +105,7 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
             }
         };
 
-        let v2 = self
-            .sessions
-            .get(&session.id)
-            .map(|state| state.v2)
-            .unwrap_or(false);
-
-        match decode(&data, v2) {
+        match decode(&data) {
             Some(item) => {
                 match item {
                     DiscoveryMessage::GetNodes {
@@ -168,7 +160,7 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
                                 items,
                             };
 
-                            let msg = encode(DiscoveryMessage::Nodes(nodes), v2);
+                            let msg = encode(DiscoveryMessage::Nodes(nodes));
                             if context.send_message(msg).is_err() {
                                 debug!("{:?} send discovery msg Nodes fail", session.id)
                             }

--- a/network/src/protocols/discovery/protocol.rs
+++ b/network/src/protocols/discovery/protocol.rs
@@ -1,45 +1,13 @@
-use p2p::{
-    bytes::{Bytes, BytesMut},
-    multiaddr::Multiaddr,
-};
-use tokio_util::codec::length_delimited::LengthDelimitedCodec;
-use tokio_util::codec::{Decoder, Encoder};
+use p2p::{bytes::Bytes, multiaddr::Multiaddr};
 
-use ckb_logger::debug;
 use ckb_types::{packed, prelude::*};
 
-pub(crate) fn encode(data: DiscoveryMessage, v2: bool) -> Bytes {
-    if v2 {
-        data.encode()
-    } else {
-        // Length Delimited Codec is not a mandatory requirement.
-        // For historical reasons, this must exist as compatibility
-        let mut codec = LengthDelimitedCodec::new();
-        let mut bytes = BytesMut::new();
-        codec
-            .encode(data.encode(), &mut bytes)
-            .expect("encode must be success");
-        bytes.freeze()
-    }
+pub(crate) fn encode(data: DiscoveryMessage) -> Bytes {
+    data.encode()
 }
 
-pub(crate) fn decode(data: &Bytes, v2: bool) -> Option<DiscoveryMessage> {
-    if v2 {
-        DiscoveryMessage::decode(data)
-    } else {
-        let mut data = BytesMut::from(data.as_ref());
-        // Length Delimited Codec is not a mandatory requirement.
-        // For historical reasons, this must exist as compatibility
-        let mut codec = LengthDelimitedCodec::new();
-        match codec.decode(&mut data) {
-            Ok(Some(frame)) => DiscoveryMessage::decode(&frame),
-            Ok(None) => None,
-            Err(err) => {
-                debug!("decode error: {:?}", err);
-                None
-            }
-        }
-    }
+pub(crate) fn decode(data: &Bytes) -> Option<DiscoveryMessage> {
+    DiscoveryMessage::decode(data)
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/network/src/protocols/discovery/state.rs
+++ b/network/src/protocols/discovery/state.rs
@@ -32,14 +32,12 @@ pub struct SessionState {
     pub(crate) announce_multiaddrs: Vec<Multiaddr>,
     pub(crate) received_get_nodes: bool,
     pub(crate) received_nodes: bool,
-    pub(crate) v2: bool,
 }
 
 impl SessionState {
     pub(crate) fn new<M: AddressManager>(
         context: ProtocolContextMutRef,
         addr_manager: &M,
-        v2: bool,
     ) -> SessionState {
         let mut addr_known = AddrKnown::default();
         let remote_addr = if context.session.ty.is_outbound() {
@@ -57,17 +55,14 @@ impl SessionState {
                 })
                 .next();
 
-            let msg = encode(
-                DiscoveryMessage::GetNodes {
-                    #[cfg(target_os = "linux")]
-                    version: REUSE_PORT_VERSION,
-                    #[cfg(not(target_os = "linux"))]
-                    version: FIRST_VERSION,
-                    count: MAX_ADDR_TO_SEND as u32,
-                    listen_port: port,
-                },
-                v2,
-            );
+            let msg = encode(DiscoveryMessage::GetNodes {
+                #[cfg(target_os = "linux")]
+                version: REUSE_PORT_VERSION,
+                #[cfg(not(target_os = "linux"))]
+                version: FIRST_VERSION,
+                count: MAX_ADDR_TO_SEND as u32,
+                listen_port: port,
+            });
 
             if context.send_message(msg).is_err() {
                 debug!("{:?} send discovery msg GetNode fail", context.session.id)
@@ -87,7 +82,6 @@ impl SessionState {
             announce_multiaddrs: Vec::new(),
             received_get_nodes: false,
             received_nodes: false,
-            v2,
         }
     }
 
@@ -117,13 +111,10 @@ impl SessionState {
                     addresses: vec![addr],
                 })
                 .collect::<Vec<_>>();
-            let msg = encode(
-                DiscoveryMessage::Nodes(Nodes {
-                    announce: true,
-                    items,
-                }),
-                self.v2,
-            );
+            let msg = encode(DiscoveryMessage::Nodes(Nodes {
+                announce: true,
+                items,
+            }));
             if cx.send_message_to(id, cx.proto_id, msg).is_err() {
                 debug!("{:?} send discovery msg Nodes fail", id)
             }

--- a/network/src/protocols/feeler.rs
+++ b/network/src/protocols/feeler.rs
@@ -5,7 +5,7 @@ use p2p::{
     context::{ProtocolContext, ProtocolContextMutRef},
     traits::ServiceProtocol,
 };
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 
 /// Feeler
 /// Currently do nothing, CKBProtocol auto refresh peer_store after connected.
@@ -22,15 +22,9 @@ impl Feeler {
 impl ServiceProtocol for Feeler {
     fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
         let session = context.session;
-        if self.network_state.ckb2021.load(Ordering::SeqCst) && version != "2" {
-            self.network_state
-                .peer_store
-                .lock()
-                .mut_addr_manager()
-                .remove(&session.address);
-        } else if context.session.ty.is_outbound() {
+        if context.session.ty.is_outbound() {
             self.network_state.with_peer_store_mut(|peer_store| {
                 peer_store.add_outbound_addr(session.address.clone());
             });

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -34,14 +34,11 @@ pub type BoxedFutureTask = Pin<Box<dyn Future<Output = ()> + 'static + Send>>;
 use crate::{
     compress::{compress, decompress},
     network::disconnect_with_message,
-    Behaviour, Error, NetworkState, Peer, ProtocolVersion, SupportProtocols,
+    Behaviour, Error, NetworkState, Peer, ProtocolVersion,
 };
 
 /// Abstract protocol context
 pub trait CKBProtocolContext: Send {
-    /// get ckb2021 flag
-    fn ckb2021(&self) -> bool;
-
     /// Set notify to tentacle
     // Interact with underlying p2p service
     fn set_notify(&self, interval: Duration, token: u64) -> Result<(), Error>;
@@ -247,23 +244,6 @@ impl ServiceProtocol for CKBHandler {
     }
 
     fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
-        // This judgment will be removed in the first release after hardfork
-        if self
-            .network_state
-            .ckb2021
-            .load(std::sync::atomic::Ordering::SeqCst)
-            && version != "2"
-            && context.proto_id != SupportProtocols::Relay.protocol_id()
-        {
-            debug!(
-                "session {}, protocol {} with version {}, not 2, so disconnect it",
-                context.session.id, context.proto_id, version
-            );
-            let id = context.session.id;
-            let _ignore = context.disconnect(id);
-            return;
-        }
-
         self.network_state.with_peer_registry_mut(|reg| {
             if let Some(peer) = reg.get_peer_mut(context.session.id) {
                 peer.protocols.insert(self.proto_id, version.to_owned());
@@ -356,11 +336,6 @@ struct DefaultCKBProtocolContext {
 }
 
 impl CKBProtocolContext for DefaultCKBProtocolContext {
-    fn ckb2021(&self) -> bool {
-        self.network_state
-            .ckb2021
-            .load(std::sync::atomic::Ordering::SeqCst)
-    }
     fn set_notify(&self, interval: Duration, token: u64) -> Result<(), Error> {
         self.p2p_control
             .set_service_notify(self.proto_id, interval, token)?;

--- a/network/src/protocols/support_protocols.rs
+++ b/network/src/protocols/support_protocols.rs
@@ -43,8 +43,6 @@ pub enum SupportProtocols {
     /// Relay: ckb's main communication protocol for synchronizing latest transactions and blocks.
     ///
     /// [RFC](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0004-ckb-block-sync/0004-ckb-block-sync.md#new-block-announcement)
-    Relay,
-    /// New Relay
     RelayV2,
     /// Time: A protocol used for node pairing that warns if there is a large gap between the local time and the remote node.
     Time,
@@ -63,9 +61,8 @@ impl SupportProtocols {
             SupportProtocols::Feeler => 3,
             SupportProtocols::DisconnectMessage => 4,
             SupportProtocols::Sync => 100,
-            SupportProtocols::Relay => 101,
+            SupportProtocols::RelayV2 => 101,
             SupportProtocols::Time => 102,
-            SupportProtocols::RelayV2 => 103,
             SupportProtocols::Alert => 110,
         }
         .into()
@@ -80,7 +77,6 @@ impl SupportProtocols {
             SupportProtocols::Feeler => "/ckb/flr",
             SupportProtocols::DisconnectMessage => "/ckb/disconnectmsg",
             SupportProtocols::Sync => "/ckb/syn",
-            SupportProtocols::Relay => "/ckb/rel",
             SupportProtocols::RelayV2 => "/ckb/relay",
             SupportProtocols::Time => "/ckb/tim",
             SupportProtocols::Alert => "/ckb/alt",
@@ -90,23 +86,18 @@ impl SupportProtocols {
 
     /// Support versions
     pub fn support_versions(&self) -> Vec<String> {
-        // we didn't invoke MetaBuilder#support_versions fn for these protocols (Ping/Discovery/Identify/Feeler/DisconnectMessage)
-        // in previous code, so the default 0.0.1 value is used ( https://github.com/nervosnetwork/tentacle/blob/master/src/builder.rs#L312 )
-        // have to keep 0.0.1 for compatibility...
-        //
         // Here you have to make sure that the list of supported versions is sorted from smallest to largest
         match self {
-            SupportProtocols::Ping => vec!["0.0.1".to_owned(), LASTEST_VERSION.to_owned()],
-            SupportProtocols::Discovery => vec!["0.0.1".to_owned(), LASTEST_VERSION.to_owned()],
-            SupportProtocols::Identify => vec!["0.0.1".to_owned(), LASTEST_VERSION.to_owned()],
-            SupportProtocols::Feeler => vec!["0.0.1".to_owned(), LASTEST_VERSION.to_owned()],
+            SupportProtocols::Ping => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Discovery => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Identify => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Feeler => vec![LASTEST_VERSION.to_owned()],
             SupportProtocols::DisconnectMessage => {
-                vec!["0.0.1".to_owned(), LASTEST_VERSION.to_owned()]
+                vec![LASTEST_VERSION.to_owned()]
             }
-            SupportProtocols::Sync => vec!["1".to_owned(), LASTEST_VERSION.to_owned()],
-            SupportProtocols::Relay => vec!["1".to_owned()],
-            SupportProtocols::Time => vec!["1".to_owned(), LASTEST_VERSION.to_owned()],
-            SupportProtocols::Alert => vec!["1".to_owned(), LASTEST_VERSION.to_owned()],
+            SupportProtocols::Sync => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Time => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Alert => vec![LASTEST_VERSION.to_owned()],
             SupportProtocols::RelayV2 => vec![LASTEST_VERSION.to_owned()],
         }
     }
@@ -114,15 +105,15 @@ impl SupportProtocols {
     /// Protocol message max length
     pub fn max_frame_length(&self) -> usize {
         match self {
-            SupportProtocols::Ping => 1024,              // 1   KB
-            SupportProtocols::Discovery => 512 * 1024,   // 512 KB
-            SupportProtocols::Identify => 2 * 1024,      // 2   KB
-            SupportProtocols::Feeler => 1024,            // 1   KB
-            SupportProtocols::DisconnectMessage => 1024, // 1   KB
-            SupportProtocols::Sync => 2 * 1024 * 1024,   // 2   MB
-            SupportProtocols::Relay | SupportProtocols::RelayV2 => 4 * 1024 * 1024, // 4   MB
-            SupportProtocols::Time => 1024,              // 1   KB
-            SupportProtocols::Alert => 128 * 1024,       // 128 KB
+            SupportProtocols::Ping => 1024,               // 1   KB
+            SupportProtocols::Discovery => 512 * 1024,    // 512 KB
+            SupportProtocols::Identify => 2 * 1024,       // 2   KB
+            SupportProtocols::Feeler => 1024,             // 1   KB
+            SupportProtocols::DisconnectMessage => 1024,  // 1   KB
+            SupportProtocols::Sync => 2 * 1024 * 1024,    // 2   MB
+            SupportProtocols::RelayV2 => 4 * 1024 * 1024, // 4   MB
+            SupportProtocols::Time => 1024,               // 1   KB
+            SupportProtocols::Alert => 128 * 1024,        // 128 KB
         }
     }
 
@@ -140,7 +131,7 @@ impl SupportProtocols {
                 no_blocking_flag.disable_all();
                 no_blocking_flag
             }
-            SupportProtocols::Sync | SupportProtocols::Relay | SupportProtocols::RelayV2 => {
+            SupportProtocols::Sync | SupportProtocols::RelayV2 => {
                 let mut blocking_recv_flag = BlockingFlag::default();
                 blocking_recv_flag.disable_connected();
                 blocking_recv_flag.disable_disconnected();

--- a/network/src/protocols/tests/discovery.rs
+++ b/network/src/protocols/tests/discovery.rs
@@ -14,38 +14,13 @@ fn test_codec() {
         listen_port: Some(2),
     };
 
-    let b1 = encode(msg1.clone(), false);
+    let b1 = encode(msg1.clone());
 
-    let decode1 = decode(&b1, false).unwrap();
+    let decode1 = decode(&b1).unwrap();
     assert_eq!(decode1, msg1);
 
-    let b2 = encode(msg2.clone(), false);
+    let b2 = encode(msg2.clone());
 
-    let decode2 = decode(&b2, false).unwrap();
-    assert_eq!(decode2, msg2);
-}
-
-#[test]
-fn test_codec_v2() {
-    let msg1 = DiscoveryMessage::GetNodes {
-        version: 0,
-        count: 1,
-        listen_port: Some(1),
-    };
-
-    let msg2 = DiscoveryMessage::GetNodes {
-        version: 0,
-        count: 1,
-        listen_port: Some(2),
-    };
-
-    let b1 = encode(msg1.clone(), true);
-
-    let decode1 = decode(&b1, true).unwrap();
-    assert_eq!(decode1, msg1);
-
-    let b2 = encode(msg2.clone(), true);
-
-    let decode2 = decode(&b2, true).unwrap();
+    let decode2 = decode(&b2).unwrap();
     assert_eq!(decode2, msg2);
 }

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -300,11 +300,7 @@ impl MinerRpc for MinerRpcImpl {
             );
             let content = packed::CompactBlock::build_from_block(&block, &HashSet::new());
             let message = packed::RelayMessage::new_builder().set(content).build();
-            let pid = if self.network_controller.load_ckb2021() {
-                SupportProtocols::RelayV2.protocol_id()
-            } else {
-                SupportProtocols::Relay.protocol_id()
-            };
+            let pid = SupportProtocols::RelayV2.protocol_id();
             if let Err(err) = self
                 .network_controller
                 .quick_broadcast(pid, message.as_bytes())

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -474,7 +474,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             let message = packed::RelayMessage::new_builder().set(content).build();
             if let Err(err) = self
                 .network_controller
-                .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
+                .quick_broadcast(SupportProtocols::RelayV2.protocol_id(), message.as_bytes())
             {
                 error!("Broadcast new block failed: {:?}", err);
             }
@@ -614,7 +614,7 @@ impl IntegrationTestRpcImpl {
         // announce new block
         if let Err(err) = self
             .network_controller
-            .quick_broadcast(SupportProtocols::Relay.protocol_id(), message.as_bytes())
+            .quick_broadcast(SupportProtocols::RelayV2.protocol_id(), message.as_bytes())
         {
             error!("Broadcast new block failed: {:?}", err);
         }

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -74,7 +74,7 @@ fn test_accept_block() {
         .uncles(vec![uncle.as_uncle().data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -136,7 +136,7 @@ fn test_unknown_request() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -201,7 +201,7 @@ fn test_invalid_transaction_root() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -297,7 +297,7 @@ fn test_collision_and_send_missing_indexes() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -319,7 +319,7 @@ fn test_collision_and_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc.has_sent(SupportProtocols::Relay.protocol_id(), peer_index, data));
+    assert!(nc.has_sent(SupportProtocols::RelayV2.protocol_id(), peer_index, data));
 
     // update cached missing_index
     {
@@ -340,7 +340,7 @@ fn test_collision_and_send_missing_indexes() {
         .transactions(vec![tx2.data(), tx3.data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -411,7 +411,7 @@ fn test_missing() {
         .transactions(vec![tx2.data()].pack())
         .build();
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
 
     let process = BlockTransactionsProcess::new(
@@ -433,7 +433,7 @@ fn test_missing() {
 
     // send missing indexes messages
     assert!(nc.has_sent(
-        SupportProtocols::Relay.protocol_id(),
+        SupportProtocols::RelayV2.protocol_id(),
         peer_index,
         message.as_bytes()
     ));

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -36,7 +36,7 @@ fn test_in_block_status_map() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
@@ -118,7 +118,7 @@ fn test_unknow_parent() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
@@ -171,7 +171,7 @@ fn test_accept_not_a_better_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
@@ -206,7 +206,7 @@ fn test_header_invalid() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
@@ -266,7 +266,7 @@ fn test_send_missing_indexes() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
@@ -295,7 +295,7 @@ fn test_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc.has_sent(SupportProtocols::Relay.protocol_id(), peer_index, data));
+    assert!(nc.has_sent(SupportProtocols::RelayV2.protocol_id(), peer_index, data));
 
     // insert inflight proposal
     assert!(relayer
@@ -311,7 +311,7 @@ fn test_send_missing_indexes() {
     let data = message.as_bytes();
 
     // send proposal request
-    assert!(nc.has_sent(SupportProtocols::Relay.protocol_id(), peer_index, data));
+    assert!(nc.has_sent(SupportProtocols::RelayV2.protocol_id(), peer_index, data));
 }
 
 #[test]
@@ -375,7 +375,7 @@ fn test_accept_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
@@ -415,7 +415,7 @@ fn test_ignore_a_too_old_block() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
 
@@ -451,7 +451,7 @@ fn test_invalid_transaction_root() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
@@ -526,7 +526,7 @@ fn test_collision() {
     prefilled_transactions_indexes.insert(0);
     let compact_block = CompactBlock::build_from_block(&block, &prefilled_transactions_indexes);
 
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 100.into();
 
@@ -554,5 +554,5 @@ fn test_collision() {
     let data = message.as_bytes();
 
     // send missing indexes messages
-    assert!(nc.has_sent(SupportProtocols::Relay.protocol_id(), peer_index, data));
+    assert!(nc.has_sent(SupportProtocols::RelayV2.protocol_id(), peer_index, data));
 }

--- a/sync/src/relayer/tests/get_block_proposal_process.rs
+++ b/sync/src/relayer/tests/get_block_proposal_process.rs
@@ -19,7 +19,7 @@ fn test_duplicate() {
         .block_hash(hash)
         .proposals(vec![id.clone(), id].into_iter().pack())
         .build();
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
     let process = GetBlockProposalProcess::new(content.as_reader(), &relayer, nc, peer_index);

--- a/sync/src/relayer/tests/get_transactions_process.rs
+++ b/sync/src/relayer/tests/get_transactions_process.rs
@@ -15,7 +15,7 @@ fn test_duplicate() {
     let content = packed::GetRelayTransactions::new_builder()
         .tx_hashes(vec![tx_hash.clone(), tx_hash].pack())
         .build();
-    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::Relay);
+    let mock_protocol_context = MockProtocolContext::new(SupportProtocols::RelayV2);
     let nc = Arc::new(mock_protocol_context);
     let peer_index: PeerIndex = 1.into();
     let process = GetTransactionsProcess::new(content.as_reader(), &relayer, nc, peer_index);

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -232,9 +232,6 @@ impl MockProtocolContext {
 }
 
 impl CKBProtocolContext for MockProtocolContext {
-    fn ckb2021(&self) -> bool {
-        false
-    }
     fn set_notify(&self, _interval: Duration, _token: u64) -> Result<(), Error> {
         unimplemented!()
     }

--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -2,9 +2,7 @@ use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
 use crate::utils::send_message_to;
 use crate::{attempt, Status, StatusCode};
-use ckb_constant::sync::{
-    INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN, NEW_INIT_BLOCKS_IN_TRANSIT_PER_PEER,
-};
+use ckb_constant::sync::{INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
 use ckb_logger::debug;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{packed, prelude::*};
@@ -44,18 +42,7 @@ impl<'a> GetBlocksProcess<'a> {
         }
         let active_chain = self.synchronizer.shared.active_chain();
 
-        let iter = match active_chain
-            .shared()
-            .state()
-            .peers()
-            .is_2021edition(self.peer)
-            .unwrap_or(true)
-        {
-            false => block_hashes.iter().take(INIT_BLOCKS_IN_TRANSIT_PER_PEER),
-            true => block_hashes
-                .iter()
-                .take(NEW_INIT_BLOCKS_IN_TRANSIT_PER_PEER),
-        };
+        let iter = block_hashes.iter().take(INIT_BLOCKS_IN_TRANSIT_PER_PEER);
 
         let mut dedup = HashSet::new();
         for block_hash in iter {

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -115,7 +115,7 @@ fn inflight_blocks_timeout() {
     assert!(inflight_blocks.insert(3.into(), (2, h256!("0x2").pack()).into()));
     assert!(inflight_blocks.insert(3.into(), (3, h256!("0x3").pack()).into()));
 
-    assert_eq!(inflight_blocks.peer_can_fetch_count(2.into()), 16 >> 4);
+    assert_eq!(inflight_blocks.peer_can_fetch_count(2.into()), 32 >> 4);
 
     assert_eq!(
         inflight_blocks
@@ -194,6 +194,6 @@ fn inflight_trace_number_state() {
         .inflight_state_by_block(&(3, h256!("0x33").pack()).into())
         .is_none());
 
-    assert_eq!(inflight_blocks.peer_can_fetch_count(3.into()), 8);
-    assert_eq!(inflight_blocks.peer_can_fetch_count(4.into()), 8);
+    assert_eq!(inflight_blocks.peer_can_fetch_count(3.into()), 32 >> 1);
+    assert_eq!(inflight_blocks.peer_can_fetch_count(4.into()), 32 >> 1);
 }

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -204,9 +204,6 @@ struct TestNetworkContext {
 }
 
 impl CKBProtocolContext for TestNetworkContext {
-    fn ckb2021(&self) -> bool {
-        false
-    }
     // Interact with underlying p2p service
     fn set_notify(&self, interval: Duration, token: u64) -> Result<(), ckb_network::Error> {
         let index = Index::Timer(self.protocol, token);

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -422,9 +422,6 @@ fn mock_header_view(total_difficulty: u64) -> HeaderView {
 }
 
 impl CKBProtocolContext for DummyNetworkContext {
-    fn ckb2021(&self) -> bool {
-        false
-    }
     // Interact with underlying p2p service
     fn set_notify(&self, _interval: Duration, _token: u64) -> Result<(), ckb_network::Error> {
         unimplemented!();

--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -55,7 +55,7 @@ fn message_name<Message: Entity>(protocol_id: ProtocolId, message: &Message) -> 
             .to_enum()
             .item_name()
             .to_owned()
-    } else if protocol_id == SupportProtocols::Relay.protocol_id() {
+    } else if protocol_id == SupportProtocols::RelayV2.protocol_id() {
         RelayMessageReader::new_unchecked(message.as_slice())
             .to_enum()
             .item_name()
@@ -70,7 +70,7 @@ fn message_name<Message: Entity>(protocol_id: ProtocolId, message: &Message) -> 
 fn item_id<Message: Entity>(protocol_id: ProtocolId, message: &Message) -> u32 {
     if protocol_id == SupportProtocols::Sync.protocol_id() {
         SyncMessageReader::new_unchecked(message.as_slice()).item_id()
-    } else if protocol_id == SupportProtocols::Relay.protocol_id() {
+    } else if protocol_id == SupportProtocols::RelayV2.protocol_id() {
         RelayMessageReader::new_unchecked(message.as_slice()).item_id()
     } else {
         0

--- a/test/src/specs/relay/get_block_proposal_process.rs
+++ b/test/src/specs/relay/get_block_proposal_process.rs
@@ -38,7 +38,7 @@ impl Spec for ProposalRespondSizelimit {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
 
         let tip = node0.get_tip_block_number();
@@ -52,7 +52,7 @@ impl Spec for ProposalRespondSizelimit {
 
         net.connect(node0);
 
-        net.send(node0, SupportProtocols::Relay, message.as_bytes());
+        net.send(node0, SupportProtocols::RelayV2, message.as_bytes());
 
         assert!(
             node0.rpc_client().get_banned_addresses().is_empty(),

--- a/test/src/specs/relay/get_block_transactions_process.rs
+++ b/test/src/specs/relay/get_block_transactions_process.rs
@@ -17,7 +17,7 @@ impl Spec for MissingUncleRequest {
         let mut net = Net::new(
             self.name(),
             node.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(node);
 
@@ -42,7 +42,7 @@ impl Spec for MissingUncleRequest {
             .build();
         let message = packed::RelayMessage::new_builder().set(content).build();
 
-        net.send(node, SupportProtocols::Relay, message.as_bytes());
+        net.send(node, SupportProtocols::RelayV2, message.as_bytes());
 
         let ret = net.should_receive(node, |data: &Bytes| {
             RelayMessage::from_slice(data)

--- a/test/src/specs/relay/too_many_unknown_transactions.rs
+++ b/test/src/specs/relay/too_many_unknown_transactions.rs
@@ -14,7 +14,7 @@ impl Spec for TooManyUnknownTransactions {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(node0);
 
@@ -34,7 +34,7 @@ impl Spec for TooManyUnknownTransactions {
         assert!(MAX_RELAY_TXS_NUM_PER_BATCH >= tx_hashes.len());
         net.send(
             node0,
-            SupportProtocols::Relay,
+            SupportProtocols::RelayV2,
             build_relay_tx_hashes(&tx_hashes),
         );
 

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -84,14 +84,14 @@ impl Spec for TransactionRelayTimeout {
         let mut net = Net::new(
             self.name(),
             node.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(&node);
         let dummy_tx = TransactionBuilder::default().build();
         info!("Sending RelayTransactionHashes to node");
         net.send(
             &node,
-            SupportProtocols::Relay,
+            SupportProtocols::RelayV2,
             build_relay_tx_hashes(&[dummy_tx.hash()]),
         );
         info!("Receiving GetRelayTransactions message from node");
@@ -121,14 +121,14 @@ impl Spec for RelayInvalidTransaction {
         let mut net = Net::new(
             self.name(),
             node.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(node);
         let dummy_tx = TransactionBuilder::default().build();
         info!("Sending RelayTransactionHashes to node");
         net.send(
             node,
-            SupportProtocols::Relay,
+            SupportProtocols::RelayV2,
             build_relay_tx_hashes(&[dummy_tx.hash()]),
         );
         info!("Receiving GetRelayTransactions message from node");
@@ -144,7 +144,7 @@ impl Spec for RelayInvalidTransaction {
         info!("Sending RelayTransactions to node");
         net.send(
             node,
-            SupportProtocols::Relay,
+            SupportProtocols::RelayV2,
             build_relay_txs(&[(dummy_tx, 333)]),
         );
 

--- a/test/src/specs/sync/block_sync.rs
+++ b/test/src/specs/sync/block_sync.rs
@@ -267,7 +267,7 @@ impl Spec for BlockSyncRelayerCollaboration {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(node0);
         let rpc_client = node0.rpc_client();
@@ -293,7 +293,7 @@ impl Spec for BlockSyncRelayerCollaboration {
         assert!(!ret, "node0 should stay the same");
 
         sync_block(&net, node0, &first);
-        net.send(node0, SupportProtocols::Relay, build_compact_block(&last));
+        net.send(node0, SupportProtocols::RelayV2, build_compact_block(&last));
 
         let ret = wait_until(10, || rpc_client.get_tip_block_number() >= tip_number + 17);
         info!("{}", rpc_client.get_tip_block_number());

--- a/test/src/specs/sync/last_common_header.rs
+++ b/test/src/specs/sync/last_common_header.rs
@@ -20,11 +20,15 @@ impl Spec for LastCommonHeaderForPeerWithWorseChain {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Sync, SupportProtocols::Relay],
+            vec![SupportProtocols::Sync, SupportProtocols::RelayV2],
         );
         net.connect(node0);
         for block in worse {
-            net.send(node0, SupportProtocols::Relay, build_compact_block(&block));
+            net.send(
+                node0,
+                SupportProtocols::RelayV2,
+                build_compact_block(&block),
+            );
         }
 
         // peer.last_common_header is expect to be advanced to peer.best_known_header

--- a/test/src/specs/tx_pool/declared_wrong_cycles.rs
+++ b/test/src/specs/tx_pool/declared_wrong_cycles.rs
@@ -17,7 +17,7 @@ impl Spec for DeclaredWrongCycles {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
         net.connect(node0);
 
@@ -45,7 +45,7 @@ impl Spec for DeclaredWrongCyclesChunk {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
         net.connect(node0);
 
@@ -81,7 +81,7 @@ impl Spec for DeclaredWrongCyclesAndRelayAgain {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
 
         let tx = node0.new_transaction_spend_tip_cellbase();

--- a/test/src/specs/tx_pool/orphan_tx.rs
+++ b/test/src/specs/tx_pool/orphan_tx.rs
@@ -20,7 +20,7 @@ impl Spec for OrphanTxAccepted {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
         net.connect(node0);
 
@@ -61,7 +61,7 @@ impl Spec for OrphanTxRejected {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
         net.connect(node0);
 

--- a/test/src/specs/tx_pool/remove_tx.rs
+++ b/test/src/specs/tx_pool/remove_tx.rs
@@ -20,7 +20,7 @@ impl Spec for RemoveTx {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay],
+            vec![SupportProtocols::RelayV2],
         );
         net.connect(node0);
 

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -242,7 +242,7 @@ impl Spec for RelayWithWrongTx {
         let mut net = Net::new(
             self.name(),
             node0.consensus(),
-            vec![SupportProtocols::Relay, SupportProtocols::Sync],
+            vec![SupportProtocols::RelayV2, SupportProtocols::Sync],
         );
         net.connect(node0);
 

--- a/test/src/util/transaction.rs
+++ b/test/src/util/transaction.rs
@@ -54,7 +54,7 @@ pub fn relay_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
                 .build(),
         )
         .build();
-    net.send(node, SupportProtocols::Relay, tx_hashes_msg.as_bytes());
+    net.send(node, SupportProtocols::RelayV2, tx_hashes_msg.as_bytes());
 
     let ret = net.should_receive(node, |data: &Bytes| {
         packed::RelayMessage::from_slice(data)
@@ -79,5 +79,5 @@ pub fn relay_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
                 .build(),
         )
         .build();
-    net.send(node, SupportProtocols::Relay, tx_msg.as_bytes());
+    net.send(node, SupportProtocols::RelayV2, tx_msg.as_bytes());
 }

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -335,17 +335,6 @@ impl TxPoolService {
         ret: &Result<Completed, Reject>,
     ) {
         let tx_hash = tx.hash();
-        // The network protocol is switched after tx-pool confirms the cache,
-        // there will be no problem with the current state as the choice of the broadcast protocol.
-        let with_vm_2021 = {
-            let epoch = snapshot
-                .tip_header()
-                .epoch()
-                .minimum_epoch_number_after_n_blocks(1);
-            self.consensus
-                .hardfork_switch
-                .is_vm_version_1_and_syscalls_2_enabled(epoch)
-        };
 
         // log tx verification result for monitor node
         if log_enabled_target!("ckb_tx_monitor", Trace) {
@@ -364,7 +353,6 @@ impl TxPoolService {
                 Ok(_) => {
                     self.send_result_to_relayer(TxVerificationResult::Ok {
                         original_peer: Some(peer),
-                        with_vm_2021,
                         tx_hash,
                     });
                     self.process_orphan_tx(&tx).await;
@@ -389,7 +377,6 @@ impl TxPoolService {
                     Ok(_) => {
                         self.send_result_to_relayer(TxVerificationResult::Ok {
                             original_peer: None,
-                            with_vm_2021,
                             tx_hash,
                         });
                         self.process_orphan_tx(&tx).await;
@@ -398,7 +385,6 @@ impl TxPoolService {
                         // re-broadcast tx when it's duplicated and submitted through local rpc
                         self.send_result_to_relayer(TxVerificationResult::Ok {
                             original_peer: None,
-                            with_vm_2021,
                             tx_hash,
                         });
                     }
@@ -456,24 +442,14 @@ impl TxPoolService {
                         .write()
                         .await
                         .add_tx(orphan.tx, Some((orphan.cycle, orphan.peer)));
-                } else if let Some((ret, snapshot)) = self
+                } else if let Some((ret, _snapshot)) = self
                     ._process_tx(orphan.tx.clone(), Some(orphan.cycle))
                     .await
                 {
-                    let with_vm_2021 = {
-                        let epoch = snapshot
-                            .tip_header()
-                            .epoch()
-                            .minimum_epoch_number_after_n_blocks(1);
-                        self.consensus
-                            .hardfork_switch
-                            .is_vm_version_1_and_syscalls_2_enabled(epoch)
-                    };
                     match ret {
                         Ok(_) => {
                             self.send_result_to_relayer(TxVerificationResult::Ok {
                                 original_peer: Some(orphan.peer),
-                                with_vm_2021,
                                 tx_hash: orphan.tx.hash(),
                             });
                             debug!(
@@ -743,10 +719,6 @@ impl TxPoolService {
         let new_tip_after_delay = after_delay_window(&snapshot);
         let is_in_delay_window = self.is_in_delay_window(&snapshot);
 
-        let epoch_of_next_block = snapshot
-            .tip_header()
-            .epoch()
-            .minimum_epoch_number_after_n_blocks(1);
         let detached_headers: HashSet<Byte32> = detached_blocks
             .iter()
             .map(|blk| blk.header().hash())
@@ -795,19 +767,6 @@ impl TxPoolService {
                 &self.callbacks,
                 mine_mode,
             );
-
-            // Updates network fork switch if required.
-            //
-            // This operation should be ahead of any transaction which is processed with new
-            // hardfork features.
-            if !self.network.load_ckb2021()
-                && self
-                    .consensus
-                    .hardfork_switch
-                    .is_vm_version_1_and_syscalls_2_enabled(epoch_of_next_block)
-            {
-                self.network.init_ckb2021()
-            }
 
             // notice: readd_detached_tx don't update cache
             self.readd_detached_tx(&mut tx_pool, retain, fetched_cache);

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -802,8 +802,6 @@ pub enum TxVerificationResult {
     Ok {
         /// original peer
         original_peer: Option<PeerIndex>,
-        /// verified by ckb vm version
-        with_vm_2021: bool,
         /// transaction hash
         tx_hash: Byte32,
     },

--- a/util/constant/src/sync.rs
+++ b/util/constant/src/sync.rs
@@ -9,9 +9,9 @@ pub const MAX_HEADERS_LEN: usize = 2_000;
 
 /// The default number of download blocks that can be requested at one time
 /* About Download Scheduler */
-pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 16;
+
 /// ckb2021 edition new limit
-pub const NEW_INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 32;
+pub const INIT_BLOCKS_IN_TRANSIT_PER_PEER: usize = 32;
 /// Maximum number of download blocks that can be requested at one time
 pub const MAX_BLOCKS_IN_TRANSIT_PER_PEER: usize = 128;
 /// The point at which the scheduler adjusts the number of tasks, by default one adjustment per 512 blocks.

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -252,16 +252,8 @@ impl Launcher {
             self.args.config.tmp_dir.as_ref(),
             relay_tx_receiver,
         ));
-        let fork_enable = {
-            let epoch = shared.snapshot().tip_header().epoch().number();
-            shared
-                .consensus()
-                .hardfork_switch
-                .is_vm_version_1_and_syscalls_2_enabled(epoch)
-        };
         let network_state = Arc::new(
             NetworkState::from_config(self.args.config.network.clone())
-                .map(|t| NetworkState::ckb2021(t, fork_enable))
                 .expect("Init network state failed"),
         );
 
@@ -280,17 +272,9 @@ impl Launcher {
 
             protocols.push(CKBProtocol::new_with_support_protocol(
                 SupportProtocols::RelayV2,
-                Box::new(relayer.clone().v2()),
+                Box::new(relayer),
                 Arc::clone(&network_state),
             ));
-
-            if !fork_enable {
-                protocols.push(CKBProtocol::new_with_support_protocol(
-                    SupportProtocols::Relay,
-                    Box::new(relayer),
-                    Arc::clone(&network_state),
-                ))
-            }
         }
 
         if support_protocols.contains(&SupportProtocol::Time) {


### PR DESCRIPTION
### What problem does this PR solve?

ckb main network has been hardfork successfully, and the compatibility code of the network module can be completely removed now.

Impacts:
1. sync block size upgrade to 32
2. remove support for low version protocols, network-related compatibility testing will not be possible
3. rename Relay to RelayV2

### Check List 

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

