### PR TITLE
chore: increase yamux.max_stream_window_size from 256K to 1M

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -868,6 +868,7 @@ impl<T: ExitHandler> NetworkService<T> {
         let mut service_builder = ServiceBuilder::default();
         let yamux_config = YamuxConfig {
             max_stream_count: protocol_metas.len(),
+            max_stream_window_size: 1024 * 1024,
             ..Default::default()
         };
         for meta in protocol_metas.into_iter() {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This PR make synchronize progress faster. @driftluo. Revert #3200 

The default yamux.max_stream_window_size is 256K, but the maximum size of a block of ckb is 500K, which may increase the times of messages are transmitted across the network.  

On my machine, it reduce synchronize time cost about 1 hour.

![image](https://user-images.githubusercontent.com/46400566/194830955-4a3735af-595c-4816-8e92-a459b2b83ce5.png)

> CKB sync progress:(timestamp(s), height)
>
> red line: not set `YamuxConfig.max_stream_window_size`, default (256K)
> blue line: set `YamuxConfig.max_stream_window_size` to `1M`
> 
> CPU: i7-9750H, 12 core, 4.5GHz; Memory: 64GB

### What is changed and how it works?


What's Changed:

change `NetworkService`'s `YamuxConfig.max_stream_window_size` from `256K(default)` to `1M`.



### Related changes

- #3141
- #3200 

Side effects

- Memory usage may increase

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

