### PR TITLE
fix: fix tcp reuse bind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,9 +1515,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -954,6 +954,7 @@ impl<T: ExitHandler> NetworkService<T> {
                             }
                             if let Some(addr) = multiaddr_to_socketaddr(addr) {
                                 use p2p::service::TcpSocket;
+                                let domain = socket2::Domain::for_address(addr);
                                 service_builder =
                                     service_builder.tcp_config(move |socket: TcpSocket| {
                                         let socket_ref = socket2::SockRef::from(&socket);
@@ -965,7 +966,9 @@ impl<T: ExitHandler> NetworkService<T> {
                                         socket_ref.set_reuse_port(true)?;
 
                                         socket_ref.set_reuse_address(true)?;
-                                        socket_ref.bind(&addr.into())?;
+                                        if socket_ref.domain()? == domain {
+                                            socket_ref.bind(&addr.into())?;
+                                        }
                                         Ok(socket)
                                     });
                                 init.transform(TransportType::Tcp)


### PR DESCRIPTION
### What problem does this PR solve?

fix https://github.com/nervosnetwork/ckb/discussions/2654#discussioncomment-3561768

Fix the panic caused by the configuration file

Reuse-bind cannot be performed between ipv4 and ipv6, and branch judgment is required

### Check List 

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

