### PR TITLE
refactor(perf): replace sync struct HeaderView with HeaderIndexView

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -101,7 +101,7 @@ bootnode_mode = false
 support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessage", "Sync", "Relay", "Time", "Alert", "LightClient", "Filter"]
 
 # [network.sync.header_map]
-# memory_limit = "600MB"
+# memory_limit = "256MB"
 
 [rpc]
 # By default RPC only binds to localhost, thus it only allows accessing from the same machine.

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -10,7 +10,7 @@ use ckb_logger::error;
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::{data_loader_wrapper::AsDataLoader, ChainStore};
-use ckb_traits::HeaderProvider;
+use ckb_traits::HeaderFieldsProvider;
 use ckb_types::core::tx_pool::TransactionWithStatus;
 use ckb_types::{
     core::{

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -1,7 +1,7 @@
 use ckb_jsonrpc_types::{AlertMessage, ChainInfo, DeploymentInfo, DeploymentPos, DeploymentsInfo};
 use ckb_network_alert::notifier::Notifier as AlertNotifier;
 use ckb_shared::shared::Shared;
-use ckb_traits::HeaderProvider;
+use ckb_traits::HeaderFieldsProvider;
 use ckb_types::prelude::Unpack;
 use ckb_util::Mutex;
 use jsonrpc_core::Result;

--- a/store/src/data_loader_wrapper.rs
+++ b/store/src/data_loader_wrapper.rs
@@ -1,6 +1,8 @@
 //! TODO(doc): @quake
 use crate::ChainStore;
-use ckb_traits::{CellDataProvider, EpochProvider, HeaderProvider};
+use ckb_traits::{
+    CellDataProvider, EpochProvider, HeaderFields, HeaderFieldsProvider, HeaderProvider,
+};
 use ckb_types::{
     bytes::Bytes,
     core::{BlockExt, BlockNumber, EpochExt, HeaderView},
@@ -53,6 +55,21 @@ where
 {
     fn get_header(&self, block_hash: &Byte32) -> Option<HeaderView> {
         ChainStore::get_block_header(self.0.as_ref(), block_hash)
+    }
+}
+
+impl<T> HeaderFieldsProvider for DataLoaderWrapper<T>
+where
+    T: ChainStore,
+{
+    fn get_header_fields(&self, hash: &Byte32) -> Option<HeaderFields> {
+        self.0.get_block_header(hash).map(|header| HeaderFields {
+            number: header.number(),
+            epoch: header.epoch(),
+            parent_hash: header.data().raw().parent_hash(),
+            timestamp: header.timestamp(),
+            hash: header.hash(),
+        })
     }
 }
 

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -404,9 +404,9 @@ fn test_accept_block() {
 fn test_ignore_a_too_old_block() {
     let (relayer, _) = build_chain(1804);
 
-    let active_chain = relayer.shared.active_chain();
-    let parent = active_chain.tip_header();
-    let parent = active_chain.get_ancestor(&parent.hash(), 2).unwrap();
+    let snapshot = relayer.shared.shared().snapshot();
+    let parent = snapshot.tip_header();
+    let parent = snapshot.get_ancestor(&parent.hash(), 2).unwrap();
 
     let too_old_block = new_header_builder(relayer.shared.shared(), &parent).build();
 

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -308,13 +308,14 @@ fn test_get_ancestor() {
     assert!(tip.is_some());
     assert!(header.is_some());
     assert!(noop.is_none());
-    assert_eq!(tip.unwrap(), shared.snapshot().tip_header().to_owned());
+    assert_eq!(tip.unwrap().hash(), shared.snapshot().tip_header().hash());
     assert_eq!(
-        header.unwrap(),
+        header.unwrap().hash(),
         shared
             .store()
             .get_block_header(&shared.store().get_block_hash(100).unwrap())
             .unwrap()
+            .hash()
     );
 }
 

--- a/sync/src/types/header_map/backend.rs
+++ b/sync/src/types/header_map/backend.rs
@@ -2,7 +2,7 @@ use std::path;
 
 use ckb_types::packed::Byte32;
 
-use crate::types::HeaderView;
+use crate::types::HeaderIndexView;
 
 pub(crate) trait KeyValueBackend {
     fn new<P>(tmpdir: Option<P>) -> Self
@@ -15,9 +15,9 @@ pub(crate) trait KeyValueBackend {
     }
 
     fn contains_key(&self, key: &Byte32) -> bool;
-    fn get(&self, key: &Byte32) -> Option<HeaderView>;
-    fn insert(&self, value: &HeaderView) -> Option<()>;
-    fn insert_batch(&self, values: &[HeaderView]);
-    fn remove(&self, key: &Byte32) -> Option<HeaderView>;
+    fn get(&self, key: &Byte32) -> Option<HeaderIndexView>;
+    fn insert(&self, value: &HeaderIndexView) -> Option<()>;
+    fn insert_batch(&self, values: &[HeaderIndexView]);
+    fn remove(&self, key: &Byte32) -> Option<HeaderIndexView>;
     fn remove_no_return(&self, key: &Byte32);
 }

--- a/sync/src/types/header_map/kernel_lru.rs
+++ b/sync/src/types/header_map/kernel_lru.rs
@@ -8,7 +8,7 @@ use ckb_util::{Mutex, MutexGuard};
 use ckb_types::packed::Byte32;
 
 use super::{KeyValueBackend, MemoryMap};
-use crate::types::HeaderView;
+use crate::types::HeaderIndexView;
 
 pub(crate) struct HeaderMapKernel<Backend>
 where
@@ -88,7 +88,7 @@ where
         self.backend.contains_key(hash)
     }
 
-    pub(crate) fn get(&self, hash: &Byte32) -> Option<HeaderView> {
+    pub(crate) fn get(&self, hash: &Byte32) -> Option<HeaderIndexView> {
         #[cfg(feature = "stats")]
         {
             self.stats().tick_primary_select();
@@ -108,20 +108,20 @@ where
             {
                 self.stats().tick_primary_insert();
             }
-            self.memory.insert(view.hash(), view.clone());
+            self.memory.insert(view.clone());
             Some(view)
         } else {
             None
         }
     }
 
-    pub(crate) fn insert(&self, view: HeaderView) -> Option<()> {
+    pub(crate) fn insert(&self, view: HeaderIndexView) -> Option<()> {
         #[cfg(feature = "stats")]
         {
             self.trace();
             self.stats().tick_primary_insert();
         }
-        self.memory.insert(view.hash(), view)
+        self.memory.insert(view)
     }
 
     pub(crate) fn remove(&self, hash: &Byte32) {

--- a/sync/src/types/header_map/memory.rs
+++ b/sync/src/types/header_map/memory.rs
@@ -1,12 +1,70 @@
-use crate::types::HeaderView;
-use crate::types::SHRINK_THRESHOLD;
-use ckb_types::packed::Byte32;
-use ckb_util::shrink_to_fit;
-use ckb_util::LinkedHashMap;
-use ckb_util::RwLock;
+use crate::types::{HeaderIndexView, SHRINK_THRESHOLD};
+use ckb_types::{
+    core::{BlockNumber, EpochNumberWithFraction},
+    packed::Byte32,
+    U256,
+};
+use ckb_util::{shrink_to_fit, LinkedHashMap, RwLock};
 use std::default;
 
-pub(crate) struct MemoryMap(RwLock<LinkedHashMap<Byte32, HeaderView>>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HeaderIndexViewInner {
+    number: BlockNumber,
+    epoch: EpochNumberWithFraction,
+    timestamp: u64,
+    parent_hash: Byte32,
+    total_difficulty: U256,
+    skip_hash: Option<Byte32>,
+}
+
+impl From<(Byte32, HeaderIndexViewInner)> for HeaderIndexView {
+    fn from((hash, inner): (Byte32, HeaderIndexViewInner)) -> Self {
+        let HeaderIndexViewInner {
+            number,
+            epoch,
+            timestamp,
+            parent_hash,
+            total_difficulty,
+            skip_hash,
+        } = inner;
+        Self {
+            hash,
+            number,
+            epoch,
+            timestamp,
+            parent_hash,
+            total_difficulty,
+            skip_hash,
+        }
+    }
+}
+
+impl From<HeaderIndexView> for (Byte32, HeaderIndexViewInner) {
+    fn from(view: HeaderIndexView) -> Self {
+        let HeaderIndexView {
+            hash,
+            number,
+            epoch,
+            timestamp,
+            parent_hash,
+            total_difficulty,
+            skip_hash,
+        } = view;
+        (
+            hash,
+            HeaderIndexViewInner {
+                number,
+                epoch,
+                timestamp,
+                parent_hash,
+                total_difficulty,
+                skip_hash,
+            },
+        )
+    }
+}
+
+pub(crate) struct MemoryMap(RwLock<LinkedHashMap<Byte32, HeaderIndexViewInner>>);
 
 impl default::Default for MemoryMap {
     fn default() -> Self {
@@ -24,29 +82,39 @@ impl MemoryMap {
         self.0.read().contains_key(key)
     }
 
-    pub(crate) fn get_refresh(&self, key: &Byte32) -> Option<HeaderView> {
+    pub(crate) fn get_refresh(&self, key: &Byte32) -> Option<HeaderIndexView> {
         let mut guard = self.0.write();
-        guard.get_refresh(key).cloned()
+        guard
+            .get_refresh(key)
+            .cloned()
+            .map(|inner| (key.clone(), inner).into())
     }
 
-    pub(crate) fn insert(&self, key: Byte32, value: HeaderView) -> Option<()> {
+    pub(crate) fn insert(&self, header: HeaderIndexView) -> Option<()> {
         let mut guard = self.0.write();
+        let (key, value) = header.into();
         guard.insert(key, value).map(|_| ())
     }
 
-    pub(crate) fn remove(&self, key: &Byte32) -> Option<HeaderView> {
+    pub(crate) fn remove(&self, key: &Byte32) -> Option<HeaderIndexView> {
         let mut guard = self.0.write();
         let ret = guard.remove(key);
         shrink_to_fit!(guard, SHRINK_THRESHOLD);
-        ret
+        ret.map(|inner| (key.clone(), inner).into())
     }
 
-    pub(crate) fn front_n(&self, size_limit: usize) -> Option<Vec<HeaderView>> {
+    pub(crate) fn front_n(&self, size_limit: usize) -> Option<Vec<HeaderIndexView>> {
         let guard = self.0.read();
         let size = guard.len();
         if size > size_limit {
             let num = size - size_limit;
-            Some(guard.values().take(num).cloned().collect())
+            Some(
+                guard
+                    .iter()
+                    .take(num)
+                    .map(|(key, value)| (key.clone(), value.clone()).into())
+                    .collect(),
+            )
         } else {
             None
         }

--- a/sync/src/types/header_map/mod.rs
+++ b/sync/src/types/header_map/mod.rs
@@ -1,10 +1,9 @@
-use crate::types::HeaderView;
 use ckb_async_runtime::Handle;
 use ckb_stop_handler::{SignalSender, StopHandler};
-use ckb_types::packed::{self, Byte32};
-use std::path;
+use ckb_types::packed::Byte32;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{mem::size_of, path};
 use tokio::sync::oneshot;
 use tokio::time::MissedTickBehavior;
 
@@ -18,6 +17,8 @@ pub(crate) use self::{
     memory::MemoryMap,
 };
 
+use super::HeaderIndexView;
+
 pub struct HeaderMap {
     inner: Arc<HeaderMapKernel<SledBackend>>,
     stop: StopHandler<()>,
@@ -30,8 +31,7 @@ impl Drop for HeaderMap {
 }
 
 const INTERVAL: Duration = Duration::from_millis(500);
-// key + total_difficulty + skip_hash
-const ITEM_BYTES_SIZE: usize = packed::HeaderView::TOTAL_SIZE + 32 * 3;
+const ITEM_BYTES_SIZE: usize = size_of::<HeaderIndexView>();
 const WARN_THRESHOLD: usize = ITEM_BYTES_SIZE * 100_000;
 
 impl HeaderMap {
@@ -76,11 +76,11 @@ impl HeaderMap {
         self.inner.contains_key(hash)
     }
 
-    pub(crate) fn get(&self, hash: &Byte32) -> Option<HeaderView> {
+    pub(crate) fn get(&self, hash: &Byte32) -> Option<HeaderIndexView> {
         self.inner.get(hash)
     }
 
-    pub(crate) fn insert(&self, view: HeaderView) -> Option<()> {
+    pub(crate) fn insert(&self, view: HeaderIndexView) -> Option<()> {
         self.inner.insert(view)
     }
 

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -19,7 +19,7 @@ use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_systemtime::unix_time_as_millis;
-use ckb_traits::HeaderProvider;
+use ckb_traits::{HeaderFields, HeaderFieldsProvider};
 use ckb_tx_pool::service::TxVerificationResult;
 use ckb_types::{
     core::{self, BlockNumber, EpochExt},
@@ -43,7 +43,7 @@ use std::{cmp, fmt, iter};
 mod header_map;
 
 use crate::utils::send_message;
-use ckb_types::core::EpochNumber;
+use ckb_types::core::{EpochNumber, EpochNumberWithFraction};
 pub use header_map::HeaderMap;
 
 const GET_HEADERS_CACHE_SIZE: usize = 10000;
@@ -174,7 +174,7 @@ impl HeadersSyncController {
         }
     }
 
-    pub(crate) fn from_header(better_tip_header: &core::HeaderView) -> Self {
+    pub(crate) fn from_header(better_tip_header: &HeaderIndexView) -> Self {
         let started_ts = unix_time_as_millis();
         let started_tip_ts = better_tip_header.timestamp();
         Self {
@@ -1011,176 +1011,6 @@ impl Peers {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HeaderView {
-    inner: core::HeaderView,
-    total_difficulty: U256,
-    // pointer to the index of some further predecessor of this block
-    pub(crate) skip_hash: Option<Byte32>,
-}
-
-impl HeaderView {
-    pub fn new(inner: core::HeaderView, total_difficulty: U256) -> Self {
-        HeaderView {
-            inner,
-            total_difficulty,
-            skip_hash: None,
-        }
-    }
-
-    pub fn number(&self) -> BlockNumber {
-        self.inner.number()
-    }
-
-    pub fn hash(&self) -> Byte32 {
-        self.inner.hash()
-    }
-
-    pub fn parent_hash(&self) -> Byte32 {
-        self.inner.data().raw().parent_hash()
-    }
-
-    pub fn timestamp(&self) -> u64 {
-        self.inner.timestamp()
-    }
-
-    pub fn total_difficulty(&self) -> &U256 {
-        &self.total_difficulty
-    }
-
-    pub fn inner(&self) -> &core::HeaderView {
-        &self.inner
-    }
-
-    pub fn into_inner(self) -> core::HeaderView {
-        self.inner
-    }
-
-    pub fn build_skip<F, G>(&mut self, tip_number: BlockNumber, get_header_view: F, fast_scanner: G)
-    where
-        F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
-        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderView>,
-    {
-        if self.inner.is_genesis() {
-            return;
-        }
-        self.skip_hash = self
-            .get_ancestor(
-                tip_number,
-                get_skip_height(self.number()),
-                get_header_view,
-                fast_scanner,
-            )
-            .map(|header| header.hash());
-    }
-
-    pub fn get_ancestor<F, G>(
-        &self,
-        tip_number: BlockNumber,
-        number: BlockNumber,
-        get_header_view: F,
-        fast_scanner: G,
-    ) -> Option<core::HeaderView>
-    where
-        F: Fn(&Byte32, Option<bool>) -> Option<HeaderView>,
-        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderView>,
-    {
-        if number > self.number() {
-            return None;
-        }
-
-        let mut current = self.clone();
-        let mut number_walk = current.number();
-        while number_walk > number {
-            let number_skip = get_skip_height(number_walk);
-            let number_skip_prev = get_skip_height(number_walk - 1);
-            let store_first = current.number() <= tip_number;
-            match current.skip_hash {
-                Some(ref hash)
-                    if number_skip == number
-                        || (number_skip > number
-                            && !(number_skip_prev + 2 < number_skip
-                                && number_skip_prev >= number)) =>
-                {
-                    // Only follow skip if parent->skip isn't better than skip->parent
-                    current = get_header_view(hash, Some(store_first))?;
-                    number_walk = number_skip;
-                }
-                _ => {
-                    current = get_header_view(&current.parent_hash(), Some(store_first))?;
-                    number_walk -= 1;
-                }
-            }
-            if let Some(target) = fast_scanner(number, (current.number(), current.hash()).into()) {
-                current = target;
-                break;
-            }
-        }
-        Some(current).map(HeaderView::into_inner)
-    }
-
-    pub fn is_better_than(&self, total_difficulty: &U256) -> bool {
-        self.total_difficulty() > total_difficulty
-    }
-
-    fn from_slice_should_be_ok(slice: &[u8]) -> Self {
-        let len_size = packed::Uint32Reader::TOTAL_SIZE;
-        if slice.len() < len_size {
-            panic!("failed to unpack item in header map: header part is broken");
-        }
-        let mut idx = 0;
-        let inner_len = {
-            let reader = packed::Uint32Reader::from_slice_should_be_ok(&slice[idx..idx + len_size]);
-            Unpack::<u32>::unpack(&reader) as usize
-        };
-        idx += len_size;
-        let total_difficulty_len = packed::Uint256Reader::TOTAL_SIZE;
-        if slice.len() < len_size + inner_len + total_difficulty_len {
-            panic!("failed to unpack item in header map: body part is broken");
-        }
-        let inner = {
-            let reader =
-                packed::HeaderViewReader::from_slice_should_be_ok(&slice[idx..idx + inner_len]);
-            Unpack::<core::HeaderView>::unpack(&reader)
-        };
-        idx += inner_len;
-        let total_difficulty = {
-            let reader = packed::Uint256Reader::from_slice_should_be_ok(
-                &slice[idx..idx + total_difficulty_len],
-            );
-            Unpack::<U256>::unpack(&reader)
-        };
-        idx += total_difficulty_len;
-        let skip_hash = {
-            packed::Byte32OptReader::from_slice_should_be_ok(&slice[idx..])
-                .to_entity()
-                .to_opt()
-        };
-        Self {
-            inner,
-            total_difficulty,
-            skip_hash,
-        }
-    }
-
-    fn to_vec(&self) -> Vec<u8> {
-        let mut v = Vec::new();
-        let inner: packed::HeaderView = self.inner.pack();
-        let total_difficulty: packed::Uint256 = self.total_difficulty.pack();
-        let skip_hash: packed::Byte32Opt = Pack::pack(&self.skip_hash);
-        let inner_len: packed::Uint32 = (inner.as_slice().len() as u32).pack();
-        v.extend_from_slice(inner_len.as_slice());
-        v.extend_from_slice(inner.as_slice());
-        v.extend_from_slice(total_difficulty.as_slice());
-        v.extend_from_slice(skip_hash.as_slice());
-        v
-    }
-
-    pub fn as_header_index(&self) -> HeaderIndex {
-        HeaderIndex::new(self.number(), self.hash(), self.total_difficulty().clone())
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HeaderIndex {
     number: BlockNumber,
     hash: Byte32,
@@ -1218,6 +1048,195 @@ impl HeaderIndex {
 
     pub fn is_better_than(&self, other_total_difficulty: &U256) -> bool {
         self.total_difficulty() > other_total_difficulty
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HeaderIndexView {
+    hash: Byte32,
+    number: BlockNumber,
+    epoch: EpochNumberWithFraction,
+    timestamp: u64,
+    parent_hash: Byte32,
+    total_difficulty: U256,
+    skip_hash: Option<Byte32>,
+}
+
+impl HeaderIndexView {
+    pub fn new(
+        hash: Byte32,
+        number: BlockNumber,
+        epoch: EpochNumberWithFraction,
+        timestamp: u64,
+        parent_hash: Byte32,
+        total_difficulty: U256,
+    ) -> Self {
+        HeaderIndexView {
+            hash,
+            number,
+            epoch,
+            timestamp,
+            parent_hash,
+            total_difficulty,
+            skip_hash: None,
+        }
+    }
+
+    pub fn hash(&self) -> Byte32 {
+        self.hash.clone()
+    }
+
+    pub fn number(&self) -> BlockNumber {
+        self.number
+    }
+
+    pub fn epoch(&self) -> EpochNumberWithFraction {
+        self.epoch
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn total_difficulty(&self) -> &U256 {
+        &self.total_difficulty
+    }
+
+    pub fn parent_hash(&self) -> Byte32 {
+        self.parent_hash.clone()
+    }
+
+    pub fn skip_hash(&self) -> Option<&Byte32> {
+        self.skip_hash.as_ref()
+    }
+
+    // deserialize from bytes
+    fn from_slice_should_be_ok(hash: &[u8], slice: &[u8]) -> Self {
+        let hash = packed::Byte32Reader::from_slice_should_be_ok(hash).to_entity();
+        let number = BlockNumber::from_le_bytes(slice[0..8].try_into().expect("stored slice"));
+        let epoch = EpochNumberWithFraction::from_full_value(u64::from_le_bytes(
+            slice[8..16].try_into().expect("stored slice"),
+        ));
+        let timestamp = u64::from_le_bytes(slice[16..24].try_into().expect("stored slice"));
+        let parent_hash = packed::Byte32Reader::from_slice_should_be_ok(&slice[24..56]).to_entity();
+        let total_difficulty = U256::from_little_endian(&slice[56..88]).expect("stored slice");
+        let skip_hash = if slice.len() == 120 {
+            Some(packed::Byte32Reader::from_slice_should_be_ok(&slice[88..120]).to_entity())
+        } else {
+            None
+        };
+        Self {
+            hash,
+            number,
+            epoch,
+            timestamp,
+            parent_hash,
+            total_difficulty,
+            skip_hash,
+        }
+    }
+
+    // serialize all fields except `hash` to bytes
+    fn to_vec(&self) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(self.number.to_le_bytes().as_slice());
+        v.extend_from_slice(self.epoch.full_value().to_le_bytes().as_slice());
+        v.extend_from_slice(self.timestamp.to_le_bytes().as_slice());
+        v.extend_from_slice(self.parent_hash.as_slice());
+        v.extend_from_slice(self.total_difficulty.to_le_bytes().as_slice());
+        if let Some(ref skip_hash) = self.skip_hash {
+            v.extend_from_slice(skip_hash.as_slice());
+        }
+        v
+    }
+
+    pub fn build_skip<F, G>(&mut self, tip_number: BlockNumber, get_header_view: F, fast_scanner: G)
+    where
+        F: Fn(&Byte32, bool) -> Option<HeaderIndexView>,
+        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderIndexView>,
+    {
+        if self.number == 0 {
+            return;
+        }
+        self.skip_hash = self
+            .get_ancestor(
+                tip_number,
+                get_skip_height(self.number()),
+                get_header_view,
+                fast_scanner,
+            )
+            .map(|header| header.hash());
+    }
+
+    pub fn get_ancestor<F, G>(
+        &self,
+        tip_number: BlockNumber,
+        number: BlockNumber,
+        get_header_view: F,
+        fast_scanner: G,
+    ) -> Option<HeaderIndexView>
+    where
+        F: Fn(&Byte32, bool) -> Option<HeaderIndexView>,
+        G: Fn(BlockNumber, BlockNumberAndHash) -> Option<HeaderIndexView>,
+    {
+        if number > self.number() {
+            return None;
+        }
+
+        let mut current = self.clone();
+        let mut number_walk = current.number();
+        while number_walk > number {
+            let number_skip = get_skip_height(number_walk);
+            let number_skip_prev = get_skip_height(number_walk - 1);
+            let store_first = current.number() <= tip_number;
+            match current.skip_hash {
+                Some(ref hash)
+                    if number_skip == number
+                        || (number_skip > number
+                            && !(number_skip_prev + 2 < number_skip
+                                && number_skip_prev >= number)) =>
+                {
+                    // Only follow skip if parent->skip isn't better than skip->parent
+                    current = get_header_view(hash, store_first)?;
+                    number_walk = number_skip;
+                }
+                _ => {
+                    current = get_header_view(&current.parent_hash(), store_first)?;
+                    number_walk -= 1;
+                }
+            }
+            if let Some(target) = fast_scanner(number, (current.number(), current.hash()).into()) {
+                current = target;
+                break;
+            }
+        }
+        Some(current)
+    }
+
+    pub fn as_header_index(&self) -> HeaderIndex {
+        HeaderIndex::new(self.number(), self.hash(), self.total_difficulty().clone())
+    }
+
+    pub fn number_and_hash(&self) -> BlockNumberAndHash {
+        (self.number(), self.hash()).into()
+    }
+
+    pub fn is_better_than(&self, total_difficulty: &U256) -> bool {
+        self.total_difficulty() > total_difficulty
+    }
+}
+
+impl From<(core::HeaderView, U256)> for HeaderIndexView {
+    fn from((header, total_difficulty): (core::HeaderView, U256)) -> Self {
+        HeaderIndexView {
+            hash: header.hash(),
+            number: header.number(),
+            epoch: header.epoch(),
+            timestamp: header.timestamp(),
+            parent_hash: header.parent_hash(),
+            total_difficulty,
+            skip_hash: None,
+        }
     }
 }
 
@@ -1286,7 +1305,7 @@ impl SyncShared {
                 snapshot.tip_header().to_owned(),
             )
         };
-        let shared_best_header = RwLock::new(HeaderView::new(header, total_difficulty));
+        let shared_best_header = RwLock::new((header, total_difficulty).into());
         ckb_logger::info!(
             "header_map.memory_limit {}",
             sync_config.header_map.memory_limit
@@ -1481,25 +1500,33 @@ impl SyncShared {
     pub fn insert_valid_header(&self, peer: PeerIndex, header: &core::HeaderView) {
         let tip_number = self.active_chain().tip_number();
         let store_first = tip_number >= header.number();
-        let parent_view = self
-            .get_header_view(&header.data().raw().parent_hash(), Some(store_first))
+        // We don't use header#parent_hash clone here because it will hold the arc counter of the SendHeaders message
+        // which will cause the 2000 headers to be held in memory for a long time
+        let parent_hash = Byte32::from_slice(header.data().raw().parent_hash().as_slice())
+            .expect("checked slice length");
+        let parent_header_index = self
+            .get_header_index_view(&parent_hash, store_first)
             .expect("parent should be verified");
-        let mut header_view = {
-            let total_difficulty = parent_view.total_difficulty() + header.difficulty();
-            HeaderView::new(header.clone(), total_difficulty)
-        };
+        let mut header_view = HeaderIndexView::new(
+            header.hash(),
+            header.number(),
+            header.epoch(),
+            header.timestamp(),
+            parent_hash,
+            parent_header_index.total_difficulty() + header.difficulty(),
+        );
 
         let snapshot = Arc::clone(&self.shared.snapshot());
         header_view.build_skip(
             tip_number,
-            |hash, store_first_opt| self.get_header_view(hash, store_first_opt),
+            |hash, store_first| self.get_header_index_view(hash, store_first),
             |number, current| {
                 // shortcut to return an ancestor block
                 if current.number <= snapshot.tip_number() && snapshot.is_main_chain(&current.hash)
                 {
                     snapshot
                         .get_block_hash(number)
-                        .and_then(|hash| self.get_header_view(&hash, Some(true)))
+                        .and_then(|hash| self.get_header_index_view(&hash, true))
                 } else {
                     None
                 }
@@ -1512,20 +1539,19 @@ impl SyncShared {
         self.state.may_set_shared_best_header(header_view);
     }
 
-    /// Get header view with hash
-    pub fn get_header_view(
+    pub(crate) fn get_header_index_view(
         &self,
         hash: &Byte32,
-        store_first_opt: Option<bool>,
-    ) -> Option<HeaderView> {
+        store_first: bool,
+    ) -> Option<HeaderIndexView> {
         let store = self.store();
-        if store_first_opt.unwrap_or(false) {
+        if store_first {
             store
                 .get_block_header(hash)
                 .and_then(|header| {
                     store
                         .get_block_ext(hash)
-                        .map(|block_ext| HeaderView::new(header, block_ext.total_difficulty))
+                        .map(|block_ext| (header, block_ext.total_difficulty).into())
                 })
                 .or_else(|| self.state.header_map.get(hash))
         } else {
@@ -1533,7 +1559,7 @@ impl SyncShared {
                 store.get_block_header(hash).and_then(|header| {
                     store
                         .get_block_ext(hash)
-                        .map(|block_ext| HeaderView::new(header, block_ext.total_difficulty))
+                        .map(|block_ext| (header, block_ext.total_difficulty).into())
                 })
             })
         }
@@ -1551,13 +1577,29 @@ impl SyncShared {
     }
 }
 
-impl HeaderProvider for SyncShared {
-    fn get_header(&self, hash: &Byte32) -> Option<core::HeaderView> {
+impl HeaderFieldsProvider for SyncShared {
+    fn get_header_fields(&self, hash: &Byte32) -> Option<HeaderFields> {
         self.state
             .header_map
             .get(hash)
-            .map(HeaderView::into_inner)
-            .or_else(|| self.store().get_block_header(hash))
+            .map(|header| HeaderFields {
+                hash: header.hash(),
+                number: header.number(),
+                epoch: header.epoch(),
+                timestamp: header.timestamp(),
+                parent_hash: header.parent_hash(),
+            })
+            .or_else(|| {
+                self.store()
+                    .get_block_header(hash)
+                    .map(|header| HeaderFields {
+                        hash: header.hash(),
+                        number: header.number(),
+                        epoch: header.epoch(),
+                        timestamp: header.timestamp(),
+                        parent_hash: header.parent_hash(),
+                    })
+            })
     }
 }
 
@@ -1625,7 +1667,7 @@ impl PartialOrd for UnknownTxHashPriority {
 
 pub struct SyncState {
     /* Status irrelevant to peers */
-    shared_best_header: RwLock<HeaderView>,
+    shared_best_header: RwLock<HeaderIndexView>,
     header_map: HeaderMap,
     block_status_map: DashMap<Byte32, BlockStatus>,
     tx_filter: Mutex<TtlFilter<Byte32>>,
@@ -1701,11 +1743,11 @@ impl SyncState {
         self.tx_relay_receiver.try_iter().take(limit).collect()
     }
 
-    pub fn shared_best_header(&self) -> HeaderView {
+    pub fn shared_best_header(&self) -> HeaderIndexView {
         self.shared_best_header.read().to_owned()
     }
 
-    pub fn shared_best_header_ref(&self) -> RwLockReadGuard<HeaderView> {
+    pub fn shared_best_header_ref(&self) -> RwLockReadGuard<HeaderIndexView> {
         self.shared_best_header.read()
     }
 
@@ -1713,7 +1755,7 @@ impl SyncState {
         &self.header_map
     }
 
-    pub fn may_set_shared_best_header(&self, header: HeaderView) {
+    pub fn may_set_shared_best_header(&self, header: HeaderIndexView) {
         if !header.is_better_than(self.shared_best_header.read().total_difficulty()) {
             return;
         }
@@ -2070,22 +2112,25 @@ impl ActiveChain {
         self.shared.shared().is_initial_block_download()
     }
 
-    pub fn get_ancestor(&self, base: &Byte32, number: BlockNumber) -> Option<core::HeaderView> {
+    pub fn get_ancestor(&self, base: &Byte32, number: BlockNumber) -> Option<HeaderIndexView> {
         let tip_number = self.tip_number();
-        self.shared.get_header_view(base, None)?.get_ancestor(
-            tip_number,
-            number,
-            |hash, store_first_opt| self.shared.get_header_view(hash, store_first_opt),
-            |number, current| {
-                // shortcut to return an ancestor block
-                if current.number <= tip_number && self.snapshot().is_main_chain(&current.hash) {
-                    self.get_block_hash(number)
-                        .and_then(|hash| self.shared.get_header_view(&hash, Some(true)))
-                } else {
-                    None
-                }
-            },
-        )
+        self.shared
+            .get_header_index_view(base, false)?
+            .get_ancestor(
+                tip_number,
+                number,
+                |hash, store_first| self.shared.get_header_index_view(hash, store_first),
+                |number, current| {
+                    // shortcut to return an ancestor block
+                    if current.number <= tip_number && self.snapshot().is_main_chain(&current.hash)
+                    {
+                        self.get_block_hash(number)
+                            .and_then(|hash| self.shared.get_header_index_view(&hash, true))
+                    } else {
+                        None
+                    }
+                },
+            )
     }
 
     pub fn get_locator(&self, start: BlockNumberAndHash) -> Vec<Byte32> {
@@ -2152,7 +2197,9 @@ impl ActiveChain {
             (pa.clone(), pb.clone())
         };
 
-        m_right = self.get_ancestor(&m_right.hash(), m_left.number())?.into();
+        m_right = self
+            .get_ancestor(&m_right.hash(), m_left.number())?
+            .number_and_hash();
         if m_left == m_right {
             return Some(m_left);
         }
@@ -2161,10 +2208,10 @@ impl ActiveChain {
         while m_left != m_right {
             m_left = self
                 .get_ancestor(&m_left.hash(), m_left.number() - 1)?
-                .into();
+                .number_and_hash();
             m_right = self
                 .get_ancestor(&m_right.hash(), m_right.number() - 1)?
-                .into();
+                .number_and_hash();
         }
         Some(m_left)
     }

--- a/traits/src/header_provider.rs
+++ b/traits/src/header_provider.rs
@@ -1,5 +1,5 @@
 use ckb_types::{
-    core::{BlockNumber, HeaderView},
+    core::{BlockNumber, EpochNumberWithFraction, HeaderView},
     packed::Byte32,
 };
 
@@ -7,27 +7,39 @@ use ckb_types::{
 pub trait HeaderProvider {
     /// Get the header of the given block hash
     fn get_header(&self, hash: &Byte32) -> Option<HeaderView>;
+}
 
-    /// Get timestamp and block_number of the corresponding block_hash, and hash of parent block
-    fn timestamp_and_parent(&self, block_hash: &Byte32) -> (u64, BlockNumber, Byte32) {
-        let header = self.get_header(block_hash).expect("parent header exist");
-        (
-            header.timestamp(),
-            header.number(),
-            header.data().raw().parent_hash(),
-        )
-    }
+/// A compact representation of header fields, used for header verification and median time calculation
+pub struct HeaderFields {
+    /// Block hash
+    pub hash: Byte32,
+    /// Block number
+    pub number: BlockNumber,
+    /// Block epoch
+    pub epoch: EpochNumberWithFraction,
+    /// Block timestamp
+    pub timestamp: u64,
+    /// Block parent hash
+    pub parent_hash: Byte32,
+}
+
+/// Trait for header fields storage
+pub trait HeaderFieldsProvider {
+    /// Get the header fields of the given block hash
+    fn get_header_fields(&self, hash: &Byte32) -> Option<HeaderFields>;
 
     /// Get past block median time, **including the timestamp of the given one**
     fn block_median_time(&self, block_hash: &Byte32, median_block_count: usize) -> u64 {
         let mut timestamps: Vec<u64> = Vec::with_capacity(median_block_count);
         let mut block_hash = block_hash.clone();
         for _ in 0..median_block_count {
-            let (timestamp, block_number, parent_hash) = self.timestamp_and_parent(&block_hash);
-            timestamps.push(timestamp);
-            block_hash = parent_hash;
+            let header_fields = self
+                .get_header_fields(&block_hash)
+                .expect("parent header exist");
+            timestamps.push(header_fields.timestamp);
+            block_hash = header_fields.parent_hash;
 
-            if block_number == 0 {
+            if header_fields.number == 0 {
                 break;
             }
         }
@@ -35,11 +47,5 @@ pub trait HeaderProvider {
         // return greater one if count is even.
         timestamps.sort_unstable();
         timestamps[timestamps.len() >> 1]
-    }
-}
-
-impl HeaderProvider for Box<dyn Fn(Byte32) -> Option<HeaderView>> {
-    fn get_header(&self, hash: &Byte32) -> Option<HeaderView> {
-        (self)(hash.to_owned())
     }
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -5,4 +5,4 @@ mod header_provider;
 
 pub use crate::cell_data_provider::CellDataProvider;
 pub use crate::epoch_provider::{BlockEpoch, EpochProvider};
-pub use crate::header_provider::HeaderProvider;
+pub use crate::header_provider::*;

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -125,13 +125,13 @@ impl Default for HeaderMapConfig {
         Self {
             primary_limit: None,
             backend_close_threshold: None,
-            memory_limit: ByteUnit::Megabyte(600),
+            memory_limit: default_memory_limit(),
         }
     }
 }
 
 const fn default_memory_limit() -> ByteUnit {
-    ByteUnit::Megabyte(600)
+    ByteUnit::Megabyte(256)
 }
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/util/snapshot/src/lib.rs
+++ b/util/snapshot/src/lib.rs
@@ -16,7 +16,7 @@ use ckb_merkle_mountain_range::{
 };
 use ckb_proposal_table::ProposalView;
 use ckb_store::{ChainStore, StoreCache, StoreSnapshot};
-use ckb_traits::HeaderProvider;
+use ckb_traits::{HeaderFields, HeaderFieldsProvider, HeaderProvider};
 use ckb_types::core::error::OutPointError;
 use ckb_types::{
     core::{
@@ -269,6 +269,20 @@ impl HeaderChecker for Snapshot {
 impl HeaderProvider for Snapshot {
     fn get_header(&self, hash: &Byte32) -> Option<HeaderView> {
         self.store.get_block_header(hash)
+    }
+}
+
+impl HeaderFieldsProvider for Snapshot {
+    fn get_header_fields(&self, hash: &Byte32) -> Option<HeaderFields> {
+        self.store
+            .get_block_header(hash)
+            .map(|header| HeaderFields {
+                hash: header.hash(),
+                number: header.number(),
+                epoch: header.epoch(),
+                timestamp: header.timestamp(),
+                parent_hash: header.parent_hash(),
+            })
     }
 }
 

--- a/verification/src/header_verifier.rs
+++ b/verification/src/header_verifier.rs
@@ -6,8 +6,8 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_error::Error;
 use ckb_pow::PowEngine;
 use ckb_systemtime::unix_time_as_millis;
-use ckb_traits::HeaderProvider;
-use ckb_types::core::{HeaderView, Version};
+use ckb_traits::HeaderFieldsProvider;
+use ckb_types::core::{BlockNumber, EpochNumberWithFraction, HeaderView, Version};
 use ckb_verification_traits::Verifier;
 
 /// Context-dependent verification checks for block header
@@ -18,7 +18,7 @@ pub struct HeaderVerifier<'a, DL> {
     consensus: &'a Consensus,
 }
 
-impl<'a, DL: HeaderProvider> HeaderVerifier<'a, DL> {
+impl<'a, DL: HeaderFieldsProvider> HeaderVerifier<'a, DL> {
     /// Crate new HeaderVerifier
     pub fn new(data_loader: &'a DL, consensus: &'a Consensus) -> Self {
         HeaderVerifier {
@@ -28,20 +28,20 @@ impl<'a, DL: HeaderProvider> HeaderVerifier<'a, DL> {
     }
 }
 
-impl<'a, DL: HeaderProvider> Verifier for HeaderVerifier<'a, DL> {
+impl<'a, DL: HeaderFieldsProvider> Verifier for HeaderVerifier<'a, DL> {
     type Target = HeaderView;
     fn verify(&self, header: &Self::Target) -> Result<(), Error> {
         VersionVerifier::new(header, self.consensus.block_version()).verify()?;
         // POW check first
         PowVerifier::new(header, self.consensus.pow_engine().as_ref()).verify()?;
-        let parent = self
+        let parent_fields = self
             .data_loader
-            .get_header(&header.parent_hash())
+            .get_header_fields(&header.parent_hash())
             .ok_or_else(|| UnknownParentError {
                 parent_hash: header.parent_hash(),
             })?;
-        NumberVerifier::new(&parent, header).verify()?;
-        EpochVerifier::new(&parent, header).verify()?;
+        NumberVerifier::new(parent_fields.number, header).verify()?;
+        EpochVerifier::new(parent_fields.epoch, header).verify()?;
         TimestampVerifier::new(
             self.data_loader,
             header,
@@ -84,7 +84,7 @@ pub struct TimestampVerifier<'a, DL> {
     now: u64,
 }
 
-impl<'a, DL: HeaderProvider> TimestampVerifier<'a, DL> {
+impl<'a, DL: HeaderFieldsProvider> TimestampVerifier<'a, DL> {
     pub fn new(data_loader: &'a DL, header: &'a HeaderView, median_block_count: usize) -> Self {
         TimestampVerifier {
             data_loader,
@@ -126,19 +126,19 @@ impl<'a, DL: HeaderProvider> TimestampVerifier<'a, DL> {
 /// Checks if the block number of the given header matches the expected number,
 /// which is the parent block's number + 1.
 pub struct NumberVerifier<'a> {
-    parent: &'a HeaderView,
+    parent: BlockNumber,
     header: &'a HeaderView,
 }
 
 impl<'a> NumberVerifier<'a> {
-    pub fn new(parent: &'a HeaderView, header: &'a HeaderView) -> Self {
+    pub fn new(parent: BlockNumber, header: &'a HeaderView) -> Self {
         NumberVerifier { parent, header }
     }
 
     pub fn verify(&self) -> Result<(), Error> {
-        if self.header.number() != self.parent.number() + 1 {
+        if self.header.number() != self.parent + 1 {
             return Err(NumberError {
-                expected: self.parent.number() + 1,
+                expected: self.parent + 1,
                 actual: self.header.number(),
             }
             .into());
@@ -148,12 +148,12 @@ impl<'a> NumberVerifier<'a> {
 }
 
 pub struct EpochVerifier<'a> {
-    parent: &'a HeaderView,
+    parent: EpochNumberWithFraction,
     header: &'a HeaderView,
 }
 
 impl<'a> EpochVerifier<'a> {
-    pub fn new(parent: &'a HeaderView, header: &'a HeaderView) -> Self {
+    pub fn new(parent: EpochNumberWithFraction, header: &'a HeaderView) -> Self {
         EpochVerifier { parent, header }
     }
 
@@ -164,10 +164,10 @@ impl<'a> EpochVerifier<'a> {
             }
             .into());
         }
-        if !self.parent.is_genesis() && !self.header.epoch().is_successor_of(self.parent.epoch()) {
+        if !self.parent.is_genesis() && !self.header.epoch().is_successor_of(self.parent) {
             return Err(EpochError::NonContinuous {
                 current: self.header.epoch(),
-                parent: self.parent.epoch(),
+                parent: self.parent,
             }
             .into());
         }

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -119,10 +119,9 @@ fn test_timestamp_too_new() {
 
 #[test]
 fn test_number() {
-    let parent = HeaderBuilder::new_with_number(10).build();
     let header = HeaderBuilder::new_with_number(10).build();
 
-    let verifier = NumberVerifier::new(&parent, &header);
+    let verifier = NumberVerifier::new(10, &header);
     assert_error_eq!(
         verifier.verify().unwrap_err(),
         NumberError {
@@ -135,10 +134,7 @@ fn test_number() {
 #[test]
 fn test_epoch() {
     {
-        let parent = HeaderBuilder::default()
-            .number(1u64.pack())
-            .epoch(EpochNumberWithFraction::new(1, 1, 10).pack())
-            .build();
+        let parent = EpochNumberWithFraction::new(1, 1, 10);
         let epochs_malformed = vec![
             EpochNumberWithFraction::new_unchecked(1, 0, 0),
             EpochNumberWithFraction::new_unchecked(1, 10, 0),
@@ -150,7 +146,7 @@ fn test_epoch() {
             let malformed = HeaderBuilder::default()
                 .epoch(epoch_malformed.pack())
                 .build();
-            let result = EpochVerifier::new(&parent, &malformed).verify();
+            let result = EpochVerifier::new(parent, &malformed).verify();
             assert!(result.is_err(), "input: {epoch_malformed:#}");
             assert_error_eq!(
                 result.unwrap_err(),
@@ -192,20 +188,16 @@ fn test_epoch() {
             ),
         ];
 
-        for (epoch_parent, epoch_current) in epochs {
-            let parent = HeaderBuilder::default()
-                .number(1u64.pack())
-                .epoch(epoch_parent.pack())
-                .build();
+        for (parent, epoch_current) in epochs {
             let current = HeaderBuilder::default().epoch(epoch_current.pack()).build();
 
-            let result = EpochVerifier::new(&parent, &current).verify();
+            let result = EpochVerifier::new(parent, &current).verify();
             assert!(result.is_err(), "current: {current:#}, parent: {parent:#}");
             assert_error_eq!(
                 result.unwrap_err(),
                 EpochError::NonContinuous {
                     current: epoch_current,
-                    parent: epoch_parent,
+                    parent,
                 },
             );
         }
@@ -225,14 +217,10 @@ fn test_epoch() {
                 EpochNumberWithFraction::new_unchecked(2, 0, 11),
             ),
         ];
-        for (epoch_parent, epoch_current) in epochs {
-            let parent = HeaderBuilder::default()
-                .number(1u64.pack())
-                .epoch(epoch_parent.pack())
-                .build();
+        for (parent, epoch_current) in epochs {
             let current = HeaderBuilder::default().epoch(epoch_current.pack()).build();
 
-            let result = EpochVerifier::new(&parent, &current).verify();
+            let result = EpochVerifier::new(parent, &current).verify();
             assert!(result.is_ok(), "current: {current:#}, parent: {parent:#}");
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

resolve https://github.com/nervosnetwork/ckb/issues/3940

### What is changed and how it works?

replace the struct `HeaderView` of sync mod with a more memory compact struct `HeaderIndexView`, and avoid holding headers messages in memory (remove bytes slice clone).

Compare with v0.109.0, this PR reduced the peak memory usage from 3.8G to 2.8G during IBD sync on my local PC. @jiangxianliang007 also did test on an aws c5.xlarge instance (4C8G), it reduced from 3.2G to 2.3G, sync performance has also improved, from 0 to 9 million, dropping from 19 hours and 25 minutes to 17 hours and 30 minutes. 

please not that this PR didn't replace the HeaderMap storage sled with other solution, there is another PR in testing

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

