### PR TITLE
fix: check in-pool chidren for all newly added tx

### DIFF
--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -151,7 +151,7 @@ fn test_add_entry_from_detached() {
         .unwrap()
         .is_empty());
 
-    assert!(pool.add_entry_from_detached(entry1).unwrap());
+    assert!(pool.add_entry(entry1).unwrap());
     for (idx, key) in pool.inner().sorted_index.iter().enumerate() {
         assert_eq!(key.id, expected[idx].0);
         assert_eq!(key.ancestors_size, expected[idx].1);

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -169,12 +169,6 @@ impl TxPool {
         self.proposed.add_entry(entry)
     }
 
-    /// Add detached transactions back to the proposed.
-    pub fn add_proposed_from_detached(&mut self, entry: TxEntry) -> Result<bool, Reject> {
-        trace!("add_proposed_from_detached {}", entry.transaction().hash());
-        self.proposed.add_entry_from_detached(entry)
-    }
-
     /// Returns true if the tx-pool contains a tx with specified id.
     pub fn contains_proposal_id(&self, id: &ProposalShortId) -> bool {
         self.pending.contains_key(id) || self.gap.contains_key(id) || self.proposed.contains_key(id)

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -752,9 +752,7 @@ impl TxPoolService {
                         verify_rtx(snapshot, &rtx, &tx_env, &verify_cache, max_cycles)
                     {
                         let entry = TxEntry::new(rtx, verified.cycles, fee, tx_size);
-                        if let Err(e) =
-                            _submit_entry_from_detached(tx_pool, status, entry, &self.callbacks)
-                        {
+                        if let Err(e) = _submit_entry(tx_pool, status, entry, &self.callbacks) {
                             error!("readd_detached_tx submit_entry {} error {}", tx_hash, e);
                         } else {
                             debug!("readd_detached_tx submit_entry {}", tx_hash);
@@ -860,42 +858,6 @@ fn _submit_entry(
         TxStatus::Proposed => {
             if tx_pool.add_proposed(entry.clone())? {
                 debug!("submit_entry proposed {}", tx_hash);
-                callbacks.call_proposed(tx_pool, &entry, true);
-            } else {
-                return Err(Reject::Duplicated(tx_hash));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn _submit_entry_from_detached(
-    tx_pool: &mut TxPool,
-    status: TxStatus,
-    entry: TxEntry,
-    callbacks: &Callbacks,
-) -> Result<(), Reject> {
-    let tx_hash = entry.transaction().hash();
-    match status {
-        TxStatus::Fresh => {
-            if tx_pool.add_pending(entry.clone()) {
-                debug!("_submit_entry_from_detached pending {}", tx_hash);
-                callbacks.call_pending(tx_pool, &entry);
-            } else {
-                return Err(Reject::Duplicated(tx_hash));
-            }
-        }
-        TxStatus::Gap => {
-            if tx_pool.add_gap(entry.clone()) {
-                debug!("_submit_entry_from_detached gap {}", tx_hash);
-                callbacks.call_pending(tx_pool, &entry);
-            } else {
-                return Err(Reject::Duplicated(tx_hash));
-            }
-        }
-        TxStatus::Proposed => {
-            if tx_pool.add_proposed_from_detached(entry.clone())? {
-                debug!("_submit_entry_from_detached proposed {}", tx_hash);
                 callbacks.call_proposed(tx_pool, &entry, true);
             } else {
                 return Err(Reject::Duplicated(tx_hash));


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Check the in-pool chidren of all newly added transactions and no longer distinguish the entry source of newly added transactions.

### What is changed and how it works?

Removed the separate `add_entry_from_detached ` interface, all new add transactions will be checked in-pool chidren


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

