### PR TITLE
Fix tx-pool potential inconsistent after reorg occurs

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -402,6 +402,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(GetRawTxPool),
         Box::new(PoolReconcile),
         Box::new(PoolResurrect),
+        Box::new(PoolResolveConflictAfterReorg),
         Box::new(InvalidHeaderDep),
         #[cfg(not(target_os = "windows"))]
         Box::new(PoolPersisted),

--- a/test/src/specs/tx_pool/pool_reconcile.rs
+++ b/test/src/specs/tx_pool/pool_reconcile.rs
@@ -1,6 +1,16 @@
 use crate::node::waiting_for_sync;
+use crate::node::{connect_all, disconnect_all};
+use crate::util::check::is_transaction_proposed;
+use crate::util::mining::out_ibd_mode;
 use crate::{Node, Spec};
+use ckb_jsonrpc_types::ProposalShortId;
 use ckb_logger::info;
+use ckb_types::core::{capacity_bytes, Capacity, FeeRate};
+use ckb_types::packed::CellOutputBuilder;
+use ckb_types::{
+    packed::{self, CellInput, OutPoint},
+    prelude::*,
+};
 
 pub struct PoolReconcile;
 
@@ -45,5 +55,125 @@ impl Spec for PoolReconcile {
             .tx_status
             .block_hash
             .is_none());
+    }
+}
+
+pub struct PoolResolveConflictAfterReorg;
+
+impl Spec for PoolResolveConflictAfterReorg {
+    crate::setup!(num_nodes: 2);
+
+    fn run(&self, nodes: &mut Vec<Node>) {
+        out_ibd_mode(nodes);
+        connect_all(nodes);
+
+        let node0 = &nodes[0];
+        let node1 = &nodes[1];
+
+        node0.mine_until_out_bootstrap_period();
+        waiting_for_sync(nodes);
+
+        info!("Use generated block's cellbase as tx input");
+        let tx1 = node0.new_transaction_spend_tip_cellbase();
+        // build txs chain
+        let mut txs = vec![tx1.clone()];
+        while txs.len() < 3 {
+            let parent = txs.last().unwrap();
+            let child = parent
+                .as_advanced_builder()
+                .set_inputs(vec![{
+                    CellInput::new_builder()
+                        .previous_output(OutPoint::new(parent.hash(), 0))
+                        .build()
+                }])
+                .set_outputs(vec![parent.output(0).unwrap()])
+                .build();
+            txs.push(child);
+        }
+        assert_eq!(txs.len(), 3);
+
+        info!("Disconnect nodes");
+        disconnect_all(nodes);
+
+        info!("submit tx1 chain to node0");
+        let ret = node0
+            .rpc_client()
+            .send_transaction_result(tx1.data().into());
+        assert!(ret.is_ok());
+
+        let target: ProposalShortId = packed::ProposalShortId::from_tx_hash(&tx1.hash()).into();
+        let last =
+            node0.mine_with_blocking(|template| !template.proposals.iter().any(|id| id == &target));
+        node0.mine_with_blocking(|template| template.number.value() != (last + 1));
+        for tx in txs[1..].iter() {
+            let ret = node0.rpc_client().send_transaction_result(tx.data().into());
+            assert!(ret.is_ok());
+        }
+        let block = node0
+            .new_block_builder_with_blocking(|template| {
+                !(template
+                    .transactions
+                    .iter()
+                    .any(|tx| tx.hash == tx1.hash().unpack()))
+            })
+            .set_proposals(txs.iter().map(|tx| tx.proposal_short_id()).collect())
+            .build();
+        node0.submit_block(&block);
+
+        node0.mine_with_blocking(|template| template.number.value() != (block.number() + 1));
+        for tx in txs[1..].iter() {
+            assert!(is_transaction_proposed(node0, tx));
+        }
+
+        info!("Tx1 mined by node1");
+        assert!(node0
+            .rpc_client()
+            .get_transaction(tx1.hash())
+            .unwrap()
+            .tx_status
+            .block_hash
+            .is_some());
+
+        let tip_number0 = node0.get_tip_block_number();
+        info!("Mine until node1 > node0");
+        while node1.get_tip_block_number() < tip_number0 + 1 {
+            let proposed_block = node1
+                .new_block_builder(None, None, None)
+                .set_proposals(txs.iter().map(|tx| tx.proposal_short_id()).collect())
+                .build();
+            node1.submit_block(&proposed_block);
+        }
+
+        info!("Connect node0 to node1");
+        node0.connect(node1);
+
+        waiting_for_sync(nodes);
+
+        for tx in txs.iter() {
+            assert!(is_transaction_proposed(node0, tx));
+        }
+
+        let conflict_tx = tx1
+            .as_advanced_builder()
+            .set_inputs(vec![{
+                CellInput::new_builder()
+                    .previous_output(OutPoint::new(tx1.hash(), 0))
+                    .build()
+            }])
+            .set_outputs(vec![CellOutputBuilder::default()
+                .capacity(capacity_bytes!(99).pack())
+                .build()])
+            .build();
+
+        let ret = node0
+            .rpc_client()
+            .send_transaction_result(conflict_tx.data().into());
+        assert!(ret.is_err());
+        let err_msg = ret.err().unwrap().to_string();
+        assert!(err_msg.contains("Resolve failed Dead"));
+    }
+
+    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
+        config.tx_pool.min_fee_rate = FeeRate::from_u64(0);
     }
 }

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -572,9 +572,10 @@ impl BlockAssembler {
                     {
                         error!(
                             "resolve transactions when build block template, \
-                             tip_number: {}, tip_hash: {}, error: {:?}",
+                             tip_number: {}, tip_hash: {}, tx_hash: {}, error: {:?}",
                             tip_header.number(),
                             tip_header.hash(),
+                            entry.transaction().hash(),
                             err
                         );
                         None

--- a/tx-pool/src/component/proposed.rs
+++ b/tx-pool/src/component/proposed.rs
@@ -67,6 +67,10 @@ impl Edges {
         self.inputs.get(out_point)
     }
 
+    pub(crate) fn get_deps_ref(&self, out_point: &OutPoint) -> Option<&HashSet<ProposalShortId>> {
+        self.deps.get(out_point)
+    }
+
     pub(crate) fn get_mut_output(
         &mut self,
         out_point: &OutPoint,
@@ -269,10 +273,73 @@ impl ProposedPool {
                     self.edges.insert_deps(d.to_owned(), tx_short_id.clone());
                 }
 
+                // record tx unconsumed output
+                for o in outputs {
+                    self.edges.insert_output(o);
+                }
+
+                // record header_deps
+                if !header_deps.is_empty() {
+                    self.edges
+                        .header_deps
+                        .insert(tx_short_id, header_deps.into_iter().collect());
+                }
+            }
+            inserted
+        })
+    }
+
+    // In the event of a reorg, the assumption that a newly added tx has no
+    // in-pool children is false.  In particular, the pool is in an
+    // inconsistent state while new transactions are being added, because there may
+    // be descendant transactions of a tx coming from a disconnected block that are
+    // unreachable from just looking at transactions in the pool (the linking
+    // transactions may also be in the disconnected block, waiting to be added).
+    // Because of this, there's not much benefit in trying to search for in-pool
+    // children in add_entry().  Instead, in the special case of transactions
+    // being added from a disconnected block, out-of-block descendants for all the
+    // in-block transactions by calling update_descendants_from_detached().  Note that
+    // until this is called, the pool state is not consistent, and in particular
+    // TxLinks may not be correct (and therefore functions like
+    // calc_ancestors() and calc_descendants() that rely
+    // on them to walk the pool are not generally safe to use).
+    pub(crate) fn add_entry_from_detached(&mut self, entry: TxEntry) -> Result<bool, Reject> {
+        let tx_short_id = entry.proposal_short_id();
+
+        if self.inner.contains_key(&tx_short_id) {
+            return Ok(false);
+        }
+
+        let inputs = entry.transaction().input_pts_iter();
+        let outputs = entry.transaction().output_pts();
+        let related_dep_out_points: Vec<_> = entry.related_dep_out_points().cloned().collect();
+        let header_deps = entry.transaction().header_deps();
+
+        self.inner.add_entry(entry).map(|inserted| {
+            if inserted {
+                let mut children = HashSet::new();
+                // if input reference a in-pool output, connect it
+                // otherwise, record input for conflict check
+                for i in inputs {
+                    if let Some(id) = self.edges.get_mut_output(&i) {
+                        *id = Some(tx_short_id.clone());
+                    }
+                    self.edges.insert_input(i.to_owned(), tx_short_id.clone());
+                }
+
+                // record dep-txid
+                for d in related_dep_out_points {
+                    self.edges.insert_deps(d.to_owned(), tx_short_id.clone());
+                }
+
                 // record tx output
                 for o in outputs {
+                    if let Some(ids) = self.edges.get_deps_ref(&o).cloned() {
+                        children.extend(ids);
+                    }
                     if let Some(id) = self.edges.get_input_ref(&o).cloned() {
-                        self.edges.insert_consumed_output(o, id);
+                        self.edges.insert_consumed_output(o, id.clone());
+                        children.insert(id);
                     } else {
                         self.edges.insert_output(o);
                     }
@@ -282,8 +349,11 @@ impl ProposedPool {
                 if !header_deps.is_empty() {
                     self.edges
                         .header_deps
-                        .insert(tx_short_id, header_deps.into_iter().collect());
+                        .insert(tx_short_id.clone(), header_deps.into_iter().collect());
                 }
+
+                self.inner
+                    .update_descendants_from_detached(&tx_short_id, children);
             }
             inserted
         })

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -169,6 +169,12 @@ impl TxPool {
         self.proposed.add_entry(entry)
     }
 
+    /// Add detached transactions back to the proposed.
+    pub fn add_proposed_from_detached(&mut self, entry: TxEntry) -> Result<bool, Reject> {
+        trace!("add_proposed_from_detached {}", entry.transaction().hash());
+        self.proposed.add_entry_from_detached(entry)
+    }
+
     /// Returns true if the tx-pool contains a tx with specified id.
     pub fn contains_proposal_id(&self, id: &ProposalShortId) -> bool {
         self.pending.contains_key(id) || self.gap.contains_key(id) || self.proposed.contains_key(id)


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Usually when a new transaction is added to the pool, it has no in-pool children (because any such children would be an orphan).  In the event of a reorg, the assumption that a newly added tx has no in-pool children is false.  In particular, the pool is in an inconsistent state while new transactions are being added.

### What is changed and how it works?

When a reorg occurs and the tx-pool adds transactions from the disconnect block, it also updates the state of the corresponding descendants to ensure that the state is consistent.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

