### PR TITLE
chore: remove Option from rpc `get_transaction` result

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -780,7 +780,7 @@ The response looks like below when the block have block filter.
 * `get_transaction(tx_hash, verbosity)`
     * `tx_hash`: [`H256`](#type-h256)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`TransactionWithStatusResponse`](#type-transactionwithstatusresponse) `|` `null`
+* result: [`TransactionWithStatusResponse`](#type-transactionwithstatusresponse)
 
 Returns the information about a transaction requested by transaction hash.
 

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -75,7 +75,7 @@ impl RpcClient {
             .expect("rpc call get_block_filter")
     }
 
-    pub fn get_transaction(&self, hash: Byte32) -> Option<TransactionWithStatusResponse> {
+    pub fn get_transaction(&self, hash: Byte32) -> TransactionWithStatusResponse {
         self.get_transaction_with_verbosity(hash, 2)
     }
 
@@ -83,7 +83,7 @@ impl RpcClient {
         &self,
         hash: Byte32,
         verbosity: u32,
-    ) -> Option<TransactionWithStatusResponse> {
+    ) -> TransactionWithStatusResponse {
         self.inner
             .get_transaction(hash.unpack(), Some(verbosity.into()))
             .expect("rpc call get_transaction")
@@ -306,7 +306,7 @@ jsonrpc!(pub struct Inner {
     pub fn get_header(&self, _hash: H256) -> Option<HeaderView>;
     pub fn get_header_by_number(&self, _number: BlockNumber) -> Option<HeaderView>;
     pub fn get_block_filter(&self, _hash: H256) -> Option<JsonBytes>;
-    pub fn get_transaction(&self, _hash: H256, verbosity: Option<Uint32>) -> Option<TransactionWithStatusResponse>;
+    pub fn get_transaction(&self, _hash: H256, verbosity: Option<Uint32>) -> TransactionWithStatusResponse;
     pub fn get_block_hash(&self, _number: BlockNumber) -> Option<H256>;
     pub fn get_tip_header(&self) -> HeaderView;
     pub fn get_live_cell(&self, _out_point: OutPoint, _with_data: bool) -> CellWithStatus;

--- a/test/src/specs/hardfork/v2021/cell_deps.rs
+++ b/test/src/specs/hardfork/v2021/cell_deps.rs
@@ -514,7 +514,6 @@ impl<'a> CheckCellDepsTestRunner<'a> {
             .node
             .rpc_client()
             .get_transaction(previous_output.tx_hash())
-            .unwrap()
             .transaction
             .unwrap()
             .inner

--- a/test/src/specs/hardfork/v2021/vm_version.rs
+++ b/test/src/specs/hardfork/v2021/vm_version.rs
@@ -289,7 +289,6 @@ impl<'a> CheckVmVersionTestRunner<'a> {
             .node
             .rpc_client()
             .get_transaction(previous_output.tx_hash())
-            .unwrap()
             .transaction
             .unwrap()
             .inner

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -29,10 +29,7 @@ impl Spec for TransactionRelayBasic {
 
         let relayed = wait_until(10, || {
             nodes.iter().all(|node| {
-                node.rpc_client()
-                    .get_transaction(hash.clone())
-                    .map(|ret| ret.cycles == Some(537.into()))
-                    .unwrap_or(false)
+                node.rpc_client().get_transaction(hash.clone()).cycles == Some(537.into())
             })
         });
         assert!(
@@ -59,9 +56,12 @@ impl Spec for TransactionRelayMultiple {
 
         let relayed = wait_until(20, || {
             nodes.iter().all(|node| {
-                transactions
-                    .iter()
-                    .all(|tx| node.rpc_client().get_transaction(tx.hash()).is_some())
+                transactions.iter().all(|tx| {
+                    node.rpc_client()
+                        .get_transaction(tx.hash())
+                        .transaction
+                        .is_some()
+                })
             })
         });
         assert!(relayed, "all transactions should be relayed");
@@ -198,6 +198,7 @@ impl Spec for TransactionRelayEmptyPeers {
             node1
                 .rpc_client()
                 .get_transaction(transaction.hash())
+                .transaction
                 .is_some()
         });
         assert!(relayed, "Transaction should be relayed to node1");

--- a/test/src/specs/tx_pool/different_txs_with_same_input.rs
+++ b/test/src/specs/tx_pool/different_txs_with_same_input.rs
@@ -47,7 +47,7 @@ impl Spec for DifferentTxsWithSameInput {
         assert!(!commit_txs_hash.contains(&tx2.hash()));
 
         // when tx1 was confirmed, tx2 should be rejected
-        let ret = node0.rpc_client().get_transaction(tx2.hash()).unwrap();
+        let ret = node0.rpc_client().get_transaction(tx2.hash());
         assert!(
             matches!(ret.tx_status.status, Status::Rejected),
             "tx2 should be rejected"
@@ -57,34 +57,26 @@ impl Spec for DifferentTxsWithSameInput {
         let ret = node0
             .rpc_client()
             .get_transaction_with_verbosity(tx1.hash(), 1);
-        assert!(ret.is_some(), "tx1 should be committed");
-        let ret1 = ret.unwrap();
-        assert!(ret1.transaction.is_none());
-        assert!(matches!(ret1.tx_status.status, Status::Committed));
+        assert!(ret.transaction.is_none());
+        assert!(matches!(ret.tx_status.status, Status::Committed));
 
         let ret = node0
             .rpc_client()
             .get_transaction_with_verbosity(tx2.hash(), 1);
-        assert!(ret.is_some(), "reject should be recorded");
-        let ret2 = ret.unwrap();
-        assert!(ret2.transaction.is_none());
-        assert!(matches!(ret2.tx_status.status, Status::Rejected));
+        assert!(ret.transaction.is_none());
+        assert!(matches!(ret.tx_status.status, Status::Rejected));
 
         // verbosity = 2
         let ret = node0
             .rpc_client()
             .get_transaction_with_verbosity(tx1.hash(), 2);
-        assert!(ret.is_some(), "tx1 should be committed");
-        let ret1 = ret.unwrap();
-        assert!(ret1.transaction.is_some());
-        assert!(matches!(ret1.tx_status.status, Status::Committed));
+        assert!(ret.transaction.is_some());
+        assert!(matches!(ret.tx_status.status, Status::Committed));
 
         let ret = node0
             .rpc_client()
             .get_transaction_with_verbosity(tx2.hash(), 2);
-        assert!(ret.is_some(), "reject should be recorded");
-        let ret2 = ret.unwrap();
-        assert!(ret2.transaction.is_none());
-        assert!(matches!(ret2.tx_status.status, Status::Rejected));
+        assert!(ret.transaction.is_none());
+        assert!(matches!(ret.tx_status.status, Status::Rejected));
     }
 }

--- a/test/src/specs/tx_pool/orphan_tx.rs
+++ b/test/src/specs/tx_pool/orphan_tx.rs
@@ -93,9 +93,7 @@ impl Spec for OrphanTxRejected {
         let ret = node0
             .rpc_client()
             .get_transaction_with_verbosity(child_hash, 2);
-        assert!(ret.is_some(), "reject should be recorded");
-        let ret2 = ret.unwrap();
-        assert!(ret2.transaction.is_none());
-        assert!(matches!(ret2.tx_status.status, Status::Rejected));
+        assert!(ret.transaction.is_none());
+        assert!(matches!(ret.tx_status.status, Status::Rejected));
     }
 }

--- a/test/src/specs/tx_pool/pool_reconcile.rs
+++ b/test/src/specs/tx_pool/pool_reconcile.rs
@@ -34,7 +34,6 @@ impl Spec for PoolReconcile {
         assert!(node0
             .rpc_client()
             .get_transaction(hash.clone())
-            .unwrap()
             .tx_status
             .block_hash
             .is_some());
@@ -51,7 +50,6 @@ impl Spec for PoolReconcile {
         assert!(node0
             .rpc_client()
             .get_transaction(hash)
-            .unwrap()
             .tx_status
             .block_hash
             .is_none());
@@ -130,7 +128,6 @@ impl Spec for PoolResolveConflictAfterReorg {
         assert!(node0
             .rpc_client()
             .get_transaction(tx1.hash())
-            .unwrap()
             .tx_status
             .block_hash
             .is_some());

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -55,7 +55,7 @@ impl Spec for SendLargeCyclesTxInBlock {
             let ret = node0
                 .rpc_client()
                 .get_transaction_with_verbosity(tx.hash(), 1);
-            ret.is_some() && matches!(ret.unwrap().tx_status.status, Status::Pending)
+            matches!(ret.tx_status.status, Status::Pending)
         });
         assert!(result, "large cycles tx rejected by node0");
         node0.mine_until_transaction_confirm(&tx.hash());
@@ -117,7 +117,11 @@ impl Spec for SendLargeCyclesTxToRelay {
         assert!(result, "node0 can't sync with node1");
 
         let result = wait_until(60, || {
-            node0.rpc_client().get_transaction(tx.hash()).is_some()
+            node0
+                .rpc_client()
+                .get_transaction(tx.hash())
+                .transaction
+                .is_some()
         });
         assert!(result, "Node0 should accept tx");
     }
@@ -159,7 +163,11 @@ impl Spec for NotifyLargeCyclesTx {
         info!("Node0 receive notify large cycles tx");
 
         let result = wait_until(60, || {
-            node0.rpc_client().get_transaction(tx.hash()).is_some()
+            node0
+                .rpc_client()
+                .get_transaction(tx.hash())
+                .transaction
+                .is_some()
         });
         assert!(result, "Node0 should accept tx");
     }
@@ -201,7 +209,11 @@ impl Spec for LoadProgramFailedTx {
         info!("Node0 receive notify large cycles tx");
 
         let result = wait_until(60, || {
-            node0.rpc_client().get_transaction(tx.hash()).is_some()
+            node0
+                .rpc_client()
+                .get_transaction(tx.hash())
+                .transaction
+                .is_some()
         });
         assert!(result, "Node0 should accept tx");
     }

--- a/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
+++ b/test/src/specs/tx_pool/send_low_fee_rate_tx.rs
@@ -16,6 +16,7 @@ impl Spec for SendLowFeeRateTx {
             node0
                 .rpc_client()
                 .get_transaction(tx_hash_0.clone())
+                .transaction
                 .is_some()
         });
         assert!(ret, "send tx should success");
@@ -23,7 +24,6 @@ impl Spec for SendLowFeeRateTx {
             if let Either::Left(tx) = node0
                 .rpc_client()
                 .get_transaction(tx_hash_0.clone())
-                .unwrap()
                 .transaction
                 .unwrap()
                 .inner

--- a/test/src/util/check.rs
+++ b/test/src/util/check.rs
@@ -3,38 +3,28 @@ use ckb_jsonrpc_types::Status;
 use ckb_types::core::{BlockView, EpochNumberWithFraction, HeaderView, TransactionView};
 
 pub fn is_transaction_pending(node: &Node, transaction: &TransactionView) -> bool {
-    node.rpc_client()
-        .get_transaction(transaction.hash())
-        .map(|ret| ret.tx_status.status == Status::Pending && ret.cycles.is_some())
-        .unwrap_or(false)
+    let ret = node.rpc_client().get_transaction(transaction.hash());
+    ret.tx_status.status == Status::Pending && ret.cycles.is_some()
 }
 
 pub fn is_transaction_proposed(node: &Node, transaction: &TransactionView) -> bool {
-    node.rpc_client()
-        .get_transaction(transaction.hash())
-        .map(|ret| ret.tx_status.status == Status::Proposed && ret.cycles.is_some())
-        .unwrap_or(false)
+    let ret = node.rpc_client().get_transaction(transaction.hash());
+    ret.tx_status.status == Status::Proposed && ret.cycles.is_some()
 }
 
 pub fn is_transaction_committed(node: &Node, transaction: &TransactionView) -> bool {
-    node.rpc_client()
-        .get_transaction(transaction.hash())
-        .map(|ret| ret.tx_status.status == Status::Committed && ret.cycles.is_some())
-        .unwrap_or(false)
+    let ret = node.rpc_client().get_transaction(transaction.hash());
+    ret.tx_status.status == Status::Committed && ret.cycles.is_some()
 }
 
 pub fn is_transaction_rejected(node: &Node, transaction: &TransactionView) -> bool {
-    node.rpc_client()
-        .get_transaction(transaction.hash())
-        .map(|txstatus| txstatus.tx_status.status == Status::Rejected)
-        .unwrap_or(false)
+    let ret = node.rpc_client().get_transaction(transaction.hash());
+    ret.tx_status.status == Status::Rejected
 }
 
 pub fn is_transaction_unknown(node: &Node, transaction: &TransactionView) -> bool {
-    node.rpc_client()
-        .get_transaction(transaction.hash())
-        .map(|txstatus| txstatus.tx_status.is_unknown())
-        .unwrap_or(true)
+    let ret = node.rpc_client().get_transaction(transaction.hash());
+    ret.tx_status.is_unknown()
 }
 
 pub fn assert_epoch_should_be(node: &Node, number: u64, index: u64, length: u64) {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

When I was doing the ckb-light-client rpc `get_transaction` alignment of the ckb rpc, I found that the `Option` was removable, because we now always return `Some(TransactionWithStatusResponse)`. This PR refactor this rpc result and simplify test related code.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

