### PR TITLE
refactor: eliminate chainstore lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,21 +146,24 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
+ "which",
 ]
 
 [[package]]
@@ -816,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-librocksdb-sys"
-version = "7.3.3"
+version = "7.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d106bb32241da368e67ce9a36545e1cc3c31b7faa9321817199b69bf1e085b4a"
+checksum = "eb64bb11f8d53b9abb526b7e9d3c5fb437a8101e4210d540d2bcee0d18055313"
 dependencies = [
  "bindgen",
  "cc",
@@ -1140,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rocksdb"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b89828fd7e60e4d857f6f1a2f40343114eece1ca20859d4ca8371d4e00ce28"
+checksum = "8e9d412caf8a7fe9080bf2c66209e1b6d9aab336c417b336adde47e184c78c41"
 dependencies = [
  "ckb-librocksdb-sys",
  "libc",
@@ -4879,6 +4882,17 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -13,7 +13,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.107.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.107.0-pre" }
 ckb-error = { path = "../error", version = "= 0.107.0-pre" }
 libc = "0.2"
-rocksdb = { package = "ckb-rocksdb", version ="=0.18.3", features = ["snappy"], default-features = false }
+rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", features = ["snappy"], default-features = false }
 ckb-db-schema = { path = "../db-schema", version = "= 0.107.0-pre" }
 
 [dev-dependencies]

--- a/db/src/transaction.rs
+++ b/db/src/transaction.rs
@@ -2,7 +2,7 @@
 use crate::db::cf_handle;
 use crate::{internal_error, Result};
 use ckb_db_schema::Col;
-use rocksdb::ops::{DeleteCF, GetCF, PutCF};
+use rocksdb::ops::{DeleteCF, GetPinnedCF, PutCF};
 pub use rocksdb::{DBPinnableSlice, DBVector};
 use rocksdb::{
     OptimisticTransaction, OptimisticTransactionDB, OptimisticTransactionSnapshot, ReadOptions,
@@ -17,9 +17,9 @@ pub struct RocksDBTransaction {
 
 impl RocksDBTransaction {
     /// Return the bytes associated with the given key and given column.
-    pub fn get(&self, col: Col, key: &[u8]) -> Result<Option<DBVector>> {
+    pub fn get_pinned(&self, col: Col, key: &[u8]) -> Result<Option<DBPinnableSlice>> {
         let cf = cf_handle(&self.db, col)?;
-        self.inner.get_cf(cf, key).map_err(internal_error)
+        self.inner.get_pinned_cf(cf, key).map_err(internal_error)
     }
 
     /// Write the bytes into the given column with associated key.
@@ -86,8 +86,8 @@ pub struct RocksDBTransactionSnapshot<'a> {
 
 impl<'a> RocksDBTransactionSnapshot<'a> {
     /// Return the bytes associated with the given key and given column.
-    pub fn get(&self, col: Col, key: &[u8]) -> Result<Option<DBVector>> {
+    pub fn get_pinned(&self, col: Col, key: &[u8]) -> Result<Option<DBPinnableSlice>> {
         let cf = cf_handle(&self.db, col)?;
-        self.inner.get_cf(cf, key).map_err(internal_error)
+        self.inner.get_pinned_cf(cf, key).map_err(internal_error)
     }
 }

--- a/store/src/data_loader_wrapper.rs
+++ b/store/src/data_loader_wrapper.rs
@@ -9,14 +9,14 @@ use ckb_types::{
 
 /// TODO(doc): @quake
 pub struct DataLoaderWrapper<'a, T>(&'a T);
-impl<'a, T: ChainStore<'a>> DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> DataLoaderWrapper<'a, T> {
     /// TODO(doc): @quake
     pub fn new(source: &'a T) -> Self {
         DataLoaderWrapper(source)
     }
 }
 
-impl<'a, T: ChainStore<'a>> CellDataProvider for DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> CellDataProvider for DataLoaderWrapper<'a, T> {
     fn get_cell_data(&self, out_point: &OutPoint) -> Option<Bytes> {
         self.0.get_cell_data(out_point).map(|(data, _)| data)
     }
@@ -26,13 +26,13 @@ impl<'a, T: ChainStore<'a>> CellDataProvider for DataLoaderWrapper<'a, T> {
     }
 }
 
-impl<'a, T: ChainStore<'a>> HeaderProvider for DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> HeaderProvider for DataLoaderWrapper<'a, T> {
     fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {
         self.0.get_block_header(block_hash)
     }
 }
 
-impl<'a, T: ChainStore<'a>> EpochProvider for DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> EpochProvider for DataLoaderWrapper<'a, T> {
     fn get_epoch_ext(&self, header: &HeaderView) -> Option<EpochExt> {
         self.0
             .get_block_epoch_index(&header.hash())

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -29,18 +29,16 @@ pub struct ChainDB {
     cache: Arc<StoreCache>,
 }
 
-impl<'a> ChainStore<'a> for ChainDB {
-    type Vector = DBPinnableSlice<'a>;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl ChainStore for ChainDB {
+    fn cache(&self) -> Option<&StoreCache> {
         Some(&self.cache)
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         self.freezer.as_ref()
     }
 
-    fn get(&'a self, col: Col, key: &[u8]) -> Option<Self::Vector> {
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice> {
         self.db
             .get_pinned(col, key)
             .expect("db operation should be ok")

--- a/store/src/snapshot.rs
+++ b/store/src/snapshot.rs
@@ -15,18 +15,16 @@ pub struct StoreSnapshot {
     pub(crate) cache: Arc<StoreCache>,
 }
 
-impl<'a> ChainStore<'a> for StoreSnapshot {
-    type Vector = DBPinnableSlice<'a>;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl ChainStore for StoreSnapshot {
+    fn cache(&self) -> Option<&StoreCache> {
         Some(&self.cache)
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         self.freezer.as_ref()
     }
 
-    fn get(&'a self, col: Col, key: &[u8]) -> Option<Self::Vector> {
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice> {
         self.inner
             .get_pinned(col, key)
             .expect("db operation should be ok")

--- a/store/src/transaction.rs
+++ b/store/src/transaction.rs
@@ -3,7 +3,7 @@ use crate::store::ChainStore;
 use ckb_chain_spec::versionbits::VersionbitsIndexer;
 use ckb_db::{
     iter::{DBIter, DBIterator, IteratorMode},
-    DBVector, RocksDBTransaction, RocksDBTransactionSnapshot,
+    DBPinnableSlice, RocksDBTransaction, RocksDBTransactionSnapshot,
 };
 use ckb_db_schema::{
     Col, COLUMN_BLOCK_BODY, COLUMN_BLOCK_EPOCH, COLUMN_BLOCK_EXT, COLUMN_BLOCK_EXTENSION,
@@ -32,19 +32,19 @@ pub struct StoreTransaction {
     pub(crate) cache: Arc<StoreCache>,
 }
 
-impl<'a> ChainStore<'a> for StoreTransaction {
-    type Vector = DBVector;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl ChainStore for StoreTransaction {
+    fn cache(&self) -> Option<&StoreCache> {
         Some(&self.cache)
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         self.freezer.as_ref()
     }
 
-    fn get(&self, col: Col, key: &[u8]) -> Option<Self::Vector> {
-        self.inner.get(col, key).expect("db operation should be ok")
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice<'_>> {
+        self.inner
+            .get_pinned(col, key)
+            .expect("db operation should be ok")
     }
 
     fn get_iter(&self, col: Col, mode: IteratorMode) -> DBIter {
@@ -105,19 +105,19 @@ pub struct StoreTransactionSnapshot<'a> {
     pub(crate) cache: Arc<StoreCache>,
 }
 
-impl<'a> ChainStore<'a> for StoreTransactionSnapshot<'a> {
-    type Vector = DBVector;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl<'a> ChainStore for StoreTransactionSnapshot<'a> {
+    fn cache(&self) -> Option<&StoreCache> {
         Some(&self.cache)
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         self.freezer.as_ref()
     }
 
-    fn get(&self, col: Col, key: &[u8]) -> Option<Self::Vector> {
-        self.inner.get(col, key).expect("db operation should be ok")
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice> {
+        self.inner
+            .get_pinned(col, key)
+            .expect("db operation should be ok")
     }
 
     fn get_iter(&self, col: Col, mode: IteratorMode) -> DBIter {

--- a/util/chain-iter/src/lib.rs
+++ b/util/chain-iter/src/lib.rs
@@ -4,13 +4,13 @@ use ckb_types::{core::BlockNumber, core::BlockView};
 
 /// TODO(doc): @quake
 // An iterator over the entries of a `Chain`.
-pub struct ChainIterator<'a, S: ChainStore<'a>> {
+pub struct ChainIterator<'a, S: ChainStore> {
     store: &'a S,
     current: Option<BlockView>,
     tip: BlockNumber,
 }
 
-impl<'a, S: ChainStore<'a>> ChainIterator<'a, S> {
+impl<'a, S: ChainStore> ChainIterator<'a, S> {
     /// TODO(doc): @quake
     pub fn new(store: &'a S) -> Self {
         let current = store.get_block_hash(0).and_then(|h| store.get_block(&h));
@@ -35,7 +35,7 @@ impl<'a, S: ChainStore<'a>> ChainIterator<'a, S> {
     }
 }
 
-impl<'a, S: ChainStore<'a>> Iterator for ChainIterator<'a, S> {
+impl<'a, S: ChainStore> Iterator for ChainIterator<'a, S> {
     type Item = BlockView;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 thiserror = "1.0"
-rocksdb = { package = "ckb-rocksdb", version ="=0.18.3", features = ["snappy"], default-features = false }
+rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", features = ["snappy"], default-features = false }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.107.0-pre" }
 ckb-types = { path = "../types", version = "= 0.107.0-pre" }
 ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.107.0-pre" }

--- a/util/indexer/src/store/secondary_db.rs
+++ b/util/indexer/src/store/secondary_db.rs
@@ -107,18 +107,16 @@ impl SecondaryDB {
     }
 }
 
-impl<'a> ChainStore<'a> for SecondaryDB {
-    type Vector = DBPinnableSlice<'a>;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl ChainStore for SecondaryDB {
+    fn cache(&self) -> Option<&StoreCache> {
         None
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         None
     }
 
-    fn get(&'a self, col: Col, key: &[u8]) -> Option<Self::Vector> {
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice> {
         self.get_pinned(col, key)
             .expect("db operation should be ok")
     }
@@ -128,7 +126,7 @@ impl<'a> ChainStore<'a> for SecondaryDB {
     }
 
     // Only block header and block body loaded
-    fn get_block(&'a self, h: &packed::Byte32) -> Option<BlockView> {
+    fn get_block(&self, h: &packed::Byte32) -> Option<BlockView> {
         let header = self.get_block_header(h)?;
         let body = self.get_block_body(h);
         let uncles = packed::UncleBlockVecView::default();

--- a/util/reward-calculator/src/lib.rs
+++ b/util/reward-calculator/src/lib.rs
@@ -35,7 +35,7 @@ pub struct RewardCalculator<'a, CS> {
     store: &'a CS,
 }
 
-impl<'a, CS: ChainStore<'a>> RewardCalculator<'a, CS> {
+impl<'a, CS: ChainStore> RewardCalculator<'a, CS> {
     /// Creates a new `RewardCalculator`.
     pub fn new(consensus: &'a Consensus, store: &'a CS) -> Self {
         RewardCalculator { consensus, store }

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -184,18 +184,16 @@ impl Snapshot {
     }
 }
 
-impl<'a> ChainStore<'a> for Snapshot {
-    type Vector = DBPinnableSlice<'a>;
-
-    fn cache(&'a self) -> Option<&'a StoreCache> {
+impl ChainStore for Snapshot {
+    fn cache(&self) -> Option<&StoreCache> {
         self.store.cache()
     }
 
-    fn get(&'a self, col: Col, key: &[u8]) -> Option<Self::Vector> {
+    fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice> {
         self.store.get(col, key)
     }
 
-    fn freezer(&'a self) -> Option<&'a Freezer> {
+    fn freezer(&self) -> Option<&Freezer> {
         self.store.freezer()
     }
 
@@ -207,7 +205,7 @@ impl<'a> ChainStore<'a> for Snapshot {
         Some(self.tip_header.clone())
     }
 
-    fn get_current_epoch_ext(&'a self) -> Option<EpochExt> {
+    fn get_current_epoch_ext(&self) -> Option<EpochExt> {
         Some(self.epoch_ext.clone())
     }
 }

--- a/verification/contextual/src/contextual_block_verifier.rs
+++ b/verification/contextual/src/contextual_block_verifier.rs
@@ -42,7 +42,7 @@ pub struct VerifyContext<'a, CS> {
     pub(crate) consensus: &'a Consensus,
 }
 
-impl<'a, CS: ChainStore<'a> + VersionbitsIndexer> VerifyContext<'a, CS> {
+impl<'a, CS: ChainStore + VersionbitsIndexer> VerifyContext<'a, CS> {
     /// Create new VerifyContext from `Store` and `Consensus`
     pub fn new(store: &'a CS, consensus: &'a Consensus) -> Self {
         VerifyContext { store, consensus }
@@ -63,13 +63,13 @@ impl<'a, CS: ChainStore<'a> + VersionbitsIndexer> VerifyContext<'a, CS> {
     }
 }
 
-impl<'a, CS: ChainStore<'a>> HeaderProvider for VerifyContext<'a, CS> {
+impl<'a, CS: ChainStore> HeaderProvider for VerifyContext<'a, CS> {
     fn get_header(&self, hash: &Byte32) -> Option<HeaderView> {
         self.store.get_block_header(hash)
     }
 }
 
-impl<'a, CS: ChainStore<'a>> HeaderChecker for VerifyContext<'a, CS> {
+impl<'a, CS: ChainStore> HeaderChecker for VerifyContext<'a, CS> {
     fn check_valid(&self, block_hash: &Byte32) -> Result<(), OutPointError> {
         if !self.store.is_main_chain(block_hash) {
             return Err(OutPointError::InvalidHeader(block_hash.clone()));
@@ -81,7 +81,7 @@ impl<'a, CS: ChainStore<'a>> HeaderChecker for VerifyContext<'a, CS> {
     }
 }
 
-impl<'a, CS: ChainStore<'a>> ConsensusProvider for VerifyContext<'a, CS> {
+impl<'a, CS: ChainStore> ConsensusProvider for VerifyContext<'a, CS> {
     fn get_consensus(&self) -> &Consensus {
         self.consensus
     }
@@ -92,13 +92,13 @@ pub struct UncleVerifierContext<'a, 'b, CS> {
     context: &'a VerifyContext<'a, CS>,
 }
 
-impl<'a, 'b, CS: ChainStore<'a>> UncleVerifierContext<'a, 'b, CS> {
+impl<'a, 'b, CS: ChainStore> UncleVerifierContext<'a, 'b, CS> {
     pub(crate) fn new(context: &'a VerifyContext<'a, CS>, epoch: &'b EpochExt) -> Self {
         UncleVerifierContext { epoch, context }
     }
 }
 
-impl<'a, 'b, CS: ChainStore<'a>> UncleProvider for UncleVerifierContext<'a, 'b, CS> {
+impl<'a, 'b, CS: ChainStore> UncleProvider for UncleVerifierContext<'a, 'b, CS> {
     fn double_inclusion(&self, hash: &Byte32) -> bool {
         self.context.store.get_block_number(hash).is_some() || self.context.store.is_uncle(hash)
     }
@@ -136,7 +136,7 @@ pub struct TwoPhaseCommitVerifier<'a, CS> {
     block: &'a BlockView,
 }
 
-impl<'a, CS: ChainStore<'a> + VersionbitsIndexer> TwoPhaseCommitVerifier<'a, CS> {
+impl<'a, CS: ChainStore + VersionbitsIndexer> TwoPhaseCommitVerifier<'a, CS> {
     pub fn new(context: &'a VerifyContext<'a, CS>, block: &'a BlockView) -> Self {
         TwoPhaseCommitVerifier { context, block }
     }
@@ -218,7 +218,7 @@ pub struct RewardVerifier<'a, 'b, CS> {
     context: &'a VerifyContext<'a, CS>,
 }
 
-impl<'a, 'b, CS: ChainStore<'a> + VersionbitsIndexer> RewardVerifier<'a, 'b, CS> {
+impl<'a, 'b, CS: ChainStore + VersionbitsIndexer> RewardVerifier<'a, 'b, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         resolved: &'a [ResolvedTransaction],
@@ -280,7 +280,7 @@ struct DaoHeaderVerifier<'a, 'b, 'c, CS> {
     header: &'c HeaderView,
 }
 
-impl<'a, 'b, 'c, CS: ChainStore<'a> + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 'c, CS> {
+impl<'a, 'b, 'c, CS: ChainStore + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 'c, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         resolved: &'a [ResolvedTransaction],
@@ -325,7 +325,7 @@ struct BlockTxsVerifier<'a, CS> {
     txs_verify_cache: &'a Arc<RwLock<TxVerificationCache>>,
 }
 
-impl<'a, CS: ChainStore<'a> + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
+impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
     pub fn new(
         context: &'a VerifyContext<'a, CS>,
         header: HeaderView,
@@ -523,7 +523,7 @@ pub struct BlockExtensionVerifier<'a, 'b, CS, MS> {
     parent: &'b HeaderView,
 }
 
-impl<'a, 'b, CS: ChainStore<'a> + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
+impl<'a, 'b, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
     BlockExtensionVerifier<'a, 'b, CS, MS>
 {
     pub fn new(
@@ -610,7 +610,7 @@ pub struct ContextualBlockVerifier<'a, CS, MS> {
     chain_root_mmr: &'a ChainRootMMR<MS>,
 }
 
-impl<'a, CS: ChainStore<'a> + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
+impl<'a, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
     ContextualBlockVerifier<'a, CS, MS>
 {
     /// Create new ContextualBlockVerifier


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


The new version of rocksdb supports transaction get_pinned, which can be used to eliminate the lifecycle on `ChainStore`, and also brings some fixes and performance improvements

https://github.com/nervosnetwork/rust-rocksdb/pull/43


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

