### PR TITLE
ci: update job run list since aarch64_build never to run

### DIFF
--- a/.github/actions/ci_prologue/ci_prologue.sh
+++ b/.github/actions/ci_prologue/ci_prologue.sh
@@ -43,7 +43,7 @@ fun_pasing_message(){
   if [ $? -eq 0 ]; then
     job_run_list=`echo "${MESSAGE}"| grep "ci-runs-only" | awk -F ':' '{print $2}'`
   else
-    job_run_list=" [ quick_checks,unit_tests,integration_tests,benchmarks,linters,wasm_build,cargo_deny ] "
+    job_run_list=" [ quick_checks,unit_tests,integration_tests,benchmarks,linters,wasm_build,cargo_deny,aarch64_build ] "
   fi
   echo "job_run_list is ""$job_run_list"
   #parsing runs os
@@ -98,7 +98,7 @@ if [[ $GITHUB_EVENT_NAME == "pull_request" ]];then
   else
     runs_on=" [ ubuntu,macos,windows ] "
     fun_run_os "$runs_on"
-    job_run_list=" [ quick_checks,unit_tests,integration_tests,benchmarks,linters,wasm_build,cargo_deny ] "
+    job_run_list=" [ quick_checks,unit_tests,integration_tests,benchmarks,linters,wasm_build,cargo_deny,aarch64_build ] "
     fun_jobs "$job_run_list"
     if [[ "$GITHUB_REPOSITORY" == "nervosnetwork/ckb" ]];then
       echo "::set-output name=linux_runner_label::self-hosted-ci-ubuntu-20.04"


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
update job run list since aarch64_build never to run.


What's Changed:



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters,aarch64_build ]

Side effects

- Performance regression
- Breaking backward compatibility



