### PR TITLE
fix: get block rpc compatibility

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -321,9 +321,7 @@ Request
   "jsonrpc": "2.0",
   "method": "get_block",
   "params": [
-    "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
-     null,
-     true
+     "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
   ]
 }
 ```
@@ -386,8 +384,7 @@ Response
         ]
       }
     ],
-    "uncles": [],
-    "cycles": []
+    "uncles": []
   }
 }
 ```
@@ -401,6 +398,21 @@ The response looks like below when `verbosity` is 0.
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x..."
+}
+```
+
+
+When specifying with_cycles, the response object will be different like below:
+
+
+```
+{
+    "id": 42,
+    "jsonrpc": "2.0",
+    "result": {
+        "block": <Object> or "0x...",
+        "cycles": []
+    }
 }
 ```
 
@@ -512,8 +524,7 @@ Response
         ]
       }
     ],
-    "uncles": [],
-    "cycles": null
+    "uncles": []
   }
 }
 ```
@@ -527,6 +538,21 @@ The response looks like below when `verbosity` is 0.
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x..."
+}
+```
+
+
+When specifying with_cycles, the response object will be different like below:
+
+
+```
+{
+    "id": 42,
+    "jsonrpc": "2.0",
+    "result": {
+        "block": <Object> or "0x...",
+        "cycles": []
+    }
 }
 ```
 
@@ -5010,13 +5036,20 @@ This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in 
 
 The wrapper represent response of `get_block` | `get_block_by_number`, return a Block with cycles.
 
-#### Fields
+`BlockResponse` is equivalent to `"regular" | "with_cycles"`.
 
-`BlockResponse` is a JSON object with the following fields.
+*   The block response regular format
 
-*   `block`: [`ResponseFormat`](#type-responseformat) - The block structure
+    [`BlockView`](#type-blockview) | [`SerializedBlock`](#type-serializedblock) - The block structure
 
-*   `cycles`: `Array<` [`Cycle`](#type-cycle) `>` `|` `null` - The block transactions consumed cycles.
+*   The block with cycles response format
+
+    A JSON object with the following fields:
+
+    *   `block`: [`BlockView`](#type-blockview) | [`SerializedBlock`](#type-serializedblock) - The block structure
+
+    *   `cycles`: `Array<` [`Cycle`](#type-cycle) `>` `|` `null` - The block transactions consumed cycles.
+
 
 
 ### Type `BlockTemplate`

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -87,9 +87,7 @@ pub trait ChainRpc {
     ///   "jsonrpc": "2.0",
     ///   "method": "get_block",
     ///   "params": [
-    ///     "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
-    ///      null,
-    ///      true
+    ///      "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     ///   ]
     /// }
     /// ```
@@ -150,8 +148,7 @@ pub trait ChainRpc {
     ///         ]
     ///       }
     ///     ],
-    ///     "uncles": [],
-    ///     "cycles": []
+    ///     "uncles": []
     ///   }
     /// }
     /// ```
@@ -163,6 +160,19 @@ pub trait ChainRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0x..."
+    /// }
+    /// ```
+    ///
+    /// When specifying with_cycles, the response object will be different like below:
+    ///
+    /// ```text
+    /// {
+    ///     "id": 42,
+    ///     "jsonrpc": "2.0",
+    ///     "result": {
+    ///         "block": <Object> or "0x...",
+    ///         "cycles": []
+    ///     }
     /// }
     /// ```
     #[rpc(name = "get_block")]
@@ -272,8 +282,7 @@ pub trait ChainRpc {
     ///         ]
     ///       }
     ///     ],
-    ///     "uncles": [],
-    ///     "cycles": null
+    ///     "uncles": []
     ///   }
     /// }
     /// ```
@@ -285,6 +294,19 @@ pub trait ChainRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0x..."
+    /// }
+    /// ```
+    ///
+    /// When specifying with_cycles, the response object will be different like below:
+    ///
+    /// ```text
+    /// {
+    ///     "id": 42,
+    ///     "jsonrpc": "2.0",
+    ///     "result": {
+    ///         "block": <Object> or "0x...",
+    ///         "cycles": []
+    ///     }
     /// }
     /// ```
     #[rpc(name = "get_block_by_number")]
@@ -1971,15 +1993,13 @@ impl ChainRpcImpl {
                 let cycles = snapshot
                     .get_block_ext(block_hash)
                     .and_then(|ext| ext.cycles);
-                BlockResponse {
+
+                BlockResponse::with_cycles(
                     block,
-                    cycles: cycles.map(|c| c.into_iter().map(Into::into).collect()),
-                }
+                    cycles.map(|c| c.into_iter().map(Into::into).collect()),
+                )
             } else {
-                BlockResponse {
-                    block,
-                    cycles: None,
-                }
+                BlockResponse::regular(block)
             }
         }))
     }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -916,9 +916,36 @@ pub struct Block {
 
 /// The wrapper represent response of `get_block` | `get_block_by_number`, return a Block with cycles.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-pub struct BlockResponse {
+#[serde(untagged)]
+pub enum BlockResponse {
+    /// The block response regular format
+    ///
+    /// [`BlockView`] | [\`SerializedBlock\`](#type-serializedblock) - The block structure
+    Regular(ResponseFormat<BlockView>),
+    /// The block with cycles response format
+    ///
+    /// A JSON object with the following fields:
+    /// * `block`: [`BlockView`] | [\`SerializedBlock\`](#type-serializedblock) - The block structure
+    /// * `cycles`: `Array<` [`Cycle`](#type-cycle) `>` `|` `null` - The block transactions consumed cycles.
+    WithCycles(BlockWithCyclesResponse),
+}
+
+impl BlockResponse {
+    /// Wrap regular block response
+    pub fn regular(block: ResponseFormat<BlockView>) -> Self {
+        BlockResponse::Regular(block)
+    }
+
+    /// Wrap with cycles block response
+    pub fn with_cycles(block: ResponseFormat<BlockView>, cycles: Option<Vec<Cycle>>) -> Self {
+        BlockResponse::WithCycles(BlockWithCyclesResponse { block, cycles })
+    }
+}
+
+/// BlockResponse with cycles format wrapper
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct BlockWithCyclesResponse {
     /// The block structure
-    #[serde(flatten)]
     pub block: ResponseFormat<BlockView>,
     /// The block transactions consumed cycles.
     #[serde(default)]

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -25,11 +25,11 @@ pub use self::block_template::{
     BlockTemplate, CellbaseTemplate, TransactionTemplate, UncleTemplate,
 };
 pub use self::blockchain::{
-    Block, BlockEconomicState, BlockIssuance, BlockResponse, BlockView, CellDep, CellInput,
-    CellOutput, Consensus, DepType, EpochView, FeeRateStatics, HardForkFeature, Header, HeaderView,
-    MerkleProof, MinerReward, OutPoint, ProposalWindow, Script, ScriptHashType, Status,
-    Transaction, TransactionProof, TransactionView, TransactionWithStatusResponse, TxStatus,
-    UncleBlock, UncleBlockView,
+    Block, BlockEconomicState, BlockIssuance, BlockResponse, BlockView, BlockWithCyclesResponse,
+    CellDep, CellInput, CellOutput, Consensus, DepType, EpochView, FeeRateStatics, HardForkFeature,
+    Header, HeaderView, MerkleProof, MinerReward, OutPoint, ProposalWindow, Script, ScriptHashType,
+    Status, Transaction, TransactionProof, TransactionView, TransactionWithStatusResponse,
+    TxStatus, UncleBlock, UncleBlockView,
 };
 pub use self::bytes::JsonBytes;
 pub use self::cell::{CellData, CellInfo, CellWithStatus};


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix https://github.com/nervosnetwork/ckb/pull/3684 introduced incompatibility issues

Because serde does not support flatten_if(https://github.com/serde-rs/serde/issues/1614), and for compatibility with verbosity mode, when with_cycles specified,  the hierarchical of response object will be different.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

