### PR TITLE
feat:ChainRpcImpl: support return raw molecule hex bytes for `get_transaction` rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,13 +1493,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi 0.3.9",
@@ -2709,9 +2709,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libloading"
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
 ]
@@ -4320,18 +4320,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4383,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa 1.0.1",
  "libc",

--- a/chain/src/tests/load_code_with_snapshot.rs
+++ b/chain/src/tests/load_code_with_snapshot.rs
@@ -2,8 +2,8 @@ use crate::tests::util::{start_chain, start_chain_with_tx_pool_config};
 use ckb_app_config::TxPoolConfig;
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_dao_utils::genesis_dao_data;
-use ckb_jsonrpc_types::{Status, TxStatus};
 use ckb_test_chain_utils::{is_even_lib, load_is_even};
+use ckb_types::core::tx_pool::TxStatus;
 use ckb_types::prelude::*;
 use ckb_types::{
     bytes::Bytes,
@@ -108,7 +108,7 @@ fn test_load_code() {
     let ret = tx_pool.submit_local_tx(tx.clone()).unwrap();
     assert!(ret.is_ok(), "ret {:?}", ret);
     let tx_status = tx_pool.get_tx_status(tx.hash());
-    assert_eq!(tx_status.unwrap().unwrap(), TxStatus::pending());
+    assert_eq!(tx_status.unwrap().unwrap(), TxStatus::Pending);
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn test_load_code_with_snapshot() {
         loop {
             let tx_status = tx_pool.get_tx_status(tx.hash());
             if let Ok(Ok(status)) = tx_status {
-                if status.status == Status::Pending {
+                if status == TxStatus::Pending {
                     break;
                 }
             }
@@ -266,7 +266,7 @@ fn _test_load_code_with_snapshot_after_hardfork(script_type: ScriptHashType) {
         loop {
             let tx_status = tx_pool.get_tx_status(tx.hash());
             if let Ok(Ok(status)) = tx_status {
-                if status.status == Status::Pending {
+                if status == TxStatus::Pending {
                     break;
                 }
             }

--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -264,8 +264,8 @@ class RPCVar():
                 self.require_children(1)
             elif self.ty == RUST_DOC_PREFIX + '/std/collections/hash/map/struct.HashMap.html':
                 self.require_children(2)
-            elif self.ty == '../../ckb_jsonrpc_types/enum.ResponseFormat.html':
-                self.require_children(2)
+            elif self.ty == '../../ckb_jsonrpc_types/struct.ResponseFormat.html':
+                self.require_children(1)
             elif self.ty == '../../ckb_indexer/service/struct.Pagination.html':
                 self.require_children(1)
             elif self.ty.startswith('../'):
@@ -318,9 +318,8 @@ class RPCVar():
                     elif self.ty == RUST_DOC_PREFIX + '/std/collections/hash/map/struct.HashMap.html':
                         self.ty = '`{{ [ key:` {} `]: ` {} `}}`'.format(
                             self.children[0].ty, self.children[1].ty)
-                    elif self.ty == '../../ckb_jsonrpc_types/enum.ResponseFormat.html':
-                        molecule_name = self.children[1].ty.split(
-                            '`](')[0][2:]
+                    elif self.ty == '../../ckb_jsonrpc_types/struct.ResponseFormat.html':
+                        molecule_name = self.children[0].ty.split('`]')[0][2:].replace('View', '')
                         self.ty = '{} `|` [`Serialized{}`](#type-serialized{})'.format(
                             self.children[0].ty, molecule_name, molecule_name.lower())
                     elif self.ty == '../../ckb_indexer/service/struct.Pagination.html':

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -121,6 +121,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `DaoWithdrawingCalculationKind`](#type-daowithdrawingcalculationkind)
     * [Type `DepType`](#type-deptype)
     * [Type `DryRunResult`](#type-dryrunresult)
+    * [Type `Either`](#type-either)
     * [Type `EpochNumber`](#type-epochnumber)
     * [Type `EpochNumberWithFraction`](#type-epochnumberwithfraction)
     * [Type `EpochView`](#type-epochview)
@@ -147,6 +148,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `RawTxPool`](#type-rawtxpool)
     * [Type `RemoteNode`](#type-remotenode)
     * [Type `RemoteNodeProtocol`](#type-remotenodeprotocol)
+    * [Type `ResponseFormat`](#type-responseformat)
     * [Type `Script`](#type-script)
     * [Type `ScriptHashType`](#type-scripthashtype)
     * [Type `SearchKey`](#type-searchkey)
@@ -159,7 +161,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `TransactionProof`](#type-transactionproof)
     * [Type `TransactionTemplate`](#type-transactiontemplate)
     * [Type `TransactionView`](#type-transactionview)
-    * [Type `TransactionWithStatus`](#type-transactionwithstatus)
+    * [Type `TransactionWithStatusResponse`](#type-transactionwithstatusresponse)
     * [Type `Tx`](#type-tx)
     * [Type `TxPoolEntries`](#type-txpoolentries)
     * [Type `TxPoolEntry`](#type-txpoolentry)
@@ -670,7 +672,7 @@ The response looks like below when `verbosity` is 0.
 * `get_transaction(tx_hash, verbosity)`
     * `tx_hash`: [`H256`](#type-h256)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`TransactionWithStatus`](#type-transactionwithstatus) `|` `null`
+* result: [`TransactionWithStatusResponse`](#type-transactionwithstatusresponse) `|` `null`
 
 Returns the information about a transaction requested by transaction hash.
 
@@ -688,7 +690,7 @@ If the transaction is in the chain, the block hash is also returned.
 
 ###### Returns
 
-When verbosity is 0 (deprecated): this is reserved for compatibility, and will be removed in the following release. It return null as the RPC response when the status is rejected or unknown, mimicking the original behaviors.
+When verbosity=0, it’s response value is as same as verbosity=2, but it return a 0x-prefixed hex encoded molecule packed::Transaction on `transaction` field
 
 When verbosity is 1: The RPC does not return the transaction content and the field transaction must be null.
 
@@ -759,6 +761,25 @@ Response
       "version": "0x0",
       "witnesses": []
     },
+    "tx_status": {
+      "block_hash": null,
+      "status": "pending",
+      "reason": null
+    }
+  }
+}
+```
+
+
+The response looks like below when `verbosity` is 0.
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": {
+    "transaction": "0x.....",
     "tx_status": {
       "block_hash": null,
       "status": "pending",
@@ -5220,6 +5241,16 @@ Response result of the RPC method `dry_run_transaction`.
 *   `cycles`: [`Cycle`](#type-cycle) - The count of cycles that the VM has consumed to verify this transaction.
 
 
+### Type `Either`
+
+The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
+
+`Either` is equivalent to `"left" | "right"`.
+
+*   A value of type `L`.
+*   A value of type `R`.
+
+
 ### Type `EpochNumber`
 
 Consecutive epoch number starting from 0.
@@ -5868,6 +5899,21 @@ The information about an active running protocol.
 *   `version`: `string` - Active protocol version.
 
 
+### Type `ResponseFormat`
+
+This is a wrapper for JSON serialization to select the format between Json and Hex.
+
+##### Examples
+
+`ResponseFormat<BlockView>` returns the block in its Json format or molecule serialized Hex format.
+
+#### Fields
+
+`ResponseFormat` is a JSON object with the following fields.
+
+*   `inner`: [`Either`](#type-either) - The inner value.
+
+
 ### Type `Script`
 
 Describes the lock script and type script for a cell.
@@ -6131,15 +6177,15 @@ This structure is serialized into a JSON object with field `hash` and all the fi
 *   `hash`: [`H256`](#type-h256) - The transaction hash.
 
 
-### Type `TransactionWithStatus`
+### Type `TransactionWithStatusResponse`
 
 The JSON view of a transaction as well as its status.
 
 #### Fields
 
-`TransactionWithStatus` is a JSON object with the following fields.
+`TransactionWithStatusResponse` is a JSON object with the following fields.
 
-*   `transaction`: [`TransactionView`](#type-transactionview) `|` `null` - The transaction.
+*   `transaction`: [`ResponseFormat`](#type-responseformat) `|` `null` - The transaction.
 
 *   `tx_status`: [`TxStatus`](#type-txstatus) - The Transaction status.
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1,17 +1,18 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
     BlockEconomicState, BlockNumber, BlockView, CellWithStatus, Consensus, EpochNumber, EpochView,
-    HeaderView, MerkleProof as JsonMerkleProof, OutPoint, ResponseFormat, Timestamp,
-    TransactionProof, TransactionWithStatus, Uint32,
+    HeaderView, MerkleProof as JsonMerkleProof, OutPoint, ResponseFormat, ResponseFormatInnerType,
+    Timestamp, TransactionProof, TransactionWithStatusResponse, Uint32,
 };
 use ckb_logger::error;
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 use ckb_traits::HeaderProvider;
+use ckb_types::core::tx_pool::TransactionWithStatus;
 use ckb_types::{
     core::{self, cell::CellProvider},
-    packed::{self, Block, Header},
+    packed,
     prelude::*,
     utilities::{merkle_root, MerkleProof, CBMT},
     H256,
@@ -158,7 +159,7 @@ pub trait ChainRpc {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>>;
+    ) -> Result<Option<ResponseFormat<BlockView>>>;
 
     /// Returns the block in the [canonical chain](#canonical-chain) with the specific block number.
     ///
@@ -277,7 +278,7 @@ pub trait ChainRpc {
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>>;
+    ) -> Result<Option<ResponseFormat<BlockView>>>;
 
     /// Returns the information about a block header by hash.
     ///
@@ -355,7 +356,7 @@ pub trait ChainRpc {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<HeaderView, Header>>>;
+    ) -> Result<Option<ResponseFormat<HeaderView>>>;
 
     /// Returns the block header in the [canonical chain](#canonical-chain) with the specific block
     /// number.
@@ -436,7 +437,7 @@ pub trait ChainRpc {
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<HeaderView, Header>>>;
+    ) -> Result<Option<ResponseFormat<HeaderView>>>;
 
     /// Returns the information about a transaction requested by transaction hash.
     ///
@@ -454,8 +455,8 @@ pub trait ChainRpc {
     ///
     /// ## Returns
     ///
-    /// When verbosity is 0 (deprecated): this is reserved for compatibility, and will be removed in the following release.
-    /// It return null as the RPC response when the status is rejected or unknown, mimicking the original behaviors.
+    /// When verbosity=0, it's response value is as same as verbosity=2, but it
+    /// return a 0x-prefixed hex encoded molecule packed::Transaction on `transaction` field
     ///
     /// When verbosity is 1: The RPC does not return the transaction content and the field transaction must be null.
     ///
@@ -532,12 +533,31 @@ pub trait ChainRpc {
     ///   }
     /// }
     /// ```
+    ///
+    ///
+    /// The response looks like below when `verbosity` is 0.
+    ///
+    /// ```text
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "result": {
+    ///     "transaction": "0x.....",
+    ///     "tx_status": {
+    ///       "block_hash": null,
+    ///       "status": "pending",
+    ///       "reason": null
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
     #[rpc(name = "get_transaction")]
     fn get_transaction(
         &self,
         tx_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<TransactionWithStatus>>;
+    ) -> Result<Option<TransactionWithStatusResponse>>;
 
     /// Returns the hash of a block in the [canonical chain](#canonical-chain) with the specified
     /// `block_number`.
@@ -646,10 +666,7 @@ pub trait ChainRpc {
     /// }
     /// ```
     #[rpc(name = "get_tip_header")]
-    fn get_tip_header(
-        &self,
-        verbosity: Option<Uint32>,
-    ) -> Result<ResponseFormat<HeaderView, Header>>;
+    fn get_tip_header(&self, verbosity: Option<Uint32>) -> Result<ResponseFormat<HeaderView>>;
 
     /// Returns the status of a cell. The RPC returns extra information if it is a [live cell](#live-cell).
     ///
@@ -1093,7 +1110,7 @@ pub trait ChainRpc {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>>;
+    ) -> Result<Option<ResponseFormat<BlockView>>>;
 
     /// Return various consensus parameters.
     ///
@@ -1221,7 +1238,7 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+    ) -> Result<Option<ResponseFormat<BlockView>>> {
         let snapshot = self.shared.snapshot();
         let block_hash = block_hash.pack();
         if !snapshot.is_main_chain(&block_hash) {
@@ -1235,11 +1252,11 @@ impl ChainRpc for ChainRpcImpl {
         if verbosity == 2 {
             Ok(snapshot
                 .get_block(&block_hash)
-                .map(|block| ResponseFormat::Json(block.into())))
+                .map(|block| ResponseFormat::json(block.into())))
         } else if verbosity == 0 {
             Ok(snapshot
                 .get_packed_block(&block_hash)
-                .map(ResponseFormat::Hex))
+                .map(|packed| ResponseFormat::hex(packed.as_bytes())))
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))
         }
@@ -1249,7 +1266,7 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+    ) -> Result<Option<ResponseFormat<BlockView>>> {
         let snapshot = self.shared.snapshot();
         let block_hash = match snapshot.get_block_hash(block_number.into()) {
             Some(block_hash) => block_hash,
@@ -1263,11 +1280,11 @@ impl ChainRpc for ChainRpcImpl {
         let result = if verbosity == 2 {
             snapshot
                 .get_block(&block_hash)
-                .map(|block| Some(ResponseFormat::Json(block.into())))
+                .map(|block| Some(ResponseFormat::json(block.into())))
         } else if verbosity == 0 {
             snapshot
                 .get_packed_block(&block_hash)
-                .map(|block| Some(ResponseFormat::Hex(block)))
+                .map(|block| Some(ResponseFormat::hex(block.as_bytes())))
         } else {
             return Err(RPCError::invalid_params("invalid verbosity level"));
         };
@@ -1286,7 +1303,7 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<HeaderView, Header>>> {
+    ) -> Result<Option<ResponseFormat<HeaderView>>> {
         let snapshot = self.shared.snapshot();
         let block_hash = block_hash.pack();
         if !snapshot.is_main_chain(&block_hash) {
@@ -1299,11 +1316,11 @@ impl ChainRpc for ChainRpcImpl {
         if verbosity == 1 {
             Ok(snapshot
                 .get_block_header(&block_hash)
-                .map(|header| ResponseFormat::Json(header.into())))
+                .map(|header| ResponseFormat::json(header.into())))
         } else if verbosity == 0 {
             Ok(snapshot
                 .get_packed_block_header(&block_hash)
-                .map(ResponseFormat::Hex))
+                .map(|packed| ResponseFormat::hex(packed.as_bytes())))
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))
         }
@@ -1313,7 +1330,7 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<HeaderView, Header>>> {
+    ) -> Result<Option<ResponseFormat<HeaderView>>> {
         let snapshot = self.shared.snapshot();
         let block_hash = match snapshot.get_block_hash(block_number.into()) {
             Some(block_hash) => block_hash,
@@ -1326,11 +1343,11 @@ impl ChainRpc for ChainRpcImpl {
         let result = if verbosity == 1 {
             snapshot
                 .get_block_header(&block_hash)
-                .map(|header| Some(ResponseFormat::Json(header.into())))
+                .map(|header| Some(ResponseFormat::json(header.into())))
         } else if verbosity == 0 {
             snapshot
                 .get_packed_block_header(&block_hash)
-                .map(|header| Some(ResponseFormat::Hex(header)))
+                .map(|header| Some(ResponseFormat::hex(header.as_bytes())))
         } else {
             return Err(RPCError::invalid_params("invalid verbosity level"));
         };
@@ -1349,27 +1366,30 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         tx_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<TransactionWithStatus>> {
+    ) -> Result<Option<TransactionWithStatusResponse>> {
         let tx_hash = tx_hash.pack();
         let verbosity = verbosity
             .map(|v| v.value())
             .unwrap_or(DEFAULT_GET_TRANSACTION_VERBOSITY_LEVEL);
 
         if verbosity == 0 {
-            // legacy mode
-            //  When verbosity is 0 (deprecated): this is reserved for compatibility,
-            //  and will be removed in the following release.
-            //  It return null as the RPC response when the status is rejected or unknown,
-            //  mimicking the original behaviors.
-            self.get_transaction_verbosity0(tx_hash)
+            // when verbosity=0, it's response value is as same as verbosity=2, but it
+            // return a 0x-prefixed hex encoded molecule packed::Transaction` on `transaction` field
+            self.get_transaction_verbosity2(tx_hash).map(|op| {
+                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Hex))
+            })
         } else if verbosity == 1 {
             // The RPC does not return the transaction content and the field transaction must be null.
-            self.get_transaction_verbosity1(tx_hash)
+            self.get_transaction_verbosity1(tx_hash).map(|op| {
+                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Json))
+            })
         } else if verbosity == 2 {
             // if tx_status.status is pending, proposed, or committed,
             // the RPC returns the transaction content as field transaction,
             // otherwise the field is null.
-            self.get_transaction_verbosity2(tx_hash)
+            self.get_transaction_verbosity2(tx_hash).map(|op| {
+                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Json))
+            })
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))
         }
@@ -1383,20 +1403,17 @@ impl ChainRpc for ChainRpcImpl {
             .map(|h| h.unpack()))
     }
 
-    fn get_tip_header(
-        &self,
-        verbosity: Option<Uint32>,
-    ) -> Result<ResponseFormat<HeaderView, Header>> {
+    fn get_tip_header(&self, verbosity: Option<Uint32>) -> Result<ResponseFormat<HeaderView>> {
         let verbosity = verbosity
             .map(|v| v.value())
             .unwrap_or(DEFAULT_HEADER_VERBOSITY_LEVEL);
         if verbosity == 1 {
-            Ok(ResponseFormat::Json(
+            Ok(ResponseFormat::json(
                 self.shared.snapshot().tip_header().clone().into(),
             ))
         } else if verbosity == 0 {
-            Ok(ResponseFormat::Hex(
-                self.shared.snapshot().tip_header().data(),
+            Ok(ResponseFormat::hex(
+                self.shared.snapshot().tip_header().data().as_bytes(),
             ))
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))
@@ -1622,7 +1639,7 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView, Block>>> {
+    ) -> Result<Option<ResponseFormat<BlockView>>> {
         let snapshot = self.shared.snapshot();
         let block_hash = block_hash.pack();
         if snapshot.is_main_chain(&block_hash) {
@@ -1636,11 +1653,11 @@ impl ChainRpc for ChainRpcImpl {
         if verbosity == 2 {
             Ok(snapshot
                 .get_block(&block_hash)
-                .map(|block| ResponseFormat::Json(block.into())))
+                .map(|block| ResponseFormat::json(block.into())))
         } else if verbosity == 0 {
             Ok(snapshot
                 .get_packed_block(&block_hash)
-                .map(ResponseFormat::Hex))
+                .map(|packed| ResponseFormat::hex(packed.as_bytes())))
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))
         }
@@ -1667,35 +1684,6 @@ impl ChainRpc for ChainRpcImpl {
 }
 
 impl ChainRpcImpl {
-    fn get_transaction_verbosity0(
-        &self,
-        tx_hash: packed::Byte32,
-    ) -> Result<Option<TransactionWithStatus>> {
-        if let Some((tx, block_hash)) = self.shared.snapshot().get_transaction(&tx_hash) {
-            return Ok(Some(TransactionWithStatus::with_committed(
-                Some(tx),
-                block_hash.unpack(),
-            )));
-        }
-
-        let tx_pool = self.shared.tx_pool_controller();
-        let fetch_tx_for_rpc = tx_pool.fetch_tx_for_rpc(tx_hash);
-        if let Err(e) = fetch_tx_for_rpc {
-            error!("send fetch_tx_for_rpc request error {}", e);
-            return Err(RPCError::ckb_internal_error(e));
-        };
-
-        let ret = fetch_tx_for_rpc.unwrap().map(|(proposed, tx)| {
-            if proposed {
-                TransactionWithStatus::with_proposed(Some(tx))
-            } else {
-                TransactionWithStatus::with_pending(Some(tx))
-            }
-        });
-
-        Ok(ret)
-    }
-
     fn get_transaction_verbosity1(
         &self,
         tx_hash: packed::Byte32,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod assertion;
 pub mod generic;
 pub mod global;

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -8,7 +8,7 @@ use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockTemplate, BlockView, Capacity,
     CellWithStatus, ChainInfo, DryRunResult, EpochNumber, EpochView, HeaderView, LocalNode,
     OutPoint, RawTxPool, RemoteNode, Timestamp, Transaction, TransactionProof,
-    TransactionWithStatus, TxPoolInfo, Uint32, Uint64, Version,
+    TransactionWithStatusResponse, TxPoolInfo, Uint32, Uint64, Version,
 };
 use ckb_types::core::{
     BlockNumber as CoreBlockNumber, Capacity as CoreCapacity, EpochNumber as CoreEpochNumber,
@@ -69,18 +69,15 @@ impl RpcClient {
             .expect("rpc call get_header_by_number")
     }
 
-    pub fn get_transaction(&self, hash: Byte32) -> Option<TransactionWithStatus> {
-        // keep legacy mode
-        self.inner
-            .get_transaction(hash.unpack(), Some(0u32.into()))
-            .expect("rpc call get_transaction")
+    pub fn get_transaction(&self, hash: Byte32) -> Option<TransactionWithStatusResponse> {
+        self.get_transaction_with_verbosity(hash, 2)
     }
 
     pub fn get_transaction_with_verbosity(
         &self,
         hash: Byte32,
         verbosity: u32,
-    ) -> Option<TransactionWithStatus> {
+    ) -> Option<TransactionWithStatusResponse> {
         self.inner
             .get_transaction(hash.unpack(), Some(verbosity.into()))
             .expect("rpc call get_transaction")
@@ -302,7 +299,7 @@ jsonrpc!(pub struct Inner {
     pub fn get_block_by_number(&self, _number: BlockNumber) -> Option<BlockView>;
     pub fn get_header(&self, _hash: H256) -> Option<HeaderView>;
     pub fn get_header_by_number(&self, _number: BlockNumber) -> Option<HeaderView>;
-    pub fn get_transaction(&self, _hash: H256, verbosity: Option<Uint32>) -> Option<TransactionWithStatus>;
+    pub fn get_transaction(&self, _hash: H256, verbosity: Option<Uint32>) -> Option<TransactionWithStatusResponse>;
     pub fn get_block_hash(&self, _number: BlockNumber) -> Option<H256>;
     pub fn get_tip_header(&self) -> HeaderView;
     pub fn get_live_cell(&self, _out_point: OutPoint, _with_data: bool) -> CellWithStatus;

--- a/test/src/specs/hardfork/v2021/cell_deps.rs
+++ b/test/src/specs/hardfork/v2021/cell_deps.rs
@@ -7,6 +7,7 @@ use crate::{
     Node, Spec,
 };
 use ckb_jsonrpc_types as rpc;
+use ckb_jsonrpc_types::Either;
 use ckb_logger::{info, trace};
 use ckb_types::packed::Byte32;
 use ckb_types::{
@@ -509,15 +510,19 @@ impl<'a> CheckCellDepsTestRunner<'a> {
     fn get_previous_output(&self, cell_input: &packed::CellInput) -> rpc::CellOutput {
         let previous_output = cell_input.previous_output();
         let previous_output_index: usize = previous_output.index().unpack();
-        self.node
+        if let Either::Left(tx) = self
+            .node
             .rpc_client()
             .get_transaction(previous_output.tx_hash())
             .unwrap()
             .transaction
             .unwrap()
             .inner
-            .outputs[previous_output_index]
-            .clone()
+        {
+            tx.inner.outputs[previous_output_index].clone()
+        } else {
+            panic!("get previous output failed");
+        }
     }
 
     fn new_data_script_as_lock_script_input(

--- a/test/src/specs/tx_pool/collision.rs
+++ b/test/src/specs/tx_pool/collision.rs
@@ -1,5 +1,5 @@
 use crate::util::check::{
-    is_transaction_committed, is_transaction_pending, is_transaction_unknown,
+    is_transaction_committed, is_transaction_pending, is_transaction_rejected,
 };
 use crate::utils::{assert_send_transaction_fail, blank, commit, propose};
 use crate::{Node, Spec};
@@ -168,8 +168,8 @@ impl Spec for RemoveConflictFromPending {
         node.wait_for_tx_pool();
 
         assert!(is_transaction_committed(node, &txa));
-        assert!(is_transaction_unknown(node, &txb));
-        assert!(is_transaction_unknown(node, &txc));
+        assert!(is_transaction_rejected(node, &txb));
+        assert!(is_transaction_rejected(node, &txc));
     }
 }
 

--- a/test/src/specs/tx_pool/different_txs_with_same_input.rs
+++ b/test/src/specs/tx_pool/different_txs_with_same_input.rs
@@ -46,10 +46,12 @@ impl Spec for DifferentTxsWithSameInput {
         assert!(commit_txs_hash.contains(&tx1.hash()));
         assert!(!commit_txs_hash.contains(&tx2.hash()));
 
-        // when tx1 was confirmed, tx2 should be discarded
-        // legacy mode return null
-        let ret = node0.rpc_client().get_transaction(tx2.hash());
-        assert!(ret.is_none(), "tx2 should be discarded");
+        // when tx1 was confirmed, tx2 should be rejected
+        let ret = node0.rpc_client().get_transaction(tx2.hash()).unwrap();
+        assert!(
+            matches!(ret.tx_status.status, Status::Rejected),
+            "tx2 should be rejected"
+        );
 
         // verbosity = 1
         let ret = node0

--- a/test/src/util/check.rs
+++ b/test/src/util/check.rs
@@ -23,10 +23,18 @@ pub fn is_transaction_committed(node: &Node, transaction: &TransactionView) -> b
         .unwrap_or(false)
 }
 
+pub fn is_transaction_rejected(node: &Node, transaction: &TransactionView) -> bool {
+    node.rpc_client()
+        .get_transaction(transaction.hash())
+        .map(|txstatus| txstatus.tx_status.status == Status::Rejected)
+        .unwrap_or(false)
+}
+
 pub fn is_transaction_unknown(node: &Node, transaction: &TransactionView) -> bool {
     node.rpc_client()
         .get_transaction(transaction.hash())
-        .is_none()
+        .map(|txstatus| txstatus.tx_status.is_unknown())
+        .unwrap_or(true)
 }
 
 pub fn assert_epoch_should_be(node: &Node, number: u64, index: u64, length: u64) {

--- a/util/types/src/core/mod.rs
+++ b/util/types/src/core/mod.rs
@@ -33,6 +33,7 @@ pub use extras::{BlockExt, EpochExt, EpochNumberWithFraction, TransactionInfo};
 pub use fee_rate::FeeRate;
 pub use reward::{BlockEconomicState, BlockIssuance, BlockReward, MinerReward};
 pub use transaction_meta::{TransactionMeta, TransactionMetaBuilder};
+pub use tx_pool::TransactionWithStatus;
 pub use views::{
     BlockView, ExtraHashView, HeaderView, TransactionView, UncleBlockVecView, UncleBlockView,
 };


### PR DESCRIPTION
Signed-off-by: Eval EXEC <execvy@gmail.com>

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #3424 <!-- REMOVE this line if no issue to close -->

Problem Summary: support return raw molecule hex bytes for `get_transaction` rpc method.

### What is changed and how it works?

What's Changed:

- rewrite `verbosity=0` branch for `get_transaction` rpc method.
- delete `get_transaction_verbosity0()` 
- make `verbosity=0` 's behaviour as same as `verbosity=2`, except for when `verbosity=0`, it will return a 0x-prefixed hex encoded raw molecule `packed::Transaction` on `transaction` field;
- change `ChainRpc::get_transaction()`'s return type from `Result<Option<TransactionWithStatus>>` to `Result<Option<TransactionWithStatusResponse>>`
- move `json_types::TransactionWithStatus` to `tx_pool::TransactionWithStatus`
- change some specs tests assertion in `test/src/specs`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

