### PR TITLE
[only_test] test for ckb-vm trace_shift_v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,9 +1409,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a239d486d010192c07f1ff82e9ff4fa7fa31494d9bac6e99cea650794d0623"
+version = "0.21.1"
+source = "git+https://github.com/nervosnetwork/ckb-vm.git?branch=trace-shift-2#a1c9b2996088de4b097734816d403012cf23cfe6"
 dependencies = [
  "byteorder",
  "bytes 1.1.0",
@@ -1429,9 +1428,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b14b5c24760e4fe8e1df2e068a5c857fd6ca0a9ca739eadcad7f7d3c3fcbd10"
+version = "0.21.1"
+source = "git+https://github.com/nervosnetwork/ckb-vm.git?branch=trace-shift-2#a1c9b2996088de4b097734816d403012cf23cfe6"
 
 [[package]]
 name = "clang-sys"

--- a/deny.toml
+++ b/deny.toml
@@ -49,3 +49,4 @@ wildcards = "deny"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = ["https://github.com/nervosnetwork/ckb-vm.git"]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -21,8 +21,8 @@ ckb-traits = { path = "../traits", version = "= 0.200.0-pre" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types", version = "= 0.200.0-pre"}
 ckb-hash = {path = "../util/hash", version = "= 0.200.0-pre"}
-ckb-vm-definitions = "=0.21.2"
-ckb-vm = { version = "=0.21.2", default-features = false }
+ckb-vm-definitions = { git = "https://github.com/nervosnetwork/ckb-vm.git", branch = "trace-shift-2" }
+ckb-vm = { git = "https://github.com/nervosnetwork/ckb-vm.git", branch = "trace-shift-2" , default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.200.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### What problem does this PR solve?

only for test ckb-vm trace_shift_v2 function, do not merge

Problem Summary:

### What is changed and how it works?

What's Changed: use ckb-vm trace-shift-v2 branch to test ckb sync/replay/pass test.


Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

