### PR TITLE
fix: potentially tx-pool panic after detached

### DIFF
--- a/tx-pool/src/component/commit_txs_scanner.rs
+++ b/tx-pool/src/component/commit_txs_scanner.rs
@@ -200,14 +200,16 @@ impl<'a> CommitTxsScanner<'a> {
                 .iter()
                 .filter(|id| !already_added.contains_key(id))
             {
-                let mut desc = self.modified_entries.remove(desc_id).unwrap_or_else(|| {
-                    self.proposed_pool
-                        .get(desc_id)
-                        .map(ToOwned::to_owned)
-                        .expect("pool consistent")
-                });
-                desc.sub_entry_weight(entry);
-                self.modified_entries.insert(desc);
+                // Note: since https://github.com/nervosnetwork/ckb/pull/3706
+                // calc_descendants() may not consistent
+                if let Some(mut desc) = self
+                    .modified_entries
+                    .remove(desc_id)
+                    .or_else(|| self.proposed_pool.get(desc_id).cloned())
+                {
+                    desc.sub_entry_weight(entry);
+                    self.modified_entries.insert(desc);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix an issue introduced from https://github.com/nervosnetwork/ckb/pull/3706/files#diff-4e835ff799b925b06ae537862d89faea15095eafdcb95f6e3ee6d74ea4045617R292-R305
that could potentially cause tx-pool panic


### What is changed and how it works?

Replace the handling of quick errors with fault tolerance


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

