### PR TITLE
feat: Flags features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
 name = "ckb-network"
 version = "0.105.0-pre"
 dependencies = [
+ "bitflags",
  "bloom-filters",
  "bs58",
  "ckb-app-config",

--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -6,7 +6,7 @@ use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_launcher::SharedBuilder;
-use ckb_network::{DefaultExitHandler, NetworkController, NetworkService, NetworkState};
+use ckb_network::{DefaultExitHandler, Flags, NetworkController, NetworkService, NetworkState};
 use ckb_shared::Shared;
 use ckb_store::ChainStore;
 use ckb_types::{
@@ -72,8 +72,11 @@ fn dummy_network(shared: &Shared) -> NetworkController {
         network_state,
         vec![],
         vec![],
-        shared.consensus().identify_name(),
-        "test".to_string(),
+        (
+            shared.consensus().identify_name(),
+            "test".to_string(),
+            Flags::COMPATIBILITY,
+        ),
         DefaultExitHandler::default(),
     )
     .start(shared.async_handle())

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -6,7 +6,7 @@ use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_launcher::SharedBuilder;
-use ckb_network::{DefaultExitHandler, NetworkController, NetworkService, NetworkState};
+use ckb_network::{DefaultExitHandler, Flags, NetworkController, NetworkService, NetworkState};
 use ckb_shared::shared::Shared;
 use ckb_store::ChainStore;
 pub use ckb_test_chain_utils::MockStore;
@@ -309,8 +309,11 @@ pub(crate) fn dummy_network(shared: &Shared) -> NetworkController {
         network_state,
         vec![],
         vec![],
-        shared.consensus().identify_name(),
-        "test".to_string(),
+        (
+            shared.consensus().identify_name(),
+            "test".to_string(),
+            Flags::COMPATIBILITY,
+        ),
         DefaultExitHandler::default(),
     )
     .start(shared.async_handle())

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0"
 bloom-filters = "0.1"
 ckb-spawn = { path = "../util/spawn", version = "= 0.105.0-pre" }
 socket2 = "0.4"
+bitflags = "1.0"
 
 p2p = { version="0.4.0", package="tentacle", features = ["upnp", "parking_lot"] }
 

--- a/network/src/benches/peer_store.rs
+++ b/network/src/benches/peer_store.rs
@@ -27,7 +27,7 @@ fn bench(c: &mut Criterion) {
                 |addrs| {
                     let mut peer_store = PeerStore::default();
                     for addr in addrs {
-                        peer_store.add_addr(addr).unwrap();
+                        peer_store.add_addr(addr, 0x1).unwrap();
                     }
                 },
                 BatchSize::PerIteration,
@@ -54,12 +54,12 @@ fn bench(c: &mut Criterion) {
                             .collect::<Vec<_>>();
                         let mut peer_store = PeerStore::default();
                         for addr in addrs {
-                            peer_store.add_addr(addr).unwrap();
+                            peer_store.add_addr(addr, 0x1).unwrap();
                         }
                         peer_store
                     },
                     |mut peer_store| {
-                        peer_store.fetch_random_addrs(*i);
+                        peer_store.fetch_random_addrs(*i, |_| true);
                     },
                     BatchSize::PerIteration,
                 )

--- a/network/src/benches/peer_store.rs
+++ b/network/src/benches/peer_store.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 extern crate ckb_network;
 extern crate ckb_util;
 
-use ckb_network::{multiaddr::Multiaddr, peer_store::PeerStore, PeerId};
+use ckb_network::{multiaddr::Multiaddr, peer_store::PeerStore, Flags, PeerId};
 use criterion::{BatchSize, BenchmarkId, Criterion};
 
 const SIZES: &[usize] = &[10_000, 20_000];
@@ -27,7 +27,7 @@ fn bench(c: &mut Criterion) {
                 |addrs| {
                     let mut peer_store = PeerStore::default();
                     for addr in addrs {
-                        peer_store.add_addr(addr, 0x1).unwrap();
+                        peer_store.add_addr(addr, Flags::COMPATIBILITY).unwrap();
                     }
                 },
                 BatchSize::PerIteration,
@@ -54,12 +54,12 @@ fn bench(c: &mut Criterion) {
                             .collect::<Vec<_>>();
                         let mut peer_store = PeerStore::default();
                         for addr in addrs {
-                            peer_store.add_addr(addr, 0x1).unwrap();
+                            peer_store.add_addr(addr, Flags::COMPATIBILITY).unwrap();
                         }
                         peer_store
                     },
                     |mut peer_store| {
-                        peer_store.fetch_random_addrs(*i, |_| true);
+                        peer_store.fetch_random_addrs(*i, Flags::COMPATIBILITY);
                     },
                     BatchSize::PerIteration,
                 )

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -32,8 +32,8 @@ pub use crate::{
     peer_registry::PeerRegistry,
     peer_store::Score,
     protocols::{
-        support_protocols::SupportProtocols, CKBProtocol, CKBProtocolContext, CKBProtocolHandler,
-        PeerIndex,
+        identify::Flags, support_protocols::SupportProtocols, CKBProtocol, CKBProtocolContext,
+        CKBProtocolHandler, PeerIndex,
     },
 };
 pub use p2p::{

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -86,7 +86,6 @@ pub struct NetworkState {
     /// Node supported protocols
     /// fields: ProtocolId, Protocol Name, Supported Versions
     pub(crate) protocols: RwLock<Vec<(ProtocolId, String, Vec<String>)>>,
-    pub(crate) target_flags_filter: Box<dyn Fn(Flags) -> bool + Send + Sync + 'static>,
     pub(crate) required_flags: Flags,
 }
 
@@ -138,22 +137,8 @@ impl NetworkState {
             local_peer_id,
             active: AtomicBool::new(true),
             protocols: RwLock::new(Vec::new()),
-            target_flags_filter: Box::new(|t| {
-                let default_target = Flags::SYNC | Flags::DISCOVERY | Flags::RELAY;
-                t.contains(default_target) || t.contains(Flags::COMPATIBILITY)
-            }),
             required_flags: Flags::SYNC | Flags::DISCOVERY | Flags::RELAY,
         })
-    }
-
-    /// which peer flag should to connect,
-    /// default with `Flags::SYNC | Flags::DISCOVERY | Flags::RELAY` or `Flags::COMPATIBILITY`
-    pub fn target_flags_filter<T>(mut self, filter: T) -> Self
-    where
-        T: Fn(Flags) -> bool + Send + Sync + 'static,
-    {
-        self.target_flags_filter = Box::new(filter);
-        self
     }
 
     /// use to discovery get nodes message to announce what kind of node information need from the other peer
@@ -1065,18 +1050,14 @@ impl<T: ExitHandler> NetworkService<T> {
             self.network_state.dial_identify(&p2p_control, addr);
         }
 
-        let target = &self.network_state.target_flags_filter;
-        let filter = |flags: u64| -> bool {
-            let out = unsafe { Flags::from_bits_unchecked(flags) };
-            target(out)
-        };
+        let target = &self.network_state.required_flags;
 
         // get bootnodes
         // try get addrs from peer_store, if peer_store have no enough addrs then use bootnodes
         let bootnodes = self.network_state.with_peer_store_mut(|peer_store| {
             let count = max((config.max_outbound_peers >> 1) as usize, 1);
             let mut addrs: Vec<_> = peer_store
-                .fetch_addrs_to_attempt(count, filter)
+                .fetch_addrs_to_attempt(count, *target)
                 .into_iter()
                 .map(|paddr| paddr.addr)
                 .collect();

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -147,7 +147,7 @@ impl NetworkState {
     }
 
     /// which peer flag should to connect,
-    /// default with `Flags::SYNC | Flags::DISCOVERY | Flags::RELAY` or `Flags::COMPATIBILITY && not support client`
+    /// default with `Flags::SYNC | Flags::DISCOVERY | Flags::RELAY` or `Flags::COMPATIBILITY`
     pub fn target_flags_filter<T>(mut self, filter: T) -> Self
     where
         T: Fn(Flags) -> bool + Send + Sync + 'static,

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -1,5 +1,7 @@
 use crate::network_group::Group;
-use crate::{multiaddr::Multiaddr, ProtocolId, ProtocolVersion, SessionType};
+use crate::{
+    multiaddr::Multiaddr, protocols::identify::Flags, ProtocolId, ProtocolVersion, SessionType,
+};
 use p2p::SessionId;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -9,6 +11,8 @@ use std::time::{Duration, Instant};
 pub struct PeerIdentifyInfo {
     /// Node version
     pub client_version: String,
+    /// Node flags
+    pub flags: Flags,
 }
 
 /// Peer info

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -24,7 +24,12 @@ impl AddrManager {
             {
                 // replace exists addr if has later last_connected_at_ms
                 if addr_info.last_connected_at_ms > exists_last_connected_at_ms {
-                    self.remove(&addr_info.addr);
+                    if let Some(old) = self.remove(&addr_info.addr) {
+                        // init from `add_outbound_addr`
+                        if addr_info.flags == 0 {
+                            addr_info.flags = old.flags;
+                        }
+                    }
                 } else {
                     return;
                 }

--- a/network/src/peer_store/mod.rs
+++ b/network/src/peer_store/mod.rs
@@ -16,6 +16,7 @@ pub mod types;
 pub(crate) use crate::Behaviour;
 pub use crate::SessionType;
 use p2p::multiaddr::Multiaddr;
+pub(crate) use peer_store_impl::required_flags_filter;
 pub use peer_store_impl::PeerStore;
 
 /// peer store evict peers after reach this limitation

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -84,6 +84,7 @@ impl PeerStore {
             .add(AddrInfo::new(addr, faketime::unix_time_as_millis(), score));
     }
 
+    /// Change peer's Flags
     pub fn change_flags(&mut self, addr: Multiaddr, flags: u64) {
         if let Some(addr_info) = self.addr_manager.get_mut(&addr) {
             addr_info.flags(flags)

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -46,6 +46,13 @@ pub struct AddrInfo {
     pub attempts_count: u32,
     /// Random id
     pub random_id_pos: usize,
+    /// Flags
+    #[serde(default = "default_flags")]
+    pub flags: u64,
+}
+
+fn default_flags() -> u64 {
+    0x1
 }
 
 impl AddrInfo {
@@ -58,6 +65,7 @@ impl AddrInfo {
             last_tried_at_ms: 0,
             attempts_count: 0,
             random_id_pos: 0,
+            flags: 0,
         }
     }
 
@@ -101,6 +109,11 @@ impl AddrInfo {
         self.last_connected_at_ms = connected_at_ms;
         // reset attempts
         self.attempts_count = 0;
+    }
+
+    /// Change address flags
+    pub fn flags(&mut self, flags: u64) {
+        self.flags = flags;
     }
 }
 

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -1,5 +1,8 @@
 //! Type used on peer store
-use crate::peer_store::{Score, SessionType, ADDR_MAX_FAILURES, ADDR_MAX_RETRIES, ADDR_TIMEOUT_MS};
+use crate::{
+    peer_store::{Score, SessionType, ADDR_MAX_FAILURES, ADDR_MAX_RETRIES, ADDR_TIMEOUT_MS},
+    Flags,
+};
 use ipnetwork::IpNetwork;
 use p2p::multiaddr::{Multiaddr, Protocol};
 use serde::{Deserialize, Serialize};
@@ -52,12 +55,12 @@ pub struct AddrInfo {
 }
 
 fn default_flags() -> u64 {
-    0x1
+    Flags::COMPATIBILITY.bits()
 }
 
 impl AddrInfo {
     /// Init
-    pub fn new(addr: Multiaddr, last_connected_at_ms: u64, score: Score) -> Self {
+    pub fn new(addr: Multiaddr, last_connected_at_ms: u64, score: Score, flags: u64) -> Self {
         AddrInfo {
             addr,
             score,
@@ -65,7 +68,7 @@ impl AddrInfo {
             last_tried_at_ms: 0,
             attempts_count: 0,
             random_id_pos: 0,
-            flags: 0,
+            flags,
         }
     }
 
@@ -112,8 +115,8 @@ impl AddrInfo {
     }
 
     /// Change address flags
-    pub fn flags(&mut self, flags: u64) {
-        self.flags = flags;
+    pub fn flags(&mut self, flags: Flags) {
+        self.flags = flags.bits();
     }
 }
 

--- a/network/src/protocols/discovery/addr.rs
+++ b/network/src/protocols/discovery/addr.rs
@@ -3,6 +3,8 @@ use std::collections::hash_map::RandomState;
 use bloom_filters::{BloomFilter, DefaultBuildHashKernels, StableBloomFilter};
 use p2p::{context::SessionContext, multiaddr::Multiaddr, ProtocolId, SessionId};
 
+use crate::Flags;
+
 pub(crate) const DEFAULT_BUCKETS_NUM: usize = 5000;
 
 #[derive(Debug, Clone)]
@@ -39,10 +41,12 @@ pub trait AddressManager {
     fn register(&self, id: SessionId, pid: ProtocolId, version: &str);
     fn unregister(&self, id: SessionId, pid: ProtocolId);
     fn is_valid_addr(&self, addr: &Multiaddr) -> bool;
-    fn add_new_addr(&mut self, session_id: SessionId, addr: Multiaddr);
-    fn add_new_addrs(&mut self, session_id: SessionId, addrs: Vec<Multiaddr>);
+    fn add_new_addr(&mut self, session_id: SessionId, addr: (Multiaddr, Flags));
+    fn add_new_addrs(&mut self, session_id: SessionId, addrs: Vec<(Multiaddr, Flags)>);
     fn misbehave(&mut self, session: &SessionContext, kind: &Misbehavior) -> MisbehaveResult;
-    fn get_random(&mut self, n: usize) -> Vec<Multiaddr>;
+    fn get_random(&mut self, n: usize, target: Flags) -> Vec<(Multiaddr, Flags)>;
+    fn required_flags(&self) -> Flags;
+    fn node_flags(&self, id: SessionId) -> Flags;
 }
 
 // bitcoin: bloom.h, bloom.cpp => CRollingBloomFilter

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -336,7 +336,7 @@ impl AddressManager for DiscoveryAddressManager {
         for addr in addrs.into_iter().filter(|addr| self.is_valid_addr(addr)) {
             trace!("Add discovered address:{:?}", addr);
             self.network_state.with_peer_store_mut(|peer_store| {
-                if let Err(err) = peer_store.add_addr(addr.clone()) {
+                if let Err(err) = peer_store.add_addr(addr.clone(), 0x1) {
                     debug!(
                         "Failed to add discoved address to peer_store {:?} {:?}",
                         err, addr
@@ -359,7 +359,7 @@ impl AddressManager for DiscoveryAddressManager {
     fn get_random(&mut self, n: usize) -> Vec<Multiaddr> {
         let fetch_random_addrs = self
             .network_state
-            .with_peer_store_mut(|peer_store| peer_store.fetch_random_addrs(n));
+            .with_peer_store_mut(|peer_store| peer_store.fetch_random_addrs(n, |_| true));
         let addrs = fetch_random_addrs
             .into_iter()
             .filter_map(|paddr| {

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -24,7 +24,7 @@ use self::{
     protocol::{decode, encode},
     state::RemoteAddress,
 };
-use crate::{NetworkState, ProtocolId};
+use crate::{Flags, NetworkState, ProtocolId};
 
 mod addr;
 pub(crate) mod protocol;
@@ -80,8 +80,10 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
         self.addr_mgr
             .register(session.id, context.proto_id, version);
 
-        self.sessions
-            .insert(session.id, SessionState::new(context, &self.addr_mgr).await);
+        self.sessions.insert(
+            session.id,
+            SessionState::new(context, &self.addr_mgr, version == "2.1").await,
+        );
     }
 
     async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
@@ -95,17 +97,24 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
         let session = context.session;
         trace!("[received message]: length={}", data.len());
 
+        let new_version = self
+            .sessions
+            .get(&session.id)
+            .map(|state| state.v21)
+            .unwrap_or_default();
+
         let mgr = &mut self.addr_mgr;
         let mut check =
             |behavior: Misbehavior| -> bool { mgr.misbehave(session, &behavior).is_disconnect() };
 
-        match decode(&data) {
+        match decode(&data, new_version) {
             Some(item) => {
                 match item {
                     DiscoveryMessage::GetNodes {
                         listen_port,
                         count,
                         version,
+                        required_flags,
                     } => {
                         if let Some(state) = self.sessions.get_mut(&session.id) {
                             if state.received_get_nodes && check(Misbehavior::DuplicateGetNodes) {
@@ -118,7 +127,7 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                             state.received_get_nodes = true;
                             // must get the item first, otherwise it is possible to load
                             // the address of peer listen.
-                            let mut items = self.addr_mgr.get_random(2500);
+                            let mut items = self.addr_mgr.get_random(2500, required_flags);
 
                             // change client random outbound port to client listen port
                             debug!("listen port: {:?}", listen_port);
@@ -127,7 +136,9 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                                 state.addr_known.insert(state.remote_addr.to_inner());
                                 // add client listen address to manager
                                 if let RemoteAddress::Listen(ref addr) = state.remote_addr {
-                                    self.addr_mgr.add_new_addr(session.id, addr.clone());
+                                    let flags = self.addr_mgr.node_flags(session.id);
+                                    self.addr_mgr
+                                        .add_new_addr(session.id, (addr.clone(), flags));
                                 }
                             }
                             if version >= state::REUSE_PORT_VERSION {
@@ -148,7 +159,8 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                             let items = items
                                 .into_iter()
                                 .map(|addr| Node {
-                                    addresses: vec![addr],
+                                    addresses: vec![addr.0],
+                                    flags: addr.1,
                                 })
                                 .collect::<Vec<_>>();
 
@@ -157,7 +169,7 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                                 items,
                             };
 
-                            let msg = encode(DiscoveryMessage::Nodes(nodes));
+                            let msg = encode(DiscoveryMessage::Nodes(nodes), new_version);
                             if context.send_message(msg).await.is_err() {
                                 debug!("{:?} send discovery msg Nodes fail", session.id)
                             }
@@ -185,7 +197,9 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                                 let addrs = nodes
                                     .items
                                     .into_iter()
-                                    .flat_map(|node| node.addresses.into_iter())
+                                    .flat_map(|node| {
+                                        node.addresses.into_iter().map(move |a| (a, node.flags))
+                                    })
                                     .collect::<Vec<_>>();
 
                                 state.addr_known.extend(addrs.iter());
@@ -226,7 +240,7 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                 .check_timer(now, ANNOUNCE_INTERVAL)
                 .filter(|addr| self.addr_mgr.is_valid_addr(addr))
             {
-                announce_list.push(addr.clone());
+                announce_list.push((addr.clone(), self.addr_mgr.node_flags(*id)));
             }
         }
 
@@ -238,7 +252,7 @@ impl<M: AddressManager + Send + Sync> ServiceProtocol for DiscoveryProtocol<M> {
                 for key in keys.iter().take(3) {
                     if let Some(value) = self.sessions.get_mut(key) {
                         trace!(
-                            ">> send {} to: {:?}, contains: {}",
+                            ">> send {:?} to: {:?}, contains: {}",
                             announce_multiaddr,
                             value.remote_addr,
                             value.addr_known.contains(&announce_multiaddr)
@@ -324,19 +338,19 @@ impl AddressManager for DiscoveryAddressManager {
         }
     }
 
-    fn add_new_addr(&mut self, session_id: SessionId, addr: Multiaddr) {
+    fn add_new_addr(&mut self, session_id: SessionId, addr: (Multiaddr, Flags)) {
         self.add_new_addrs(session_id, vec![addr])
     }
 
-    fn add_new_addrs(&mut self, _session_id: SessionId, addrs: Vec<Multiaddr>) {
+    fn add_new_addrs(&mut self, _session_id: SessionId, addrs: Vec<(Multiaddr, Flags)>) {
         if addrs.is_empty() {
             return;
         }
 
-        for addr in addrs.into_iter().filter(|addr| self.is_valid_addr(addr)) {
+        for (addr, flags) in addrs.into_iter().filter(|addr| self.is_valid_addr(&addr.0)) {
             trace!("Add discovered address:{:?}", addr);
             self.network_state.with_peer_store_mut(|peer_store| {
-                if let Err(err) = peer_store.add_addr(addr.clone(), 0x1) {
+                if let Err(err) = peer_store.add_addr(addr.clone(), flags.bits()) {
                     debug!(
                         "Failed to add discoved address to peer_store {:?} {:?}",
                         err, addr
@@ -356,20 +370,41 @@ impl AddressManager for DiscoveryAddressManager {
         MisbehaveResult::Disconnect
     }
 
-    fn get_random(&mut self, n: usize) -> Vec<Multiaddr> {
-        let fetch_random_addrs = self
-            .network_state
-            .with_peer_store_mut(|peer_store| peer_store.fetch_random_addrs(n, |_| true));
+    fn get_random(&mut self, n: usize, flags: Flags) -> Vec<(Multiaddr, Flags)> {
+        let fetch_random_addrs = self.network_state.with_peer_store_mut(|peer_store| {
+            peer_store.fetch_random_addrs(n, |a| {
+                let f = unsafe { Flags::from_bits_unchecked(a) };
+                f.contains(flags)
+            })
+        });
         let addrs = fetch_random_addrs
             .into_iter()
             .filter_map(|paddr| {
                 if !self.is_valid_addr(&paddr.addr) {
                     return None;
                 }
-                Some(paddr.addr)
+                let f = unsafe { Flags::from_bits_unchecked(paddr.flags) };
+                Some((paddr.addr, f))
             })
             .collect();
         trace!("discovery send random addrs: {:?}", addrs);
         addrs
+    }
+
+    fn required_flags(&self) -> super::identify::Flags {
+        self.network_state.required_flags
+    }
+
+    fn node_flags(&self, id: SessionId) -> Flags {
+        self.network_state.with_peer_registry(|reg| {
+            if let Some(peer) = reg.get_peer(id) {
+                peer.identify_info
+                    .as_ref()
+                    .map(|a| a.flags)
+                    .unwrap_or(Flags::COMPATIBILITY)
+            } else {
+                Flags::COMPATIBILITY
+            }
+        })
     }
 }

--- a/network/src/protocols/discovery/protocol.rs
+++ b/network/src/protocols/discovery/protocol.rs
@@ -118,7 +118,7 @@ impl DiscoveryMessage {
                     let get_nodes2 =
                         packed::GetNodes2::from_compatible_slice(reader.as_slice()).ok()?;
                     let reader = get_nodes2.as_reader();
-                    unsafe { Flags::from_bits_unchecked(reader.required_flags().unpack()) }
+                    Flags::from_bits_truncate(reader.required_flags().unpack())
                 } else {
                     Flags::COMPATIBILITY
                 };
@@ -146,7 +146,7 @@ impl DiscoveryMessage {
                         let node2 =
                             packed::Node2::from_compatible_slice(node_reader.as_slice()).ok()?;
                         let reader = node2.as_reader();
-                        unsafe { Flags::from_bits_unchecked(reader.flags().unpack()) }
+                        Flags::from_bits_truncate(reader.flags().unpack())
                     } else {
                         Flags::COMPATIBILITY
                     };

--- a/network/src/protocols/discovery/protocol.rs
+++ b/network/src/protocols/discovery/protocol.rs
@@ -7,7 +7,7 @@ pub(crate) fn encode(data: DiscoveryMessage) -> Bytes {
 }
 
 pub(crate) fn decode(data: &Bytes) -> Option<DiscoveryMessage> {
-    DiscoveryMessage::decode(data)
+    DiscoveryMessage::decode_v2(data)
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -92,7 +92,7 @@ impl DiscoveryMessage {
             .as_bytes()
     }
 
-    pub fn decode(data: &[u8]) -> Option<Self> {
+    pub fn decode_v2(data: &[u8]) -> Option<Self> {
         let reader = packed::DiscoveryMessageReader::from_compatible_slice(data).ok()?;
         match reader.payload().to_enum() {
             packed::DiscoveryPayloadUnionReader::GetNodes(reader) => {

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -591,24 +591,19 @@ impl Identify {
 }
 
 bitflags::bitflags! {
+    /// Node Function Identification
     pub struct Flags: u64 {
         /// Compatibility reserved
         const COMPATIBILITY = 0b1;
         /// Discovery protocol, which can provide peers data service
         const DISCOVERY = 0b10;
-        /// Sync protocol, can provide Block and Header download service
+        /// Sync protocol can provide Block and Header download service
         const SYNC = 0b100;
         /// Relay protocol, which can provide CompactBlock and Transaction broadcast/forwarding services
         const RELAY = 0b1000;
-        /// Light client protocol, which can provide Block / Transaction data and existence proof services
+        /// Light client protocol, which can provide Block / Transaction data and existence-proof services
         const LIGHT_CLIENT = 0b10000;
-        /// Client side block filter protocol, can provide BlockFilter download service
+        /// Client-side block filter protocol can provide BlockFilter download service
         const BLOCK_FILTER = 0b100000;
-    }
-}
-
-impl Flags {
-    pub fn support_light_client(&self) -> bool {
-        self.contains(Flags::LIGHT_CLIENT) || self.contains(Flags::BLOCK_FILTER)
     }
 }

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -342,9 +342,8 @@ impl IdentifyCallback {
         network_state: Arc<NetworkState>,
         name: String,
         client_version: String,
+        flags: Flags,
     ) -> IdentifyCallback {
-        let flags = Flags::COMPATIBILITY | Flags::DISCOVERY | Flags::RELAY | Flags::SYNC;
-
         IdentifyCallback {
             network_state,
             identify: Identify::new(name, flags, client_version),

--- a/network/src/protocols/support_protocols.rs
+++ b/network/src/protocols/support_protocols.rs
@@ -97,7 +97,7 @@ impl SupportProtocols {
         // Here you have to make sure that the list of supported versions is sorted from smallest to largest
         match self {
             SupportProtocols::Ping => vec![LASTEST_VERSION.to_owned()],
-            SupportProtocols::Discovery => vec![LASTEST_VERSION.to_owned()],
+            SupportProtocols::Discovery => vec![LASTEST_VERSION.to_owned(), "2.1".to_owned()],
             SupportProtocols::Identify => vec![LASTEST_VERSION.to_owned()],
             SupportProtocols::Feeler => vec![LASTEST_VERSION.to_owned()],
             SupportProtocols::DisconnectMessage => {

--- a/network/src/protocols/tests/discovery.rs
+++ b/network/src/protocols/tests/discovery.rs
@@ -1,4 +1,7 @@
-use crate::protocols::discovery::protocol::{decode, encode, DiscoveryMessage};
+use crate::protocols::{
+    discovery::protocol::{decode, encode, DiscoveryMessage},
+    identify::Flags,
+};
 
 #[test]
 fn test_codec() {
@@ -6,21 +9,23 @@ fn test_codec() {
         version: 0,
         count: 1,
         listen_port: Some(1),
+        required_flags: Flags::COMPATIBILITY,
     };
 
     let msg2 = DiscoveryMessage::GetNodes {
         version: 0,
         count: 1,
         listen_port: Some(2),
+        required_flags: Flags::COMPATIBILITY,
     };
 
-    let b1 = encode(msg1.clone());
+    let b1 = encode(msg1.clone(), true);
 
-    let decode1 = decode(&b1).unwrap();
+    let decode1 = decode(&b1, true).unwrap();
     assert_eq!(decode1, msg1);
 
-    let b2 = encode(msg2.clone());
+    let b2 = encode(msg2.clone(), true);
 
-    let decode2 = decode(&b2).unwrap();
+    let decode2 = decode(&b2, true).unwrap();
     assert_eq!(decode2, msg2);
 }

--- a/network/src/protocols/tests/discovery.rs
+++ b/network/src/protocols/tests/discovery.rs
@@ -19,13 +19,13 @@ fn test_codec() {
         required_flags: Flags::COMPATIBILITY,
     };
 
-    let b1 = encode(msg1.clone(), true);
+    let b1 = encode(msg1.clone());
 
-    let decode1 = decode(&b1, true).unwrap();
+    let decode1 = decode(&b1).unwrap();
     assert_eq!(decode1, msg1);
 
-    let b2 = encode(msg2.clone(), true);
+    let b2 = encode(msg2.clone());
 
-    let decode2 = decode(&b2, true).unwrap();
+    let decode2 = decode(&b2).unwrap();
     assert_eq!(decode2, msg2);
 }

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -98,16 +98,12 @@ impl Node {
     }
 }
 
-fn net_service_start<F>(
+fn net_service_start(
     name: String,
     enable_discovery_push: bool,
-    target_flags_filter: F,
     required_flags: Flags,
     self_flags: Flags,
-) -> Node
-where
-    F: Fn(Flags) -> bool + Send + Sync + 'static,
-{
+) -> Node {
     let config = NetworkConfig {
         max_peers: 19,
         max_outbound_peers: 5,
@@ -133,7 +129,6 @@ where
     let network_state = Arc::new(
         NetworkState::from_config(config.clone())
             .expect("Init network state failed")
-            .target_flags_filter(target_flags_filter)
             .required_flags(required_flags),
     );
 
@@ -306,21 +301,18 @@ fn test_identify_behavior() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         false,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/2".to_string(),
         false,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node3 = net_service_start(
         "/test/1".to_string(),
         false,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
@@ -328,11 +320,7 @@ fn test_identify_behavior() {
     let node4 = net_service_start(
         "/test/1".to_string(),
         false,
-        |t| {
-            let target = Flags::SYNC | Flags::RELAY | Flags::DISCOVERY;
-            t.contains(target)
-        },
-        Flags::SYNC | Flags::RELAY | Flags::DISCOVERY,
+        Flags::SYNC | Flags::RELAY | Flags::DISCOVERY | Flags::BLOCK_FILTER,
         Flags::SYNC | Flags::RELAY | Flags::DISCOVERY,
     );
 
@@ -425,14 +413,12 @@ fn test_feeler_behavior() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
@@ -459,30 +445,19 @@ fn test_discovery_behavior() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node3 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
-        Flags::COMPATIBILITY,
-    );
-
-    let node4 = net_service_start(
-        "/test/1".to_string(),
-        true,
-        |_| true,
-        Flags::SYNC,
         Flags::COMPATIBILITY,
     );
 
@@ -539,14 +514,6 @@ fn test_discovery_behavior() {
     wait_connect_state(&node2, 2);
     wait_connect_state(&node3, 2);
 
-    node4.dial(
-        &node2,
-        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
-    );
-
-    wait_connect_state(&node4, 1);
-    wait_discovery(&node4, |num| num >= 2);
-
     thread::sleep(Duration::from_secs(10));
 
     let checker = ProtocolTypeCheckerService::new(
@@ -579,14 +546,12 @@ fn test_dial_all() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
@@ -602,14 +567,12 @@ fn test_ban() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
@@ -653,42 +616,36 @@ fn test_bootnode_mode_inbound_eviction() {
     let node1 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node2 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node3 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node4 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node5 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );
     let node6 = net_service_start(
         "/test/1".to_string(),
         true,
-        |_| true,
         Flags::COMPATIBILITY,
         Flags::COMPATIBILITY,
     );

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -2,7 +2,7 @@ use super::{
     disconnect_message::DisconnectMessageProtocol,
     discovery::{DiscoveryAddressManager, DiscoveryProtocol},
     feeler::Feeler,
-    identify::{IdentifyCallback, IdentifyProtocol},
+    identify::{Flags, IdentifyCallback, IdentifyProtocol},
     ping::PingHandler,
 };
 
@@ -98,7 +98,16 @@ impl Node {
     }
 }
 
-fn net_service_start(name: String, enable_discovery_push: bool) -> Node {
+fn net_service_start<F>(
+    name: String,
+    enable_discovery_push: bool,
+    target_flags_filter: F,
+    required_flags: Flags,
+    self_flags: Flags,
+) -> Node
+where
+    F: Fn(Flags) -> bool + Send + Sync + 'static,
+{
     let config = NetworkConfig {
         max_peers: 19,
         max_outbound_peers: 5,
@@ -121,8 +130,12 @@ fn net_service_start(name: String, enable_discovery_push: bool) -> Node {
         ..Default::default()
     };
 
-    let network_state =
-        Arc::new(NetworkState::from_config(config.clone()).expect("Init network state failed"));
+    let network_state = Arc::new(
+        NetworkState::from_config(config.clone())
+            .expect("Init network state failed")
+            .target_flags_filter(target_flags_filter)
+            .required_flags(required_flags),
+    );
 
     network_state.protocols.write().push((
         SupportProtocols::Ping.protocol_id(),
@@ -172,8 +185,12 @@ fn net_service_start(name: String, enable_discovery_push: bool) -> Node {
     });
 
     // Identify protocol
-    let identify_callback =
-        IdentifyCallback::new(Arc::clone(&network_state), name, "0.1.0".to_string());
+    let identify_callback = IdentifyCallback::new(
+        Arc::clone(&network_state),
+        name,
+        "0.1.0".to_string(),
+        self_flags,
+    );
     let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
         ProtocolHandle::Callback(Box::new(
             IdentifyProtocol::new(identify_callback).global_ip_only(false),
@@ -270,14 +287,15 @@ fn wait_connect_state(node: &Node, expect_num: usize) {
 }
 
 #[allow(clippy::blocks_in_if_conditions)]
-fn wait_discovery(node: &Node) {
+fn wait_discovery(node: &Node, assert: impl Fn(usize) -> bool) {
     if !wait_until(100, || {
-        node.network_state
-            .peer_store
-            .lock()
-            .mut_addr_manager()
-            .count()
-            >= 2
+        assert(
+            node.network_state
+                .peer_store
+                .lock()
+                .mut_addr_manager()
+                .count(),
+        )
     }) {
         panic!("discovery can't find other node")
     }
@@ -285,9 +303,46 @@ fn wait_discovery(node: &Node) {
 
 #[test]
 fn test_identify_behavior() {
-    let node1 = net_service_start("/test/1".to_string(), false);
-    let node2 = net_service_start("/test/2".to_string(), false);
-    let node3 = net_service_start("/test/1".to_string(), false);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        false,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/2".to_string(),
+        false,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node3 = net_service_start(
+        "/test/1".to_string(),
+        false,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+
+    let node4 = net_service_start(
+        "/test/1".to_string(),
+        false,
+        |t| {
+            let target = Flags::SYNC | Flags::RELAY | Flags::DISCOVERY;
+            t.contains(target)
+        },
+        Flags::SYNC | Flags::RELAY | Flags::DISCOVERY,
+        Flags::SYNC | Flags::RELAY | Flags::DISCOVERY,
+    );
+
+    node4.dial(
+        &node1,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+
+    thread::sleep(Duration::from_secs(1));
+    wait_connect_state(&node4, 0);
 
     node1.dial(
         &node3,
@@ -367,8 +422,20 @@ fn test_identify_behavior() {
 
 #[test]
 fn test_feeler_behavior() {
-    let node1 = net_service_start("/test/1".to_string(), true);
-    let node2 = net_service_start("/test/1".to_string(), true);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
 
     node1.dial(
         &node2,
@@ -389,9 +456,35 @@ fn test_feeler_behavior() {
 
 #[test]
 fn test_discovery_behavior() {
-    let node1 = net_service_start("/test/1".to_string(), true);
-    let node2 = net_service_start("/test/1".to_string(), true);
-    let node3 = net_service_start("/test/1".to_string(), true);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node3 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+
+    let node4 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::SYNC,
+        Flags::COMPATIBILITY,
+    );
 
     node1.dial(
         &node2,
@@ -407,7 +500,7 @@ fn test_discovery_behavior() {
 
     wait_connect_state(&node2, 2);
 
-    wait_discovery(&node3);
+    wait_discovery(&node3, |num| num >= 2);
 
     let addrs = {
         let listen_addr = &node3.listen_addr;
@@ -446,6 +539,14 @@ fn test_discovery_behavior() {
     wait_connect_state(&node2, 2);
     wait_connect_state(&node3, 2);
 
+    node4.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+
+    wait_connect_state(&node4, 1);
+    wait_discovery(&node4, |num| num >= 2);
+
     thread::sleep(Duration::from_secs(10));
 
     let checker = ProtocolTypeCheckerService::new(
@@ -475,8 +576,20 @@ fn test_discovery_behavior() {
 
 #[test]
 fn test_dial_all() {
-    let node1 = net_service_start("/test/1".to_string(), true);
-    let node2 = net_service_start("/test/1".to_string(), true);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
 
     node1.dial(&node2, TargetProtocol::All);
 
@@ -486,8 +599,20 @@ fn test_dial_all() {
 
 #[test]
 fn test_ban() {
-    let node1 = net_service_start("/test/1".to_string(), true);
-    let node2 = net_service_start("/test/1".to_string(), true);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
 
     node1.dial(
         &node2,
@@ -525,12 +650,48 @@ fn test_ban() {
 
 #[test]
 fn test_bootnode_mode_inbound_eviction() {
-    let node1 = net_service_start("/test/1".to_string(), true);
-    let node2 = net_service_start("/test/1".to_string(), true);
-    let node3 = net_service_start("/test/1".to_string(), true);
-    let node4 = net_service_start("/test/1".to_string(), true);
-    let node5 = net_service_start("/test/1".to_string(), true);
-    let node6 = net_service_start("/test/1".to_string(), true);
+    let node1 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node3 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node4 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node5 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node6 = net_service_start(
+        "/test/1".to_string(),
+        true,
+        |_| true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
 
     node2.dial(
         &node1,

--- a/network/src/services/dns_seeding/mod.rs
+++ b/network/src/services/dns_seeding/mod.rs
@@ -107,7 +107,7 @@ impl DnsSeedingService {
         debug!("DNS seeding got {} address", addrs.len());
         self.network_state.with_peer_store_mut(|peer_store| {
             for addr in addrs {
-                let _ = peer_store.add_addr(addr);
+                let _ = peer_store.add_addr(addr, 0x0);
             }
         });
         Ok(())

--- a/network/src/services/dns_seeding/mod.rs
+++ b/network/src/services/dns_seeding/mod.rs
@@ -5,6 +5,8 @@ use faster_hex::hex_decode;
 use secp256k1::key::PublicKey;
 use tokio::time::Interval;
 
+use crate::Flags;
+
 mod seed_record;
 
 #[cfg(test)]
@@ -107,7 +109,7 @@ impl DnsSeedingService {
         debug!("DNS seeding got {} address", addrs.len());
         self.network_state.with_peer_store_mut(|peer_store| {
             for addr in addrs {
-                let _ = peer_store.add_addr(addr, 0x0);
+                let _ = peer_store.add_addr(addr, Flags::empty());
             }
         });
         Ok(())

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -1,6 +1,5 @@
 use crate::{
     peer_store::{types::AddrInfo, PeerStore},
-    protocols::identify::Flags,
     NetworkState,
 };
 use ckb_logger::trace;
@@ -80,14 +79,10 @@ impl OutboundPeerService {
         }
         self.try_identify_count += 1;
 
-        let target = &self.network_state.target_flags_filter;
-        let filter = |flags: u64| -> bool {
-            let out = unsafe { Flags::from_bits_unchecked(flags) };
-            target(out)
-        };
+        let target = &self.network_state.required_flags;
 
         let f = |peer_store: &mut PeerStore, number: usize, now_ms: u64| -> Vec<AddrInfo> {
-            let paddrs = peer_store.fetch_addrs_to_attempt(number, filter);
+            let paddrs = peer_store.fetch_addrs_to_attempt(number, *target);
             for paddr in paddrs.iter() {
                 // mark addr as tried
                 if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&paddr.addr) {

--- a/network/src/tests/addr_manager.rs
+++ b/network/src/tests/addr_manager.rs
@@ -18,6 +18,7 @@ proptest! {
                 addr,
                 0,
                 0,
+                0
             )
         }
         let mut addr_manager: AddrManager = Default::default();

--- a/network/src/tests/peer_store_db.rs
+++ b/network/src/tests/peer_store_db.rs
@@ -22,13 +22,13 @@ fn test_peer_store_persistent() {
         let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/42/p2p/{}", PeerId::random().to_base58())
             .parse()
             .unwrap();
-        AddrInfo::new(addr, 0, 60)
+        AddrInfo::new(addr, 0, 60, 0)
     };
     let addr2 = {
         let addr: Multiaddr = format!("/ip4/127.0.0.5/tcp/42/p2p/{}", PeerId::random().to_base58())
             .parse()
             .unwrap();
-        let mut addr_info = AddrInfo::new(addr, 100, 30);
+        let mut addr_info = AddrInfo::new(addr, 100, 30, 0);
         addr_info.mark_tried(now_ms);
         addr_info
     };
@@ -169,7 +169,7 @@ fn test_peer_store_dump_with_broken_tmp_file_should_be_ok() {
         )
         .parse()
         .unwrap();
-        addr_manager.add(AddrInfo::new(addr, 0, 60));
+        addr_manager.add(AddrInfo::new(addr, 0, 60, 0));
     }
     let ban_list = peer_store.mut_ban_list();
     let now_ms = faketime::unix_time_as_millis();

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -9,7 +9,7 @@ use ckb_chain::chain::ChainService;
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_launcher::SharedBuilder;
-use ckb_network::{DefaultExitHandler, NetworkService, NetworkState};
+use ckb_network::{DefaultExitHandler, Flags, NetworkService, NetworkState};
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_notify::NotifyService;
 use ckb_sync::SyncShared;
@@ -132,8 +132,11 @@ fn setup_rpc_test_suite(height: u64) -> RpcTestSuite {
             Arc::clone(&network_state),
             Vec::new(),
             Vec::new(),
-            shared.consensus().identify_name(),
-            "0.1.0".to_string(),
+            (
+                shared.consensus().identify_name(),
+                "0.1.0".to_string(),
+                Flags::COMPATIBILITY,
+            ),
             DefaultExitHandler::default(),
         )
         .start(shared.async_handle())

--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -4,7 +4,7 @@ use ckb_chain::chain::{ChainController, ChainService};
 use ckb_dao::DaoCalculator;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_launcher::SharedBuilder;
-use ckb_network::{DefaultExitHandler, NetworkService, NetworkState};
+use ckb_network::{DefaultExitHandler, Flags, NetworkService, NetworkState};
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::{Shared, Snapshot};
 use ckb_store::ChainStore;
@@ -243,8 +243,11 @@ fn setup() -> RpcTestSuite {
             Arc::clone(&network_state),
             Vec::new(),
             Vec::new(),
-            shared.consensus().identify_name(),
-            "0.1.0".to_string(),
+            (
+                shared.consensus().identify_name(),
+                "0.1.0".to_string(),
+                Flags::COMPATIBILITY,
+            ),
             DefaultExitHandler::default(),
         )
         .start(shared.async_handle())

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -5,7 +5,7 @@ use ckb_chain_spec::consensus::{build_genesis_epoch_ext, ConsensusBuilder};
 use ckb_launcher::SharedBuilder;
 use ckb_network::{
     async_trait, bytes::Bytes as P2pBytes, Behaviour, CKBProtocolContext, DefaultExitHandler,
-    Error, NetworkController, NetworkService, NetworkState, Peer, PeerIndex, ProtocolId,
+    Error, Flags, NetworkController, NetworkService, NetworkState, Peer, PeerIndex, ProtocolId,
     SupportProtocols, TargetSession,
 };
 use ckb_shared::Shared;
@@ -117,8 +117,11 @@ pub(crate) fn dummy_network(shared: &Shared) -> NetworkController {
         network_state,
         vec![],
         vec![],
-        shared.consensus().identify_name(),
-        "test".to_string(),
+        (
+            shared.consensus().identify_name(),
+            "test".to_string(),
+            Flags::COMPATIBILITY,
+        ),
         DefaultExitHandler::default(),
     )
     .start(shared.async_handle())

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -7,7 +7,7 @@ use ckb_channel::{self as channel, unbounded, Receiver, RecvTimeoutError, Sender
 use ckb_logger::info;
 use ckb_network::{
     async_trait, bytes::Bytes, extract_peer_id, CKBProtocol, CKBProtocolContext,
-    CKBProtocolHandler, DefaultExitHandler, NetworkController, NetworkService, NetworkState,
+    CKBProtocolHandler, DefaultExitHandler, Flags, NetworkController, NetworkService, NetworkState,
     PeerIndex, ProtocolId, SupportProtocols,
 };
 use ckb_util::Mutex;
@@ -68,8 +68,11 @@ impl Net {
             Arc::clone(&network_state),
             ckb_protocols,
             Vec::new(),
-            consensus.identify_name(),
-            "0.1.0".to_string(),
+            (
+                consensus.identify_name(),
+                "0.1.0".to_string(),
+                Flags::COMPATIBILITY,
+            ),
             DefaultExitHandler::default(),
         )
         .start(&async_handle)

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -20,7 +20,7 @@ use ckb_jsonrpc_types::ScriptHashType;
 use ckb_light_client_protocol_server::LightClientProtocol;
 use ckb_logger::info;
 use ckb_network::{
-    observe_listen_port_occupancy, CKBProtocol, DefaultExitHandler, NetworkController,
+    observe_listen_port_occupancy, CKBProtocol, DefaultExitHandler, Flags, NetworkController,
     NetworkService, NetworkState, SupportProtocols,
 };
 use ckb_network_alert::alert_relayer::AlertRelayer;
@@ -329,8 +329,11 @@ impl Launcher {
             Arc::clone(&network_state),
             protocols,
             required_protocol_ids,
-            shared.consensus().identify_name(),
-            self.version.to_string(),
+            (
+                shared.consensus().identify_name(),
+                self.version.to_string(),
+                Flags::all(),
+            ),
             exit_handler.clone(),
         )
         .start(shared.async_handle())

--- a/util/types/schemas/protocols.mol
+++ b/util/types/schemas/protocols.mol
@@ -28,8 +28,6 @@ option PortOpt (Uint16);
 union DiscoveryPayload {
     GetNodes,
     Nodes,
-    GetNodes2,
-    Nodes2,
 }
 
 table DiscoveryMessage {

--- a/util/types/schemas/protocols.mol
+++ b/util/types/schemas/protocols.mol
@@ -20,6 +20,7 @@ table Pong {
 }
 
 vector NodeVec <Node>;
+vector Node2Vec <Node2>;
 array Uint16 [byte; 2];
 option PortOpt (Uint16);
 
@@ -27,6 +28,8 @@ option PortOpt (Uint16);
 union DiscoveryPayload {
     GetNodes,
     Nodes,
+    GetNodes2,
+    Nodes2,
 }
 
 table DiscoveryMessage {
@@ -39,13 +42,30 @@ table GetNodes {
     listen_port: PortOpt,
 }
 
+table GetNodes2 {
+    version: Uint32,
+    count: Uint32,
+    listen_port: PortOpt,
+    required_flags: Uint64,
+}
+
 table Nodes {
     announce: Bool,
     items: NodeVec,
 }
 
+table Nodes2 {
+    announce: Bool,
+    items: Node2Vec,
+}
+
 table Node {
     addresses: BytesVec,
+}
+
+table Node2 {
+    addresses: BytesVec,
+    flags: Uint64,
 }
 
 // identify 0.0.1

--- a/util/types/src/generated/protocols.rs
+++ b/util/types/src/generated/protocols.rs
@@ -1344,6 +1344,345 @@ impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for NodeVecReaderIterator<'t, '
     }
 }
 #[derive(Clone)]
+pub struct Node2Vec(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Node2Vec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Node2Vec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Node2Vec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl ::core::default::Default for Node2Vec {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        Node2Vec::new_unchecked(v.into())
+    }
+}
+impl Node2Vec {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<Node2> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> Node2 {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            Node2::new_unchecked(self.0.slice(start..))
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            Node2::new_unchecked(self.0.slice(start..end))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> Node2VecReader<'r> {
+        Node2VecReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Node2Vec {
+    type Builder = Node2VecBuilder;
+    const NAME: &'static str = "Node2Vec";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Node2Vec(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Node2VecReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Node2VecReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().extend(self.into_iter())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Node2VecReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for Node2VecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for Node2VecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for Node2VecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl<'r> Node2VecReader<'r> {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<Node2Reader<'r>> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> Node2Reader<'r> {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            Node2Reader::new_unchecked(&self.as_slice()[start..])
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            Node2Reader::new_unchecked(&self.as_slice()[start..end])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Node2VecReader<'r> {
+    type Entity = Node2Vec;
+    const NAME: &'static str = "Node2VecReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Node2VecReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(
+                Self,
+                TotalSizeNotMatch,
+                molecule::NUMBER_SIZE * 2,
+                slice_len
+            );
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        for pair in offsets.windows(2) {
+            let start = pair[0];
+            let end = pair[1];
+            Node2Reader::verify(&slice[start..end], compatible)?;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct Node2VecBuilder(pub(crate) Vec<Node2>);
+impl Node2VecBuilder {
+    pub fn set(mut self, v: Vec<Node2>) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn push(mut self, v: Node2) -> Self {
+        self.0.push(v);
+        self
+    }
+    pub fn extend<T: ::core::iter::IntoIterator<Item = Node2>>(mut self, iter: T) -> Self {
+        for elem in iter {
+            self.0.push(elem);
+        }
+        self
+    }
+    pub fn replace(&mut self, index: usize, v: Node2) -> Option<Node2> {
+        self.0
+            .get_mut(index)
+            .map(|item| ::core::mem::replace(item, v))
+    }
+}
+impl molecule::prelude::Builder for Node2VecBuilder {
+    type Entity = Node2Vec;
+    const NAME: &'static str = "Node2VecBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (self.0.len() + 1)
+            + self
+                .0
+                .iter()
+                .map(|inner| inner.as_slice().len())
+                .sum::<usize>()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let item_count = self.0.len();
+        if item_count == 0 {
+            writer.write_all(&molecule::pack_number(
+                molecule::NUMBER_SIZE as molecule::Number,
+            ))?;
+        } else {
+            let (total_size, offsets) = self.0.iter().fold(
+                (
+                    molecule::NUMBER_SIZE * (item_count + 1),
+                    Vec::with_capacity(item_count),
+                ),
+                |(start, mut offsets), inner| {
+                    offsets.push(start);
+                    (start + inner.as_slice().len(), offsets)
+                },
+            );
+            writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+            for offset in offsets.into_iter() {
+                writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+            }
+            for inner in self.0.iter() {
+                writer.write_all(inner.as_slice())?;
+            }
+        }
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Node2Vec::new_unchecked(inner.into())
+    }
+}
+pub struct Node2VecIterator(Node2Vec, usize, usize);
+impl ::core::iter::Iterator for Node2VecIterator {
+    type Item = Node2;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl ::core::iter::ExactSizeIterator for Node2VecIterator {
+    fn len(&self) -> usize {
+        self.2 - self.1
+    }
+}
+impl ::core::iter::IntoIterator for Node2Vec {
+    type Item = Node2;
+    type IntoIter = Node2VecIterator;
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        Node2VecIterator(self, 0, len)
+    }
+}
+impl<'r> Node2VecReader<'r> {
+    pub fn iter<'t>(&'t self) -> Node2VecReaderIterator<'t, 'r> {
+        Node2VecReaderIterator(&self, 0, self.len())
+    }
+}
+pub struct Node2VecReaderIterator<'t, 'r>(&'t Node2VecReader<'r>, usize, usize);
+impl<'t: 'r, 'r> ::core::iter::Iterator for Node2VecReaderIterator<'t, 'r> {
+    type Item = Node2Reader<'t>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for Node2VecReaderIterator<'t, 'r> {
+    fn len(&self) -> usize {
+        self.2 - self.1
+    }
+}
+#[derive(Clone)]
 pub struct Uint16(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for Uint16 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -1713,7 +2052,7 @@ impl ::core::default::Default for DiscoveryPayload {
     }
 }
 impl DiscoveryPayload {
-    pub const ITEMS_COUNT: usize = 2;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -1722,6 +2061,8 @@ impl DiscoveryPayload {
         match self.item_id() {
             0 => GetNodes::new_unchecked(inner).into(),
             1 => Nodes::new_unchecked(inner).into(),
+            2 => GetNodes2::new_unchecked(inner).into(),
+            3 => Nodes2::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -1778,7 +2119,7 @@ impl<'r> ::core::fmt::Display for DiscoveryPayloadReader<'r> {
     }
 }
 impl<'r> DiscoveryPayloadReader<'r> {
-    pub const ITEMS_COUNT: usize = 2;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -1787,6 +2128,8 @@ impl<'r> DiscoveryPayloadReader<'r> {
         match self.item_id() {
             0 => GetNodesReader::new_unchecked(inner).into(),
             1 => NodesReader::new_unchecked(inner).into(),
+            2 => GetNodes2Reader::new_unchecked(inner).into(),
+            3 => Nodes2Reader::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -1814,6 +2157,8 @@ impl<'r> molecule::prelude::Reader<'r> for DiscoveryPayloadReader<'r> {
         match item_id {
             0 => GetNodesReader::verify(inner_slice, compatible),
             1 => NodesReader::verify(inner_slice, compatible),
+            2 => GetNodes2Reader::verify(inner_slice, compatible),
+            3 => Nodes2Reader::verify(inner_slice, compatible),
             _ => ve!(Self, UnknownItem, Self::ITEMS_COUNT, item_id),
         }?;
         Ok(())
@@ -1822,7 +2167,7 @@ impl<'r> molecule::prelude::Reader<'r> for DiscoveryPayloadReader<'r> {
 #[derive(Debug, Default)]
 pub struct DiscoveryPayloadBuilder(pub(crate) DiscoveryPayloadUnion);
 impl DiscoveryPayloadBuilder {
-    pub const ITEMS_COUNT: usize = 2;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn set<I>(mut self, v: I) -> Self
     where
         I: ::core::convert::Into<DiscoveryPayloadUnion>,
@@ -1852,11 +2197,15 @@ impl molecule::prelude::Builder for DiscoveryPayloadBuilder {
 pub enum DiscoveryPayloadUnion {
     GetNodes(GetNodes),
     Nodes(Nodes),
+    GetNodes2(GetNodes2),
+    Nodes2(Nodes2),
 }
 #[derive(Debug, Clone, Copy)]
 pub enum DiscoveryPayloadUnionReader<'r> {
     GetNodes(GetNodesReader<'r>),
     Nodes(NodesReader<'r>),
+    GetNodes2(GetNodes2Reader<'r>),
+    Nodes2(Nodes2Reader<'r>),
 }
 impl ::core::default::Default for DiscoveryPayloadUnion {
     fn default() -> Self {
@@ -1872,6 +2221,12 @@ impl ::core::fmt::Display for DiscoveryPayloadUnion {
             DiscoveryPayloadUnion::Nodes(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, Nodes::NAME, item)
             }
+            DiscoveryPayloadUnion::GetNodes2(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, GetNodes2::NAME, item)
+            }
+            DiscoveryPayloadUnion::Nodes2(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, Nodes2::NAME, item)
+            }
         }
     }
 }
@@ -1884,6 +2239,12 @@ impl<'r> ::core::fmt::Display for DiscoveryPayloadUnionReader<'r> {
             DiscoveryPayloadUnionReader::Nodes(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, Nodes::NAME, item)
             }
+            DiscoveryPayloadUnionReader::GetNodes2(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, GetNodes2::NAME, item)
+            }
+            DiscoveryPayloadUnionReader::Nodes2(ref item) => {
+                write!(f, "{}::{}({})", Self::NAME, Nodes2::NAME, item)
+            }
         }
     }
 }
@@ -1892,6 +2253,8 @@ impl DiscoveryPayloadUnion {
         match self {
             DiscoveryPayloadUnion::GetNodes(ref item) => write!(f, "{}", item),
             DiscoveryPayloadUnion::Nodes(ref item) => write!(f, "{}", item),
+            DiscoveryPayloadUnion::GetNodes2(ref item) => write!(f, "{}", item),
+            DiscoveryPayloadUnion::Nodes2(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -1900,6 +2263,8 @@ impl<'r> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(ref item) => write!(f, "{}", item),
             DiscoveryPayloadUnionReader::Nodes(ref item) => write!(f, "{}", item),
+            DiscoveryPayloadUnionReader::GetNodes2(ref item) => write!(f, "{}", item),
+            DiscoveryPayloadUnionReader::Nodes2(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -1913,6 +2278,16 @@ impl ::core::convert::From<Nodes> for DiscoveryPayloadUnion {
         DiscoveryPayloadUnion::Nodes(item)
     }
 }
+impl ::core::convert::From<GetNodes2> for DiscoveryPayloadUnion {
+    fn from(item: GetNodes2) -> Self {
+        DiscoveryPayloadUnion::GetNodes2(item)
+    }
+}
+impl ::core::convert::From<Nodes2> for DiscoveryPayloadUnion {
+    fn from(item: Nodes2) -> Self {
+        DiscoveryPayloadUnion::Nodes2(item)
+    }
+}
 impl<'r> ::core::convert::From<GetNodesReader<'r>> for DiscoveryPayloadUnionReader<'r> {
     fn from(item: GetNodesReader<'r>) -> Self {
         DiscoveryPayloadUnionReader::GetNodes(item)
@@ -1923,36 +2298,56 @@ impl<'r> ::core::convert::From<NodesReader<'r>> for DiscoveryPayloadUnionReader<
         DiscoveryPayloadUnionReader::Nodes(item)
     }
 }
+impl<'r> ::core::convert::From<GetNodes2Reader<'r>> for DiscoveryPayloadUnionReader<'r> {
+    fn from(item: GetNodes2Reader<'r>) -> Self {
+        DiscoveryPayloadUnionReader::GetNodes2(item)
+    }
+}
+impl<'r> ::core::convert::From<Nodes2Reader<'r>> for DiscoveryPayloadUnionReader<'r> {
+    fn from(item: Nodes2Reader<'r>) -> Self {
+        DiscoveryPayloadUnionReader::Nodes2(item)
+    }
+}
 impl DiscoveryPayloadUnion {
     pub const NAME: &'static str = "DiscoveryPayloadUnion";
     pub fn as_bytes(&self) -> molecule::bytes::Bytes {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_bytes(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_bytes(),
+            DiscoveryPayloadUnion::GetNodes2(item) => item.as_bytes(),
+            DiscoveryPayloadUnion::Nodes2(item) => item.as_bytes(),
         }
     }
     pub fn as_slice(&self) -> &[u8] {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_slice(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_slice(),
+            DiscoveryPayloadUnion::GetNodes2(item) => item.as_slice(),
+            DiscoveryPayloadUnion::Nodes2(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
         match self {
             DiscoveryPayloadUnion::GetNodes(_) => 0,
             DiscoveryPayloadUnion::Nodes(_) => 1,
+            DiscoveryPayloadUnion::GetNodes2(_) => 2,
+            DiscoveryPayloadUnion::Nodes2(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
         match self {
             DiscoveryPayloadUnion::GetNodes(_) => "GetNodes",
             DiscoveryPayloadUnion::Nodes(_) => "Nodes",
+            DiscoveryPayloadUnion::GetNodes2(_) => "GetNodes2",
+            DiscoveryPayloadUnion::Nodes2(_) => "Nodes2",
         }
     }
     pub fn as_reader<'r>(&'r self) -> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_reader().into(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_reader().into(),
+            DiscoveryPayloadUnion::GetNodes2(item) => item.as_reader().into(),
+            DiscoveryPayloadUnion::Nodes2(item) => item.as_reader().into(),
         }
     }
 }
@@ -1962,18 +2357,24 @@ impl<'r> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(item) => item.as_slice(),
             DiscoveryPayloadUnionReader::Nodes(item) => item.as_slice(),
+            DiscoveryPayloadUnionReader::GetNodes2(item) => item.as_slice(),
+            DiscoveryPayloadUnionReader::Nodes2(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(_) => 0,
             DiscoveryPayloadUnionReader::Nodes(_) => 1,
+            DiscoveryPayloadUnionReader::GetNodes2(_) => 2,
+            DiscoveryPayloadUnionReader::Nodes2(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(_) => "GetNodes",
             DiscoveryPayloadUnionReader::Nodes(_) => "Nodes",
+            DiscoveryPayloadUnionReader::GetNodes2(_) => "GetNodes2",
+            DiscoveryPayloadUnionReader::Nodes2(_) => "Nodes2",
         }
     }
 }
@@ -2505,6 +2906,321 @@ impl molecule::prelude::Builder for GetNodesBuilder {
     }
 }
 #[derive(Clone)]
+pub struct GetNodes2(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for GetNodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for GetNodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for GetNodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "version", self.version())?;
+        write!(f, ", {}: {}", "count", self.count())?;
+        write!(f, ", {}: {}", "listen_port", self.listen_port())?;
+        write!(f, ", {}: {}", "required_flags", self.required_flags())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for GetNodes2 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            36, 0, 0, 0, 20, 0, 0, 0, 24, 0, 0, 0, 28, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        GetNodes2::new_unchecked(v.into())
+    }
+}
+impl GetNodes2 {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn version(&self) -> Uint32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn count(&self) -> Uint32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Uint32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn listen_port(&self) -> PortOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        PortOpt::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn required_flags(&self) -> Uint64 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            Uint64::new_unchecked(self.0.slice(start..end))
+        } else {
+            Uint64::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> GetNodes2Reader<'r> {
+        GetNodes2Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for GetNodes2 {
+    type Builder = GetNodes2Builder;
+    const NAME: &'static str = "GetNodes2";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        GetNodes2(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        GetNodes2Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        GetNodes2Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .version(self.version())
+            .count(self.count())
+            .listen_port(self.listen_port())
+            .required_flags(self.required_flags())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct GetNodes2Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for GetNodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for GetNodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for GetNodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "version", self.version())?;
+        write!(f, ", {}: {}", "count", self.count())?;
+        write!(f, ", {}: {}", "listen_port", self.listen_port())?;
+        write!(f, ", {}: {}", "required_flags", self.required_flags())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> GetNodes2Reader<'r> {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn version(&self) -> Uint32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn count(&self) -> Uint32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Uint32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn listen_port(&self) -> PortOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        PortOptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn required_flags(&self) -> Uint64Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Uint64Reader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for GetNodes2Reader<'r> {
+    type Entity = GetNodes2;
+    const NAME: &'static str = "GetNodes2Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        GetNodes2Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Uint32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Uint32Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        PortOptReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Uint64Reader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct GetNodes2Builder {
+    pub(crate) version: Uint32,
+    pub(crate) count: Uint32,
+    pub(crate) listen_port: PortOpt,
+    pub(crate) required_flags: Uint64,
+}
+impl GetNodes2Builder {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn version(mut self, v: Uint32) -> Self {
+        self.version = v;
+        self
+    }
+    pub fn count(mut self, v: Uint32) -> Self {
+        self.count = v;
+        self
+    }
+    pub fn listen_port(mut self, v: PortOpt) -> Self {
+        self.listen_port = v;
+        self
+    }
+    pub fn required_flags(mut self, v: Uint64) -> Self {
+        self.required_flags = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for GetNodes2Builder {
+    type Entity = GetNodes2;
+    const NAME: &'static str = "GetNodes2Builder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.version.as_slice().len()
+            + self.count.as_slice().len()
+            + self.listen_port.as_slice().len()
+            + self.required_flags.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.version.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.count.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.listen_port.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.required_flags.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.version.as_slice())?;
+        writer.write_all(self.count.as_slice())?;
+        writer.write_all(self.listen_port.as_slice())?;
+        writer.write_all(self.required_flags.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        GetNodes2::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct Nodes(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for Nodes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -2767,6 +3483,268 @@ impl molecule::prelude::Builder for NodesBuilder {
     }
 }
 #[derive(Clone)]
+pub struct Nodes2(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Nodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Nodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Nodes2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "announce", self.announce())?;
+        write!(f, ", {}: {}", "items", self.items())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for Nodes2 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![17, 0, 0, 0, 12, 0, 0, 0, 13, 0, 0, 0, 0, 4, 0, 0, 0];
+        Nodes2::new_unchecked(v.into())
+    }
+}
+impl Nodes2 {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn announce(&self) -> Bool {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Bool::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn items(&self) -> Node2Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Node2Vec::new_unchecked(self.0.slice(start..end))
+        } else {
+            Node2Vec::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> Nodes2Reader<'r> {
+        Nodes2Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Nodes2 {
+    type Builder = Nodes2Builder;
+    const NAME: &'static str = "Nodes2";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Nodes2(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Nodes2Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Nodes2Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .announce(self.announce())
+            .items(self.items())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Nodes2Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for Nodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for Nodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for Nodes2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "announce", self.announce())?;
+        write!(f, ", {}: {}", "items", self.items())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> Nodes2Reader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn announce(&self) -> BoolReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        BoolReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn items(&self) -> Node2VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Node2VecReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Node2VecReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Nodes2Reader<'r> {
+    type Entity = Nodes2;
+    const NAME: &'static str = "Nodes2Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Nodes2Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        BoolReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Node2VecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct Nodes2Builder {
+    pub(crate) announce: Bool,
+    pub(crate) items: Node2Vec,
+}
+impl Nodes2Builder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn announce(mut self, v: Bool) -> Self {
+        self.announce = v;
+        self
+    }
+    pub fn items(mut self, v: Node2Vec) -> Self {
+        self.items = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Nodes2Builder {
+    type Entity = Nodes2;
+    const NAME: &'static str = "Nodes2Builder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.announce.as_slice().len()
+            + self.items.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.announce.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.items.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.announce.as_slice())?;
+        writer.write_all(self.items.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Nodes2::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct Node(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for Node {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -2999,6 +3977,270 @@ impl molecule::prelude::Builder for NodeBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         Node::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct Node2(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Node2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Node2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Node2 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "addresses", self.addresses())?;
+        write!(f, ", {}: {}", "flags", self.flags())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for Node2 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            24, 0, 0, 0, 12, 0, 0, 0, 16, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        Node2::new_unchecked(v.into())
+    }
+}
+impl Node2 {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn addresses(&self) -> BytesVec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        BytesVec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn flags(&self) -> Uint64 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Uint64::new_unchecked(self.0.slice(start..end))
+        } else {
+            Uint64::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> Node2Reader<'r> {
+        Node2Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Node2 {
+    type Builder = Node2Builder;
+    const NAME: &'static str = "Node2";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Node2(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Node2Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Node2Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .addresses(self.addresses())
+            .flags(self.flags())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Node2Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for Node2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for Node2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for Node2Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "addresses", self.addresses())?;
+        write!(f, ", {}: {}", "flags", self.flags())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> Node2Reader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn addresses(&self) -> BytesVecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        BytesVecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn flags(&self) -> Uint64Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Uint64Reader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Node2Reader<'r> {
+    type Entity = Node2;
+    const NAME: &'static str = "Node2Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Node2Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        BytesVecReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Uint64Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct Node2Builder {
+    pub(crate) addresses: BytesVec,
+    pub(crate) flags: Uint64,
+}
+impl Node2Builder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn addresses(mut self, v: BytesVec) -> Self {
+        self.addresses = v;
+        self
+    }
+    pub fn flags(mut self, v: Uint64) -> Self {
+        self.flags = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Node2Builder {
+    type Entity = Node2;
+    const NAME: &'static str = "Node2Builder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.addresses.as_slice().len()
+            + self.flags.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.addresses.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.flags.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.addresses.as_slice())?;
+        writer.write_all(self.flags.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Node2::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/util/types/src/generated/protocols.rs
+++ b/util/types/src/generated/protocols.rs
@@ -2052,7 +2052,7 @@ impl ::core::default::Default for DiscoveryPayload {
     }
 }
 impl DiscoveryPayload {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 2;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -2061,8 +2061,6 @@ impl DiscoveryPayload {
         match self.item_id() {
             0 => GetNodes::new_unchecked(inner).into(),
             1 => Nodes::new_unchecked(inner).into(),
-            2 => GetNodes2::new_unchecked(inner).into(),
-            3 => Nodes2::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -2119,7 +2117,7 @@ impl<'r> ::core::fmt::Display for DiscoveryPayloadReader<'r> {
     }
 }
 impl<'r> DiscoveryPayloadReader<'r> {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 2;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -2128,8 +2126,6 @@ impl<'r> DiscoveryPayloadReader<'r> {
         match self.item_id() {
             0 => GetNodesReader::new_unchecked(inner).into(),
             1 => NodesReader::new_unchecked(inner).into(),
-            2 => GetNodes2Reader::new_unchecked(inner).into(),
-            3 => Nodes2Reader::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -2157,8 +2153,6 @@ impl<'r> molecule::prelude::Reader<'r> for DiscoveryPayloadReader<'r> {
         match item_id {
             0 => GetNodesReader::verify(inner_slice, compatible),
             1 => NodesReader::verify(inner_slice, compatible),
-            2 => GetNodes2Reader::verify(inner_slice, compatible),
-            3 => Nodes2Reader::verify(inner_slice, compatible),
             _ => ve!(Self, UnknownItem, Self::ITEMS_COUNT, item_id),
         }?;
         Ok(())
@@ -2167,7 +2161,7 @@ impl<'r> molecule::prelude::Reader<'r> for DiscoveryPayloadReader<'r> {
 #[derive(Debug, Default)]
 pub struct DiscoveryPayloadBuilder(pub(crate) DiscoveryPayloadUnion);
 impl DiscoveryPayloadBuilder {
-    pub const ITEMS_COUNT: usize = 4;
+    pub const ITEMS_COUNT: usize = 2;
     pub fn set<I>(mut self, v: I) -> Self
     where
         I: ::core::convert::Into<DiscoveryPayloadUnion>,
@@ -2197,15 +2191,11 @@ impl molecule::prelude::Builder for DiscoveryPayloadBuilder {
 pub enum DiscoveryPayloadUnion {
     GetNodes(GetNodes),
     Nodes(Nodes),
-    GetNodes2(GetNodes2),
-    Nodes2(Nodes2),
 }
 #[derive(Debug, Clone, Copy)]
 pub enum DiscoveryPayloadUnionReader<'r> {
     GetNodes(GetNodesReader<'r>),
     Nodes(NodesReader<'r>),
-    GetNodes2(GetNodes2Reader<'r>),
-    Nodes2(Nodes2Reader<'r>),
 }
 impl ::core::default::Default for DiscoveryPayloadUnion {
     fn default() -> Self {
@@ -2221,12 +2211,6 @@ impl ::core::fmt::Display for DiscoveryPayloadUnion {
             DiscoveryPayloadUnion::Nodes(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, Nodes::NAME, item)
             }
-            DiscoveryPayloadUnion::GetNodes2(ref item) => {
-                write!(f, "{}::{}({})", Self::NAME, GetNodes2::NAME, item)
-            }
-            DiscoveryPayloadUnion::Nodes2(ref item) => {
-                write!(f, "{}::{}({})", Self::NAME, Nodes2::NAME, item)
-            }
         }
     }
 }
@@ -2239,12 +2223,6 @@ impl<'r> ::core::fmt::Display for DiscoveryPayloadUnionReader<'r> {
             DiscoveryPayloadUnionReader::Nodes(ref item) => {
                 write!(f, "{}::{}({})", Self::NAME, Nodes::NAME, item)
             }
-            DiscoveryPayloadUnionReader::GetNodes2(ref item) => {
-                write!(f, "{}::{}({})", Self::NAME, GetNodes2::NAME, item)
-            }
-            DiscoveryPayloadUnionReader::Nodes2(ref item) => {
-                write!(f, "{}::{}({})", Self::NAME, Nodes2::NAME, item)
-            }
         }
     }
 }
@@ -2253,8 +2231,6 @@ impl DiscoveryPayloadUnion {
         match self {
             DiscoveryPayloadUnion::GetNodes(ref item) => write!(f, "{}", item),
             DiscoveryPayloadUnion::Nodes(ref item) => write!(f, "{}", item),
-            DiscoveryPayloadUnion::GetNodes2(ref item) => write!(f, "{}", item),
-            DiscoveryPayloadUnion::Nodes2(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -2263,8 +2239,6 @@ impl<'r> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(ref item) => write!(f, "{}", item),
             DiscoveryPayloadUnionReader::Nodes(ref item) => write!(f, "{}", item),
-            DiscoveryPayloadUnionReader::GetNodes2(ref item) => write!(f, "{}", item),
-            DiscoveryPayloadUnionReader::Nodes2(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -2278,16 +2252,6 @@ impl ::core::convert::From<Nodes> for DiscoveryPayloadUnion {
         DiscoveryPayloadUnion::Nodes(item)
     }
 }
-impl ::core::convert::From<GetNodes2> for DiscoveryPayloadUnion {
-    fn from(item: GetNodes2) -> Self {
-        DiscoveryPayloadUnion::GetNodes2(item)
-    }
-}
-impl ::core::convert::From<Nodes2> for DiscoveryPayloadUnion {
-    fn from(item: Nodes2) -> Self {
-        DiscoveryPayloadUnion::Nodes2(item)
-    }
-}
 impl<'r> ::core::convert::From<GetNodesReader<'r>> for DiscoveryPayloadUnionReader<'r> {
     fn from(item: GetNodesReader<'r>) -> Self {
         DiscoveryPayloadUnionReader::GetNodes(item)
@@ -2298,56 +2262,36 @@ impl<'r> ::core::convert::From<NodesReader<'r>> for DiscoveryPayloadUnionReader<
         DiscoveryPayloadUnionReader::Nodes(item)
     }
 }
-impl<'r> ::core::convert::From<GetNodes2Reader<'r>> for DiscoveryPayloadUnionReader<'r> {
-    fn from(item: GetNodes2Reader<'r>) -> Self {
-        DiscoveryPayloadUnionReader::GetNodes2(item)
-    }
-}
-impl<'r> ::core::convert::From<Nodes2Reader<'r>> for DiscoveryPayloadUnionReader<'r> {
-    fn from(item: Nodes2Reader<'r>) -> Self {
-        DiscoveryPayloadUnionReader::Nodes2(item)
-    }
-}
 impl DiscoveryPayloadUnion {
     pub const NAME: &'static str = "DiscoveryPayloadUnion";
     pub fn as_bytes(&self) -> molecule::bytes::Bytes {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_bytes(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_bytes(),
-            DiscoveryPayloadUnion::GetNodes2(item) => item.as_bytes(),
-            DiscoveryPayloadUnion::Nodes2(item) => item.as_bytes(),
         }
     }
     pub fn as_slice(&self) -> &[u8] {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_slice(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_slice(),
-            DiscoveryPayloadUnion::GetNodes2(item) => item.as_slice(),
-            DiscoveryPayloadUnion::Nodes2(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
         match self {
             DiscoveryPayloadUnion::GetNodes(_) => 0,
             DiscoveryPayloadUnion::Nodes(_) => 1,
-            DiscoveryPayloadUnion::GetNodes2(_) => 2,
-            DiscoveryPayloadUnion::Nodes2(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
         match self {
             DiscoveryPayloadUnion::GetNodes(_) => "GetNodes",
             DiscoveryPayloadUnion::Nodes(_) => "Nodes",
-            DiscoveryPayloadUnion::GetNodes2(_) => "GetNodes2",
-            DiscoveryPayloadUnion::Nodes2(_) => "Nodes2",
         }
     }
     pub fn as_reader<'r>(&'r self) -> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnion::GetNodes(item) => item.as_reader().into(),
             DiscoveryPayloadUnion::Nodes(item) => item.as_reader().into(),
-            DiscoveryPayloadUnion::GetNodes2(item) => item.as_reader().into(),
-            DiscoveryPayloadUnion::Nodes2(item) => item.as_reader().into(),
         }
     }
 }
@@ -2357,24 +2301,18 @@ impl<'r> DiscoveryPayloadUnionReader<'r> {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(item) => item.as_slice(),
             DiscoveryPayloadUnionReader::Nodes(item) => item.as_slice(),
-            DiscoveryPayloadUnionReader::GetNodes2(item) => item.as_slice(),
-            DiscoveryPayloadUnionReader::Nodes2(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(_) => 0,
             DiscoveryPayloadUnionReader::Nodes(_) => 1,
-            DiscoveryPayloadUnionReader::GetNodes2(_) => 2,
-            DiscoveryPayloadUnionReader::Nodes2(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
         match self {
             DiscoveryPayloadUnionReader::GetNodes(_) => "GetNodes",
             DiscoveryPayloadUnionReader::Nodes(_) => "Nodes",
-            DiscoveryPayloadUnionReader::GetNodes2(_) => "GetNodes2",
-            DiscoveryPayloadUnionReader::Nodes2(_) => "Nodes2",
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Expand the identify flags feature, and introduce some new concepts:
```rust
bitflags::bitflags! {
    pub struct Flags: u64 {
        /// Compatibility reserved
        const COMPATIBILITY = 0b1;
        /// Discovery protocol, which can provide peers data service
        const DISCOVERY = 0b10;
        /// Sync protocol can provide Block and Header download service
        const SYNC = 0b100;
        /// Relay protocol, which can provide CompactBlock and Transaction broadcast/forwarding services
        const RELAY = 0b1000;
        /// Light client protocol, which can provide Block / Transaction data and existence-proof services
        const LIGHT_CLIENT = 0b10000;
        /// Client-side block filter protocol can provide BlockFilter download service
        const BLOCK_FILTER = 0b100000;
    }
}
```
1. discovery peer address with flags
2. extended flags semantics
3. allow discovery messages to specify the address of the flags corresponding to the request
4. introduction of three concepts: `target_flags_filter`, `required_flags`, `identify_announce`, used to determine, respectively, the address to which this node will try to connect, the address to which this node will request from the remote end, and the attributes of this node to declare itself

Considering the emergence of light nodes, the above three concepts are not entirely consistent and must be configured externally. By default, this node is considered a full node, and there are not too many restrictions on discovery messages.

It is important to note that the discovery protocol does not verify the data given by the remote end, but stores it in the peer store and then checks the connection through the feeler. The advantage of this is that the peer store data is relatively even across the network, so that nodes with special needs can request some of the data, but cannot deny the data it does not need to spread across the network.

### Check List

Tests

- Unit test
- Integration test
- Manual test

### Release note 

```release-note
Title Only: Include only the PR title in the release note.
```

