### PR TITLE
chore: upgrade tempfile to remove remove_dir_all dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,6 +2023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "faux"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,7 +3384,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -3390,7 +3399,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "petgraph",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "thread-id",
  "windows-sys 0.36.1",
@@ -3770,12 +3779,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -3799,15 +3802,6 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "reqwest"
@@ -4354,16 +4348,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "rand 0.7.3",
- "redox_syscall 0.1.57",
- "remove_dir_all",
- "winapi 0.3.9",
+ "cfg-if 1.0.0",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4478,7 +4471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
 dependencies = [
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ members = [
     "ckb-bin"
 ]
 
+[workspace.dependencies]
+tempfile = "3"
+
 [profile.release]
 overflow-checks = true
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -33,7 +33,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.109.0-pre" }
 ckb-resource = { path = "../resource", version = "= 0.109.0-pre" }
 ckb-network = { path = "../network", version = "= 0.109.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 
 [[bench]]
 name = "bench_main"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -38,7 +38,7 @@ ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.109.0-pre" 
 ckb-network = { path = "../network", version = "= 0.109.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.109.0-pre" }
 lazy_static = "1.4"
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.109.0-pre" ,features = ["enable_faketime"]}
 
 [features]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -39,7 +39,7 @@ ckb-async-runtime = { path = "../util/runtime", version = "= 0.109.0-pre" }
 ckb-db = { path = "../db", version = "= 0.109.0-pre" }
 ckb-launcher = { path = "../util/launcher", version = "= 0.109.0-pre" }
 base64 = "0.13.0"
-tempfile = "3.0"
+tempfile.workspace = true
 rayon = "1.0"
 sentry = { version = "0.26.0", optional = true }
 atty = "0.2"

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -19,7 +19,7 @@ indicatif = "0.16"
 console = ">=0.9.1, <1.0.0"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-app-config = { path = "../util/app-config", version = "= 0.109.0-pre" }
 
 [features]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -17,7 +17,7 @@ rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", features = ["snappy"], 
 ckb-db-schema = { path = "../db-schema", version = "= 0.109.0-pre" }
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 
 [features]
 default = []

--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -123,7 +123,8 @@ function check_dependencies_for() {
     for dependency_original in $(${SED} -n "/^\[${deptype}\]/,/^\[/p" "${cargo_toml}" |
       { ${GREP} -v "^\(\[\|[ ]*$\|[ ]*#\)" || true; } |
       ${SED} -n "s/\([^ =]*\).*/\1/p"); do
-      local dependency=$(printf "${dependency_original}" | tr '-' '_')
+      local workspace_suffix=".workspace"
+      local dependency=$(printf "${dependency_original}" | tr '-' '_' |  ${SED} -e s/$workspace_suffix$//)
       local tmpcnt=0
       local depcnt=0
       local srcdir=

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -21,7 +21,7 @@ snap = "1"
 lru = "0.7.1"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 
 [[test]]
 name = "failpoints"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -43,7 +43,7 @@ with_sentry = ["sentry"]
 with_dns_seeding = ["lazy_static", "bs58", "faster-hex", "trust-dns-resolver", "secp256k1"]
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 criterion = "0.4"
 proptest = "1.0"
 num_cpus = "1.10"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -23,5 +23,4 @@ ckb-types = { path = "../util/types", version = "= 0.109.0-pre" }
 ckb-system-scripts = { version = "= 0.5.4" }
 
 [dev-dependencies]
-# Lock tempfile so wasm-build-test will use getrandom 0.1.*
-tempfile = "=3.1.0"
+tempfile.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -51,6 +51,6 @@ reqwest = { version = "0.11.4", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 ckb-launcher = { path = "../util/launcher", version = "= 0.109.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 pretty_assertions = "1.3.0"
 ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.109.0-pre" }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -37,5 +37,5 @@ ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.109.0
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 ckb-crypto = { path = "../util/crypto", version = "= 0.109.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 rand = "0.8.4"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -23,7 +23,7 @@ ckb-hash = { path = "../util/hash", version = "= 0.109.0-pre" }
 ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 
 [features]
 portable = ["ckb-db/portable"]

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["sync"] }
 lru = "0.7.1"
 futures = "0.3"
 governor = "0.3.1"
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.109.0-pre" }
 bitflags = "1.0"
 dashmap = "4.0"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -29,7 +29,7 @@ ckb-logger-config = { path = "../util/logger-config", version = "= 0.109.0-pre" 
 ckb-logger-service = { path = "../util/logger-service", version = "= 0.109.0-pre" }
 ckb-error = { path = "../error", version = "= 0.109.0-pre" }
 ckb-constant = { path = "../util/constant", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile = "3"
 reqwest = { version = "0.11.4", features = ["blocking", "json"] }
 rand = "0.7"
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.109.0-pre" }

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -38,7 +38,7 @@ rand = "0.8.4"
 hyper = { version = "0.14", features = ["http1", "client", "tcp"] }
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-hash = { path = "../util/hash", version = "= 0.109.0-pre" }
 ckb-systemtime = {path = "../util/systemtime", version = "= 0.109.0-pre", features = ["enable_faketime"]}
 

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -36,5 +36,5 @@ ubyte = { version = "0.10", features = ["serde"] }
 with_sentry = ["sentry"]
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-systemtime = { path = "../systemtime", version = "= 0.109.0-pre" ,features = ["enable_faketime"]}

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -19,4 +19,4 @@ ckb-traits = { path = "../../traits", version = "= 0.109.0-pre" }
 ckb-db = { path = "../../db", version = "= 0.109.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.109.0-pre" }
 ckb-store = { path = "../../store", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -27,5 +27,5 @@ serde_json = "1.0"
 numext-fixed-uint = "0.1"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile.workspace = true
 rand = "0.8"

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -45,7 +45,7 @@ ckb-block-filter = { path = "../../block-filter", version = "= 0.109.0-pre" }
 ckb-hash = { path = "../hash", version = "= 0.109.0-pre" }
 num_cpus = "1.10"
 once_cell = "1.8.0"
-tempfile = "3.0"
+tempfile.workspace = true
 
 [dev-dependencies]
 ckb-systemtime = {path = "../systemtime", version = "= 0.109.0-pre", features = ["enable_faketime"]  }

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -27,6 +27,6 @@ ckb-app-config = { path = "../app-config", version = "= 0.109.0-pre" }
 ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.109.0-pre" }
 ckb-dao-utils = { path = "../dao/utils", version = "= 0.109.0-pre" }
 ckb-test-chain-utils = { path = "../test-chain-utils", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 ckb-systemtime = {path = "../systemtime", version = "= 0.109.0-pre", features = ["enable_faketime"]}
 tokio = "1.20"

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -23,7 +23,7 @@ time = { version = "0.3.11", features = ["formatting"] }
 
 [dev-dependencies]
 ckb-logger = { path = "../logger", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 
 [features]
 with_sentry = ["sentry"]

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -20,4 +20,4 @@ ckb-chain-spec = {path = "../../spec", version = "= 0.109.0-pre"}
 ckb-db = { path = "../../db", version = "= 0.109.0-pre" }
 ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.109.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -20,7 +20,7 @@ ckb-systemtime = { path = "../systemtime", version = "= 0.109.0-pre" }
 ckb-resource = { path = "../../resource", version = "= 0.109.0-pre" }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.109.0-pre" }
 ckb-util = { path = "..", version = "= 0.109.0-pre" }
-tempfile = "3.0"
+tempfile.workspace = true
 
 [dev-dependencies]
 ckb-systemtime = { path = "../systemtime", version = "= 0.109.0-pre", features = ["enable_faketime"] }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The remove_dir_all crate is a Rust library that offers additional features over the Rust standard library fs::remove_dir_all function. It suffers the same class of failure as the code it was layering over: TOCTOU race conditions, with the ability to cause arbitrary paths to be deleted by substituting a symlink for a path after the type of the path was checked.

### What is changed and how it works?

Upgrade tempfile to remove remove_dir_all dependency, introduce https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

