### PR TITLE
chore: tweak block filter message batch size to 1000

### DIFF
--- a/sync/src/filter/get_block_filters_process.rs
+++ b/sync/src/filter/get_block_filters_process.rs
@@ -7,7 +7,7 @@ use ckb_types::core::BlockNumber;
 use ckb_types::{packed, prelude::*};
 use std::sync::Arc;
 
-const BATCH_SIZE: BlockNumber = 100;
+const BATCH_SIZE: BlockNumber = 1000;
 
 pub struct GetBlockFiltersProcess<'a> {
     message: packed::GetBlockFiltersReader<'a>,


### PR DESCRIPTION
increase `GetBlockFilters` message batch size to 1000, same as bip157:
```
The height of the block with hash StopHash MUST be greater than or equal to StartHeight, and the difference MUST be strictly less than 1000.
```