### PR TITLE
[ckb_chain]: Calculate tx fees when switch is Switch::DISABLE_ALL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "ckb-verification-traits",
  "faux",
  "lazy_static",
+ "rand 0.7.3",
  "tempfile",
 ]
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -40,6 +40,7 @@ ckb-launcher = { path = "../util/launcher", version = "= 0.109.0-pre" }
 lazy_static = "1.4"
 tempfile.workspace = true
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.109.0-pre" ,features = ["enable_faketime"]}
+rand = "0.7"
 
 [features]
 default = []

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -826,6 +826,12 @@ impl ChainService {
                                 .collect::<Result<Vec<Completed>, Error>>()
                             {
                                 Ok(cache_entries) => {
+                                    let txs_sizes = resolved
+                                        .iter()
+                                        .map(|rtx| {
+                                            rtx.transaction.data().serialized_size_in_block() as u64
+                                        })
+                                        .collect();
                                     txn.attach_block(b)?;
                                     attach_block_cell(&txn, b)?;
                                     mmr.push(b.digest())
@@ -836,7 +842,7 @@ impl ChainService {
                                         &b.header().hash(),
                                         ext.clone(),
                                         Some(&cache_entries),
-                                        None,
+                                        Some(txs_sizes),
                                     )?;
                                 }
                                 Err(err) => {

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -1,6 +1,6 @@
 use crate::tests::util::{
     create_cellbase, create_multi_outputs_transaction, create_transaction,
-    create_transaction_with_out_point, dao_data, start_chain, MockChain, MockStore,
+    create_transaction_with_input, dao_data, start_chain, MockChain, MockStore,
 };
 use ckb_error::assert_error_eq;
 use ckb_store::ChainStore;
@@ -144,7 +144,7 @@ fn test_invalid_out_point_index_in_same_block() {
     let tx1_hash = tx1.hash();
     let tx2 = create_transaction(&tx1_hash, 2);
     // create an invalid OutPoint index
-    let tx3 = create_transaction_with_out_point(OutPoint::new(tx1_hash.clone(), 1), 3);
+    let tx3 = create_transaction_with_input(OutPoint::new(tx1_hash.clone(), 1), 3);
     let txs = vec![tx1, tx2, tx3];
 
     chain2.gen_block_with_proposal_txs(txs.clone(), &mock_store);
@@ -200,7 +200,7 @@ fn test_invalid_out_point_index_in_different_blocks() {
     let tx1_hash = tx1.hash();
     let tx2 = create_transaction(&tx1_hash, 2);
     // create an invalid OutPoint index
-    let tx3 = create_transaction_with_out_point(OutPoint::new(tx1_hash.clone(), 1), 3);
+    let tx3 = create_transaction_with_input(OutPoint::new(tx1_hash.clone(), 1), 3);
 
     chain2.gen_block_with_proposal_txs(vec![tx1.clone(), tx2.clone(), tx3.clone()], &mock_store);
     chain2.gen_empty_block_with_inc_diff(20000u64, &mock_store);

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::genesis_verifier::GenesisVerifier;
 pub use crate::header_verifier::HeaderVerifier;
 pub use crate::transaction_verifier::{
     CapacityVerifier, ContextualTransactionVerifier, ContextualWithoutScriptTransactionVerifier,
-    NonContextualTransactionVerifier, ScriptVerifier, Since, SinceMetric,
+    FeeCalculator, NonContextualTransactionVerifier, ScriptVerifier, Since, SinceMetric,
     TimeRelativeTransactionVerifier,
 };
 pub use ckb_script::{

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -210,6 +210,7 @@ where
 //     }
 // }
 
+/// FeeCalculator calculates transaction fee
 pub struct FeeCalculator<'a, DL> {
     transaction: Arc<ResolvedTransaction>,
     consensus: &'a Consensus,
@@ -217,7 +218,8 @@ pub struct FeeCalculator<'a, DL> {
 }
 
 impl<'a, DL: CellDataProvider + HeaderProvider + EpochProvider> FeeCalculator<'a, DL> {
-    fn new(
+    /// Creates a new FeeCalculator
+    pub fn new(
         transaction: Arc<ResolvedTransaction>,
         consensus: &'a Consensus,
         data_loader: DL,
@@ -229,7 +231,8 @@ impl<'a, DL: CellDataProvider + HeaderProvider + EpochProvider> FeeCalculator<'a
         }
     }
 
-    fn transaction_fee(&self) -> Result<Capacity, DaoError> {
+    /// Calculate transaction fee
+    pub fn transaction_fee(&self) -> Result<Capacity, DaoError> {
         // skip tx fee calculation for cellbase
         if self.transaction.is_cellbase() {
             Ok(Capacity::zero())


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

https://github.com/nervosnetwork/ckb/blob/b78864dce2ad1a7236d14124c5a7afbe6f0f0cc2/chain/src/chain.rs#L804-L810

In `fn reconcile_main_chain`, if `switch` is `Switch::DISABLE_ALL`, tx fees won't be calculated and saved into `BlockExt`, this will cause `RewardCalculator::block_reward_internal` failed to calculate right `block_reward`:
https://github.com/nervosnetwork/ckb/blob/3aa30517f31b798e25c955e053b497c24c2f64d0/util/reward-calculator/src/lib.rs#L95-L102

### What is changed and how it works?

What's Changed:
- Make `FeeCalculator` and it's `new` and `transaction_fee` methods public.
- Calculate tx fees and txs_sizes, then insert tx fees and tx_sizes to `BlockExt` when `switch` is `Switch::DISABLE_ALL`

### TODO
- [x] Add unit test, start a mock chain and process_block in `Switch::DISABLE_ALL` mode, then continue to process_block in `Switch::NONE` mode.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

