### PR TITLE
feat: thread-safe vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.22.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1223acc8054ce96f91c5d99d4942898d0bdadd618c3b14f1acd3e67212991d8e"
+checksum = "93fee7eb8d6525a0d3a4f113414c1b51dd3aaf75ef7b54fe7ce306e545c87cdd"
 dependencies = [
  "byteorder",
  "bytes 1.3.0",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.22.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af800ae2b6c54b70efa398dab015a09a52eeac2dd1ac3ad32c9bbe224974225"
+checksum = "a9403cda7180a8203facf05e96537f0038d188b2efdcef13c84538bfbdfcbcbf"
 
 [[package]]
 name = "clang-sys"

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -177,7 +177,7 @@ pub fn gen_always_success_block(
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&p_block.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&p_block.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -387,7 +387,7 @@ pub fn gen_secp_block(
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&p_block.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&p_block.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -498,7 +498,7 @@ pub fn dao_data(shared: &Shared, parent: &HeaderView, txs: &[TransactionView]) -
         }
     });
     let rtxs = rtxs.expect("dao_data resolve_transaction");
-    let data_loader = snapshot.as_data_provider();
+    let data_loader = snapshot.borrow_as_data_loader();
     let calculator = DaoCalculator::new(snapshot.consensus(), &data_loader);
     calculator
         .dao_field(rtxs.iter(), parent)
@@ -511,7 +511,7 @@ pub(crate) fn calculate_reward(shared: &Shared, parent: &HeaderView) -> Capacity
     let target_number = shared.consensus().finalize_target(number).unwrap();
     let target_hash = snapshot.get_block_hash(target_number).unwrap();
     let target = snapshot.get_block_header(&target_hash).unwrap();
-    let data_loader = snapshot.as_data_provider();
+    let data_loader = snapshot.borrow_as_data_loader();
     let calculator = DaoCalculator::new(shared.consensus(), &data_loader);
     calculator
         .primary_block_reward(&target)

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -501,7 +501,7 @@ pub fn dao_data(shared: &Shared, parent: &HeaderView, txs: &[TransactionView]) -
     let data_loader = snapshot.as_data_provider();
     let calculator = DaoCalculator::new(snapshot.consensus(), &data_loader);
     calculator
-        .dao_field(&rtxs, parent)
+        .dao_field(rtxs.iter(), parent)
         .expect("calculator dao_field")
 }
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -362,7 +362,7 @@ impl ChainService {
     }
 
     fn insert_block(&mut self, block: Arc<BlockView>, switch: Switch) -> Result<bool, Error> {
-        let db_txn = self.shared.store().begin_transaction();
+        let db_txn = Arc::new(self.shared.store().begin_transaction());
         let txn_snapshot = db_txn.get_snapshot();
         let _snapshot_tip_hash = db_txn.get_update_for_tip_hash(&txn_snapshot);
 
@@ -449,7 +449,7 @@ impl ChainService {
 
             // update and verify chain root
             // MUST update index before reconcile_main_chain
-            self.reconcile_main_chain(&db_txn, &mut fork, switch)?;
+            self.reconcile_main_chain(Arc::clone(&db_txn), &mut fork, switch)?;
 
             db_txn.insert_tip_header(&block.header())?;
             if new_epoch || fork.has_detached() {
@@ -707,7 +707,7 @@ impl ChainService {
     // we found new best_block
     pub(crate) fn reconcile_main_chain(
         &self,
-        txn: &StoreTransaction,
+        txn: Arc<StoreTransaction>,
         fork: &mut ForkChanges,
         switch: Switch,
     ) -> Result<(), Error> {
@@ -716,23 +716,23 @@ impl ChainService {
         }
 
         let txs_verify_cache = self.shared.txs_verify_cache();
-        let consensus = self.shared.consensus();
+        let consensus = self.shared.cloned_consensus();
         let async_handle = self.shared.tx_pool_controller().handle();
 
         let start_block_header = fork.attached_blocks()[0].header();
         let mmr_size = leaf_index_to_mmr_size(start_block_header.number() - 1);
         trace!("light-client: new chain root MMR with size = {}", mmr_size);
-        let mut mmr = ChainRootMMR::new(mmr_size, txn);
+        let mut mmr = ChainRootMMR::new(mmr_size, txn.as_ref());
 
         let verified_len = fork.verified_len();
         for b in fork.attached_blocks().iter().take(verified_len) {
             txn.attach_block(b)?;
-            attach_block_cell(txn, b)?;
+            attach_block_cell(&txn, b)?;
             mmr.push(b.digest())
                 .map_err(|e| InternalErrorKind::MMR.other(e))?;
         }
 
-        let verify_context = VerifyContext::new(txn, consensus);
+        let verify_context = VerifyContext::new(Arc::clone(&txn), consensus);
 
         let mut found_error = None;
         for (ext, b) in fork
@@ -742,12 +742,12 @@ impl ChainService {
         {
             if !switch.disable_all() {
                 if found_error.is_none() {
-                    let resolved = self.resolve_block_transactions(txn, b, &verify_context);
+                    let resolved = self.resolve_block_transactions(&txn, b, &verify_context);
                     match resolved {
                         Ok(resolved) => {
                             let verified = {
                                 let contextual_block_verifier = ContextualBlockVerifier::new(
-                                    &verify_context,
+                                    verify_context.clone(),
                                     async_handle,
                                     switch,
                                     Arc::clone(&txs_verify_cache),
@@ -764,12 +764,12 @@ impl ChainService {
                                         })
                                         .collect();
                                     txn.attach_block(b)?;
-                                    attach_block_cell(txn, b)?;
+                                    attach_block_cell(&txn, b)?;
                                     mmr.push(b.digest())
                                         .map_err(|e| InternalErrorKind::MMR.other(e))?;
 
                                     self.insert_ok_ext(
-                                        txn,
+                                        &txn,
                                         &b.header().hash(),
                                         ext.clone(),
                                         Some(&cache_entries),
@@ -788,24 +788,24 @@ impl ChainService {
                                 Err(err) => {
                                     self.print_error(b, &err);
                                     found_error = Some(err);
-                                    self.insert_failure_ext(txn, &b.header().hash(), ext.clone())?;
+                                    self.insert_failure_ext(&txn, &b.header().hash(), ext.clone())?;
                                 }
                             }
                         }
                         Err(err) => {
                             found_error = Some(err);
-                            self.insert_failure_ext(txn, &b.header().hash(), ext.clone())?;
+                            self.insert_failure_ext(&txn, &b.header().hash(), ext.clone())?;
                         }
                     }
                 } else {
-                    self.insert_failure_ext(txn, &b.header().hash(), ext.clone())?;
+                    self.insert_failure_ext(&txn, &b.header().hash(), ext.clone())?;
                 }
             } else {
                 txn.attach_block(b)?;
-                attach_block_cell(txn, b)?;
+                attach_block_cell(&txn, b)?;
                 mmr.push(b.digest())
                     .map_err(|e| InternalErrorKind::MMR.other(e))?;
-                self.insert_ok_ext(txn, &b.header().hash(), ext.clone(), None, None)?;
+                self.insert_ok_ext(&txn, &b.header().hash(), ext.clone(), None, None)?;
             }
         }
 
@@ -824,7 +824,7 @@ impl ChainService {
         txn: &StoreTransaction,
         block: &BlockView,
         verify_context: &HC,
-    ) -> Result<Vec<ResolvedTransaction>, Error> {
+    ) -> Result<Vec<Arc<ResolvedTransaction>>, Error> {
         let mut seen_inputs = HashSet::new();
         let block_cp = BlockCellProvider::new(block)?;
         let transactions = block.transactions();
@@ -832,8 +832,11 @@ impl ChainService {
         let resolved = transactions
             .iter()
             .cloned()
-            .map(|tx| resolve_transaction(tx, &mut seen_inputs, &cell_provider, verify_context))
-            .collect::<Result<Vec<ResolvedTransaction>, _>>()?;
+            .map(|tx| {
+                resolve_transaction(tx, &mut seen_inputs, &cell_provider, verify_context)
+                    .map(Arc::new)
+            })
+            .collect::<Result<Vec<Arc<ResolvedTransaction>>, _>>()?;
         Ok(resolved)
     }
 
@@ -871,7 +874,7 @@ impl ChainService {
     fn monitor_block_txs_verified(
         &self,
         b: &BlockView,
-        resolved: &[ResolvedTransaction],
+        resolved: &[Arc<ResolvedTransaction>],
         cache_entries: &[Completed],
         cycles: Cycle,
     ) {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -401,7 +401,7 @@ impl ChainService {
         let next_block_epoch = self
             .shared
             .consensus()
-            .next_epoch_ext(&parent_header, &txn_snapshot.as_data_provider())
+            .next_epoch_ext(&parent_header, &txn_snapshot.borrow_as_data_loader())
             .expect("epoch should be stored");
         let new_epoch = next_block_epoch.is_head();
         let epoch = next_block_epoch.epoch();

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -491,7 +491,7 @@ fn prepare_context_chain(
     for _ in 1..final_number - 1 {
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&parent, &shared.store().as_data_provider())
+            .next_epoch_ext(&parent, &shared.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -526,7 +526,7 @@ fn prepare_context_chain(
     for i in 1..final_number {
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&parent, &shared.store().as_data_provider())
+            .next_epoch_ext(&parent, &shared.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
         let mut uncles = vec![];
@@ -601,7 +601,7 @@ fn test_epoch_hash_rate_dampening() {
 
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -638,7 +638,7 @@ fn test_epoch_hash_rate_dampening() {
 
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -693,7 +693,7 @@ fn test_orphan_rate_estimation_overflow() {
 
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -751,7 +751,7 @@ fn test_next_epoch_ext() {
 
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -808,7 +808,7 @@ fn test_next_epoch_ext() {
 
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -850,7 +850,7 @@ fn test_next_epoch_ext() {
         // last_duration 7980
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&tip, &snapshot.as_data_provider())
+            .next_epoch_ext(&tip, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 

--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -236,7 +236,7 @@ fn test_prepare_uncles() {
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&block1_1.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&block1_1.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -260,7 +260,7 @@ fn test_prepare_uncles() {
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&block2_1.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&block2_1.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -317,7 +317,7 @@ fn test_candidate_uncles_retain() {
         let snapshot = shared.snapshot();
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&block1_1.header(), &shared.store().as_data_provider())
+            .next_epoch_ext(&block1_1.header(), &shared.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
         let uncles = candidate_uncles.prepare_uncles(&snapshot, &epoch);
@@ -343,7 +343,7 @@ fn test_candidate_uncles_retain() {
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&block2_0.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&block2_0.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -356,7 +356,7 @@ fn test_candidate_uncles_retain() {
         let snapshot = shared.snapshot();
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&block3_0.header(), &shared.store().as_data_provider())
+            .next_epoch_ext(&block3_0.header(), &shared.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
         let uncles = candidate_uncles.prepare_uncles(&snapshot, &epoch);

--- a/chain/src/tests/cell.rs
+++ b/chain/src/tests/cell.rs
@@ -58,7 +58,7 @@ pub(crate) fn gen_block(
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(parent_header, &shared.store().as_data_provider())
+        .next_epoch_ext(parent_header, &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -256,7 +256,7 @@ fn test_full_dead_transaction() {
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent, &shared.store().as_data_provider())
+        .next_epoch_ext(&parent, &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -284,7 +284,7 @@ fn test_full_dead_transaction() {
 
             let epoch = shared
                 .consensus()
-                .next_epoch_ext(&parent, &shared.store().as_data_provider())
+                .next_epoch_ext(&parent, &shared.store().borrow_as_data_loader())
                 .unwrap()
                 .epoch();
 
@@ -360,7 +360,7 @@ fn test_full_dead_transaction() {
 
                 let epoch = shared
                     .consensus()
-                    .next_epoch_ext(&parent, &shared.store().as_data_provider())
+                    .next_epoch_ext(&parent, &shared.store().borrow_as_data_loader())
                     .unwrap()
                     .epoch();
 

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -349,7 +349,7 @@ fn repeatedly_switch_fork() {
     let parent = fork1.blocks().last().cloned().unwrap();
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&parent.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
     let new_block1 = BlockBuilder::default()
@@ -368,7 +368,7 @@ fn repeatedly_switch_fork() {
     let mut parent = fork2.blocks().last().cloned().unwrap();
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&parent.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
     let new_block2 = BlockBuilder::default()
@@ -384,7 +384,7 @@ fn repeatedly_switch_fork() {
         .unwrap();
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&parent.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
     let new_block3 = BlockBuilder::default()
@@ -402,7 +402,7 @@ fn repeatedly_switch_fork() {
     parent = new_block1;
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&parent.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
     let new_block4 = BlockBuilder::default()
@@ -419,7 +419,7 @@ fn repeatedly_switch_fork() {
     parent = new_block4;
     let epoch = shared
         .consensus()
-        .next_epoch_ext(&parent.header(), &shared.store().as_data_provider())
+        .next_epoch_ext(&parent.header(), &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
     let new_block5 = BlockBuilder::default()

--- a/chain/src/tests/non_contextual_block_txs_verify.rs
+++ b/chain/src/tests/non_contextual_block_txs_verify.rs
@@ -65,7 +65,7 @@ pub(crate) fn gen_block(
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(parent_header, &shared.store().as_data_provider())
+        .next_epoch_ext(parent_header, &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -84,7 +84,7 @@ pub(crate) fn gen_block(
 
     let epoch = shared
         .consensus()
-        .next_epoch_ext(parent_header, &shared.store().as_data_provider())
+        .next_epoch_ext(parent_header, &shared.store().borrow_as_data_loader())
         .unwrap()
         .epoch();
 

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -586,5 +586,5 @@ pub fn dao_data(
     };
     let data_loader = store.store().as_data_provider();
     let calculator = DaoCalculator::new(consensus, &data_loader);
-    calculator.dao_field(&rtxs, parent).unwrap()
+    calculator.dao_field(rtxs.iter(), parent).unwrap()
 }

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -164,7 +164,7 @@ pub(crate) fn calculate_reward(
     let target_number = consensus.finalize_target(number).unwrap();
     let target_hash = store.store().get_block_hash(target_number).unwrap();
     let target = store.store().get_block_header(&target_hash).unwrap();
-    let data_loader = store.store().as_data_provider();
+    let data_loader = store.store().borrow_as_data_loader();
     let calculator = DaoCalculator::new(consensus, &data_loader);
     calculator
         .primary_block_reward(&target)
@@ -354,7 +354,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -383,7 +383,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -407,7 +407,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -431,7 +431,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -454,7 +454,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -478,7 +478,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -514,7 +514,7 @@ impl<'a> MockChain<'a> {
 
         let epoch = self
             .consensus
-            .next_epoch_ext(&parent, &store.store().as_data_provider())
+            .next_epoch_ext(&parent, &store.store().borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -584,7 +584,7 @@ pub fn dao_data(
     } else {
         rtxs.unwrap()
     };
-    let data_loader = store.store().as_data_provider();
+    let data_loader = store.store().borrow_as_data_loader();
     let calculator = DaoCalculator::new(consensus, &data_loader);
     calculator.dao_field(rtxs.iter(), parent).unwrap()
 }

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -180,7 +180,7 @@ impl ExperimentRpc for ExperimentRpcImpl {
         let snapshot: &Snapshot = &self.shared.snapshot();
         let consensus = snapshot.consensus();
         let out_point: packed::OutPoint = out_point.into();
-        let data_loader = snapshot.as_data_provider();
+        let data_loader = snapshot.borrow_as_data_loader();
         let calculator = DaoCalculator::new(consensus, &data_loader);
         match kind {
             DaoWithdrawingCalculationKind::WithdrawingHeaderHash(withdrawing_header_hash) => {

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -586,7 +586,7 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .collect::<Result<Vec<ResolvedTransaction>>>()?;
 
         Ok(DaoCalculator::new(consensus, &snapshot.as_data_provider())
-            .dao_field(&rtxs, &parent_header)
+            .dao_field(rtxs.iter(), &parent_header)
             .expect("dao calculation should be OK")
             .into())
     }

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -585,10 +585,12 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             })
             .collect::<Result<Vec<ResolvedTransaction>>>()?;
 
-        Ok(DaoCalculator::new(consensus, &snapshot.as_data_provider())
-            .dao_field(rtxs.iter(), &parent_header)
-            .expect("dao calculation should be OK")
-            .into())
+        Ok(
+            DaoCalculator::new(consensus, &snapshot.borrow_as_data_loader())
+                .dao_field(rtxs.iter(), &parent_header)
+                .expect("dao calculation should be OK")
+                .into(),
+        )
     }
 }
 

--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -176,7 +176,7 @@ fn next_block(shared: &Shared, parent: &HeaderView) -> BlockView {
             resolve_transaction(cellbase.clone(), &mut HashSet::new(), snapshot, snapshot).unwrap();
         let data_loader = shared.store().as_data_provider();
         DaoCalculator::new(shared.consensus(), &data_loader)
-            .dao_field(&[resolved_cellbase], parent)
+            .dao_field([resolved_cellbase].iter(), parent)
             .unwrap()
     };
     BlockBuilder::default()

--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -163,7 +163,7 @@ fn next_block(shared: &Shared, parent: &HeaderView) -> BlockView {
     let snapshot: &Snapshot = &shared.snapshot();
     let epoch = shared
         .consensus()
-        .next_epoch_ext(parent, &snapshot.as_data_provider())
+        .next_epoch_ext(parent, &snapshot.borrow_as_data_loader())
         .unwrap()
         .epoch();
     let (_, reward) = RewardCalculator::new(snapshot.consensus(), snapshot)
@@ -174,7 +174,7 @@ fn next_block(shared: &Shared, parent: &HeaderView) -> BlockView {
     let dao = {
         let resolved_cellbase =
             resolve_transaction(cellbase.clone(), &mut HashSet::new(), snapshot, snapshot).unwrap();
-        let data_loader = shared.store().as_data_provider();
+        let data_loader = shared.store().borrow_as_data_loader();
         DaoCalculator::new(shared.consensus(), &data_loader)
             .dao_field([resolved_cellbase].iter(), parent)
             .unwrap()

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -22,7 +22,7 @@ ckb-traits = { path = "../traits", version = "= 0.109.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.109.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.109.0-pre" }
-ckb-vm = { version = "=0.22.2", default-features = false }
+ckb-vm = { version = "=0.23.2", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.109.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/script/src/syscalls/debugger.rs
+++ b/script/src/syscalls/debugger.rs
@@ -1,3 +1,4 @@
+use crate::types::DebugPrinter;
 use crate::{cost_model::transferred_byte_cycles, syscalls::DEBUG_PRINT_SYSCALL_NUMBER};
 use ckb_types::packed::Byte32;
 use ckb_vm::{
@@ -5,18 +6,18 @@ use ckb_vm::{
     Error as VMError, Memory, Register, SupportMachine, Syscalls,
 };
 
-pub struct Debugger<'a> {
+pub struct Debugger {
     hash: Byte32,
-    printer: &'a dyn Fn(&Byte32, &str),
+    printer: DebugPrinter,
 }
 
-impl<'a> Debugger<'a> {
-    pub fn new(hash: Byte32, printer: &'a dyn Fn(&Byte32, &str)) -> Debugger<'a> {
+impl Debugger {
+    pub fn new(hash: Byte32, printer: DebugPrinter) -> Debugger {
         Debugger { hash, printer }
     }
 }
 
-impl<'a, Mac: SupportMachine> Syscalls<Mac> for Debugger<'a> {
+impl<Mac: SupportMachine> Syscalls<Mac> for Debugger {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
         Ok(())
     }

--- a/script/src/syscalls/load_cell.rs
+++ b/script/src/syscalls/load_cell.rs
@@ -1,3 +1,4 @@
+use crate::types::Indices;
 use crate::{
     cost_model::transferred_byte_cycles,
     syscalls::{
@@ -8,7 +9,10 @@ use crate::{
 use byteorder::{LittleEndian, WriteBytesExt};
 use ckb_traits::CellDataProvider;
 use ckb_types::{
-    core::{cell::CellMeta, Capacity},
+    core::{
+        cell::{CellMeta, ResolvedTransaction},
+        Capacity,
+    },
     packed::CellOutput,
     prelude::*,
 };
@@ -16,53 +20,62 @@ use ckb_vm::{
     registers::{A0, A3, A4, A5, A7},
     Error as VMError, Register, SupportMachine, Syscalls,
 };
+use std::sync::Arc;
 
-pub struct LoadCell<'a, DL> {
-    data_loader: &'a DL,
-    outputs: &'a [CellMeta],
-    resolved_inputs: &'a [CellMeta],
-    resolved_cell_deps: &'a [CellMeta],
-    group_inputs: &'a [usize],
-    group_outputs: &'a [usize],
+pub struct LoadCell<DL> {
+    data_loader: DL,
+    rtx: Arc<ResolvedTransaction>,
+    outputs: Arc<Vec<CellMeta>>,
+    group_inputs: Indices,
+    group_outputs: Indices,
 }
 
-impl<'a, DL: CellDataProvider + 'a> LoadCell<'a, DL> {
+impl<DL: CellDataProvider> LoadCell<DL> {
     pub fn new(
-        data_loader: &'a DL,
-        outputs: &'a [CellMeta],
-        resolved_inputs: &'a [CellMeta],
-        resolved_cell_deps: &'a [CellMeta],
-        group_inputs: &'a [usize],
-        group_outputs: &'a [usize],
-    ) -> LoadCell<'a, DL> {
+        data_loader: DL,
+        rtx: Arc<ResolvedTransaction>,
+        outputs: Arc<Vec<CellMeta>>,
+        group_inputs: Indices,
+        group_outputs: Indices,
+    ) -> LoadCell<DL> {
         LoadCell {
             data_loader,
+            rtx,
             outputs,
-            resolved_inputs,
-            resolved_cell_deps,
             group_inputs,
             group_outputs,
         }
     }
 
-    fn fetch_cell(&self, source: Source, index: usize) -> Result<&'a CellMeta, u8> {
+    #[inline]
+    fn resolved_inputs(&self) -> &Vec<CellMeta> {
+        &self.rtx.resolved_inputs
+    }
+
+    #[inline]
+    fn resolved_cell_deps(&self) -> &Vec<CellMeta> {
+        &self.rtx.resolved_cell_deps
+    }
+
+    fn fetch_cell(&self, source: Source, index: usize) -> Result<&CellMeta, u8> {
         match source {
             Source::Transaction(SourceEntry::Input) => {
-                self.resolved_inputs.get(index).ok_or(INDEX_OUT_OF_BOUND)
+                self.resolved_inputs().get(index).ok_or(INDEX_OUT_OF_BOUND)
             }
             Source::Transaction(SourceEntry::Output) => {
                 self.outputs.get(index).ok_or(INDEX_OUT_OF_BOUND)
             }
-            Source::Transaction(SourceEntry::CellDep) => {
-                self.resolved_cell_deps.get(index).ok_or(INDEX_OUT_OF_BOUND)
-            }
+            Source::Transaction(SourceEntry::CellDep) => self
+                .resolved_cell_deps()
+                .get(index)
+                .ok_or(INDEX_OUT_OF_BOUND),
             Source::Transaction(SourceEntry::HeaderDep) => Err(INDEX_OUT_OF_BOUND),
             Source::Group(SourceEntry::Input) => self
                 .group_inputs
                 .get(index)
                 .ok_or(INDEX_OUT_OF_BOUND)
                 .and_then(|actual_index| {
-                    self.resolved_inputs
+                    self.resolved_inputs()
                         .get(*actual_index)
                         .ok_or(INDEX_OUT_OF_BOUND)
                 }),
@@ -152,7 +165,7 @@ impl<'a, DL: CellDataProvider + 'a> LoadCell<'a, DL> {
     }
 }
 
-impl<'a, Mac: SupportMachine, DL: CellDataProvider> Syscalls<Mac> for LoadCell<'a, DL> {
+impl<Mac: SupportMachine, DL: CellDataProvider + Send + Sync> Syscalls<Mac> for LoadCell<DL> {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
         Ok(())
     }

--- a/script/src/syscalls/load_cell_data.rs
+++ b/script/src/syscalls/load_cell_data.rs
@@ -1,3 +1,4 @@
+use crate::types::Indices;
 use crate::{
     cost_model::transferred_byte_cycles,
     syscalls::{
@@ -7,59 +8,68 @@ use crate::{
     },
 };
 use ckb_traits::CellDataProvider;
-use ckb_types::core::cell::CellMeta;
+use ckb_types::core::cell::{CellMeta, ResolvedTransaction};
 use ckb_vm::{
     memory::{Memory, FLAG_EXECUTABLE, FLAG_FREEZED},
     registers::{A0, A1, A2, A3, A4, A5, A7},
     Error as VMError, Register, SupportMachine, Syscalls,
 };
+use std::sync::Arc;
 
-pub struct LoadCellData<'a, DL> {
-    data_loader: &'a DL,
-    outputs: &'a [CellMeta],
-    resolved_inputs: &'a [CellMeta],
-    resolved_cell_deps: &'a [CellMeta],
-    group_inputs: &'a [usize],
-    group_outputs: &'a [usize],
+pub struct LoadCellData<DL> {
+    data_loader: DL,
+    rtx: Arc<ResolvedTransaction>,
+    outputs: Arc<Vec<CellMeta>>,
+    group_inputs: Indices,
+    group_outputs: Indices,
 }
 
-impl<'a, DL: CellDataProvider + 'a> LoadCellData<'a, DL> {
+impl<DL: CellDataProvider> LoadCellData<DL> {
     pub fn new(
-        data_loader: &'a DL,
-        outputs: &'a [CellMeta],
-        resolved_inputs: &'a [CellMeta],
-        resolved_cell_deps: &'a [CellMeta],
-        group_inputs: &'a [usize],
-        group_outputs: &'a [usize],
-    ) -> LoadCellData<'a, DL> {
+        data_loader: DL,
+        rtx: Arc<ResolvedTransaction>,
+        outputs: Arc<Vec<CellMeta>>,
+        group_inputs: Indices,
+        group_outputs: Indices,
+    ) -> LoadCellData<DL> {
         LoadCellData {
             data_loader,
+            rtx,
             outputs,
-            resolved_inputs,
-            resolved_cell_deps,
             group_inputs,
             group_outputs,
         }
     }
 
-    fn fetch_cell(&self, source: Source, index: usize) -> Result<&'a CellMeta, u8> {
+    #[inline]
+    fn resolved_inputs(&self) -> &Vec<CellMeta> {
+        &self.rtx.resolved_inputs
+    }
+
+    #[inline]
+    fn resolved_cell_deps(&self) -> &Vec<CellMeta> {
+        &self.rtx.resolved_cell_deps
+    }
+
+    fn fetch_cell(&self, source: Source, index: usize) -> Result<&CellMeta, u8> {
         match source {
             Source::Transaction(SourceEntry::Input) => {
-                self.resolved_inputs.get(index).ok_or(INDEX_OUT_OF_BOUND)
+                self.resolved_inputs().get(index).ok_or(INDEX_OUT_OF_BOUND)
             }
             Source::Transaction(SourceEntry::Output) => {
                 self.outputs.get(index).ok_or(INDEX_OUT_OF_BOUND)
             }
-            Source::Transaction(SourceEntry::CellDep) => {
-                self.resolved_cell_deps.get(index).ok_or(INDEX_OUT_OF_BOUND)
-            }
+            Source::Transaction(SourceEntry::CellDep) => self
+                .resolved_cell_deps()
+                .get(index)
+                .ok_or(INDEX_OUT_OF_BOUND),
             Source::Transaction(SourceEntry::HeaderDep) => Err(INDEX_OUT_OF_BOUND),
             Source::Group(SourceEntry::Input) => self
                 .group_inputs
                 .get(index)
                 .ok_or(INDEX_OUT_OF_BOUND)
                 .and_then(|actual_index| {
-                    self.resolved_inputs
+                    self.resolved_inputs()
                         .get(*actual_index)
                         .ok_or(INDEX_OUT_OF_BOUND)
                 }),
@@ -146,7 +156,7 @@ impl<'a, DL: CellDataProvider + 'a> LoadCellData<'a, DL> {
     }
 }
 
-impl<'a, Mac: SupportMachine, DL: CellDataProvider> Syscalls<Mac> for LoadCellData<'a, DL> {
+impl<Mac: SupportMachine, DL: CellDataProvider + Send + Sync> Syscalls<Mac> for LoadCellData<DL> {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
         Ok(())
     }

--- a/script/src/syscalls/pause.rs
+++ b/script/src/syscalls/pause.rs
@@ -1,19 +1,22 @@
 use crate::syscalls::DEBUG_PAUSE;
 use ckb_vm::{registers::A7, Error as VMError, Register, SupportMachine, Syscalls};
-use std::cell::RefCell;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[derive(Debug)]
-pub struct Pause<'a> {
-    skip: &'a RefCell<bool>,
+pub struct Pause {
+    skip: Arc<AtomicBool>,
 }
 
-impl<'a> Pause<'a> {
-    pub fn new(skip: &'a RefCell<bool>) -> Self {
+impl Pause {
+    pub fn new(skip: Arc<AtomicBool>) -> Self {
         Self { skip }
     }
 }
 
-impl<'a, Mac: SupportMachine> Syscalls<Mac> for Pause<'a> {
+impl<Mac: SupportMachine> Syscalls<Mac> for Pause {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
         Ok(())
     }
@@ -22,7 +25,7 @@ impl<'a, Mac: SupportMachine> Syscalls<Mac> for Pause<'a> {
         if machine.registers()[A7].to_u64() != DEBUG_PAUSE {
             return Ok(false);
         }
-        if *self.skip.borrow() {
+        if self.skip.load(Ordering::SeqCst) {
             return Ok(true);
         }
         Err(VMError::CyclesExceeded)

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     type_id::TypeIdSystemScript,
     types::{
-        CoreMachine, Machine, ResumableMachine, ScriptGroup, ScriptGroupType, ScriptVersion,
-        TransactionSnapshot, TransactionState, VerifyResult,
+        CoreMachine, DebugPrinter, Indices, Machine, ResumableMachine, ScriptGroup,
+        ScriptGroupType, ScriptVersion, TransactionSnapshot, TransactionState, VerifyResult,
     },
 };
 use ckb_chain_spec::consensus::TYPE_ID_CODE_HASH;
@@ -24,28 +24,30 @@ use ckb_types::{
         cell::{CellMeta, ResolvedTransaction},
         Cycle, ScriptHashType,
     },
-    packed::{Byte32, Byte32Vec, BytesVec, CellInputVec, CellOutput, OutPoint, Script},
+    packed::{Byte32, CellOutput, OutPoint, Script},
     prelude::*,
 };
-
 use ckb_vm::{
     snapshot::{resume, Snapshot},
     DefaultMachineBuilder, Error as VMInternalError, SupportMachine, Syscalls,
 };
-
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+#[cfg(test)]
+use core::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(test)]
 mod tests;
 
-pub enum ChunkState<'a> {
-    Suspended(Option<ResumableMachine<'a>>),
+pub enum ChunkState {
+    Suspended(Option<ResumableMachine>),
     Completed(Cycle),
 }
 
-impl<'a> ChunkState<'a> {
-    pub fn suspended(machine: ResumableMachine<'a>) -> Self {
+impl ChunkState {
+    pub fn suspended(machine: ResumableMachine) -> Self {
         ChunkState::Suspended(Some(machine))
     }
 
@@ -113,19 +115,17 @@ impl Binaries {
     }
 }
 
-type DebugPrinter = Box<dyn Fn(&Byte32, &str)>;
-
 /// This struct leverages CKB VM to verify transaction inputs.
 ///
 /// FlatBufferBuilder owned `Vec<u8>` that grows as needed, in the
 /// future, we might refactor this to share buffer to achieve zero-copy
-pub struct TransactionScriptsVerifier<'a, DL> {
-    data_loader: &'a DL,
+pub struct TransactionScriptsVerifier<DL> {
+    data_loader: DL,
 
     debug_printer: DebugPrinter,
 
-    outputs: Vec<CellMeta>,
-    rtx: &'a ResolvedTransaction,
+    outputs: Arc<Vec<CellMeta>>,
+    rtx: Arc<ResolvedTransaction>,
 
     binaries_by_data_hash: HashMap<Byte32, LazyData>,
     binaries_by_type_hash: HashMap<Byte32, Binaries>,
@@ -134,43 +134,43 @@ pub struct TransactionScriptsVerifier<'a, DL> {
     type_groups: BTreeMap<Byte32, ScriptGroup>,
 
     #[cfg(test)]
-    skip_pause: RefCell<bool>,
+    skip_pause: Arc<AtomicBool>,
 }
 
-impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, DL> {
+impl<DL: CellDataProvider + HeaderProvider + Send + Sync + Clone + 'static>
+    TransactionScriptsVerifier<DL>
+{
     /// Creates a script verifier for the transaction.
     ///
     /// ## Params
     ///
     /// * `rtx` - transaction which cell out points have been resolved.
     /// * `data_loader` - used to load cell data.
-    pub fn new(
-        rtx: &'a ResolvedTransaction,
-        data_loader: &'a DL,
-    ) -> TransactionScriptsVerifier<'a, DL> {
+    pub fn new(rtx: Arc<ResolvedTransaction>, data_loader: DL) -> TransactionScriptsVerifier<DL> {
         let tx_hash = rtx.transaction.hash();
         let resolved_cell_deps = &rtx.resolved_cell_deps;
         let resolved_inputs = &rtx.resolved_inputs;
-        let outputs = rtx
-            .transaction
-            .outputs_with_data_iter()
-            .enumerate()
-            .map(|(index, (cell_output, data))| {
-                let out_point = OutPoint::new_builder()
-                    .tx_hash(tx_hash.clone())
-                    .index(index.pack())
-                    .build();
-                let data_hash = CellOutput::calc_data_hash(&data);
-                CellMeta {
-                    cell_output,
-                    out_point,
-                    transaction_info: None,
-                    data_bytes: data.len() as u64,
-                    mem_cell_data: Some(data),
-                    mem_cell_data_hash: Some(data_hash),
-                }
-            })
-            .collect();
+        let outputs = Arc::new(
+            rtx.transaction
+                .outputs_with_data_iter()
+                .enumerate()
+                .map(|(index, (cell_output, data))| {
+                    let out_point = OutPoint::new_builder()
+                        .tx_hash(tx_hash.clone())
+                        .index(index.pack())
+                        .build();
+                    let data_hash = CellOutput::calc_data_hash(&data);
+                    CellMeta {
+                        cell_output,
+                        out_point,
+                        transaction_info: None,
+                        data_bytes: data.len() as u64,
+                        mem_cell_data: Some(data),
+                        mem_cell_data_hash: Some(data_hash),
+                    }
+                })
+                .collect(),
+        );
 
         let mut binaries_by_data_hash: HashMap<Byte32, LazyData> = HashMap::default();
         let mut binaries_by_type_hash: HashMap<Byte32, Binaries> = HashMap::default();
@@ -223,7 +223,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             rtx,
             lock_groups,
             type_groups,
-            debug_printer: Box::new(
+            debug_printer: Arc::new(
                 #[allow(unused_variables)]
                 |hash: &Byte32, message: &str| {
                     #[cfg(feature = "logging")]
@@ -231,7 +231,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                 },
             ),
             #[cfg(test)]
-            skip_pause: RefCell::new(false),
+            skip_pause: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -244,38 +244,13 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     ///
     /// * `hash: &Byte32`: this is the script hash of currently running script group.
     /// * `message: &str`: message passed to the debug syscall.
-    pub fn set_debug_printer<F: Fn(&Byte32, &str) + 'static>(&mut self, func: F) {
-        self.debug_printer = Box::new(func);
+    pub fn set_debug_printer<F: Fn(&Byte32, &str) + Sync + Send + 'static>(&mut self, func: F) {
+        self.debug_printer = Arc::new(func);
     }
 
     #[cfg(test)]
-    pub(crate) fn set_skip_pause(&mut self, skip_pause: bool) {
-        *self.skip_pause.borrow_mut() = skip_pause;
-    }
-
-    #[inline]
-    fn inputs(&self) -> CellInputVec {
-        self.rtx.transaction.inputs()
-    }
-
-    #[inline]
-    fn header_deps(&self) -> Byte32Vec {
-        self.rtx.transaction.header_deps()
-    }
-
-    #[inline]
-    fn resolved_inputs(&self) -> &Vec<CellMeta> {
-        &self.rtx.resolved_inputs
-    }
-
-    #[inline]
-    fn resolved_cell_deps(&self) -> &Vec<CellMeta> {
-        &self.rtx.resolved_cell_deps
-    }
-
-    #[inline]
-    fn witnesses(&self) -> BytesVec {
-        self.rtx.transaction.witnesses()
+    pub(crate) fn set_skip_pause(&self, skip_pause: bool) {
+        self.skip_pause.store(skip_pause, Ordering::SeqCst);
     }
 
     #[inline]
@@ -292,76 +267,62 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
         VMVersion::new()
     }
 
-    fn build_exec(&'a self, group_inputs: &'a [usize], group_outputs: &'a [usize]) -> Exec<'a, DL> {
+    fn build_exec(&self, group_inputs: Indices, group_outputs: Indices) -> Exec<DL> {
         Exec::new(
-            self.data_loader,
-            &self.outputs,
-            self.resolved_inputs(),
-            self.resolved_cell_deps(),
+            self.data_loader.clone(),
+            Arc::clone(&self.rtx),
+            Arc::clone(&self.outputs),
             group_inputs,
             group_outputs,
-            self.witnesses(),
         )
     }
 
     fn build_load_tx(&self) -> LoadTx {
-        LoadTx::new(&self.rtx.transaction)
+        LoadTx::new(Arc::clone(&self.rtx))
     }
 
-    fn build_load_cell(
-        &'a self,
-        group_inputs: &'a [usize],
-        group_outputs: &'a [usize],
-    ) -> LoadCell<'a, DL> {
+    fn build_load_cell(&self, group_inputs: Indices, group_outputs: Indices) -> LoadCell<DL> {
         LoadCell::new(
-            self.data_loader,
-            &self.outputs,
-            self.resolved_inputs(),
-            self.resolved_cell_deps(),
+            self.data_loader.clone(),
+            Arc::clone(&self.rtx),
+            Arc::clone(&self.outputs),
             group_inputs,
             group_outputs,
         )
     }
 
     fn build_load_cell_data(
-        &'a self,
-        group_inputs: &'a [usize],
-        group_outputs: &'a [usize],
-    ) -> LoadCellData<'a, DL> {
+        &self,
+        group_inputs: Indices,
+        group_outputs: Indices,
+    ) -> LoadCellData<DL> {
         LoadCellData::new(
-            self.data_loader,
-            &self.outputs,
-            self.resolved_inputs(),
-            self.resolved_cell_deps(),
+            self.data_loader.clone(),
+            Arc::clone(&self.rtx),
+            Arc::clone(&self.outputs),
             group_inputs,
             group_outputs,
         )
     }
 
-    fn build_load_input(&self, group_inputs: &'a [usize]) -> LoadInput {
-        LoadInput::new(self.inputs(), group_inputs)
+    fn build_load_input(&self, group_inputs: Indices) -> LoadInput {
+        LoadInput::new(Arc::clone(&self.rtx), group_inputs)
     }
 
     fn build_load_script_hash(&self, hash: Byte32) -> LoadScriptHash {
         LoadScriptHash::new(hash)
     }
 
-    fn build_load_header(&'a self, group_inputs: &'a [usize]) -> LoadHeader<'a, DL> {
+    fn build_load_header(&self, group_inputs: Indices) -> LoadHeader<DL> {
         LoadHeader::new(
-            self.data_loader,
-            self.header_deps(),
-            self.resolved_inputs(),
-            self.resolved_cell_deps(),
+            self.data_loader.clone(),
+            Arc::clone(&self.rtx),
             group_inputs,
         )
     }
 
-    fn build_load_witness(
-        &'a self,
-        group_inputs: &'a [usize],
-        group_outputs: &'a [usize],
-    ) -> LoadWitness<'a> {
-        LoadWitness::new(self.witnesses(), group_inputs, group_outputs)
+    fn build_load_witness(&self, group_inputs: Indices, group_outputs: Indices) -> LoadWitness {
+        LoadWitness::new(Arc::clone(&self.rtx), group_inputs, group_outputs)
     }
 
     fn build_load_script(&self, script: Script) -> LoadScript {
@@ -369,13 +330,13 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     }
 
     /// Extracts actual script binary either in dep cells.
-    pub fn extract_script(&self, script: &'a Script) -> Result<Bytes, ScriptError> {
+    pub fn extract_script(&self, script: &Script) -> Result<Bytes, ScriptError> {
         let script_hash_type = ScriptHashType::try_from(script.hash_type())
             .map_err(|err| ScriptError::InvalidScriptHashType(err.to_string()))?;
         match script_hash_type {
             ScriptHashType::Data | ScriptHashType::Data1 => {
                 if let Some(lazy) = self.binaries_by_data_hash.get(&script.code_hash()) {
-                    Ok(lazy.access(self.data_loader))
+                    Ok(lazy.access(&self.data_loader))
                 } else {
                     Err(ScriptError::ScriptNotFound(script.code_hash()))
                 }
@@ -383,8 +344,8 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             ScriptHashType::Type => {
                 if let Some(ref bin) = self.binaries_by_type_hash.get(&script.code_hash()) {
                     match bin {
-                        Binaries::Unique(_, ref lazy) => Ok(lazy.access(self.data_loader)),
-                        Binaries::Duplicate(_, ref lazy) => Ok(lazy.access(self.data_loader)),
+                        Binaries::Unique(_, ref lazy) => Ok(lazy.access(&self.data_loader)),
+                        Binaries::Duplicate(_, ref lazy) => Ok(lazy.access(&self.data_loader)),
                         Binaries::Multiple => Err(ScriptError::MultipleMatches),
                     }
                 } else {
@@ -395,7 +356,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     }
 
     /// Returns the version of the machine based on the script and the consensus rules.
-    pub fn select_version(&self, script: &'a Script) -> Result<ScriptVersion, ScriptError> {
+    pub fn select_version(&self, script: &Script) -> Result<ScriptVersion, ScriptError> {
         let script_hash_type = ScriptHashType::try_from(script.hash_type())
             .map_err(|err| ScriptError::InvalidScriptHashType(err.to_string()))?;
         match script_hash_type {
@@ -436,11 +397,11 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
 
     fn build_state(
         &self,
-        vm: Option<ResumableMachine<'a>>,
+        vm: Option<ResumableMachine>,
         current: usize,
         current_cycles: Cycle,
         limit_cycles: Cycle,
-    ) -> TransactionState<'a> {
+    ) -> TransactionState {
         TransactionState {
             current,
             vm,
@@ -586,10 +547,10 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     /// It returns the total consumed cycles if verification completed,
     /// If verify is suspended, a borrowed state will returned.
     pub fn resume_from_state(
-        &'a self,
-        state: TransactionState<'a>,
+        &self,
+        state: TransactionState,
         limit_cycles: Cycle,
-    ) -> Result<VerifyResult<'a>, Error> {
+    ) -> Result<VerifyResult, Error> {
         let TransactionState {
             current,
             vm,
@@ -772,7 +733,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
             && Into::<u8>::into(group.script.hash_type()) == Into::<u8>::into(ScriptHashType::Type)
         {
             let verifier = TypeIdSystemScript {
-                rtx: self.rtx,
+                rtx: &self.rtx,
                 script_group: group,
                 max_cycles,
             };
@@ -801,16 +762,16 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     }
 
     fn verify_group_with_chunk(
-        &'a self,
-        group: &'a ScriptGroup,
+        &self,
+        group: &ScriptGroup,
         max_cycles: Cycle,
         snap: &Option<(Snapshot, Cycle)>,
-    ) -> Result<ChunkState<'a>, ScriptError> {
+    ) -> Result<ChunkState, ScriptError> {
         if group.script.code_hash() == TYPE_ID_CODE_HASH.pack()
             && Into::<u8>::into(group.script.hash_type()) == Into::<u8>::into(ScriptHashType::Type)
         {
             let verifier = TypeIdSystemScript {
-                rtx: self.rtx,
+                rtx: &self.rtx,
                 script_group: group,
                 max_cycles,
             };
@@ -838,54 +799,60 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
 
     /// Prepares syscalls.
     pub fn generate_syscalls(
-        &'a self,
+        &self,
         script_version: ScriptVersion,
-        script_group: &'a ScriptGroup,
-    ) -> Vec<Box<(dyn Syscalls<CoreMachine> + 'a)>> {
+        script_group: &ScriptGroup,
+    ) -> Vec<Box<(dyn Syscalls<CoreMachine>)>> {
         let current_script_hash = script_group.script.calc_script_hash();
-        let mut syscalls: Vec<Box<(dyn Syscalls<CoreMachine> + 'a)>> = vec![
+        let script_group_input_indices = Arc::new(script_group.input_indices.clone());
+        let script_group_output_indices = Arc::new(script_group.output_indices.clone());
+        let mut syscalls: Vec<Box<(dyn Syscalls<CoreMachine>)>> = vec![
             Box::new(self.build_load_script_hash(current_script_hash.clone())),
             Box::new(self.build_load_tx()),
-            Box::new(
-                self.build_load_cell(&script_group.input_indices, &script_group.output_indices),
-            ),
-            Box::new(self.build_load_input(&script_group.input_indices)),
-            Box::new(self.build_load_header(&script_group.input_indices)),
-            Box::new(
-                self.build_load_witness(&script_group.input_indices, &script_group.output_indices),
-            ),
+            Box::new(self.build_load_cell(
+                Arc::clone(&script_group_input_indices),
+                Arc::clone(&script_group_output_indices),
+            )),
+            Box::new(self.build_load_input(Arc::clone(&script_group_input_indices))),
+            Box::new(self.build_load_header(Arc::clone(&script_group_input_indices))),
+            Box::new(self.build_load_witness(
+                Arc::clone(&script_group_input_indices),
+                Arc::clone(&script_group_output_indices),
+            )),
             Box::new(self.build_load_script(script_group.script.clone())),
-            Box::new(
-                self.build_load_cell_data(
-                    &script_group.input_indices,
-                    &script_group.output_indices,
-                ),
-            ),
-            Box::new(Debugger::new(current_script_hash, &self.debug_printer)),
+            Box::new(self.build_load_cell_data(
+                Arc::clone(&script_group_input_indices),
+                Arc::clone(&script_group_output_indices),
+            )),
+            Box::new(Debugger::new(
+                current_script_hash,
+                Arc::clone(&self.debug_printer),
+            )),
         ];
         #[cfg(test)]
-        syscalls.push(Box::new(Pause::new(&self.skip_pause)));
+        syscalls.push(Box::new(Pause::new(Arc::clone(&self.skip_pause))));
         if script_version >= ScriptVersion::V1 {
             syscalls.append(&mut vec![
                 Box::new(self.build_vm_version()),
                 Box::new(self.build_current_cycles()),
-                Box::new(
-                    self.build_exec(&script_group.input_indices, &script_group.output_indices),
-                ),
+                Box::new(self.build_exec(
+                    Arc::clone(&script_group_input_indices),
+                    Arc::clone(&script_group_output_indices),
+                )),
             ])
         }
         syscalls
     }
 
     fn build_machine(
-        &'a self,
-        script_group: &'a ScriptGroup,
+        &self,
+        script_group: &ScriptGroup,
         max_cycles: Cycle,
-    ) -> Result<Machine<'a>, ScriptError> {
+    ) -> Result<Machine, ScriptError> {
         let script_version = self.select_version(&script_group.script)?;
         let core_machine = script_version.init_core_machine(max_cycles);
         let machine_builder = DefaultMachineBuilder::<CoreMachine>::new(core_machine)
-            .instruction_cycle_func(&instruction_cycles);
+            .instruction_cycle_func(Box::new(instruction_cycles));
         let machine_builder = self
             .generate_syscalls(script_version, script_group)
             .into_iter()
@@ -920,11 +887,11 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     }
 
     fn chunk_run(
-        &'a self,
-        script_group: &'a ScriptGroup,
+        &self,
+        script_group: &ScriptGroup,
         max_cycles: Cycle,
         snap: &Option<(Snapshot, Cycle)>,
-    ) -> Result<ChunkState<'a>, ScriptError> {
+    ) -> Result<ChunkState, ScriptError> {
         let mut machine = self.build_machine(script_group, max_cycles)?;
 
         let map_vm_internal_error = |error: VMInternalError| match error {

--- a/script/src/verify/tests/ckb_latest/features_since_v2019.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2019.rs
@@ -1265,7 +1265,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_resume_load_cycles(step_cycles: 
     let verifier = TransactionScriptsVerifierWithEnv::new();
 
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut init_state: Option<TransactionState<'_>> = None;
+        let mut init_state: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(step_cycles).unwrap() {
             init_state = Some(state);

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -501,7 +501,7 @@ fn _check_type_id_one_in_one_out_resume(step_cycles: Cycle) -> Result<(), TestCa
 
     verifier.verify_map(script_version, &rtx, |verifier| {
         let mut groups: VecDeque<_> = verifier.groups_with_type().collect();
-        let mut tmp: Option<ResumableMachine<'_>> = None;
+        let mut tmp: Option<ResumableMachine> = None;
         let mut limit = step_cycles;
 
         loop {
@@ -597,7 +597,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_chunk(step_cycles: Cycle
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
         let mut groups: Vec<_> = verifier.groups_with_type().collect();
-        let mut tmp: Option<ResumableMachine<'_>> = None;
+        let mut tmp: Option<ResumableMachine> = None;
         let mut limit = step_cycles;
 
         loop {
@@ -677,7 +677,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_state(step_cycles: Cycle
     let mut cycles = 0;
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut init_state: Option<TransactionState<'_>> = None;
+        let mut init_state: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(step_cycles).unwrap() {
             init_state = Some(state);
@@ -727,7 +727,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap(step_cycles: Cycle)
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
         let mut init_snap: Option<TransactionSnapshot> = None;
-        let mut init_state: Option<TransactionState<'_>> = None;
+        let mut init_state: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(step_cycles).unwrap() {
             init_snap = Some(state.try_into().unwrap());
@@ -938,7 +938,7 @@ fn load_code_with_snapshot() {
     let mut cycles = 0;
     let max_cycles = Cycle::MAX;
     let verifier = TransactionScriptsVerifierWithEnv::new();
-    let result = verifier.verify_map(script_version, &rtx, |mut verifier| {
+    let result = verifier.verify_map(script_version, &rtx, |verifier| {
         let mut init_snap: Option<TransactionSnapshot> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(max_cycles).unwrap() {

--- a/script/src/verify/tests/utils.rs
+++ b/script/src/verify/tests/utils.rs
@@ -3,7 +3,10 @@ use ckb_crypto::secp::{Generator, Privkey, Pubkey, Signature};
 use ckb_db::RocksDB;
 use ckb_db_schema::COLUMNS;
 use ckb_hash::{blake2b_256, new_blake2b};
-use ckb_store::{data_loader_wrapper::DataLoaderWrapper, ChainDB};
+use ckb_store::{
+    data_loader_wrapper::{AsDataLoader, DataLoaderWrapper},
+    ChainDB,
+};
 use ckb_test_chain_utils::{
     ckb_testnet_consensus, secp256k1_blake160_sighash_cell, secp256k1_data_cell,
     type_lock_script_code_hash,
@@ -21,6 +24,7 @@ use ckb_types::{
     H256,
 };
 use faster_hex::hex_encode;
+use std::sync::Arc;
 use std::{convert::TryInto as _, fs::File, path::Path};
 use tempfile::TempDir;
 
@@ -115,7 +119,7 @@ pub(crate) struct TransactionScriptsVerifierWithEnv {
     // So, put `ChainDB` (`RocksDB`) before `TempDir`.
     //
     // Ref: https://doc.rust-lang.org/reference/destructors.html
-    store: ChainDB,
+    store: Arc<ChainDB>,
     _tmp_dir: TempDir,
 }
 
@@ -123,7 +127,7 @@ impl TransactionScriptsVerifierWithEnv {
     pub(crate) fn new() -> Self {
         let tmp_dir = TempDir::new().unwrap();
         let db = RocksDB::open_in(&tmp_dir, COLUMNS);
-        let store = ChainDB::new(db, Default::default());
+        let store = Arc::new(ChainDB::new(db, Default::default()));
         Self {
             store,
             _tmp_dir: tmp_dir,
@@ -155,7 +159,7 @@ impl TransactionScriptsVerifierWithEnv {
         rtx: &ResolvedTransaction,
         max_cycles: Cycle,
     ) -> Result<Cycle, Error> {
-        self.verify_map(version, rtx, |mut verifier| {
+        self.verify_map(version, rtx, |verifier| {
             verifier.set_skip_pause(true);
             verifier.verify(max_cycles)
         })
@@ -204,10 +208,10 @@ impl TransactionScriptsVerifierWithEnv {
         mut verify_func: F,
     ) -> R
     where
-        F: FnMut(TransactionScriptsVerifier<'_, DataLoaderWrapper<'_, ChainDB>>) -> R,
+        F: FnMut(TransactionScriptsVerifier<DataLoaderWrapper<ChainDB>>) -> R,
     {
-        let data_loader = DataLoaderWrapper::new(&self.store);
-        let verifier = TransactionScriptsVerifier::new(rtx, &data_loader);
+        let data_loader = self.store.as_data_loader();
+        let verifier = TransactionScriptsVerifier::new(Arc::new(rtx.clone()), data_loader);
         verify_func(verifier)
     }
 }

--- a/shared/src/shared.rs
+++ b/shared/src/shared.rs
@@ -290,6 +290,11 @@ impl Shared {
         self.snapshot_mgr.load()
     }
 
+    /// Return arc cloned snapshot
+    pub fn cloned_snapshot(&self) -> Arc<Snapshot> {
+        Arc::clone(&self.snapshot())
+    }
+
     /// TODO(doc): @quake
     pub fn store_snapshot(&self, snapshot: Arc<Snapshot>) {
         self.snapshot_mgr.store(snapshot)
@@ -322,6 +327,11 @@ impl Shared {
     /// TODO(doc): @quake
     pub fn consensus(&self) -> &Consensus {
         &self.consensus
+    }
+
+    /// Return arc cloned consensus re
+    pub fn cloned_consensus(&self) -> Arc<Consensus> {
+        Arc::clone(&self.consensus)
     }
 
     /// Return async runtime handle

--- a/spec/src/tests/consensus.rs
+++ b/spec/src/tests/consensus.rs
@@ -1,10 +1,10 @@
 use ckb_traits::{BlockEpoch, EpochProvider};
 use ckb_types::{
     core::{
-        capacity_bytes, BlockBuilder, Capacity, EpochExt, HeaderBuilder, HeaderView,
-        TransactionBuilder,
+        capacity_bytes, BlockBuilder, BlockExt, BlockNumber, Capacity, EpochExt, HeaderBuilder,
+        HeaderView, TransactionBuilder,
     },
-    packed::Bytes,
+    packed::{Byte32, Bytes},
     prelude::*,
     utilities::DIFF_TWO,
 };
@@ -63,6 +63,19 @@ fn test_halving_epoch_reward() {
         fn get_epoch_ext(&self, _block_header: &HeaderView) -> Option<EpochExt> {
             Some(self.0.clone())
         }
+
+        fn get_block_hash(&self, _number: BlockNumber) -> Option<Byte32> {
+            None
+        }
+
+        fn get_block_ext(&self, _block_hash: &Byte32) -> Option<BlockExt> {
+            None
+        }
+
+        fn get_block_header(&self, _hash: &Byte32) -> Option<HeaderView> {
+            None
+        }
+
         fn get_block_epoch(&self, block_header: &HeaderView) -> Option<BlockEpoch> {
             let block_epoch =
                 if block_header.number() == self.0.start_number() + self.0.length() - 1 {

--- a/store/src/data_loader_wrapper.rs
+++ b/store/src/data_loader_wrapper.rs
@@ -1,22 +1,93 @@
 //! TODO(doc): @quake
 use crate::ChainStore;
-use ckb_traits::{BlockEpoch, CellDataProvider, EpochProvider, HeaderProvider};
+use ckb_traits::{CellDataProvider, EpochProvider, HeaderProvider};
 use ckb_types::{
     bytes::Bytes,
-    core::{EpochExt, HeaderView},
+    core::{BlockExt, BlockNumber, EpochExt, HeaderView},
     packed::{Byte32, OutPoint},
 };
+use std::sync::Arc;
 
-/// TODO(doc): @quake
-pub struct DataLoaderWrapper<'a, T>(&'a T);
-impl<'a, T: ChainStore> DataLoaderWrapper<'a, T> {
-    /// TODO(doc): @quake
-    pub fn new(source: &'a T) -> Self {
-        DataLoaderWrapper(source)
+/// DataLoaderWrapper wrap`ChainStore`
+/// impl `HeaderProvider` `CellDataProvider` `EpochProvider`
+pub struct DataLoaderWrapper<T>(Arc<T>);
+
+// auto derive don't work
+impl<T> Clone for DataLoaderWrapper<T> {
+    fn clone(&self) -> Self {
+        DataLoaderWrapper(Arc::clone(&self.0))
     }
 }
 
-impl<'a, T: ChainStore> CellDataProvider for DataLoaderWrapper<'a, T> {
+/// Auto transform Arc wrapped `ChainStore` to `DataLoaderWrapper`
+pub trait AsDataLoader<T> {
+    /// Return arc cloned DataLoaderWrapper
+    fn as_data_loader(&self) -> DataLoaderWrapper<T>;
+}
+
+impl<T> AsDataLoader<T> for Arc<T>
+where
+    T: ChainStore,
+{
+    fn as_data_loader(&self) -> DataLoaderWrapper<T> {
+        DataLoaderWrapper(Arc::clone(self))
+    }
+}
+
+impl<T> CellDataProvider for DataLoaderWrapper<T>
+where
+    T: ChainStore,
+{
+    fn get_cell_data(&self, out_point: &OutPoint) -> Option<Bytes> {
+        ChainStore::get_cell_data(self.0.as_ref(), out_point).map(|(data, _)| data)
+    }
+
+    fn get_cell_data_hash(&self, out_point: &OutPoint) -> Option<Byte32> {
+        ChainStore::get_cell_data_hash(self.0.as_ref(), out_point)
+    }
+}
+
+impl<T> HeaderProvider for DataLoaderWrapper<T>
+where
+    T: ChainStore,
+{
+    fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {
+        ChainStore::get_block_header(self.0.as_ref(), block_hash)
+    }
+}
+
+impl<T> EpochProvider for DataLoaderWrapper<T>
+where
+    T: ChainStore,
+{
+    fn get_epoch_ext(&self, header: &HeaderView) -> Option<EpochExt> {
+        ChainStore::get_block_epoch_index(self.0.as_ref(), &header.hash())
+            .and_then(|index| ChainStore::get_epoch_ext(self.0.as_ref(), &index))
+    }
+
+    fn get_block_hash(&self, number: BlockNumber) -> Option<Byte32> {
+        ChainStore::get_block_hash(self.0.as_ref(), number)
+    }
+
+    fn get_block_ext(&self, block_hash: &Byte32) -> Option<BlockExt> {
+        ChainStore::get_block_ext(self.0.as_ref(), block_hash)
+    }
+
+    fn get_block_header(&self, hash: &Byte32) -> Option<HeaderView> {
+        ChainStore::get_block_header(self.0.as_ref(), hash)
+    }
+}
+
+/// Borrowed DataLoaderWrapper with lifetime
+pub struct BorrowedDataLoaderWrapper<'a, T>(&'a T);
+impl<'a, T: ChainStore> BorrowedDataLoaderWrapper<'a, T> {
+    /// Construct new BorrowedDataLoaderWrapper
+    pub fn new(source: &'a T) -> Self {
+        BorrowedDataLoaderWrapper(source)
+    }
+}
+
+impl<'a, T: ChainStore> CellDataProvider for BorrowedDataLoaderWrapper<'a, T> {
     fn get_cell_data(&self, out_point: &OutPoint) -> Option<Bytes> {
         self.0.get_cell_data(out_point).map(|(data, _)| data)
     }
@@ -26,52 +97,27 @@ impl<'a, T: ChainStore> CellDataProvider for DataLoaderWrapper<'a, T> {
     }
 }
 
-impl<'a, T: ChainStore> HeaderProvider for DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> HeaderProvider for BorrowedDataLoaderWrapper<'a, T> {
     fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {
         self.0.get_block_header(block_hash)
     }
 }
 
-impl<'a, T: ChainStore> EpochProvider for DataLoaderWrapper<'a, T> {
+impl<'a, T: ChainStore> EpochProvider for BorrowedDataLoaderWrapper<'a, T> {
     fn get_epoch_ext(&self, header: &HeaderView) -> Option<EpochExt> {
-        self.0
-            .get_block_epoch_index(&header.hash())
-            .and_then(|index| self.0.get_epoch_ext(&index))
+        ChainStore::get_block_epoch_index(self.0, &header.hash())
+            .and_then(|index| ChainStore::get_epoch_ext(self.0, &index))
     }
 
-    fn get_block_epoch(&self, header: &HeaderView) -> Option<BlockEpoch> {
-        self.get_epoch_ext(header).map(|epoch| {
-            if header.number() != epoch.start_number() + epoch.length() - 1 {
-                BlockEpoch::NonTailBlock { epoch }
-            } else {
-                let last_block_hash_in_previous_epoch = if epoch.is_genesis() {
-                    self.0.get_block_hash(0).expect("genesis block stored")
-                } else {
-                    epoch.last_block_hash_in_previous_epoch()
-                };
-                let epoch_uncles_count = self
-                    .0
-                    .get_block_ext(&header.hash())
-                    .expect("stored block ext")
-                    .total_uncles_count
-                    - self
-                        .0
-                        .get_block_ext(&last_block_hash_in_previous_epoch)
-                        .expect("stored block ext")
-                        .total_uncles_count;
-                let epoch_duration_in_milliseconds = header.timestamp()
-                    - self
-                        .0
-                        .get_block_header(&last_block_hash_in_previous_epoch)
-                        .expect("stored block header")
-                        .timestamp();
+    fn get_block_hash(&self, number: BlockNumber) -> Option<Byte32> {
+        ChainStore::get_block_hash(self.0, number)
+    }
 
-                BlockEpoch::TailBlock {
-                    epoch,
-                    epoch_uncles_count,
-                    epoch_duration_in_milliseconds,
-                }
-            }
-        })
+    fn get_block_ext(&self, block_hash: &Byte32) -> Option<BlockExt> {
+        ChainStore::get_block_ext(self.0, block_hash)
+    }
+
+    fn get_block_header(&self, hash: &Byte32) -> Option<HeaderView> {
+        ChainStore::get_block_header(self.0, hash)
     }
 }

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -1,5 +1,5 @@
 use crate::cache::StoreCache;
-use crate::data_loader_wrapper::DataLoaderWrapper;
+use crate::data_loader_wrapper::BorrowedDataLoaderWrapper;
 use ckb_db::{
     iter::{DBIter, Direction, IteratorMode},
     DBPinnableSlice,
@@ -33,8 +33,8 @@ pub trait ChainStore: Send + Sync + Sized {
     /// TODO(doc): @quake
     fn get_iter(&self, col: Col, mode: IteratorMode) -> DBIter;
     /// Return the provider trait default implementation
-    fn as_data_provider(&self) -> DataLoaderWrapper<'_, Self> {
-        DataLoaderWrapper::new(self)
+    fn as_data_provider(&self) -> BorrowedDataLoaderWrapper<Self> {
+        BorrowedDataLoaderWrapper::new(self)
     }
 
     /// Get block by block header hash

--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -32,8 +32,8 @@ pub trait ChainStore: Send + Sync + Sized {
     fn get(&self, col: Col, key: &[u8]) -> Option<DBPinnableSlice>;
     /// TODO(doc): @quake
     fn get_iter(&self, col: Col, mode: IteratorMode) -> DBIter;
-    /// Return the provider trait default implementation
-    fn as_data_provider(&self) -> BorrowedDataLoaderWrapper<Self> {
+    /// Return the borrowed data loader wrapper
+    fn borrow_as_data_loader(&self) -> BorrowedDataLoaderWrapper<Self> {
         BorrowedDataLoaderWrapper::new(self)
     }
 

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -50,7 +50,7 @@ pub(crate) fn new_header_builder(shared: &Shared, parent: &HeaderView) -> Header
     let snapshot = shared.snapshot();
     let epoch = snapshot
         .consensus()
-        .next_epoch_ext(parent, &snapshot.as_data_provider())
+        .next_epoch_ext(parent, &snapshot.borrow_as_data_loader())
         .unwrap()
         .epoch();
     HeaderBuilder::default()

--- a/sync/src/tests/synchronizer/basic_sync.rs
+++ b/sync/src/tests/synchronizer/basic_sync.rs
@@ -146,7 +146,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
             .unwrap();
             let data_loader = snapshot.as_data_provider();
             DaoCalculator::new(shared.consensus(), &data_loader)
-                .dao_field(&[resolved_cellbase], &block.header())
+                .dao_field([resolved_cellbase].iter(), &block.header())
                 .unwrap()
         };
 

--- a/sync/src/tests/synchronizer/basic_sync.rs
+++ b/sync/src/tests/synchronizer/basic_sync.rs
@@ -110,7 +110,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
         let snapshot = shared.snapshot();
         let epoch = snapshot
             .consensus()
-            .next_epoch_ext(&block.header(), &snapshot.as_data_provider())
+            .next_epoch_ext(&block.header(), &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
 
@@ -144,7 +144,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
                 snapshot.as_ref(),
             )
             .unwrap();
-            let data_loader = snapshot.as_data_provider();
+            let data_loader = snapshot.borrow_as_data_loader();
             DaoCalculator::new(shared.consensus(), &data_loader)
                 .dao_field([resolved_cellbase].iter(), &block.header())
                 .unwrap()

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -103,7 +103,7 @@ fn gen_block(
             resolve_transaction(cellbase.clone(), &mut HashSet::new(), snapshot, snapshot).unwrap();
         let data_loader = shared.store().as_data_provider();
         DaoCalculator::new(shared.consensus(), &data_loader)
-            .dao_field(&[resolved_cellbase], parent_header)
+            .dao_field([resolved_cellbase].iter(), parent_header)
             .unwrap()
     };
 

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -101,7 +101,7 @@ fn gen_block(
         let snapshot: &Snapshot = &shared.snapshot();
         let resolved_cellbase =
             resolve_transaction(cellbase.clone(), &mut HashSet::new(), snapshot, snapshot).unwrap();
-        let data_loader = shared.store().as_data_provider();
+        let data_loader = shared.store().borrow_as_data_loader();
         DaoCalculator::new(shared.consensus(), &data_loader)
             .dao_field([resolved_cellbase].iter(), parent_header)
             .unwrap()
@@ -131,7 +131,7 @@ fn insert_block(
         .unwrap();
     let epoch = snapshot
         .consensus()
-        .next_epoch_ext(&parent, &snapshot.as_data_provider())
+        .next_epoch_ext(&parent, &snapshot.borrow_as_data_loader())
         .unwrap()
         .epoch();
 
@@ -226,7 +226,7 @@ fn test_locate_latest_common_block2() {
         let store = shared1.store();
         let epoch = shared1
             .consensus()
-            .next_epoch_ext(&parent, &store.as_data_provider())
+            .next_epoch_ext(&parent, &store.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = gen_block(&shared1, &parent, &epoch, i);
@@ -247,7 +247,7 @@ fn test_locate_latest_common_block2() {
         let store = shared2.store();
         let epoch = shared2
             .consensus()
-            .next_epoch_ext(&parent, &store.as_data_provider())
+            .next_epoch_ext(&parent, &store.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = gen_block(&shared2, &parent, &epoch, i + 100);
@@ -334,7 +334,7 @@ fn test_process_new_block() {
         let store = shared1.store();
         let epoch = shared1
             .consensus()
-            .next_epoch_ext(&parent, &store.as_data_provider())
+            .next_epoch_ext(&parent, &store.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = gen_block(&shared1, &parent, &epoch, i + 100);
@@ -370,7 +370,7 @@ fn test_get_locator_response() {
         let store = shared.snapshot();
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&parent, &store.as_data_provider())
+            .next_epoch_ext(&parent, &store.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = gen_block(&shared, &parent, &epoch, i + 100);

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -66,7 +66,7 @@ pub fn inherit_block(shared: &Shared, parent_hash: &Byte32) -> BlockBuilder {
         .unwrap();
         let data_loader = snapshot.as_data_provider();
         DaoCalculator::new(shared.consensus(), &data_loader)
-            .dao_field(&[resolved_cellbase], &parent.header())
+            .dao_field([resolved_cellbase].iter(), &parent.header())
             .unwrap()
     };
 

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -52,7 +52,7 @@ pub fn inherit_block(shared: &Shared, parent_hash: &Byte32) -> BlockBuilder {
     let parent_number = parent.header().number();
     let epoch = snapshot
         .consensus()
-        .next_epoch_ext(&parent.header(), &snapshot.as_data_provider())
+        .next_epoch_ext(&parent.header(), &snapshot.borrow_as_data_loader())
         .unwrap()
         .epoch();
     let cellbase = inherit_cellbase(&snapshot, parent_number);
@@ -64,7 +64,7 @@ pub fn inherit_block(shared: &Shared, parent_hash: &Byte32) -> BlockBuilder {
             snapshot.as_ref(),
         )
         .unwrap();
-        let data_loader = snapshot.as_data_provider();
+        let data_loader = snapshot.borrow_as_data_loader();
         DaoCalculator::new(shared.consensus(), &data_loader)
             .dao_field([resolved_cellbase].iter(), &parent.header())
             .unwrap()

--- a/traits/src/epoch_provider.rs
+++ b/traits/src/epoch_provider.rs
@@ -1,11 +1,52 @@
-use ckb_types::core::{EpochExt, HeaderView};
+use ckb_types::{
+    core::{BlockExt, BlockNumber, EpochExt, HeaderView},
+    packed,
+};
 
 /// Trait for epoch storage.
 pub trait EpochProvider {
     /// Get corresponding `EpochExt` by block header
     fn get_epoch_ext(&self, block_header: &HeaderView) -> Option<EpochExt>;
+    /// Get block header hash by block number
+    fn get_block_hash(&self, number: BlockNumber) -> Option<packed::Byte32>;
+    /// Get block ext by block header hash
+    fn get_block_ext(&self, block_hash: &packed::Byte32) -> Option<BlockExt>;
+    /// Get header by block header hash
+    fn get_block_header(&self, hash: &packed::Byte32) -> Option<HeaderView>;
+
     /// Get corresponding epoch progress information by block header
-    fn get_block_epoch(&self, block_header: &HeaderView) -> Option<BlockEpoch>;
+    fn get_block_epoch(&self, header: &HeaderView) -> Option<BlockEpoch> {
+        self.get_epoch_ext(header).map(|epoch| {
+            if header.number() != epoch.start_number() + epoch.length() - 1 {
+                BlockEpoch::NonTailBlock { epoch }
+            } else {
+                let last_block_hash_in_previous_epoch = if epoch.is_genesis() {
+                    self.get_block_hash(0).expect("genesis block stored")
+                } else {
+                    epoch.last_block_hash_in_previous_epoch()
+                };
+                let epoch_uncles_count = self
+                    .get_block_ext(&header.hash())
+                    .expect("stored block ext")
+                    .total_uncles_count
+                    - self
+                        .get_block_ext(&last_block_hash_in_previous_epoch)
+                        .expect("stored block ext")
+                        .total_uncles_count;
+                let epoch_duration_in_milliseconds = header.timestamp()
+                    - self
+                        .get_block_header(&last_block_hash_in_previous_epoch)
+                        .expect("stored block header")
+                        .timestamp();
+
+                BlockEpoch::TailBlock {
+                    epoch,
+                    epoch_uncles_count,
+                    epoch_duration_in_milliseconds,
+                }
+            }
+        })
+    }
 }
 
 /// Progress of block's corresponding epoch

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -613,7 +613,7 @@ impl BlockAssembler {
         let dummy_cellbase_entry = TxEntry::dummy_resolve(cellbase, 0, Capacity::zero(), 0);
         let entries_iter = iter::once(&dummy_cellbase_entry)
             .chain(checked_entries.iter())
-            .map(|entry| &entry.rtx);
+            .map(|entry| entry.rtx.as_ref());
 
         // Generate DAO fields here
         let dao = DaoCalculator::new(consensus, &snapshot.as_data_provider())

--- a/tx-pool/src/block_assembler/mod.rs
+++ b/tx-pool/src/block_assembler/mod.rs
@@ -109,7 +109,7 @@ impl BlockAssembler {
         let consensus = snapshot.consensus();
         let tip_header = snapshot.tip_header();
         let current_epoch = consensus
-            .next_epoch_ext(tip_header, &snapshot.as_data_provider())
+            .next_epoch_ext(tip_header, &snapshot.borrow_as_data_loader())
             .expect("tip header's epoch should be stored")
             .epoch();
         let mut builder = BlockTemplateBuilder::new(&snapshot, &current_epoch);
@@ -237,7 +237,7 @@ impl BlockAssembler {
         let consensus = snapshot.consensus();
         let tip_header = snapshot.tip_header();
         let current_epoch = consensus
-            .next_epoch_ext(tip_header, &snapshot.as_data_provider())
+            .next_epoch_ext(tip_header, &snapshot.borrow_as_data_loader())
             .expect("tip header's epoch should be stored")
             .epoch();
         let mut builder = BlockTemplateBuilder::new(&snapshot, &current_epoch);
@@ -616,7 +616,7 @@ impl BlockAssembler {
             .map(|entry| entry.rtx.as_ref());
 
         // Generate DAO fields here
-        let dao = DaoCalculator::new(consensus, &snapshot.as_data_provider())
+        let dao = DaoCalculator::new(consensus, &snapshot.borrow_as_data_loader())
             .dao_field_with_current_epoch(entries_iter, tip_header, current_epoch)?;
 
         Ok((dao, checked_entries))

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -10,12 +10,13 @@ use ckb_types::{
 };
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 /// An entry in the transaction pool.
 #[derive(Debug, Clone, Eq)]
 pub struct TxEntry {
     /// Transaction
-    pub rtx: ResolvedTransaction,
+    pub rtx: Arc<ResolvedTransaction>,
     /// Cycles
     pub cycles: Cycle,
     /// tx size
@@ -36,7 +37,7 @@ pub struct TxEntry {
 
 impl TxEntry {
     /// Create new transaction pool entry
-    pub fn new(rtx: ResolvedTransaction, cycles: Cycle, fee: Capacity, size: usize) -> Self {
+    pub fn new(rtx: Arc<ResolvedTransaction>, cycles: Cycle, fee: Capacity, size: usize) -> Self {
         TxEntry {
             rtx,
             cycles,
@@ -53,7 +54,7 @@ impl TxEntry {
     /// Create dummy entry from tx, skip resolve
     pub fn dummy_resolve(tx: TransactionView, cycles: Cycle, fee: Capacity, size: usize) -> Self {
         let rtx = ResolvedTransaction::dummy_resolve(tx);
-        TxEntry::new(rtx, cycles, fee, size)
+        TxEntry::new(Arc::new(rtx), cycles, fee, size)
     }
 
     /// Return related dep out_points
@@ -69,7 +70,7 @@ impl TxEntry {
     /// Converts a Entry into a TransactionView
     /// This consumes the Entry
     pub fn into_transaction(self) -> TransactionView {
-        self.rtx.transaction
+        self.rtx.transaction.clone()
     }
 
     /// Return proposal_short_id of transaction

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -14,11 +14,12 @@ use ckb_types::{
     prelude::*,
 };
 use std::collections::HashSet;
+use std::sync::Arc;
 
 fn dummy_resolve<F: Fn(&OutPoint) -> Option<Bytes>>(
     tx: TransactionView,
     get_cell_data: F,
-) -> ResolvedTransaction {
+) -> Arc<ResolvedTransaction> {
     let resolved_cell_deps = get_related_dep_out_points(&tx, get_cell_data)
         .expect("dummy resolve")
         .into_iter()
@@ -34,12 +35,12 @@ fn dummy_resolve<F: Fn(&OutPoint) -> Option<Bytes>>(
         })
         .collect();
 
-    ResolvedTransaction {
+    Arc::new(ResolvedTransaction {
         transaction: tx,
         resolved_cell_deps,
         resolved_inputs: vec![],
         resolved_dep_groups: vec![],
-    }
+    })
 }
 
 #[test]

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -367,7 +367,7 @@ impl TxPool {
     pub(crate) fn resolve_tx_from_pending_and_proposed(
         &self,
         tx: TransactionView,
-    ) -> Result<ResolvedTransaction, Reject> {
+    ) -> Result<Arc<ResolvedTransaction>, Reject> {
         let snapshot = self.snapshot();
         let proposed_provider = OverlayCellProvider::new(&self.proposed, snapshot);
         let gap_and_proposed_provider = OverlayCellProvider::new(&self.gap, &proposed_provider);
@@ -380,6 +380,7 @@ impl TxPool {
             &pending_and_proposed_provider,
             snapshot,
         )
+        .map(Arc::new)
         .map_err(Reject::Resolve)
     }
 
@@ -400,11 +401,13 @@ impl TxPool {
     pub(crate) fn resolve_tx_from_proposed(
         &self,
         tx: TransactionView,
-    ) -> Result<ResolvedTransaction, Reject> {
+    ) -> Result<Arc<ResolvedTransaction>, Reject> {
         let snapshot = self.snapshot();
         let cell_provider = OverlayCellProvider::new(&self.proposed, snapshot);
         let mut seen_inputs = HashSet::new();
-        resolve_transaction(tx, &mut seen_inputs, &cell_provider, snapshot).map_err(Reject::Resolve)
+        resolve_transaction(tx, &mut seen_inputs, &cell_provider, snapshot)
+            .map(Arc::new)
+            .map_err(Reject::Resolve)
     }
 
     pub(crate) fn check_rtx_from_proposed(&self, rtx: &ResolvedTransaction) -> Result<(), Reject> {
@@ -419,15 +422,21 @@ impl TxPool {
         &mut self,
         cache_entry: CacheEntry,
         size: usize,
-        rtx: ResolvedTransaction,
+        rtx: Arc<ResolvedTransaction>,
     ) -> Result<CacheEntry, Reject> {
-        let snapshot = self.snapshot();
+        let snapshot = self.cloned_snapshot();
         let tip_header = snapshot.tip_header();
         let tx_env = TxVerifyEnv::new_proposed(tip_header, 0);
         self.check_rtx_from_pending_and_proposed(&rtx)?;
 
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let verified = verify_rtx(snapshot, &rtx, &tx_env, &Some(cache_entry), max_cycles)?;
+        let verified = verify_rtx(
+            snapshot,
+            Arc::clone(&rtx),
+            &tx_env,
+            &Some(cache_entry),
+            max_cycles,
+        )?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);
         let tx_hash = entry.transaction().hash();
@@ -442,15 +451,21 @@ impl TxPool {
         &mut self,
         cache_entry: CacheEntry,
         size: usize,
-        rtx: ResolvedTransaction,
+        rtx: Arc<ResolvedTransaction>,
     ) -> Result<CacheEntry, Reject> {
-        let snapshot = self.snapshot();
+        let snapshot = self.cloned_snapshot();
         let tip_header = snapshot.tip_header();
         let tx_env = TxVerifyEnv::new_proposed(tip_header, 1);
         self.check_rtx_from_proposed(&rtx)?;
 
         let max_cycles = snapshot.consensus().max_block_cycles();
-        let verified = verify_rtx(snapshot, &rtx, &tx_env, &Some(cache_entry), max_cycles)?;
+        let verified = verify_rtx(
+            snapshot,
+            Arc::clone(&rtx),
+            &tx_env,
+            &Some(cache_entry),
+            max_cycles,
+        )?;
 
         let entry = TxEntry::new(rtx, verified.cycles, verified.fee, size);
         let tx_hash = entry.transaction().hash();
@@ -531,7 +546,7 @@ impl TxPool {
             .txs_to_commit(self.total_tx_size, self.total_tx_cycles)
             .0
             .into_iter()
-            .map(|tx_entry| tx_entry.rtx.transaction)
+            .map(|tx_entry| tx_entry.into_transaction())
             .collect::<Vec<_>>();
         self.proposed.clear();
         txs.append(&mut self.gap.drain());

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -16,6 +16,7 @@ use ckb_logger::Level::Trace;
 use ckb_logger::{debug, error, log_enabled_target, trace_target};
 use ckb_network::PeerIndex;
 use ckb_snapshot::Snapshot;
+use ckb_store::data_loader_wrapper::AsDataLoader;
 use ckb_store::ChainStore;
 use ckb_types::{
     core::{cell::ResolvedTransaction, BlockView, Capacity, Cycle, HeaderView, TransactionView},
@@ -114,11 +115,11 @@ impl TxPoolService {
                     );
 
                     // destructuring assignments are not currently supported
-                    status = check_rtx(tx_pool, snapshot, &entry.rtx)?;
+                    status = check_rtx(tx_pool, &snapshot, &entry.rtx)?;
 
                     let tip_header = snapshot.tip_header();
                     let tx_env = status.with_env(tip_header);
-                    time_relative_verify(snapshot, &entry.rtx, &tx_env)?;
+                    time_relative_verify(snapshot, Arc::clone(&entry.rtx), &tx_env)?;
                 }
 
                 _submit_entry(tx_pool, status, entry.clone(), &self.callbacks)?;
@@ -168,25 +169,25 @@ impl TxPoolService {
         chunk.contains_key(&tx.proposal_short_id())
     }
 
-    pub(crate) async fn with_tx_pool_read_lock<U, F: FnMut(&TxPool, &Snapshot) -> U>(
+    pub(crate) async fn with_tx_pool_read_lock<U, F: FnMut(&TxPool, Arc<Snapshot>) -> U>(
         &self,
         mut f: F,
     ) -> (U, Arc<Snapshot>) {
         let tx_pool = self.tx_pool.read().await;
         let snapshot = tx_pool.cloned_snapshot();
 
-        let ret = f(&tx_pool, &snapshot);
+        let ret = f(&tx_pool, Arc::clone(&snapshot));
         (ret, snapshot)
     }
 
-    pub(crate) async fn with_tx_pool_write_lock<U, F: FnMut(&mut TxPool, &Snapshot) -> U>(
+    pub(crate) async fn with_tx_pool_write_lock<U, F: FnMut(&mut TxPool, Arc<Snapshot>) -> U>(
         &self,
         mut f: F,
     ) -> (U, Arc<Snapshot>) {
         let mut tx_pool = self.tx_pool.write().await;
         let snapshot = tx_pool.cloned_snapshot();
 
-        let ret = f(&mut tx_pool, &snapshot);
+        let ret = f(&mut tx_pool, Arc::clone(&snapshot));
         (ret, snapshot)
     }
 
@@ -204,9 +205,9 @@ impl TxPoolService {
 
                 check_txid_collision(tx_pool, tx)?;
 
-                let (rtx, status) = resolve_tx(tx_pool, snapshot, tx.clone())?;
+                let (rtx, status) = resolve_tx(tx_pool, &snapshot, tx.clone())?;
 
-                let fee = check_tx_fee(tx_pool, snapshot, &rtx, tx_size)?;
+                let fee = check_tx_fee(tx_pool, &snapshot, &rtx, tx_size)?;
 
                 Ok((tip_hash, rtx, status, fee, tx_size))
             })
@@ -530,13 +531,15 @@ impl TxPoolService {
         let tip_header = snapshot.tip_header();
         let tx_env = status.with_env(tip_header);
 
+        let data_loader = snapshot.as_data_loader();
+
         let completed = if let Some(ref entry) = cached {
             match entry {
                 CacheEntry::Completed(completed) => {
                     let ret = TimeRelativeTransactionVerifier::new(
-                        &rtx,
+                        Arc::clone(&rtx),
                         &self.consensus,
-                        snapshot.as_ref(),
+                        data_loader,
                         &tx_env,
                     )
                     .verify()
@@ -550,12 +553,15 @@ impl TxPoolService {
             }
         } else {
             let consensus = snapshot.consensus();
-            let data_provider = snapshot.as_data_provider();
             let is_chunk_full = self.is_chunk_full().await;
 
             let ret = block_in_place(|| {
-                let verifier =
-                    ContextualTransactionVerifier::new(&rtx, consensus, &data_provider, &tx_env);
+                let verifier = ContextualTransactionVerifier::new(
+                    Arc::clone(&rtx),
+                    consensus,
+                    data_loader,
+                    &tx_env,
+                );
 
                 let (ret, fee) = verifier
                     .resumable_verify(limit_cycles)
@@ -651,7 +657,14 @@ impl TxPoolService {
         let max_cycles = declared_cycles.unwrap_or_else(|| self.consensus.max_block_cycles());
         let tip_header = snapshot.tip_header();
         let tx_env = status.with_env(tip_header);
-        let verified_ret = verify_rtx(&snapshot, &rtx, &tx_env, &verify_cache, max_cycles);
+
+        let verified_ret = verify_rtx(
+            Arc::clone(&snapshot),
+            Arc::clone(&rtx),
+            &tx_env,
+            &verify_cache,
+            max_cycles,
+        );
 
         let verified = try_or_return_with_snapshot!(verified_ret, snapshot);
 
@@ -751,12 +764,16 @@ impl TxPoolService {
             if let Ok((rtx, status)) = resolve_tx(tx_pool, tx_pool.snapshot(), tx) {
                 if let Ok(fee) = check_tx_fee(tx_pool, tx_pool.snapshot(), &rtx, tx_size) {
                     let verify_cache = fetched_cache.get(&tx_hash).cloned();
-                    let snapshot = tx_pool.snapshot();
+                    let snapshot = tx_pool.cloned_snapshot();
                     let tip_header = snapshot.tip_header();
                     let tx_env = status.with_env(tip_header);
-                    if let Ok(verified) =
-                        verify_rtx(snapshot, &rtx, &tx_env, &verify_cache, max_cycles)
-                    {
+                    if let Ok(verified) = verify_rtx(
+                        snapshot,
+                        Arc::clone(&rtx),
+                        &tx_env,
+                        &verify_cache,
+                        max_cycles,
+                    ) {
                         let entry = TxEntry::new(rtx, verified.cycles, fee, tx_size);
                         if let Err(e) = _submit_entry(tx_pool, status, entry, &self.callbacks) {
                             error!("readd_detached_tx submit_entry {} error {}", tx_hash, e);
@@ -793,9 +810,9 @@ impl TxPoolService {
     }
 }
 
-type PreCheckedTx = (Byte32, ResolvedTransaction, TxStatus, Capacity, usize);
+type PreCheckedTx = (Byte32, Arc<ResolvedTransaction>, TxStatus, Capacity, usize);
 
-type ResolveResult = Result<(ResolvedTransaction, TxStatus), Reject>;
+type ResolveResult = Result<(Arc<ResolvedTransaction>, TxStatus), Reject>;
 
 fn check_rtx(
     tx_pool: &TxPool,
@@ -924,7 +941,7 @@ fn _update_tx_pool_for_reorg(
             debug!("tx move to proposed {}", entry.transaction().hash());
             let cached = CacheEntry::completed(entry.cycles, entry.fee);
             let tx_hash = entry.transaction().hash();
-            if let Err(e) = tx_pool.proposed_rtx(cached, entry.size, entry.rtx.clone()) {
+            if let Err(e) = tx_pool.proposed_rtx(cached, entry.size, Arc::clone(&entry.rtx)) {
                 debug!("Failed to add proposed tx {}, reason: {}", tx_hash, e);
                 callbacks.call_reject(tx_pool, &entry, e.clone());
             } else {
@@ -936,7 +953,7 @@ fn _update_tx_pool_for_reorg(
             debug!("tx move to gap {}", entry.transaction().hash());
             let tx_hash = entry.transaction().hash();
             let cached = CacheEntry::completed(entry.cycles, entry.fee);
-            if let Err(e) = tx_pool.gap_rtx(cached, entry.size, entry.rtx.clone()) {
+            if let Err(e) = tx_pool.gap_rtx(cached, entry.size, Arc::clone(&entry.rtx)) {
                 debug!("Failed to add tx to gap {}, reason: {}", tx_hash, e);
                 callbacks.call_reject(tx_pool, &entry, e.clone());
             }

--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -3,6 +3,7 @@ use crate::pool::TxPool;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_dao::DaoCalculator;
 use ckb_snapshot::Snapshot;
+use ckb_store::data_loader_wrapper::AsDataLoader;
 use ckb_store::ChainStore;
 use ckb_types::core::{cell::ResolvedTransaction, Capacity, Cycle, TransactionView};
 use ckb_verification::{
@@ -10,6 +11,7 @@ use ckb_verification::{
     ContextualTransactionVerifier, NonContextualTransactionVerifier,
     TimeRelativeTransactionVerifier, TxVerifyEnv,
 };
+use std::sync::Arc;
 use tokio::task::block_in_place;
 
 pub(crate) fn check_txid_collision(tx_pool: &TxPool, tx: &TransactionView) -> Result<(), Reject> {
@@ -76,34 +78,32 @@ pub(crate) fn non_contextual_verify(
 }
 
 pub(crate) fn verify_rtx(
-    snapshot: &Snapshot,
-    rtx: &ResolvedTransaction,
+    snapshot: Arc<Snapshot>,
+    rtx: Arc<ResolvedTransaction>,
     tx_env: &TxVerifyEnv,
     cache_entry: &Option<CacheEntry>,
     max_tx_verify_cycles: Cycle,
 ) -> Result<Completed, Reject> {
     let consensus = snapshot.consensus();
+    let data_loader = snapshot.as_data_loader();
 
     if let Some(ref cached) = cache_entry {
         match cached {
             CacheEntry::Completed(completed) => {
-                TimeRelativeTransactionVerifier::new(rtx, consensus, snapshot, tx_env)
+                TimeRelativeTransactionVerifier::new(rtx, consensus, data_loader, tx_env)
                     .verify()
                     .map(|_| *completed)
                     .map_err(Reject::Verification)
             }
-            CacheEntry::Suspended(suspended) => ContextualTransactionVerifier::new(
-                rtx,
-                consensus,
-                &snapshot.as_data_provider(),
-                tx_env,
-            )
-            .complete(max_tx_verify_cycles, false, &suspended.snap)
-            .map_err(Reject::Verification),
+            CacheEntry::Suspended(suspended) => {
+                ContextualTransactionVerifier::new(rtx, consensus, data_loader, tx_env)
+                    .complete(max_tx_verify_cycles, false, &suspended.snap)
+                    .map_err(Reject::Verification)
+            }
         }
     } else {
         block_in_place(|| {
-            ContextualTransactionVerifier::new(rtx, consensus, &snapshot.as_data_provider(), tx_env)
+            ContextualTransactionVerifier::new(rtx, consensus, data_loader, tx_env)
                 .verify(max_tx_verify_cycles, false)
                 .map_err(Reject::Verification)
         })
@@ -111,12 +111,12 @@ pub(crate) fn verify_rtx(
 }
 
 pub(crate) fn time_relative_verify(
-    snapshot: &Snapshot,
-    rtx: &ResolvedTransaction,
+    snapshot: Arc<Snapshot>,
+    rtx: Arc<ResolvedTransaction>,
     tx_env: &TxVerifyEnv,
 ) -> Result<(), Reject> {
     let consensus = snapshot.consensus();
-    TimeRelativeTransactionVerifier::new(rtx, consensus, snapshot, tx_env)
+    TimeRelativeTransactionVerifier::new(rtx, consensus, snapshot.as_data_loader(), tx_env)
         .verify()
         .map_err(Reject::Verification)
 }

--- a/tx-pool/src/util.rs
+++ b/tx-pool/src/util.rs
@@ -45,7 +45,7 @@ pub(crate) fn check_tx_fee(
     rtx: &ResolvedTransaction,
     tx_size: usize,
 ) -> Result<Capacity, Reject> {
-    let fee = DaoCalculator::new(snapshot.consensus(), &snapshot.as_data_provider())
+    let fee = DaoCalculator::new(snapshot.consensus(), &snapshot.borrow_as_data_loader())
         .transaction_fee(rtx)
         .map_err(|err| Reject::Malformed(format!("{err}")))?;
     // Theoretically we cannot use size as weight directly to calculate fee_rate,

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -135,7 +135,7 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
     /// [`extract_dao_data`]: ../ckb_dao_utils/fn.extract_dao_data.html
     pub fn dao_field(
         &self,
-        rtxs: &[ResolvedTransaction],
+        rtxs: impl Iterator<Item = &'a ResolvedTransaction> + Clone,
         parent: &HeaderView,
     ) -> Result<Byte32, DaoError> {
         let current_block_epoch = self
@@ -143,7 +143,7 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
             .next_epoch_ext(parent, self.data_loader)
             .ok_or(DaoError::InvalidHeader)?
             .epoch();
-        self.dao_field_with_current_epoch(rtxs.iter(), parent, &current_block_epoch)
+        self.dao_field_with_current_epoch(rtxs, parent, &current_block_epoch)
     }
 
     /// Returns the total transactions fee of `rtx`.

--- a/util/dao/src/tests.rs
+++ b/util/dao/src/tests.rs
@@ -75,7 +75,7 @@ fn check_dao_data_calculation() {
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
-        .dao_field(&[], &parent_header)
+        .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
     assert_eq!(
@@ -106,7 +106,7 @@ fn check_initial_dao_data_calculation() {
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(0));
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
-        .dao_field(&[], &parent_header)
+        .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
     assert_eq!(
@@ -139,7 +139,7 @@ fn check_first_epoch_block_dao_data_calculation() {
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(12340));
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
-        .dao_field(&[], &parent_header)
+        .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
     assert_eq!(
@@ -171,8 +171,8 @@ fn check_dao_data_calculation_overflows() {
         .build();
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
-    let result =
-        DaoCalculator::new(&consensus, &store.as_data_provider()).dao_field(&[], &parent_header);
+    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+        .dao_field([].iter(), &parent_header);
     assert!(result.unwrap_err().to_string().contains("Overflow"));
 }
 
@@ -217,7 +217,7 @@ fn check_dao_data_calculation_with_transactions() {
     };
 
     let result = DaoCalculator::new(&consensus, &store.as_data_provider())
-        .dao_field(&[rtx], &parent_header)
+        .dao_field([rtx].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
     assert_eq!(

--- a/util/dao/src/tests.rs
+++ b/util/dao/src/tests.rs
@@ -74,7 +74,7 @@ fn check_dao_data_calculation() {
         .build();
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
-    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+    let result = DaoCalculator::new(&consensus, &store.borrow_as_data_loader())
         .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
@@ -105,7 +105,7 @@ fn check_initial_dao_data_calculation() {
         .build();
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(0));
-    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+    let result = DaoCalculator::new(&consensus, &store.borrow_as_data_loader())
         .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
@@ -138,7 +138,7 @@ fn check_first_epoch_block_dao_data_calculation() {
         .build();
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, Some(12340));
-    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+    let result = DaoCalculator::new(&consensus, &store.borrow_as_data_loader())
         .dao_field([].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
@@ -171,7 +171,7 @@ fn check_dao_data_calculation_overflows() {
         .build();
 
     let (_tmp_dir, store, parent_header) = prepare_store(&parent_header, None);
-    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+    let result = DaoCalculator::new(&consensus, &store.borrow_as_data_loader())
         .dao_field([].iter(), &parent_header);
     assert!(result.unwrap_err().to_string().contains("Overflow"));
 }
@@ -216,7 +216,7 @@ fn check_dao_data_calculation_with_transactions() {
         resolved_dep_groups: vec![],
     };
 
-    let result = DaoCalculator::new(&consensus, &store.as_data_provider())
+    let result = DaoCalculator::new(&consensus, &store.borrow_as_data_loader())
         .dao_field([rtx].iter(), &parent_header)
         .unwrap();
     let dao_data = extract_dao_data(result);
@@ -281,7 +281,7 @@ fn check_withdraw_calculation() {
     txn.commit().unwrap();
 
     let consensus = Consensus::default();
-    let data_loader = store.as_data_provider();
+    let data_loader = store.borrow_as_data_loader();
     let calculator = DaoCalculator::new(&consensus, &data_loader);
     let result = calculator.calculate_maximum_withdraw(
         &output,
@@ -338,7 +338,7 @@ fn check_withdraw_calculation_overflows() {
     txn.commit().unwrap();
 
     let consensus = Consensus::default();
-    let data_loader = store.as_data_provider();
+    let data_loader = store.borrow_as_data_loader();
     let calculator = DaoCalculator::new(&consensus, &data_loader);
     let result = calculator.calculate_maximum_withdraw(
         &output,

--- a/util/reward-calculator/src/lib.rs
+++ b/util/reward-calculator/src/lib.rs
@@ -254,7 +254,7 @@ impl<'a, CS: ChainStore> RewardCalculator<'a, CS> {
     }
 
     fn base_block_reward(&self, target: &HeaderView) -> Result<(Capacity, Capacity), DaoError> {
-        let data_loader = self.store.as_data_provider();
+        let data_loader = self.store.borrow_as_data_loader();
         let calculator = DaoCalculator::new(self.consensus, &data_loader);
         let primary_block_reward = calculator.primary_block_reward(target)?;
         let secondary_block_reward = calculator.secondary_block_reward(target)?;

--- a/util/test-chain-utils/src/median_time.rs
+++ b/util/test-chain-utils/src/median_time.rs
@@ -5,6 +5,7 @@ use ckb_types::{
     prelude::*,
 };
 use ckb_util::LinkedHashMap;
+use std::sync::Arc;
 
 /// There's a consensus rule to verify that the block timestamp must be larger than
 /// the median timestamp of the previous 37 blocks.
@@ -12,8 +13,9 @@ use ckb_util::LinkedHashMap;
 /// `MockMedianTime` is a mock for the median time in testing.
 /// And the number of previous blocks for calculating median timestamp is set as 11.
 #[doc(hidden)]
+#[derive(Clone)]
 pub struct MockMedianTime {
-    headers: LinkedHashMap<Byte32, HeaderView>,
+    headers: Arc<LinkedHashMap<Byte32, HeaderView>>,
 }
 
 #[doc(hidden)]
@@ -40,26 +42,28 @@ impl MockMedianTime {
     #[doc(hidden)]
     pub fn new(timestamps: Vec<u64>) -> Self {
         Self {
-            headers: timestamps
-                .iter()
-                .enumerate()
-                .map(|(idx, timestamp)| {
-                    let number = idx as BlockNumber;
-                    let header = HeaderBuilder::default()
-                        .timestamp(timestamp.pack())
-                        .number(number.pack())
-                        .epoch(
-                            EpochNumberWithFraction::new(
-                                number % MOCK_EPOCH_LENGTH,
-                                number / MOCK_EPOCH_LENGTH,
-                                MOCK_EPOCH_LENGTH,
+            headers: Arc::new(
+                timestamps
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, timestamp)| {
+                        let number = idx as BlockNumber;
+                        let header = HeaderBuilder::default()
+                            .timestamp(timestamp.pack())
+                            .number(number.pack())
+                            .epoch(
+                                EpochNumberWithFraction::new(
+                                    number % MOCK_EPOCH_LENGTH,
+                                    number / MOCK_EPOCH_LENGTH,
+                                    MOCK_EPOCH_LENGTH,
+                                )
+                                .pack(),
                             )
-                            .pack(),
-                        )
-                        .build();
-                    (header.hash(), header)
-                })
-                .collect(),
+                            .build();
+                        (header.hash(), header)
+                    })
+                    .collect(),
+            ),
         }
     }
 

--- a/verification/contextual/src/contextual_block_verifier.rs
+++ b/verification/contextual/src/contextual_block_verifier.rs
@@ -10,7 +10,7 @@ use ckb_error::{Error, InternalErrorKind};
 use ckb_logger::error_target;
 use ckb_merkle_mountain_range::MMRStore;
 use ckb_reward_calculator::RewardCalculator;
-use ckb_store::ChainStore;
+use ckb_store::{data_loader_wrapper::AsDataLoader, ChainStore};
 use ckb_traits::HeaderProvider;
 use ckb_types::{
     core::error::OutPointError,
@@ -37,14 +37,23 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 
 /// Context for context-dependent block verification
-pub struct VerifyContext<'a, CS> {
-    pub(crate) store: &'a CS,
-    pub(crate) consensus: &'a Consensus,
+pub struct VerifyContext<CS> {
+    pub(crate) store: Arc<CS>,
+    pub(crate) consensus: Arc<Consensus>,
 }
 
-impl<'a, CS: ChainStore + VersionbitsIndexer> VerifyContext<'a, CS> {
+impl<CS> Clone for VerifyContext<CS> {
+    fn clone(&self) -> Self {
+        VerifyContext {
+            store: Arc::clone(&self.store),
+            consensus: Arc::clone(&self.consensus),
+        }
+    }
+}
+
+impl<CS: ChainStore + VersionbitsIndexer> VerifyContext<CS> {
     /// Create new VerifyContext from `Store` and `Consensus`
-    pub fn new(store: &'a CS, consensus: &'a Consensus) -> Self {
+    pub fn new(store: Arc<CS>, consensus: Arc<Consensus>) -> Self {
         VerifyContext { store, consensus }
     }
 
@@ -52,24 +61,24 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> VerifyContext<'a, CS> {
         &self,
         parent: &HeaderView,
     ) -> Result<(Script, BlockReward), DaoError> {
-        RewardCalculator::new(self.consensus, self.store).block_reward_to_finalize(parent)
+        RewardCalculator::new(&self.consensus, self.store.as_ref()).block_reward_to_finalize(parent)
     }
 
     fn versionbits_active(&self, pos: DeploymentPos, header: &HeaderView) -> bool {
         self.consensus
-            .versionbits_state(pos, header, self.store)
+            .versionbits_state(pos, header, self.store.as_ref())
             .map(|state| state == ThresholdState::Active)
             .unwrap_or(false)
     }
 }
 
-impl<'a, CS: ChainStore> HeaderProvider for VerifyContext<'a, CS> {
+impl<CS: ChainStore> HeaderProvider for VerifyContext<CS> {
     fn get_header(&self, hash: &Byte32) -> Option<HeaderView> {
         self.store.get_block_header(hash)
     }
 }
 
-impl<'a, CS: ChainStore> HeaderChecker for VerifyContext<'a, CS> {
+impl<CS: ChainStore> HeaderChecker for VerifyContext<CS> {
     fn check_valid(&self, block_hash: &Byte32) -> Result<(), OutPointError> {
         if !self.store.is_main_chain(block_hash) {
             return Err(OutPointError::InvalidHeader(block_hash.clone()));
@@ -81,19 +90,19 @@ impl<'a, CS: ChainStore> HeaderChecker for VerifyContext<'a, CS> {
     }
 }
 
-impl<'a, CS: ChainStore> ConsensusProvider for VerifyContext<'a, CS> {
+impl<CS: ChainStore> ConsensusProvider for VerifyContext<CS> {
     fn get_consensus(&self) -> &Consensus {
-        self.consensus
+        &self.consensus
     }
 }
 
 pub struct UncleVerifierContext<'a, 'b, CS> {
     epoch: &'b EpochExt,
-    context: &'a VerifyContext<'a, CS>,
+    context: &'a VerifyContext<CS>,
 }
 
 impl<'a, 'b, CS: ChainStore> UncleVerifierContext<'a, 'b, CS> {
-    pub(crate) fn new(context: &'a VerifyContext<'a, CS>, epoch: &'b EpochExt) -> Self {
+    pub(crate) fn new(context: &'a VerifyContext<CS>, epoch: &'b EpochExt) -> Self {
         UncleVerifierContext { epoch, context }
     }
 }
@@ -106,7 +115,7 @@ impl<'a, 'b, CS: ChainStore> UncleProvider for UncleVerifierContext<'a, 'b, CS> 
     fn descendant(&self, uncle: &HeaderView) -> bool {
         let parent_hash = uncle.data().raw().parent_hash();
         let uncle_number = uncle.number();
-        let store = self.context.store;
+        let store = &self.context.store;
 
         if store.get_block_number(&parent_hash).is_some() {
             return store
@@ -127,17 +136,17 @@ impl<'a, 'b, CS: ChainStore> UncleProvider for UncleVerifierContext<'a, 'b, CS> 
     }
 
     fn consensus(&self) -> &Consensus {
-        self.context.consensus
+        &self.context.consensus
     }
 }
 
 pub struct TwoPhaseCommitVerifier<'a, CS> {
-    context: &'a VerifyContext<'a, CS>,
+    context: &'a VerifyContext<CS>,
     block: &'a BlockView,
 }
 
 impl<'a, CS: ChainStore + VersionbitsIndexer> TwoPhaseCommitVerifier<'a, CS> {
-    pub fn new(context: &'a VerifyContext<'a, CS>, block: &'a BlockView) -> Self {
+    pub fn new(context: &'a VerifyContext<CS>, block: &'a BlockView) -> Self {
         TwoPhaseCommitVerifier { context, block }
     }
 
@@ -213,15 +222,15 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> TwoPhaseCommitVerifier<'a, CS> {
 }
 
 pub struct RewardVerifier<'a, 'b, CS> {
-    resolved: &'a [ResolvedTransaction],
+    resolved: &'a [Arc<ResolvedTransaction>],
     parent: &'b HeaderView,
-    context: &'a VerifyContext<'a, CS>,
+    context: &'a VerifyContext<CS>,
 }
 
 impl<'a, 'b, CS: ChainStore + VersionbitsIndexer> RewardVerifier<'a, 'b, CS> {
     pub fn new(
-        context: &'a VerifyContext<'a, CS>,
-        resolved: &'a [ResolvedTransaction],
+        context: &'a VerifyContext<CS>,
+        resolved: &'a [Arc<ResolvedTransaction>],
         parent: &'b HeaderView,
     ) -> Self {
         RewardVerifier {
@@ -274,16 +283,16 @@ impl<'a, 'b, CS: ChainStore + VersionbitsIndexer> RewardVerifier<'a, 'b, CS> {
 }
 
 struct DaoHeaderVerifier<'a, 'b, 'c, CS> {
-    context: &'a VerifyContext<'a, CS>,
-    resolved: &'a [ResolvedTransaction],
+    context: &'a VerifyContext<CS>,
+    resolved: &'a [Arc<ResolvedTransaction>],
     parent: &'b HeaderView,
     header: &'c HeaderView,
 }
 
 impl<'a, 'b, 'c, CS: ChainStore + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 'c, CS> {
     pub fn new(
-        context: &'a VerifyContext<'a, CS>,
-        resolved: &'a [ResolvedTransaction],
+        context: &'a VerifyContext<CS>,
+        resolved: &'a [Arc<ResolvedTransaction>],
         parent: &'b HeaderView,
         header: &'c HeaderView,
     ) -> Self {
@@ -297,10 +306,10 @@ impl<'a, 'b, 'c, CS: ChainStore + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 
 
     pub fn verify(&self) -> Result<(), Error> {
         let dao = DaoCalculator::new(
-            self.context.consensus,
+            &self.context.consensus,
             &self.context.store.as_data_provider(),
         )
-        .dao_field(self.resolved, self.parent)
+        .dao_field(self.resolved.iter().map(AsRef::as_ref), self.parent)
         .map_err(|e| {
             error_target!(
                 crate::LOG_TARGET,
@@ -319,15 +328,15 @@ impl<'a, 'b, 'c, CS: ChainStore + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 
 }
 
 struct BlockTxsVerifier<'a, CS> {
-    context: &'a VerifyContext<'a, CS>,
+    context: VerifyContext<CS>,
     header: HeaderView,
     handle: &'a Handle,
     txs_verify_cache: &'a Arc<RwLock<TxVerificationCache>>,
 }
 
-impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
+impl<'a, CS: ChainStore + VersionbitsIndexer + 'static> BlockTxsVerifier<'a, CS> {
     pub fn new(
-        context: &'a VerifyContext<'a, CS>,
+        context: VerifyContext<CS>,
         header: HeaderView,
         handle: &'a Handle,
         txs_verify_cache: &'a Arc<RwLock<TxVerificationCache>>,
@@ -374,7 +383,7 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
 
     pub fn verify(
         &self,
-        resolved: &'a [ResolvedTransaction],
+        resolved: &'a [Arc<ResolvedTransaction>],
         skip_script_verify: bool,
     ) -> Result<(Cycle, Vec<Completed>), Error> {
         // We should skip updating tx_verify_cache about the cellbase tx,
@@ -401,9 +410,9 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
                 if let Some(cache_entry) = fetched_cache.get(&tx_hash) {
                     match cache_entry {
                         CacheEntry::Completed(completed) => TimeRelativeTransactionVerifier::new(
-                            tx,
-                            self.context.consensus,
-                            self.context,
+                            Arc::clone(tx),
+                            &self.context.consensus,
+                            self.context.store.as_data_loader(),
                             &tx_env,
                         )
                         .verify()
@@ -416,9 +425,9 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
                         })
                         .map(|_| (tx_hash, *completed)),
                         CacheEntry::Suspended(suspended) => ContextualTransactionVerifier::new(
-                            tx,
-                            self.context.consensus,
-                            &self.context.store.as_data_provider(),
+                            Arc::clone(tx),
+                            &self.context.consensus,
+                            self.context.store.as_data_loader(),
                             &tx_env,
                         )
                         .complete(
@@ -437,9 +446,9 @@ impl<'a, CS: ChainStore + VersionbitsIndexer> BlockTxsVerifier<'a, CS> {
                     }
                 } else {
                     ContextualTransactionVerifier::new(
-                        tx,
-                        self.context.consensus,
-                        &self.context.store.as_data_provider(),
+                        Arc::clone(tx),
+                        &self.context.consensus,
+                        self.context.store.as_data_loader(),
                         &tx_env,
                     )
                     .verify(
@@ -518,7 +527,7 @@ impl<'a> EpochVerifier<'a> {
 /// Check block extension.
 #[derive(Clone)]
 pub struct BlockExtensionVerifier<'a, 'b, CS, MS> {
-    context: &'a VerifyContext<'a, CS>,
+    context: &'a VerifyContext<CS>,
     chain_root_mmr: &'a ChainRootMMR<MS>,
     parent: &'b HeaderView,
 }
@@ -527,7 +536,7 @@ impl<'a, 'b, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
     BlockExtensionVerifier<'a, 'b, CS, MS>
 {
     pub fn new(
-        context: &'a VerifyContext<'a, CS>,
+        context: &'a VerifyContext<CS>,
         chain_root_mmr: &'a ChainRootMMR<MS>,
         parent: &'b HeaderView,
     ) -> Self {
@@ -603,19 +612,19 @@ impl<'a, 'b, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
 /// - [`RewardVerifier`](./struct.RewardVerifier.html)
 /// - [`BlockTxsVerifier`](./struct.BlockTxsVerifier.html)
 pub struct ContextualBlockVerifier<'a, CS, MS> {
-    context: &'a VerifyContext<'a, CS>,
+    context: VerifyContext<CS>,
     switch: Switch,
     handle: &'a Handle,
     txs_verify_cache: Arc<RwLock<TxVerificationCache>>,
     chain_root_mmr: &'a ChainRootMMR<MS>,
 }
 
-impl<'a, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
+impl<'a, CS: ChainStore + VersionbitsIndexer + 'static, MS: MMRStore<HeaderDigest>>
     ContextualBlockVerifier<'a, CS, MS>
 {
     /// Create new ContextualBlockVerifier
     pub fn new(
-        context: &'a VerifyContext<'a, CS>,
+        context: VerifyContext<CS>,
         handle: &'a Handle,
         switch: Switch,
         txs_verify_cache: Arc<RwLock<TxVerificationCache>>,
@@ -633,7 +642,7 @@ impl<'a, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
     /// Perform context-dependent verification checks for block
     pub fn verify(
         &'a self,
-        resolved: &'a [ResolvedTransaction],
+        resolved: &'a [Arc<ResolvedTransaction>],
         block: &'a BlockView,
     ) -> Result<(Cycle, Vec<Completed>), Error> {
         let parent_hash = block.data().header().raw().parent_hash();
@@ -663,26 +672,31 @@ impl<'a, CS: ChainStore + VersionbitsIndexer, MS: MMRStore<HeaderDigest>>
         }
 
         if !self.switch.disable_uncles() {
-            let uncle_verifier_context = UncleVerifierContext::new(self.context, &epoch_ext);
+            let uncle_verifier_context = UncleVerifierContext::new(&self.context, &epoch_ext);
             UnclesVerifier::new(uncle_verifier_context, block).verify()?;
         }
 
         if !self.switch.disable_two_phase_commit() {
-            TwoPhaseCommitVerifier::new(self.context, block).verify()?;
+            TwoPhaseCommitVerifier::new(&self.context, block).verify()?;
         }
 
         if !self.switch.disable_daoheader() {
-            DaoHeaderVerifier::new(self.context, resolved, &parent, &block.header()).verify()?;
+            DaoHeaderVerifier::new(&self.context, resolved, &parent, &block.header()).verify()?;
         }
 
         if !self.switch.disable_reward() {
-            RewardVerifier::new(self.context, resolved, &parent).verify()?;
+            RewardVerifier::new(&self.context, resolved, &parent).verify()?;
         }
 
-        BlockExtensionVerifier::new(self.context, self.chain_root_mmr, &parent).verify(block)?;
+        BlockExtensionVerifier::new(&self.context, self.chain_root_mmr, &parent).verify(block)?;
 
-        let ret = BlockTxsVerifier::new(self.context, header, self.handle, &self.txs_verify_cache)
-            .verify(resolved, self.switch.disable_script())?;
+        let ret = BlockTxsVerifier::new(
+            self.context.clone(),
+            header,
+            self.handle,
+            &self.txs_verify_cache,
+        )
+        .verify(resolved, self.switch.disable_script())?;
         Ok(ret)
     }
 }

--- a/verification/contextual/src/contextual_block_verifier.rs
+++ b/verification/contextual/src/contextual_block_verifier.rs
@@ -307,7 +307,7 @@ impl<'a, 'b, 'c, CS: ChainStore + VersionbitsIndexer> DaoHeaderVerifier<'a, 'b, 
     pub fn verify(&self) -> Result<(), Error> {
         let dao = DaoCalculator::new(
             &self.context.consensus,
-            &self.context.store.as_data_provider(),
+            &self.context.store.borrow_as_data_loader(),
         )
         .dao_field(self.resolved.iter().map(AsRef::as_ref), self.parent)
         .map_err(|e| {
@@ -660,7 +660,7 @@ impl<'a, CS: ChainStore + VersionbitsIndexer + 'static, MS: MMRStore<HeaderDiges
         } else {
             self.context
                 .consensus
-                .next_epoch_ext(&parent, &self.context.store.as_data_provider())
+                .next_epoch_ext(&parent, &self.context.store.borrow_as_data_loader())
                 .ok_or_else(|| UnknownParentError {
                     parent_hash: parent.hash(),
                 })?

--- a/verification/contextual/src/tests/contextual_block_verifier.rs
+++ b/verification/contextual/src/tests/contextual_block_verifier.rs
@@ -89,8 +89,8 @@ fn start_chain(consensus: Option<Consensus>) -> (ChainController, Shared) {
     (chain_controller, shared)
 }
 
-fn dummy_context(shared: &Shared) -> VerifyContext<'_, ChainDB> {
-    VerifyContext::new(shared.store(), shared.consensus())
+fn dummy_context(shared: &Shared) -> VerifyContext<ChainDB> {
+    VerifyContext::new(Arc::new(shared.store().clone()), shared.cloned_consensus())
 }
 
 fn create_cellbase(number: BlockNumber) -> TransactionView {
@@ -154,7 +154,7 @@ pub fn test_should_have_no_output_in_cellbase_no_finalization_target() {
         resolved_dep_groups: vec![],
     };
 
-    let ret = RewardVerifier::new(&context, &[cellbase], &parent).verify();
+    let ret = RewardVerifier::new(&context, &[Arc::new(cellbase)], &parent).verify();
 
     assert_error_eq!(ret.unwrap_err(), CellbaseError::InvalidRewardTarget,);
 }

--- a/verification/contextual/src/tests/uncle_verifier.rs
+++ b/verification/contextual/src/tests/uncle_verifier.rs
@@ -84,7 +84,7 @@ fn prepare() -> (Shared, Vec<BlockView>, Vec<BlockView>) {
         let snapshot = shared.snapshot();
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&parent, &snapshot.as_data_provider())
+            .next_epoch_ext(&parent, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = gen_block(&parent, random(), &epoch);
@@ -102,7 +102,7 @@ fn prepare() -> (Shared, Vec<BlockView>, Vec<BlockView>) {
         let snapshot = shared.snapshot();
         let epoch = shared
             .consensus()
-            .next_epoch_ext(&parent, &snapshot.as_data_provider())
+            .next_epoch_ext(&parent, &snapshot.borrow_as_data_loader())
             .unwrap()
             .epoch();
         let new_block = if i > 10 {
@@ -129,7 +129,7 @@ fn epoch(shared: &Shared, chain: &[BlockView], index: usize) -> EpochExt {
     let snapshot = shared.snapshot();
     shared
         .consensus()
-        .next_epoch_ext(&chain[index].header(), &snapshot.as_data_provider())
+        .next_epoch_ext(&chain[index].header(), &snapshot.borrow_as_data_loader())
         .unwrap()
         .epoch()
 }

--- a/verification/contextual/src/tests/uncle_verifier.rs
+++ b/verification/contextual/src/tests/uncle_verifier.rs
@@ -121,8 +121,8 @@ fn prepare() -> (Shared, Vec<BlockView>, Vec<BlockView>) {
     (shared, chain1, chain2)
 }
 
-fn dummy_context(shared: &Shared) -> VerifyContext<'_, ChainDB> {
-    VerifyContext::new(shared.store(), shared.consensus())
+fn dummy_context(shared: &Shared) -> VerifyContext<ChainDB> {
+    VerifyContext::new(Arc::new(shared.store().clone()), shared.cloned_consensus())
 }
 
 fn epoch(shared: &Shared, chain: &[BlockView], index: usize) -> EpochExt {

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::header_verifier::HeaderVerifier;
 pub use crate::transaction_verifier::{
     CapacityVerifier, ContextualTransactionVerifier, ContextualWithoutScriptTransactionVerifier,
     NonContextualTransactionVerifier, ScriptVerifier, Since, SinceMetric,
-    TimeRelativeTransactionVerifier, TransactionVerifier,
+    TimeRelativeTransactionVerifier,
 };
 pub use ckb_script::{
     ScriptError, ScriptGroupType, TransactionSnapshot, TransactionState as ScriptVerifyState,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Upgrade ckb-vm  to v0.23.2

### What is changed and how it works?

https://github.com/nervosnetwork/ckb-vm/pull/299 
According to https://github.com/nervosnetwork/ckb-vm/pull/299, ckb-vm adds Send and Sync bound to `InstructionCycleFunc`, `Debugger`, `Syscalls`, and goes further to thread-safe by eliminating lifetime.

The CKB side upgrade, need to rewrite the Syscalls to be Send or Sync.
There are some gray areas where some types are theoretically not Sync, such as store_transaction, and for this PR it would be too far to go to fix these issues, currently we can guarantee that store_transaction will not be modified concurrently, so it is safe.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

