### PR TITLE
fix: handle the case when no item to prove

### DIFF
--- a/util/light-client-protocol-server/src/components/get_blocks_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_blocks_proof.rs
@@ -29,6 +29,10 @@ impl<'a> GetBlocksProofProcess<'a> {
     }
 
     pub(crate) fn execute(self) -> Status {
+        if self.message.block_hashes().is_empty() {
+            return StatusCode::MalformedProtocolMessage.with_context("no block");
+        }
+
         if self.message.block_hashes().len() > constant::GET_BLOCKS_PROOF_LIMIT {
             return StatusCode::MalformedProtocolMessage.with_context("too many blocks");
         }

--- a/util/light-client-protocol-server/src/components/get_transactions_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_transactions_proof.rs
@@ -30,8 +30,12 @@ impl<'a> GetTransactionsProofProcess<'a> {
     }
 
     pub(crate) fn execute(self) -> Status {
+        if self.message.tx_hashes().is_empty() {
+            return StatusCode::MalformedProtocolMessage.with_context("no transaction");
+        }
+
         if self.message.tx_hashes().len() > constant::GET_TRANSACTIONS_PROOF_LIMIT {
-            return StatusCode::MalformedProtocolMessage.with_context("Too many transactions");
+            return StatusCode::MalformedProtocolMessage.with_context("too many transactions");
         }
 
         let active_chain = self.protocol.shared.active_chain();

--- a/util/light-client-protocol-server/src/lib.rs
+++ b/util/light-client-protocol-server/src/lib.rs
@@ -188,11 +188,15 @@ impl LightClientProtocol {
                     return StatusCode::InternalError.with_context(errmsg);
                 }
             };
-            let proof = match mmr.gen_proof(items_positions) {
-                Ok(proof) => proof.proof_items().to_owned(),
-                Err(err) => {
-                    let errmsg = format!("failed to generate a proof since {:?}", err);
-                    return StatusCode::InternalError.with_context(errmsg);
+            let proof = if items_positions.is_empty() {
+                Default::default()
+            } else {
+                match mmr.gen_proof(items_positions) {
+                    Ok(proof) => proof.proof_items().to_owned(),
+                    Err(err) => {
+                        let errmsg = format!("failed to generate a proof since {:?}", err);
+                        return StatusCode::InternalError.with_context(errmsg);
+                    }
                 }
             };
             (parent_chain_root, proof)


### PR DESCRIPTION
Handle the follow cases:
- Receive a request for asking a proof without nothing required to be proved.
- Receive a request for asking a proof and all items required to be proved are missing.