### PR TITLE
portable release

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,12 +40,13 @@ jobs:
   package-for-linux:
     name: package-for-linux
     runs-on: ubuntu-20.04
-    matrix:
-      include:
-        - rel_pkg: "x86_64-unknown-linux-gnu.tar.gz"
-          build_target: "prod"
-        - rel_pkg: "x86_64-unknown-linux-gnu-portable.tar.gz"
-          build_target: "prod_portable"
+    strategy:
+      matrix:
+        include:
+          - rel_pkg: "x86_64-unknown-linux-gnu.tar.gz"
+            build_target: "prod"
+          - rel_pkg: "x86_64-unknown-linux-gnu-portable.tar.gz"
+            build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env
@@ -133,12 +134,13 @@ jobs:
   package-for-centos:
     name: package-for-centos
     runs-on: ubuntu-20.04
-    matrix:
-      include:
-        - rel_pkg: "x86_64-unknown-centos-gnu.tar.gz"
-          build_target: "prod"
-        - rel_pkg: "x86_64-unknown-centos-gnu-portable.tar.gz"
-          build_target: "prod_portable"
+    strategy:
+      matrix:
+        include:
+          - rel_pkg: "x86_64-unknown-centos-gnu.tar.gz"
+            build_target: "prod"
+          - rel_pkg: "x86_64-unknown-centos-gnu-portable.tar.gz"
+            build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env
@@ -174,12 +176,13 @@ jobs:
   package-for-mac:
     name: package-for-mac
     runs-on: macos-11
-    matrix:
-      include:
-        - rel_pkg: "x86_64-apple-darwin.zip"
-          build_target: "prod"
-        - rel_pkg: "x86_64-apple-darwin-portable.zip"
-          build_target: "prod_portable"
+    strategy:
+      matrix:
+        include:
+          - rel_pkg: "x86_64-apple-darwin.zip"
+            build_target: "prod"
+          - rel_pkg: "x86_64-apple-darwin-portable.zip"
+            build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,6 +40,12 @@ jobs:
   package-for-linux:
     name: package-for-linux
     runs-on: ubuntu-20.04
+    matrix:
+      include:
+        - rel_pkg: "x86_64-unknown-linux-gnu.tar.gz"
+          build_target: "prod"
+        - rel_pkg: "x86_64-unknown-linux-gnu-portable.tar.gz"
+          build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env
@@ -54,13 +60,12 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 $BUILDER_IMAGE make prod
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
-        devtools/ci/qput-7z "releases/ckb_${GIT_TAG_NAME}_x86_64-unknown-linux-gnu"
     - name: upload-zip-file
       uses: actions/upload-artifact@v2
       with:
@@ -73,7 +78,7 @@ jobs:
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
       BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.61.0
-      REL_PKG: x86_64-unknown-linux-gnu.tar.gz
+      REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-linux-aarch64:
     name: package-for-linux-aarch64
@@ -112,7 +117,6 @@ jobs:
         devtools/ci/package.sh target/aarch64-unknown-linux-gnu/release/ckb
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
         mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
-        devtools/ci/qput-7z "releases/ckb_${GIT_TAG_NAME}_aarch64-unknown-linux-gnu"
     - name: upload-zip-file
       uses: actions/upload-artifact@v2
       with:
@@ -129,6 +133,12 @@ jobs:
   package-for-centos:
     name: package-for-centos
     runs-on: ubuntu-20.04
+    matrix:
+      include:
+        - rel_pkg: "x86_64-unknown-centos-gnu.tar.gz"
+          build_target: "prod"
+        - rel_pkg: "x86_64-unknown-centos-gnu-portable.tar.gz"
+          build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env
@@ -141,7 +151,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb $BUILDER_IMAGE make prod
+        docker run --rm -i -w /ckb -v $(pwd):/ckb $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -159,11 +169,17 @@ jobs:
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
       BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.61.0
-      REL_PKG: x86_64-unknown-centos-gnu.tar.gz
+      REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-mac:
     name: package-for-mac
     runs-on: macos-11
+    matrix:
+      include:
+        - rel_pkg: "x86_64-apple-darwin.zip"
+          build_target: "prod"
+        - rel_pkg: "x86_64-apple-darwin-portable.zip"
+          build_target: "prod_portable"
     steps:
     - uses: actions/checkout@v3
     - name: Set Env
@@ -176,7 +192,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include prod
+        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -193,7 +209,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      REL_PKG: x86_64-apple-darwin.zip
+      REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-windows:
     name: package-for-windows

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -61,7 +61,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 $BUILDER_IMAGE make ${{ matrix.build_target }}
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu -e OPENSSL_INCLUDE_DIR=/usr/include $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -153,7 +153,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb $BUILDER_IMAGE make ${{ matrix.build_target }}
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -280,9 +280,12 @@ jobs:
       matrix:
         include:
           - REL_PKG: x86_64-unknown-linux-gnu.tar.gz
+          - REL_PKG: x86_64-unknown-linux-gnu-portable.tar.gz
           - REL_PKG: aarch64-unknown-linux-gnu.tar.gz
           - REL_PKG: x86_64-unknown-centos-gnu.tar.gz
+          - REL_PKG: x86_64-unknown-centos-gnu-portable.tar.gz
           - REL_PKG: x86_64-apple-darwin.zip
+          - REL_PKG: x86_64-apple-darwin-portable.zip
           - REL_PKG: x86_64-pc-windows-msvc.zip
     needs:
       - create-release

--- a/devtools/ci/package.sh
+++ b/devtools/ci/package.sh
@@ -25,13 +25,14 @@ cp -R docs "releases/$PKG_NAME"
 cp rpc/README.md "releases/$PKG_NAME/docs/rpc.md"
 
 if [ ! "${SKIP_CKB_CLI:-false}" == "true" ]; then
-  curl -LO "https://github.com/nervosnetwork/ckb-cli/releases/download/${CKB_CLI_VERSION}/ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
-  if [ "${REL_PKG##*.}" = "zip" ]; then
-    unzip "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+  CKB_CLI_REL_PKG="$(echo "$REL_PKG" | sed 's/-portable//')"
+  curl -LO "https://github.com/nervosnetwork/ckb-cli/releases/download/${CKB_CLI_VERSION}/ckb-cli_${CKB_CLI_VERSION}_${CKB_CLI_REL_PKG}"
+  if [ "${CKB_CLI_REL_PKG##*.}" = "zip" ]; then
+    unzip "ckb-cli_${CKB_CLI_VERSION}_${CKB_CLI_REL_PKG}"
   else
-    tar -xzf "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG}"
+    tar -xzf "ckb-cli_${CKB_CLI_VERSION}_${CKB_CLI_REL_PKG}"
   fi
-  mv "ckb-cli_${CKB_CLI_VERSION}_${REL_PKG%%.*}/ckb-cli" "releases/$PKG_NAME/ckb-cli"
+  mv "ckb-cli_${CKB_CLI_VERSION}_${CKB_CLI_REL_PKG%%.*}/ckb-cli" "releases/$PKG_NAME/ckb-cli"
 fi
 
 pushd releases


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

- #3567 Add better cross-platform builds in releases.
- #3560 error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

### What is changed and how it works?

- Fix #3567 by creating portable binaries for Linux, CentOS and macOS.
- Fix #3560 by statically linking OpenSSL.

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```
