### PR TITLE
Fix bug in truncate RPC all and add limit for better error message

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3086,7 +3086,7 @@ Response
     * `target_tip_hash`: [`H256`](#type-h256)
 * result: `null`
 
-Truncate chain to specified tip hash.
+Truncate chain to specified tip hash, can only truncate less then 50000 blocks each time.
 
 ###### Params
 

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -107,7 +107,7 @@ pub trait IntegrationTestRpc {
     #[rpc(name = "process_block_without_verify")]
     fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Result<Option<H256>>;
 
-    /// Truncate chain to specified tip hash.
+    /// Truncate chain to specified tip hash, can only truncate less then 50000 blocks each time.
     ///
     /// ## Params
     ///


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #3941

Problem Summary:

- The RPC call has a timeout limitation, so we can not rollback too many blocks, with some testing I found 50000 is a proper limit.
- The iteration on `attached_blocks` is a typo, we can remove it.


### What is changed and how it works?

We add a limit on the number of blocks, if we have a requirement for rollbacking many blocks in one time, we will implement it `cli` mode.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```