### PR TITLE
chore: leverage link-hash-map drain

### DIFF
--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -63,6 +63,12 @@ impl TxEntry {
         &self.rtx.transaction
     }
 
+    /// Converts a Entry into a TransactionView
+    /// This consumes the Entry
+    pub fn into_transaction(self) -> TransactionView {
+        self.rtx.transaction
+    }
+
     /// Return proposal_short_id of transaction
     pub fn proposal_short_id(&self) -> ProposalShortId {
         self.transaction().proposal_short_id()

--- a/tx-pool/src/component/pending.rs
+++ b/tx-pool/src/component/pending.rs
@@ -311,10 +311,9 @@ impl PendingQueue {
     pub(crate) fn drain(&mut self) -> Vec<TransactionView> {
         let txs = self
             .inner
-            .values()
-            .map(|entry| entry.transaction().clone())
+            .drain()
+            .map(|(_k, entry)| entry.into_transaction())
             .collect::<Vec<_>>();
-        self.inner.clear();
         self.deps.clear();
         self.inputs.clear();
         self.header_deps.clear();


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->


### What is changed and how it works?

https://github.com/contain-rs/linked-hash-map/releases/tag/v0.5.5

linked-hash-map was recently updated and supports drain 

https://docs.rs/linked-hash-map/latest/linked_hash_map/struct.LinkedHashMap.html#method.drain
> Current performance implications (why to use this over into_iter()):
>* Clears the inner HashMap instead of dropping it
>* Puts all drained nodes in the free-list instead of deallocating them
>* Avoids deallocating the sentinel node

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

