### PR TITLE
chore: upgrade gcs filter lib and rebuild data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,10 +2238,11 @@ dependencies = [
 
 [[package]]
 name = "golomb-coded-set"
-version = "0.1.0"
-source = "git+https://github.com/TheWaWaR/golomb-coded-set#a7dee669ae2b73ead2c69649ca45c17065905558"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7076c0cd6257d84b785b0f22c36443dd47a5e86a1256d7ef82c8cb88ea9a7e"
 dependencies = [
- "bitcoin_hashes",
+ "siphasher",
 ]
 
 [[package]]

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -16,4 +16,4 @@ ckb-notify = { path = "../notify", version = "= 0.105.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.105.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.105.0-pre" }
 ckb-types = { path = "../util/types", version = "= 0.105.0-pre" }
-golomb-coded-set = { git = "https://github.com/TheWaWaR/golomb-coded-set"}
+golomb-coded-set = "0.2.0"

--- a/block-filter/src/filter.rs
+++ b/block-filter/src/filter.rs
@@ -7,11 +7,13 @@ use std::thread;
 
 const THREAD_NAME: &str = "ckb-block-filter-thread";
 
+/// A block filter creation service
 pub struct BlockFilter {
     db: ChainDB,
 }
 
 impl BlockFilter {
+    /// Create a new block filter service
     pub fn new(db: ChainDB) -> Self {
         Self { db }
     }

--- a/block-filter/src/filter.rs
+++ b/block-filter/src/filter.rs
@@ -3,9 +3,10 @@ use ckb_logger::debug;
 use ckb_notify::NotifyController;
 use ckb_store::{ChainDB, ChainStore};
 use ckb_types::{core::HeaderView, prelude::*};
+use golomb_coded_set::{GCSFilterWriter, SipHasher24Builder, M, P};
 use std::thread;
 
-const THREAD_NAME: &str = "ckb-block-filter-thread";
+const THREAD_NAME: &str = "BlockFilter";
 
 /// A block filter creation service
 pub struct BlockFilter {
@@ -140,9 +141,6 @@ impl BlockFilter {
     }
 }
 
-fn build_gcs_filter(out: &mut dyn std::io::Write) -> golomb_coded_set::GCSFilterWriter {
-    // use same value as bip158
-    let p = 19;
-    let m = 1.497_137 * f64::from(2u32.pow(p));
-    golomb_coded_set::GCSFilterWriter::new(out, 0, 0, m as u64, p as u8)
+fn build_gcs_filter(out: &mut dyn std::io::Write) -> GCSFilterWriter<SipHasher24Builder> {
+    GCSFilterWriter::new(out, SipHasher24Builder::new(0, 0), M, P)
 }

--- a/block-filter/src/lib.rs
+++ b/block-filter/src/lib.rs
@@ -1,1 +1,4 @@
+//! ckb block filter module
+
+/// A block filter module
 pub mod filter;

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -277,7 +277,7 @@ fn test_full_dead_transaction() {
     let root_tx = &shared.consensus().genesis_block().transactions()[1];
     let tx1 = create_multi_outputs_transaction(root_tx, vec![0], 1, vec![1]);
 
-    for is_new_chain in vec![false, true] {
+    for is_new_chain in [false, true] {
         parent = block.header();
         for i in 2..switch_fork_number {
             let compact_target = parent.compact_target();

--- a/docs/hashes.toml
+++ b/docs/hashes.toml
@@ -90,7 +90,7 @@ index = 1
 
 # Spec: ckb_staging
 [ckb_staging]
-spec_hash = "0x1e501d0048dbfee37707432fb5ec4c5e2b0404d887ebc882564c8761ef54e68a"
+spec_hash = "0x754a6a35c71e267e638697a7cfabd1338735dac0e164306d562aa813bc19833c"
 genesis = "0xbc081e6b2e31149c1dc39007f161ed0a0b63d5d30b3b771acc6a3b622133fcc0"
 cellbase = "0x7295631c414e50a8d9bb73d9845231ac212d10404045c96de7f149ec874ac6b7"
 
@@ -134,7 +134,7 @@ index = 1
 
 # Spec: ckb_dev
 [ckb_dev]
-spec_hash = "0x307bfa518f3dd6ffe6d82317c5ce7eb738db4623402edcc06b5adbee2e3a6b29"
+spec_hash = "0x9b457fe9ba2600eed42bff4e15cbdde2d9a1175eb49fb46e4d793bb4dc4259f0"
 genesis = "0x823b2ff5785b12da8b1363cac9a5cbe566d8b715a4311441b119c39a0367488c"
 cellbase = "0xa563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541"
 

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1183,6 +1183,7 @@ impl NetworkController {
         self.network_state.node_id()
     }
 
+    /// p2p service control
     pub fn p2p_control(&self) -> &ServiceControl {
         &self.p2p_control
     }

--- a/spec/src/hardfork.rs
+++ b/spec/src/hardfork.rs
@@ -57,7 +57,7 @@ pub struct HardForkConfig {
     /// Ref: CKB RFC 0038
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rfc_0038: Option<EpochNumber>,
-    // TODO(light-client) update the description
+    /// TODO(light-client) update the description
     pub rfc_tmp1: Option<EpochNumber>,
 }
 

--- a/spec/src/tests/consensus.rs
+++ b/spec/src/tests/consensus.rs
@@ -84,7 +84,7 @@ fn test_halving_epoch_reward() {
     {
         let epoch = consensus
             .next_epoch_ext(
-                &header(&genesis_epoch, genesis_epoch.length() - 1),
+                &header(genesis_epoch, genesis_epoch.length() - 1),
                 &DummyEpochProvider(genesis_epoch.clone()),
             )
             .expect("test: get next epoch")

--- a/sync/src/filter/mod.rs
+++ b/sync/src/filter/mod.rs
@@ -168,7 +168,11 @@ impl CKBProtocolHandler for BlockFilter {
         );
     }
 
-    async fn disconnected(&mut self, _nc: Arc<dyn CKBProtocolContext + Sync>, peer_index: PeerIndex) {
+    async fn disconnected(
+        &mut self,
+        _nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer_index: PeerIndex,
+    ) {
         info_target!(
             crate::LOG_TARGET_FILTER,
             "FilterProtocol.disconnected peer={}",

--- a/sync/src/filter/mod.rs
+++ b/sync/src/filter/mod.rs
@@ -26,6 +26,7 @@ pub struct BlockFilter {
 }
 
 impl BlockFilter {
+    /// Create a new block filter protocol handler
     pub fn new(shared: Arc<SyncShared>) -> Self {
         Self { shared }
     }

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1886,6 +1886,7 @@ pub struct ActiveChain {
     state: Arc<SyncState>,
 }
 
+#[doc(hidden)]
 impl ActiveChain {
     fn store(&self) -> &ChainDB {
         self.shared.store()

--- a/util/launcher/src/migrate.rs
+++ b/util/launcher/src/migrate.rs
@@ -27,7 +27,8 @@ impl Migrate {
         migrations.add_migration(Box::new(migrations::AddExtraDataHash)); // since v0.43.0
         migrations.add_migration(Box::new(migrations::AddBlockExtensionColumnFamily)); // since v0.100.0
         migrations.add_migration(Box::new(migrations::AddChainRootMMR)); // TODO(light-client) update the comment: which version?
-        migrations.add_migration(Box::new(migrations::AddBlockFilterColumnFamily)); // since v0.101.2
+        migrations.add_migration(Box::new(migrations::AddBlockFilterColumnFamily)); // since v0.105.0
+        migrations.add_migration(Box::new(migrations::RebuildBlockFilter)); // since v0.105.0
 
         Migrate {
             migrations,

--- a/util/launcher/src/migrations/mod.rs
+++ b/util/launcher/src/migrations/mod.rs
@@ -4,6 +4,7 @@ mod add_chain_root_mmr;
 mod add_extra_data_hash;
 mod add_number_hash_mapping;
 mod cell;
+mod rebuild_block_filter;
 mod table_to_struct;
 
 pub use add_block_extension_cf::AddBlockExtensionColumnFamily;
@@ -12,4 +13,5 @@ pub use add_chain_root_mmr::AddChainRootMMR;
 pub use add_extra_data_hash::AddExtraDataHash;
 pub use add_number_hash_mapping::AddNumberHashMapping;
 pub use cell::CellMigration;
+pub use rebuild_block_filter::RebuildBlockFilter;
 pub use table_to_struct::ChangeMoleculeTableToStruct;

--- a/util/launcher/src/migrations/rebuild_block_filter.rs
+++ b/util/launcher/src/migrations/rebuild_block_filter.rs
@@ -1,0 +1,38 @@
+use ckb_db::RocksDB;
+use ckb_db_migration::{Migration, ProgressBar};
+use ckb_db_schema::{COLUMN_BLOCK_FILTER, COLUMN_META, META_LATEST_BUILT_FILTER_DATA_KEY};
+use ckb_error::Error;
+use std::sync::Arc;
+
+pub struct RebuildBlockFilter;
+
+const VERSION: &str = "20220803143236";
+
+/// TODO: this migration can be archived when release a new version of ckb
+impl Migration for RebuildBlockFilter {
+    fn migrate(
+        &self,
+        mut db: RocksDB,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<RocksDB, Error> {
+        clean_block_filter_column(&mut db)?;
+        let mut wb = db.new_write_batch();
+        wb.delete(COLUMN_META, META_LATEST_BUILT_FILTER_DATA_KEY)?;
+        db.write(&wb)?;
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        VERSION
+    }
+
+    fn expensive(&self) -> bool {
+        false
+    }
+}
+
+fn clean_block_filter_column(db: &mut RocksDB) -> Result<(), Error> {
+    db.drop_cf(COLUMN_BLOCK_FILTER)?;
+    db.create_cf(COLUMN_BLOCK_FILTER)?;
+    Ok(())
+}

--- a/util/light-client-protocol-server/src/lib.rs
+++ b/util/light-client-protocol-server/src/lib.rs
@@ -10,18 +10,21 @@ use ckb_sync::SyncShared;
 use ckb_types::{packed, prelude::*};
 
 mod components;
-pub mod constant;
+mod constant;
 mod prelude;
 mod status;
 
 use prelude::LightClientProtocolReply;
 pub use status::{Status, StatusCode};
 
+/// Light client protocol handler.
 pub struct LightClientProtocol {
+    /// Sync shared state.
     pub shared: Arc<SyncShared>,
 }
 
 impl LightClientProtocol {
+    /// Create a new light client protocol handler.
     pub fn new(shared: Arc<SyncShared>) -> Self {
         Self { shared }
     }

--- a/util/light-client-protocol-server/src/lib.rs
+++ b/util/light-client-protocol-server/src/lib.rs
@@ -44,7 +44,12 @@ impl CKBProtocolHandler for LightClientProtocol {
         info!("LightClient.disconnected peer={}", peer);
     }
 
-    async fn received(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, peer: PeerIndex, data: Bytes) {
+    async fn received(
+        &mut self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer: PeerIndex,
+        data: Bytes,
+    ) {
         trace!("LightClient.received peer={}", peer);
 
         let msg = match packed::LightClientMessageReader::from_slice(&data) {

--- a/util/light-client-protocol-server/src/status.rs
+++ b/util/light-client-protocol-server/src/status.rs
@@ -94,7 +94,7 @@ impl Status {
     /// Whether the session should be banned.
     pub fn should_ban(&self) -> Option<Duration> {
         let code = self.code as u16;
-        if code < 400 || code >= 500 {
+        if !(400..500).contains(&code) {
             None
         } else {
             Some(constant::BAD_MESSAGE_BAN_TIME)
@@ -104,7 +104,7 @@ impl Status {
     /// Whether a warning log should be output.
     pub fn should_warn(&self) -> bool {
         let code = self.code as u16;
-        500 <= code && code < 600
+        (500..600).contains(&code)
     }
 
     /// Returns the status code.

--- a/util/types/src/core/hardfork.rs
+++ b/util/types/src/core/hardfork.rs
@@ -149,7 +149,7 @@ pub struct HardForkSwitchBuilder {
     ///
     /// Ref: CKB RFC 0038
     pub rfc_0038: Option<EpochNumber>,
-    // TODO(light-client) update the description and the rfc link
+    /// TODO(light-client) update the description and the rfc link
     pub rfc_tmp1: Option<EpochNumber>,
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

upgrade gcs lib to 0.2.0 and rebuild the block filter data since the gcs params M has been changed from `784930` to `784931`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
