### PR TITLE
Debug: why unit tests are skipped on CI action?

### DIFF
--- a/.github/actions/ci_prologue/ci_prologue.sh
+++ b/.github/actions/ci_prologue/ci_prologue.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -evx
 fun_run_os(){
   runs_on="$1"
   github_workflow_os=`echo $GITHUB_WORKFLOW | awk -F '_' '{print $NF}'`

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -62,6 +62,8 @@ jobs:
         if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
             devtools/ci/ci_main.sh
         else
+          echo "debug ci: " ${{ needs.prologue.outputs.os_skip }}
+          echo "debug ci: " ${{ needs.prologue.outputs.job_skip }}
           echo "skip job"
           exit 0
         fi


### PR DESCRIPTION
Debug why unit test CI job are skipped on CI action: https://github.com/nervosnetwork/ckb/actions/runs/4628485650/jobs/8187907723?pr=3905