### PR TITLE
feat: add rpc estimate_cycles

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -51,6 +51,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
         * [Method `get_fork_block`](#method-get_fork_block)
         * [Method `get_consensus`](#method-get_consensus)
         * [Method `get_block_median_time`](#method-get_block_median_time)
+        * [Method `estimate_cycles`](#method-estimate_cycles)
     * [Module Experiment](#module-experiment)
         * [Method `dry_run_transaction`](#method-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#method-calculate_dao_maximum_withdraw)
@@ -124,11 +125,11 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `DeploymentPos`](#type-deploymentpos)
     * [Type `DeploymentState`](#type-deploymentstate)
     * [Type `DeploymentsInfo`](#type-deploymentsinfo)
-    * [Type `DryRunResult`](#type-dryrunresult)
     * [Type `Either`](#type-either)
     * [Type `EpochNumber`](#type-epochnumber)
     * [Type `EpochNumberWithFraction`](#type-epochnumberwithfraction)
     * [Type `EpochView`](#type-epochview)
+    * [Type `EstimateCycles`](#type-estimatecycles)
     * [Type `H256`](#type-h256)
     * [Type `HardForkFeature`](#type-hardforkfeature)
     * [Type `Header`](#type-header)
@@ -1574,6 +1575,92 @@ Response
 ```
 
 
+#### Method `estimate_cycles`
+* `estimate_cycles(tx)`
+    * `tx`: [`Transaction`](#type-transaction)
+* result: [`EstimateCycles`](#type-estimatecycles)
+
+`estimate_cycles` run a transaction and return the execution consumed cycles.
+
+This method will not check the transaction validity, but only run the lock script and type script and then return the execution cycles.
+
+It is used to estimate how many cycles the scripts consume.
+
+###### Errors
+
+*   [`TransactionFailedToResolve (-301)`](#error-transactionfailedtoresolve) - Failed to resolve the referenced cells and headers used in the transaction, as inputs or dependencies.
+
+*   [`TransactionFailedToVerify (-302)`](#error-transactionfailedtoverify) - There is a script returns with an error.
+
+###### Examples
+
+Request
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "estimate_cycles",
+  "params": [
+    {
+      "cell_deps": [
+        {
+          "dep_type": "code",
+          "out_point": {
+            "index": "0x0",
+            "tx_hash": "0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3"
+          }
+        }
+      ],
+      "header_deps": [
+        "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed"
+      ],
+      "inputs": [
+        {
+          "previous_output": {
+            "index": "0x0",
+            "tx_hash": "0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17"
+          },
+          "since": "0x0"
+        }
+      ],
+      "outputs": [
+        {
+          "capacity": "0x2540be400",
+          "lock": {
+            "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+            "hash_type": "data",
+            "args": "0x"
+          },
+          "type": null
+        }
+      ],
+      "outputs_data": [
+        "0x"
+      ],
+      "version": "0x0",
+      "witnesses": []
+    }
+  ]
+}
+```
+
+
+Response
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": {
+    "cycles": "0x219"
+  }
+}
+```
+
+
 ### Module Experiment
 
 RPC Module Experiment for experimenting methods.
@@ -1585,7 +1672,11 @@ The methods here may be removed or changed in future releases without prior noti
 #### Method `dry_run_transaction`
 * `dry_run_transaction(tx)`
     * `tx`: [`Transaction`](#type-transaction)
-* result: [`DryRunResult`](#type-dryrunresult)
+* result: [`EstimateCycles`](#type-estimatecycles)
+
+👎 Deprecated since 0.105.1:
+Please use the RPC method [`estimate_cycles`](#method-estimate_cycles) instead
+
 
 Dry run a transaction and return the execution cycles.
 
@@ -5385,17 +5476,6 @@ Chain information.
 *   `deployments`: `{ [ key:` [`DeploymentPos`](#type-deploymentpos) `]: ` [`DeploymentInfo`](#type-deploymentinfo) `}` - deployments info
 
 
-### Type `DryRunResult`
-
-Response result of the RPC method `dry_run_transaction`.
-
-#### Fields
-
-`DryRunResult` is a JSON object with the following fields.
-
-*   `cycles`: [`Cycle`](#type-cycle) - The count of cycles that the VM has consumed to verify this transaction.
-
-
 ### Type `Either`
 
 The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
@@ -5466,6 +5546,17 @@ CKB adjusts difficulty based on epochs.
 *   `length`: [`BlockNumber`](#type-blocknumber) - The number of blocks in this epoch.
 
 *   `compact_target`: [`Uint32`](#type-uint32) - The difficulty target for any block in this epoch.
+
+
+### Type `EstimateCycles`
+
+Response result of the RPC method `estimate_cycles`.
+
+#### Fields
+
+`EstimateCycles` is a JSON object with the following fields.
+
+*   `cycles`: [`Cycle`](#type-cycle) - The count of cycles that the VM has consumed to verify this transaction.
 
 
 ### Type `H256`

--- a/rpc/src/module/mod.rs
+++ b/rpc/src/module/mod.rs
@@ -111,7 +111,7 @@
 #![allow(deprecated)]
 
 mod alert;
-mod chain;
+pub(crate) mod chain;
 mod debug;
 mod experiment;
 mod indexer;

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -6,7 +6,7 @@ mod error;
 use ckb_error::AnyError;
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockTemplate, BlockView, Capacity,
-    CellWithStatus, ChainInfo, DryRunResult, EpochNumber, EpochView, HeaderView, JsonBytes,
+    CellWithStatus, ChainInfo, EpochNumber, EpochView, EstimateCycles, HeaderView, JsonBytes,
     LocalNode, OutPoint, RawTxPool, RemoteNode, Timestamp, Transaction, TransactionProof,
     TransactionWithStatusResponse, TxPoolInfo, Uint32, Uint64, Version,
 };
@@ -215,10 +215,10 @@ impl RpcClient {
             .expect("rpc call get_raw_tx_pool")
     }
 
-    pub fn dry_run_transaction(&self, tx: Transaction) -> DryRunResult {
+    pub fn estimate_cycles(&self, tx: Transaction) -> EstimateCycles {
         self.inner
-            .dry_run_transaction(tx)
-            .expect("rpc call dry_run_transaction")
+            .estimate_cycles(tx)
+            .expect("rpc call estimate_cycles")
     }
 
     pub fn send_alert(&self, alert: Alert) {
@@ -336,7 +336,7 @@ jsonrpc!(pub struct Inner {
     pub fn submit_block(&self, _work_id: String, _data: Block) -> H256;
     pub fn get_blockchain_info(&self) -> ChainInfo;
     pub fn get_block_median_time(&self, block_hash: H256) -> Option<Timestamp>;
-    pub fn dry_run_transaction(&self, _tx: Transaction) -> DryRunResult;
+    pub fn estimate_cycles(&self, _tx: Transaction) -> EstimateCycles;
     pub fn send_transaction(&self, tx: Transaction, outputs_validator: Option<String>) -> H256;
     pub fn remove_transaction(&self, tx_hash: H256) -> bool;
     pub fn tx_pool_info(&self) -> TxPoolInfo;

--- a/util/jsonrpc-types/src/experiment.rs
+++ b/util/jsonrpc-types/src/experiment.rs
@@ -2,9 +2,9 @@ use crate::{Cycle, OutPoint};
 use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 
-/// Response result of the RPC method `dry_run_transaction`.
+/// Response result of the RPC method `estimate_cycles`.
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-pub struct DryRunResult {
+pub struct EstimateCycles {
     /// The count of cycles that the VM has consumed to verify this transaction.
     pub cycles: Cycle,
 }

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::blockchain::{
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellData, CellInfo, CellWithStatus};
 pub use self::debug::{ExtraLoggerConfig, MainLoggerConfig};
-pub use self::experiment::{DaoWithdrawingCalculationKind, DryRunResult};
+pub use self::experiment::{DaoWithdrawingCalculationKind, EstimateCycles};
 pub use self::fee_rate::FeeRateDef;
 pub use self::fixed_bytes::Byte32;
 pub use self::info::{ChainInfo, DeploymentInfo, DeploymentPos, DeploymentState, DeploymentsInfo};


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

An new RPC to run the transaction and return cycles.

### What is changed and how it works?

`estimate_cycles` is essentially a renaming of the previous `dry_run_transaction`, which was then moved from Experiment to Chain module, with the original `dry_run_transaction` retained and marked as deprecated.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

