### PR TITLE
chore(light-client): update according to the RFC changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-merkle-mountain-range"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d659aac26a152a9d384bb759eaf56c028d58416f98bd4cbb089ef56424a1b0a4"
+checksum = "56ccb671c5921be8a84686e6212ca184cb1d7c51cadcdbfcbd1cc3f042f5dfb8"
 dependencies = [
  "cfg-if 1.0.0",
 ]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -27,7 +27,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.105.0-pre" }
 ckb-rust-unstable-port = { path = "../util/rust-unstable-port", version = "= 0.105.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.105.0-pre" }
 faux = { version = "^0.1", optional = true }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.105.0-pre" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -19,7 +19,7 @@ ckb-error = { path = "../error", version = "= 0.105.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.105.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.105.0-pre" }
 ckb-freezer = { path = "../freezer", version = "= 0.105.0-pre" }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -15,7 +15,7 @@ ckb-shared = { path = "../../shared", version = "= 0.105.0-pre" }
 ckb-logger = { path = "../logger", version = "= 0.105.0-pre" }
 ckb-types = { path = "../types", version = "= 0.105.0-pre" }
 ckb-store = { path = "../../store", version = "= 0.105.0-pre" }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
 ckb-chain = { path = "../../chain", version = "= 0.105.0-pre" }

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -20,7 +20,7 @@ ckb-proposal-table = { path = "../proposal-table", version = "= 0.105.0-pre" }
 arc-swap = "1.3"
 ckb-db-schema = { path = "../../db-schema", version = "= 0.105.0-pre" }
 ckb-freezer = { path = "../../freezer", version = "= 0.105.0-pre" }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [features]
 portable = ["ckb-db/portable", "ckb-store/portable"]

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -22,7 +22,7 @@ ckb-error = { path = "../../error", version = "= 0.105.0-pre" }
 ckb-rational = { path = "../rational", version = "= 0.105.0-pre" }
 once_cell = "1.8.0"
 derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
 proptest = "1.0"

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -26,7 +26,7 @@ vector OutPointVec <OutPoint>;
 /* Types for Light Client */
 
 struct HeaderDigest {
-    hash:                   Byte32,
+    children_hash:          Byte32,
 
     total_difficulty:       Uint256,
 

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -2490,7 +2490,7 @@ impl ::core::fmt::Debug for HeaderDigest {
 impl ::core::fmt::Display for HeaderDigest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "hash", self.hash())?;
+        write!(f, "{}: {}", "children_hash", self.children_hash())?;
         write!(f, ", {}: {}", "total_difficulty", self.total_difficulty())?;
         write!(f, ", {}: {}", "start_number", self.start_number())?;
         write!(f, ", {}: {}", "end_number", self.end_number())?;
@@ -2529,7 +2529,7 @@ impl HeaderDigest {
     pub const TOTAL_SIZE: usize = 120;
     pub const FIELD_SIZES: [usize; 10] = [32, 32, 8, 8, 8, 8, 8, 8, 4, 4];
     pub const FIELD_COUNT: usize = 10;
-    pub fn hash(&self) -> Byte32 {
+    pub fn children_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(0..32))
     }
     pub fn total_difficulty(&self) -> Uint256 {
@@ -2586,7 +2586,7 @@ impl molecule::prelude::Entity for HeaderDigest {
     }
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
-            .hash(self.hash())
+            .children_hash(self.children_hash())
             .total_difficulty(self.total_difficulty())
             .start_number(self.start_number())
             .end_number(self.end_number())
@@ -2617,7 +2617,7 @@ impl<'r> ::core::fmt::Debug for HeaderDigestReader<'r> {
 impl<'r> ::core::fmt::Display for HeaderDigestReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
-        write!(f, "{}: {}", "hash", self.hash())?;
+        write!(f, "{}: {}", "children_hash", self.children_hash())?;
         write!(f, ", {}: {}", "total_difficulty", self.total_difficulty())?;
         write!(f, ", {}: {}", "start_number", self.start_number())?;
         write!(f, ", {}: {}", "end_number", self.end_number())?;
@@ -2644,7 +2644,7 @@ impl<'r> HeaderDigestReader<'r> {
     pub const TOTAL_SIZE: usize = 120;
     pub const FIELD_SIZES: [usize; 10] = [32, 32, 8, 8, 8, 8, 8, 8, 4, 4];
     pub const FIELD_COUNT: usize = 10;
-    pub fn hash(&self) -> Byte32Reader<'r> {
+    pub fn children_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[0..32])
     }
     pub fn total_difficulty(&self) -> Uint256Reader<'r> {
@@ -2698,7 +2698,7 @@ impl<'r> molecule::prelude::Reader<'r> for HeaderDigestReader<'r> {
 }
 #[derive(Debug, Default)]
 pub struct HeaderDigestBuilder {
-    pub(crate) hash: Byte32,
+    pub(crate) children_hash: Byte32,
     pub(crate) total_difficulty: Uint256,
     pub(crate) start_number: Uint64,
     pub(crate) end_number: Uint64,
@@ -2713,8 +2713,8 @@ impl HeaderDigestBuilder {
     pub const TOTAL_SIZE: usize = 120;
     pub const FIELD_SIZES: [usize; 10] = [32, 32, 8, 8, 8, 8, 8, 8, 4, 4];
     pub const FIELD_COUNT: usize = 10;
-    pub fn hash(mut self, v: Byte32) -> Self {
-        self.hash = v;
+    pub fn children_hash(mut self, v: Byte32) -> Self {
+        self.children_hash = v;
         self
     }
     pub fn total_difficulty(mut self, v: Uint256) -> Self {
@@ -2761,7 +2761,7 @@ impl molecule::prelude::Builder for HeaderDigestBuilder {
         Self::TOTAL_SIZE
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        writer.write_all(self.hash.as_slice())?;
+        writer.write_all(self.children_hash.as_slice())?;
         writer.write_all(self.total_difficulty.as_slice())?;
         writer.write_all(self.start_number.as_slice())?;
         writer.write_all(self.end_number.as_slice())?;

--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -1,88 +1,8 @@
 //! Types for variable difficulty Merkle Mountain Range (MMR) in CKB.
 //!
-//! Since CKB doesn't record MMR data in headers since the genesis block, we use an activation
-//! block number to enable MMR and create all MMR nodes before that block to make sure that the
-//! index of MMR leaf is EQUAL to the block number.
-//!
-//! ```text
-//!          height                position
-//!
-//!             3                     14
-//!                                  /  \
-//!                                 /    \
-//!                                /      \
-//!                               /        \
-//!                              /          \
-//!                             /            \
-//!             2              6             13
-//!                           / \            / \
-//!                          /   \          /   \
-//!                         /     \        /     \
-//!             1          2       5       9      12      17
-//!                       / \     / \     / \    /  \    /  \
-//!             0        0   1   3   4   7   8  10  11  15  16   18
-//!         --------------------------------------------------------
-//! index                0   1   2   3   4   5   6   7   8   9   10 ... N
-//!         --------------------------------------------------------
-//! number               0   1   2   3   4   5   6   7   8   9   10 ... N
-//!         --------------------------------------------------------
-//! ```
-//!
-//! - `height`: the MMR node height.
-//! - `position`: the MMR node position.
-//! - `index`: the MMR leaf index; same as the block height.
-//! - `number`: the block height.
-//! - `N`: the activation block number; the block number of the last block which doesn't records MMR root hash.
-//!
-//! There are three kind of blocks base on its MMR data:
-//!
-//! - The genesis block
-//!
-//!   First node, also first leaf node in MMR; no chain root;
-//!
-//! - The blocks which height is less than `N`
-//!
-//!   No chain root in blocks but store them in database.
-//!
-//! - The blocks which height is equal to or greater than `N`
-//!
-//!   Has chain root in blocks.
-//!
-//! There are two kinds of MMR nodes: leaf node and non-leaf node.
-//!
-//! Each MMR node is defined as follows:
-//!
-//! - `hash`
-//!
-//!   - For leaf node, it's an empty hash (`0x0000...0000`).
-//!
-//!   - For non-leaf node, it's the hash of it's child nodes' hashes (concatenate serialized data).
-//!
-//! - `total_difficulty`
-//!
-//!  - For leaf node, it's the difficulty it took to mine the current block.
-//!
-//!  - For non-leaf node, it's the sum of `total_difficulty` in it's child nodes.
-//!
-//! - `start_*`
-//!
-//!   Such as `start_number`, `start_epoch`, `start_timestamp`, `start_compact_target`.
-//!
-//!   - For leaf node, it's the data of current block.
-//!
-//!   - For non-leaf node, it's the `start_*` of left node.
-//!
-//! - `end_*`
-//!
-//!   Such as `end_number`, `end_epoch`, `end_timestamp`, `end_compact_target`.
-//!
-//!   - For leaf node, it's the data of current block.
-//!
-//!   - For non-leaf node, it's the `end_*` of right node.
-//!
 //! ## References
 //!
-//! - [Peter Todd, Merkle mountain range.](https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md).
+//! - [CKB RFC 0044](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md)
 
 use ckb_hash::new_blake2b;
 use ckb_merkle_mountain_range::{Error as MMRError, Merge, MerkleProof, Result as MMRResult, MMR};

--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -211,7 +211,7 @@ impl Merge for MergeHeaderDigest {
     type Item = packed::HeaderDigest;
 
     fn merge(lhs: &Self::Item, rhs: &Self::Item) -> MMRResult<Self::Item> {
-        let hash = {
+        let children_hash = {
             let mut hasher = new_blake2b();
             let mut hash = [0u8; 32];
             hasher.update(&lhs.calc_mmr_hash().raw_data());
@@ -249,7 +249,7 @@ impl Merge for MergeHeaderDigest {
         }
 
         Ok(Self::Item::new_builder()
-            .hash(hash.pack())
+            .children_hash(children_hash.pack())
             .total_difficulty(total_difficulty.pack())
             .start_number(lhs.start_number())
             .start_epoch(lhs.start_epoch())

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
 ckb-async-runtime = { path = "../../util/runtime", version = "= 0.105.0-pre" }
 ckb-verification-traits = { path = "../traits", version = "= 0.105.0-pre" }
 ckb-verification = { path = "..", version = "= 0.105.0-pre" }
-ckb-merkle-mountain-range = "0.5.1"
+ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
 ckb-chain = { path = "../../chain", version = "= 0.105.0-pre" }


### PR DESCRIPTION
### What problem does this PR solve?

- chore(light-client): update according to the RFC changes

  - chore(light-client): rename the "hash" filed in HeaderDigest to "children_hash"

    Ref: https://github.com/nervosnetwork/rfcs/pull/370#discussion_r1000116358

  - docs(light-client): remove outdated documentation and link to the related RFC

- chore(deps): bump ckb-merkle-mountain-range from 0.5.1 to 0.5.2

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects： None

### Release note

```release-note
None: Exclude this PR from the release note.
```

