### PR TITLE
fix(rpc): return the cycles of the first non-cellbase transaction as cellbase's cycles

### DIFF
--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -2028,13 +2028,17 @@ impl ChainRpcImpl {
     fn get_transaction_verbosity1(&self, tx_hash: packed::Byte32) -> Result<TransactionWithStatus> {
         let snapshot = self.shared.snapshot();
         if let Some(tx_info) = snapshot.get_transaction_info(&tx_hash) {
-            let cycles = snapshot
-                .get_block_ext(&tx_info.block_hash)
-                .and_then(|block_ext| {
-                    block_ext
-                        .cycles
-                        .and_then(|v| v.get(tx_info.index.saturating_sub(1)).copied())
-                });
+            let cycles = if tx_info.is_cellbase() {
+                None
+            } else {
+                snapshot
+                    .get_block_ext(&tx_info.block_hash)
+                    .and_then(|block_ext| {
+                        block_ext
+                            .cycles
+                            .and_then(|v| v.get(tx_info.index.saturating_sub(1)).copied())
+                    })
+            };
 
             return Ok(TransactionWithStatus::with_committed(
                 None,
@@ -2062,13 +2066,17 @@ impl ChainRpcImpl {
     fn get_transaction_verbosity2(&self, tx_hash: packed::Byte32) -> Result<TransactionWithStatus> {
         let snapshot = self.shared.snapshot();
         if let Some((tx, tx_info)) = snapshot.get_transaction_with_info(&tx_hash) {
-            let cycles = snapshot
-                .get_block_ext(&tx_info.block_hash)
-                .and_then(|block_ext| {
-                    block_ext
-                        .cycles
-                        .and_then(|v| v.get(tx_info.index.saturating_sub(1)).copied())
-                });
+            let cycles = if tx_info.is_cellbase() {
+                None
+            } else {
+                snapshot
+                    .get_block_ext(&tx_info.block_hash)
+                    .and_then(|block_ext| {
+                        block_ext
+                            .cycles
+                            .and_then(|v| v.get(tx_info.index.saturating_sub(1)).copied())
+                    })
+            };
 
             return Ok(TransactionWithStatus::with_committed(
                 Some(tx),


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When call the RPC method `get_transaction`:

- If a block has no non-cellbase transactions, the cycles of its cellbase are null.

  e.g.:
  - [Cellbase](https://pudge.explorer.nervos.org/transaction/0x3e8795baab13a6590077fed50bd10153302189492348c6e73948fa741ba8cd3e)

- If a block has at least one non-cellbase transactions, the cycles of its cellbase are the same as the first non-cellbase transaction.

  Since `0.saturating_sub(1) == 1.saturating_sub(1) == 0` in the follow code:
  https://github.com/nervosnetwork/ckb/blob/adcfac420560f3ca8b9d733ee23f930e53f5f6f3/rpc/src/module/chain.rs#L2034-L2036

  e.g.:
  - [Cellbase](https://pudge.explorer.nervos.org/transaction/0x160beca4ac14b44a7f055d2da77ad8422a1a128575e26273e66e07cf9e1e4f94)
  - [First Non-Cellbase Transaction](https://pudge.explorer.nervos.org/transaction/0xcdb40e5b741472af59ff34cdbbb752746b1e2bde1644e386ce76cf91cd9720be)

If I understood correctly, the cycles for cellbases should always be null.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

