### PR TITLE
fix: unknown list should get header from headermap and db

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -379,6 +379,15 @@ impl Synchronizer {
                 }
             }
 
+            // On ibd, node should only have one peer to sync headers, and it's state can control by
+            // headers_sync_controller.
+            //
+            // The header sync of other nodes does not matter in the ibd phase, and parallel synchronization
+            // can be enabled by unknown list, so there is no need to repeatedly download headers with
+            // multiple nodes at the same time.
+            if active_chain.is_initial_block_download() {
+                continue;
+            }
             if state.peer_flags.is_outbound {
                 let best_known_header = state.best_known_header.as_ref();
                 let (tip_header, local_total_difficulty) = {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1887,19 +1887,6 @@ impl SyncState {
             }
         }
     }
-
-    pub fn try_update_best_known_with_unknown_header_list(&self, pi: PeerIndex) {
-        // header list is an ordered list, sorted from highest to lowest,
-        // when header hash unknown, break loop is ok
-        while let Some(hash) = self.peers().take_unknown_last(pi) {
-            if let Some(header) = self.header_map.get(&hash) {
-                self.peers.may_set_best_known_header(pi, header);
-            } else {
-                self.peers.insert_unknown_header_hash(pi, hash);
-                break;
-            }
-        }
-    }
 }
 
 /** ActiveChain captures a point-in-time view of indexed chain of blocks. */


### PR DESCRIPTION
### What problem does this PR solve?

Thanks to @eval-exec for pointing out these problems

ref: #3668

#### unknown list bug
`unknown_list` is the key to enabling multi-node parallel download in ibd phase. Its implementation is the get locator algorithm:
https://github.com/nervosnetwork/ckb/blob/1ce2b34cbad6c9573cb2dbb50af8de1dce4b027c/sync/src/types/mod.rs#L2032-L2035

Note this line in the algorithm, all results are added to the genesis hash again at the end

If `insert_peer_unknown_header_list` can find the corresponding value at the beginning of a new connection, this node can be used as one of the download sources:
https://github.com/nervosnetwork/ckb/blob/1ce2b34cbad6c9573cb2dbb50af8de1dce4b027c/sync/src/types/mod.rs#L1875-L1889

Otherwise, `try_update_best_known_with_unknown_header_list` will get stuck in a dead loop on the genesis hash and the node will not be able to become a download source again in the connected state:

https://github.com/nervosnetwork/ckb/blob/1ce2b34cbad6c9573cb2dbb50af8de1dce4b027c/sync/src/types/mod.rs#L1891-L1903

**Finally**, the `try_update_best_known_with_unknown_header_list` function is removed and `get_header_view` is used instead of just looking from the headermap.

Because if the block is inserted into the DB and the header map is cleaned up, the unknown list may get stuck in this situation where the hash cannot be found, resulting in reduce the download of the source. 

#### eviction bug

In the ibd process, a node can only request headers data from one peer at a time. For headers, multiple data sources will result in duplicate downloads.

When synchronization starts, the headers_sync_controller of the node will be initialized to the normal state:

https://github.com/nervosnetwork/ckb/blob/1ce2b34cbad6c9573cb2dbb50af8de1dce4b027c/sync/src/synchronizer/mod.rs#L370-L380

`eviction`'s remaining judgments will likely result in simultaneous requests for headers to multiple data sources, which is unnecessary in the ibd phase and should be disabled

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

