### PR TITLE
refactor: use BlockNumberAndHash in get_ancestor

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1023,7 +1023,7 @@ impl HeaderView {
 
     pub fn build_skip<F, G>(&mut self, tip_number: BlockNumber, get_header_view: F, fast_scanner: G)
     where
-        F: FnMut(&Byte32, Option<bool>) -> Option<HeaderView>,
+        F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
         G: Fn(BlockNumber, &HeaderView) -> Option<HeaderView>,
     {
         if self.inner.is_genesis() {
@@ -1040,16 +1040,15 @@ impl HeaderView {
             .map(|header| header.hash());
     }
 
-    // NOTE: get_header_view may change source state, for cache or for tests
     pub fn get_ancestor<F, G>(
         self,
         tip_number: BlockNumber,
         number: BlockNumber,
-        mut get_header_view: F,
+        get_header_view: F,
         fast_scanner: G,
     ) -> Option<core::HeaderView>
     where
-        F: FnMut(&Byte32, Option<bool>) -> Option<HeaderView>,
+        F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
         G: Fn(BlockNumber, &HeaderView) -> Option<HeaderView>,
     {
         let mut current = self;

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1024,7 +1024,7 @@ impl HeaderView {
     pub fn build_skip<F, G>(&mut self, tip_number: BlockNumber, get_header_view: F, fast_scanner: G)
     where
         F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
-        G: Fn(BlockNumber, &HeaderView) -> Option<HeaderView>,
+        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderView>,
     {
         if self.inner.is_genesis() {
             return;
@@ -1049,7 +1049,7 @@ impl HeaderView {
     ) -> Option<core::HeaderView>
     where
         F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
-        G: Fn(BlockNumber, &HeaderView) -> Option<HeaderView>,
+        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderView>,
     {
         let mut current = self;
         if number > current.number() {
@@ -1077,7 +1077,7 @@ impl HeaderView {
                     number_walk -= 1;
                 }
             }
-            if let Some(target) = fast_scanner(number, &current) {
+            if let Some(target) = fast_scanner(number, (current.number(), current.hash()).into()) {
                 current = target;
                 break;
             }
@@ -1416,8 +1416,7 @@ impl SyncShared {
             |hash, store_first_opt| self.get_header_view(hash, store_first_opt),
             |number, current| {
                 // shortcut to return an ancestor block
-                if current.number() <= snapshot.tip_number()
-                    && snapshot.is_main_chain(&current.hash())
+                if current.number <= snapshot.tip_number() && snapshot.is_main_chain(&current.hash)
                 {
                     snapshot
                         .get_block_hash(number)
@@ -1995,7 +1994,7 @@ impl ActiveChain {
             |hash, store_first_opt| self.shared.get_header_view(hash, store_first_opt),
             |number, current| {
                 // shortcut to return an ancestor block
-                if current.number() <= tip_number && self.snapshot().is_main_chain(&current.hash())
+                if current.number <= tip_number && self.snapshot().is_main_chain(&current.hash)
                 {
                     self.get_block_hash(number)
                         .and_then(|hash| self.shared.get_header_view(&hash, Some(true)))

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1030,7 +1030,6 @@ impl HeaderView {
             return;
         }
         self.skip_hash = self
-            .clone()
             .get_ancestor(
                 tip_number,
                 get_skip_height(self.number()),
@@ -1041,7 +1040,7 @@ impl HeaderView {
     }
 
     pub fn get_ancestor<F, G>(
-        self,
+        &self,
         tip_number: BlockNumber,
         number: BlockNumber,
         get_header_view: F,
@@ -1051,11 +1050,11 @@ impl HeaderView {
         F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
         G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderView>,
     {
-        let mut current = self;
-        if number > current.number() {
+        if number > self.number() {
             return None;
         }
 
+        let mut current = self.clone();
         let mut number_walk = current.number();
         while number_walk > number {
             let number_skip = get_skip_height(number_walk);
@@ -1994,8 +1993,7 @@ impl ActiveChain {
             |hash, store_first_opt| self.shared.get_header_view(hash, store_first_opt),
             |number, current| {
                 // shortcut to return an ancestor block
-                if current.number <= tip_number && self.snapshot().is_main_chain(&current.hash)
-                {
+                if current.number <= tip_number && self.snapshot().is_main_chain(&current.hash) {
                     self.get_block_hash(number)
                         .and_then(|hash| self.shared.get_header_view(&hash, Some(true)))
                 } else {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Same purpose as https://github.com/nervosnetwork/ckb/pull/3952, this PR replaced`HeaderView` with `BlockNumberAndHash` in fn `gen_ancestor`, also removed the mutable requirement since it's only used in unit test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

