### PR TITLE
fix: thread locals runtime drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,9 @@ dependencies = [
 name = "ckb-async-runtime"
 version = "0.104.0-pre"
 dependencies = [
+ "ckb-logger",
  "ckb-spawn",
+ "ckb-stop-handler",
  "tokio",
 ]
 
@@ -748,6 +750,7 @@ dependencies = [
  "ckb-rpc",
  "ckb-shared",
  "ckb-snapshot",
+ "ckb-stop-handler",
  "ckb-store",
  "ckb-sync",
  "ckb-tx-pool",

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -39,6 +39,7 @@ ckb-freezer = { path = "../../freezer", version = "= 0.104.0-pre" }
 ckb-notify = { path = "../../notify", version = "= 0.104.0-pre" }
 ckb-snapshot = { path = "../snapshot", version = "= 0.104.0-pre" }
 ckb-tx-pool = { path = "../../tx-pool", version = "= 0.104.0-pre" }
+ckb-stop-handler = { path = "../stop-handler", version = "= 0.104.0-pre" }
 num_cpus = "1.10"
 once_cell = "1.8.0"
 tempfile = "3.0"

--- a/util/launcher/src/shared_builder.rs
+++ b/util/launcher/src/shared_builder.rs
@@ -5,7 +5,7 @@
 use crate::migrate::Migrate;
 use ckb_app_config::ExitCode;
 use ckb_app_config::{BlockAssemblerConfig, DBConfig, NotifyConfig, StoreConfig, TxPoolConfig};
-use ckb_async_runtime::{new_global_runtime, Handle, Runtime};
+use ckb_async_runtime::{new_background_runtime, Handle};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_chain_spec::SpecError;
 use ckb_channel::Receiver;
@@ -19,6 +19,7 @@ use ckb_proposal_table::ProposalTable;
 use ckb_proposal_table::ProposalView;
 use ckb_shared::Shared;
 use ckb_snapshot::{Snapshot, SnapshotMgr};
+use ckb_stop_handler::StopHandler;
 use ckb_store::ChainDB;
 use ckb_store::ChainStore;
 use ckb_tx_pool::{
@@ -149,7 +150,9 @@ impl SharedBuilder {
 
         thread_local! {
             static TMP_DIR: sync::OnceCell<TempDir> = sync::OnceCell::new();
-            static RUNTIME_HANDLE: unsync::OnceCell<(Handle, Runtime)> = unsync::OnceCell::new();
+            // NOTICE：we can't put the runtime directly into thread_local here,
+            // on windows the runtime in thread_local will get stuck when dropping
+            static RUNTIME_HANDLE: unsync::OnceCell<(Handle, StopHandler<()>)> = unsync::OnceCell::new();
         }
 
         static DB_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -176,7 +179,11 @@ impl SharedBuilder {
             notify_config: None,
             store_config: None,
             block_assembler_config: None,
-            async_handle: runtime.borrow().get_or_init(new_global_runtime).0.clone(),
+            async_handle: runtime
+                .borrow()
+                .get_or_init(new_background_runtime)
+                .0
+                .clone(),
         })
     }
 }

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -10,4 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+ckb-stop-handler = { path = "../stop-handler", version = "= 0.104.0-pre" }
+ckb-logger = { path = "../logger", version = "= 0.104.0-pre" }
 ckb-spawn = {  path = "../spawn", version = "= 0.104.0-pre" }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

On windows the runtime in thread_local will get stuck when dropping

### What is changed and how it works?

Only the join handle is stored in thread_local instead of the runtime.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

