### PR TITLE
Fix: block_filter: refresh_snapshot() in build_filter_data may race with ChainService

### DIFF
--- a/block-filter/src/filter.rs
+++ b/block-filter/src/filter.rs
@@ -91,7 +91,6 @@ impl BlockFilter {
                 .expect("header stored");
             self.build_filter_data_for_block(&header);
         }
-        self.shared.refresh_snapshot();
     }
 
     fn build_filter_data_for_block(&self, header: &HeaderView) {

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1544,12 +1544,12 @@ impl ChainRpc for ChainRpcImpl {
     }
 
     fn get_block_filter(&self, block_hash: H256) -> Result<Option<JsonBytes>> {
-        let snapshot = self.shared.snapshot();
+        let store = self.shared.store();
         let block_hash = block_hash.pack();
-        if !snapshot.is_main_chain(&block_hash) {
+        if !store.is_main_chain(&block_hash) {
             return Ok(None);
         }
-        Ok(snapshot.get_block_filter(&block_hash).map(Into::into))
+        Ok(store.get_block_filter(&block_hash).map(Into::into))
     }
 
     fn get_transaction(

--- a/sync/src/filter/get_block_filter_hashes_process.rs
+++ b/sync/src/filter/get_block_filter_hashes_process.rs
@@ -2,7 +2,6 @@ use crate::filter::{block_filter_hash, BlockFilter};
 use crate::utils::send_message_to;
 use crate::{attempt, Status};
 use ckb_network::{CKBProtocolContext, PeerIndex};
-use ckb_store::ChainStore;
 use ckb_types::{core::BlockNumber, packed, prelude::*};
 use std::sync::Arc;
 
@@ -31,17 +30,18 @@ impl<'a> GetBlockFilterHashesProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
-        let snapshot = self.filter.shared.shared().snapshot();
+        let active_chain = self.filter.shared.active_chain();
         let start_number: BlockNumber = self.message.to_entity().start_number().unpack();
-        let tip_number: BlockNumber = snapshot.get_tip_header().expect("tip stored").number();
+        let tip_number: BlockNumber = active_chain.tip_number();
 
         let mut parent_block_filter_hash = packed::Byte32::zero();
         let mut block_filter_hashes = Vec::new();
 
         if tip_number >= start_number {
             if start_number > 0 {
-                if let Some(parent_block_hash) = snapshot.get_block_hash(start_number - 1) {
-                    if let Some(parent_block_filter) = snapshot.get_block_filter(&parent_block_hash)
+                if let Some(parent_block_hash) = active_chain.get_block_hash(start_number - 1) {
+                    if let Some(parent_block_filter) =
+                        active_chain.get_block_filter(&parent_block_hash)
                     {
                         parent_block_filter_hash = block_filter_hash(parent_block_filter)
                     }
@@ -49,8 +49,8 @@ impl<'a> GetBlockFilterHashesProcess<'a> {
             };
 
             for block_number in start_number..start_number + BATCH_SIZE {
-                if let Some(block_hash) = snapshot.get_block_hash(block_number) {
-                    if let Some(block_filter) = snapshot.get_block_filter(&block_hash) {
+                if let Some(block_hash) = active_chain.get_block_hash(block_number) {
+                    if let Some(block_filter) = active_chain.get_block_filter(&block_hash) {
                         block_filter_hashes.push(block_filter_hash(block_filter));
                     } else {
                         break;

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1923,6 +1923,10 @@ impl ActiveChain {
         self.snapshot().get_block_ext(h)
     }
 
+    pub fn get_block_filter(&self, hash: &packed::Byte32) -> Option<packed::Bytes> {
+        self.store().get_block_filter(hash)
+    }
+
     pub fn shared(&self) -> &SyncShared {
         &self.shared
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

`block-filter::build_filter_data` call `refresh_snapshot` on every `new_block_watcher.changed()` here:
https://github.com/nervosnetwork/ckb/blob/d3fc58fa24a8c26783c604122c643602dfb527fb/block-filter/src/filter.rs#L94
and `ChainService` may update `snapshot` simultaneously in here:
https://github.com/nervosnetwork/ckb/blob/d3fc58fa24a8c26783c604122c643602dfb527fb/chain/src/chain.rs#L480-L486

For example: 
1. In `fn build_filter_data`, `refresh_snapshot` load a `Snapshot` with tip_header(100)  
2. `ChainService` received a new_tip_header(101), and store it into snapshot
3. In `fn build_filter_data`, `refresh_snapshot` store the `Snapshot` with tip_header(100), this cause `tip_header` goes backwards. 

What's Changed:

remove `refresh_snapshot()` in `block-filter::build_filter_data`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

