### PR TITLE
fix: fee_rate statistics target limit

### DIFF
--- a/rpc/src/tests/fee_rate.rs
+++ b/rpc/src/tests/fee_rate.rs
@@ -6,13 +6,15 @@ use std::collections::HashMap;
 struct DummyFeeRateProvider {
     tip_number: BlockNumber,
     block_exts: HashMap<BlockNumber, BlockExt>,
+    max_target: u64,
 }
 
 impl DummyFeeRateProvider {
-    pub fn new() -> DummyFeeRateProvider {
+    pub fn new(max_target: u64) -> DummyFeeRateProvider {
         DummyFeeRateProvider {
             tip_number: 0,
             block_exts: HashMap::new(),
+            max_target,
         }
     }
 
@@ -21,6 +23,10 @@ impl DummyFeeRateProvider {
             self.tip_number = number;
         }
         self.block_exts.insert(number, ext);
+    }
+
+    pub fn set_max_target(&mut self, max_target: u64) {
+        self.max_target = max_target
     }
 }
 
@@ -32,11 +38,15 @@ impl FeeRateProvider for DummyFeeRateProvider {
     fn get_block_ext_by_number(&self, number: BlockNumber) -> Option<BlockExt> {
         self.block_exts.get(&number).cloned()
     }
+
+    fn max_target(&self) -> u64 {
+        self.max_target
+    }
 }
 
 #[test]
 fn test_fee_rate_statics() {
-    let mut provider = DummyFeeRateProvider::new();
+    let mut provider = DummyFeeRateProvider::new(30);
     for i in 0..=21 {
         let ext = BlockExt {
             received_at: 0,
@@ -83,6 +93,18 @@ fn test_fee_rate_statics() {
         Some(FeeRateStatics {
             mean: 21_000.into(),
             median: 21_000.into(),
+        })
+    );
+
+    provider.set_max_target(10);
+    let statistics11 = FeeRateCollector::new(&provider).statistics(Some(11));
+    let statistics12 = FeeRateCollector::new(&provider).statistics(Some(12));
+    assert_eq!(statistics11, statistics12);
+    assert_eq!(
+        statistics11,
+        Some(FeeRateStatics {
+            mean: 16500.into(),
+            median: 16500.into(),
         })
     );
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The previous implementation had a bug that limited the maximum value of the target only when the input target was an even number



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

