### PR TITLE
refactor(light-client): let the function that builds filter data to be standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,6 @@ dependencies = [
  "ckb-stop-handler",
  "ckb-store",
  "ckb-types",
- "golomb-coded-set",
 ]
 
 [[package]]
@@ -1301,7 +1300,6 @@ dependencies = [
  "ckb-db-schema",
  "ckb-error",
  "ckb-freezer",
- "ckb-hash",
  "ckb-merkle-mountain-range",
  "ckb-traits",
  "ckb-types",
@@ -1443,6 +1441,7 @@ dependencies = [
  "ckb-occupied-capacity",
  "ckb-rational",
  "derive_more",
+ "golomb-coded-set",
  "merkle-cbt",
  "molecule",
  "numext-fixed-uint",

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -17,4 +17,3 @@ ckb-logger = { path = "../util/logger", version = "= 0.109.0-pre" }
 ckb-types = { path = "../util/types", version = "= 0.109.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.109.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.109.0-pre" }
-golomb-coded-set = "0.2.0"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -19,7 +19,6 @@ ckb-error = { path = "../error", version = "= 0.109.0-pre" }
 ckb-app-config = { path = "../util/app-config", version = "= 0.109.0-pre" }
 ckb-db-schema = { path = "../db-schema", version = "= 0.109.0-pre" }
 ckb-freezer = { path = "../freezer", version = "= 0.109.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.109.0-pre" }
 ckb-merkle-mountain-range = "0.5.2"
 
 [dev-dependencies]

--- a/store/src/transaction.rs
+++ b/store/src/transaction.rs
@@ -15,7 +15,6 @@ use ckb_db_schema::{
 };
 use ckb_error::Error;
 use ckb_freezer::Freezer;
-use ckb_hash::blake2b_256;
 use ckb_merkle_mountain_range::{Error as MMRError, MMRStore, Result as MMRResult};
 use ckb_types::{
     core::{
@@ -24,6 +23,7 @@ use ckb_types::{
     },
     packed::{self, Byte32, OutPoint},
     prelude::*,
+    utilities::calc_filter_hash,
 };
 use std::sync::Arc;
 
@@ -394,13 +394,7 @@ impl StoreTransaction {
             block_hash.as_slice(),
             filter_data.as_slice(),
         )?;
-        let current_block_filter_hash = blake2b_256(
-            [
-                parent_block_filter_hash.as_slice(),
-                filter_data.calc_raw_data_hash().as_slice(),
-            ]
-            .concat(),
-        );
+        let current_block_filter_hash = calc_filter_hash(parent_block_filter_hash, filter_data);
         self.insert_raw(
             COLUMN_BLOCK_FILTER_HASH,
             block_hash.as_slice(),

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -23,6 +23,7 @@ ckb-rational = { path = "../rational", version = "= 0.109.0-pre" }
 once_cell = "1.8.0"
 derive_more = { version = "0.99.0", default-features=false, features = ["display"] }
 ckb-merkle-mountain-range = "0.5.2"
+golomb-coded-set = "0.2.0"
 
 [dev-dependencies]
 proptest = "1.0"

--- a/util/types/src/utilities/block_filter.rs
+++ b/util/types/src/utilities/block_filter.rs
@@ -1,0 +1,65 @@
+use std::io::{Cursor, Write};
+
+use ckb_hash::blake2b_256;
+use golomb_coded_set::{GCSFilterWriter, SipHasher24Builder, M, P};
+
+use crate::{core::TransactionView, packed, prelude::*};
+
+/// Provides data for building block filter data.
+pub trait FilterDataProvider {
+    /// Finds the cell through its out point.
+    fn cell(&self, out_point: &packed::OutPoint) -> Option<packed::CellOutput>;
+}
+
+/// Builds filter data for transactions.
+pub fn build_filter_data<P: FilterDataProvider>(
+    provider: P,
+    transactions: &[TransactionView],
+) -> (Vec<u8>, Vec<packed::OutPoint>) {
+    let mut filter_writer = Cursor::new(Vec::new());
+    let mut filter = build_gcs_filter(&mut filter_writer);
+    let mut missing_out_points = Vec::new();
+    for tx in transactions {
+        if !tx.is_cellbase() {
+            for out_point in tx.input_pts_iter() {
+                if let Some(input_cell) = provider.cell(&out_point) {
+                    filter.add_element(input_cell.calc_lock_hash().as_slice());
+                    if let Some(type_script) = input_cell.type_().to_opt() {
+                        filter.add_element(type_script.calc_script_hash().as_slice());
+                    }
+                } else {
+                    missing_out_points.push(out_point);
+                }
+            }
+        }
+        for output_cell in tx.outputs() {
+            filter.add_element(output_cell.calc_lock_hash().as_slice());
+            if let Some(type_script) = output_cell.type_().to_opt() {
+                filter.add_element(type_script.calc_script_hash().as_slice());
+            }
+        }
+    }
+    filter
+        .finish()
+        .expect("flush to memory writer should be OK");
+    let filter_data = filter_writer.into_inner();
+    (filter_data, missing_out_points)
+}
+
+/// Calculates a block filter hash.
+pub fn calc_filter_hash(
+    parent_block_filter_hash: &packed::Byte32,
+    filter_data: &packed::Bytes,
+) -> [u8; 32] {
+    blake2b_256(
+        [
+            parent_block_filter_hash.as_slice(),
+            filter_data.calc_raw_data_hash().as_slice(),
+        ]
+        .concat(),
+    )
+}
+
+fn build_gcs_filter(out: &mut dyn Write) -> GCSFilterWriter<SipHasher24Builder> {
+    GCSFilterWriter::new(out, SipHasher24Builder::new(0, 0), M, P)
+}

--- a/util/types/src/utilities/mod.rs
+++ b/util/types/src/utilities/mod.rs
@@ -1,4 +1,5 @@
 //! Types utilities.
+mod block_filter;
 mod difficulty;
 pub mod merkle_mountain_range;
 mod merkle_tree;
@@ -6,6 +7,7 @@ mod merkle_tree;
 #[cfg(test)]
 mod tests;
 
+pub use block_filter::{build_filter_data, calc_filter_hash, FilterDataProvider};
 pub use difficulty::{
     compact_to_difficulty, compact_to_target, difficulty_to_compact, target_to_compact, DIFF_TWO,
 };


### PR DESCRIPTION
### What problem does this PR solve?

The code that builds filter data could not be reuse.

### What is changed and how it works?

Move those code to be a standalone function.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

