### PR TITLE
rpc(ChainRpc): Add `time_added_to_pool` field for `ChainRpcImpl::get_transaction`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -878,6 +878,7 @@ Response
       "witnesses": []
     },
     "cycles": "0x219",
+    "time_added_to_pool" : "0x187b3d137a1",
     "tx_status": {
       "block_hash": null,
       "status": "pending",

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6936,6 +6936,8 @@ The JSON view of a transaction as well as its status.
 
 *   `cycles`: [`Cycle`](#type-cycle) `|` `null` - The transaction consumed cycles.
 
+*   `time_added_to_pool`: [`Uint64`](#type-uint64) `|` `null` - If the transaction is in tx-pool, `time_added_to_pool` represent when it enter the tx-pool. unit: Millisecond
+
 *   `tx_status`: [`TxStatus`](#type-txstatus) - The Transaction status.
 
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -614,6 +614,7 @@ pub trait ChainRpc {
     ///       "witnesses": []
     ///     },
     ///     "cycles": "0x219",
+    ///     "time_added_to_pool" : "0x187b3d137a1",
     ///     "tx_status": {
     ///       "block_hash": null,
     ///       "status": "pending",

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -625,6 +625,10 @@ fn mock_rpc_response(example: &RpcTestExample, response: &mut RpcTestResponse) {
             response.result["current_time"] = example.response.result["current_time"].clone();
             response.result["work_id"] = example.response.result["work_id"].clone();
         }
+        "get_transaction" => {
+            response.result["time_added_to_pool"] =
+                example.response.result["time_added_to_pool"].clone();
+        }
         "tx_pool_info" => {
             response.result["last_txs_updated_at"] =
                 example.response.result["last_txs_updated_at"].clone()

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -900,11 +900,13 @@ async fn process(mut service: TxPoolService, message: Message) {
                 Ok(TransactionWithStatus::with_proposed(
                     Some(entry.transaction().clone()),
                     entry.cycles,
+                    entry.timestamp,
                 ))
             } else if let Some(entry) = tx_pool.get_entry_from_pending_or_gap(&id) {
                 Ok(TransactionWithStatus::with_pending(
                     Some(entry.transaction().clone()),
                     entry.cycles,
+                    entry.timestamp,
                 ))
             } else if let Some(ref recent_reject_db) = tx_pool.recent_reject {
                 let recent_reject_result = recent_reject_db.get(&hash);

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -525,6 +525,8 @@ pub struct TransactionWithStatusResponse {
     pub transaction: Option<ResponseFormat<TransactionView>>,
     /// The transaction consumed cycles.
     pub cycles: Option<Cycle>,
+    /// If the transaction is in tx-pool, `time_added_to_pool` represent when it enter the tx-pool. unit: Millisecond
+    pub time_added_to_pool: Option<Uint64>,
     /// The Transaction status.
     pub tx_status: TxStatus,
 }
@@ -540,6 +542,7 @@ impl TransactionWithStatusResponse {
                     .map(|tx| ResponseFormat::hex(tx.data().as_bytes())),
                 tx_status: t.tx_status.into(),
                 cycles: t.cycles.map(Into::into),
+                time_added_to_pool: t.time_added_to_pool.map(Into::into),
             },
             ResponseFormatInnerType::Json => TransactionWithStatusResponse {
                 transaction: t
@@ -547,6 +550,7 @@ impl TransactionWithStatusResponse {
                     .map(|tx| ResponseFormat::json(TransactionView::from(tx))),
                 tx_status: t.tx_status.into(),
                 cycles: t.cycles.map(Into::into),
+                time_added_to_pool: t.time_added_to_pool.map(Into::into),
             },
         }
     }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -161,24 +161,36 @@ pub struct TransactionWithStatus {
     pub tx_status: TxStatus,
     /// The transaction verification consumed cycles
     pub cycles: Option<core::Cycle>,
+    /// If the transaction is in tx-pool, `time_added_to_pool` represent when it enter the tx-pool. unit: Millisecond
+    pub time_added_to_pool: Option<u64>,
 }
 
 impl TransactionWithStatus {
     /// Build with pending status
-    pub fn with_pending(tx: Option<core::TransactionView>, cycles: core::Cycle) -> Self {
+    pub fn with_pending(
+        tx: Option<core::TransactionView>,
+        cycles: core::Cycle,
+        time_added_to_pool: u64,
+    ) -> Self {
         Self {
             tx_status: TxStatus::Pending,
             transaction: tx,
             cycles: Some(cycles),
+            time_added_to_pool: Some(time_added_to_pool),
         }
     }
 
     /// Build with proposed status
-    pub fn with_proposed(tx: Option<core::TransactionView>, cycles: core::Cycle) -> Self {
+    pub fn with_proposed(
+        tx: Option<core::TransactionView>,
+        cycles: core::Cycle,
+        time_added_to_pool: u64,
+    ) -> Self {
         Self {
             tx_status: TxStatus::Proposed,
             transaction: tx,
             cycles: Some(cycles),
+            time_added_to_pool: Some(time_added_to_pool),
         }
     }
 
@@ -192,6 +204,7 @@ impl TransactionWithStatus {
             tx_status: TxStatus::Committed(hash),
             transaction: tx,
             cycles,
+            time_added_to_pool: None,
         }
     }
 
@@ -201,6 +214,7 @@ impl TransactionWithStatus {
             tx_status: TxStatus::Rejected(reason),
             transaction: None,
             cycles: None,
+            time_added_to_pool: None,
         }
     }
 
@@ -210,6 +224,7 @@ impl TransactionWithStatus {
             tx_status: TxStatus::Unknown,
             transaction: None,
             cycles: None,
+            time_added_to_pool: None,
         }
     }
 
@@ -219,6 +234,7 @@ impl TransactionWithStatus {
             tx_status,
             transaction: None,
             cycles,
+            time_added_to_pool: None,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #3938 

Problem Summary:

### What is changed and how it works?

What's Changed:

### Related changes

- Add `time_added_to_pool` field to `TransactionWithStatus`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

