### PR TITLE
fix(light-client): recovery block extensions to incorrect data

### DIFF
--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -289,19 +289,20 @@ table InIBD {
 
 vector HeaderDigestVec <HeaderDigest>;
 
-struct HeaderWithChainRoot {
-    header:                 Header,
-    uncles_hash:            Byte32,
-    chain_root:             HeaderDigest,
-}
-
-vector HeaderWithChainRootVec <HeaderWithChainRoot>;
-
 table VerifiableHeader {
     header:                 Header,
     uncles_hash:            Byte32,
     extension:              BytesOpt,
 }
+
+table VerifiableHeaderWithChainRoot {
+    header:                 Header,
+    uncles_hash:            Byte32,
+    extension:              BytesOpt,
+    chain_root:             HeaderDigest,
+}
+
+vector VerifiableHeaderWithChainRootVec <VerifiableHeaderWithChainRoot>;
 
 union LightClientMessage {
     GetLastState,
@@ -336,9 +337,9 @@ table SendBlockSamples {
     root:                       HeaderDigest,
     proof:                      HeaderDigestVec,
     // The headers before `GetBlockSamples.start_number` (inclusive) for client side to detect the fork number
-    reorg_last_n_headers:       HeaderWithChainRootVec,
-    sampled_headers:            HeaderWithChainRootVec,
-    last_n_headers:             HeaderWithChainRootVec,
+    reorg_last_n_headers:       VerifiableHeaderWithChainRootVec,
+    sampled_headers:            VerifiableHeaderWithChainRootVec,
+    last_n_headers:             VerifiableHeaderWithChainRootVec,
 }
 
 table GetBlockProof {

--- a/util/types/src/conversion/network.rs
+++ b/util/types/src/conversion/network.rs
@@ -4,4 +4,7 @@ impl_conversion_for_packed_iterator_pack!(IndexTransaction, IndexTransactionVec)
 impl_conversion_for_packed_iterator_pack!(RelayTransaction, RelayTransactionVec);
 impl_conversion_for_packed_iterator_pack!(Uint256, Uint256Vec);
 impl_conversion_for_packed_iterator_pack!(HeaderDigest, HeaderDigestVec);
-impl_conversion_for_packed_iterator_pack!(HeaderWithChainRoot, HeaderWithChainRootVec);
+impl_conversion_for_packed_iterator_pack!(
+    VerifiableHeaderWithChainRoot,
+    VerifiableHeaderWithChainRootVec
+);

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -14581,476 +14581,6 @@ impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for HeaderDigestVecReaderIterat
     }
 }
 #[derive(Clone)]
-pub struct HeaderWithChainRoot(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for HeaderWithChainRoot {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for HeaderWithChainRoot {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for HeaderWithChainRoot {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "header", self.header())?;
-        write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
-        write!(f, ", {}: {}", "chain_root", self.chain_root())?;
-        write!(f, " }}")
-    }
-}
-impl ::core::default::Default for HeaderWithChainRoot {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ];
-        HeaderWithChainRoot::new_unchecked(v.into())
-    }
-}
-impl HeaderWithChainRoot {
-    pub const TOTAL_SIZE: usize = 360;
-    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
-    pub const FIELD_COUNT: usize = 3;
-    pub fn header(&self) -> Header {
-        Header::new_unchecked(self.0.slice(0..208))
-    }
-    pub fn uncles_hash(&self) -> Byte32 {
-        Byte32::new_unchecked(self.0.slice(208..240))
-    }
-    pub fn chain_root(&self) -> HeaderDigest {
-        HeaderDigest::new_unchecked(self.0.slice(240..360))
-    }
-    pub fn as_reader<'r>(&'r self) -> HeaderWithChainRootReader<'r> {
-        HeaderWithChainRootReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for HeaderWithChainRoot {
-    type Builder = HeaderWithChainRootBuilder;
-    const NAME: &'static str = "HeaderWithChainRoot";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        HeaderWithChainRoot(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        HeaderWithChainRootReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        HeaderWithChainRootReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder()
-            .header(self.header())
-            .uncles_hash(self.uncles_hash())
-            .chain_root(self.chain_root())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct HeaderWithChainRootReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for HeaderWithChainRootReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for HeaderWithChainRootReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for HeaderWithChainRootReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "header", self.header())?;
-        write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
-        write!(f, ", {}: {}", "chain_root", self.chain_root())?;
-        write!(f, " }}")
-    }
-}
-impl<'r> HeaderWithChainRootReader<'r> {
-    pub const TOTAL_SIZE: usize = 360;
-    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
-    pub const FIELD_COUNT: usize = 3;
-    pub fn header(&self) -> HeaderReader<'r> {
-        HeaderReader::new_unchecked(&self.as_slice()[0..208])
-    }
-    pub fn uncles_hash(&self) -> Byte32Reader<'r> {
-        Byte32Reader::new_unchecked(&self.as_slice()[208..240])
-    }
-    pub fn chain_root(&self) -> HeaderDigestReader<'r> {
-        HeaderDigestReader::new_unchecked(&self.as_slice()[240..360])
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootReader<'r> {
-    type Entity = HeaderWithChainRoot;
-    const NAME: &'static str = "HeaderWithChainRootReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        HeaderWithChainRootReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len != Self::TOTAL_SIZE {
-            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
-        }
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct HeaderWithChainRootBuilder {
-    pub(crate) header: Header,
-    pub(crate) uncles_hash: Byte32,
-    pub(crate) chain_root: HeaderDigest,
-}
-impl HeaderWithChainRootBuilder {
-    pub const TOTAL_SIZE: usize = 360;
-    pub const FIELD_SIZES: [usize; 3] = [208, 32, 120];
-    pub const FIELD_COUNT: usize = 3;
-    pub fn header(mut self, v: Header) -> Self {
-        self.header = v;
-        self
-    }
-    pub fn uncles_hash(mut self, v: Byte32) -> Self {
-        self.uncles_hash = v;
-        self
-    }
-    pub fn chain_root(mut self, v: HeaderDigest) -> Self {
-        self.chain_root = v;
-        self
-    }
-}
-impl molecule::prelude::Builder for HeaderWithChainRootBuilder {
-    type Entity = HeaderWithChainRoot;
-    const NAME: &'static str = "HeaderWithChainRootBuilder";
-    fn expected_length(&self) -> usize {
-        Self::TOTAL_SIZE
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        writer.write_all(self.header.as_slice())?;
-        writer.write_all(self.uncles_hash.as_slice())?;
-        writer.write_all(self.chain_root.as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        HeaderWithChainRoot::new_unchecked(inner.into())
-    }
-}
-#[derive(Clone)]
-pub struct HeaderWithChainRootVec(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for HeaderWithChainRootVec {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for HeaderWithChainRootVec {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for HeaderWithChainRootVec {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} [", Self::NAME)?;
-        for i in 0..self.len() {
-            if i == 0 {
-                write!(f, "{}", self.get_unchecked(i))?;
-            } else {
-                write!(f, ", {}", self.get_unchecked(i))?;
-            }
-        }
-        write!(f, "]")
-    }
-}
-impl ::core::default::Default for HeaderWithChainRootVec {
-    fn default() -> Self {
-        let v: Vec<u8> = vec![0, 0, 0, 0];
-        HeaderWithChainRootVec::new_unchecked(v.into())
-    }
-}
-impl HeaderWithChainRootVec {
-    pub const ITEM_SIZE: usize = 360;
-    pub fn total_size(&self) -> usize {
-        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.item_count()
-    }
-    pub fn item_count(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn len(&self) -> usize {
-        self.item_count()
-    }
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-    pub fn get(&self, idx: usize) -> Option<HeaderWithChainRoot> {
-        if idx >= self.len() {
-            None
-        } else {
-            Some(self.get_unchecked(idx))
-        }
-    }
-    pub fn get_unchecked(&self, idx: usize) -> HeaderWithChainRoot {
-        let start = molecule::NUMBER_SIZE + Self::ITEM_SIZE * idx;
-        let end = start + Self::ITEM_SIZE;
-        HeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
-    }
-    pub fn as_reader<'r>(&'r self) -> HeaderWithChainRootVecReader<'r> {
-        HeaderWithChainRootVecReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for HeaderWithChainRootVec {
-    type Builder = HeaderWithChainRootVecBuilder;
-    const NAME: &'static str = "HeaderWithChainRootVec";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        HeaderWithChainRootVec(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        HeaderWithChainRootVecReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        HeaderWithChainRootVecReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().extend(self.into_iter())
-    }
-}
-#[derive(Clone, Copy)]
-pub struct HeaderWithChainRootVecReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for HeaderWithChainRootVecReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for HeaderWithChainRootVecReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for HeaderWithChainRootVecReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{} [", Self::NAME)?;
-        for i in 0..self.len() {
-            if i == 0 {
-                write!(f, "{}", self.get_unchecked(i))?;
-            } else {
-                write!(f, ", {}", self.get_unchecked(i))?;
-            }
-        }
-        write!(f, "]")
-    }
-}
-impl<'r> HeaderWithChainRootVecReader<'r> {
-    pub const ITEM_SIZE: usize = 360;
-    pub fn total_size(&self) -> usize {
-        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.item_count()
-    }
-    pub fn item_count(&self) -> usize {
-        molecule::unpack_number(self.as_slice()) as usize
-    }
-    pub fn len(&self) -> usize {
-        self.item_count()
-    }
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-    pub fn get(&self, idx: usize) -> Option<HeaderWithChainRootReader<'r>> {
-        if idx >= self.len() {
-            None
-        } else {
-            Some(self.get_unchecked(idx))
-        }
-    }
-    pub fn get_unchecked(&self, idx: usize) -> HeaderWithChainRootReader<'r> {
-        let start = molecule::NUMBER_SIZE + Self::ITEM_SIZE * idx;
-        let end = start + Self::ITEM_SIZE;
-        HeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for HeaderWithChainRootVecReader<'r> {
-    type Entity = HeaderWithChainRootVec;
-    const NAME: &'static str = "HeaderWithChainRootVecReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        HeaderWithChainRootVecReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len < molecule::NUMBER_SIZE {
-            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
-        }
-        let item_count = molecule::unpack_number(slice) as usize;
-        if item_count == 0 {
-            if slice_len != molecule::NUMBER_SIZE {
-                return ve!(Self, TotalSizeNotMatch, molecule::NUMBER_SIZE, slice_len);
-            }
-            return Ok(());
-        }
-        let total_size = molecule::NUMBER_SIZE + Self::ITEM_SIZE * item_count;
-        if slice_len != total_size {
-            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
-        }
-        Ok(())
-    }
-}
-#[derive(Debug, Default)]
-pub struct HeaderWithChainRootVecBuilder(pub(crate) Vec<HeaderWithChainRoot>);
-impl HeaderWithChainRootVecBuilder {
-    pub const ITEM_SIZE: usize = 360;
-    pub fn set(mut self, v: Vec<HeaderWithChainRoot>) -> Self {
-        self.0 = v;
-        self
-    }
-    pub fn push(mut self, v: HeaderWithChainRoot) -> Self {
-        self.0.push(v);
-        self
-    }
-    pub fn extend<T: ::core::iter::IntoIterator<Item = HeaderWithChainRoot>>(
-        mut self,
-        iter: T,
-    ) -> Self {
-        for elem in iter {
-            self.0.push(elem);
-        }
-        self
-    }
-    pub fn replace(&mut self, index: usize, v: HeaderWithChainRoot) -> Option<HeaderWithChainRoot> {
-        self.0
-            .get_mut(index)
-            .map(|item| ::core::mem::replace(item, v))
-    }
-}
-impl molecule::prelude::Builder for HeaderWithChainRootVecBuilder {
-    type Entity = HeaderWithChainRootVec;
-    const NAME: &'static str = "HeaderWithChainRootVecBuilder";
-    fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE + Self::ITEM_SIZE * self.0.len()
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        writer.write_all(&molecule::pack_number(self.0.len() as molecule::Number))?;
-        for inner in &self.0[..] {
-            writer.write_all(inner.as_slice())?;
-        }
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        HeaderWithChainRootVec::new_unchecked(inner.into())
-    }
-}
-pub struct HeaderWithChainRootVecIterator(HeaderWithChainRootVec, usize, usize);
-impl ::core::iter::Iterator for HeaderWithChainRootVecIterator {
-    type Item = HeaderWithChainRoot;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.1 >= self.2 {
-            None
-        } else {
-            let ret = self.0.get_unchecked(self.1);
-            self.1 += 1;
-            Some(ret)
-        }
-    }
-}
-impl ::core::iter::ExactSizeIterator for HeaderWithChainRootVecIterator {
-    fn len(&self) -> usize {
-        self.2 - self.1
-    }
-}
-impl ::core::iter::IntoIterator for HeaderWithChainRootVec {
-    type Item = HeaderWithChainRoot;
-    type IntoIter = HeaderWithChainRootVecIterator;
-    fn into_iter(self) -> Self::IntoIter {
-        let len = self.len();
-        HeaderWithChainRootVecIterator(self, 0, len)
-    }
-}
-impl<'r> HeaderWithChainRootVecReader<'r> {
-    pub fn iter<'t>(&'t self) -> HeaderWithChainRootVecReaderIterator<'t, 'r> {
-        HeaderWithChainRootVecReaderIterator(&self, 0, self.len())
-    }
-}
-pub struct HeaderWithChainRootVecReaderIterator<'t, 'r>(
-    &'t HeaderWithChainRootVecReader<'r>,
-    usize,
-    usize,
-);
-impl<'t: 'r, 'r> ::core::iter::Iterator for HeaderWithChainRootVecReaderIterator<'t, 'r> {
-    type Item = HeaderWithChainRootReader<'t>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.1 >= self.2 {
-            None
-        } else {
-            let ret = self.0.get_unchecked(self.1);
-            self.1 += 1;
-            Some(ret)
-        }
-    }
-}
-impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for HeaderWithChainRootVecReaderIterator<'t, 'r> {
-    fn len(&self) -> usize {
-        self.2 - self.1
-    }
-}
-#[derive(Clone)]
 pub struct VerifiableHeader(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for VerifiableHeader {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -15345,6 +14875,687 @@ impl molecule::prelude::Builder for VerifiableHeaderBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         VerifiableHeader::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct VerifiableHeaderWithChainRoot(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for VerifiableHeaderWithChainRoot {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for VerifiableHeaderWithChainRoot {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for VerifiableHeaderWithChainRoot {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "header", self.header())?;
+        write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
+        write!(f, ", {}: {}", "extension", self.extension())?;
+        write!(f, ", {}: {}", "chain_root", self.chain_root())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for VerifiableHeaderWithChainRoot {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            124, 1, 0, 0, 20, 0, 0, 0, 228, 0, 0, 0, 4, 1, 0, 0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ];
+        VerifiableHeaderWithChainRoot::new_unchecked(v.into())
+    }
+}
+impl VerifiableHeaderWithChainRoot {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn header(&self) -> Header {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Header::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn uncles_hash(&self) -> Byte32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Byte32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn extension(&self) -> BytesOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        BytesOpt::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn chain_root(&self) -> HeaderDigest {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            HeaderDigest::new_unchecked(self.0.slice(start..end))
+        } else {
+            HeaderDigest::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> VerifiableHeaderWithChainRootReader<'r> {
+        VerifiableHeaderWithChainRootReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for VerifiableHeaderWithChainRoot {
+    type Builder = VerifiableHeaderWithChainRootBuilder;
+    const NAME: &'static str = "VerifiableHeaderWithChainRoot";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        VerifiableHeaderWithChainRoot(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        VerifiableHeaderWithChainRootReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        VerifiableHeaderWithChainRootReader::from_compatible_slice(slice)
+            .map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .header(self.header())
+            .uncles_hash(self.uncles_hash())
+            .extension(self.extension())
+            .chain_root(self.chain_root())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct VerifiableHeaderWithChainRootReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for VerifiableHeaderWithChainRootReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for VerifiableHeaderWithChainRootReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for VerifiableHeaderWithChainRootReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "header", self.header())?;
+        write!(f, ", {}: {}", "uncles_hash", self.uncles_hash())?;
+        write!(f, ", {}: {}", "extension", self.extension())?;
+        write!(f, ", {}: {}", "chain_root", self.chain_root())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> VerifiableHeaderWithChainRootReader<'r> {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn header(&self) -> HeaderReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        HeaderReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn uncles_hash(&self) -> Byte32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn extension(&self) -> BytesOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        BytesOptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn chain_root(&self) -> HeaderDigestReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            HeaderDigestReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            HeaderDigestReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for VerifiableHeaderWithChainRootReader<'r> {
+    type Entity = VerifiableHeaderWithChainRoot;
+    const NAME: &'static str = "VerifiableHeaderWithChainRootReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        VerifiableHeaderWithChainRootReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        HeaderReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Byte32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        BytesOptReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        HeaderDigestReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct VerifiableHeaderWithChainRootBuilder {
+    pub(crate) header: Header,
+    pub(crate) uncles_hash: Byte32,
+    pub(crate) extension: BytesOpt,
+    pub(crate) chain_root: HeaderDigest,
+}
+impl VerifiableHeaderWithChainRootBuilder {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn header(mut self, v: Header) -> Self {
+        self.header = v;
+        self
+    }
+    pub fn uncles_hash(mut self, v: Byte32) -> Self {
+        self.uncles_hash = v;
+        self
+    }
+    pub fn extension(mut self, v: BytesOpt) -> Self {
+        self.extension = v;
+        self
+    }
+    pub fn chain_root(mut self, v: HeaderDigest) -> Self {
+        self.chain_root = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for VerifiableHeaderWithChainRootBuilder {
+    type Entity = VerifiableHeaderWithChainRoot;
+    const NAME: &'static str = "VerifiableHeaderWithChainRootBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.header.as_slice().len()
+            + self.uncles_hash.as_slice().len()
+            + self.extension.as_slice().len()
+            + self.chain_root.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.header.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.uncles_hash.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.extension.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.chain_root.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.header.as_slice())?;
+        writer.write_all(self.uncles_hash.as_slice())?;
+        writer.write_all(self.extension.as_slice())?;
+        writer.write_all(self.chain_root.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        VerifiableHeaderWithChainRoot::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct VerifiableHeaderWithChainRootVec(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for VerifiableHeaderWithChainRootVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for VerifiableHeaderWithChainRootVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for VerifiableHeaderWithChainRootVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl ::core::default::Default for VerifiableHeaderWithChainRootVec {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        VerifiableHeaderWithChainRootVec::new_unchecked(v.into())
+    }
+}
+impl VerifiableHeaderWithChainRootVec {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<VerifiableHeaderWithChainRoot> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> VerifiableHeaderWithChainRoot {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            VerifiableHeaderWithChainRoot::new_unchecked(self.0.slice(start..))
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            VerifiableHeaderWithChainRoot::new_unchecked(self.0.slice(start..end))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> VerifiableHeaderWithChainRootVecReader<'r> {
+        VerifiableHeaderWithChainRootVecReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for VerifiableHeaderWithChainRootVec {
+    type Builder = VerifiableHeaderWithChainRootVecBuilder;
+    const NAME: &'static str = "VerifiableHeaderWithChainRootVec";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        VerifiableHeaderWithChainRootVec(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        VerifiableHeaderWithChainRootVecReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        VerifiableHeaderWithChainRootVecReader::from_compatible_slice(slice)
+            .map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().extend(self.into_iter())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct VerifiableHeaderWithChainRootVecReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for VerifiableHeaderWithChainRootVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for VerifiableHeaderWithChainRootVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for VerifiableHeaderWithChainRootVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl<'r> VerifiableHeaderWithChainRootVecReader<'r> {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<VerifiableHeaderWithChainRootReader<'r>> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> VerifiableHeaderWithChainRootReader<'r> {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            VerifiableHeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..])
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            VerifiableHeaderWithChainRootReader::new_unchecked(&self.as_slice()[start..end])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for VerifiableHeaderWithChainRootVecReader<'r> {
+    type Entity = VerifiableHeaderWithChainRootVec;
+    const NAME: &'static str = "VerifiableHeaderWithChainRootVecReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        VerifiableHeaderWithChainRootVecReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(
+                Self,
+                TotalSizeNotMatch,
+                molecule::NUMBER_SIZE * 2,
+                slice_len
+            );
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        for pair in offsets.windows(2) {
+            let start = pair[0];
+            let end = pair[1];
+            VerifiableHeaderWithChainRootReader::verify(&slice[start..end], compatible)?;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct VerifiableHeaderWithChainRootVecBuilder(pub(crate) Vec<VerifiableHeaderWithChainRoot>);
+impl VerifiableHeaderWithChainRootVecBuilder {
+    pub fn set(mut self, v: Vec<VerifiableHeaderWithChainRoot>) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn push(mut self, v: VerifiableHeaderWithChainRoot) -> Self {
+        self.0.push(v);
+        self
+    }
+    pub fn extend<T: ::core::iter::IntoIterator<Item = VerifiableHeaderWithChainRoot>>(
+        mut self,
+        iter: T,
+    ) -> Self {
+        for elem in iter {
+            self.0.push(elem);
+        }
+        self
+    }
+    pub fn replace(
+        &mut self,
+        index: usize,
+        v: VerifiableHeaderWithChainRoot,
+    ) -> Option<VerifiableHeaderWithChainRoot> {
+        self.0
+            .get_mut(index)
+            .map(|item| ::core::mem::replace(item, v))
+    }
+}
+impl molecule::prelude::Builder for VerifiableHeaderWithChainRootVecBuilder {
+    type Entity = VerifiableHeaderWithChainRootVec;
+    const NAME: &'static str = "VerifiableHeaderWithChainRootVecBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (self.0.len() + 1)
+            + self
+                .0
+                .iter()
+                .map(|inner| inner.as_slice().len())
+                .sum::<usize>()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let item_count = self.0.len();
+        if item_count == 0 {
+            writer.write_all(&molecule::pack_number(
+                molecule::NUMBER_SIZE as molecule::Number,
+            ))?;
+        } else {
+            let (total_size, offsets) = self.0.iter().fold(
+                (
+                    molecule::NUMBER_SIZE * (item_count + 1),
+                    Vec::with_capacity(item_count),
+                ),
+                |(start, mut offsets), inner| {
+                    offsets.push(start);
+                    (start + inner.as_slice().len(), offsets)
+                },
+            );
+            writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+            for offset in offsets.into_iter() {
+                writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+            }
+            for inner in self.0.iter() {
+                writer.write_all(inner.as_slice())?;
+            }
+        }
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        VerifiableHeaderWithChainRootVec::new_unchecked(inner.into())
+    }
+}
+pub struct VerifiableHeaderWithChainRootVecIterator(VerifiableHeaderWithChainRootVec, usize, usize);
+impl ::core::iter::Iterator for VerifiableHeaderWithChainRootVecIterator {
+    type Item = VerifiableHeaderWithChainRoot;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl ::core::iter::ExactSizeIterator for VerifiableHeaderWithChainRootVecIterator {
+    fn len(&self) -> usize {
+        self.2 - self.1
+    }
+}
+impl ::core::iter::IntoIterator for VerifiableHeaderWithChainRootVec {
+    type Item = VerifiableHeaderWithChainRoot;
+    type IntoIter = VerifiableHeaderWithChainRootVecIterator;
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        VerifiableHeaderWithChainRootVecIterator(self, 0, len)
+    }
+}
+impl<'r> VerifiableHeaderWithChainRootVecReader<'r> {
+    pub fn iter<'t>(&'t self) -> VerifiableHeaderWithChainRootVecReaderIterator<'t, 'r> {
+        VerifiableHeaderWithChainRootVecReaderIterator(&self, 0, self.len())
+    }
+}
+pub struct VerifiableHeaderWithChainRootVecReaderIterator<'t, 'r>(
+    &'t VerifiableHeaderWithChainRootVecReader<'r>,
+    usize,
+    usize,
+);
+impl<'t: 'r, 'r> ::core::iter::Iterator for VerifiableHeaderWithChainRootVecReaderIterator<'t, 'r> {
+    type Item = VerifiableHeaderWithChainRootReader<'t>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator
+    for VerifiableHeaderWithChainRootVecReaderIterator<'t, 'r>
+{
+    fn len(&self) -> usize {
+        self.2 - self.1
     }
 }
 #[derive(Clone)]
@@ -16674,7 +16885,7 @@ impl ::core::default::Default for SendBlockSamples {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0,
         ];
         SendBlockSamples::new_unchecked(v.into())
     }
@@ -16709,26 +16920,26 @@ impl SendBlockSamples {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         HeaderDigestVec::new_unchecked(self.0.slice(start..end))
     }
-    pub fn reorg_last_n_headers(&self) -> HeaderWithChainRootVec {
+    pub fn reorg_last_n_headers(&self) -> VerifiableHeaderWithChainRootVec {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         let end = molecule::unpack_number(&slice[16..]) as usize;
-        HeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
+        VerifiableHeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
     }
-    pub fn sampled_headers(&self) -> HeaderWithChainRootVec {
+    pub fn sampled_headers(&self) -> VerifiableHeaderWithChainRootVec {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[16..]) as usize;
         let end = molecule::unpack_number(&slice[20..]) as usize;
-        HeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
+        VerifiableHeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
     }
-    pub fn last_n_headers(&self) -> HeaderWithChainRootVec {
+    pub fn last_n_headers(&self) -> VerifiableHeaderWithChainRootVec {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[20..]) as usize;
         if self.has_extra_fields() {
             let end = molecule::unpack_number(&slice[24..]) as usize;
-            HeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
+            VerifiableHeaderWithChainRootVec::new_unchecked(self.0.slice(start..end))
         } else {
-            HeaderWithChainRootVec::new_unchecked(self.0.slice(start..))
+            VerifiableHeaderWithChainRootVec::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> SendBlockSamplesReader<'r> {
@@ -16831,26 +17042,26 @@ impl<'r> SendBlockSamplesReader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         HeaderDigestVecReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn reorg_last_n_headers(&self) -> HeaderWithChainRootVecReader<'r> {
+    pub fn reorg_last_n_headers(&self) -> VerifiableHeaderWithChainRootVecReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         let end = molecule::unpack_number(&slice[16..]) as usize;
-        HeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
+        VerifiableHeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn sampled_headers(&self) -> HeaderWithChainRootVecReader<'r> {
+    pub fn sampled_headers(&self) -> VerifiableHeaderWithChainRootVecReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[16..]) as usize;
         let end = molecule::unpack_number(&slice[20..]) as usize;
-        HeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
+        VerifiableHeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn last_n_headers(&self) -> HeaderWithChainRootVecReader<'r> {
+    pub fn last_n_headers(&self) -> VerifiableHeaderWithChainRootVecReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[20..]) as usize;
         if self.has_extra_fields() {
             let end = molecule::unpack_number(&slice[24..]) as usize;
-            HeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
+            VerifiableHeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            HeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..])
+            VerifiableHeaderWithChainRootVecReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -16905,9 +17116,9 @@ impl<'r> molecule::prelude::Reader<'r> for SendBlockSamplesReader<'r> {
         }
         HeaderDigestReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         HeaderDigestVecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        HeaderWithChainRootVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
-        HeaderWithChainRootVecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
-        HeaderWithChainRootVecReader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
+        VerifiableHeaderWithChainRootVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        VerifiableHeaderWithChainRootVecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        VerifiableHeaderWithChainRootVecReader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
         Ok(())
     }
 }
@@ -16915,9 +17126,9 @@ impl<'r> molecule::prelude::Reader<'r> for SendBlockSamplesReader<'r> {
 pub struct SendBlockSamplesBuilder {
     pub(crate) root: HeaderDigest,
     pub(crate) proof: HeaderDigestVec,
-    pub(crate) reorg_last_n_headers: HeaderWithChainRootVec,
-    pub(crate) sampled_headers: HeaderWithChainRootVec,
-    pub(crate) last_n_headers: HeaderWithChainRootVec,
+    pub(crate) reorg_last_n_headers: VerifiableHeaderWithChainRootVec,
+    pub(crate) sampled_headers: VerifiableHeaderWithChainRootVec,
+    pub(crate) last_n_headers: VerifiableHeaderWithChainRootVec,
 }
 impl SendBlockSamplesBuilder {
     pub const FIELD_COUNT: usize = 5;
@@ -16929,15 +17140,15 @@ impl SendBlockSamplesBuilder {
         self.proof = v;
         self
     }
-    pub fn reorg_last_n_headers(mut self, v: HeaderWithChainRootVec) -> Self {
+    pub fn reorg_last_n_headers(mut self, v: VerifiableHeaderWithChainRootVec) -> Self {
         self.reorg_last_n_headers = v;
         self
     }
-    pub fn sampled_headers(mut self, v: HeaderWithChainRootVec) -> Self {
+    pub fn sampled_headers(mut self, v: VerifiableHeaderWithChainRootVec) -> Self {
         self.sampled_headers = v;
         self
     }
-    pub fn last_n_headers(mut self, v: HeaderWithChainRootVec) -> Self {
+    pub fn last_n_headers(mut self, v: VerifiableHeaderWithChainRootVec) -> Self {
         self.last_n_headers = v;
         self
     }


### PR DESCRIPTION
### What problem does this PR solve?

The client couldn't recovery the block extension with `HeaderWithChainRoot`.

Because the data after the 32nd byte of a block extension is unknown.

### Side effects

- `VerifiableHeaderWithChainRoot` is not fixed-size.
- `VerifiableHeaderWithChainRoot` is bigger than `HeaderWithChainRoot` 20~120 bytes.