### PR TITLE
fix: rpc deployment info doc

### DIFF
--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -523,8 +523,11 @@ class EnumSchema(HTMLParser):
             if tag == 'h3':
                 attrs_dict = dict(attrs)
                 if 'id' in attrs_dict and attrs_dict['id'].startswith('variant.') and ('class', 'variant small-section-header') in attrs:
-                    self.next_variant = camel_to_snake(
-                        attrs_dict['id'].split('.')[1])
+                    if self.name in ["DeploymentPos", "DeploymentState"]:
+                        self.next_variant = attrs_dict['id'].split('.')[1]
+                    else:
+                        self.next_variant = camel_to_snake(
+                            attrs_dict['id'].split('.')[1])
         elif self.variant_parser is None:
             if tag == 'div' and attrs == [("class", "docblock")]:
                 self.variant_parser = MarkdownParser(title_level=3)

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -5442,7 +5442,7 @@ An object containing various state info regarding deployments of consensus chang
 
 Deployment name
 
-`DeploymentPos` is equivalent to `"testdummy" | "light_client"`.
+`DeploymentPos` is equivalent to `"Testdummy" | "LightClient"`.
 
 *   Dummy
 *   light client protocol
@@ -5452,7 +5452,7 @@ Deployment name
 
 The possible softfork deployment state
 
-`DeploymentState` is equivalent to `"defined" | "started" | "locked_in" | "active" | "failed"`.
+`DeploymentState` is equivalent to `"Defined" | "Started" | "LockedIn" | "Active" | "Failed"`.
 
 *   First state that each softfork starts. The 0 epoch is by definition in this state for each deployment.
 *   For epochs past the `start` epoch.


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The current implementation of deployment info RPC returns an enum that is PascalCase, and the document is converted to a snake_case


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

