### PR TITLE
chore: bump ckb-vm to v0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1126bf0240d100234bc06efa7020f0d50ca35fe90e5ac7cac1b7721e1bacb7"
+checksum = "d8e8f7ba49aa55d08f8a575b69bc535cad65fdba75fea90856cee1fd3822a7a9"
 dependencies = [
  "byteorder",
  "bytes 1.2.1",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14739bf59648c169de9257ec7dd6aba1aeb6a41725d636005f1c91853df58fcc"
+checksum = "5445b62604e7ab2bf5abb37bf6cca7ac26b2e4a76fddb27ceb61850f24864d58"
 
 [[package]]
 name = "clang-sys"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -21,7 +21,7 @@ ckb-traits = { path = "../traits", version = "= 0.106.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.106.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.106.0-pre" }
-ckb-vm = { version = "=0.22.0", default-features = false }
+ckb-vm = { version = "=0.22.1", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.106.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

bump ckb-vm to v0.22.1
https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.22.1

Fix issues that ckb-vm runs under macos ventura AArch64

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

