### PR TITLE
fix(light-client): do not skip the genesis block for last state proofs

### DIFF
--- a/util/light-client-protocol-server/src/tests/components/get_last_state_proof.rs
+++ b/util/light-client-protocol-server/src/tests/components/get_last_state_proof.rs
@@ -1,0 +1,95 @@
+use ckb_merkle_mountain_range::{leaf_index_to_mmr_size, leaf_index_to_pos};
+use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
+use ckb_types::{
+    packed,
+    prelude::*,
+    utilities::merkle_mountain_range::{MMRProof, VerifiableHeader},
+};
+
+use crate::tests::{
+    prelude::*,
+    utils::{MockChain, MockNetworkContext},
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_last_state_proof_with_the_genesis_block() {
+    let chain = MockChain::new();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    chain.mine_to(1);
+
+    let snapshot = chain.shared().snapshot();
+    let verifiable_tip_header: VerifiableHeader =
+        snapshot.get_verifiable_header_by_number(1).unwrap().into();
+    let tip_header = verifiable_tip_header.header();
+    let genesis_header = snapshot.get_header_by_number(0).unwrap();
+
+    let mut protocol = chain.create_light_client_protocol();
+
+    let data = {
+        let content = packed::GetLastStateProof::new_builder()
+            .last_hash(tip_header.hash())
+            .start_hash(genesis_header.hash())
+            .start_number(0u64.pack())
+            .last_n_blocks(10u64.pack())
+            .difficulty_boundary(genesis_header.difficulty().pack())
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    assert!(nc.sent_messages().borrow().is_empty());
+
+    let peer_index = PeerIndex::new(1);
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.not_banned(peer_index));
+
+    assert_eq!(nc.sent_messages().borrow().len(), 1);
+
+    let data = &nc.sent_messages().borrow()[0].2;
+    let message = packed::LightClientMessageReader::new_unchecked(data);
+    let content = if let packed::LightClientMessageUnionReader::SendLastStateProof(content) =
+        message.to_enum()
+    {
+        content
+    } else {
+        panic!("unexpected message");
+    }
+    .to_entity();
+
+    // Verify MMR Proof
+    {
+        let parent_chain_root = verifiable_tip_header.parent_chain_root();
+        let proof: MMRProof = {
+            let mmr_size = leaf_index_to_mmr_size(parent_chain_root.end_number().unpack());
+            let proof = content.proof().into_iter().collect();
+            MMRProof::new(mmr_size, proof)
+        };
+        let digests_with_positions = {
+            let result = content
+                .headers()
+                .into_iter()
+                .map(|verifiable_header| {
+                    let header = verifiable_header.header().into_view();
+                    let index = header.number();
+                    let position = leaf_index_to_pos(index);
+                    let digest = header.digest();
+                    digest.verify()?;
+                    Ok((position, digest))
+                })
+                .collect::<Result<Vec<_>, String>>();
+            assert!(result.is_ok(), "failed since {}", result.unwrap_err());
+            result.unwrap()
+        };
+        let result = proof.verify(parent_chain_root, digests_with_positions);
+        assert!(result.is_ok(), "failed since {}", result.unwrap_err());
+    }
+
+    assert_eq!(content.headers().len(), 1);
+
+    let verifiable_header: VerifiableHeader = content.headers().get(0).unwrap().into();
+    assert!(verifiable_header.header().is_genesis());
+}

--- a/util/light-client-protocol-server/src/tests/components/mod.rs
+++ b/util/light-client-protocol-server/src/tests/components/mod.rs
@@ -1,2 +1,3 @@
 mod get_blocks_proof;
+mod get_last_state_proof;
 mod get_transactions_proof;


### PR DESCRIPTION
### What problem does this PR solve?

Should not skip the genesis block for last state proofs.

For example, when current tip header at 1, then the last state proof have to contain the genesis block.

### What is changed and how it works?

Since #3675, the genesis block will use a default struct as its parent chain root, so we don't have to skip it anymore.

https://github.com/nervosnetwork/ckb/blob/5aa8b426d0aef48c5a854a74176b5eb9b85896fb/util/light-client-protocol-server/src/lib.rs#L125-L127

And, for more security, we should check if the parent chain root of a genesis block is a default struct.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```