### PR TITLE
feat(light-client): add GetBlockProof message handler

### DIFF
--- a/util/light-client-protocol-server/src/components/get_block_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_block_proof.rs
@@ -26,47 +26,39 @@ impl<'a> GetBlockProofProcess<'a> {
         }
     }
 
-    fn send_empty_proof(&self) {
-        let message = packed::LightClientMessage::new_builder()
-            .set(packed::SendBlockProof::default())
-            .build();
-        self.nc.reply(self.peer, &message);
-    }
-
     pub(crate) fn execute(self) -> Status {
         let active_chain = self.protocol.shared.active_chain();
         let snapshot = self.protocol.shared.shared().snapshot();
 
-        let block_hash = self.message.block_hash().to_entity();
+        let block_hashes: Vec<_> = self
+            .message
+            .block_hashes()
+            .iter()
+            .map(|hash| hash.to_entity())
+            .collect();
         let tip_hash = self.message.tip_hash().to_entity();
 
-        let block_header = if let Some(header) = active_chain.get_block_header(&block_hash) {
+        let tip_header = if let Some(header) = active_chain.get_block_header(&tip_hash) {
             header
         } else {
-            // The block is not on the chain
-            self.send_empty_proof();
+            // The tip_hash is not on the chain
+            let message = packed::LightClientMessage::new_builder()
+                .set(packed::SendBlockProof::default())
+                .build();
+            self.nc.reply(self.peer, &message);
             return Status::ok();
         };
-        let tip_header =
-            if let Some(header) = active_chain.get_ancestor(&tip_hash, block_header.number()) {
-                header
-            } else {
-                // The tip_hash is not on the chain or block_hash is not ancestor of tip_hash
-                self.send_empty_proof();
-                return Status::ok();
-            };
-        let uncles_hash = if let Some(block) = active_chain.get_block(&block_hash) {
-            block.calc_uncles_hash()
-        } else {
-            let errmsg = format!(
-                "failed to find block for header#{} (hash: {:#x})",
-                block_header.number(),
-                block_hash
-            );
-            return StatusCode::InternalError.with_context(errmsg);
-        };
+        let block_headers: Vec<_> = block_hashes
+            .iter()
+            .filter_map(|hash| active_chain.get_block_header(hash))
+            .map(|header| header.number())
+            .filter_map(|number| active_chain.get_ancestor(&tip_hash, number))
+            .collect();
 
-        let positions = vec![leaf_index_to_pos(block_header.number())];
+        let positions: Vec<_> = block_headers
+            .iter()
+            .map(|header| leaf_index_to_pos(header.number()))
+            .collect();
         let mmr_size = leaf_index_to_mmr_size(tip_header.number() - 1);
         let mmr = ChainRootMMR::new(mmr_size, &**snapshot);
         let root = match mmr.get_root() {
@@ -83,20 +75,11 @@ impl<'a> GetBlockProofProcess<'a> {
                 return StatusCode::InternalError.with_context(errmsg);
             }
         };
-        let content = {
-            let header_with_chain_root = packed::HeaderWithChainRoot::new_builder()
-                .header(block_header.data())
-                .uncles_hash(uncles_hash)
-                .chain_root(root)
-                .build();
-            let single_block_proof = packed::SingleBlockProof::new_builder()
-                .proof(proof.pack())
-                .header(header_with_chain_root)
-                .build();
-            packed::SendBlockProof::new_builder()
-                .proof(Some(single_block_proof).pack())
-                .build()
-        };
+        let content = packed::SendBlockProof::new_builder()
+            .root(root)
+            .proof(proof.pack())
+            .headers(block_headers.into_iter().map(|view| view.data()).pack())
+            .build();
         let message = packed::LightClientMessage::new_builder()
             .set(content)
             .build();

--- a/util/light-client-protocol-server/src/components/get_block_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_block_proof.rs
@@ -1,0 +1,107 @@
+use ckb_merkle_mountain_range::{leaf_index_to_mmr_size, leaf_index_to_pos};
+use ckb_network::{CKBProtocolContext, PeerIndex};
+use ckb_types::{packed, prelude::*, utilities::merkle_mountain_range::ChainRootMMR};
+
+use crate::{prelude::LightClientProtocolReply, LightClientProtocol, Status, StatusCode};
+
+pub(crate) struct GetBlockProofProcess<'a> {
+    message: packed::GetBlockProofReader<'a>,
+    protocol: &'a LightClientProtocol,
+    peer: PeerIndex,
+    nc: &'a dyn CKBProtocolContext,
+}
+
+impl<'a> GetBlockProofProcess<'a> {
+    pub(crate) fn new(
+        message: packed::GetBlockProofReader<'a>,
+        protocol: &'a LightClientProtocol,
+        peer: PeerIndex,
+        nc: &'a dyn CKBProtocolContext,
+    ) -> Self {
+        Self {
+            message,
+            protocol,
+            peer,
+            nc,
+        }
+    }
+
+    fn send_empty_proof(&self) {
+        let message = packed::LightClientMessage::new_builder()
+            .set(packed::SendBlockProof::default())
+            .build();
+        self.nc.reply(self.peer, &message);
+    }
+
+    pub(crate) fn execute(self) -> Status {
+        let active_chain = self.protocol.shared.active_chain();
+        let snapshot = self.protocol.shared.shared().snapshot();
+
+        let block_hash = self.message.block_hash().to_entity();
+        let tip_hash = self.message.tip_hash().to_entity();
+
+        let block_header = if let Some(header) = active_chain.get_block_header(&block_hash) {
+            header
+        } else {
+            // The block is not on the chain
+            self.send_empty_proof();
+            return Status::ok();
+        };
+        let tip_header =
+            if let Some(header) = active_chain.get_ancestor(&tip_hash, block_header.number()) {
+                header
+            } else {
+                // The tip_hash is not on the chain or block_hash is not ancestor of tip_hash
+                self.send_empty_proof();
+                return Status::ok();
+            };
+        let uncles_hash = if let Some(block) = active_chain.get_block(&block_hash) {
+            block.calc_uncles_hash()
+        } else {
+            let errmsg = format!(
+                "failed to find block for header#{} (hash: {:#x})",
+                block_header.number(),
+                block_hash
+            );
+            return StatusCode::InternalError.with_context(errmsg);
+        };
+
+        let positions = vec![leaf_index_to_pos(block_header.number())];
+        let mmr_size = leaf_index_to_mmr_size(tip_header.number() - 1);
+        let mmr = ChainRootMMR::new(mmr_size, &**snapshot);
+        let root = match mmr.get_root() {
+            Ok(root) => root,
+            Err(err) => {
+                let errmsg = format!("failed to generate a root since {:?}", err);
+                return StatusCode::InternalError.with_context(errmsg);
+            }
+        };
+        let proof = match mmr.gen_proof(positions) {
+            Ok(proof) => proof,
+            Err(err) => {
+                let errmsg = format!("failed to generate a proof since {:?}", err);
+                return StatusCode::InternalError.with_context(errmsg);
+            }
+        };
+        let content = {
+            let header_with_chain_root = packed::HeaderWithChainRoot::new_builder()
+                .header(block_header.data())
+                .uncles_hash(uncles_hash)
+                .chain_root(root)
+                .build();
+            let single_block_proof = packed::SingleBlockProof::new_builder()
+                .proof(proof.pack())
+                .header(header_with_chain_root)
+                .build();
+            packed::SendBlockProof::new_builder()
+                .proof(Some(single_block_proof).pack())
+                .build()
+        };
+        let message = packed::LightClientMessage::new_builder()
+            .set(content)
+            .build();
+        self.nc.reply(self.peer, &message);
+
+        Status::ok()
+    }
+}

--- a/util/light-client-protocol-server/src/components/get_block_samples.rs
+++ b/util/light-client-protocol-server/src/components/get_block_samples.rs
@@ -188,10 +188,6 @@ impl<'a> GetBlockSamplesProcess<'a> {
     }
 
     pub(crate) fn execute(self) -> Status {
-        if !self.protocol.peer_is_lightclient(self.nc, self.peer) {
-            return StatusCode::UnexpectedProtocolMessage.into();
-        }
-
         let active_chain = self.protocol.shared.active_chain();
         let snapshot = self.protocol.shared.shared().snapshot();
 

--- a/util/light-client-protocol-server/src/components/mod.rs
+++ b/util/light-client-protocol-server/src/components/mod.rs
@@ -1,5 +1,7 @@
 mod get_block_samples;
 mod get_last_state;
+mod get_block_proof;
 
 pub(crate) use get_block_samples::GetBlockSamplesProcess;
 pub(crate) use get_last_state::GetLastStateProcess;
+pub(crate) use get_block_proof::GetBlockProofProcess;

--- a/util/light-client-protocol-server/src/components/mod.rs
+++ b/util/light-client-protocol-server/src/components/mod.rs
@@ -1,7 +1,7 @@
+mod get_block_proof;
 mod get_block_samples;
 mod get_last_state;
-mod get_block_proof;
 
+pub(crate) use get_block_proof::GetBlockProofProcess;
 pub(crate) use get_block_samples::GetBlockSamplesProcess;
 pub(crate) use get_last_state::GetLastStateProcess;
-pub(crate) use get_block_proof::GetBlockProofProcess;

--- a/util/light-client-protocol-server/src/lib.rs
+++ b/util/light-client-protocol-server/src/lib.rs
@@ -85,12 +85,23 @@ impl LightClientProtocol {
         peer_index: PeerIndex,
         message: packed::LightClientMessageUnionReader<'_>,
     ) -> Status {
+        if !matches!(
+            message,
+            packed::LightClientMessageUnionReader::GetLastState(_)
+        ) && !self.peer_is_lightclient(nc, peer_index)
+        {
+            return StatusCode::UnexpectedProtocolMessage.into();
+        }
+
         match message {
             packed::LightClientMessageUnionReader::GetLastState(reader) => {
                 components::GetLastStateProcess::new(reader, self, peer_index, nc).execute()
             }
             packed::LightClientMessageUnionReader::GetBlockSamples(reader) => {
                 components::GetBlockSamplesProcess::new(reader, self, peer_index, nc).execute()
+            }
+            packed::LightClientMessageUnionReader::GetBlockProof(reader) => {
+                components::GetBlockProofProcess::new(reader, self, peer_index, nc).execute()
             }
             _ => StatusCode::UnexpectedProtocolMessage.into(),
         }

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -344,22 +344,21 @@ table SendBlockSamples {
 }
 
 table GetBlockProof {
-    block_hash:             Byte32,
+    // The requested block hashes
+    block_hashes:           Byte32Vec,
     // Light Client's local tip hash
     tip_hash:               Byte32,
 }
 
-table SingleBlockProof {
-    // The proof of `GetBlockProof.block_hash`
-    proof:                  BlockProof,
-    // The header of `GetBlockProof.tip_hash` and its root
-    header:                 HeaderWithChainRoot,
-}
-
-option SingleBlockProofOpt(SingleBlockProof);
-
 table SendBlockProof {
-    proof: SingleBlockProofOpt,
+    // The root of `GetBlockProof.tip_hash`
+    root:                   HeaderDigest,
+    // The proof of `GetBlockProof.block_hashs`. If `proof.mmr_size` is zero it
+    // means `tip_hash` is not in chain.
+    proof:                  BlockProof,
+    // The headers of `GetBlockProof.block_hashes`. If a block hash not ancestor
+    // of tip hash it will not included in headers.
+    headers:                HeaderVec,
 }
 
 /* Types for Network/Others */

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -301,8 +301,6 @@ table BlockProof {
     items:                  HeaderDigestVec,
 }
 
-option BlockProofOpt (BlockProof);
-
 table VerifiableHeader {
     header:                 Header,
     uncles_hash:            Byte32,
@@ -314,6 +312,8 @@ union LightClientMessage {
     SendLastState,
     GetBlockSamples,
     SendBlockSamples,
+    GetBlockProof,
+    SendBlockProof,
 }
 
 table GetLastState {}
@@ -341,6 +341,25 @@ table SendBlockSamples {
     reorg_last_n_headers:       HeaderWithChainRootVec,
     sampled_headers:            HeaderWithChainRootVec,
     last_n_headers:             HeaderWithChainRootVec,
+}
+
+table GetBlockProof {
+    block_hash:             Byte32,
+    // Light Client's local tip hash
+    tip_hash:               Byte32,
+}
+
+table SingleBlockProof {
+    // The proof of `GetBlockProof.block_hash`
+    proof:                  BlockProof,
+    // The header of `GetBlockProof.tip_hash` and its root
+    header:                 HeaderWithChainRoot,
+}
+
+option SingleBlockProofOpt(SingleBlockProof);
+
+table SendBlockProof {
+    proof: SingleBlockProofOpt,
 }
 
 /* Types for Network/Others */

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -356,6 +356,8 @@ table SendBlockProof {
     // The proof of `GetBlockProof.block_hashs`. If `proof.mmr_size` is zero it
     // means `tip_hash` is not in chain.
     proof:                  BlockProof,
+    /// The tip header
+    tip_header:             VerifiableHeader,
     // The headers of `GetBlockProof.block_hashes`. If a block hash not ancestor
     // of tip hash it will not included in headers.
     headers:                HeaderVec,

--- a/util/types/src/conversion/mmr.rs
+++ b/util/types/src/conversion/mmr.rs
@@ -27,4 +27,3 @@ impl<'r> Unpack<MMRProof> for packed::BlockProofReader<'r> {
     }
 }
 impl_conversion_for_entity_unpack!(MMRProof, BlockProof);
-impl_conversion_for_packed_optional_pack!(SingleBlockProof, SingleBlockProofOpt);

--- a/util/types/src/conversion/mmr.rs
+++ b/util/types/src/conversion/mmr.rs
@@ -27,4 +27,4 @@ impl<'r> Unpack<MMRProof> for packed::BlockProofReader<'r> {
     }
 }
 impl_conversion_for_entity_unpack!(MMRProof, BlockProof);
-impl_conversion_for_packed_optional_pack!(BlockProof, BlockProofOpt);
+impl_conversion_for_packed_optional_pack!(SingleBlockProof, SingleBlockProofOpt);

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -17180,7 +17180,7 @@ impl ::core::fmt::Debug for GetBlockProof {
 impl ::core::fmt::Display for GetBlockProof {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "block_hash", self.block_hash())?;
+        write!(f, "{}: {}", "block_hashes", self.block_hashes())?;
         write!(f, ", {}: {}", "tip_hash", self.tip_hash())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -17192,9 +17192,8 @@ impl ::core::fmt::Display for GetBlockProof {
 impl ::core::default::Default for GetBlockProof {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            76, 0, 0, 0, 12, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            48, 0, 0, 0, 12, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         GetBlockProof::new_unchecked(v.into())
     }
@@ -17217,11 +17216,11 @@ impl GetBlockProof {
     pub fn has_extra_fields(&self) -> bool {
         Self::FIELD_COUNT != self.field_count()
     }
-    pub fn block_hash(&self) -> Byte32 {
+    pub fn block_hashes(&self) -> Byte32Vec {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
         let end = molecule::unpack_number(&slice[8..]) as usize;
-        Byte32::new_unchecked(self.0.slice(start..end))
+        Byte32Vec::new_unchecked(self.0.slice(start..end))
     }
     pub fn tip_hash(&self) -> Byte32 {
         let slice = self.as_slice();
@@ -17260,7 +17259,7 @@ impl molecule::prelude::Entity for GetBlockProof {
     }
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
-            .block_hash(self.block_hash())
+            .block_hashes(self.block_hashes())
             .tip_hash(self.tip_hash())
     }
 }
@@ -17283,7 +17282,7 @@ impl<'r> ::core::fmt::Debug for GetBlockProofReader<'r> {
 impl<'r> ::core::fmt::Display for GetBlockProofReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "block_hash", self.block_hash())?;
+        write!(f, "{}: {}", "block_hashes", self.block_hashes())?;
         write!(f, ", {}: {}", "tip_hash", self.tip_hash())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -17310,11 +17309,11 @@ impl<'r> GetBlockProofReader<'r> {
     pub fn has_extra_fields(&self) -> bool {
         Self::FIELD_COUNT != self.field_count()
     }
-    pub fn block_hash(&self) -> Byte32Reader<'r> {
+    pub fn block_hashes(&self) -> Byte32VecReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
         let end = molecule::unpack_number(&slice[8..]) as usize;
-        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+        Byte32VecReader::new_unchecked(&self.as_slice()[start..end])
     }
     pub fn tip_hash(&self) -> Byte32Reader<'r> {
         let slice = self.as_slice();
@@ -17376,20 +17375,20 @@ impl<'r> molecule::prelude::Reader<'r> for GetBlockProofReader<'r> {
         if offsets.windows(2).any(|i| i[0] > i[1]) {
             return ve!(Self, OffsetsNotMatch);
         }
-        Byte32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Byte32VecReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         Byte32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         Ok(())
     }
 }
 #[derive(Debug, Default)]
 pub struct GetBlockProofBuilder {
-    pub(crate) block_hash: Byte32,
+    pub(crate) block_hashes: Byte32Vec,
     pub(crate) tip_hash: Byte32,
 }
 impl GetBlockProofBuilder {
     pub const FIELD_COUNT: usize = 2;
-    pub fn block_hash(mut self, v: Byte32) -> Self {
-        self.block_hash = v;
+    pub fn block_hashes(mut self, v: Byte32Vec) -> Self {
+        self.block_hashes = v;
         self
     }
     pub fn tip_hash(mut self, v: Byte32) -> Self {
@@ -17402,21 +17401,21 @@ impl molecule::prelude::Builder for GetBlockProofBuilder {
     const NAME: &'static str = "GetBlockProofBuilder";
     fn expected_length(&self) -> usize {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
-            + self.block_hash.as_slice().len()
+            + self.block_hashes.as_slice().len()
             + self.tip_hash.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
         let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
         offsets.push(total_size);
-        total_size += self.block_hash.as_slice().len();
+        total_size += self.block_hashes.as_slice().len();
         offsets.push(total_size);
         total_size += self.tip_hash.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
-        writer.write_all(self.block_hash.as_slice())?;
+        writer.write_all(self.block_hashes.as_slice())?;
         writer.write_all(self.tip_hash.as_slice())?;
         Ok(())
     }
@@ -17425,446 +17424,6 @@ impl molecule::prelude::Builder for GetBlockProofBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         GetBlockProof::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct SingleBlockProof(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for SingleBlockProof {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for SingleBlockProof {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for SingleBlockProof {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "proof", self.proof())?;
-        write!(f, ", {}: {}", "header", self.header())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl ::core::default::Default for SingleBlockProof {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![
-            140, 1, 0, 0, 12, 0, 0, 0, 36, 0, 0, 0, 24, 0, 0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ];
-        SingleBlockProof::new_unchecked(v.into())
-    }
-}
-impl SingleBlockProof {
-    pub const FIELD_COUNT: usize = 2;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn proof(&self) -> BlockProof {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[4..]) as usize;
-        let end = molecule::unpack_number(&slice[8..]) as usize;
-        BlockProof::new_unchecked(self.0.slice(start..end))
-    }
-    pub fn header(&self) -> HeaderWithChainRoot {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[8..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[12..]) as usize;
-            HeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
-        } else {
-            HeaderWithChainRoot::new_unchecked(self.0.slice(start..))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> SingleBlockProofReader<'r> {
-        SingleBlockProofReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for SingleBlockProof {
-    type Builder = SingleBlockProofBuilder;
-    const NAME: &'static str = "SingleBlockProof";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        SingleBlockProof(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SingleBlockProofReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SingleBlockProofReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder()
-            .proof(self.proof())
-            .header(self.header())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct SingleBlockProofReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for SingleBlockProofReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for SingleBlockProofReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for SingleBlockProofReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "proof", self.proof())?;
-        write!(f, ", {}: {}", "header", self.header())?;
-        let extra_count = self.count_extra_fields();
-        if extra_count != 0 {
-            write!(f, ", .. ({} fields)", extra_count)?;
-        }
-        write!(f, " }}")
-    }
-}
-impl<'r> SingleBlockProofReader<'r> {
-    pub const FIELD_COUNT: usize = 2;
-    pub fn total_size(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn field_count(&self) -> usize {
-        if self.total_size() == molecule::NUMBER_SIZE {
-            0
-        } else {
-            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
-        }
-    }
-    pub fn count_extra_fields(&self) -> usize {
-        self.field_count() - Self::FIELD_COUNT
-    }
-    pub fn has_extra_fields(&self) -> bool {
-        Self::FIELD_COUNT != self.field_count()
-    }
-    pub fn proof(&self) -> BlockProofReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[4..]) as usize;
-        let end = molecule::unpack_number(&slice[8..]) as usize;
-        BlockProofReader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn header(&self) -> HeaderWithChainRootReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[8..]) as usize;
-        if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[12..]) as usize;
-            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
-        } else {
-            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..])
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for SingleBlockProofReader<'r> {
-    type Entity = SingleBlockProof;
-    const NAME: &'static str = "SingleBlockProofReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        SingleBlockProofReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let total_size = molecule::unpack_number(slice) as usize;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
-            return Ok(());
-        }
-        if slice_len < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
-        }
-        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
-        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        if slice_len < offset_first {
-            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
-        }
-        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
-        if field_count < Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        } else if !compatible && field_count > Self::FIELD_COUNT {
-            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
-        };
-        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
-            .chunks_exact(molecule::NUMBER_SIZE)
-            .map(|x| molecule::unpack_number(x) as usize)
-            .collect();
-        offsets.push(total_size);
-        if offsets.windows(2).any(|i| i[0] > i[1]) {
-            return ve!(Self, OffsetsNotMatch);
-        }
-        BlockProofReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        HeaderWithChainRootReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct SingleBlockProofBuilder {
-    pub(crate) proof: BlockProof,
-    pub(crate) header: HeaderWithChainRoot,
-}
-impl SingleBlockProofBuilder {
-    pub const FIELD_COUNT: usize = 2;
-    pub fn proof(mut self, v: BlockProof) -> Self {
-        self.proof = v;
-        self
-    }
-    pub fn header(mut self, v: HeaderWithChainRoot) -> Self {
-        self.header = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for SingleBlockProofBuilder {
-    type Entity = SingleBlockProof;
-    const NAME: &'static str = "SingleBlockProofBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
-            + self.proof.as_slice().len()
-            + self.header.as_slice().len()
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
-        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
-        offsets.push(total_size);
-        total_size += self.proof.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.header.as_slice().len();
-        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
-        for offset in offsets.into_iter() {
-            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
-        }
-        writer.write_all(self.proof.as_slice())?;
-        writer.write_all(self.header.as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        SingleBlockProof::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct SingleBlockProofOpt(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for SingleBlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for SingleBlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for SingleBlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        if let Some(v) = self.to_opt() {
-            write!(f, "{}(Some({}))", Self::NAME, v)
-        } else {
-            write!(f, "{}(None)", Self::NAME)
-        }
-    }
-}
-impl ::core::default::Default for SingleBlockProofOpt {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![];
-        SingleBlockProofOpt::new_unchecked(v.into())
-    }
-}
-impl SingleBlockProofOpt {
-    pub fn is_none(&self) -> bool {
-        self.0.is_empty()
-    }
-    pub fn is_some(&self) -> bool {
-        !self.0.is_empty()
-    }
-    pub fn to_opt(&self) -> Option<SingleBlockProof> {
-        if self.is_none() {
-            None
-        } else {
-            Some(SingleBlockProof::new_unchecked(self.0.clone()))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> SingleBlockProofOptReader<'r> {
-        SingleBlockProofOptReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for SingleBlockProofOpt {
-    type Builder = SingleBlockProofOptBuilder;
-    const NAME: &'static str = "SingleBlockProofOpt";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        SingleBlockProofOpt(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SingleBlockProofOptReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        SingleBlockProofOptReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().set(self.to_opt())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct SingleBlockProofOptReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for SingleBlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for SingleBlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for SingleBlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        if let Some(v) = self.to_opt() {
-            write!(f, "{}(Some({}))", Self::NAME, v)
-        } else {
-            write!(f, "{}(None)", Self::NAME)
-        }
-    }
-}
-impl<'r> SingleBlockProofOptReader<'r> {
-    pub fn is_none(&self) -> bool {
-        self.0.is_empty()
-    }
-    pub fn is_some(&self) -> bool {
-        !self.0.is_empty()
-    }
-    pub fn to_opt(&self) -> Option<SingleBlockProofReader<'r>> {
-        if self.is_none() {
-            None
-        } else {
-            Some(SingleBlockProofReader::new_unchecked(self.as_slice()))
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for SingleBlockProofOptReader<'r> {
-    type Entity = SingleBlockProofOpt;
-    const NAME: &'static str = "SingleBlockProofOptReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        SingleBlockProofOptReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        if !slice.is_empty() {
-            SingleBlockProofReader::verify(&slice[..], compatible)?;
-        }
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct SingleBlockProofOptBuilder(pub(crate) Option<SingleBlockProof>);
-impl SingleBlockProofOptBuilder {
-    pub fn set(mut self, v: Option<SingleBlockProof>) -> Self {
-        self.0 = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for SingleBlockProofOptBuilder {
-    type Entity = SingleBlockProofOpt;
-    const NAME: &'static str = "SingleBlockProofOptBuilder";
-    fn expected_length(&self) -> usize {
-        self.0
-            .as_ref()
-            .map(|ref inner| inner.as_slice().len())
-            .unwrap_or(0)
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        self.0
-            .as_ref()
-            .map(|ref inner| writer.write_all(inner.as_slice()))
-            .unwrap_or(Ok(()))
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        SingleBlockProofOpt::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]
@@ -17886,7 +17445,9 @@ impl ::core::fmt::Debug for SendBlockProof {
 impl ::core::fmt::Display for SendBlockProof {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "proof", self.proof())?;
+        write!(f, "{}: {}", "root", self.root())?;
+        write!(f, ", {}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "headers", self.headers())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -17896,12 +17457,19 @@ impl ::core::fmt::Display for SendBlockProof {
 }
 impl ::core::default::Default for SendBlockProof {
     fn default() -> Self {
-        let v: Vec<u8> = vec![8, 0, 0, 0, 8, 0, 0, 0];
+        let v: Vec<u8> = vec![
+            164, 0, 0, 0, 16, 0, 0, 0, 136, 0, 0, 0, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 12, 0,
+            0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
         SendBlockProof::new_unchecked(v.into())
     }
 }
 impl SendBlockProof {
-    pub const FIELD_COUNT: usize = 1;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -17918,14 +17486,26 @@ impl SendBlockProof {
     pub fn has_extra_fields(&self) -> bool {
         Self::FIELD_COUNT != self.field_count()
     }
-    pub fn proof(&self) -> SingleBlockProofOpt {
+    pub fn root(&self) -> HeaderDigest {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        HeaderDigest::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn proof(&self) -> BlockProof {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        BlockProof::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn headers(&self) -> HeaderVec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[8..]) as usize;
-            SingleBlockProofOpt::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            HeaderVec::new_unchecked(self.0.slice(start..end))
         } else {
-            SingleBlockProofOpt::new_unchecked(self.0.slice(start..))
+            HeaderVec::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> SendBlockProofReader<'r> {
@@ -17954,7 +17534,10 @@ impl molecule::prelude::Entity for SendBlockProof {
         ::core::default::Default::default()
     }
     fn as_builder(self) -> Self::Builder {
-        Self::new_builder().proof(self.proof())
+        Self::new_builder()
+            .root(self.root())
+            .proof(self.proof())
+            .headers(self.headers())
     }
 }
 #[derive(Clone, Copy)]
@@ -17976,7 +17559,9 @@ impl<'r> ::core::fmt::Debug for SendBlockProofReader<'r> {
 impl<'r> ::core::fmt::Display for SendBlockProofReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "proof", self.proof())?;
+        write!(f, "{}: {}", "root", self.root())?;
+        write!(f, ", {}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "headers", self.headers())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -17985,7 +17570,7 @@ impl<'r> ::core::fmt::Display for SendBlockProofReader<'r> {
     }
 }
 impl<'r> SendBlockProofReader<'r> {
-    pub const FIELD_COUNT: usize = 1;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -18002,14 +17587,26 @@ impl<'r> SendBlockProofReader<'r> {
     pub fn has_extra_fields(&self) -> bool {
         Self::FIELD_COUNT != self.field_count()
     }
-    pub fn proof(&self) -> SingleBlockProofOptReader<'r> {
+    pub fn root(&self) -> HeaderDigestReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        HeaderDigestReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn proof(&self) -> BlockProofReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        BlockProofReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn headers(&self) -> HeaderVecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[8..]) as usize;
-            SingleBlockProofOptReader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            HeaderVecReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            SingleBlockProofOptReader::new_unchecked(&self.as_slice()[start..])
+            HeaderVecReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -18062,18 +17659,30 @@ impl<'r> molecule::prelude::Reader<'r> for SendBlockProofReader<'r> {
         if offsets.windows(2).any(|i| i[0] > i[1]) {
             return ve!(Self, OffsetsNotMatch);
         }
-        SingleBlockProofOptReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        HeaderDigestReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        BlockProofReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        HeaderVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Ok(())
     }
 }
 #[derive(Debug, Default)]
 pub struct SendBlockProofBuilder {
-    pub(crate) proof: SingleBlockProofOpt,
+    pub(crate) root: HeaderDigest,
+    pub(crate) proof: BlockProof,
+    pub(crate) headers: HeaderVec,
 }
 impl SendBlockProofBuilder {
-    pub const FIELD_COUNT: usize = 1;
-    pub fn proof(mut self, v: SingleBlockProofOpt) -> Self {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn root(mut self, v: HeaderDigest) -> Self {
+        self.root = v;
+        self
+    }
+    pub fn proof(mut self, v: BlockProof) -> Self {
         self.proof = v;
+        self
+    }
+    pub fn headers(mut self, v: HeaderVec) -> Self {
+        self.headers = v;
         self
     }
 }
@@ -18081,18 +17690,27 @@ impl molecule::prelude::Builder for SendBlockProofBuilder {
     type Entity = SendBlockProof;
     const NAME: &'static str = "SendBlockProofBuilder";
     fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1) + self.proof.as_slice().len()
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.root.as_slice().len()
+            + self.proof.as_slice().len()
+            + self.headers.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
         let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
         offsets.push(total_size);
+        total_size += self.root.as_slice().len();
+        offsets.push(total_size);
         total_size += self.proof.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.headers.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
+        writer.write_all(self.root.as_slice())?;
         writer.write_all(self.proof.as_slice())?;
+        writer.write_all(self.headers.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -15289,169 +15289,6 @@ impl molecule::prelude::Builder for BlockProofBuilder {
     }
 }
 #[derive(Clone)]
-pub struct BlockProofOpt(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for BlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for BlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for BlockProofOpt {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        if let Some(v) = self.to_opt() {
-            write!(f, "{}(Some({}))", Self::NAME, v)
-        } else {
-            write!(f, "{}(None)", Self::NAME)
-        }
-    }
-}
-impl ::core::default::Default for BlockProofOpt {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![];
-        BlockProofOpt::new_unchecked(v.into())
-    }
-}
-impl BlockProofOpt {
-    pub fn is_none(&self) -> bool {
-        self.0.is_empty()
-    }
-    pub fn is_some(&self) -> bool {
-        !self.0.is_empty()
-    }
-    pub fn to_opt(&self) -> Option<BlockProof> {
-        if self.is_none() {
-            None
-        } else {
-            Some(BlockProof::new_unchecked(self.0.clone()))
-        }
-    }
-    pub fn as_reader<'r>(&'r self) -> BlockProofOptReader<'r> {
-        BlockProofOptReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for BlockProofOpt {
-    type Builder = BlockProofOptBuilder;
-    const NAME: &'static str = "BlockProofOpt";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        BlockProofOpt(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        BlockProofOptReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        BlockProofOptReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().set(self.to_opt())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct BlockProofOptReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for BlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for BlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for BlockProofOptReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        if let Some(v) = self.to_opt() {
-            write!(f, "{}(Some({}))", Self::NAME, v)
-        } else {
-            write!(f, "{}(None)", Self::NAME)
-        }
-    }
-}
-impl<'r> BlockProofOptReader<'r> {
-    pub fn is_none(&self) -> bool {
-        self.0.is_empty()
-    }
-    pub fn is_some(&self) -> bool {
-        !self.0.is_empty()
-    }
-    pub fn to_opt(&self) -> Option<BlockProofReader<'r>> {
-        if self.is_none() {
-            None
-        } else {
-            Some(BlockProofReader::new_unchecked(self.as_slice()))
-        }
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for BlockProofOptReader<'r> {
-    type Entity = BlockProofOpt;
-    const NAME: &'static str = "BlockProofOptReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        BlockProofOptReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
-        if !slice.is_empty() {
-            BlockProofReader::verify(&slice[..], compatible)?;
-        }
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct BlockProofOptBuilder(pub(crate) Option<BlockProof>);
-impl BlockProofOptBuilder {
-    pub fn set(mut self, v: Option<BlockProof>) -> Self {
-        self.0 = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for BlockProofOptBuilder {
-    type Entity = BlockProofOpt;
-    const NAME: &'static str = "BlockProofOptBuilder";
-    fn expected_length(&self) -> usize {
-        self.0
-            .as_ref()
-            .map(|ref inner| inner.as_slice().len())
-            .unwrap_or(0)
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        self.0
-            .as_ref()
-            .map(|ref inner| writer.write_all(inner.as_slice()))
-            .unwrap_or(Ok(()))
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        BlockProofOpt::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
 pub struct VerifiableHeader(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for VerifiableHeader {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -15778,7 +15615,7 @@ impl ::core::default::Default for LightClientMessage {
     }
 }
 impl LightClientMessage {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 6;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -15789,6 +15626,8 @@ impl LightClientMessage {
             1 => SendLastState::new_unchecked(inner).into(),
             2 => GetBlockSamples::new_unchecked(inner).into(),
             3 => SendBlockSamples::new_unchecked(inner).into(),
+            4 => GetBlockProof::new_unchecked(inner).into(),
+            5 => SendBlockProof::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -15845,7 +15684,7 @@ impl<'r> ::core::fmt::Display for LightClientMessageReader<'r> {
     }
 }
 impl<'r> LightClientMessageReader<'r> {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 6;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -15856,6 +15695,8 @@ impl<'r> LightClientMessageReader<'r> {
             1 => SendLastStateReader::new_unchecked(inner).into(),
             2 => GetBlockSamplesReader::new_unchecked(inner).into(),
             3 => SendBlockSamplesReader::new_unchecked(inner).into(),
+            4 => GetBlockProofReader::new_unchecked(inner).into(),
+            5 => SendBlockProofReader::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -15885,6 +15726,8 @@ impl<'r> molecule::prelude::Reader<'r> for LightClientMessageReader<'r> {
             1 => SendLastStateReader::verify(inner_slice, compatible),
             2 => GetBlockSamplesReader::verify(inner_slice, compatible),
             3 => SendBlockSamplesReader::verify(inner_slice, compatible),
+            4 => GetBlockProofReader::verify(inner_slice, compatible),
+            5 => SendBlockProofReader::verify(inner_slice, compatible),
             _ => ve!(Self, UnknownItem, Self::ITEMS_COUNT, item_id),
         }?;
         Ok(())
@@ -15893,7 +15736,7 @@ impl<'r> molecule::prelude::Reader<'r> for LightClientMessageReader<'r> {
 #[derive(Debug, Default)]
 pub struct LightClientMessageBuilder(pub(crate) LightClientMessageUnion);
 impl LightClientMessageBuilder {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 6;
     pub fn set<I>(mut self, v: I) -> Self
     where
         I: ::core::convert::Into<LightClientMessageUnion>,
@@ -15925,6 +15768,8 @@ pub enum LightClientMessageUnion {
     SendLastState(SendLastState),
     GetBlockSamples(GetBlockSamples),
     SendBlockSamples(SendBlockSamples),
+    GetBlockProof(GetBlockProof),
+    SendBlockProof(SendBlockProof),
 }
 #[derive(Debug, Clone, Copy)]
 pub enum LightClientMessageUnionReader<'r> {
@@ -15932,6 +15777,8 @@ pub enum LightClientMessageUnionReader<'r> {
     SendLastState(SendLastStateReader<'r>),
     GetBlockSamples(GetBlockSamplesReader<'r>),
     SendBlockSamples(SendBlockSamplesReader<'r>),
+    GetBlockProof(GetBlockProofReader<'r>),
+    SendBlockProof(SendBlockProofReader<'r>),
 }
 impl ::core::default::Default for LightClientMessageUnion {
     fn default() -> Self {
@@ -15953,6 +15800,12 @@ impl ::core::fmt::Display for LightClientMessageUnion {
             LightClientMessageUnion::SendBlockSamples(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, SendBlockSamples::NAME, item)
             }
+            LightClientMessageUnion::GetBlockProof(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, GetBlockProof::NAME, item)
+            }
+            LightClientMessageUnion::SendBlockProof(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, SendBlockProof::NAME, item)
+            }
         }
     }
 }
@@ -15971,6 +15824,12 @@ impl<'r> ::core::fmt::Display for LightClientMessageUnionReader<'r> {
             LightClientMessageUnionReader::SendBlockSamples(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, SendBlockSamples::NAME, item)
             }
+            LightClientMessageUnionReader::GetBlockProof(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, GetBlockProof::NAME, item)
+            }
+            LightClientMessageUnionReader::SendBlockProof(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, SendBlockProof::NAME, item)
+            }
         }
     }
 }
@@ -15981,6 +15840,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(ref item) => write!(f, "{}", item),
             LightClientMessageUnion::GetBlockSamples(ref item) => write!(f, "{}", item),
             LightClientMessageUnion::SendBlockSamples(ref item) => write!(f, "{}", item),
+            LightClientMessageUnion::GetBlockProof(ref item) => write!(f, "{}", item),
+            LightClientMessageUnion::SendBlockProof(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -15991,6 +15852,8 @@ impl<'r> LightClientMessageUnionReader<'r> {
             LightClientMessageUnionReader::SendLastState(ref item) => write!(f, "{}", item),
             LightClientMessageUnionReader::GetBlockSamples(ref item) => write!(f, "{}", item),
             LightClientMessageUnionReader::SendBlockSamples(ref item) => write!(f, "{}", item),
+            LightClientMessageUnionReader::GetBlockProof(ref item) => write!(f, "{}", item),
+            LightClientMessageUnionReader::SendBlockProof(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -16014,6 +15877,16 @@ impl ::core::convert::From<SendBlockSamples> for LightClientMessageUnion {
         LightClientMessageUnion::SendBlockSamples(item)
     }
 }
+impl ::core::convert::From<GetBlockProof> for LightClientMessageUnion {
+    fn from(item: GetBlockProof) -> Self {
+        LightClientMessageUnion::GetBlockProof(item)
+    }
+}
+impl ::core::convert::From<SendBlockProof> for LightClientMessageUnion {
+    fn from(item: SendBlockProof) -> Self {
+        LightClientMessageUnion::SendBlockProof(item)
+    }
+}
 impl<'r> ::core::convert::From<GetLastStateReader<'r>> for LightClientMessageUnionReader<'r> {
     fn from(item: GetLastStateReader<'r>) -> Self {
         LightClientMessageUnionReader::GetLastState(item)
@@ -16034,6 +15907,16 @@ impl<'r> ::core::convert::From<SendBlockSamplesReader<'r>> for LightClientMessag
         LightClientMessageUnionReader::SendBlockSamples(item)
     }
 }
+impl<'r> ::core::convert::From<GetBlockProofReader<'r>> for LightClientMessageUnionReader<'r> {
+    fn from(item: GetBlockProofReader<'r>) -> Self {
+        LightClientMessageUnionReader::GetBlockProof(item)
+    }
+}
+impl<'r> ::core::convert::From<SendBlockProofReader<'r>> for LightClientMessageUnionReader<'r> {
+    fn from(item: SendBlockProofReader<'r>) -> Self {
+        LightClientMessageUnionReader::SendBlockProof(item)
+    }
+}
 impl LightClientMessageUnion {
     pub const NAME: &'static str = "LightClientMessageUnion";
     pub fn as_bytes(&self) -> molecule::bytes::Bytes {
@@ -16042,6 +15925,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(item) => item.as_bytes(),
             LightClientMessageUnion::GetBlockSamples(item) => item.as_bytes(),
             LightClientMessageUnion::SendBlockSamples(item) => item.as_bytes(),
+            LightClientMessageUnion::GetBlockProof(item) => item.as_bytes(),
+            LightClientMessageUnion::SendBlockProof(item) => item.as_bytes(),
         }
     }
     pub fn as_slice(&self) -> &[u8] {
@@ -16050,6 +15935,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(item) => item.as_slice(),
             LightClientMessageUnion::GetBlockSamples(item) => item.as_slice(),
             LightClientMessageUnion::SendBlockSamples(item) => item.as_slice(),
+            LightClientMessageUnion::GetBlockProof(item) => item.as_slice(),
+            LightClientMessageUnion::SendBlockProof(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
@@ -16058,6 +15945,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(_) => 1,
             LightClientMessageUnion::GetBlockSamples(_) => 2,
             LightClientMessageUnion::SendBlockSamples(_) => 3,
+            LightClientMessageUnion::GetBlockProof(_) => 4,
+            LightClientMessageUnion::SendBlockProof(_) => 5,
         }
     }
     pub fn item_name(&self) -> &str {
@@ -16066,6 +15955,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(_) => "SendLastState",
             LightClientMessageUnion::GetBlockSamples(_) => "GetBlockSamples",
             LightClientMessageUnion::SendBlockSamples(_) => "SendBlockSamples",
+            LightClientMessageUnion::GetBlockProof(_) => "GetBlockProof",
+            LightClientMessageUnion::SendBlockProof(_) => "SendBlockProof",
         }
     }
     pub fn as_reader<'r>(&'r self) -> LightClientMessageUnionReader<'r> {
@@ -16074,6 +15965,8 @@ impl LightClientMessageUnion {
             LightClientMessageUnion::SendLastState(item) => item.as_reader().into(),
             LightClientMessageUnion::GetBlockSamples(item) => item.as_reader().into(),
             LightClientMessageUnion::SendBlockSamples(item) => item.as_reader().into(),
+            LightClientMessageUnion::GetBlockProof(item) => item.as_reader().into(),
+            LightClientMessageUnion::SendBlockProof(item) => item.as_reader().into(),
         }
     }
 }
@@ -16085,6 +15978,8 @@ impl<'r> LightClientMessageUnionReader<'r> {
             LightClientMessageUnionReader::SendLastState(item) => item.as_slice(),
             LightClientMessageUnionReader::GetBlockSamples(item) => item.as_slice(),
             LightClientMessageUnionReader::SendBlockSamples(item) => item.as_slice(),
+            LightClientMessageUnionReader::GetBlockProof(item) => item.as_slice(),
+            LightClientMessageUnionReader::SendBlockProof(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
@@ -16093,6 +15988,8 @@ impl<'r> LightClientMessageUnionReader<'r> {
             LightClientMessageUnionReader::SendLastState(_) => 1,
             LightClientMessageUnionReader::GetBlockSamples(_) => 2,
             LightClientMessageUnionReader::SendBlockSamples(_) => 3,
+            LightClientMessageUnionReader::GetBlockProof(_) => 4,
+            LightClientMessageUnionReader::SendBlockProof(_) => 5,
         }
     }
     pub fn item_name(&self) -> &str {
@@ -16101,6 +15998,8 @@ impl<'r> LightClientMessageUnionReader<'r> {
             LightClientMessageUnionReader::SendLastState(_) => "SendLastState",
             LightClientMessageUnionReader::GetBlockSamples(_) => "GetBlockSamples",
             LightClientMessageUnionReader::SendBlockSamples(_) => "SendBlockSamples",
+            LightClientMessageUnionReader::GetBlockProof(_) => "GetBlockProof",
+            LightClientMessageUnionReader::SendBlockProof(_) => "SendBlockProof",
         }
     }
 }
@@ -17260,6 +17159,947 @@ impl molecule::prelude::Builder for SendBlockSamplesBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         SendBlockSamples::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct GetBlockProof(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for GetBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for GetBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for GetBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "block_hash", self.block_hash())?;
+        write!(f, ", {}: {}", "tip_hash", self.tip_hash())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for GetBlockProof {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            76, 0, 0, 0, 12, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        GetBlockProof::new_unchecked(v.into())
+    }
+}
+impl GetBlockProof {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn block_hash(&self) -> Byte32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn tip_hash(&self) -> Byte32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Byte32::new_unchecked(self.0.slice(start..end))
+        } else {
+            Byte32::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> GetBlockProofReader<'r> {
+        GetBlockProofReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for GetBlockProof {
+    type Builder = GetBlockProofBuilder;
+    const NAME: &'static str = "GetBlockProof";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        GetBlockProof(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        GetBlockProofReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        GetBlockProofReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .block_hash(self.block_hash())
+            .tip_hash(self.tip_hash())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct GetBlockProofReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for GetBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for GetBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for GetBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "block_hash", self.block_hash())?;
+        write!(f, ", {}: {}", "tip_hash", self.tip_hash())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> GetBlockProofReader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn block_hash(&self) -> Byte32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn tip_hash(&self) -> Byte32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Byte32Reader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for GetBlockProofReader<'r> {
+    type Entity = GetBlockProof;
+    const NAME: &'static str = "GetBlockProofReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        GetBlockProofReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Byte32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Byte32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct GetBlockProofBuilder {
+    pub(crate) block_hash: Byte32,
+    pub(crate) tip_hash: Byte32,
+}
+impl GetBlockProofBuilder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn block_hash(mut self, v: Byte32) -> Self {
+        self.block_hash = v;
+        self
+    }
+    pub fn tip_hash(mut self, v: Byte32) -> Self {
+        self.tip_hash = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for GetBlockProofBuilder {
+    type Entity = GetBlockProof;
+    const NAME: &'static str = "GetBlockProofBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.block_hash.as_slice().len()
+            + self.tip_hash.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.block_hash.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.tip_hash.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.block_hash.as_slice())?;
+        writer.write_all(self.tip_hash.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        GetBlockProof::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct SingleBlockProof(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for SingleBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for SingleBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for SingleBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "header", self.header())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for SingleBlockProof {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            140, 1, 0, 0, 12, 0, 0, 0, 36, 0, 0, 0, 24, 0, 0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        SingleBlockProof::new_unchecked(v.into())
+    }
+}
+impl SingleBlockProof {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn proof(&self) -> BlockProof {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        BlockProof::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn header(&self) -> HeaderWithChainRoot {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            HeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
+        } else {
+            HeaderWithChainRoot::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> SingleBlockProofReader<'r> {
+        SingleBlockProofReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for SingleBlockProof {
+    type Builder = SingleBlockProofBuilder;
+    const NAME: &'static str = "SingleBlockProof";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        SingleBlockProof(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SingleBlockProofReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SingleBlockProofReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .proof(self.proof())
+            .header(self.header())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct SingleBlockProofReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for SingleBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for SingleBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for SingleBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "header", self.header())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> SingleBlockProofReader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn proof(&self) -> BlockProofReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        BlockProofReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn header(&self) -> HeaderWithChainRootReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for SingleBlockProofReader<'r> {
+    type Entity = SingleBlockProof;
+    const NAME: &'static str = "SingleBlockProofReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        SingleBlockProofReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        BlockProofReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        HeaderWithChainRootReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct SingleBlockProofBuilder {
+    pub(crate) proof: BlockProof,
+    pub(crate) header: HeaderWithChainRoot,
+}
+impl SingleBlockProofBuilder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn proof(mut self, v: BlockProof) -> Self {
+        self.proof = v;
+        self
+    }
+    pub fn header(mut self, v: HeaderWithChainRoot) -> Self {
+        self.header = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for SingleBlockProofBuilder {
+    type Entity = SingleBlockProof;
+    const NAME: &'static str = "SingleBlockProofBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.proof.as_slice().len()
+            + self.header.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.proof.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.header.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.proof.as_slice())?;
+        writer.write_all(self.header.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        SingleBlockProof::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct SingleBlockProofOpt(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for SingleBlockProofOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for SingleBlockProofOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for SingleBlockProofOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        if let Some(v) = self.to_opt() {
+            write!(f, "{}(Some({}))", Self::NAME, v)
+        } else {
+            write!(f, "{}(None)", Self::NAME)
+        }
+    }
+}
+impl ::core::default::Default for SingleBlockProofOpt {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![];
+        SingleBlockProofOpt::new_unchecked(v.into())
+    }
+}
+impl SingleBlockProofOpt {
+    pub fn is_none(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn is_some(&self) -> bool {
+        !self.0.is_empty()
+    }
+    pub fn to_opt(&self) -> Option<SingleBlockProof> {
+        if self.is_none() {
+            None
+        } else {
+            Some(SingleBlockProof::new_unchecked(self.0.clone()))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> SingleBlockProofOptReader<'r> {
+        SingleBlockProofOptReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for SingleBlockProofOpt {
+    type Builder = SingleBlockProofOptBuilder;
+    const NAME: &'static str = "SingleBlockProofOpt";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        SingleBlockProofOpt(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SingleBlockProofOptReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SingleBlockProofOptReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set(self.to_opt())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct SingleBlockProofOptReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for SingleBlockProofOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for SingleBlockProofOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for SingleBlockProofOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        if let Some(v) = self.to_opt() {
+            write!(f, "{}(Some({}))", Self::NAME, v)
+        } else {
+            write!(f, "{}(None)", Self::NAME)
+        }
+    }
+}
+impl<'r> SingleBlockProofOptReader<'r> {
+    pub fn is_none(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn is_some(&self) -> bool {
+        !self.0.is_empty()
+    }
+    pub fn to_opt(&self) -> Option<SingleBlockProofReader<'r>> {
+        if self.is_none() {
+            None
+        } else {
+            Some(SingleBlockProofReader::new_unchecked(self.as_slice()))
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for SingleBlockProofOptReader<'r> {
+    type Entity = SingleBlockProofOpt;
+    const NAME: &'static str = "SingleBlockProofOptReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        SingleBlockProofOptReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        if !slice.is_empty() {
+            SingleBlockProofReader::verify(&slice[..], compatible)?;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct SingleBlockProofOptBuilder(pub(crate) Option<SingleBlockProof>);
+impl SingleBlockProofOptBuilder {
+    pub fn set(mut self, v: Option<SingleBlockProof>) -> Self {
+        self.0 = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for SingleBlockProofOptBuilder {
+    type Entity = SingleBlockProofOpt;
+    const NAME: &'static str = "SingleBlockProofOptBuilder";
+    fn expected_length(&self) -> usize {
+        self.0
+            .as_ref()
+            .map(|ref inner| inner.as_slice().len())
+            .unwrap_or(0)
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        self.0
+            .as_ref()
+            .map(|ref inner| writer.write_all(inner.as_slice()))
+            .unwrap_or(Ok(()))
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        SingleBlockProofOpt::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct SendBlockProof(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for SendBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for SendBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for SendBlockProof {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "proof", self.proof())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for SendBlockProof {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![8, 0, 0, 0, 8, 0, 0, 0];
+        SendBlockProof::new_unchecked(v.into())
+    }
+}
+impl SendBlockProof {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn proof(&self) -> SingleBlockProofOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[8..]) as usize;
+            SingleBlockProofOpt::new_unchecked(self.0.slice(start..end))
+        } else {
+            SingleBlockProofOpt::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> SendBlockProofReader<'r> {
+        SendBlockProofReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for SendBlockProof {
+    type Builder = SendBlockProofBuilder;
+    const NAME: &'static str = "SendBlockProof";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        SendBlockProof(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SendBlockProofReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        SendBlockProofReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().proof(self.proof())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct SendBlockProofReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for SendBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for SendBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for SendBlockProofReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "proof", self.proof())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> SendBlockProofReader<'r> {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn proof(&self) -> SingleBlockProofOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[8..]) as usize;
+            SingleBlockProofOptReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            SingleBlockProofOptReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for SendBlockProofReader<'r> {
+    type Entity = SendBlockProof;
+    const NAME: &'static str = "SendBlockProofReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        SendBlockProofReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        SingleBlockProofOptReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct SendBlockProofBuilder {
+    pub(crate) proof: SingleBlockProofOpt,
+}
+impl SendBlockProofBuilder {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn proof(mut self, v: SingleBlockProofOpt) -> Self {
+        self.proof = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for SendBlockProofBuilder {
+    type Entity = SendBlockProof;
+    const NAME: &'static str = "SendBlockProofBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1) + self.proof.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.proof.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.proof.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        SendBlockProof::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -17447,6 +17447,7 @@ impl ::core::fmt::Display for SendBlockProof {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "root", self.root())?;
         write!(f, ", {}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "tip_header", self.tip_header())?;
         write!(f, ", {}: {}", "headers", self.headers())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -17458,18 +17459,27 @@ impl ::core::fmt::Display for SendBlockProof {
 impl ::core::default::Default for SendBlockProof {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            164, 0, 0, 0, 16, 0, 0, 0, 136, 0, 0, 0, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            168, 1, 0, 0, 20, 0, 0, 0, 140, 0, 0, 0, 164, 0, 0, 0, 164, 1, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 12, 0,
-            0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0,
+            0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 16, 0,
+            0, 0, 224, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         SendBlockProof::new_unchecked(v.into())
     }
 }
 impl SendBlockProof {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -17498,11 +17508,17 @@ impl SendBlockProof {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         BlockProof::new_unchecked(self.0.slice(start..end))
     }
-    pub fn headers(&self) -> HeaderVec {
+    pub fn tip_header(&self) -> VerifiableHeader {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        VerifiableHeader::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn headers(&self) -> HeaderVec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
+            let end = molecule::unpack_number(&slice[20..]) as usize;
             HeaderVec::new_unchecked(self.0.slice(start..end))
         } else {
             HeaderVec::new_unchecked(self.0.slice(start..))
@@ -17537,6 +17553,7 @@ impl molecule::prelude::Entity for SendBlockProof {
         Self::new_builder()
             .root(self.root())
             .proof(self.proof())
+            .tip_header(self.tip_header())
             .headers(self.headers())
     }
 }
@@ -17561,6 +17578,7 @@ impl<'r> ::core::fmt::Display for SendBlockProofReader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "root", self.root())?;
         write!(f, ", {}: {}", "proof", self.proof())?;
+        write!(f, ", {}: {}", "tip_header", self.tip_header())?;
         write!(f, ", {}: {}", "headers", self.headers())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -17570,7 +17588,7 @@ impl<'r> ::core::fmt::Display for SendBlockProofReader<'r> {
     }
 }
 impl<'r> SendBlockProofReader<'r> {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -17599,11 +17617,17 @@ impl<'r> SendBlockProofReader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         BlockProofReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn headers(&self) -> HeaderVecReader<'r> {
+    pub fn tip_header(&self) -> VerifiableHeaderReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        VerifiableHeaderReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn headers(&self) -> HeaderVecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
+            let end = molecule::unpack_number(&slice[20..]) as usize;
             HeaderVecReader::new_unchecked(&self.as_slice()[start..end])
         } else {
             HeaderVecReader::new_unchecked(&self.as_slice()[start..])
@@ -17661,7 +17685,8 @@ impl<'r> molecule::prelude::Reader<'r> for SendBlockProofReader<'r> {
         }
         HeaderDigestReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         BlockProofReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        HeaderVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        VerifiableHeaderReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        HeaderVecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
         Ok(())
     }
 }
@@ -17669,16 +17694,21 @@ impl<'r> molecule::prelude::Reader<'r> for SendBlockProofReader<'r> {
 pub struct SendBlockProofBuilder {
     pub(crate) root: HeaderDigest,
     pub(crate) proof: BlockProof,
+    pub(crate) tip_header: VerifiableHeader,
     pub(crate) headers: HeaderVec,
 }
 impl SendBlockProofBuilder {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn root(mut self, v: HeaderDigest) -> Self {
         self.root = v;
         self
     }
     pub fn proof(mut self, v: BlockProof) -> Self {
         self.proof = v;
+        self
+    }
+    pub fn tip_header(mut self, v: VerifiableHeader) -> Self {
+        self.tip_header = v;
         self
     }
     pub fn headers(mut self, v: HeaderVec) -> Self {
@@ -17693,6 +17723,7 @@ impl molecule::prelude::Builder for SendBlockProofBuilder {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.root.as_slice().len()
             + self.proof.as_slice().len()
+            + self.tip_header.as_slice().len()
             + self.headers.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
@@ -17703,6 +17734,8 @@ impl molecule::prelude::Builder for SendBlockProofBuilder {
         offsets.push(total_size);
         total_size += self.proof.as_slice().len();
         offsets.push(total_size);
+        total_size += self.tip_header.as_slice().len();
+        offsets.push(total_size);
         total_size += self.headers.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
@@ -17710,6 +17743,7 @@ impl molecule::prelude::Builder for SendBlockProofBuilder {
         }
         writer.write_all(self.root.as_slice())?;
         writer.write_all(self.proof.as_slice())?;
+        writer.write_all(self.tip_header.as_slice())?;
         writer.write_all(self.headers.as_slice())?;
         Ok(())
     }


### PR DESCRIPTION

### What is changed and how it works?

What's Changed:
Add `GetBlockProof` light-client message handler to send proof of a batch of blocks.