### PR TITLE
enhance: Improve ScriptError::InvalidCodeHash when code_hash can't be resolved

### DIFF
--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -1,15 +1,15 @@
 use crate::types::{ScriptGroup, ScriptGroupType};
 use ckb_error::{prelude::*, Error, ErrorKind};
 use ckb_types::core::{Cycle, ScriptHashType};
-use ckb_types::packed::Script;
+use ckb_types::packed::{Byte32, Script};
 use std::{error::Error as StdError, fmt};
 
 /// Script execution error.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum ScriptError {
-    /// The field code_hash in script is invalid
-    #[error("InvalidCodeHash")]
-    InvalidCodeHash,
+    /// The field code_hash in script can't be resolved
+    #[error("ScriptNotFound: code_hash: {0}")]
+    ScriptNotFound(Byte32),
 
     /// The script consumes too much cycles
     #[error("ExceededMaximumCycles: expect cycles <= {0}")]

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -377,7 +377,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                 if let Some(lazy) = self.binaries_by_data_hash.get(&script.code_hash()) {
                     Ok(lazy.access(self.data_loader))
                 } else {
-                    Err(ScriptError::InvalidCodeHash)
+                    Err(ScriptError::ScriptNotFound(script.code_hash()))
                 }
             }
             ScriptHashType::Type => {
@@ -388,7 +388,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
                         Binaries::Multiple => Err(ScriptError::MultipleMatches),
                     }
                 } else {
-                    Err(ScriptError::InvalidCodeHash)
+                    Err(ScriptError::ScriptNotFound(script.code_hash()))
                 }
             }
         }
@@ -759,7 +759,7 @@ impl<'a, DL: CellDataProvider + HeaderProvider> TransactionScriptsVerifier<'a, D
     ) -> Result<Cycle, ScriptError> {
         match self.find_script_group(script_group_type, script_hash) {
             Some(group) => self.verify_script_group(group, max_cycles),
-            None => Err(ScriptError::InvalidCodeHash),
+            None => Err(ScriptError::ScriptNotFound(script_hash.clone())),
         }
     }
 

--- a/script/src/verify/tests/ckb_latest/features_since_v2019.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2019.rs
@@ -359,9 +359,10 @@ fn check_invalid_dep_reference() {
     let dep_out_point = OutPoint::new(h256!("0x123").pack(), 8);
     let cell_dep = CellDep::new_builder().out_point(dep_out_point).build();
 
+    let script_code_hash = blake2b_256(&buffer).pack();
     let script = Script::new_builder()
         .args(Bytes::from(args).pack())
-        .code_hash(blake2b_256(&buffer).pack())
+        .code_hash(script_code_hash.clone())
         .hash_type(ScriptHashType::Data.into())
         .build();
     let input = CellInput::new(OutPoint::null(), 0);
@@ -388,7 +389,7 @@ fn check_invalid_dep_reference() {
     let result = verifier.verify_without_limit(script_version, &rtx);
     assert_error_eq!(
         result.unwrap_err(),
-        ScriptError::InvalidCodeHash.input_lock_script(0),
+        ScriptError::ScriptNotFound(script_code_hash).input_lock_script(0),
     );
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
`InvalidCodeHash` is not friendly enough for the caller. Ref: #3854 

### What is changed and how it works?

This PR change `ScriptError::InvalidCodeHash` to `ScriptError::ScriptNotFound(Byte32)`, This makes the error message more friendly.

What's Changed:

### Related changes

- change `ScriptError::InvalidCodeHash` to `ScriptError::ScriptNotFound(Byte32)`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects



### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

