### PR TITLE
chore: add test/ to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@ target/
 data/
 specs/
 docs/
+test/
 docker/
 !docker/docker-entrypoint.sh


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Test folder can occupy a lot of space and is not used in Docker.

### What is changed and how it works?

What's Changed: Ignore the folder in .dockerignore to shrink the Docker build context.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

