### PR TITLE
chore: fix outdate warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"


### PR DESCRIPTION
### What problem does this PR solve?

ref: https://github.com/webdesus/fs_extra/pull/38

will warning during cargo build with 1.68

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

