### PR TITLE
refactor: use BlockNumberAndHash as last_common_header

### DIFF
--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -1133,13 +1133,13 @@ fn test_fix_last_common_header() {
             HeaderView::new(header, total_difficulty)
         };
         if let Some(mut state) = synchronizer.shared.state().peers().state.get_mut(&peer) {
-            state.last_common_header = last_common_header;
+            state.last_common_header = last_common_header.map(Into::into);
             state.best_known_header = Some(best_known_header.clone());
         }
 
         let expected = fix_last_common.map(|mark| mark.to_string());
         let actual = BlockFetcher::new(&synchronizer, peer, IBDState::In)
-            .update_last_common_header(&best_known_header)
+            .update_last_common_header(&best_known_header.inner().into())
             .map(|header| {
                 if graph
                     .get(&m_(header.number()))


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Same purpose as https://github.com/nervosnetwork/ckb/pull/3952, this PR changed `last_common_header` field to  `BlockNumberAndHash`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

