### PR TITLE
Improve support for cycles access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "ckb-verification",
  "ckb-verification-traits",
  "faketime",
+ "itertools",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
@@ -2594,9 +2595,9 @@ checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -66,6 +66,8 @@ fn test_find_fork_case1() {
         // if txs in parent is invalid, txs in block is also invalid
         verified: None,
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
 
     let mut fork = ForkChanges::default();
@@ -136,6 +138,8 @@ fn test_find_fork_case2() {
         // if txs in parent is invalid, txs in block is also invalid
         verified: None,
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
 
     let mut fork = ForkChanges::default();
@@ -207,6 +211,8 @@ fn test_find_fork_case3() {
         // if txs in parent is invalid, txs in block is also invalid
         verified: None,
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
     let mut fork = ForkChanges::default();
 
@@ -277,6 +283,8 @@ fn test_find_fork_case4() {
         // if txs in parent is invalid, txs in block is also invalid
         verified: None,
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
 
     let mut fork = ForkChanges::default();

--- a/chain/src/tests/load_code_with_snapshot.rs
+++ b/chain/src/tests/load_code_with_snapshot.rs
@@ -108,7 +108,10 @@ fn test_load_code() {
     let ret = tx_pool.submit_local_tx(tx.clone()).unwrap();
     assert!(ret.is_ok(), "ret {:?}", ret);
     let tx_status = tx_pool.get_tx_status(tx.hash());
-    assert_eq!(tx_status.unwrap().unwrap(), TxStatus::Pending);
+    assert_eq!(
+        tx_status.unwrap().unwrap(),
+        (TxStatus::Pending, Some(11174))
+    );
 }
 
 #[test]
@@ -177,7 +180,7 @@ fn test_load_code_with_snapshot() {
         let mut counter = 0;
         loop {
             let tx_status = tx_pool.get_tx_status(tx.hash());
-            if let Ok(Ok(status)) = tx_status {
+            if let Ok(Ok((status, _))) = tx_status {
                 if status == TxStatus::Pending {
                     break;
                 }
@@ -265,7 +268,7 @@ fn _test_load_code_with_snapshot_after_hardfork(script_type: ScriptHashType) {
         let mut counter = 0;
         loop {
             let tx_status = tx_pool.get_tx_status(tx.hash());
-            if let Ok(Ok(status)) = tx_status {
+            if let Ok(Ok((status, _))) = tx_status {
                 if status == TxStatus::Pending {
                     break;
                 }

--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -256,6 +256,8 @@ class RPCVar():
                 self.ty = '`null`'
             if self.ty == RUST_DOC_PREFIX + '/std/primitive.bool.html':
                 self.ty = '`boolean`'
+            if self.ty == RUST_DOC_PREFIX + '/std/primitive.f64.html':
+                self.ty = '`64-bit floating point`'
             if self.ty == RUST_DOC_PREFIX + '/alloc/string/struct.String.html':
                 self.ty = '`string`'
             elif self.ty == RUST_DOC_PREFIX + '/core/option/enum.Option.html':

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -43,6 +43,7 @@ ckb-tx-pool = { path = "../tx-pool", version = "= 0.106.0-pre" }
 ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.106.0-pre" }
 ckb-pow = { path = "../pow", version = "= 0.106.0-pre" }
 ckb-indexer = { path = "../util/indexer", version = "= 0.106.0-pre" }
+itertools = "0.10.5"
 tokio = "1"
 
 [dev-dependencies]

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -827,6 +827,7 @@ Response
       "version": "0x0",
       "witnesses": []
     },
+    "cycles": "0x219",
     "tx_status": {
       "block_hash": null,
       "status": "pending",
@@ -846,6 +847,7 @@ The response looks like below when `verbosity` is 0.
   "jsonrpc": "2.0",
   "result": {
     "transaction": "0x.....",
+    "cycles": "0x219",
     "tx_status": {
       "block_hash": null,
       "status": "pending",
@@ -6572,6 +6574,8 @@ The JSON view of a transaction as well as its status.
 `TransactionWithStatusResponse` is a JSON object with the following fields.
 
 *   `transaction`: [`ResponseFormat`](#type-responseformat) `|` `null` - The transaction.
+
+*   `cycles`: [`Cycle`](#type-cycle) `|` `null` - The transaction consumed cycles.
 
 *   `tx_status`: [`TxStatus`](#type-txstatus) - The Transaction status.
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -52,6 +52,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
         * [Method `get_consensus`](#method-get_consensus)
         * [Method `get_block_median_time`](#method-get_block_median_time)
         * [Method `estimate_cycles`](#method-estimate_cycles)
+        * [Method `get_fee_rate_statics`](#method-get_fee_rate_statics)
     * [Module Experiment](#module-experiment)
         * [Method `dry_run_transaction`](#method-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#method-calculate_dao_maximum_withdraw)
@@ -105,6 +106,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `BlockEconomicState`](#type-blockeconomicstate)
     * [Type `BlockIssuance`](#type-blockissuance)
     * [Type `BlockNumber`](#type-blocknumber)
+    * [Type `BlockResponse`](#type-blockresponse)
     * [Type `BlockTemplate`](#type-blocktemplate)
     * [Type `BlockView`](#type-blockview)
     * [Type `Byte32`](#type-byte32)
@@ -130,6 +132,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.61.0.
     * [Type `EpochNumberWithFraction`](#type-epochnumberwithfraction)
     * [Type `EpochView`](#type-epochview)
     * [Type `EstimateCycles`](#type-estimatecycles)
+    * [Type `FeeRateStatics`](#type-feeratestatics)
     * [Type `H256`](#type-h256)
     * [Type `HardForkFeature`](#type-hardforkfeature)
     * [Type `Header`](#type-header)
@@ -281,10 +284,11 @@ A cell is live if
 *   it is not found as an input in any transaction in the canonical chain.
 
 #### Method `get_block`
-* `get_block(block_hash, verbosity)`
+* `get_block(block_hash, verbosity, with_cycles)`
     * `block_hash`: [`H256`](#type-h256)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`BlockView`](#type-blockview) `|` [`SerializedBlock`](#type-serializedblock) `|` `null`
+    * `with_cycles`: `boolean` `|` `null`
+* result: [`BlockResponse`](#type-blockresponse) `|` `null`
 
 Returns the information about a block by hash.
 
@@ -293,6 +297,8 @@ Returns the information about a block by hash.
 *   `block_hash` - the block hash.
 
 *   `verbosity` - result format which allows 0 and 2. (**Optional**, the default is 2.)
+
+*   `with_cycles` - whether the return cycles of block transactions. (**Optional**, default false.)
 
 ###### Returns
 
@@ -315,7 +321,9 @@ Request
   "jsonrpc": "2.0",
   "method": "get_block",
   "params": [
-    "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
+    "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+     null,
+     true
   ]
 }
 ```
@@ -378,7 +386,8 @@ Response
         ]
       }
     ],
-    "uncles": []
+    "uncles": [],
+    "cycles": []
   }
 }
 ```
@@ -397,10 +406,11 @@ The response looks like below when `verbosity` is 0.
 
 
 #### Method `get_block_by_number`
-* `get_block_by_number(block_number, verbosity)`
+* `get_block_by_number(block_number, verbosity, with_cycles)`
     * `block_number`: [`BlockNumber`](#type-blocknumber)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`BlockView`](#type-blockview) `|` [`SerializedBlock`](#type-serializedblock) `|` `null`
+    * `with_cycles`: `boolean` `|` `null`
+* result: [`BlockResponse`](#type-blockresponse) `|` `null`
 
 Returns the block in the [canonical chain](#canonical-chain) with the specific block number.
 
@@ -409,6 +419,8 @@ Returns the block in the [canonical chain](#canonical-chain) with the specific b
 *   `block_number` - the block number.
 
 *   `verbosity` - result format which allows 0 and 2. (**Optional**, the default is 2.)
+
+*   `with_cycles` - whether the return cycles of block transactions. (**Optional**, default false.)
 
 ###### Returns
 
@@ -500,7 +512,8 @@ Response
         ]
       }
     ],
-    "uncles": []
+    "uncles": [],
+    "cycles": null
   }
 }
 ```
@@ -1659,6 +1672,51 @@ Response
   "result": {
     "cycles": "0x219"
   }
+}
+```
+
+
+#### Method `get_fee_rate_statics`
+* `get_fee_rate_statics(target)`
+    * `target`: [`Uint64`](#type-uint64) `|` `null`
+* result: [`FeeRateStatics`](#type-feeratestatics) `|` `null`
+
+Returns the fee_rate statistics of confirmed blocks on the chain
+
+###### Params
+
+*   `target` - Specify the number (1 - 101) of confirmed blocks to be counted. If the number is even, automatically add one. If not specified, defaults to 21
+
+###### Returns
+
+If the query has data records, it returns statistics, if not, it returns null.
+
+###### Examples
+
+Request
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "get_fee_rate_statics",
+  "params": []
+}
+```
+
+
+Response
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": {
+    "mean":59.29387293275573,
+    "median":5.288207297726071
+   }
 }
 ```
 
@@ -4948,6 +5006,19 @@ Consecutive block number starting from 0.
 
 This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](#type-uint64).
 
+### Type `BlockResponse`
+
+The wrapper represent response of `get_block` | `get_block_by_number`, return a Block with cycles.
+
+#### Fields
+
+`BlockResponse` is a JSON object with the following fields.
+
+*   `block`: [`ResponseFormat`](#type-responseformat) - The block structure
+
+*   `cycles`: `Array<` [`Cycle`](#type-cycle) `>` `|` `null` - The block transactions consumed cycles.
+
+
 ### Type `BlockTemplate`
 
 A block template for miners.
@@ -5559,6 +5630,19 @@ Response result of the RPC method `estimate_cycles`.
 `EstimateCycles` is a JSON object with the following fields.
 
 *   `cycles`: [`Cycle`](#type-cycle) - The count of cycles that the VM has consumed to verify this transaction.
+
+
+### Type `FeeRateStatics`
+
+The fee_rate statistics information, includes mean and median
+
+#### Fields
+
+`FeeRateStatics` is a JSON object with the following fields.
+
+*   `mean`: `64-bit floating point` - mean
+
+*   `median`: `64-bit floating point` - median
 
 
 ### Type `H256`

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -3,6 +3,7 @@
 pub(crate) mod error;
 pub(crate) mod server;
 pub(crate) mod service_builder;
+pub(crate) mod util;
 
 pub mod module;
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1376,10 +1376,7 @@ pub trait ChainRpc {
     ///
     /// ## Returns
     ///
-    /// When the given block hash is not on the current canonical chain, this RPC returns null;
-    /// otherwise returns the median time of the consecutive 37 blocks where the given block_hash has the highest height.
-    ///
-    /// Note that the given block is included in the median time. The included block number range is `[MAX(block - 36, 0), block]`.
+    /// If the query has data records, it returns statistics, if not, it returns null.
     ///
     /// ## Examples
     ///

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1,15 +1,16 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
     BlockEconomicState, BlockNumber, BlockResponse, BlockView, CellWithStatus, Consensus,
-    EpochNumber, EpochView, EstimateCycles, HeaderView, JsonBytes, MerkleProof as JsonMerkleProof,
-    OutPoint, ResponseFormat, ResponseFormatInnerType, Timestamp, TransactionProof,
-    TransactionWithStatusResponse, Uint32,
+    EpochNumber, EpochView, EstimateCycles, FeeRateStatics, HeaderView, JsonBytes,
+    MerkleProof as JsonMerkleProof, OutPoint, ResponseFormat, ResponseFormatInnerType, Timestamp,
+    Transaction, TransactionProof, TransactionWithStatusResponse, Uint32, Uint64,
 };
 use ckb_logger::error;
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::ChainStore;
 use ckb_traits::HeaderProvider;
+use ckb_tx_pool::get_transaction_virtual_bytes;
 use ckb_types::core::tx_pool::TransactionWithStatus;
 use ckb_types::{
     core::{
@@ -1365,6 +1366,48 @@ pub trait ChainRpc {
     /// ```
     #[rpc(name = "estimate_cycles")]
     fn estimate_cycles(&self, tx: Transaction) -> Result<EstimateCycles>;
+
+    /// Returns the fee_rate statistics of confirmed blocks on the chain
+    ///
+    /// ## Params
+    ///
+    /// * `target` - Specify the number (1 - 101) of confirmed blocks to be counted.
+    ///  If the number is even, automatically add one. If not specified, defaults to 21
+    ///
+    /// ## Returns
+    ///
+    /// When the given block hash is not on the current canonical chain, this RPC returns null;
+    /// otherwise returns the median time of the consecutive 37 blocks where the given block_hash has the highest height.
+    ///
+    /// Note that the given block is included in the median time. The included block number range is `[MAX(block - 36, 0), block]`.
+    ///
+    /// ## Examples
+    ///
+    /// Request
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "method": "get_fee_rate_statics",
+    ///   "params": []
+    /// }
+    /// ```
+    ///
+    /// Response
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "result": {
+    ///     "mean":59.29387293275573,
+    ///     "median":5.288207297726071
+    ///    }
+    /// }
+    /// ```
+    #[rpc(name = "get_fee_rate_statics")]
+    fn get_fee_rate_statics(&self, target: Option<Uint64>) -> Result<Option<FeeRateStatics>>;
 }
 
 pub(crate) struct ChainRpcImpl {
@@ -1811,6 +1854,75 @@ impl ChainRpc for ChainRpcImpl {
         let tx: packed::Transaction = tx.into();
         CyclesEstimator::new(&self.shared).run(tx)
     }
+
+    fn get_fee_rate_statics(&self, target: Option<Uint64>) -> Result<Option<FeeRateStatics>> {
+        const DEFAULT_TARGET: u64 = 21;
+        const MIN_TARGET: u64 = 1;
+        const MAX_TARGET: u64 = 101;
+
+        fn is_even(n: u64) -> bool {
+            n & 1 == 0
+        }
+
+        fn mean(numbers: &[f64]) -> f64 {
+            let sum: f64 = numbers.iter().sum();
+            sum / numbers.len() as f64
+        }
+
+        fn median(numbers: &mut [f64]) -> f64 {
+            numbers.sort_unstable_by(|a, b| a.partial_cmp(b).expect("slice does not contain NaN"));
+            let mid = numbers.len() / 2;
+            if numbers.len() % 2 == 0 {
+                mean(&[numbers[mid - 1], numbers[mid]]) as f64
+            } else {
+                numbers[mid]
+            }
+        }
+
+        let mut target: u64 = target.map(Into::into).unwrap_or(DEFAULT_TARGET);
+        if is_even(target) {
+            target = std::cmp::min(MAX_TARGET, target.saturating_add(1));
+        }
+        let snapshot = self.shared.snapshot();
+        let tip_number = snapshot.tip_number();
+        let start = std::cmp::max(
+            MIN_TARGET,
+            tip_number.saturating_add(1).saturating_sub(target),
+        );
+
+        let mut fee_rates = Vec::new();
+        for number in start..=tip_number {
+            if let Some(block_ext) = snapshot
+                .get_block_hash(number)
+                .and_then(|hash| snapshot.get_block_ext(&hash))
+            {
+                if !block_ext.txs_fees.is_empty()
+                    && block_ext.cycles.is_some()
+                    && block_ext.txs_sizes.is_some()
+                {
+                    for (fee, cycles, size) in itertools::izip!(
+                        block_ext.txs_fees,
+                        block_ext.cycles.expect("checked"),
+                        block_ext.txs_sizes.expect("checked")
+                    ) {
+                        let vbytes = get_transaction_virtual_bytes(size as usize, cycles);
+                        if vbytes > 0 {
+                            fee_rates.push(fee.as_u64() as f64 / vbytes as f64);
+                        }
+                    }
+                }
+            }
+        }
+
+        if fee_rates.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(FeeRateStatics {
+                mean: mean(&fee_rates),
+                median: median(&mut fee_rates),
+            }))
+        }
+    }
 }
 
 impl ChainRpcImpl {
@@ -1897,7 +2009,7 @@ impl ChainRpcImpl {
         verbosity: Option<Uint32>,
         with_cycles: Option<bool>,
     ) -> Result<Option<BlockResponse>> {
-        if !snapshot.is_main_chain(&block_hash) {
+        if !snapshot.is_main_chain(block_hash) {
             return Ok(None);
         }
 
@@ -1911,11 +2023,11 @@ impl ChainRpcImpl {
         // TODO: verbosity level == 1, output block only contains tx_hash in JSON format
         let block_view = if verbosity == 2 {
             snapshot
-                .get_block(&block_hash)
+                .get_block(block_hash)
                 .map(|block| ResponseFormat::json(block.into()))
         } else if verbosity == 0 {
             snapshot
-                .get_packed_block(&block_hash)
+                .get_packed_block(block_hash)
                 .map(|packed| ResponseFormat::hex(packed.as_bytes()))
         } else {
             return Err(RPCError::invalid_params("invalid verbosity level"));

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1,8 +1,8 @@
 use crate::error::RPCError;
 use ckb_jsonrpc_types::{
-    BlockEconomicState, BlockNumber, BlockView, CellWithStatus, Consensus, EpochNumber, EpochView,
-    EstimateCycles, HeaderView, JsonBytes, MerkleProof as JsonMerkleProof, OutPoint,
-    ResponseFormat, ResponseFormatInnerType, Timestamp, Transaction, TransactionProof,
+    BlockEconomicState, BlockNumber, BlockResponse, BlockView, CellWithStatus, Consensus,
+    EpochNumber, EpochView, EstimateCycles, HeaderView, JsonBytes, MerkleProof as JsonMerkleProof,
+    OutPoint, ResponseFormat, ResponseFormatInnerType, Timestamp, TransactionProof,
     TransactionWithStatusResponse, Uint32,
 };
 use ckb_logger::error;
@@ -57,6 +57,7 @@ pub trait ChainRpc {
     ///
     /// * `block_hash` - the block hash.
     /// * `verbosity` - result format which allows 0 and 2. (**Optional**, the default is 2.)
+    /// * `with_cycles` - whether the return cycles of block transactions. (**Optional**, default false.)
     ///
     /// ## Returns
     ///
@@ -85,7 +86,9 @@ pub trait ChainRpc {
     ///   "jsonrpc": "2.0",
     ///   "method": "get_block",
     ///   "params": [
-    ///     "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
+    ///     "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+    ///      null,
+    ///      true
     ///   ]
     /// }
     /// ```
@@ -146,7 +149,8 @@ pub trait ChainRpc {
     ///         ]
     ///       }
     ///     ],
-    ///     "uncles": []
+    ///     "uncles": [],
+    ///     "cycles": []
     ///   }
     /// }
     /// ```
@@ -165,7 +169,8 @@ pub trait ChainRpc {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView>>>;
+        with_cycles: Option<bool>,
+    ) -> Result<Option<BlockResponse>>;
 
     /// Returns the block in the [canonical chain](#canonical-chain) with the specific block number.
     ///
@@ -173,6 +178,7 @@ pub trait ChainRpc {
     ///
     /// * `block_number` - the block number.
     /// * `verbosity` - result format which allows 0 and 2. (**Optional**, the default is 2.)
+    /// * `with_cycles` - whether the return cycles of block transactions. (**Optional**, default false.)
     ///
     /// ## Returns
     ///
@@ -265,7 +271,8 @@ pub trait ChainRpc {
     ///         ]
     ///       }
     ///     ],
-    ///     "uncles": []
+    ///     "uncles": [],
+    ///     "cycles": null
     ///   }
     /// }
     /// ```
@@ -284,7 +291,8 @@ pub trait ChainRpc {
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView>>>;
+        with_cycles: Option<bool>,
+    ) -> Result<Option<BlockResponse>>;
 
     /// Returns the information about a block header by hash.
     ///
@@ -1372,65 +1380,39 @@ impl ChainRpc for ChainRpcImpl {
         &self,
         block_hash: H256,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView>>> {
+        with_cycles: Option<bool>,
+    ) -> Result<Option<BlockResponse>> {
         let snapshot = self.shared.snapshot();
         let block_hash = block_hash.pack();
-        if !snapshot.is_main_chain(&block_hash) {
-            return Ok(None);
-        }
 
-        let verbosity = verbosity
-            .map(|v| v.value())
-            .unwrap_or(DEFAULT_BLOCK_VERBOSITY_LEVEL);
-        // TODO: verbosity level == 1, output block only contains tx_hash in JSON format
-        if verbosity == 2 {
-            Ok(snapshot
-                .get_block(&block_hash)
-                .map(|block| ResponseFormat::json(block.into())))
-        } else if verbosity == 0 {
-            Ok(snapshot
-                .get_packed_block(&block_hash)
-                .map(|packed| ResponseFormat::hex(packed.as_bytes())))
-        } else {
-            Err(RPCError::invalid_params("invalid verbosity level"))
-        }
+        self.get_block_by_hash(&snapshot, &block_hash, verbosity, with_cycles)
     }
 
     fn get_block_by_number(
         &self,
         block_number: BlockNumber,
         verbosity: Option<Uint32>,
-    ) -> Result<Option<ResponseFormat<BlockView>>> {
+        with_cycles: Option<bool>,
+    ) -> Result<Option<BlockResponse>> {
         let snapshot = self.shared.snapshot();
         let block_hash = match snapshot.get_block_hash(block_number.into()) {
             Some(block_hash) => block_hash,
             None => return Ok(None),
         };
 
-        let verbosity = verbosity
-            .map(|v| v.value())
-            .unwrap_or(DEFAULT_BLOCK_VERBOSITY_LEVEL);
-        // TODO: verbosity level == 1, output block only contains tx_hash in json format
-        let result = if verbosity == 2 {
-            snapshot
-                .get_block(&block_hash)
-                .map(|block| Some(ResponseFormat::json(block.into())))
-        } else if verbosity == 0 {
-            snapshot
-                .get_packed_block(&block_hash)
-                .map(|block| Some(ResponseFormat::hex(block.as_bytes())))
-        } else {
-            return Err(RPCError::invalid_params("invalid verbosity level"));
-        };
-
-        result.ok_or_else(|| {
+        let ret = self.get_block_by_hash(&snapshot, &block_hash, verbosity, with_cycles);
+        if ret == Ok(None) {
             let message = format!(
                 "Chain Index says block #{} is {:#x}, but that block is not in the database",
                 block_number, block_hash
             );
             error!("{}", message);
-            RPCError::custom(RPCError::ChainIndexIsInconsistent, message)
-        })
+            return Err(RPCError::custom(
+                RPCError::ChainIndexIsInconsistent,
+                message,
+            ));
+        }
+        ret
     }
 
     fn get_header(
@@ -1906,6 +1888,55 @@ impl ChainRpcImpl {
         };
         let transaction_with_status = transaction_with_status.unwrap();
         Ok(Some(transaction_with_status))
+    }
+
+    fn get_block_by_hash(
+        &self,
+        snapshot: &Snapshot,
+        block_hash: &packed::Byte32,
+        verbosity: Option<Uint32>,
+        with_cycles: Option<bool>,
+    ) -> Result<Option<BlockResponse>> {
+        if !snapshot.is_main_chain(&block_hash) {
+            return Ok(None);
+        }
+
+        let verbosity = verbosity
+            .map(|v| v.value())
+            .unwrap_or(DEFAULT_BLOCK_VERBOSITY_LEVEL);
+
+        // default false
+        let with_cycles = with_cycles.unwrap_or(false);
+
+        // TODO: verbosity level == 1, output block only contains tx_hash in JSON format
+        let block_view = if verbosity == 2 {
+            snapshot
+                .get_block(&block_hash)
+                .map(|block| ResponseFormat::json(block.into()))
+        } else if verbosity == 0 {
+            snapshot
+                .get_packed_block(&block_hash)
+                .map(|packed| ResponseFormat::hex(packed.as_bytes()))
+        } else {
+            return Err(RPCError::invalid_params("invalid verbosity level"));
+        };
+
+        Ok(block_view.map(|block| {
+            if with_cycles {
+                let cycles = snapshot
+                    .get_block_ext(block_hash)
+                    .and_then(|ext| ext.cycles);
+                BlockResponse {
+                    block,
+                    cycles: cycles.map(|c| c.into_iter().map(Into::into).collect()),
+                }
+            } else {
+                BlockResponse {
+                    block,
+                    cycles: None,
+                }
+            }
+        }))
     }
 }
 

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -661,6 +661,7 @@ fn before_rpc_example(suite: &RpcTestSuite, example: &mut RpcTestExample) -> boo
             );
         }
         ("generate_block", 42) => return false,
+        ("get_fee_rate_statics", 42) => return false,
         ("generate_block_with_template", 42) => return false,
         ("process_block_without_verify", 42) => return false,
         ("notify_transaction", 42) => return false,

--- a/rpc/src/tests/fee_rate.rs
+++ b/rpc/src/tests/fee_rate.rs
@@ -1,0 +1,88 @@
+use crate::util::{FeeRateCollector, FeeRateProvider};
+use ckb_jsonrpc_types::FeeRateStatics;
+use ckb_types::core::{BlockExt, BlockNumber, Capacity};
+use std::collections::HashMap;
+
+struct DummyFeeRateProvider {
+    tip_number: BlockNumber,
+    block_exts: HashMap<BlockNumber, BlockExt>,
+}
+
+impl DummyFeeRateProvider {
+    pub fn new() -> DummyFeeRateProvider {
+        DummyFeeRateProvider {
+            tip_number: 0,
+            block_exts: HashMap::new(),
+        }
+    }
+
+    pub fn append(&mut self, number: BlockNumber, ext: BlockExt) {
+        if number > self.tip_number {
+            self.tip_number = number;
+        }
+        self.block_exts.insert(number, ext);
+    }
+}
+
+impl FeeRateProvider for DummyFeeRateProvider {
+    fn get_tip_number(&self) -> BlockNumber {
+        self.tip_number
+    }
+
+    fn get_block_ext_by_number(&self, number: BlockNumber) -> Option<BlockExt> {
+        self.block_exts.get(&number).cloned()
+    }
+}
+
+#[test]
+fn test_fee_rate_statics() {
+    let mut provider = DummyFeeRateProvider::new();
+    for i in 0..=21 {
+        let ext = BlockExt {
+            received_at: 0,
+            total_difficulty: 0u64.into(),
+            total_uncles_count: 0,
+            verified: None,
+            txs_fees: vec![Capacity::shannons(i * i * 100)],
+            cycles: Some(vec![i * 100]),
+            txs_sizes: Some(vec![i * 100]),
+        };
+        provider.append(i, ext);
+    }
+
+    let statistics = FeeRateCollector::new(&provider).statistics(None);
+    assert_eq!(
+        statistics,
+        Some(FeeRateStatics {
+            mean: 11.0,
+            median: 11.0
+        })
+    );
+
+    let statistics = FeeRateCollector::new(&provider).statistics(Some(9));
+    assert_eq!(
+        statistics,
+        Some(FeeRateStatics {
+            mean: 17.0,
+            median: 17.0
+        })
+    );
+
+    let statistics = FeeRateCollector::new(&provider).statistics(Some(30));
+    assert_eq!(
+        statistics,
+        Some(FeeRateStatics {
+            mean: 11.0,
+            median: 11.0
+        })
+    );
+
+    let statistics = FeeRateCollector::new(&provider).statistics(Some(0));
+    assert_eq!(
+        statistics,
+        Some(FeeRateStatics {
+            mean: 21.0,
+            median: 21.0
+        })
+    );
+}

--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -27,6 +27,7 @@ use std::{cmp, collections::HashSet, fmt, sync::Arc};
 
 mod error;
 mod examples;
+mod fee_rate;
 mod module;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Default)]

--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -1,0 +1,108 @@
+use ckb_jsonrpc_types::FeeRateStatics;
+use ckb_shared::Snapshot;
+use ckb_store::ChainStore;
+use ckb_tx_pool::get_transaction_virtual_bytes;
+use ckb_types::core::{BlockExt, BlockNumber};
+
+const DEFAULT_TARGET: u64 = 21;
+const MIN_TARGET: u64 = 1;
+const MAX_TARGET: u64 = 101;
+
+fn is_even(n: u64) -> bool {
+    n & 1 == 0
+}
+
+fn mean(numbers: &[f64]) -> f64 {
+    let sum: f64 = numbers.iter().sum();
+    sum / numbers.len() as f64
+}
+
+fn median(numbers: &mut [f64]) -> f64 {
+    numbers.sort_unstable_by(|a, b| a.partial_cmp(b).expect("slice does not contain NaN"));
+    let mid = numbers.len() / 2;
+    if numbers.len() % 2 == 0 {
+        mean(&[numbers[mid - 1], numbers[mid]]) as f64
+    } else {
+        numbers[mid]
+    }
+}
+
+pub(crate) trait FeeRateProvider {
+    fn get_tip_number(&self) -> BlockNumber;
+    fn get_block_ext_by_number(&self, number: BlockNumber) -> Option<BlockExt>;
+
+    fn collect<F>(&self, target: u64, f: F) -> Vec<f64>
+    where
+        F: FnMut(Vec<f64>, BlockExt) -> Vec<f64>,
+    {
+        let tip_number = self.get_tip_number();
+        let start = std::cmp::max(
+            MIN_TARGET,
+            tip_number.saturating_add(1).saturating_sub(target),
+        );
+
+        let block_ext_iter =
+            (start..=tip_number).filter_map(|number| self.get_block_ext_by_number(number));
+        block_ext_iter.fold(Vec::new(), f)
+    }
+}
+
+impl FeeRateProvider for Snapshot {
+    fn get_tip_number(&self) -> BlockNumber {
+        self.tip_number()
+    }
+
+    fn get_block_ext_by_number(&self, number: BlockNumber) -> Option<BlockExt> {
+        self.get_block_hash(number)
+            .and_then(|hash| self.get_block_ext(&hash))
+    }
+}
+
+// FeeRateCollector collect fee_rate related information
+pub(crate) struct FeeRateCollector<'a, P> {
+    provider: &'a P,
+}
+
+impl<'a, P> FeeRateCollector<'a, P>
+where
+    P: FeeRateProvider,
+{
+    pub fn new(provider: &'a P) -> Self {
+        FeeRateCollector { provider }
+    }
+
+    pub fn statistics(&self, target: Option<u64>) -> Option<FeeRateStatics> {
+        let mut target = target.unwrap_or(DEFAULT_TARGET);
+        if is_even(target) {
+            target = std::cmp::min(MAX_TARGET, target.saturating_add(1));
+        }
+
+        let mut fee_rates = self.provider.collect(target, |mut fee_rates, block_ext| {
+            if !block_ext.txs_fees.is_empty()
+                && block_ext.cycles.is_some()
+                && block_ext.txs_sizes.is_some()
+            {
+                for (fee, cycles, size) in itertools::izip!(
+                    block_ext.txs_fees,
+                    block_ext.cycles.expect("checked"),
+                    block_ext.txs_sizes.expect("checked")
+                ) {
+                    let vbytes = get_transaction_virtual_bytes(size as usize, cycles);
+                    if vbytes > 0 {
+                        fee_rates.push(fee.as_u64() as f64 / vbytes as f64);
+                    }
+                }
+            }
+            fee_rates
+        });
+
+        if fee_rates.is_empty() {
+            None
+        } else {
+            Some(FeeRateStatics {
+                mean: mean(&fee_rates),
+                median: median(&mut fee_rates),
+            })
+        }
+    }
+}

--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -1,8 +1,7 @@
 use ckb_jsonrpc_types::FeeRateStatics;
 use ckb_shared::Snapshot;
 use ckb_store::ChainStore;
-use ckb_tx_pool::get_transaction_virtual_bytes;
-use ckb_types::core::{BlockExt, BlockNumber};
+use ckb_types::core::{tx_pool::get_transaction_virtual_bytes, BlockExt, BlockNumber};
 
 const DEFAULT_TARGET: u64 = 21;
 const MIN_TARGET: u64 = 1;

--- a/rpc/src/util/mod.rs
+++ b/rpc/src/util/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod fee_rate;
 
 pub(crate) use fee_rate::FeeRateCollector;
+
+#[cfg(test)]
+pub(crate) use fee_rate::FeeRateProvider;

--- a/rpc/src/util/mod.rs
+++ b/rpc/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod fee_rate;
+
+pub(crate) use fee_rate::FeeRateCollector;

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -181,6 +181,8 @@ impl ChainDB {
             total_uncles_count: 0,
             verified: Some(true),
             txs_fees: vec![],
+            cycles: Some(vec![]),
+            txs_sizes: Some(vec![]),
         };
 
         attach_block_cell(&db_txn, genesis)?;

--- a/store/src/tests/db.rs
+++ b/store/src/tests/db.rs
@@ -58,6 +58,8 @@ fn save_and_get_block_ext() {
         total_uncles_count: block.data().uncles().len() as u64,
         verified: Some(true),
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
 
     let hash = block.hash();

--- a/store/src/transaction.rs
+++ b/store/src/transaction.rs
@@ -243,10 +243,11 @@ impl StoreTransaction {
         block_hash: &packed::Byte32,
         ext: &BlockExt,
     ) -> Result<(), Error> {
+        let packed_ext: packed::BlockExtV1 = ext.pack();
         self.insert_raw(
             COLUMN_BLOCK_EXT,
             block_hash.as_slice(),
-            ext.pack().as_slice(),
+            packed_ext.as_slice(),
         )
     }
 

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -28,9 +28,12 @@ impl Spec for TransactionRelayBasic {
         let hash = node1.submit_transaction(&transaction);
 
         let relayed = wait_until(10, || {
-            nodes
-                .iter()
-                .all(|node| node.rpc_client().get_transaction(hash.clone()).is_some())
+            nodes.iter().all(|node| {
+                node.rpc_client()
+                    .get_transaction(hash.clone())
+                    .map(|ret| ret.cycles == Some(537.into()))
+                    .unwrap_or(false)
+            })
         });
         assert!(
             relayed,

--- a/test/src/util/check.rs
+++ b/test/src/util/check.rs
@@ -5,21 +5,21 @@ use ckb_types::core::{BlockView, EpochNumberWithFraction, HeaderView, Transactio
 pub fn is_transaction_pending(node: &Node, transaction: &TransactionView) -> bool {
     node.rpc_client()
         .get_transaction(transaction.hash())
-        .map(|txstatus| txstatus.tx_status.status == Status::Pending)
+        .map(|ret| ret.tx_status.status == Status::Pending && ret.cycles.is_some())
         .unwrap_or(false)
 }
 
 pub fn is_transaction_proposed(node: &Node, transaction: &TransactionView) -> bool {
     node.rpc_client()
         .get_transaction(transaction.hash())
-        .map(|txstatus| txstatus.tx_status.status == Status::Proposed)
+        .map(|ret| ret.tx_status.status == Status::Proposed && ret.cycles.is_some())
         .unwrap_or(false)
 }
 
 pub fn is_transaction_committed(node: &Node, transaction: &TransactionView) -> bool {
     node.rpc_client()
         .get_transaction(transaction.hash())
-        .map(|txstatus| txstatus.tx_status.status == Status::Committed)
+        .map(|ret| ret.tx_status.status == Status::Committed && ret.cycles.is_some())
         .unwrap_or(false)
 }
 

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -1,7 +1,10 @@
 use crate::component::container::AncestorsScoreSortKey;
-use crate::component::get_transaction_virtual_bytes;
 use ckb_types::{
-    core::{cell::ResolvedTransaction, tx_pool::TxEntryInfo, Capacity, Cycle, TransactionView},
+    core::{
+        cell::ResolvedTransaction,
+        tx_pool::{get_transaction_virtual_bytes, TxEntryInfo},
+        Capacity, Cycle, TransactionView,
+    },
     packed::{OutPoint, ProposalShortId},
 };
 use faketime::unix_time_as_millis;

--- a/tx-pool/src/component/mod.rs
+++ b/tx-pool/src/component/mod.rs
@@ -20,7 +20,7 @@ const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_170_571_4_f64;
 
 /// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
 /// tx_pool use vbytes to estimate transaction fee rate.
-pub(crate) fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
+pub fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
     std::cmp::max(
         tx_size as u64,
         (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,

--- a/tx-pool/src/component/mod.rs
+++ b/tx-pool/src/component/mod.rs
@@ -12,17 +12,3 @@ pub(crate) mod recent_reject;
 mod tests;
 
 pub use self::entry::TxEntry;
-
-/// Equal to MAX_BLOCK_BYTES / MAX_BLOCK_CYCLES, see ckb-chain-spec.
-/// The precision is set so that the difference between MAX_BLOCK_CYCLES * DEFAULT_BYTES_PER_CYCLES
-/// and MAX_BLOCK_BYTES is less than 1.
-const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_170_571_4_f64;
-
-/// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
-/// tx_pool use vbytes to estimate transaction fee rate.
-pub fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
-    std::cmp::max(
-        tx_size as u64,
-        (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,
-    )
-}

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -13,7 +13,7 @@ pub mod service;
 mod util;
 
 pub use ckb_jsonrpc_types::BlockTemplate;
-pub use component::{entry::TxEntry, get_transaction_virtual_bytes};
+pub use component::entry::TxEntry;
 pub use pool::TxPool;
 pub use process::PlugTarget;
 pub use service::{TxPoolController, TxPoolServiceBuilder};

--- a/tx-pool/src/lib.rs
+++ b/tx-pool/src/lib.rs
@@ -13,7 +13,7 @@ pub mod service;
 mod util;
 
 pub use ckb_jsonrpc_types::BlockTemplate;
-pub use component::entry::TxEntry;
+pub use component::{entry::TxEntry, get_transaction_virtual_bytes};
 pub use pool::TxPool;
 pub use process::PlugTarget;
 pub use service::{TxPoolController, TxPoolServiceBuilder};

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -200,11 +200,8 @@ impl TxPool {
     }
 
     /// Returns tx from pending and gap corresponding to the id. RPC
-    pub fn get_tx_from_pending_or_else_gap(
-        &self,
-        id: &ProposalShortId,
-    ) -> Option<&TransactionView> {
-        self.pending.get_tx(id).or_else(|| self.gap.get_tx(id))
+    pub fn get_entry_from_pending_or_gap(&self, id: &ProposalShortId) -> Option<&TxEntry> {
+        self.pending.get(id).or_else(|| self.gap.get(id))
     }
 
     pub(crate) fn proposed(&self) -> &ProposedPool {

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -520,6 +520,8 @@ impl From<Transaction> for packed::Transaction {
 pub struct TransactionWithStatusResponse {
     /// The transaction.
     pub transaction: Option<ResponseFormat<TransactionView>>,
+    /// The transaction consumed cycles.
+    pub cycles: Option<Cycle>,
     /// The Transaction status.
     pub tx_status: TxStatus,
 }
@@ -534,12 +536,14 @@ impl TransactionWithStatusResponse {
                     .transaction
                     .map(|tx| ResponseFormat::hex(tx.data().as_bytes())),
                 tx_status: t.tx_status.into(),
+                cycles: t.cycles.map(Into::into),
             },
             ResponseFormatInnerType::Json => TransactionWithStatusResponse {
                 transaction: t
                     .transaction
                     .map(|tx| ResponseFormat::json(TransactionView::from(tx))),
                 tx_status: t.tx_status.into(),
+                cycles: t.cycles.map(Into::into),
             },
         }
     }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1347,7 +1347,7 @@ impl HardForkFeature {
 }
 
 /// The fee_rate statistics information, includes mean and median
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct FeeRateStatics {
     /// mean
     pub mean: f64,

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1345,3 +1345,12 @@ impl HardForkFeature {
         ]
     }
 }
+
+/// The fee_rate statistics information, includes mean and median
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct FeeRateStatics {
+    /// mean
+    pub mean: f64,
+    /// median
+    pub median: f64,
+}

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -914,6 +914,17 @@ pub struct Block {
     pub extension: Option<JsonBytes>,
 }
 
+/// The wrapper represent response of `get_block` | `get_block_by_number`, return a Block with cycles.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct BlockResponse {
+    /// The block structure
+    #[serde(flatten)]
+    pub block: ResponseFormat<BlockView>,
+    /// The block transactions consumed cycles.
+    #[serde(default)]
+    pub cycles: Option<Vec<Cycle>>,
+}
+
 /// The JSON view of a Block including header and body.
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct BlockView {

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -25,10 +25,11 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, BlockEconomicState, BlockIssuance, BlockView, CellDep, CellInput, CellOutput, Consensus,
-    DepType, EpochView, HardForkFeature, Header, HeaderView, MerkleProof, MinerReward, OutPoint,
-    ProposalWindow, Script, ScriptHashType, Status, Transaction, TransactionProof, TransactionView,
-    TransactionWithStatusResponse, TxStatus, UncleBlock, UncleBlockView,
+    Block, BlockEconomicState, BlockIssuance, BlockResponse, BlockView, CellDep, CellInput,
+    CellOutput, Consensus, DepType, EpochView, HardForkFeature, Header, HeaderView, MerkleProof,
+    MinerReward, OutPoint, ProposalWindow, Script, ScriptHashType, Status, Transaction,
+    TransactionProof, TransactionView, TransactionWithStatusResponse, TxStatus, UncleBlock,
+    UncleBlockView,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellData, CellInfo, CellWithStatus};
@@ -63,7 +64,7 @@ use ckb_types::bytes::Bytes;
 
 /// The enum `Either` with variants `Left` and `Right` is a general purpose
 /// sum type with two cases.
-#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Either<L, R> {
     /// A value of type `L`.
@@ -78,7 +79,7 @@ pub enum Either<L, R> {
 ///
 /// `ResponseFormat<BlockView>` returns the block in its Json format or molecule serialized
 /// Hex format.
-#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(transparent)]
 pub struct ResponseFormat<V> {
     /// The inner value.

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -26,10 +26,10 @@ pub use self::block_template::{
 };
 pub use self::blockchain::{
     Block, BlockEconomicState, BlockIssuance, BlockResponse, BlockView, CellDep, CellInput,
-    CellOutput, Consensus, DepType, EpochView, HardForkFeature, Header, HeaderView, MerkleProof,
-    MinerReward, OutPoint, ProposalWindow, Script, ScriptHashType, Status, Transaction,
-    TransactionProof, TransactionView, TransactionWithStatusResponse, TxStatus, UncleBlock,
-    UncleBlockView,
+    CellOutput, Consensus, DepType, EpochView, FeeRateStatics, HardForkFeature, Header, HeaderView,
+    MerkleProof, MinerReward, OutPoint, ProposalWindow, Script, ScriptHashType, Status,
+    Transaction, TransactionProof, TransactionView, TransactionWithStatusResponse, TxStatus,
+    UncleBlock, UncleBlockView,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellData, CellInfo, CellWithStatus};

--- a/util/launcher/src/tests.rs
+++ b/util/launcher/src/tests.rs
@@ -78,6 +78,8 @@ fn test_mock_migration() {
         total_uncles_count: 0,
         verified: None,
         txs_fees: vec![],
+        cycles: None,
+        txs_sizes: None,
     };
 
     // insert_block_epoch_index

--- a/util/light-client-protocol-server/src/tests/components/mod.rs
+++ b/util/light-client-protocol-server/src/tests/components/mod.rs
@@ -1,2 +1,2 @@
-mod get_blocks_proof;
-mod get_transactions_proof;
+// mod get_blocks_proof;
+// mod get_transactions_proof;

--- a/util/light-client-protocol-server/src/tests/components/mod.rs
+++ b/util/light-client-protocol-server/src/tests/components/mod.rs
@@ -1,2 +1,2 @@
-// mod get_blocks_proof;
-// mod get_transactions_proof;
+mod get_blocks_proof;
+mod get_transactions_proof;

--- a/util/reward-calculator/src/tests.rs
+++ b/util/reward-calculator/src/tests.rs
@@ -80,6 +80,8 @@ fn test_txs_fees() {
         total_uncles_count: block.data().uncles().len() as u64,
         verified: Some(true),
         txs_fees: ext_tx_fees,
+        cycles: None,
+        txs_sizes: None,
     };
 
     let txn = store.begin_transaction();
@@ -256,6 +258,8 @@ fn test_proposal_reward() {
         total_uncles_count: block_14.data().uncles().len() as u64,
         verified: Some(true),
         txs_fees: ext_tx_fees_14,
+        cycles: None,
+        txs_sizes: None,
     };
 
     // txs(p4)
@@ -267,6 +271,8 @@ fn test_proposal_reward() {
         total_uncles_count: block_15.data().uncles().len() as u64,
         verified: Some(true),
         txs_fees: ext_tx_fees_15,
+        cycles: None,
+        txs_sizes: None,
     };
 
     // txs(p5, p6)
@@ -278,6 +284,8 @@ fn test_proposal_reward() {
         total_uncles_count: block_18.data().uncles().len() as u64,
         verified: Some(true),
         txs_fees: ext_tx_fees_18,
+        cycles: None,
+        txs_sizes: None,
     };
 
     let txn = store.begin_transaction();

--- a/util/test-chain-utils/src/mock_store.rs
+++ b/util/test-chain-utils/src/mock_store.rs
@@ -52,6 +52,8 @@ impl MockStore {
             total_uncles_count: 0,
             verified: Some(true),
             txs_fees: vec![],
+            cycles: None,
+            txs_sizes: None,
         };
         let store = Self::default();
         {
@@ -94,6 +96,8 @@ impl MockStore {
                     + block.data().uncles().len() as u64,
                 verified: Some(true),
                 txs_fees: vec![],
+                cycles: None,
+                txs_sizes: None,
             };
             db_txn.insert_block_ext(&block.hash(), &block_ext).unwrap();
         }

--- a/util/types/schemas/extensions.mol
+++ b/util/types/schemas/extensions.mol
@@ -23,6 +23,8 @@ option CellOutputOpt (CellOutput);
 vector HeaderVec <Header>;
 vector OutPointVec <OutPoint>;
 
+option Uint64VecOpt (Uint64Vec);
+
 /* Types for Light Client */
 
 struct HeaderDigest {
@@ -67,6 +69,16 @@ table BlockExt {
     received_at:        Uint64,
     txs_fees:           Uint64Vec,
     verified:           BoolOpt,
+}
+
+table BlockExtV1 {
+    total_difficulty:   Uint256,
+    total_uncles_count: Uint64,
+    received_at:        Uint64,
+    txs_fees:           Uint64Vec,
+    verified:           BoolOpt,
+    cycles:             Uint64VecOpt,
+    txs_sizes:          Uint64VecOpt,
 }
 
 struct EpochExt {

--- a/util/types/src/conversion/primitive.rs
+++ b/util/types/src/conversion/primitive.rs
@@ -173,6 +173,26 @@ impl Pack<packed::Bytes> for String {
     }
 }
 
+impl<'r> Unpack<Option<Vec<u64>>> for packed::Uint64VecOptReader<'r> {
+    fn unpack(&self) -> Option<Vec<u64>> {
+        self.to_opt().map(|x| x.unpack())
+    }
+}
+
+impl_conversion_for_entity_unpack!(Option<Vec<u64>>, Uint64VecOpt);
+
+impl Pack<packed::Uint64VecOpt> for Option<Vec<u64>> {
+    fn pack(&self) -> packed::Uint64VecOpt {
+        if let Some(inner) = self.as_ref() {
+            packed::Uint64VecOptBuilder::default()
+                .set(Some(inner.pack()))
+                .build()
+        } else {
+            packed::Uint64VecOpt::default()
+        }
+    }
+}
+
 impl_conversion_for_option!(bool, BoolOpt, BoolOptReader);
 impl_conversion_for_vector!(u32, Uint32Vec, Uint32VecReader);
 impl_conversion_for_vector!(usize, Uint32Vec, Uint32VecReader);

--- a/util/types/src/conversion/storage.rs
+++ b/util/types/src/conversion/storage.rs
@@ -59,18 +59,6 @@ impl<'r> Unpack<core::TransactionView> for packed::TransactionViewReader<'r> {
 }
 impl_conversion_for_entity_unpack!(core::TransactionView, TransactionView);
 
-impl Pack<packed::BlockExt> for core::BlockExt {
-    fn pack(&self) -> packed::BlockExt {
-        packed::BlockExt::new_builder()
-            .received_at(self.received_at.pack())
-            .total_difficulty(self.total_difficulty.pack())
-            .total_uncles_count(self.total_uncles_count.pack())
-            .verified(self.verified.pack())
-            .txs_fees((&self.txs_fees[..]).pack())
-            .build()
-    }
-}
-
 impl<'r> Unpack<core::BlockExt> for packed::BlockExtReader<'r> {
     fn unpack(&self) -> core::BlockExt {
         core::BlockExt {
@@ -79,10 +67,41 @@ impl<'r> Unpack<core::BlockExt> for packed::BlockExtReader<'r> {
             total_uncles_count: self.total_uncles_count().unpack(),
             verified: self.verified().unpack(),
             txs_fees: self.txs_fees().unpack(),
+            cycles: None,
+            txs_sizes: None,
         }
     }
 }
 impl_conversion_for_entity_unpack!(core::BlockExt, BlockExt);
+
+impl Pack<packed::BlockExtV1> for core::BlockExt {
+    fn pack(&self) -> packed::BlockExtV1 {
+        packed::BlockExtV1::new_builder()
+            .received_at(self.received_at.pack())
+            .total_difficulty(self.total_difficulty.pack())
+            .total_uncles_count(self.total_uncles_count.pack())
+            .verified(self.verified.pack())
+            .txs_fees((&self.txs_fees[..]).pack())
+            .cycles(self.cycles.pack())
+            .txs_sizes(self.txs_sizes.pack())
+            .build()
+    }
+}
+
+impl<'r> Unpack<core::BlockExt> for packed::BlockExtV1Reader<'r> {
+    fn unpack(&self) -> core::BlockExt {
+        core::BlockExt {
+            received_at: self.received_at().unpack(),
+            total_difficulty: self.total_difficulty().unpack(),
+            total_uncles_count: self.total_uncles_count().unpack(),
+            verified: self.verified().unpack(),
+            txs_fees: self.txs_fees().unpack(),
+            cycles: self.cycles().unpack(),
+            txs_sizes: self.txs_sizes().unpack(),
+        }
+    }
+}
+impl_conversion_for_entity_unpack!(core::BlockExt, BlockExtV1);
 
 impl Pack<packed::EpochExt> for core::EpochExt {
     fn pack(&self) -> packed::EpochExt {

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{BlockNumber, Capacity, CapacityResult, EpochNumber},
+    core::{BlockNumber, Capacity, CapacityResult, Cycle, EpochNumber},
     packed,
     prelude::*,
     U256,
@@ -23,6 +23,10 @@ pub struct BlockExt {
     pub verified: Option<bool>,
     /// TODO(doc): @quake
     pub txs_fees: Vec<Capacity>,
+    /// block txs consumed cycles
+    pub cycles: Option<Vec<Cycle>>,
+    /// block txs serialized sizes
+    pub txs_sizes: Option<Vec<u64>>,
 }
 
 /// TODO(doc): @quake

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -142,32 +142,41 @@ pub struct TxPoolEntryInfo {
 pub struct TransactionWithStatus {
     /// The transaction.
     pub transaction: Option<core::TransactionView>,
-    /// The Transaction status.
+    /// The transaction status.
     pub tx_status: TxStatus,
+    /// The transaction verification consumed cycles
+    pub cycles: Option<core::Cycle>,
 }
 
 impl TransactionWithStatus {
     /// Build with pending status
-    pub fn with_pending(tx: Option<core::TransactionView>) -> Self {
+    pub fn with_pending(tx: Option<core::TransactionView>, cycles: core::Cycle) -> Self {
         Self {
             tx_status: TxStatus::Pending,
             transaction: tx,
+            cycles: Some(cycles),
         }
     }
 
     /// Build with proposed status
-    pub fn with_proposed(tx: Option<core::TransactionView>) -> Self {
+    pub fn with_proposed(tx: Option<core::TransactionView>, cycles: core::Cycle) -> Self {
         Self {
             tx_status: TxStatus::Proposed,
             transaction: tx,
+            cycles: Some(cycles),
         }
     }
 
     /// Build with committed status
-    pub fn with_committed(tx: Option<core::TransactionView>, hash: H256) -> Self {
+    pub fn with_committed(
+        tx: Option<core::TransactionView>,
+        hash: H256,
+        cycles: Option<core::Cycle>,
+    ) -> Self {
         Self {
             tx_status: TxStatus::Committed(hash),
             transaction: tx,
+            cycles,
         }
     }
 
@@ -176,6 +185,7 @@ impl TransactionWithStatus {
         Self {
             tx_status: TxStatus::Rejected(reason),
             transaction: None,
+            cycles: None,
         }
     }
 
@@ -184,14 +194,16 @@ impl TransactionWithStatus {
         Self {
             tx_status: TxStatus::Unknown,
             transaction: None,
+            cycles: None,
         }
     }
 
-    /// Build with status only
-    pub fn status_only(tx_status: TxStatus) -> Self {
+    /// Omit transaction
+    pub fn omit_transaction(tx_status: TxStatus, cycles: Option<core::Cycle>) -> Self {
         Self {
             tx_status,
             transaction: None,
+            cycles,
         }
     }
 

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -212,3 +212,17 @@ impl TransactionWithStatus {
         matches!(self.tx_status, TxStatus::Unknown)
     }
 }
+
+/// Equal to MAX_BLOCK_BYTES / MAX_BLOCK_CYCLES, see ckb-chain-spec.
+/// The precision is set so that the difference between MAX_BLOCK_CYCLES * DEFAULT_BYTES_PER_CYCLES
+/// and MAX_BLOCK_BYTES is less than 1.
+pub const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_170_571_4_f64;
+
+/// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
+/// tx_pool use vbytes to estimate transaction fee rate.
+pub fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
+    std::cmp::max(
+        tx_size as u64,
+        (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,
+    )
+}

--- a/util/types/src/generated/extensions.rs
+++ b/util/types/src/generated/extensions.rs
@@ -2472,6 +2472,169 @@ impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for OutPointVecReaderIterator<'
     }
 }
 #[derive(Clone)]
+pub struct Uint64VecOpt(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Uint64VecOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Uint64VecOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Uint64VecOpt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        if let Some(v) = self.to_opt() {
+            write!(f, "{}(Some({}))", Self::NAME, v)
+        } else {
+            write!(f, "{}(None)", Self::NAME)
+        }
+    }
+}
+impl ::core::default::Default for Uint64VecOpt {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![];
+        Uint64VecOpt::new_unchecked(v.into())
+    }
+}
+impl Uint64VecOpt {
+    pub fn is_none(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn is_some(&self) -> bool {
+        !self.0.is_empty()
+    }
+    pub fn to_opt(&self) -> Option<Uint64Vec> {
+        if self.is_none() {
+            None
+        } else {
+            Some(Uint64Vec::new_unchecked(self.0.clone()))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> Uint64VecOptReader<'r> {
+        Uint64VecOptReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Uint64VecOpt {
+    type Builder = Uint64VecOptBuilder;
+    const NAME: &'static str = "Uint64VecOpt";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Uint64VecOpt(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Uint64VecOptReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Uint64VecOptReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set(self.to_opt())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Uint64VecOptReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for Uint64VecOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for Uint64VecOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for Uint64VecOptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        if let Some(v) = self.to_opt() {
+            write!(f, "{}(Some({}))", Self::NAME, v)
+        } else {
+            write!(f, "{}(None)", Self::NAME)
+        }
+    }
+}
+impl<'r> Uint64VecOptReader<'r> {
+    pub fn is_none(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn is_some(&self) -> bool {
+        !self.0.is_empty()
+    }
+    pub fn to_opt(&self) -> Option<Uint64VecReader<'r>> {
+        if self.is_none() {
+            None
+        } else {
+            Some(Uint64VecReader::new_unchecked(self.as_slice()))
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Uint64VecOptReader<'r> {
+    type Entity = Uint64VecOpt;
+    const NAME: &'static str = "Uint64VecOptReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Uint64VecOptReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        if !slice.is_empty() {
+            Uint64VecReader::verify(&slice[..], compatible)?;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct Uint64VecOptBuilder(pub(crate) Option<Uint64Vec>);
+impl Uint64VecOptBuilder {
+    pub fn set(mut self, v: Option<Uint64Vec>) -> Self {
+        self.0 = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Uint64VecOptBuilder {
+    type Entity = Uint64VecOpt;
+    const NAME: &'static str = "Uint64VecOptBuilder";
+    fn expected_length(&self) -> usize {
+        self.0
+            .as_ref()
+            .map(|ref inner| inner.as_slice().len())
+            .unwrap_or(0)
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        self.0
+            .as_ref()
+            .map(|ref inner| writer.write_all(inner.as_slice()))
+            .unwrap_or(Ok(()))
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Uint64VecOpt::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct HeaderDigest(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for HeaderDigest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -3856,6 +4019,407 @@ impl molecule::prelude::Builder for BlockExtBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         BlockExt::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct BlockExtV1(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for BlockExtV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for BlockExtV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for BlockExtV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "total_difficulty", self.total_difficulty())?;
+        write!(
+            f,
+            ", {}: {}",
+            "total_uncles_count",
+            self.total_uncles_count()
+        )?;
+        write!(f, ", {}: {}", "received_at", self.received_at())?;
+        write!(f, ", {}: {}", "txs_fees", self.txs_fees())?;
+        write!(f, ", {}: {}", "verified", self.verified())?;
+        write!(f, ", {}: {}", "cycles", self.cycles())?;
+        write!(f, ", {}: {}", "txs_sizes", self.txs_sizes())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for BlockExtV1 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            84, 0, 0, 0, 32, 0, 0, 0, 64, 0, 0, 0, 72, 0, 0, 0, 80, 0, 0, 0, 84, 0, 0, 0, 84, 0, 0,
+            0, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        BlockExtV1::new_unchecked(v.into())
+    }
+}
+impl BlockExtV1 {
+    pub const FIELD_COUNT: usize = 7;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn total_difficulty(&self) -> Uint256 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint256::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn total_uncles_count(&self) -> Uint64 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Uint64::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn received_at(&self) -> Uint64 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        Uint64::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn txs_fees(&self) -> Uint64Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        let end = molecule::unpack_number(&slice[20..]) as usize;
+        Uint64Vec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn verified(&self) -> BoolOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[20..]) as usize;
+        let end = molecule::unpack_number(&slice[24..]) as usize;
+        BoolOpt::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn cycles(&self) -> Uint64VecOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[24..]) as usize;
+        let end = molecule::unpack_number(&slice[28..]) as usize;
+        Uint64VecOpt::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn txs_sizes(&self) -> Uint64VecOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[28..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[32..]) as usize;
+            Uint64VecOpt::new_unchecked(self.0.slice(start..end))
+        } else {
+            Uint64VecOpt::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> BlockExtV1Reader<'r> {
+        BlockExtV1Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for BlockExtV1 {
+    type Builder = BlockExtV1Builder;
+    const NAME: &'static str = "BlockExtV1";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        BlockExtV1(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        BlockExtV1Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        BlockExtV1Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .total_difficulty(self.total_difficulty())
+            .total_uncles_count(self.total_uncles_count())
+            .received_at(self.received_at())
+            .txs_fees(self.txs_fees())
+            .verified(self.verified())
+            .cycles(self.cycles())
+            .txs_sizes(self.txs_sizes())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct BlockExtV1Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for BlockExtV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for BlockExtV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for BlockExtV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "total_difficulty", self.total_difficulty())?;
+        write!(
+            f,
+            ", {}: {}",
+            "total_uncles_count",
+            self.total_uncles_count()
+        )?;
+        write!(f, ", {}: {}", "received_at", self.received_at())?;
+        write!(f, ", {}: {}", "txs_fees", self.txs_fees())?;
+        write!(f, ", {}: {}", "verified", self.verified())?;
+        write!(f, ", {}: {}", "cycles", self.cycles())?;
+        write!(f, ", {}: {}", "txs_sizes", self.txs_sizes())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> BlockExtV1Reader<'r> {
+    pub const FIELD_COUNT: usize = 7;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn total_difficulty(&self) -> Uint256Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint256Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn total_uncles_count(&self) -> Uint64Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn received_at(&self) -> Uint64Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn txs_fees(&self) -> Uint64VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
+        let end = molecule::unpack_number(&slice[20..]) as usize;
+        Uint64VecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn verified(&self) -> BoolOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[20..]) as usize;
+        let end = molecule::unpack_number(&slice[24..]) as usize;
+        BoolOptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn cycles(&self) -> Uint64VecOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[24..]) as usize;
+        let end = molecule::unpack_number(&slice[28..]) as usize;
+        Uint64VecOptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn txs_sizes(&self) -> Uint64VecOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[28..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[32..]) as usize;
+            Uint64VecOptReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Uint64VecOptReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for BlockExtV1Reader<'r> {
+    type Entity = BlockExtV1;
+    const NAME: &'static str = "BlockExtV1Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        BlockExtV1Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Uint256Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Uint64Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Uint64Reader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Uint64VecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        BoolOptReader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
+        Uint64VecOptReader::verify(&slice[offsets[5]..offsets[6]], compatible)?;
+        Uint64VecOptReader::verify(&slice[offsets[6]..offsets[7]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct BlockExtV1Builder {
+    pub(crate) total_difficulty: Uint256,
+    pub(crate) total_uncles_count: Uint64,
+    pub(crate) received_at: Uint64,
+    pub(crate) txs_fees: Uint64Vec,
+    pub(crate) verified: BoolOpt,
+    pub(crate) cycles: Uint64VecOpt,
+    pub(crate) txs_sizes: Uint64VecOpt,
+}
+impl BlockExtV1Builder {
+    pub const FIELD_COUNT: usize = 7;
+    pub fn total_difficulty(mut self, v: Uint256) -> Self {
+        self.total_difficulty = v;
+        self
+    }
+    pub fn total_uncles_count(mut self, v: Uint64) -> Self {
+        self.total_uncles_count = v;
+        self
+    }
+    pub fn received_at(mut self, v: Uint64) -> Self {
+        self.received_at = v;
+        self
+    }
+    pub fn txs_fees(mut self, v: Uint64Vec) -> Self {
+        self.txs_fees = v;
+        self
+    }
+    pub fn verified(mut self, v: BoolOpt) -> Self {
+        self.verified = v;
+        self
+    }
+    pub fn cycles(mut self, v: Uint64VecOpt) -> Self {
+        self.cycles = v;
+        self
+    }
+    pub fn txs_sizes(mut self, v: Uint64VecOpt) -> Self {
+        self.txs_sizes = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for BlockExtV1Builder {
+    type Entity = BlockExtV1;
+    const NAME: &'static str = "BlockExtV1Builder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.total_difficulty.as_slice().len()
+            + self.total_uncles_count.as_slice().len()
+            + self.received_at.as_slice().len()
+            + self.txs_fees.as_slice().len()
+            + self.verified.as_slice().len()
+            + self.cycles.as_slice().len()
+            + self.txs_sizes.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.total_difficulty.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.total_uncles_count.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.received_at.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.txs_fees.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.verified.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.cycles.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.txs_sizes.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.total_difficulty.as_slice())?;
+        writer.write_all(self.total_uncles_count.as_slice())?;
+        writer.write_all(self.received_at.as_slice())?;
+        writer.write_all(self.txs_fees.as_slice())?;
+        writer.write_all(self.verified.as_slice())?;
+        writer.write_all(self.cycles.as_slice())?;
+        writer.write_all(self.txs_sizes.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        BlockExtV1::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/util/types/src/prelude.rs
+++ b/util/types/src/prelude.rs
@@ -35,6 +35,9 @@ impl<T> ShouldBeOk<T> for molecule::error::VerificationResult<T> {
 pub trait FromSliceShouldBeOk<'r>: Reader<'r> {
     /// Unwraps the result of `from_slice(..)` with confidence and we assume that it's impossible to fail.
     fn from_slice_should_be_ok(slice: &'r [u8]) -> Self;
+
+    /// Unwraps the result of `from_compatible_slice(..)` with confidence and we assume that it's impossible to fail.
+    fn from_compatible_slice_should_be_ok(slice: &'r [u8]) -> Self;
 }
 
 impl<'r, R> FromSliceShouldBeOk<'r> for R
@@ -43,6 +46,17 @@ where
 {
     fn from_slice_should_be_ok(slice: &'r [u8]) -> Self {
         match Self::from_slice(slice) {
+            Ok(ret) => ret,
+            Err(err) => panic!(
+                "failed to convert from slice: reason: {}; data: 0x{}.",
+                err,
+                hex_string(slice)
+            ),
+        }
+    }
+
+    fn from_compatible_slice_should_be_ok(slice: &'r [u8]) -> Self {
+        match Self::from_compatible_slice(slice) {
             Ok(ret) => ret,
             Err(err) => panic!(
                 "failed to convert from slice: reason: {}; data: 0x{}.",


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Improve ckb's support for recording and accessing cycles as described in [3613](https://github.com/nervosnetwork/ckb/issues/3673), while implementing the fee_rate estimate short-term scheme.


### What is changed and how it works?

* For cycles and tx_size, the appending of records is done in a compatible way, so that when a new version of the node is run, new data is written, cycles and tx_size are appended, and old data is read in a compatible way. RPC returns data that is not recorded as `null`.
* `get_block`/`get_block_by_number` adds a parameter `with_cycles` to choose whether to return cycles or not, mainly because some scenarios, such as indexer, do not need cycles and are performance sensitive, so an additional parameter is added to avoid the extra overhead needed to return cycles.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

