### PR TITLE
fix: disable ckb-miner notify mode by default

### DIFF
--- a/miner/src/client.rs
+++ b/miner/src/client.rs
@@ -204,6 +204,20 @@ impl Client {
         let client = self.clone();
         if let Some(addr) = self.config.listen {
             ckb_logger::info!("listen notify mode : {}", addr);
+            ckb_logger::info!(
+                r#"
+Please note that ckb-miner runs in notify mode,
+and you need to configure the corresponding information in the block assembler of the ckb,
+for example
+
+[block_assembler]
+...
+notify = ["http://{}"]
+
+Otherwise ckb-miner does not work properly and will behave as it stopped committing new valid blocks after a while
+"#,
+                addr
+            );
             self.handle.spawn(async move {
                 client.listen_block_template_notify(addr, stop_rx).await;
             });

--- a/resource/ckb-miner.toml
+++ b/resource/ckb-miner.toml
@@ -54,7 +54,7 @@ block_on_submit = true
 poll_interval = 1000
 
 # enable listen notify mode
-listen = "127.0.0.1:8888"
+# listen = "127.0.0.1:8888"
 
 [[miner.workers]]
 worker_type = "EaglesongSimple" # {{


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Previously, ckb-miner notify mode was turned on by default, and there were some compatibility problems, such as the default block_assembler was not configured accordingly, so it is better to turn off ckb-miner notify mode by default, and add a prompt when ckb-miner starts in notify mode





### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

