### PR TITLE
fix: p2p alerts are not filterred in block chain info

### DIFF
--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -342,7 +342,7 @@ impl Launcher {
 
         let alert_signature_config = self.args.config.alert_signature.clone().unwrap_or_default();
         let alert_relayer = AlertRelayer::new(
-            self.version.to_string(),
+            self.version.short(),
             shared.notify_controller().clone(),
             alert_signature_config,
         );


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The alerts returned in RPC `get_blockchain_info` will return all the alerts.

The expected behavior is that is should filter based on the alert version range requirements.

Related: https://github.com/nervosnetwork/ckb/issues/3800#issuecomment-1383685702

### What is changed and how it works?

What's Changed:

The root cause is that when launcher passes client version to alert notifier, it uses the full format such as `0.107.0-rc1 (1b3e6b1 2023-01-12)`. However, the notifier internal uses semver to parse the version directly. If it fails, it will consider all alerts as effective.

The solution: The launcher pass the short version format to alert notifier.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - Build the ckb
  - Run a testnet node, and call rpc `get_blockchain_info`
  - The alerts MUST be empty, since the built ckb version is not `ckb v0.105.*`.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

