### PR TITLE
fix transaction rebroadcast by resubmitting

### DIFF
--- a/sync/src/relayer/transaction_hashes_process.rs
+++ b/sync/src/relayer/transaction_hashes_process.rs
@@ -36,7 +36,8 @@ impl<'a> TransactionHashesProcess<'a> {
         }
 
         let tx_hashes: Vec<_> = {
-            let tx_filter = state.tx_filter();
+            let mut tx_filter = state.tx_filter();
+            tx_filter.remove_expired();
             self.message
                 .tx_hashes()
                 .iter()

--- a/sync/src/relayer/transactions_process.rs
+++ b/sync/src/relayer/transactions_process.rs
@@ -38,7 +38,8 @@ impl<'a> TransactionsProcess<'a> {
         let shared_state = self.relayer.shared().state();
         let txs: Vec<(TransactionView, Cycle)> = {
             // ignore the tx if it's already known or it has never been requested before
-            let tx_filter = shared_state.tx_filter();
+            let mut tx_filter = shared_state.tx_filter();
+            tx_filter.remove_expired();
             let unknown_tx_hashes = shared_state.unknown_tx_hashes();
 
             self.message

--- a/sync/src/tests/types.rs
+++ b/sync/src/tests/types.rs
@@ -7,7 +7,7 @@ use ckb_types::{
 use rand::{thread_rng, Rng};
 use std::collections::{BTreeMap, HashMap};
 
-use crate::types::HeaderView;
+use crate::types::{HeaderView, TtlFilter, FILTER_TTL};
 
 const SKIPLIST_LENGTH: u64 = 10_000;
 
@@ -88,4 +88,18 @@ fn test_get_ancestor_use_skip_list() {
         let found_0_header = a_to_b(from, 0, 120);
         assert_eq!(found_0_header.hash(), view_0.hash());
     }
+}
+
+#[test]
+fn ttl_filter() {
+    let mut filter = TtlFilter::default();
+    let mut _faketime_guard = ckb_systemtime::faketime();
+    _faketime_guard.set_faketime(0);
+    filter.insert(1);
+    let mut _faketime_guard = ckb_systemtime::faketime();
+    _faketime_guard.set_faketime(FILTER_TTL * 1000 + 1000);
+    filter.insert(2);
+    filter.remove_expired();
+    assert!(!filter.contains(&1));
+    assert!(filter.contains(&2));
 }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -414,6 +414,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RelayInvalidTransaction),
         Box::new(TransactionRelayTimeout),
         Box::new(TransactionRelayEmptyPeers),
+        Box::new(TransactionRelayConflict),
         Box::new(Discovery),
         Box::new(Disconnect),
         Box::new(MalformedMessage),

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -5,11 +5,12 @@ use crate::util::transaction::{always_success_transaction, always_success_transa
 use crate::utils::{build_relay_tx_hashes, build_relay_txs, sleep, wait_until};
 use crate::{Net, Node, Spec};
 use ckb_constant::sync::RETRY_ASK_TX_TIMEOUT_INCREASE;
+use ckb_jsonrpc_types::Status;
 use ckb_logger::info;
 use ckb_network::SupportProtocols;
 use ckb_types::{
-    core::TransactionBuilder,
-    packed::{GetRelayTransactions, RelayMessage},
+    core::{capacity_bytes, Capacity, TransactionBuilder},
+    packed::{CellOutputBuilder, GetRelayTransactions, RelayMessage},
     prelude::*,
 };
 
@@ -197,6 +198,93 @@ impl Spec for TransactionRelayEmptyPeers {
             node1
                 .rpc_client()
                 .get_transaction(transaction.hash())
+                .transaction
+                .is_some()
+        });
+        assert!(relayed, "Transaction should be relayed to node1");
+    }
+}
+
+pub struct TransactionRelayConflict;
+
+impl Spec for TransactionRelayConflict {
+    crate::setup!(num_nodes: 2);
+
+    fn run(&self, nodes: &mut Vec<Node>) {
+        out_ibd_mode(nodes);
+        connect_all(nodes);
+
+        let node0 = &nodes[0];
+        let node1 = &nodes[1];
+
+        node0.mine_until_out_bootstrap_period();
+        waiting_for_sync(nodes);
+
+        let tx_hash_0 = node0.generate_transaction();
+        info!("Generate 2 txs with same input");
+        let tx1 = node0.new_transaction(tx_hash_0.clone());
+        let tx2_temp = node0.new_transaction(tx_hash_0);
+        let output = CellOutputBuilder::default()
+            .capacity(capacity_bytes!(80).pack())
+            .build();
+
+        let tx2 = tx2_temp
+            .as_advanced_builder()
+            .set_outputs(vec![output])
+            .build();
+        node0.rpc_client().send_transaction(tx1.data().into());
+        sleep(6);
+        node0.rpc_client().send_transaction(tx2.data().into());
+
+        let relayed = wait_until(20, || {
+            [tx1.hash(), tx2.hash()].iter().all(|hash| {
+                node1
+                    .rpc_client()
+                    .get_transaction(hash.clone())
+                    .transaction
+                    .is_some()
+            })
+        });
+        assert!(relayed, "all transactions should be relayed");
+
+        let proposed = node1.mine_with_blocking(|template| template.proposals.len() != 3);
+        node1.mine_with_blocking(|template| template.number.value() != (proposed + 1));
+
+        waiting_for_sync(nodes);
+        node0.wait_for_tx_pool();
+        node1.wait_for_tx_pool();
+
+        let ret = node1
+            .rpc_client()
+            .get_transaction_with_verbosity(tx2.hash(), 1);
+        assert!(matches!(ret.tx_status.status, Status::Rejected));
+
+        node0.remove_transaction(tx1.hash());
+        node0.remove_transaction(tx2.hash());
+        node1.remove_transaction(tx1.hash());
+        node1.remove_transaction(tx2.hash());
+        node0.wait_for_tx_pool();
+        node1.wait_for_tx_pool();
+
+        let result = wait_until(5, || {
+            let tx_pool_info = node0.get_tip_tx_pool_info();
+            tx_pool_info.orphan.value() == 0 && tx_pool_info.pending.value() == 0
+        });
+        assert!(result, "remove txs from node0");
+        let result = wait_until(5, || {
+            let tx_pool_info = node1.get_tip_tx_pool_info();
+            tx_pool_info.orphan.value() == 0 && tx_pool_info.pending.value() == 0
+        });
+        assert!(result, "remove txs from node1");
+
+        let relayed = wait_until(10, || {
+            // re-broadcast
+            let _ = node1
+                .rpc_client()
+                .send_transaction_result(tx2.data().into());
+            node0
+                .rpc_client()
+                .get_transaction(tx2.hash())
                 .transaction
                 .is_some()
         });

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -588,6 +588,11 @@ impl TxPoolServiceBuilder {
         self.callbacks.register_pending(callback);
     }
 
+    /// Return cloned tx relayer sender
+    pub fn tx_relay_sender(&self) -> ckb_channel::Sender<TxVerificationResult> {
+        self.tx_relay_sender.clone()
+    }
+
     /// Register new proposed callback
     pub fn register_proposed(&mut self, callback: ProposedCallback) {
         self.callbacks.register_proposed(callback);

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -79,6 +79,17 @@ impl Reject {
             _ => false,
         }
     }
+
+    /// Returns true if tx can be resubmitted, allowing relay
+    /// * Declared wrong cycles should allow relay with the correct cycles
+    /// * Reject but is not malformed and the fee rate reached the threshold,
+    ///     it may be due to double spending
+    ///     or temporary limitations of the pool resources,
+    ///     and expired clearing
+    pub fn is_allowed_relay(&self) -> bool {
+        matches!(self, Reject::DeclaredWrongCycles(..))
+            || (!matches!(self, Reject::LowFeeRate(..)) && !self.is_malformed_tx())
+    }
 }
 
 impl_error_conversion_with_kind!(Reject, ErrorKind::SubmitTransaction, Error);


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

When a transaction fails a double-spend check, it is still marked as known, making it impossible to rebroadcast by resubmitting

### What is changed and how it works?

Ensure that if a transaction can be rebroadcast in case of verification failure, it should be removed from the known filter。

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test



### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

