### PR TITLE
refactor(light-client): add extension field to MMR Header

### DIFF
--- a/util/light-client-protocol-server/src/components/get_block_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_block_proof.rs
@@ -115,9 +115,9 @@ impl BlockSampler {
         positions: &mut Vec<u64>,
         last_hash: &packed::Byte32,
         numbers: &[BlockNumber],
-    ) -> Result<Vec<packed::HeaderWithChainRoot>, String> {
+    ) -> Result<Vec<packed::MMRHeader>, String> {
         let active_chain = self.active_chain();
-        let mut headers_with_chain_root = Vec::new();
+        let mut mmr_headers = Vec::new();
 
         for number in numbers {
             // Genesis block doesn't has chain root.
@@ -155,20 +155,20 @@ impl BlockSampler {
                     }
                 };
 
-                let header_with_chain_root = packed::HeaderWithChainRoot::new_builder()
+                let mmr_header = packed::MMRHeader::new_builder()
                     .header(ancestor_header.data())
                     .uncles_hash(uncles_hash)
                     .chain_root(chain_root)
                     .build();
 
-                headers_with_chain_root.push(header_with_chain_root);
+                mmr_headers.push(mmr_header);
             } else {
                 let errmsg = format!("failed to find ancestor header ({})", number);
                 return Err(errmsg);
             }
         }
 
-        Ok(headers_with_chain_root)
+        Ok(mmr_headers)
     }
 }
 

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -288,13 +288,14 @@ table InIBD {
 
 vector HeaderDigestVec <HeaderDigest>;
 
-table HeaderWithChainRoot {
+table MMRHeader {
     header:                 Header,
     uncles_hash:            Byte32,
+    extension:              BytesOpt,
     chain_root:             HeaderDigest,
 }
 
-vector HeaderWithChainRootVec <HeaderWithChainRoot>;
+vector MMRHeaderVec <MMRHeader>;
 
 table BlockProof {
     mmr_size:               Uint64,
@@ -334,8 +335,8 @@ table GetBlockProof {
 table SendBlockProof {
     root:                       HeaderDigest,
     proof:                      BlockProof,
-    sampled_headers:            HeaderWithChainRootVec,
-    last_n_headers:             HeaderWithChainRootVec,
+    sampled_headers:            MMRHeaderVec,
+    last_n_headers:             MMRHeaderVec,
 }
 
 /* Types for Network/Others */

--- a/util/types/src/conversion/network.rs
+++ b/util/types/src/conversion/network.rs
@@ -4,4 +4,4 @@ impl_conversion_for_packed_iterator_pack!(IndexTransaction, IndexTransactionVec)
 impl_conversion_for_packed_iterator_pack!(RelayTransaction, RelayTransactionVec);
 impl_conversion_for_packed_iterator_pack!(Uint256, Uint256Vec);
 impl_conversion_for_packed_iterator_pack!(HeaderDigest, HeaderDigestVec);
-impl_conversion_for_packed_iterator_pack!(HeaderWithChainRoot, HeaderWithChainRootVec);
+impl_conversion_for_packed_iterator_pack!(MMRHeader, MMRHeaderVec);

--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -320,18 +320,11 @@ impl VerifiableHeader {
         }
     }
 
-    /// Creates a new verifiable header from a header with chain root.
-    pub fn new_from_header_with_chain_root(
-        header_with_chain_root: packed::HeaderWithChainRoot,
-    ) -> Self {
-        let header = header_with_chain_root.header().into_view();
-        let uncles_hash = header_with_chain_root.uncles_hash();
-        let bytes = header_with_chain_root
-            .chain_root()
-            .calc_mmr_hash()
-            .as_bytes()
-            .pack();
-        let extension = Some(bytes);
+    /// Creates a new verifiable header from a MMR header.
+    pub fn new_from_mmr_header(mmr_header: packed::MMRHeader) -> Self {
+        let header = mmr_header.header().into_view();
+        let uncles_hash = mmr_header.uncles_hash();
+        let extension = mmr_header.extension().to_opt();
         Self::new(header, uncles_hash, extension)
     }
 


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:

* Rename `HeaderWithChainRoot` to `MMRHeader`
* Add extension field to `MMRHeader`
* When create `VerifiableHeader`, use extension field from `MMRHeader`