### PR TITLE
feat: tuning the locator algorithm

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -2014,7 +2014,7 @@ impl ActiveChain {
                 step <<= 1;
             }
 
-            if index < step {
+            if index < step * 2 {
                 // Insert some low-height blocks in the locator
                 // to quickly start parallel ibd block downloads
                 // and it should not be too much


### PR DESCRIPTION
### What problem does this PR solve?

This previous PR #3261 increased the locator length, but it didn't solve the problem

Take the current height as an example：
Current Algorithm：
[8480818...8480809, 8480807 ...4286507, 92203, 46101, 23050, 11525, 5762]
PR Algorithm：
[8480818...8480809, 8480807 ...4286507, 2143253, 1071626, 535813, 267906, 133953, 66976, 33488, 16744, 8372, 4186]

At the moment `index < step * 2`, too much data is skipped. This will cause a break in the download process, resulting in ibd not being able to be in a multi-node download state as much as possible.

What we want to do is, at the moment `index < step * 2`, turn on the right-shift decrement of the `index` directly, so that the data is not broken as much as possible

ref: #3668

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

