### PR TITLE
fix(light-client): subtract overflow when try to get chain root for genesis block

### DIFF
--- a/util/light-client-protocol-server/src/lib.rs
+++ b/util/light-client-protocol-server/src/lib.rs
@@ -122,7 +122,9 @@ impl LightClientProtocol {
         let tip_block = active_chain
             .get_block(&tip_hash)
             .expect("checked: tip block should be existed");
-        let parent_chain_root = {
+        let parent_chain_root = if tip_block.is_genesis() {
+            Default::default()
+        } else {
             let snapshot = self.shared.shared().snapshot();
             let mmr = snapshot.chain_root_mmr(tip_block.number() - 1);
             match mmr.get_root() {

--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -216,7 +216,8 @@ impl VerifiableHeader {
 
     /// Checks if the current verifiable header is valid.
     pub fn is_valid(&self, mmr_activated_epoch: EpochNumber) -> bool {
-        let has_chain_root = self.header().epoch().number() >= mmr_activated_epoch;
+        let has_chain_root =
+            !self.header().is_genesis() && self.header().epoch().number() >= mmr_activated_epoch;
         if has_chain_root {
             let is_extension_beginning_with_chain_root_hash = self
                 .extension()


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The genesis block could NOT have a chain root, since chain root is a state for previous blocks of a chain.
Even for dev chains.

Hence, we have to skip fetching a chain root for the genesis block.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```