### PR TITLE
fix v0.104.0 package

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -106,7 +106,7 @@ jobs:
         cd ..
         export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-1.1.1
         export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-1.1.1/include
-        PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release
+        PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --features portable
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/aarch64-unknown-linux-gnu/release/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -57,7 +57,7 @@ jobs:
         docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
-        devtools/ci/package.sh target/release/ckb
+        devtools/ci/package.sh target/prod/ckb
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
         devtools/ci/qput-7z "releases/ckb_${GIT_TAG_NAME}_x86_64-unknown-linux-gnu"
@@ -144,7 +144,7 @@ jobs:
         docker run --rm -i -w /ckb -v $(pwd):/ckb $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
-        devtools/ci/package.sh target/release/ckb
+        devtools/ci/package.sh target/prod/ckb
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
     - name: upload-zip-file
@@ -179,7 +179,7 @@ jobs:
         make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
-        devtools/ci/package.sh target/release/ckb
+        devtools/ci/package.sh target/prod/ckb
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
     - name: upload-zip-file

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ integration: submodule-init setup-ckb-test ## Run integration tests in "test" di
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin "${CARGO_TARGET_DIR}/release/${BINARY_NAME}" ${CKB_TEST_ARGS}
 
 .PHONY: integration-release
-integration-release: submodule-init setup-ckb-test prod
+integration-release: submodule-init setup-ckb-test build
 	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} test/run.sh -- --bin ${CARGO_TARGET_DIR}/release/ckb ${CKB_TEST_ARGS}
 
 .PHONY: integration-cov

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ prod: ## Build binary for production release.
 
 .PHONY: prod_portable
 prod_portable: ## Build binary for portable production release.
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" cargo build ${VERBOSE} --profile prod --features "with_sentry,with_dns_seeding,ckb-db/portable"
+	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" cargo build ${VERBOSE} --profile prod --features "with_sentry,with_dns_seeding,portable"
 
 .PHONY: prod-docker
 prod-docker:

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=ckb-docker-builder \
      /usr/lib/x86_64-linux-gnu/libssl.so.* \
      /usr/lib/x86_64-linux-gnu/libcrypto.so.* \
      /usr/lib/x86_64-linux-gnu/
-COPY --from=ckb-docker-builder /ckb/target/release/ckb /ckb/docker/docker-entrypoint.sh /bin/
+COPY --from=ckb-docker-builder /ckb/target/prod/ckb /ckb/docker/docker-entrypoint.sh /bin/
 RUN chown -R ckb:ckb /var/lib/ckb \
  && chmod 755 /var/lib/ckb
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Failed to package v0.104.0 because `make prod` now places ckb binary under `target/prod`.

### What is changed and how it works?

What's Changed:

- chore: use target/prod/ckb after make prod
- chore: fix aarch64 package
- chore: fix feature name in make prod_portable

### Check List

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

