### PR TITLE
fix: Tests db paths without thread_local

### DIFF
--- a/chain/src/tests/load_code_with_snapshot.rs
+++ b/chain/src/tests/load_code_with_snapshot.rs
@@ -160,11 +160,9 @@ fn test_load_code_with_snapshot() {
         .cellbase_maturity(EpochNumberWithFraction::new(0, 0, 1))
         .genesis_block(genesis_block)
         .build();
-    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
     {
         let tx_pool_config = TxPoolConfig {
             max_tx_verify_cycles: 10_000, // 10_000/ 11_740
-            recent_reject: tmp_dir.path().to_path_buf(),
             ..Default::default()
         };
 
@@ -248,11 +246,9 @@ fn _test_load_code_with_snapshot_after_hardfork(script_type: ScriptHashType) {
         .hardfork_switch(hardfork_switch)
         .build();
 
-    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
     {
         let tx_pool_config = TxPoolConfig {
             max_tx_verify_cycles: 10_000, // 10_000/ 11_740
-            recent_reject: tmp_dir.path().to_path_buf(),
             ..Default::default()
         };
 

--- a/util/launcher/src/shared_builder.rs
+++ b/util/launcher/src/shared_builder.rs
@@ -147,26 +147,23 @@ impl SharedBuilder {
         // once #[thread_local] is stable
         // #[thread_local]
         // static RUNTIME_HANDLE: unsync::OnceCell<...
-
         thread_local! {
-            static TMP_DIR: sync::OnceCell<TempDir> = sync::OnceCell::new();
             // NOTICE：we can't put the runtime directly into thread_local here,
             // on windows the runtime in thread_local will get stuck when dropping
             static RUNTIME_HANDLE: unsync::OnceCell<(Handle, StopHandler<()>)> = unsync::OnceCell::new();
         }
 
         static DB_COUNT: AtomicUsize = AtomicUsize::new(0);
+        static TMP_DIR: sync::OnceCell<TempDir> = sync::OnceCell::new();
 
         let db = {
             let db_id = DB_COUNT.fetch_add(1, Ordering::SeqCst);
-            let db_base_dir = TMP_DIR.with(|tmp_dir| {
-                tmp_dir
-                    .borrow()
-                    .get_or_try_init(TempDir::new)
-                    .unwrap()
-                    .path()
-                    .to_path_buf()
-            });
+            let db_base_dir = TMP_DIR
+                .borrow()
+                .get_or_try_init(TempDir::new)
+                .unwrap()
+                .path()
+                .to_path_buf();
             let db_dir = db_base_dir.join(format!("db_{}", db_id));
             RocksDB::open_in(db_dir, COLUMNS)
         };


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->



### What is changed and how it works?

`thread_local` is not necessary and has caused some unexpected problems since the switch to nextest runner


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

