### PR TITLE
chore(ci): avoid duplicated ci jobs for push and merge-group

### DIFF
--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -22,8 +22,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -24,8 +24,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -25,8 +25,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -26,8 +26,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -26,8 +26,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')

--- a/.github/workflows/ci_wasm_build_ubuntu.yaml
+++ b/.github/workflows/ci_wasm_build_ubuntu.yaml
@@ -23,8 +23,7 @@ jobs:
        github.event_name != 'push' ||
        ( github.event_name == 'push' &&
         ( github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/gh-readonly-queue/develop' ||
-          (github.ref == 'refs/heads/develop' && github.event.head_commit.author.name != 'bors[bot]') ||
+          (github.ref == 'refs/heads/develop' && startsWith(github.event.head_commit.message, 'Merge pull request #')) ||
           startsWith(github.ref, 'refs/heads/rc/')
         )
        ) || (github.repository_owner != 'nervosnetwork')


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: CI runs twice on the same commit, once for merge queue, another after the merge commit has been pushed to the develop branch.

### What is changed and how it works?

What's Changed:

Update CI conditions to skip the jobs on pushing merge commit to the develop branch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

