### PR TITLE
fix publish crates

### DIFF
--- a/devtools/release/publish-crates.sh
+++ b/devtools/release/publish-crates.sh
@@ -10,7 +10,10 @@ RUST_VERSION="$(cat rust-toolchain)"
 retry_cargo_publish() {
   # Ignore dev dependencies
   rm -f Cargo.toml.bak
-  sed -i.bak -e '/^\[dev-dependencies\]/, /^\[/ { /^[^\[]/d }' Cargo.toml
+  sed -i.bak \
+    -e '/^\[dev-dependencies\]/, /^\[/ { /^[^\[]/d }' \
+    -e '/# dev-feature$/d' \
+    Cargo.toml
 
   local RETRIES=5
   local INTERVAL=2

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -35,7 +35,7 @@ ckb-db = { path = "../db", version = "= 0.105.0-pre" }
 sentry = { version = "0.26.0", optional = true }
 serde_json = "1.0"
 rand = "0.8.4"
-hyper = { version = "0.14", features = ["http1", "client"] }
+hyper = { version = "0.14", features = ["http1", "client", "tcp"] }
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. Failed to publish tx-pool because it requires hyper/tcp but is not explicitly specified in Cargo.toml.
2. Allow adding dev only feature to avoid issues like #3500 in the future.

### What is changed and how it works?

- chore(deps): enable hyper/tcp to publish crate
- chore: allow adding dev only feature in Cargo.toml


### Check List <!--REMOVE the items that are not applicable-->

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

