### PR TITLE
fix: fix atomic fetch update ordering

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use self::headers_process::HeadersProcess;
 pub(crate) use self::in_ibd_process::InIBDProcess;
 
 use crate::block_status::BlockStatus;
-use crate::types::{HeaderView, HeadersSyncController, IBDState, PeerFlags, Peers, SyncShared};
+use crate::types::{HeaderView, HeadersSyncController, IBDState, Peers, SyncShared};
 use crate::utils::send_message_to;
 use crate::{Status, StatusCode};
 
@@ -21,7 +21,7 @@ use ckb_chain::chain::ChainController;
 use ckb_channel as channel;
 use ckb_constant::sync::{
     BAD_MESSAGE_BAN_TIME, CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME,
-    INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT, MAX_TIP_AGE,
+    INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_TIP_AGE,
 };
 use ckb_error::Error as CKBError;
 use ckb_logger::{debug, error, info, trace, warn};
@@ -347,27 +347,7 @@ impl Synchronizer {
             .map(|peer| (peer.is_outbound(), peer.is_whitelist))
             .unwrap_or((false, false));
 
-        let sync_state = self.shared().state();
-        let protect_outbound = is_outbound
-            && sync_state
-                .n_protected_outbound_peers()
-                .load(Ordering::Acquire)
-                < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT;
-
-        if protect_outbound {
-            sync_state
-                .n_protected_outbound_peers()
-                .fetch_add(1, Ordering::AcqRel);
-        }
-
-        self.peers().sync_connected(
-            peer,
-            PeerFlags {
-                is_outbound,
-                is_whitelist,
-                is_protect: protect_outbound,
-            },
-        );
+        self.peers().sync_connected(peer, is_outbound, is_whitelist);
     }
 
     /// Regularly check and eject some nodes that do not respond in time
@@ -485,23 +465,24 @@ impl Synchronizer {
 
         for peer in peers {
             // Only sync with 1 peer if we're in IBD
-            if ibd
-                && self
-                    .shared()
-                    .state()
-                    .n_sync_started()
-                    .load(Ordering::Acquire)
-                    != 0
+            if self
+                .shared()
+                .state()
+                .n_sync_started()
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |x| {
+                    if ibd && x != 0 {
+                        None
+                    } else {
+                        Some(x + 1)
+                    }
+                })
+                .is_err()
             {
                 break;
             }
             {
                 if let Some(mut peer_state) = self.peers().state.get_mut(&peer) {
                     peer_state.start_sync(HeadersSyncController::from_header(&tip));
-                    self.shared()
-                        .state()
-                        .n_sync_started()
-                        .fetch_add(1, Ordering::AcqRel);
                 }
             }
 
@@ -769,31 +750,7 @@ impl CKBProtocolHandler for Synchronizer {
         peer_index: PeerIndex,
     ) {
         let sync_state = self.shared().state();
-        if let Some(peer_state) = sync_state.disconnected(peer_index) {
-            info!("SyncProtocol.disconnected peer={}", peer_index);
-
-            if peer_state.sync_started() {
-                // It shouldn't happen
-                // fetch_sub wraps around on overflow, we still check manually
-                // panic here to prevent some bug be hidden silently.
-                assert_ne!(
-                    sync_state.n_sync_started().fetch_sub(1, Ordering::AcqRel),
-                    0,
-                    "n_sync_started overflow when disconnects"
-                );
-            }
-
-            // Protection node disconnected
-            if peer_state.peer_flags.is_protect {
-                assert_ne!(
-                    sync_state
-                        .n_protected_outbound_peers()
-                        .fetch_sub(1, Ordering::AcqRel),
-                    0,
-                    "n_protected_outbound_peers overflow when disconnects"
-                );
-            }
-        }
+        sync_state.disconnected(peer_index);
     }
 
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -364,7 +364,7 @@ impl Synchronizer {
         if protect_outbound {
             sync_state
                 .n_protected_outbound_peers()
-                .fetch_add(1, Ordering::Release);
+                .fetch_add(1, Ordering::AcqRel);
         }
 
         self.peers().sync_connected(
@@ -509,7 +509,7 @@ impl Synchronizer {
                     self.shared()
                         .state()
                         .n_sync_started()
-                        .fetch_add(1, Ordering::Release);
+                        .fetch_add(1, Ordering::AcqRel);
                 }
             }
 
@@ -785,7 +785,7 @@ impl CKBProtocolHandler for Synchronizer {
                 // fetch_sub wraps around on overflow, we still check manually
                 // panic here to prevent some bug be hidden silently.
                 assert_ne!(
-                    sync_state.n_sync_started().fetch_sub(1, Ordering::Release),
+                    sync_state.n_sync_started().fetch_sub(1, Ordering::AcqRel),
                     0,
                     "n_sync_started overflow when disconnects"
                 );
@@ -796,7 +796,7 @@ impl CKBProtocolHandler for Synchronizer {
                 assert_ne!(
                     sync_state
                         .n_protected_outbound_peers()
-                        .fetch_sub(1, Ordering::Release),
+                        .fetch_sub(1, Ordering::AcqRel),
                     0,
                     "n_protected_outbound_peers overflow when disconnects"
                 );

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -342,17 +342,10 @@ impl Synchronizer {
     }
 
     pub(crate) fn on_connected(&self, nc: &dyn CKBProtocolContext, peer: PeerIndex) {
-        let pid = SupportProtocols::Sync.protocol_id();
-        let (is_outbound, is_whitelist, is_2021edition) = nc
+        let (is_outbound, is_whitelist) = nc
             .get_peer(peer)
-            .map(|peer| {
-                (
-                    peer.is_outbound(),
-                    peer.is_whitelist,
-                    peer.protocols.get(&pid).map(|v| v == "2").unwrap_or(false),
-                )
-            })
-            .unwrap_or((false, false, false));
+            .map(|peer| (peer.is_outbound(), peer.is_whitelist))
+            .unwrap_or((false, false));
 
         let sync_state = self.shared().state();
         let protect_outbound = is_outbound
@@ -373,7 +366,6 @@ impl Synchronizer {
                 is_outbound,
                 is_whitelist,
                 is_protect: protect_outbound,
-                is_2021edition,
             },
         );
     }

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -820,7 +820,7 @@ fn test_chain_sync_timeout() {
             .shared()
             .state()
             .n_sync_started()
-            .fetch_add(1, Ordering::Release);
+            .fetch_add(1, Ordering::AcqRel);
     }
     synchronizer.eviction(&network_context);
     {
@@ -987,7 +987,7 @@ fn test_n_sync_started() {
             .shared()
             .state()
             .n_sync_started()
-            .fetch_add(1, Ordering::Release);
+            .fetch_add(1, Ordering::AcqRel);
     }
     synchronizer.eviction(&network_context);
 

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -362,6 +362,8 @@ impl<T: Eq + Hash> Filter<T> {
 #[derive(Default)]
 pub struct Peers {
     pub state: DashMap<PeerIndex, PeerState>,
+    pub n_sync_started: AtomicUsize,
+    pub n_protected_outbound_peers: AtomicUsize,
 }
 
 #[derive(Debug, Clone)]
@@ -804,7 +806,24 @@ impl InflightBlocks {
 }
 
 impl Peers {
-    pub fn sync_connected(&self, peer: PeerIndex, peer_flags: PeerFlags) {
+    pub fn sync_connected(&self, peer: PeerIndex, is_outbound: bool, is_whitelist: bool) {
+        let protect_outbound = is_outbound
+            && self
+                .n_protected_outbound_peers
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |x| {
+                    if x < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT {
+                        Some(x + 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok();
+
+        let peer_flags = PeerFlags {
+            is_outbound,
+            is_whitelist,
+            is_protect: protect_outbound,
+        };
         self.state
             .entry(peer)
             .and_modify(|state| {
@@ -858,8 +877,29 @@ impl Peers {
         // TODO:
     }
 
-    pub fn disconnected(&self, peer: PeerIndex) -> Option<PeerState> {
-        self.state.remove(&peer).map(|(_, peer_state)| peer_state)
+    pub fn disconnected(&self, peer: PeerIndex) {
+        if let Some(peer_state) = self.state.remove(&peer).map(|(_, peer_state)| peer_state) {
+            if peer_state.sync_started() {
+                // It shouldn't happen
+                // fetch_sub wraps around on overflow, we still check manually
+                // panic here to prevent some bug be hidden silently.
+                assert_ne!(
+                    self.n_sync_started.fetch_sub(1, Ordering::AcqRel),
+                    0,
+                    "n_sync_started overflow when disconnects"
+                );
+            }
+
+            // Protection node disconnected
+            if peer_state.peer_flags.is_protect {
+                assert_ne!(
+                    self.n_protected_outbound_peers
+                        .fetch_sub(1, Ordering::AcqRel),
+                    0,
+                    "n_protected_outbound_peers overflow when disconnects"
+                );
+            }
+        }
     }
 
     pub fn insert_unknown_header_hash(&self, peer: PeerIndex, hash: Byte32) {
@@ -1158,8 +1198,6 @@ impl SyncShared {
         );
 
         let state = SyncState {
-            n_sync_started: AtomicUsize::new(0),
-            n_protected_outbound_peers: AtomicUsize::new(0),
             shared_best_header,
             header_map,
             block_status_map: DashMap::new(),
@@ -1486,9 +1524,6 @@ impl PartialOrd for UnknownTxHashPriority {
 }
 
 pub struct SyncState {
-    n_sync_started: AtomicUsize,
-    n_protected_outbound_peers: AtomicUsize,
-
     /* Status irrelevant to peers */
     shared_best_header: RwLock<HeaderView>,
     header_map: HeaderMap,
@@ -1533,11 +1568,7 @@ impl SyncState {
     }
 
     pub fn n_sync_started(&self) -> &AtomicUsize {
-        &self.n_sync_started
-    }
-
-    pub fn n_protected_outbound_peers(&self) -> &AtomicUsize {
-        &self.n_protected_outbound_peers
+        &self.peers.n_sync_started
     }
 
     pub fn peers(&self) -> &Peers {
@@ -1598,7 +1629,7 @@ impl SyncState {
     pub(crate) fn suspend_sync(&self, peer_state: &mut PeerState) {
         if peer_state.sync_started() {
             assert_ne!(
-                self.n_sync_started().fetch_sub(1, Ordering::AcqRel),
+                self.peers.n_sync_started.fetch_sub(1, Ordering::AcqRel),
                 0,
                 "n_sync_started overflow when suspend_sync"
             );
@@ -1609,7 +1640,7 @@ impl SyncState {
     pub(crate) fn tip_synced(&self, peer_state: &mut PeerState) {
         if peer_state.sync_started() {
             assert_ne!(
-                self.n_sync_started().fetch_sub(1, Ordering::AcqRel),
+                self.peers.n_sync_started.fetch_sub(1, Ordering::AcqRel),
                 0,
                 "n_sync_started overflow when tip_synced"
             );
@@ -1828,9 +1859,9 @@ impl SyncState {
         }
     }
 
-    pub fn disconnected(&self, pi: PeerIndex) -> Option<PeerState> {
+    pub fn disconnected(&self, pi: PeerIndex) {
         self.write_inflight_blocks().remove_by_peer(pi);
-        self.peers().disconnected(pi)
+        self.peers().disconnected(pi);
     }
 
     pub fn get_orphan_block(&self, block_hash: &Byte32) -> Option<core::BlockView> {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1605,7 +1605,7 @@ impl SyncState {
     pub(crate) fn suspend_sync(&self, peer_state: &mut PeerState) {
         if peer_state.sync_started() {
             assert_ne!(
-                self.n_sync_started().fetch_sub(1, Ordering::Release),
+                self.n_sync_started().fetch_sub(1, Ordering::AcqRel),
                 0,
                 "n_sync_started overflow when suspend_sync"
             );
@@ -1616,7 +1616,7 @@ impl SyncState {
     pub(crate) fn tip_synced(&self, peer_state: &mut PeerState) {
         if peer_state.sync_started() {
             assert_ne!(
-                self.n_sync_started().fetch_sub(1, Ordering::Release),
+                self.n_sync_started().fetch_sub(1, Ordering::AcqRel),
                 0,
                 "n_sync_started overflow when tip_synced"
             );

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -140,7 +140,6 @@ pub struct PeerFlags {
     pub is_outbound: bool,
     pub is_protect: bool,
     pub is_whitelist: bool,
-    pub is_2021edition: bool,
 }
 
 #[derive(Clone, Default, Debug, Copy)]
@@ -911,12 +910,6 @@ impl Peers {
 
     pub fn get_flag(&self, peer: PeerIndex) -> Option<PeerFlags> {
         self.state.get(&peer).map(|state| state.peer_flags)
-    }
-
-    pub fn is_2021edition(&self, peer: PeerIndex) -> Option<bool> {
-        self.state
-            .get(&peer)
-            .map(|state| state.peer_flags.is_2021edition)
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
We need to ensure the order of `Acquire + Release`, because the operation here is multi-threaded and parallel

`fetch_x`
> Note that using [Acquire](https://doc.rust-lang.org/nightly/std/sync/atomic/enum.Ordering.html#variant.Acquire) makes the store part of this operation [Relaxed](https://doc.rust-lang.org/nightly/std/sync/atomic/enum.Ordering.html#variant.Relaxed), and using [Release](https://doc.rust-lang.org/nightly/std/sync/atomic/enum.Ordering.html#variant.Release) makes the load part [Relaxed](https://doc.rust-lang.org/nightly/std/sync/atomic/enum.Ordering.html#variant.Relaxed).

so we need at least use [`AcqRel`](https://doc.rust-lang.org/nightly/std/sync/atomic/enum.Ordering.html#variant.AcqRel) to make sure the order is right

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

