### PR TITLE
fix: the last block hash of GetBlockSamples no need in main chain

### DIFF
--- a/util/light-client-protocol-server/src/components/get_block_samples.rs
+++ b/util/light-client-protocol-server/src/components/get_block_samples.rs
@@ -275,14 +275,6 @@ impl<'a> GetBlockSamplesProcess<'a> {
                     };
                 }
             }
-            // The last block should be in main chain.
-            if !sampler.active_chain().is_main_chain(&last_block_hash) {
-                let errmsg = format!(
-                    "the last block ({:#x}) sent from the client is not in the main chain",
-                    last_block_hash
-                );
-                return StatusCode::InvalidLastBlock.with_context(errmsg);
-            }
         }
 
         let (sampled_numbers, last_n_numbers) =


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

Check last_block_hash not in main chain is allowed, since we will return `reorg_last_n_headers` to let light-client side fix fork problem.