### PR TITLE
[hotfix 0.107.x] fix: p2p alerts are not filterred in block chain info

### DIFF
--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -342,7 +342,7 @@ impl Launcher {
 
         let alert_signature_config = self.args.config.alert_signature.clone().unwrap_or_default();
         let alert_relayer = AlertRelayer::new(
-            self.version.to_string(),
+            self.version.short(),
             shared.notify_controller().clone(),
             alert_signature_config,
         );


### PR DESCRIPTION
Rebase #3802 to v0.107.*

Merge #3804 first, which has upgraded tokio for https://rustsec.org/advisories/RUSTSEC-2023-0001