### PR TITLE
fix: set recent reject db log file limit to 10

### DIFF
--- a/db/src/db_with_ttl.rs
+++ b/db/src/db_with_ttl.rs
@@ -35,6 +35,7 @@ impl DBWithTTL {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.set_keep_log_file_num(10);
 
         let cf_descriptors: Vec<_> = cf_names
             .into_iter()


### PR DESCRIPTION
### What problem does this PR solve?

In this [PR](https://github.com/nervosnetwork/ckb/pull/3029), we introduce the recent reject DB to record recently rejected transactions, which is implemented as rocksdb with TTL, using the default DB parameter configuration.

Since then, this db has been very heavily used on my machine until now:
```bash
dust -n 50 -d 1                                                                                                                      
4.0K   ┌── logs
8.0K   ├── ancient
212K   ├── tmp
2.8M   ├── network
164M   ├── indexer
1.5G   ├── tx_pool
 24G   ├── db
 26G ┌─┴ .        
```
However, the data inside is actually all `LOG.old.xxx` logs.

As a TTL database, its data storage is inherently time-limited, and it is obviously not reasonable to keep so many DB logs by default. 

By default, rocksdb keeps 1000 log files, which is too heavy for this DB, so this PR will change the default value to 10

### Check List 

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

