### PR TITLE
Fix cargo doc not generate dependencies type document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,17 +98,16 @@ integration-cov: cov-install-tools submodule-init setup-ckb-test ## Run integrat
 ##@ Document
 .PHONY: doc
 doc: ## Build the documentation for the local package.
-	cargo doc --all --no-deps
+	cargo doc --workspace --no-deps
 
 .PHONY: doc-deps
 doc-deps: ## Build the documentation for the local package and all dependencies.
-	cargo doc --all
+	cargo doc --workspace
 
 .PHONY: gen-rpc-doc
 gen-rpc-doc:  ## Generate rpc documentation
 	rm -f ${CARGO_TARGET_DIR}/doc/ckb_rpc/module/trait.*.html
-	cargo doc -p ckb-types -p ckb-fixed-hash -p ckb-fixed-hash-core --no-deps
-	cargo doc -p ckb-types -p ckb-fixed-hash -p ckb-fixed-hash-core -p ckb-rpc -p ckb-jsonrpc-types --no-deps
+	cargo doc --workspace
 	ln -nsf "${CARGO_TARGET_DIR}" "target"
 	if command -v python3 &> /dev/null; then \
 		python3 ./devtools/doc/rpc.py > rpc/README.md; \

--- a/db-schema/src/lib.rs
+++ b/db-schema/src/lib.rs
@@ -28,7 +28,7 @@ pub const COLUMN_EPOCH: Col = "9";
 pub const COLUMN_CELL: Col = "10";
 /// Column store main chain consensus include uncles
 ///
-/// https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0020-ckb-consensus-protocol/0020-ckb-consensus-protocol.md#specification
+/// <https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0020-ckb-consensus-protocol/0020-ckb-consensus-protocol.md#specification>
 pub const COLUMN_UNCLES: Col = "11";
 /// Column store cell data
 pub const COLUMN_CELL_DATA: Col = "12";

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 /// RocksDB wrapper base on OptimisticTransactionDB
 ///
-/// https://github.com/facebook/rocksdb/wiki/Transactions#optimistictransactiondb
+/// <https://github.com/facebook/rocksdb/wiki/Transactions#optimistictransactiondb>
 #[derive(Clone)]
 pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,

--- a/devtools/doc/rpc.py
+++ b/devtools/doc/rpc.py
@@ -824,7 +824,7 @@ class RPCDoc(object):
 
 def main():
     if not os.path.exists("target/doc/ckb_rpc/module/index.html"):
-        print("Please run cargo doc first:\n  cargo doc -p ckb-rpc -p ckb-types -p ckb-fixed-hash -p ckb-fixed-hash-core -p ckb-jsonrpc-types --no-deps", file=sys.stderr)
+        print("Please run cargo doc first:\n  cargo doc --workspace", file=sys.stderr)
         sys.exit(128)
 
     doc = RPCDoc()

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -143,7 +143,7 @@ function run-integration-directly {
 
 function run-gen-rpc-doc {
   rm -ErrorAction SilentlyContinue -Force target/doc/ckb_rpc/module/trait.*.html
-  cargo doc -p ckb-rpc -p ckb-types -p ckb-fixed-hash -p ckb-fixed-hash-core -p ckb-jsonrpc-types --no-deps
+  cargo doc --workspace
   python3 ./devtools/doc/rpc.py > rpc/README.md
 }
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -164,6 +164,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.67.1.
     * [Type `PoolTransactionReject`](#type-pooltransactionreject)
     * [Type `ProposalShortId`](#type-proposalshortid)
     * [Type `ProposalWindow`](#type-proposalwindow)
+    * [Type `Ratio`](#type-ratio)
     * [Type `RationalU256`](#type-rationalu256)
     * [Type `RawTxPool`](#type-rawtxpool)
     * [Type `RemoteNode`](#type-remotenode)
@@ -5735,7 +5736,9 @@ An object containing various state info regarding deployments of consensus chang
 
 *   `period`: [`EpochNumber`](#type-epochnumber) - the length in epochs of the signalling period
 
-*   `threshold`: [`EpochNumber`](#type-epochnumber) - The first epoch which the current state applies
+*   `threshold`: [`Ratio`](#type-ratio) - the ratio of blocks with the version bit set required to activate the feature
+
+*   `since`: [`EpochNumber`](#type-epochnumber) - The first epoch which the current state applies
 
 *   `state`: [`DeploymentState`](#type-deploymentstate) - With each epoch and softfork, we associate a deployment state. The possible states are:
 
@@ -6481,6 +6484,12 @@ A non-cellbase transaction is committed at height h_c if all of the following co
 *   `closest`: [`BlockNumber`](#type-blocknumber) - The closest distance between the proposal and the commitment.
 
 *   `farthest`: [`BlockNumber`](#type-blocknumber) - The farthest distance between the proposal and the commitment.
+
+
+### Type `Ratio`
+
+Represents the ratio `numerator / denominator`, where `numerator` and `denominator` are both unsigned 64-bit integers.
+
 
 
 ### Type `RationalU256`

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -1,7 +1,7 @@
 //! # The Sync module
 //!
 //! Sync module implement ckb sync protocol as specified here:
-//! https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0004-ckb-block-sync/0004-ckb-block-sync.md
+//! <https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0004-ckb-block-sync/0004-ckb-block-sync.md>
 
 mod block_status;
 mod filter;

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -98,7 +98,7 @@ impl TxPool {
         &self.snapshot
     }
 
-    /// Makes a clone of the Arc<Snapshot>
+    /// Makes a clone of the `Arc<Snapshot>`
     pub fn cloned_snapshot(&self) -> Arc<Snapshot> {
         Arc::clone(&self.snapshot)
     }

--- a/util/app-config/src/app_config.rs
+++ b/util/app-config/src/app_config.rs
@@ -2,7 +2,7 @@
 //!
 //! Because the limitation of toml library,
 //! we must put nested config struct in the tail to make it serializable,
-//! details https://docs.rs/toml/0.5.0/toml/ser/index.html
+//! details <https://docs.rs/toml/0.5.0/toml/ser/index.html>
 
 use path_clean::PathClean;
 use std::fs;

--- a/util/network-alert/src/lib.rs
+++ b/util/network-alert/src/lib.rs
@@ -1,5 +1,5 @@
 //! Network Alert
-//! See https://en.bitcoin.it/wiki/Alert_system to learn the history of Bitcoin alert system.
+//! See <https://en.bitcoin.it/wiki/Alert_system> to learn the history of Bitcoin alert system.
 //! We implement the alert system in CKB for urgent situation,
 //! In CKB early stage we may meet the same crisis bugs that Bitcoin meet,
 //! in urgent case, CKB core team can send an alert message across CKB P2P network,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #3951 

Problem Summary:
To avoid potential race conditions, it is recommended to generate documentation for all members in the workspace using the command `cargo doc --workspace`.

### What is changed and how it works?

What's Changed:

### Related changes

- use `cargo doc --workspace` to generate all crates' documents.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

