### PR TITLE
Fix typo: cannonical to canonical

### DIFF
--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -146,7 +146,7 @@ pub struct BlockTransactionsError {
     pub error: Error,
 }
 
-/// Cannot access the parent block to the cannonical chain.
+/// Cannot access the parent block to the canonical chain.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 #[error("UnknownParentError(parent_hash: {parent_hash})")]
 pub struct UnknownParentError {


### PR DESCRIPTION

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix a typo, I think it should be `canonical`.

Ref: [Canonical Chain](https://ethereum.stackexchange.com/questions/47016/what-does-block-reached-canonical-chain-mean)


### Related changes
- None
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects
- None
### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```