### PR TITLE
fix: use snapshot in light-client protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,6 @@ dependencies = [
  "ckb-network",
  "ckb-shared",
  "ckb-store",
- "ckb-sync",
  "ckb-systemtime",
  "ckb-test-chain-utils",
  "ckb-tx-pool",

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -329,7 +329,7 @@ impl Launcher {
         }
 
         if support_protocols.contains(&SupportProtocol::LightClient) {
-            let light_client = LightClientProtocol::new(Arc::clone(&sync_shared));
+            let light_client = LightClientProtocol::new(shared.clone());
             protocols.push(CKBProtocol::new_with_support_protocol(
                 SupportProtocols::LightClient,
                 Box::new(light_client),

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 ckb-network = { path = "../../network", version = "= 0.110.0-pre" }
-ckb-sync = { path = "../../sync", version = "= 0.110.0-pre" }
 ckb-shared = { path = "../../shared", version = "= 0.110.0-pre" }
 ckb-logger = { path = "../logger", version = "= 0.110.0-pre" }
 ckb-types = { path = "../types", version = "= 0.110.0-pre" }

--- a/util/light-client-protocol-server/src/components/get_last_state_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_last_state_proof.rs
@@ -3,7 +3,7 @@ use std::cmp::{min, Ordering};
 use ckb_merkle_mountain_range::leaf_index_to_pos;
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_shared::Snapshot;
-use ckb_sync::ActiveChain;
+use ckb_store::ChainStore;
 use ckb_types::{core::BlockNumber, packed, prelude::*, U256};
 
 use crate::{constant, LightClientProtocol, Status, StatusCode};
@@ -100,60 +100,54 @@ pub(crate) trait FindBlocksViaDifficulties {
     }
 }
 
-pub(crate) struct BlockSampler {
-    active_chain: ActiveChain,
+pub(crate) struct BlockSampler<'a> {
+    snapshot: &'a Snapshot,
 }
 
-impl FindBlocksViaDifficulties for BlockSampler {
+impl<'a> FindBlocksViaDifficulties for BlockSampler<'a> {
     fn get_block_total_difficulty(&self, number: BlockNumber) -> Option<U256> {
-        self.active_chain()
+        self.snapshot
             .get_block_hash(number)
-            .and_then(|block_hash| self.active_chain().get_block_ext(&block_hash))
+            .and_then(|block_hash| self.snapshot.get_block_ext(&block_hash))
             .map(|block_ext| block_ext.total_difficulty)
     }
 }
 
-impl BlockSampler {
-    fn new(active_chain: ActiveChain) -> Self {
-        Self { active_chain }
-    }
-
-    fn active_chain(&self) -> &ActiveChain {
-        &self.active_chain
+impl<'a> BlockSampler<'a> {
+    fn new(snapshot: &'a Snapshot) -> Self {
+        Self { snapshot }
     }
 
     fn complete_headers(
         &self,
-        snapshot: &Snapshot,
         positions: &mut Vec<u64>,
         last_hash: &packed::Byte32,
         numbers: &[BlockNumber],
     ) -> Result<Vec<packed::VerifiableHeader>, String> {
-        let active_chain = self.active_chain();
         let mut headers = Vec::new();
 
         for number in numbers {
-            if let Some(ancestor_header) = active_chain.get_ancestor(last_hash, *number) {
+            if let Some(ancestor_header) = self.snapshot.get_ancestor(last_hash, *number) {
                 let position = leaf_index_to_pos(*number);
                 positions.push(position);
 
-                let ancestor_block =
-                    active_chain
-                        .get_block(&ancestor_header.hash())
-                        .ok_or_else(|| {
-                            format!(
-                                "failed to find block for header#{} (hash: {:#x})",
-                                number,
-                                ancestor_header.hash()
-                            )
-                        })?;
+                let ancestor_block = self
+                    .snapshot
+                    .get_block(&ancestor_header.hash())
+                    .ok_or_else(|| {
+                        format!(
+                            "failed to find block for header#{} (hash: {:#x})",
+                            number,
+                            ancestor_header.hash()
+                        )
+                    })?;
                 let uncles_hash = ancestor_block.calc_uncles_hash();
                 let extension = ancestor_block.extension();
 
                 let parent_chain_root = if *number == 0 {
                     Default::default()
                 } else {
-                    let mmr = snapshot.chain_root_mmr(*number - 1);
+                    let mmr = self.snapshot.chain_root_mmr(*number - 1);
                     match mmr.get_root() {
                         Ok(root) => root,
                         Err(err) => {
@@ -207,18 +201,16 @@ impl<'a> GetLastStateProofProcess<'a> {
             return StatusCode::MalformedProtocolMessage.with_context("too many samples");
         }
 
-        let active_chain = self.protocol.shared.active_chain();
+        let snapshot = self.protocol.shared.snapshot();
 
         let last_block_hash = self.message.last_hash().to_entity();
-        let last_block = if let Some(block) = active_chain.get_block(&last_block_hash) {
+        let last_block = if let Some(block) = snapshot.get_block(&last_block_hash) {
             block
         } else {
             return self
                 .protocol
                 .reply_tip_state::<packed::SendLastStateProof>(self.peer, self.nc);
         };
-
-        let snapshot = self.protocol.shared.shared().snapshot();
 
         let start_block_hash = self.message.start_hash().to_entity();
         let start_block_number: BlockNumber = self.message.start_number().unpack();
@@ -233,7 +225,7 @@ impl<'a> GetLastStateProofProcess<'a> {
         let last_block_number = last_block.number();
 
         let reorg_last_n_numbers = if start_block_number == 0
-            || active_chain
+            || snapshot
                 .get_ancestor(&last_block_hash, start_block_number)
                 .map(|header| header.hash() == start_block_hash)
                 .unwrap_or(false)
@@ -244,7 +236,7 @@ impl<'a> GetLastStateProofProcess<'a> {
             (min_block_number..start_block_number).collect()
         };
 
-        let sampler = BlockSampler::new(active_chain);
+        let sampler = BlockSampler::new(&snapshot);
 
         // Check the request data.
         {
@@ -356,17 +348,13 @@ impl<'a> GetLastStateProofProcess<'a> {
 
         let (positions, headers) = {
             let mut positions: Vec<u64> = Vec::new();
-            let headers = match sampler.complete_headers(
-                &snapshot,
-                &mut positions,
-                &last_block_hash,
-                &block_numbers,
-            ) {
-                Ok(headers) => headers,
-                Err(errmsg) => {
-                    return StatusCode::InternalError.with_context(errmsg);
-                }
-            };
+            let headers =
+                match sampler.complete_headers(&mut positions, &last_block_hash, &block_numbers) {
+                    Ok(headers) => headers,
+                    Err(errmsg) => {
+                        return StatusCode::InternalError.with_context(errmsg);
+                    }
+                };
             (positions, headers)
         };
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

light-client protocol should not use the `ActiveChain` to find ancestor headers, because of `ActiveChain` finding headers from the sync `HeaderMap` which contains unverified block body.

### What is changed and how it works?

Use snapshot to find ancestor headers.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

