### PR TITLE
fix(light-client): Fix create variable header

### DIFF
--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -288,7 +288,7 @@ table InIBD {
 
 vector HeaderDigestVec <HeaderDigest>;
 
-table HeaderWithChainRoot {
+struct HeaderWithChainRoot {
     header:                 Header,
     uncles_hash:            Byte32,
     chain_root:             HeaderDigest,

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -14576,17 +14576,12 @@ impl ::core::fmt::Display for HeaderWithChainRoot {
         write!(f, "{}: {}", "header", self.header())?;
         write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
         write!(f, ", {}: {}", "chain_root", self.chain_root())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
         write!(f, " }}")
     }
 }
 impl ::core::default::Default for HeaderWithChainRoot {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            120, 1, 0, 0, 16, 0, 0, 0, 224, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14599,50 +14594,23 @@ impl ::core::default::Default for HeaderWithChainRoot {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         HeaderWithChainRoot::new_unchecked(v.into())
     }
 }
 impl HeaderWithChainRoot {
+    pub const TOTAL_SIZE: usize = 360;
+    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
     pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
     pub fn header(&self) -> Header {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[4..]) as usize;
-        let end = molecule::unpack_number(&slice[8..]) as usize;
-        Header::new_unchecked(self.0.slice(start..end))
+        Header::new_unchecked(self.0.slice(0..208))
     }
     pub fn uncles_hash(&self) -> Byte32 {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[8..]) as usize;
-        let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte32::new_unchecked(self.0.slice(start..end))
+        Byte32::new_unchecked(self.0.slice(208..240))
     }
     pub fn chain_root(&self) -> HeaderDigest {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[12..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            HeaderDigest::new_unchecked(self.0.slice(start..end))
-        } else {
-            HeaderDigest::new_unchecked(self.0.slice(start..))
-        }
+        HeaderDigest::new_unchecked(self.0.slice(240..360))
     }
     pub fn as_reader<'r>(&'r self) -> HeaderWithChainRootReader<'r> {
         HeaderWithChainRootReader::new_unchecked(self.as_slice())
@@ -14698,52 +14666,21 @@ impl<'r> ::core::fmt::Display for HeaderWithChainRootReader<'r> {
         write!(f, "{}: {}", "header", self.header())?;
         write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
         write!(f, ", {}: {}", "chain_root", self.chain_root())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
         write!(f, " }}")
     }
 }
 impl<'r> HeaderWithChainRootReader<'r> {
+    pub const TOTAL_SIZE: usize = 360;
+    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
     pub const FIELD_COUNT: usize = 3;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
     pub fn header(&self) -> HeaderReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[4..]) as usize;
-        let end = molecule::unpack_number(&slice[8..]) as usize;
-        HeaderReader::new_unchecked(&self.as_slice()[start..end])
+        HeaderReader::new_unchecked(&self.as_slice()[0..208])
     }
     pub fn uncles_hash(&self) -> Byte32Reader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[8..]) as usize;
-        let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+        Byte32Reader::new_unchecked(&self.as_slice()[208..240])
     }
     pub fn chain_root(&self) -> HeaderDigestReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[12..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            HeaderDigestReader::new_unchecked(&self.as_slice()[start..end])
-        } else {
-            HeaderDigestReader::new_unchecked(&self.as_slice()[start..])
-        }
+        HeaderDigestReader::new_unchecked(&self.as_slice()[240..360])
     }
 }
 impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootReader<'r> {
@@ -14758,46 +14695,12 @@ impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootReader<'r> {
     fn as_slice(&self) -> &'r [u8] {
         self.0
     }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
         use molecule::verification_error as ve;
         let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        if slice_len != Self::TOTAL_SIZE {
+            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
         }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-            return Ok(());
-        }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        if slice_len < offset_first {
-            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
-        }
-        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
-        if field_count < Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        } else if !compatible && field_count > Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        };
-        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
-            .chunks_exact(molecule::NUMBER_SIZE)
-            .map(|x| molecule::unpack_number(x) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        HeaderReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        Byte32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        HeaderDigestReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Ok(())
     }
 }
@@ -14808,6 +14711,8 @@ pub struct HeaderWithChainRootBuilder {
     pub(crate) chain_root: HeaderDigest,
 }
 impl HeaderWithChainRootBuilder {
+    pub const TOTAL_SIZE: usize = 360;
+    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
     pub const FIELD_COUNT: usize = 3;
     pub fn header(mut self, v: Header) -> Self {
         self.header = v;
@@ -14826,24 +14731,9 @@ impl molecule::prelude::Builder for HeaderWithChainRootBuilder {
     type Entity = HeaderWithChainRoot;
     const NAME: &'static str = "HeaderWithChainRootBuilder";
     fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
-            + self.header.as_slice().len()
-            + self.uncles_hash.as_slice().len()
-            + self.chain_root.as_slice().len()
+        Self::TOTAL_SIZE
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-        offsets.push(total_size);
-        total_size += self.header.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.uncles_hash.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.chain_root.as_slice().len();
-        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-        for offset in offsets.into_iter() {
-            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-        }
         writer.write_all(self.header.as_slice())?;
         writer.write_all(self.uncles_hash.as_slice())?;
         writer.write_all(self.chain_root.as_slice())?;
@@ -14887,20 +14777,17 @@ impl ::core::fmt::Display for HeaderWithChainRootVec {
 }
 impl ::core::default::Default for HeaderWithChainRootVec {
     fn default() -> Self {
-        let v: Vec<u8> = vec![4, 0, 0, 0];
+        let v: Vec<u8> = vec![0, 0, 0, 0];
         HeaderWithChainRootVec::new_unchecked(v.into())
     }
 }
 impl HeaderWithChainRootVec {
+    pub const ITEM_SIZE: usize = 360;
     pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
+        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.item_count()
     }
     pub fn item_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
+        molecule::unpack_number(self.as_slice()) as usize
     }
     pub fn len(&self) -> usize {
         self.item_count()
@@ -14916,16 +14803,9 @@ impl HeaderWithChainRootVec {
         }
     }
     pub fn get_unchecked(&self, idx: usize) -> HeaderWithChainRoot {
-        let slice = self.as_slice();
-        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
-        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
-        if idx == self.len() - 1 {
-            HeaderWithChainRoot::new_unchecked(self.0.slice(start..))
-        } else {
-            let end_idx = start_idx + molecule::NUMBER_SIZE;
-            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
-            HeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
-        }
+        let start = molecule::NUMBER_SIZE + Self::ITEM_SIZE * idx;
+        let end = start + Self::ITEM_SIZE;
+        HeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
     }
     pub fn as_reader<'r>(&'r self) -> HeaderWithChainRootVecReader<'r> {
         HeaderWithChainRootVecReader::new_unchecked(self.as_slice())
@@ -14986,15 +14866,12 @@ impl<'r> ::core::fmt::Display for HeaderWithChainRootVecReader<'r> {
     }
 }
 impl<'r> HeaderWithChainRootVecReader<'r> {
+    pub const ITEM_SIZE: usize = 360;
     pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
+        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.item_count()
     }
     pub fn item_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
+        molecule::unpack_number(self.as_slice()) as usize
     }
     pub fn len(&self) -> usize {
         self.item_count()
@@ -15010,16 +14887,9 @@ impl<'r> HeaderWithChainRootVecReader<'r> {
         }
     }
     pub fn get_unchecked(&self, idx: usize) -> HeaderWithChainRootReader<'r> {
-        let slice = self.as_slice();
-        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
-        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
-        if idx == self.len() - 1 {
-            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..])
-        } else {
-            let end_idx = start_idx + molecule::NUMBER_SIZE;
-            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
-            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
-        }
+        let start = molecule::NUMBER_SIZE + Self::ITEM_SIZE * idx;
+        let end = start + Self::ITEM_SIZE;
+        HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
     }
 }
 impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootVecReader<'r> {
@@ -15034,46 +14904,22 @@ impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootVecReader<'r> {
     fn as_slice(&self) -> &'r [u8] {
         self.0
     }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
         use molecule::verification_error as ve;
         let slice_len = slice.len();
         if slice_len < molecule::NUMBER_SIZE {
             return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
         }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE {
+        let item_count = molecule::unpack_number(slice) as usize;
+        if item_count == 0 {
+            if slice_len != molecule::NUMBER_SIZE {
+                return ve!(Self, TotalSizeNotMatch, molecule::NUMBER_SIZE, slice_len);
+            }
             return Ok(());
         }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(
-                Self,
-                TotalSizeNotMatch,
-                molecule::NUMBER_SIZE * 2,
-                slice_len
-            );
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        if slice_len < offset_first {
-            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
-        }
-        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
-            .chunks_exact(molecule::NUMBER_SIZE)
-            .map(|x| molecule::unpack_number(x) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        for pair in offsets.windows(2) {
-            let start = pair[0];
-            let end = pair[1];
-            HeaderWithChainRootReader::verify(&slice[start..end], compatible)?;
+        let total_size = molecule::NUMBER_SIZE + Self::ITEM_SIZE * item_count;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
         }
         Ok(())
     }
@@ -15081,6 +14927,7 @@ impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootVecReader<'r> {
 #[derive(Debug, Default)]
 pub struct HeaderWithChainRootVecBuilder(pub(crate) Vec<HeaderWithChainRoot>);
 impl HeaderWithChainRootVecBuilder {
+    pub const ITEM_SIZE: usize = 360;
     pub fn set(mut self, v: Vec<HeaderWithChainRoot>) -> Self {
         self.0 = v;
         self
@@ -15108,37 +14955,12 @@ impl molecule::prelude::Builder for HeaderWithChainRootVecBuilder {
     type Entity = HeaderWithChainRootVec;
     const NAME: &'static str = "HeaderWithChainRootVecBuilder";
     fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (self.0.len() + 1)
-            + self
-                .0
-                .iter()
-                .map(|inner| inner.as_slice().len())
-                .sum::<usize>()
+        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.0.len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        let item_count = self.0.len();
-        if item_count == 0 {
-            writer.write_all(&molecule::pack_number(
-                molecule::NUMBER_SIZE as molecule::Number,
-            ))?;
-        } else {
-            let (total_size, offsets) = self.0.iter().fold(
-                (
-                    molecule::NUMBER_SIZE * (item_count + 1),
-                    Vec::with_capacity(item_count),
-                ),
-                |(start, mut offsets), inner| {
-                    offsets.push(start);
-                    (start + inner.as_slice().len(), offsets)
-                },
-            );
-            writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-            for offset in offsets.into_iter() {
-                writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-            }
-            for inner in self.0.iter() {
-                writer.write_all(inner.as_slice())?;
-            }
+        writer.write_all(&molecule::pack_number(self.0.len() as molecule::Number))?;
+        for inner in &self.0[..] {
+            writer.write_all(inner.as_slice())?;
         }
         Ok(())
     }
@@ -16994,7 +16816,7 @@ impl ::core::default::Default for SendBlockProof {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0,
-            0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0,
+            0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0,
         ];
         SendBlockProof::new_unchecked(v.into())

--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -323,15 +323,20 @@ impl VerifiableHeader {
     /// Creates a new verifiable header from a header with chain root.
     pub fn new_from_header_with_chain_root(
         header_with_chain_root: packed::HeaderWithChainRoot,
+        mmr_activated_number: BlockNumber,
     ) -> Self {
         let header = header_with_chain_root.header().into_view();
         let uncles_hash = header_with_chain_root.uncles_hash();
-        let bytes = header_with_chain_root
-            .chain_root()
-            .calc_mmr_hash()
-            .as_bytes()
-            .pack();
-        let extension = Some(bytes);
+        let extension = if header.number() >= mmr_activated_number {
+            let bytes = header_with_chain_root
+                .chain_root()
+                .calc_mmr_hash()
+                .as_bytes()
+                .pack();
+            Some(bytes)
+        } else {
+            None
+        };
         Self::new(header, uncles_hash, extension)
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Currently implementation of creating `VerifiableHeader` from `HeaderWithChainRoot` always fill a extension field that calculated from the chain root, this is wrong when `header.number()` less than `mmr_activated_number`.

### What is changed and how it works?
What's Changed:
* When `header.number() < mmr_activated_number` let extension be `None`
* change `HeaderWithChainRoot` data type from table to struct