### PR TITLE
ci: The set-output command is deprecated and will be disabled soon, f…

### DIFF
--- a/.github/actions/ci_prologue/ci_prologue.sh
+++ b/.github/actions/ci_prologue/ci_prologue.sh
@@ -15,7 +15,7 @@ fun_run_os(){
       fi
   done < "runs_on.txt"
   echo "OS skip is "$os_skip
-  echo "::set-output name=os_skip::$os_skip"
+  echo "os_skip=$os_skip" >> $GITHUB_OUTPUT
 }
 
 fun_jobs(){
@@ -32,7 +32,7 @@ fun_jobs(){
     fi
   done < "job_run.txt"
   echo "JOB skip is" $job_skip
-  echo "::set-output name=job_skip::$job_skip"
+  echo "job_skip=$job_skip" >> $GITHUB_OUTPUT
 }
 
 fun_pasing_message(){
@@ -77,8 +77,8 @@ fun_pasing_message(){
   fi
   echo "linux_runner_label is "$linux_runner_label
   echo "windows_runner_label is "$windows_runner_label
-  echo "::set-output name=linux_runner_label::$linux_runner_label"
-  echo "::set-output name=windows_runner_label::$windows_runner_label"
+  echo "linux_runner_label=$linux_runner_label" >> $GITHUB_OUTPUT
+  echo "windows_runner_label=$windows_runner_label" >> $GITHUB_OUTPUT
 }
 
 if [[ $GITHUB_EVENT_NAME == "push" ]];then
@@ -101,11 +101,11 @@ if [[ $GITHUB_EVENT_NAME == "pull_request" ]];then
     job_run_list=" [ quick_checks,unit_tests,integration_tests,benchmarks,linters,wasm_build,cargo_deny,aarch64_build ] "
     fun_jobs "$job_run_list"
     if [[ "$GITHUB_REPOSITORY" == "nervosnetwork/ckb" ]];then
-      echo "::set-output name=linux_runner_label::self-hosted-ci-ubuntu-20.04"
-      echo "::set-output name=windows_runner_label::self-hosted-ci-windows-2019"
+      echo "linux_runner_label=self-hosted-ci-ubuntu-20.04" >> $GITHUB_OUTPUT
+      echo "windows_runner_label=self-hosted-ci-windows-2019" >> $GITHUB_OUTPUT
     else
-      echo "::set-output name=linux_runner_label::ubuntu-20.04"
-      echo "::set-output name=windows_runner_label::windows-2019"
+      echo "linux_runner_label=ubuntu-20.04" >> $GITHUB_OUTPUT
+      echo "windows_runner_label=windows-2019" >> $GITHUB_OUTPUT
     fi
   fi
 fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get Current Date & Set ENV
         id: date
         run: |
-          echo "::set-output name=date::$(date +'%Y-%m-%d')"
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           echo "START_TIME=$(date +%Y-%m-%d' '%H:%M:%S.%6N)" >> $GITHUB_ENV
           echo "CKB_COMMIT_ID=$(git describe --dirty --always --match _EXCLUDE__ --abbrev=7)" >> $GITHUB_ENV
           echo "CKB_COMMIT_TIME=$(git log -1 --date=iso "--pretty=format:%cd" | cut -d ' ' -f 1,2)" >> $GITHUB_ENV

--- a/.github/workflows/sync-mainnet.yml
+++ b/.github/workflows/sync-mainnet.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get Current Date
         id: date
         run: |
-          echo "::set-output name=date::$(date +'%Y-%m-%d')"
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           echo "START_TIME=$(date +%Y-%m-%d' '%H:%M:%S.%6N)" >> $GITHUB_ENV
           echo "CKB_COMMIT_ID=$(git describe --dirty --always --match _EXCLUDE__ --abbrev=7)" >> $GITHUB_ENV
           echo "CKB_COMMIT_TIME=$(git log -1 --date=iso "--pretty=format:%cd" | cut -d ' ' -f 1,2)" >> $GITHUB_ENV


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes
- Fixed the warning that the set-output command  is deprecated.
- Still have some warning about set-output command since the  https://github.com/actions-rs
[toolchain](https://github.com/actions-rs/toolchain)  need to bump @actions deps. A PR https://github.com/actions-rs/toolchain/pull/222 to filx it ,but not merge yet.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
