### PR TITLE
refactor(testcase): add ckb command line bats testcases

### DIFF
--- a/util/app-config/src/tests/ckb_run_replay.bats
+++ b/util/app-config/src/tests/ckb_run_replay.bats
@@ -2,6 +2,8 @@
 bats_load_library 'bats-assert'
 bats_load_library 'bats-support'
 
+# ckb run testcase only test assume-valid-target param check
+
 _ckb_run() {
   ckb run -C ${CKB_DIRNAME} 1>${TMP_DIR}/ckb_run.log 2>&1 &
   echo $! >${TMP_DIR}/ckb_run.pid
@@ -9,9 +11,16 @@ _ckb_run() {
   kill "$(<"${TMP_DIR}/ckb_run.pid")"
   tail -n 50 ${TMP_DIR}/ckb_run.log
 }
-_ckb_replay() {
+_ckb_assume_valid_target() {
+  ckb run -C ${CKB_DIRNAME} --assume-valid-target 0xabcd1234
+}
+
+_ckb_replay_profile() {
   # from 1 to 2000 enough to trigger profile action
-  CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} --profile 1 2000
+  CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} profile 1 2000
+}
+_ckb_replay_sanity_check() {
+  CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} sanity-check --full-verification
 }
 
 function ckb_run { #@test
@@ -19,12 +28,24 @@ function ckb_run { #@test
   [ "$status" -eq 0 ]
   # assert_output --regexp "ckb_chain::chain.*block number:.*, hash:.*, size:.*, cycles:.*"
   assert_output --regexp "ckb_bin::subcommand::run  Finishing work, please wait"
+
+  run _ckb_assume_valid_target
+  [ "$status" -ne 0 ]
+  assert_output --regexp ".*[iI]nvalid.*hexadecimal.*"
 }
 
 function ckb_replay { #@test
-  run _ckb_replay
-  [ "$status" -eq 0 ]
-  assert_output --regexp "End profiling, duration:.*, txs:.*, tps:.*"
+  #run _ckb_replay
+  #[ "$status" -eq 0 ]
+  #assert_output --regexp "End profiling, duration:.*, txs:.*, tps:.*"
+
+  #run _ckb_replay_sanity_check
+  #[ "$status" -eq 0 ]
+  #assert_output --regexp ".*sanity-check pass, tip.*replay finishing"
+}
+
+setup_file() {
+  ckb import -C ${CKB_DIRNAME} ${CKB_DIRNAME}/ckb_mainnet_4000.json
 }
 
 teardown_file() {

--- a/util/app-config/src/tests/export_import.bats
+++ b/util/app-config/src/tests/export_import.bats
@@ -2,29 +2,44 @@
 bats_load_library 'bats-assert'
 bats_load_library 'bats-support'
 
-_export() {
+_export_target() {
   bash -c "ckb export -C ${CKB_DIRNAME} -t ${TMP_DIR}"
+}
+_export_create_directory() {
+  bash -c "ckb export -C ${CKB_DIRNAME} -t ${TMP_DIR}/create_directory"
 }
 
 function export { #@test
-  run _export
+  run _export_target
   [ "$status" -eq 0 ]
   # output is dynamically print on console, skip the content match
+
+  run _export_create_directory
+  [ "$status" -eq 0 ]
+  ls ${TMP_DIR}/create_directory
 }
 
 _import() {
   bash -c "ckb import -C ${CKB_DIRNAME} ${TMP_DIR}/ckb*.json"
 }
+_import_non_exist_directory() {
+  bash -c "ckb import -C ${CKB_DIRNAME} -t ${TMP_DIR}/non_exist_directory"
+}
 
 function ckb_import { #@test
   run _import
   [ "$status" -eq 0 ]
+
+  run _import_non_exist_directory
+  [ "$status" -ne 0 ]
 }
 
 setup_file() {
   rm -f ${TMP_DIR}/ckb*.json
+  rm -rf ${TMP_DIR}/create_directory
 }
 
 teardown_file() {
   rm -f ${TMP_DIR}/ckb*.json
+  rm -rf ${TMP_DIR}/create_directory
 }

--- a/util/app-config/src/tests/init_reset.bats
+++ b/util/app-config/src/tests/init_reset.bats
@@ -3,19 +3,200 @@ bats_load_library 'bats-assert'
 bats_load_library 'bats-support'
 
 _init() {
-  bash -c "ckb init -C ${CKB_DIRNAME} -f "
+  bash -c "ckb init -C ${CKB_DIRNAME} -f"
 }
+
 _init_mainnet() {
   bash -c "ckb init -f -C ${CKB_DIRNAME} -c mainnet"
 }
+
 _reset_all() {
   bash -c "ckb reset-data -C ${CKB_DIRNAME} --all -f"
 }
+
+_init_ba_1() {
+  # full args
+  bash -c "ckb init --ba-arg 0xabcdef \
+        --ba-code-hash 0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 \
+        --ba-hash-type type \
+        --ba-message 0x -C ${CKB_DIRNAME} -f"
+}
+_init_ba_2() {
+  # ba-code-hash should coop with ba-arg and ba-message
+  bash -c "ckb init --ba-code-hash 0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 -C ${CKB_DIRNAME} -f"
+}
+
+_init_ba_3() {
+  bash -c "ckb init --ba-code-hash 0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8 \
+        --ba-arg 0xabcdef --ba-message 0x -C ${CKB_DIRNAME} -f"
+}
+_init_ba_4() {
+  # ba-arg and ba-message should be even length
+  bash -c "ckb init --ba-arg 0xabc -C ${CKB_DIRNAME} -f"
+}
+_init_ba_5() {
+  # ba-arg and ba-message should be even length
+  bash -c "ckb init --ba-message 0x0 -C ${CKB_DIRNAME} -f"
+}
+_init_ba_6() {
+  bash -c "ckb init --ba-arg 0xabcd --ba-message 0x -C ${CKB_DIRNAME} -f"
+}
+_init_ba_7() {
+  # ba-hash-type set, but should coop with ba-arg and message, otherwise ckb-miner part disabled
+  bash -c "ckb init --ba-hash-type type -C ${CKB_DIRNAME} -f"
+}
+_init_ba_8() {
+  bash -c "ckb init --ba-arg 0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7 --ba-message 0x --ba-hash-type type -C ${CKB_DIRNAME} -f"
+}
+
+_init_list_chain_1() {
+  # avaiable chains
+  bash -c "ckb init -l"
+}
+_init_list_chain_2() {
+  bash -c "ckb init --list-chains"
+}
+
+_init_genesis_message_1() {
+  # only for dev chain
+  bash -c "ckb init -C ${CKB_DIRNAME} --genesis-message test_genesis_message"
+}
+_init_genesis_message_2() {
+  # message set in message section of specs/dev.toml
+  bash -c "ckb init -C ${CKB_DIRNAME} -f -c dev --genesis-message test_genesis_message"
+}
+_init_import_spec_1() {
+  # make spec/dev.toml
+  bash -c "ckb init -C ${CKB_DIRNAME} -f -c dev"
+  mv specs/dev.toml ${CKB_DIRNAME}/dev
+
+  # import dev spec
+  bash -c "ckb init -C ${CKB_DIRNAME} -f -c dev --import-spec ${CKB_DIRNAME}/dev"
+}
+_init_import_spec_2() {
+  # import not found spec
+  bash -c "ckb init -C ${CKB_DIRNAME} -f -c dev --import-spec not_found_file.toml"
+}
+
+_init_log_1() {
+  # default log to both: file and stdout
+  bash -c "ckb init -C ${CKB_DIRNAME} -f"
+}
+_init_log_2() {
+  # log to file
+  bash -c "ckb init -C ${CKB_DIRNAME} -f --log-to file"
+}
+_init_log_3() {
+  # log to stdout
+  bash -c "ckb init -C ${CKB_DIRNAME} -f --log-to stdout"
+}
+
+_init_p2p_port() {
+  # change to 3115
+  bash -c "ckb init -C ${CKB_DIRNAME} -f --p2p-port 3115"
+}
+_init_rpc_port() {
+  # change to 3114
+  bash -c "ckb init -C ${CKB_DIRNAME} -f --rpc-port 3114"
+}
+
+function init_ba { #@test
+  run _init_ba_1
+  [ "$status" -eq 0 ]
+  assert_output --regexp "WARN: the block assembler arg is not a valid secp256k1 pubkey hash.*It will require \`ckb run --ba-advanced\` to enable this block assembler.*Reinitialized CKB directory.*create.*Genesis Hash: .*"
+
+  run _init_ba_2
+  [ "$status" -ne 0 ]
+
+  run _init_ba_3
+  [ "$status" -eq 0 ]
+  assert_output --regexp "WARN: the block assembler arg is not a valid secp256k1 pubkey hash.*It will require \`ckb run --ba-advanced\` to enable this block assembler.*Reinitialized CKB directory.*create.*Genesis Hash: .*"
+
+  run _init_ba_4
+  [ "$status" -ne 0 ]
+
+  run _init_ba_5
+  [ "$status" -ne 0 ]
+
+  run _init_ba_6
+  [ "$status" -eq 0 ]
+  assert_output --regexp "WARN: the block assembler arg is not a valid secp256k1 pubkey hash.*It will require \`ckb run --ba-advanced\` to enable this block assembler.*Reinitialized CKB directory.*create.*Genesis Hash: .*"
+
+  run _init_ba_7
+  [ "$status" -eq 0 ]
+  assert_output --regexp "WARN: mining feature is disabled because of lacking the block assembler config options.*Reinitialized CKB directory.*create.*Genesis Hash: .*"
+
+  run _init_ba_8
+  [ "$status" -eq 0 ]
+  assert_output --regexp "Reinitialized CKB directory.*create.*Genesis Hash: .*"
+}
+
+function init_list_chain { #@test
+  run _init_list_chain_1
+  [ "$status" -eq 0 ]
+  assert_output --regexp "mainnet.*testnet.*staging.*dev"
+  run _init_list_chain_2
+  [ "$status" -eq 0 ]
+  assert_output --regexp "mainnet.*testnet.*staging.*dev"
+}
+
+function init_chain { #@test
+  run _init_chain
+}
+
+function init_genesis_message { #@test
+  run _init_genesis_message_1
+  [ "$status" -ne 0 ]
+  assert_output --regexp "Customizing consensus parameters for chain spec only works for dev chains"
+
+  run _init_genesis_message_2
+  [ "$status" -eq 0 ]
+  $(grep -q "message = \"test_genesis_message\""  "${CKB_DIRNAME}"/specs/dev.toml)
+}
+
+function init_import_spec { #@test
+  run _init_import_spec_1
+  [ "$status" -eq 0 ]
+  assert_output --regexp "create ckb.toml.*create ckb-miner.toml.*create default.db-options.*Genesis Hash:.*"
+
+  run _init_import_spec_2
+  [ "$status" -ne 0 ]
+  assert_output --regexp "Reinitialized CKB directory in .*cp.*IO Error.*NotFound"
+}
+
+function init_log { #@test
+  run _init_log_1
+  [ "$status" -eq 0 ]
+  $(grep -q "log_to_file = true" "${CKB_DIRNAME}"/ckb.toml)
+  $(grep -q "log_to_stdout = true" "${CKB_DIRNAME}"/ckb.toml)
+
+  run _init_log_2
+  [ "$status" -eq 0 ]
+  $(grep -q "log_to_file = true" "${CKB_DIRNAME}"/ckb.toml)
+  $(grep -q "log_to_stdout = false" "${CKB_DIRNAME}"/ckb.toml)
+
+  run _init_log_3
+  [ "$status" -eq 0 ]
+  $(grep -q "log_to_file = false" "${CKB_DIRNAME}"/ckb.toml)
+  $(grep -q "log_to_stdout = true" "${CKB_DIRNAME}"/ckb.toml)
+}
+
+function init_port { #@test
+  run _init_p2p_port
+  [ "$status" -eq 0 ]
+  $(grep -q "listen_addresses = \[\"/ip4/0.0.0.0/tcp/3115\"\]" "${CKB_DIRNAME}"/ckb.toml)
+
+  run _init_rpc_port
+  [ "$status" -eq 0 ]
+  $(grep -q "listen_address = \"127.0.0.1:3114\"" "${CKB_DIRNAME}"/ckb.toml)
+}
+
 function init { #@test
   run _init
   [ "$status" -eq 0 ]
   assert_output --regexp "[iI]nitialized CKB directory.*create.*Genesis Hash: 0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5"
 }
+
 function init_mainnet { #@test
   run _init_mainnet
   [ "$status" -eq 0 ]
@@ -30,16 +211,16 @@ function reset_all { #@test
 
 setup_file() {
   # backup test bed files/dirs: ckb.toml, ckb-miner.toml, default.db-options, data
-  mv ${CKB_DIRNAME}/ckb.toml ${TMP_DIR}/.
-  mv ${CKB_DIRNAME}/ckb-miner.toml ${TMP_DIR}/.
-  mv ${CKB_DIRNAME}/default.db-options ${TMP_DIR}/.
-  mv ${CKB_DIRNAME}/data ${TMP_DIR}/.
+  cp ${CKB_DIRNAME}/ckb.toml ${TMP_DIR}/.
+  cp ${CKB_DIRNAME}/ckb-miner.toml ${TMP_DIR}/.
+  cp ${CKB_DIRNAME}/default.db-options ${TMP_DIR}/.
+  cp -rf ${CKB_DIRNAME}/data ${TMP_DIR}/.
 }
 
 teardown_file() {
   # recover test bed files/dirs: ckb.toml, ckb-miner.toml, default.db-options, data
-  mv ${TMP_DIR}/ckb.toml ${CKB_DIRNAME}/.
-  mv ${TMP_DIR}/ckb-miner.toml ${CKB_DIRNAME}/.
-  mv ${TMP_DIR}/default.db-options ${CKB_DIRNAME}/.
-  mv ${TMP_DIR}/data ${CKB_DIRNAME}/.
+  cp ${TMP_DIR}/ckb.toml ${CKB_DIRNAME}/.
+  cp ${TMP_DIR}/ckb-miner.toml ${CKB_DIRNAME}/.
+  cp ${TMP_DIR}/default.db-options ${CKB_DIRNAME}/.
+  cp -rf ${TMP_DIR}/data ${CKB_DIRNAME}/.
 }

--- a/util/app-config/src/tests/list_hashes.bats
+++ b/util/app-config/src/tests/list_hashes.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+bats_load_library 'bats-assert'
+bats_load_library 'bats-support'
+
+_list_hashes() {
+  bash -c "ckb -C ${CKB_DIRNAME} list-hashes"
+}
+_list_hashes_bundle() {
+  bash -c "ckb -C ${CKB_DIRNAME} list-hashes -b"
+}
+
+function ckb_import { #@test
+  run _list_hashes
+  [ "$status" -eq 0 ]
+  assert_output --regexp ".*# Spec: ckb.*ckb.system_cells.*ckb.dep_groups"
+
+  run _list_hashes_bundle
+  [ "$status" -eq 0 ]
+  assert_output --regexp ".*# Spec: ckb.*ckb.system_cells.*ckb.dep_groups.*# Spec: ckb_testnet.*# Spec: ckb_staging.*# Spec: ckb_dev"
+}

--- a/util/app-config/src/tests/reset_data.bats
+++ b/util/app-config/src/tests/reset_data.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+bats_load_library 'bats-assert'
+bats_load_library 'bats-support'
+
+_reset_network_secret_key() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --network-secret-key"
+}
+_reset_network_peer_store() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --network-peer-store"
+}
+_reset_network() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --network"
+}
+_reset_logs() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --logs"
+}
+_reset_database() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --database"
+}
+_reset_all() {
+  bash -c "ckb -C ${CKB_DIRNAME} reset-data -f --all"
+}
+
+function ckb_reset { #@test
+  run _reset_network_secret_key
+  [ "$status" -eq 0 ]
+  line=$(ls data/network/ | grep "secret_key" | wc -l) && [ $line -eq 0 ]
+
+  run _reset_network_peer_store
+  [ "$status" -eq 0 ]
+  line=$(ls data/network/ | grep "peer_store" | wc -l) && [ $line -eq 0 ]
+
+  run _reset_network
+  [ "$status" -eq 0 ]
+  line=$(ls data/ | grep "network" | wc -l) && [ $line -eq 0 ]
+
+  run _reset_logs
+  [ "$status" -eq 0 ]
+  line=$(ls data/ | grep "logs" | wc -l) && [ $line -eq 0 ]
+
+  run _reset_database
+  [ "$status" -eq 0 ]
+  line=$(ls data/ | grep "db" | wc -l) && [ $line -eq 0 ]
+
+  run _reset_all
+  [ "$status" -eq 0 ]
+  line=$(ls -d | grep "data" | wc -l) && [ $line -eq 0 ]
+}
+
+teardown_file() {
+  ckb import -C ${CKB_DIRNAME} ${CKB_DIRNAME}/ckb_mainnet_4000.json
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Add ckb command line bats testcases, for later ckb clap derive pr.

### What is changed and how it works?

What's Changed: add more bats, including:
- ckb run
- ckb init
- ckb export
- ckb import
- ckb list-hashes
- ckb replay
- ckb reset-data

### Notes

- Not includes ckb db-repair, migrate, miner, stats, for program behavior depends on inner state, invisible for bats tests
- Not include some pararmeters if it involves interactive console input
- temporoarily disable ckb replay cases for later replay refactor PR.

- PR to update `owner/repo`:


Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- whole bats test will take about 1.5 minutes 

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

