### PR TITLE
[hotfix 0.107.x] fix: fix identify unregister 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,9 +4455,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes 1.3.0",

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -22,15 +22,8 @@ impl AddrManager {
                 .get(&addr_info.addr)
                 .map(|addr| addr.last_connected_at_ms)
             {
-                // replace exists addr if has later last_connected_at_ms
-                if addr_info.last_connected_at_ms > exists_last_connected_at_ms {
-                    if let Some(old) = self.remove(&addr_info.addr) {
-                        // init from `add_outbound_addr`
-                        if addr_info.flags == 0 {
-                            addr_info.flags = old.flags;
-                        }
-                    }
-                } else {
+                // Get time earlier than record time, return directly
+                if addr_info.last_connected_at_ms < exists_last_connected_at_ms {
                     return;
                 }
             }

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -85,6 +85,16 @@ impl PeerStore {
         ));
     }
 
+    /// Update outbound peer last connected ms
+    pub fn update_outbound_addr_last_connected_ms(&mut self, addr: Multiaddr) {
+        if self.ban_list.is_addr_banned(&addr) {
+            return;
+        }
+        if let Some(info) = self.addr_manager.get_mut(&addr) {
+            info.last_connected_at_ms = ckb_systemtime::unix_time_as_millis()
+        }
+    }
+
     /// Get address manager
     pub fn addr_manager(&self) -> &AddrManager {
         &self.addr_manager

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -91,7 +91,7 @@ impl PeerStore {
             return;
         }
         if let Some(info) = self.addr_manager.get_mut(&addr) {
-            info.last_connected_at_ms = ckb_systemtime::unix_time_as_millis()
+            info.last_connected_at_ms = faketime::unix_time_as_millis()
         }
     }
 

--- a/network/src/protocols/discovery/addr.rs
+++ b/network/src/protocols/discovery/addr.rs
@@ -46,7 +46,7 @@ pub trait AddressManager {
     fn misbehave(&mut self, session: &SessionContext, kind: &Misbehavior) -> MisbehaveResult;
     fn get_random(&mut self, n: usize, target: Flags) -> Vec<(Multiaddr, Flags)>;
     fn required_flags(&self) -> Flags;
-    fn node_flags(&self, id: SessionId) -> Flags;
+    fn node_flags(&self, id: SessionId) -> Option<Flags>;
 }
 
 // bitcoin: bloom.h, bloom.cpp => CRollingBloomFilter

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -374,19 +374,9 @@ impl Callback for IdentifyCallback {
             // Due to the filtering strategy of the peer store, if the node is
             // disconnected after a long connection is maintained for more than seven days,
             // it is possible that the node will be accidentally evicted, so it is necessary
-            // to reset the information of the node when disconnected.
-            let flags = self.network_state.with_peer_registry(|reg| {
-                if let Some(p) = reg.get_peer(context.session.id) {
-                    p.identify_info
-                        .as_ref()
-                        .map(|i| i.flags)
-                        .unwrap_or(Flags::COMPATIBILITY)
-                } else {
-                    Flags::COMPATIBILITY
-                }
-            });
+            // to reset the last_connected_time of the node when disconnected.
             self.network_state.with_peer_store_mut(|peer_store| {
-                peer_store.add_outbound_addr(context.session.address.clone(), flags);
+                peer_store.update_outbound_addr_last_connected_ms(context.session.address.clone());
             });
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

we introduced peer flags network-wide propagation in https://github.com/nervosnetwork/ckb/pull/3595

But there is a problem here, only the outbound connection time needs to be refreshed when disconnecting because the global state of connected peers may be deleted first and the flags obtained may be empty, which will reset the correct flags to the default state

### Check List

Tests

- Unit test
- Integration test

Side effects

- Performance regression
- Breaking backward compatibility

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

