### PR TITLE
feat: indexer db simple configuration

### DIFF
--- a/db/src/db_with_ttl.rs
+++ b/db/src/db_with_ttl.rs
@@ -8,6 +8,7 @@ use rocksdb::{
 use std::path::Path;
 
 const PROPERTY_NUM_KEYS: &str = "rocksdb.estimate-num-keys";
+const DB_LOG_KEEP_NUM: usize = 10;
 
 /// DB with ttl support wrapper
 ///
@@ -35,7 +36,7 @@ impl DBWithTTL {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        opts.set_keep_log_file_num(10);
+        opts.set_keep_log_file_num(DB_LOG_KEEP_NUM);
 
         let cf_descriptors: Vec<_> = cf_names
             .into_iter()

--- a/resource/default.db-options
+++ b/resource/default.db-options
@@ -6,8 +6,7 @@
 
 [DBOptions]
 bytes_per_sync=1048576
-max_background_compactions=4
-max_background_flushes=2
+max_background_jobs=6
 max_total_wal_size=134217728
 keep_log_file_num=32
 

--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 /// Indexer config options.
@@ -21,6 +22,12 @@ pub struct IndexerConfig {
     /// Customize cell filter
     #[serde(default)]
     pub cell_filter: Option<String>,
+    /// Maximum number of concurrent db background jobs (compactions and flushes)
+    #[serde(default)]
+    pub db_background_jobs: Option<NonZeroUsize>,
+    /// Maximal db info log files to be kept.
+    #[serde(default)]
+    pub db_keep_log_file_num: Option<NonZeroUsize>,
 }
 
 const fn default_poll_interval() -> u64 {
@@ -36,6 +43,8 @@ impl Default for IndexerConfig {
             secondary_path: PathBuf::new(),
             block_filter: None,
             cell_filter: None,
+            db_background_jobs: None,
+            db_keep_log_file_num: None,
         }
     }
 }

--- a/util/indexer/src/indexer.rs
+++ b/util/indexer/src/indexer.rs
@@ -1012,7 +1012,7 @@ mod tests {
 
     fn new_indexer<S: Store>(prefix: &str) -> Indexer<S> {
         let tmp_dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-        let store = S::new(tmp_dir.path().to_str().unwrap());
+        let store = S::new(&S::default_options(), tmp_dir.path().to_str().unwrap());
         Indexer::new(store, KEEP_NUM, 1, None, CustomFilters::new(None, None))
     }
 
@@ -2005,7 +2005,7 @@ mod tests {
         cell_filter_str: Option<&str>,
     ) -> Indexer<S> {
         let tmp_dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-        let store = S::new(tmp_dir.path().to_str().unwrap());
+        let store = S::new(&S::default_options(), tmp_dir.path().to_str().unwrap());
         Indexer::new(
             store,
             10,

--- a/util/indexer/src/store/mod.rs
+++ b/util/indexer/src/store/mod.rs
@@ -15,10 +15,13 @@ pub(crate) enum IteratorDirection {
 
 pub(crate) trait Store {
     type Batch: Batch;
+    type Opts;
 
-    fn new<P>(path: P) -> Self
+    fn new<P>(opts: &Self::Opts, path: P) -> Self
     where
         P: AsRef<Path>;
+
+    fn default_options() -> Self::Opts;
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Error>;
 

--- a/util/indexer/src/store/secondary_db.rs
+++ b/util/indexer/src/store/secondary_db.rs
@@ -42,16 +42,12 @@ pub(crate) struct SecondaryDB {
 
 impl SecondaryDB {
     /// Open a SecondaryDB
-    pub fn open_cf<P, I, N>(path: P, cf_names: I, secondary_path: String) -> Self
+    pub fn open_cf<P, I, N>(opts: &Options, path: P, cf_names: I, secondary_path: String) -> Self
     where
         P: AsRef<Path>,
         I: IntoIterator<Item = N>,
         N: Into<String>,
     {
-        let mut opts = Options::default();
-        opts.create_if_missing(true);
-        opts.create_missing_column_families(true);
-
         let cf_descriptors: Vec<_> = cf_names
             .into_iter()
             .map(|name| ColumnFamilyDescriptor::new(name, Options::default()))
@@ -59,7 +55,7 @@ impl SecondaryDB {
 
         let descriptor = SecondaryOpenDescriptor::new(secondary_path);
         let inner = SecondaryRocksDB::open_cf_descriptors_with_descriptor(
-            &opts,
+            opts,
             path,
             cf_descriptors,
             descriptor,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Resolve configuration issues with Indexer db
https://github.com/nervosnetwork/ckb/issues/3696
https://github.com/nervosnetwork/ckb/issues/3730


### What is changed and how it works?

the RocksDB debug log is not really of much use to the average user, just setting keep_log_file_num to 1 (0 is not allowed). only maintain a single LOG file which is probably the cleanest and simplest solution.

I don't  introduce `FullOptions::load_from_file` here, because `FullOptions::load_from_file` is also a legacy dirty patch, and users don't want to see all the configuration items of rocksdb in front of them and have no idea what they can do, so for now we'll just provide the simplest and most useful options.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

