### PR TITLE
Fix: migrate --check should return exit with 0 when DB version is equal

### DIFF
--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -24,16 +24,10 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
                 return Err(ExitCode::Failure);
             }
 
-            if args.check {
-                if matches!(db_status, Ordering::Less) {
-                    return Ok(());
-                } else {
-                    return Err(ExitCode::Cli);
-                }
-            }
-
             if matches!(db_status, Ordering::Equal) {
                 return Ok(());
+            } else if args.check {
+                return Err(ExitCode::Cli);
             }
 
             if migrate.require_expensive(&db) && !args.force {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

`ckb migrate --check` will exit with non-zero when the DB version is `Equal`:

```console
➜  test-ckb git:✗ ../target/debug/ckb migrate --check
path: "/Users/yukang/code/ckb/test-ckb/data/db"
read_only_db: false
db_status: Equal
➜  test-ckb git:✗ echo $?
64
```

### What is changed and how it works?

What's Changed:

Fix the checking logic

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```console
➜  test-ckb git:✗ ../target/debug/ckb migrate --check
path: "/Users/yukang/code/ckb/test-ckb/data/db"
read_only_db: false
db_status: Equal
➜  test-ckb git:✗ echo $?
0
```


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

