### PR TITLE
fix: resolve a long reorg error

### DIFF
--- a/util/indexer/src/indexer.rs
+++ b/util/indexer/src/indexer.rs
@@ -691,6 +691,7 @@ where
     }
 
     /// Return block hash by specified block_number
+    #[cfg(test)]
     pub(crate) fn get_block_hash(
         &self,
         block_number: BlockNumber,

--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -150,27 +150,8 @@ impl IndexerService {
                             info!("append {}, {}", block.number(), block.hash());
                             indexer.append(&block).expect("append block should be OK");
                         } else {
-                            // Long fork detection
-                            let longest_fork_number = tip_number.saturating_sub(keep_num);
-                            match self.get_block_by_number(longest_fork_number) {
-                                Some(block) => {
-                                    let stored_block_hash = indexer
-                                        .get_block_hash(longest_fork_number)
-                                        .expect("get block hash should be OK")
-                                        .expect("stored block header");
-                                    if block.hash() != stored_block_hash {
-                                        error!("long fork detected, ckb-indexer stored block {} => {:#x}, ckb node returns block {} => {:#x}, please check if ckb-indexer is connected to the same network ckb node.", longest_fork_number, stored_block_hash, longest_fork_number, block.hash());
-                                        break;
-                                    } else {
-                                        info!("rollback {}, {}", tip_number, tip_hash);
-                                        indexer.rollback().expect("rollback block should be OK");
-                                    }
-                                }
-                                None => {
-                                    error!("long fork detected, ckb-indexer stored block {}, ckb node returns none, please check if ckb-indexer is connected to the same network ckb node.", longest_fork_number);
-                                    break;
-                                }
-                            }
+                            info!("rollback {}, {}", tip_number, tip_hash);
+                            indexer.rollback().expect("rollback block should be OK");
                         }
                     }
                     None => {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

resolve https://github.com/nervosnetwork/ckb-indexer/issues/60

### What is changed and how it works?

remove all long fork checking code and resolve the panic error since built-in indexer always connect to the ckb node in the same chain

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (ref: https://github.com/nervosnetwork/ckb-indexer/issues/60)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes orew features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

