### PR TITLE
chore: set edition to 2021 in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 max_width = 100
 tab_spaces = 4
 reorder_imports = true


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Some tools use rustfmt dirctly. Setting edition to 2021 in rustfmt.toml
tells these tools to recognize new features added in edition 2021 such
as async/await.


### What is changed and how it works?

What's Changed: Set edition to 2021 in rustfmt.toml

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    - Run `rustfmt notify/src/lib.rs`
        - Expected result: no error
        - Remove edition config from rustfmt.toml: show errors on `async`

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

