### PR TITLE
fix: incorrect optimization to find blocks through total difficulties

### DIFF
--- a/util/light-client-protocol-server/src/components/get_block_samples.rs
+++ b/util/light-client-protocol-server/src/components/get_block_samples.rs
@@ -95,7 +95,9 @@ impl BlockSampler {
                 end_block_number,
                 difficulty,
             ) {
-                start_block_number = num;
+                if num > start_block_number {
+                    start_block_number = num - 1;
+                }
                 numbers.push(num);
             } else {
                 let errmsg = format!(


### PR DESCRIPTION
### Issues

- If the found number is the same as the start block number, then the start block number in the next turn should be the same.

- If the found number is greater than the start block number, then the start block number in the next turn should be the found number subtract one.

  Why have to  subtract one?

  Because the found number (denoted as $N$) is the first block number whose total difficulty (denoted as $D_{block,N}$) is not less than the provided total difficulty (denoted as $D_{i}$), so next total difficulty (denoted as $D_{i+1}$) could have $D_{i} \lt D_{i+1} \lt D_{block,N}$. So, if we set $N$ as new start number, it may raise an error.
  But there must have $D_{i+1} \gt D_{i} \gt D_{block,N-1}$, so $N-1$ could be the new start number.