### PR TITLE
CI: upgrade nextest-rs/nextest on windows CI job runner

### DIFF
--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -61,11 +61,10 @@ jobs:
         scoop install git
         scoop bucket add extras
         scoop install llvm yasm
-    - name: Install cargo-nextest
-      run: |
-        scoop install wget
-        wget https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.36/cargo-nextest-0.9.36-x86_64-pc-windows-msvc.zip
-        7z x cargo-nextest-0.9.36-x86_64-pc-windows-msvc.zip -oC:\Users\Administrator\.cargo\bin -y
+    - name: Install nextest dependency
+      run: scoop install jq
+    - name: Install nextest-rs/nextest
+      uses: taiki-e/install-action@nextest
     - run: |
         if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
             devtools/ci/ci_main.sh


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: upgrade CI runner's dependency.

### What is changed and how it works?

nextest-rs/nextest was introduces in PR: #3777
I didn't install latest nextest-rs/nextest on windows CI runner in #3777 because it's rust-toolchain is `1.61.0`, since we have specific rust-toolchain `1.67.1` in develop, we can upgrade nextest-rs/nextest to latest version on windows CI runner. 
https://github.com/nervosnetwork/ckb/pull/3777#issuecomment-1367167069


### Related changes

- Upgrade windows CI runner's nextest-rs/nextest to latest.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

