### PR TITLE
fix: satoshi_dao_occupied test

### DIFF
--- a/test/src/utils.rs
+++ b/test/src/utils.rs
@@ -259,6 +259,7 @@ pub fn generate_utxo_set(node: &Node, n: usize) -> TXOSet {
     txs.iter()
         .for_each(|tx| utxos.extend(Into::<TXOSet>::into(tx)));
     utxos.truncate(n);
+    node.wait_for_tx_pool();
     utxos
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

satoshi_dao_occupied test random failed

### What is changed and how it works?

Wait tx_pool sync when generate unspent cell


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

