### PR TITLE
ci: remove outdated ignored advisory criterias

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,6 @@ unmaintained = "warn"
 yanked = "deny"
 notice = "deny"
 ignore = [
-    # TODO Potential segfault in the time crate; waiting for the fix from upstream (chrono)
-    "RUSTSEC-2020-0071",
-    # TODO Potential segfault in the chrono crate; waiting for the new release of chrono
-    "RUSTSEC-2020-0159",
     # waiting https://github.com/bheisler/criterion.rs/pull/628 bump release
     "RUSTSEC-2021-0145"
 ]


### PR DESCRIPTION
### What problem does this PR solve?

Remove outdated ignored advisory criterias.

### Check List

Tests

- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
None: Exclude this PR from the release note.
```

