### PR TITLE
refactor: replace best_known_header with HeaderIndex

### DIFF
--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -1,6 +1,6 @@
 use crate::block_status::BlockStatus;
 use crate::synchronizer::Synchronizer;
-use crate::types::{ActiveChain, BlockNumberAndHash, HeaderView, IBDState};
+use crate::types::{ActiveChain, BlockNumberAndHash, HeaderIndex, IBDState};
 use ckb_constant::sync::{
     BLOCK_DOWNLOAD_WINDOW, CHECK_POINT_WINDOW, INIT_BLOCKS_IN_TRANSIT_PER_PEER,
 };
@@ -35,11 +35,7 @@ impl<'a> BlockFetcher<'a> {
         inflight.peer_can_fetch_count(self.peer) == 0
     }
 
-    pub fn is_better_chain(&self, header: &HeaderView) -> bool {
-        header.is_better_than(self.active_chain.total_difficulty())
-    }
-
-    pub fn peer_best_known_header(&self) -> Option<HeaderView> {
+    pub fn peer_best_known_header(&self) -> Option<HeaderIndex> {
         self.synchronizer.peers().get_best_known_header(self.peer)
     }
 
@@ -91,7 +87,14 @@ impl<'a> BlockFetcher<'a> {
                 // Here we need to first try search from headermap, if not, fallback to search from the db.
                 // if not search from db, it can stuck here when the headermap may have been removed just as the block was downloaded
                 if let Some(header) = self.synchronizer.shared.get_header_view(&hash, None) {
-                    state.peers().may_set_best_known_header(self.peer, header);
+                    let header_index = HeaderIndex::new(
+                        header.number(),
+                        header.hash(),
+                        header.total_difficulty().clone(),
+                    );
+                    state
+                        .peers()
+                        .may_set_best_known_header(self.peer, header_index);
                 } else {
                     state.peers().insert_unknown_header_hash(self.peer, hash);
                     break;
@@ -101,7 +104,7 @@ impl<'a> BlockFetcher<'a> {
 
         // This peer has nothing interesting.
         let best_known = self.peer_best_known_header()?;
-        if !self.is_better_chain(&best_known) {
+        if !best_known.is_better_than(self.active_chain.total_difficulty()) {
             // Advancing this peer's last_common_header is unnecessary for block-sync mechanism.
             // However, RPC `get_peers`, returns peers information which includes
             // last_common_header, is expected to provide a more realistic picture. Hence here we
@@ -110,13 +113,13 @@ impl<'a> BlockFetcher<'a> {
             if self.active_chain.is_main_chain(&best_known.hash()) {
                 self.synchronizer
                     .peers()
-                    .set_last_common_header(self.peer, best_known.inner().into());
+                    .set_last_common_header(self.peer, best_known.number_and_hash());
             }
 
             return None;
         }
 
-        let best_known = best_known.inner().into();
+        let best_known = best_known.number_and_hash();
         let last_common = self.update_last_common_header(&best_known)?;
         if last_common == best_known {
             return None;

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -291,7 +291,7 @@ impl<'a, DL: HeaderProvider> HeaderAcceptor<'a, DL> {
                 .expect("header with HEADER_VALID should exist");
             state
                 .peers()
-                .may_set_best_known_header(self.peer, header_view);
+                .may_set_best_known_header(self.peer, header_view.as_header_index());
             return result;
         }
 

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use self::headers_process::HeadersProcess;
 pub(crate) use self::in_ibd_process::InIBDProcess;
 
 use crate::block_status::BlockStatus;
-use crate::types::{HeaderView, HeadersSyncController, IBDState, Peers, SyncShared};
+use crate::types::{HeadersSyncController, IBDState, Peers, SyncShared};
 use crate::utils::{metric_ckb_message_bytes, send_message_to, MetricDirection};
 use crate::{Status, StatusCode};
 
@@ -393,8 +393,10 @@ impl Synchronizer {
                         active_chain.total_difficulty().to_owned(),
                     )
                 };
-                if best_known_header.map(HeaderView::total_difficulty)
-                    >= Some(&local_total_difficulty)
+                if best_known_header
+                    .map(|header_index| header_index.total_difficulty().clone())
+                    .unwrap_or_default()
+                    >= local_total_difficulty
                 {
                     if state.chain_sync.timeout != 0 {
                         state.chain_sync.timeout = 0;
@@ -404,8 +406,9 @@ impl Synchronizer {
                     }
                 } else if state.chain_sync.timeout == 0
                     || (best_known_header.is_some()
-                        && best_known_header.map(HeaderView::total_difficulty)
-                            >= state.chain_sync.total_difficulty.as_ref())
+                        && best_known_header
+                            .map(|header_index| header_index.total_difficulty().clone())
+                            >= state.chain_sync.total_difficulty)
                 {
                     // Our best block known by this peer is behind our tip, and we're either noticing
                     // that for the first time, OR this peer was able to catch up to some earlier point

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -14,8 +14,8 @@ use ckb_store::ChainStore;
 use ckb_systemtime::unix_time_as_millis;
 use ckb_types::{
     core::{
-        cell::resolve_transaction, BlockBuilder, BlockNumber, BlockView, EpochExt, HeaderBuilder,
-        HeaderView as CoreHeaderView, TransactionBuilder, TransactionView,
+        cell::resolve_transaction, BlockBuilder, BlockNumber, BlockView, EpochExt, HeaderView,
+        TransactionBuilder, TransactionView,
     },
     packed::{
         self, Byte32, CellInput, CellOutputBuilder, Script, SendBlockBuilder, SendHeadersBuilder,
@@ -37,7 +37,7 @@ use std::{
 
 use crate::{
     synchronizer::{BlockFetcher, BlockProcess, GetBlocksProcess, HeadersProcess, Synchronizer},
-    types::{HeaderView, HeadersSyncController, IBDState, PeerState},
+    types::{HeaderIndex, HeadersSyncController, IBDState, PeerState},
     Status, StatusCode, SyncShared,
 };
 
@@ -64,7 +64,7 @@ fn start_chain(consensus: Option<Consensus>) -> (ChainController, Shared, Synchr
 
 fn create_cellbase(
     shared: &Shared,
-    parent_header: &CoreHeaderView,
+    parent_header: &HeaderView,
     number: BlockNumber,
 ) -> TransactionView {
     let (_, reward) = RewardCalculator::new(shared.consensus(), shared.snapshot().as_ref())
@@ -90,7 +90,7 @@ fn create_cellbase(
 
 fn gen_block(
     shared: &Shared,
-    parent_header: &CoreHeaderView,
+    parent_header: &HeaderView,
     epoch: &EpochExt,
     nonce: u128,
 ) -> BlockView {
@@ -414,11 +414,8 @@ fn mock_peer_info() -> Peer {
     )
 }
 
-fn mock_header_view(total_difficulty: u64) -> HeaderView {
-    HeaderView::new(
-        HeaderBuilder::default().build(),
-        U256::from(total_difficulty),
-    )
+fn mock_header_index(total_difficulty: u64) -> HeaderIndex {
+    HeaderIndex::new(0, Default::default(), U256::from(total_difficulty))
 }
 
 #[async_trait]
@@ -633,7 +630,10 @@ fn test_sync_process() {
 
     let best_known_header = synchronizer1.peers().get_best_known_header(peer1);
 
-    assert_eq!(best_known_header.unwrap().inner(), headers.last().unwrap());
+    assert_eq!(
+        best_known_header.unwrap().hash(),
+        headers.last().unwrap().hash()
+    );
 
     let blocks_to_fetch = synchronizer1
         .get_blocks_to_fetch(peer1, IBDState::Out)
@@ -806,10 +806,10 @@ fn test_chain_sync_timeout() {
         peers.state.insert(5.into(), state_5);
         peers.state.insert(6.into(), state_6);
     }
-    peers.may_set_best_known_header(0.into(), mock_header_view(1));
-    peers.may_set_best_known_header(2.into(), mock_header_view(3));
-    peers.may_set_best_known_header(3.into(), mock_header_view(1));
-    peers.may_set_best_known_header(5.into(), mock_header_view(3));
+    peers.may_set_best_known_header(0.into(), mock_header_index(1));
+    peers.may_set_best_known_header(2.into(), mock_header_index(3));
+    peers.may_set_best_known_header(3.into(), mock_header_index(1));
+    peers.may_set_best_known_header(5.into(), mock_header_index(3));
     {
         // Protected peer 0 start sync
         peers
@@ -1130,7 +1130,7 @@ fn test_fix_last_common_header() {
                 .cloned()
                 .unwrap()
                 .total_difficulty;
-            HeaderView::new(header, total_difficulty)
+            HeaderIndex::new(header.number(), header.hash(), total_difficulty)
         };
         if let Some(mut state) = synchronizer.shared.state().peers().state.get_mut(&peer) {
             state.last_common_header = last_common_header.map(Into::into);
@@ -1139,7 +1139,7 @@ fn test_fix_last_common_header() {
 
         let expected = fix_last_common.map(|mark| mark.to_string());
         let actual = BlockFetcher::new(&synchronizer, peer, IBDState::In)
-            .update_last_common_header(&best_known_header.inner().into())
+            .update_last_common_header(&best_known_header.number_and_hash())
             .map(|header| {
                 if graph
                     .get(&m_(header.number()))


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Same purpose as https://github.com/nervosnetwork/ckb/pull/3952, this PR changed `best_known_header` field to a smaller struct `HeaderIndex`. After this PR, the `HeaderView` is only used in the `HeaderMap`, then we can refactor it to a smaller struct `HeaderIndexView`:

```
pub struct HeaderIndexView {
    number: BlockNumber,
    hash: Byte32,
    parent_hash: Byte32,
    total_difficulty: U256,
    skip_hash: Option<Byte32>
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

