### PR TITLE
feat: Add flatmemory feature for FlatMemory based machine types

### DIFF
--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -15,6 +15,7 @@ default = ["logging", "detect-asm"]
 asm = ["ckb-vm/asm"]
 detect-asm = ["ckb-vm/detect-asm"]
 logging = ["ckb-logger"]
+flatmemory = []
 
 [dependencies]
 ckb-traits = { path = "../traits", version = "= 0.109.0-pre" }

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 
 #[cfg(not(has_asm))]
-use ckb_vm::{DefaultCoreMachine, SparseMemory, TraceMachine, WXorXMemory};
+use ckb_vm::{DefaultCoreMachine, TraceMachine, WXorXMemory};
 
 /// The type of CKB-VM ISA.
 pub type VmIsa = u8;
@@ -25,15 +25,19 @@ pub type VmVersion = u32;
 
 #[cfg(has_asm)]
 pub(crate) type CoreMachineType = AsmCoreMachine;
-#[cfg(not(has_asm))]
-pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>;
+#[cfg(all(not(has_asm), not(feature = "flatmemory")))]
+pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::SparseMemory<u64>>>;
+#[cfg(all(not(has_asm), feature = "flatmemory"))]
+pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::FlatMemory<u64>>>;
 
 /// The type of core VM machine when uses ASM.
 #[cfg(has_asm)]
 pub type CoreMachine = Box<AsmCoreMachine>;
 /// The type of core VM machine when doesn't use ASM.
-#[cfg(not(has_asm))]
-pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>;
+#[cfg(all(not(has_asm), not(feature = "flatmemory")))]
+pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::SparseMemory<u64>>>;
+#[cfg(all(not(has_asm), feature = "flatmemory"))]
+pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::FlatMemory<u64>>>;
 
 /// The version of CKB Script Verifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
### What problem does this PR solve?

This change adds a new `flatmemory` feature to ckb-script, which will use `FlatMemory` as the memory type for
`CoreMachine`/`CoreMachineType`. While this is not gonna be used in CKB, a FlatMemory will be quite useful in the development of surrounding tools, including ckb-debugger. Note that one option is that a debugger could maintain its own ckb-script package, but considering the fact that the change here is rather small, I would suggest we include this here feature in CKB.
