### PR TITLE
Fix(unit test): make temporary rocksdb's tmp_dir live as longer as test process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "ckb-systemtime",
  "ckb-tx-pool",
  "ckb-types",
+ "ckb-util",
  "ckb-verification",
  "ckb-verification-traits",
  "num_cpus",
@@ -1458,6 +1459,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "regex",
+ "tempfile",
 ]
 
 [[package]]

--- a/chain/src/tests/load_code_with_snapshot.rs
+++ b/chain/src/tests/load_code_with_snapshot.rs
@@ -160,11 +160,9 @@ fn test_load_code_with_snapshot() {
         .cellbase_maturity(EpochNumberWithFraction::new(0, 0, 1))
         .genesis_block(genesis_block)
         .build();
-    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
     {
         let tx_pool_config = TxPoolConfig {
             max_tx_verify_cycles: 10_000, // 10_000/ 11_740
-            recent_reject: tmp_dir.path().to_path_buf(),
             ..Default::default()
         };
 
@@ -248,11 +246,9 @@ fn _test_load_code_with_snapshot_after_hardfork(script_type: ScriptHashType) {
         .hardfork_switch(hardfork_switch)
         .build();
 
-    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
     {
         let tx_pool_config = TxPoolConfig {
             max_tx_verify_cycles: 10_000, // 10_000/ 11_740
-            recent_reject: tmp_dir.path().to_path_buf(),
             ..Default::default()
         };
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -13,7 +13,7 @@ parking_lot = "0.12"
 linked-hash-map = { version = "0.5", features  = ["serde_impl"] }
 regex = "1.1.6"
 once_cell = "1.8.0"
-
+tempfile = "3"
 [dev-dependencies]
 ckb-fixed-hash = { path = "fixed-hash", version = "= 0.108.0-pre" }
 

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -42,6 +42,7 @@ ckb-tx-pool = { path = "../../tx-pool", version = "= 0.108.0-pre" }
 ckb-stop-handler = { path = "../stop-handler", version = "= 0.108.0-pre" }
 ckb-light-client-protocol-server = { path = "../light-client-protocol-server", version = "= 0.108.0-pre" }
 ckb-block-filter = { path = "../../block-filter", version = "= 0.108.0-pre" }
+ckb-util = { path = "../../util", version = "= 0.108.0-pre" }
 num_cpus = "1.10"
 once_cell = "1.8.0"
 tempfile = "3.0"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -5,8 +5,11 @@ mod linked_hash_set;
 mod shrink_to_fit;
 pub mod strings;
 
+mod long_live_tmp_dir;
 #[cfg(test)]
 mod tests;
+
+pub use long_live_tmp_dir::long_live_tmp_dir;
 
 pub use linked_hash_map::{Entries as LinkedHashMapEntries, LinkedHashMap};
 pub use linked_hash_set::LinkedHashSet;

--- a/util/src/long_live_tmp_dir.rs
+++ b/util/src/long_live_tmp_dir.rs
@@ -1,0 +1,13 @@
+use once_cell::sync::OnceCell;
+use std::sync::{Mutex, MutexGuard};
+use tempfile::TempDir;
+
+static TMP_DIRS: OnceCell<Mutex<TempDir>> = OnceCell::new();
+
+/// open a temporary dir, the dir will be deleted when current process exit.
+pub fn long_live_tmp_dir() -> MutexGuard<'static, TempDir> {
+    TMP_DIRS
+        .get_or_init(|| Mutex::new(tempfile::tempdir().unwrap()))
+        .lock()
+        .unwrap()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want let the temporary rocksdb's `db_base_tmp_dir` live as longer as `RUNTIME`.
) to archive this.

### What is changed and how it works?


What's Changed:

### Related changes

- add `fn open_long_live_tmp_db() -> RocksDB` to help init a temporary rocksdb.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

