### PR TITLE
[Draft] feat: add cycles field in Chain RPC: get_transaction() & get_block()

### DIFF
--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1432,19 +1432,37 @@ impl ChainRpc for ChainRpcImpl {
             // when verbosity=0, it's response value is as same as verbosity=2, but it
             // return a 0x-prefixed hex encoded molecule packed::Transaction` on `transaction` field
             self.get_transaction_verbosity2(tx_hash).map(|op| {
-                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Hex))
+                op.map(|tx| {
+                    TransactionWithStatusResponse::from(
+                        tx,
+                        tx.cycles.into(),
+                        ResponseFormatInnerType::Hex,
+                    )
+                })
             })
         } else if verbosity == 1 {
             // The RPC does not return the transaction content and the field transaction must be null.
             self.get_transaction_verbosity1(tx_hash).map(|op| {
-                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Json))
+                op.map(|tx| {
+                    TransactionWithStatusResponse::from(
+                        tx,
+                        tx.cycles.into(),
+                        ResponseFormatInnerType::Json,
+                    )
+                })
             })
         } else if verbosity == 2 {
             // if tx_status.status is pending, proposed, or committed,
             // the RPC returns the transaction content as field transaction,
             // otherwise the field is null.
             self.get_transaction_verbosity2(tx_hash).map(|op| {
-                op.map(|tx| TransactionWithStatusResponse::from(tx, ResponseFormatInnerType::Json))
+                op.map(|tx| {
+                    TransactionWithStatusResponse::from(
+                        tx,
+                        tx.cycles.into(),
+                        ResponseFormatInnerType::Json,
+                    )
+                })
             })
         } else {
             Err(RPCError::invalid_params("invalid verbosity level"))

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -199,12 +199,18 @@ impl TxPool {
             .or_else(|| self.proposed.get_tx(id))
     }
 
+    /// Returns tx entry from pending and gap corresponding to the id. RPC
+    pub fn get_tx_entry_from_pending_or_else_gap(&self, id: &ProposalShortId) -> Option<&TxEntry> {
+        self.pending.get(id).or_else(|| self.gap.get(id))
+    }
+
     /// Returns tx from pending and gap corresponding to the id. RPC
     pub fn get_tx_from_pending_or_else_gap(
         &self,
         id: &ProposalShortId,
     ) -> Option<&TransactionView> {
-        self.pending.get_tx(id).or_else(|| self.gap.get_tx(id))
+        self.get_tx_entry_from_pending_or_else_gap(id)
+            .map(|entry| entry.transaction())
     }
 
     pub(crate) fn proposed(&self) -> &ProposedPool {

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -520,6 +520,8 @@ impl From<Transaction> for packed::Transaction {
 pub struct TransactionWithStatusResponse {
     /// The transaction.
     pub transaction: Option<ResponseFormat<TransactionView>>,
+    /// The cycles of the transaction
+    pub cycles: Cycle,
     /// The Transaction status.
     pub tx_status: TxStatus,
 }
@@ -527,18 +529,24 @@ pub struct TransactionWithStatusResponse {
 impl TransactionWithStatusResponse {
     /// Transpose `tx_pool::TransactionWithStatus` to `TransactionWithStatusResponse`
     /// according to the type of inner_type
-    pub fn from(t: tx_pool::TransactionWithStatus, inner_type: ResponseFormatInnerType) -> Self {
+    pub fn from(
+        t: tx_pool::TransactionWithStatus,
+        cycles: Cycle,
+        inner_type: ResponseFormatInnerType,
+    ) -> Self {
         match inner_type {
             ResponseFormatInnerType::Hex => TransactionWithStatusResponse {
                 transaction: t
                     .transaction
                     .map(|tx| ResponseFormat::hex(tx.data().as_bytes())),
+                cycles: cycles,
                 tx_status: t.tx_status.into(),
             },
             ResponseFormatInnerType::Json => TransactionWithStatusResponse {
                 transaction: t
                     .transaction
                     .map(|tx| ResponseFormat::json(TransactionView::from(tx))),
+                cycles: cycles,
                 tx_status: t.tx_status.into(),
             },
         }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -142,24 +142,28 @@ pub struct TxPoolEntryInfo {
 pub struct TransactionWithStatus {
     /// The transaction.
     pub transaction: Option<core::TransactionView>,
+    /// The cycles of the transaction
+    pub cycles: Cycle,
     /// The Transaction status.
     pub tx_status: TxStatus,
 }
 
 impl TransactionWithStatus {
     /// Build with pending status
-    pub fn with_pending(tx: Option<core::TransactionView>) -> Self {
+    pub fn with_pending(tx: Option<core::TransactionView>, cycles: Cycle) -> Self {
         Self {
             tx_status: TxStatus::Pending,
             transaction: tx,
+            cycles,
         }
     }
 
     /// Build with proposed status
-    pub fn with_proposed(tx: Option<core::TransactionView>) -> Self {
+    pub fn with_proposed(tx: Option<core::TransactionView>, cycles: Cycle) -> Self {
         Self {
             tx_status: TxStatus::Proposed,
             transaction: tx,
+            cycles,
         }
     }
 
@@ -176,6 +180,7 @@ impl TransactionWithStatus {
         Self {
             tx_status: TxStatus::Rejected(reason),
             transaction: None,
+            cycles: 0
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #3649
Problem Summary:

### What is changed and how it works?


What's Changed:

### Related changes

- [ ] return a transaction's `cycles` from `ChainStore`
- [x] add `cycles` field to `TransactionWithStatus` and `TransactionWithStatusResponse`
- [x] add `tx_pool::get_tx_entry_from_pending_or_else_gap()`
- [ ] return block's `cycles`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]



### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

