### PR TITLE
refactor: vbytes changed to weight to prevent ambiguity

### DIFF
--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -1,7 +1,7 @@
 use ckb_jsonrpc_types::FeeRateStatics;
 use ckb_shared::Snapshot;
 use ckb_store::ChainStore;
-use ckb_types::core::{tx_pool::get_transaction_virtual_bytes, BlockExt, BlockNumber};
+use ckb_types::core::{tx_pool::get_transaction_weight, BlockExt, BlockNumber};
 
 const DEFAULT_TARGET: u64 = 21;
 const MIN_TARGET: u64 = 1;
@@ -86,9 +86,9 @@ where
                     block_ext.cycles.expect("checked"),
                     block_ext.txs_sizes.expect("checked")
                 ) {
-                    let vbytes = get_transaction_virtual_bytes(size as usize, cycles);
-                    if vbytes > 0 {
-                        fee_rates.push(fee.as_u64() as f64 / vbytes as f64);
+                    let weight = get_transaction_weight(size as usize, cycles);
+                    if weight > 0 {
+                        fee_rates.push(fee.as_u64() as f64 / weight as f64);
                     }
                 }
             }

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -2,7 +2,7 @@ use crate::component::container::AncestorsScoreSortKey;
 use ckb_types::{
     core::{
         cell::ResolvedTransaction,
-        tx_pool::{get_transaction_virtual_bytes, TxEntryInfo},
+        tx_pool::{get_transaction_weight, TxEntryInfo},
         Capacity, Cycle, TransactionView,
     },
     packed::{OutPoint, ProposalShortId},
@@ -129,16 +129,15 @@ impl TxEntry {
 
 impl From<&TxEntry> for AncestorsScoreSortKey {
     fn from(entry: &TxEntry) -> Self {
-        let vbytes = get_transaction_virtual_bytes(entry.size, entry.cycles);
-        let ancestors_vbytes =
-            get_transaction_virtual_bytes(entry.ancestors_size, entry.ancestors_cycles);
+        let weight = get_transaction_weight(entry.size, entry.cycles);
+        let ancestors_weight = get_transaction_weight(entry.ancestors_size, entry.ancestors_cycles);
         AncestorsScoreSortKey {
             fee: entry.fee,
-            vbytes,
+            weight,
             id: entry.proposal_short_id(),
             ancestors_fee: entry.ancestors_fee,
             ancestors_size: entry.ancestors_size,
-            ancestors_vbytes,
+            ancestors_weight,
         }
     }
 }

--- a/tx-pool/src/component/tests/container.rs
+++ b/tx-pool/src/component/tests/container.rs
@@ -14,7 +14,7 @@ use crate::component::{
 const DEFAULT_MAX_ANCESTORS_COUNT: usize = 125;
 
 #[test]
-fn test_min_fee_and_vbytes() {
+fn test_min_fee_and_weight() {
     let result = vec![
         (0, 0, 0, 0),
         (1, 0, 1, 0),
@@ -26,16 +26,16 @@ fn test_min_fee_and_vbytes() {
         (std::u64::MAX, std::u64::MAX, std::u64::MAX, std::u64::MAX),
     ]
     .into_iter()
-    .map(|(fee, vbytes, ancestors_fee, ancestors_vbytes)| {
+    .map(|(fee, weight, ancestors_fee, ancestors_weight)| {
         let key = AncestorsScoreSortKey {
             fee: Capacity::shannons(fee),
-            vbytes,
+            weight,
             id: ProposalShortId::new([0u8; 10]),
             ancestors_fee: Capacity::shannons(ancestors_fee),
-            ancestors_vbytes,
+            ancestors_weight,
             ancestors_size: 0,
         };
-        key.min_fee_and_vbytes()
+        key.min_fee_and_weight()
     })
     .collect::<Vec<_>>();
     assert_eq!(
@@ -69,15 +69,15 @@ fn test_ancestors_sorted_key_order() {
     ]
     .into_iter()
     .enumerate()
-    .map(|(i, (fee, vbytes, ancestors_fee, ancestors_vbytes))| {
+    .map(|(i, (fee, weight, ancestors_fee, ancestors_weight))| {
         let mut id = [0u8; 10];
         id[..size_of::<u32>()].copy_from_slice(&(i as u32).to_be_bytes());
         AncestorsScoreSortKey {
             fee: Capacity::shannons(fee),
-            vbytes,
+            weight,
             id: ProposalShortId::new(id),
             ancestors_fee: Capacity::shannons(ancestors_fee),
-            ancestors_vbytes,
+            ancestors_weight,
             ancestors_size: 0,
         }
     })

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -388,8 +388,8 @@ fn test_sorted_by_ancestors_score_competitive() {
 
     let mut pool = ProposedPool::new(DEFAULT_MAX_ANCESTORS_COUNT);
 
-    // Choose 5_000_839, so the vbytes is 853.0001094046, which will not lead to carry when
-    // calculating the vbytes for a package.
+    // Choose 5_000_839, so the weight is 853.0001094046, which will not lead to carry when
+    // calculating the weight for a package.
     let cycles = 5_000_839;
     let size = 200;
 

--- a/util/types/src/core/fee_rate.rs
+++ b/util/types/src/core/fee_rate.rs
@@ -8,11 +8,11 @@ const KB: u64 = 1000;
 
 impl FeeRate {
     /// TODO(doc): @doitian
-    pub fn calculate(fee: Capacity, vbytes: usize) -> Self {
-        if vbytes == 0 {
+    pub fn calculate(fee: Capacity, weight: usize) -> Self {
+        if weight == 0 {
             return FeeRate::zero();
         }
-        FeeRate::from_u64(fee.as_u64().saturating_mul(KB) / (vbytes as u64))
+        FeeRate::from_u64(fee.as_u64().saturating_mul(KB) / (weight as u64))
     }
 
     /// TODO(doc): @doitian

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -218,9 +218,24 @@ impl TransactionWithStatus {
 /// and MAX_BLOCK_BYTES is less than 1.
 pub const DEFAULT_BYTES_PER_CYCLES: f64 = 0.000_170_571_4_f64;
 
-/// Virtual bytes(aka vbytes) is a concept to unify the size and cycles of a transaction,
-/// tx_pool use vbytes to estimate transaction fee rate.
+/// vbytes has been deprecated, renamed to weight to prevent ambiguity
+#[deprecated(
+    since = "0.107.0",
+    note = "Please use the get_transaction_weight instead"
+)]
 pub fn get_transaction_virtual_bytes(tx_size: usize, cycles: u64) -> u64 {
+    std::cmp::max(
+        tx_size as u64,
+        (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,
+    )
+}
+
+/// The miners select transactions to fill the limited block space which gives the highest fee.
+/// Because there are two different limits, serialized size and consumed cycles,
+/// the selection algorithm is a multi-dimensional knapsack problem.
+/// Introducing the transaction weight converts the multi-dimensional knapsack to a typical knapsack problem,
+/// which has a simple greedy algorithm.
+pub fn get_transaction_weight(tx_size: usize, cycles: u64) -> u64 {
     std::cmp::max(
         tx_size as u64,
         (cycles as f64 * DEFAULT_BYTES_PER_CYCLES) as u64,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

vbytes changed to weight to prevent ambiguity

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

