### PR TITLE
refactor(light-client): update light-client schema for chain reorg

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -8,7 +8,7 @@ use ckb_logger::{
     self, debug, error, info, log_enabled, log_enabled_target, trace, trace_target, warn,
 };
 use ckb_merkle_mountain_range::leaf_index_to_mmr_size;
-use ckb_metrics::{metrics, Timer};
+use ckb_metrics::metrics;
 use ckb_proposal_table::ProposalTable;
 #[cfg(debug_assertions)]
 use ckb_rust_unstable_port::IsSorted;

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1171,6 +1171,10 @@ impl NetworkController {
         self.network_state.node_id()
     }
 
+    pub fn p2p_control(&self) -> &ServiceControl {
+        &self.p2p_control
+    }
+
     /// Dial remote node
     pub fn add_node(&self, address: Multiaddr) {
         self.network_state.add_node(&self.p2p_control, address)

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -36,6 +36,8 @@ pub struct Peer {
     pub protocols: HashMap<ProtocolId, ProtocolVersion>,
     /// Whether a whitelist
     pub is_whitelist: bool,
+    /// Remote peer is light client
+    pub is_lightclient: bool,
 }
 
 impl Peer {
@@ -58,6 +60,7 @@ impl Peer {
             session_type,
             protocols: HashMap::with_capacity_and_hasher(1, Default::default()),
             is_whitelist,
+            is_lightclient: false,
         }
     }
 

--- a/rpc/src/module/miner.rs
+++ b/rpc/src/module/miner.rs
@@ -1,9 +1,10 @@
 use crate::error::RPCError;
 use ckb_chain::chain::ChainController;
 use ckb_jsonrpc_types::{Block, BlockTemplate, Uint64, Version};
-use ckb_logger::{debug, error, info};
-use ckb_network::{NetworkController, SupportProtocols};
+use ckb_logger::{debug, error, info, warn};
+use ckb_network::{NetworkController, PeerIndex, SupportProtocols, TargetSession};
 use ckb_shared::{shared::Shared, Snapshot};
+use ckb_store::ChainStore;
 use ckb_types::{core, packed, prelude::*, H256};
 use ckb_verification::HeaderVerifier;
 use ckb_verification_traits::Verifier;
@@ -300,6 +301,41 @@ impl MinerRpc for MinerRpcImpl {
                 .quick_broadcast(pid, message.as_bytes())
             {
                 error!("Broadcast new block failed: {:?}", err);
+            }
+
+            let tip_header = packed::VerifiableHeader::new_builder()
+                .header(header.data())
+                .uncles_hash(block.calc_uncles_hash())
+                .extension(Pack::pack(&block.extension()))
+                .build();
+            let total_difficulty = self
+                .shared
+                .snapshot()
+                .get_block_ext(&header.hash())
+                .map(|block_ext| block_ext.total_difficulty)
+                .expect("checked: new block should have block ext");
+            let light_client_message = {
+                let content = packed::SendLastState::new_builder()
+                    .tip_header(tip_header)
+                    .total_difficulty(total_difficulty.pack())
+                    .build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            };
+            let light_client_peers: HashSet<PeerIndex> = self
+                .network_controller
+                .connected_peers()
+                .into_iter()
+                .filter(|(_id, peer)| peer.is_lightclient)
+                .map(|(id, _)| id)
+                .collect();
+            if let Err(err) = self.network_controller.p2p_control().filter_broadcast(
+                TargetSession::Filter(Box::new(move |id| light_client_peers.contains(id))),
+                SupportProtocols::LightClient.protocol_id(),
+                light_client_message.as_bytes(),
+            ) {
+                warn!("Broadcast last state to light client failed: {:?}", err);
             }
         }
 

--- a/util/light-client-protocol-server/src/components/get_last_state.rs
+++ b/util/light-client-protocol-server/src/components/get_last_state.rs
@@ -1,11 +1,10 @@
-use ckb_merkle_mountain_range::{leaf_index_to_mmr_size, leaf_index_to_pos};
 use ckb_network::{CKBProtocolContext, PeerIndex};
-use ckb_types::{packed, prelude::*, utilities::merkle_mountain_range::ChainRootMMR};
+use ckb_types::packed;
 
-use crate::{prelude::*, LightClientProtocol, Status, StatusCode};
+use crate::{LightClientProtocol, Status};
 
 pub(crate) struct GetLastStateProcess<'a> {
-    message: packed::GetLastStateReader<'a>,
+    _message: packed::GetLastStateReader<'a>,
     protocol: &'a LightClientProtocol,
     peer: PeerIndex,
     nc: &'a dyn CKBProtocolContext,
@@ -13,13 +12,13 @@ pub(crate) struct GetLastStateProcess<'a> {
 
 impl<'a> GetLastStateProcess<'a> {
     pub(crate) fn new(
-        message: packed::GetLastStateReader<'a>,
+        _message: packed::GetLastStateReader<'a>,
         protocol: &'a LightClientProtocol,
         peer: PeerIndex,
         nc: &'a dyn CKBProtocolContext,
     ) -> Self {
         Self {
-            message,
+            _message,
             protocol,
             peer,
             nc,
@@ -27,67 +26,13 @@ impl<'a> GetLastStateProcess<'a> {
     }
 
     pub(crate) fn execute(self) -> Status {
-        let active_chain = self.protocol.shared.active_chain();
-        let snapshot = self.protocol.shared.shared().snapshot();
+        self.nc.with_peer_mut(
+            self.peer,
+            Box::new(|peer| {
+                peer.is_lightclient = true;
+            }),
+        );
 
-        let last_hash = self.message.last_hash().to_entity();
-        let last_number_opt = active_chain
-            .get_block_header(&last_hash)
-            .map(|header| header.number());
-
-        let tip_hash = active_chain.tip_hash();
-        let tip_block = active_chain
-            .get_block(&tip_hash)
-            .expect("checked: tip block should be existed");
-        let tip_header = tip_block.header();
-        let tip_number = tip_header.number();
-        let uncles_hash = tip_block.calc_uncles_hash();
-        let extension = tip_block.extension();
-        let tip_header = packed::VerifiableHeader::new_builder()
-            .header(tip_header.data())
-            .uncles_hash(uncles_hash)
-            .extension(Pack::pack(&extension))
-            .build();
-        let total_difficulty = active_chain
-            .get_block_ext(&tip_hash)
-            .map(|block_ext| block_ext.total_difficulty)
-            .expect("checked: tip block should have block ext");
-
-        let (chain_root, proof_opt) = {
-            let mmr_size = leaf_index_to_mmr_size(tip_number - 1);
-            let mmr = ChainRootMMR::new(mmr_size, &**snapshot);
-            let root = match mmr.get_root() {
-                Ok(root) => root,
-                Err(err) => {
-                    let errmsg = format!("failed to generate a root since {:?}", err);
-                    return StatusCode::InternalError.with_context(errmsg);
-                }
-            };
-            let proof_opt = if let Some(last_number) = last_number_opt {
-                let positions = vec![leaf_index_to_pos(last_number)];
-                match mmr.gen_proof(positions) {
-                    Ok(proof) => Some(proof.pack()),
-                    Err(err) => {
-                        let errmsg = format!("failed to generate a proof since {:?}", err);
-                        return StatusCode::InternalError.with_context(errmsg);
-                    }
-                }
-            } else {
-                None
-            };
-            (root, proof_opt)
-        };
-
-        let content = packed::SendLastState::new_builder()
-            .tip_header(tip_header)
-            .total_difficulty(total_difficulty.pack())
-            .chain_root(chain_root)
-            .proof(proof_opt.pack())
-            .build();
-        let message = packed::LightClientMessage::new_builder()
-            .set(content)
-            .build();
-
-        self.nc.reply(self.peer, &message)
+        self.protocol.send_last_state(self.nc, self.peer)
     }
 }

--- a/util/light-client-protocol-server/src/constant.rs
+++ b/util/light-client-protocol-server/src/constant.rs
@@ -1,3 +1,5 @@
+use ckb_types::core::BlockNumber;
 use std::time::Duration;
 
 pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
+pub const LAST_N_BLOCKS: BlockNumber = 100;

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -316,23 +316,20 @@ union LightClientMessage {
     SendBlockSamples,
 }
 
-table GetLastState {
-    // light client's local tip hash
-    last_hash:              Byte32,
-}
+table GetLastState {}
 
 table SendLastState {
     tip_header:                 VerifiableHeader,
     total_difficulty:           Uint256,
-    proof:                      BlockProofOpt,
-    chain_root:                 HeaderDigest,
 }
 
 table GetBlockSamples {
-    // light client's local tip hash
+    // SendLastState.tip_header.hash
     last_hash:                  Byte32,
+    // Last proved tip hash
+    start_hash:                 Byte32,
+    // Last proved tip number
     start_number:               Uint64,
-    last_n_blocks:              Uint64,
     difficulty_boundary:        Uint256,
     difficulties:               Uint256Vec,
 }
@@ -340,6 +337,8 @@ table GetBlockSamples {
 table SendBlockSamples {
     root:                       HeaderDigest,
     proof:                      BlockProof,
+    // The headers before `GetBlockSamples.start_number` (inclusive) for client side to detect the fork number
+    reorg_last_n_headers:       HeaderWithChainRootVec,
     sampled_headers:            HeaderWithChainRootVec,
     last_n_headers:             HeaderWithChainRootVec,
 }


### PR DESCRIPTION
### Changes
* Rollback fields
  - GetLastState.last_hash
  - SendLastState.proof
  - SendLastState.chain_root
* Add fields
  - GetBlockSamples.start_hash
  - SendBlockSamples.reorg_last_n_headers
* Remove fields
  - GetBlockSamples.last_n_blocks