### PR TITLE
chore(deps): bump ckb-vm to v0.21.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc81aeacb7eaa4981e4c4f8285e30bca92f8d7346937cbcfc0b77f26b21da2de"
+checksum = "4c5f3cff8cb9e28295f32a35b0aa9faa988bf992d06ce3d304abb3e0fbf2d8c7"
 dependencies = [
  "byteorder",
  "bytes 1.2.1",
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7968c559498b68833791364e87182fdd1a3aba803e8a16c34b1aa45fc08add1c"
+checksum = "165d9c1cc347aa6c2aa4a4fadee26433b4a8dac314d55c4b5885eb2ec6526296"
 
 [[package]]
 name = "clang-sys"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -21,7 +21,7 @@ ckb-traits = { path = "../traits", version = "= 0.105.0-pre" }
 byteorder = "1.3.1"
 ckb-types = {path = "../util/types", version = "= 0.105.0-pre"}
 ckb-hash = {path = "../util/hash", version = "= 0.105.0-pre"}
-ckb-vm = { version = "=0.21.3", default-features = false }
+ckb-vm = { version = "=0.21.4", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.105.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Release Note:

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.21.4

Greatly improve the performance of ckb-vm. When run `./ckb replay --tmp-target tmp --profile 7000000 7100000` in mainnet,

- ckb v0.103.0 took 47 hours 30 minutes
- ckb v0.103.0 with new ckb-vm only took 25 hours and 15 minutes