### PR TITLE
chore: remove block_filter_enable option

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -97,6 +97,9 @@ discovery_local_address = false # {{
 # Ensure that itself can continue to serve as a bootnode node
 bootnode_mode = false
 
+# Supported protocols list, only "Sync" and "Identify" are mandatory, others are optional
+support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessage", "Sync", "Relay", "Time", "Alert", "LightClient", "Filter"]
+
 # [network.sync.header_map]
 # memory_limit = "600MB"
 

--- a/test/src/specs/sync/block_filter.rs
+++ b/test/src/specs/sync/block_filter.rs
@@ -78,10 +78,6 @@ impl Spec for GetBlockFilterCheckPoints {
             _ => panic!("unexpected message"),
         }
     }
-
-    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
-        config.store.block_filter_enable = true;
-    }
 }
 
 pub struct GetBlockFilterHashes;
@@ -158,10 +154,6 @@ impl Spec for GetBlockFilterHashes {
             },
             _ => panic!("unexpected message"),
         }
-    }
-
-    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
-        config.store.block_filter_enable = true;
     }
 }
 
@@ -245,10 +237,6 @@ impl Spec for GetBlockFilters {
             },
             _ => panic!("unexpected message"),
         }
-    }
-
-    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
-        config.store.block_filter_enable = true;
     }
 }
 
@@ -335,10 +323,6 @@ impl Spec for GetBlockFiltersNotReachBatch {
             },
             _ => panic!("unexpected message"),
         }
-    }
-
-    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
-        config.store.block_filter_enable = true;
     }
 }
 

--- a/util/app-config/src/configs/store.rs
+++ b/util/app-config/src/configs/store.rs
@@ -18,6 +18,4 @@ pub struct Config {
     pub block_extensions_cache_size: usize,
     /// whether enable freezer
     pub freezer_enable: bool,
-    /// whether enable block filter
-    pub block_filter_enable: bool,
 }

--- a/util/app-config/src/legacy/store.rs
+++ b/util/app-config/src/legacy/store.rs
@@ -13,8 +13,6 @@ pub(crate) struct StoreConfig {
     block_extensions_cache_size: usize,
     #[serde(default = "default_freezer_enable")]
     freezer_enable: bool,
-    #[serde(default = "default_block_filter_enable")]
-    block_filter_enable: bool,
 }
 
 const fn default_block_extensions_cache_size() -> usize {
@@ -22,10 +20,6 @@ const fn default_block_extensions_cache_size() -> usize {
 }
 
 const fn default_freezer_enable() -> bool {
-    false
-}
-
-const fn default_block_filter_enable() -> bool {
     false
 }
 
@@ -46,7 +40,6 @@ impl Default for StoreConfig {
             cellbase_cache_size: None,
             block_extensions_cache_size: default_block_extensions_cache_size(),
             freezer_enable: default_freezer_enable(),
-            block_filter_enable: default_block_filter_enable(),
         }
     }
 }
@@ -62,7 +55,6 @@ impl From<StoreConfig> for crate::StoreConfig {
             cellbase_cache_size: _,
             block_extensions_cache_size,
             freezer_enable,
-            block_filter_enable,
         } = input;
         Self {
             header_cache_size,
@@ -72,7 +64,6 @@ impl From<StoreConfig> for crate::StoreConfig {
             block_uncles_cache_size,
             block_extensions_cache_size,
             freezer_enable,
-            block_filter_enable,
         }
     }
 }

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -252,7 +252,13 @@ impl Launcher {
 
     /// start block filter service
     pub fn start_block_filter(&self, shared: &Shared) -> Option<StopHandler<()>> {
-        if self.args.config.store.block_filter_enable {
+        if self
+            .args
+            .config
+            .network
+            .support_protocols
+            .contains(&SupportProtocol::Filter)
+        {
             Some(BlockFilterService::new(shared.clone()).start())
         } else {
             None


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Two configuration options (block_filter_enable and support_protocols) are conflicting, one is off by default and one is on by default

### What is changed and how it works?

Remove the `block_filter_enable` option.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

