### PR TITLE
refactor: use BlockNumberAndHash in get_locator

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -264,7 +264,7 @@ fn contextual_check(
             block_hash,
             peer
         );
-        active_chain.send_getheaders_to_peer(nc.as_ref(), peer, &tip);
+        active_chain.send_getheaders_to_peer(nc.as_ref(), peer, (&tip).into());
         return StatusCode::CompactBlockRequiresParent.with_context(format!(
             "{} parent: {}",
             block_hash,

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -136,7 +136,7 @@ fn test_unknow_parent() {
 
     let active_chain = relayer.shared.active_chain();
     let header = active_chain.tip_header();
-    let locator_hash = active_chain.get_locator(&header);
+    let locator_hash = active_chain.get_locator((&header).into());
 
     let content = packed::GetHeaders::new_builder()
         .block_locator_hashes(locator_hash.pack())

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -175,7 +175,7 @@ impl<'a> HeadersProcess<'a> {
         self.debug();
 
         if headers.len() == MAX_HEADERS_LEN {
-            let start = headers.last().expect("empty checked");
+            let start = headers.last().expect("empty checked").into();
             self.active_chain
                 .send_getheaders_to_peer(self.nc, self.peer, start);
         } else if let Some(mut state) = self.synchronizer.peers().state.get_mut(&self.peer) {

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -372,7 +372,7 @@ impl Synchronizer {
                         continue;
                     }
                 } else {
-                    active_chain.send_getheaders_to_peer(nc, *peer, &better_tip_header);
+                    active_chain.send_getheaders_to_peer(nc, *peer, (&better_tip_header).into());
                 }
             }
 
@@ -433,11 +433,12 @@ impl Synchronizer {
                         active_chain.send_getheaders_to_peer(
                             nc,
                             *peer,
-                            &state
+                            state
                                 .chain_sync
                                 .work_header
-                                .clone()
-                                .expect("work_header be assigned"),
+                                .as_ref()
+                                .expect("work_header be assigned")
+                                .into(),
                         );
                     }
                 }
@@ -493,7 +494,7 @@ impl Synchronizer {
             }
 
             debug!("start sync peer={}", peer);
-            active_chain.send_getheaders_to_peer(nc, peer, &tip);
+            active_chain.send_getheaders_to_peer(nc, peer, (&tip).into());
         }
     }
 

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -158,7 +158,7 @@ fn test_locator() {
     let locator = synchronizer
         .shared
         .active_chain()
-        .get_locator(shared.snapshot().tip_header());
+        .get_locator(shared.snapshot().tip_header().into());
 
     let mut expect = Vec::new();
 
@@ -189,7 +189,7 @@ fn test_locate_latest_common_block() {
     let locator1 = synchronizer1
         .shared
         .active_chain()
-        .get_locator(shared1.snapshot().tip_header());
+        .get_locator(shared1.snapshot().tip_header().into());
 
     let latest_common = synchronizer2
         .shared
@@ -261,7 +261,7 @@ fn test_locate_latest_common_block2() {
     let locator1 = synchronizer1
         .shared
         .active_chain()
-        .get_locator(shared1.snapshot().tip_header());
+        .get_locator(shared1.snapshot().tip_header().into());
 
     let latest_common = synchronizer2
         .shared
@@ -590,7 +590,7 @@ fn test_sync_process() {
     let locator1 = synchronizer1
         .shared
         .active_chain()
-        .get_locator(shared1.snapshot().tip_header());
+        .get_locator(shared1.snapshot().tip_header().into());
 
     for i in 1..=num {
         let j = if i > 192 { i + 1 } else { i };


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

To reduce [memory usage](https://github.com/nervosnetwork/ckb/issues/3940) during synchronization (especially for IBD), I plan to refactor the synchronization-related code in several PRs, this PR replaced the `HeaderView` struct in the `get_locator` related code with a smaller memory struct `BlockNumberAndHash`.

To make it easier for code reviewers, I split multiple PRs into smaller ones, with the goal of replacing the `HeaderView` under the sync mod with a smaller memory struct.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

