### PR TITLE
ckb-network: add try_from<ProtocolId> trait for SupportProtocols

### DIFF
--- a/network/src/protocols/support_protocols.rs
+++ b/network/src/protocols/support_protocols.rs
@@ -158,3 +158,23 @@ impl From<SupportProtocols> for MetaBuilder {
             })
     }
 }
+
+impl TryFrom<ProtocolId> for SupportProtocols {
+    type Error = ();
+    fn try_from(proto_id: ProtocolId) -> Result<Self, Self::Error> {
+        match proto_id.value() {
+            0 => Ok(SupportProtocols::Ping),
+            1 => Ok(SupportProtocols::Discovery),
+            2 => Ok(SupportProtocols::Identify),
+            3 => Ok(SupportProtocols::Feeler),
+            4 => Ok(SupportProtocols::DisconnectMessage),
+            100 => Ok(SupportProtocols::Sync),
+            101 => Ok(SupportProtocols::RelayV2),
+            102 => Ok(SupportProtocols::Time),
+            110 => Ok(SupportProtocols::Alert),
+            120 => Ok(SupportProtocols::LightClient),
+            121 => Ok(SupportProtocols::Filter),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Enhance the readability of network module

### What is changed and how it works?

add a try_from trait for SupportProtocols 

```rust
impl TryFrom<ProtocolId> for SupportProtocols {
    type Error = ();
    fn try_from(proto_id: ProtocolId) -> Result<Self, Self::Error> {
        match proto_id.value() {
            0 => Ok(SupportProtocols::Ping),
            1 => Ok(SupportProtocols::Discovery),
            2 => Ok(SupportProtocols::Identify),
            3 => Ok(SupportProtocols::Feeler),
            4 => Ok(SupportProtocols::DisconnectMessage),
            100 => Ok(SupportProtocols::Sync),
            101 => Ok(SupportProtocols::RelayV2),
            102 => Ok(SupportProtocols::Time),
            110 => Ok(SupportProtocols::Alert),
            120 => Ok(SupportProtocols::LightClient),
            121 => Ok(SupportProtocols::Filter),
            _ => Err(()),
        }
    }
}
```

so that we can not only log proto message as int, but also as protocol_name.
```rust
    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
        let proto = SupportProtocols::try_from(context.proto_id).unwrap();
        println!(
            "Received new message: proto [{}] data {:?}",
            proto.name(),
            str::from_utf8(data.as_ref()).unwrap(),
        );
    }
```

### Release note
None
