### PR TITLE
chore: fix publish-crates.sh for macOS

### DIFF
--- a/devtools/release/publish-crates.sh
+++ b/devtools/release/publish-crates.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 [ -n "${DEBUG:-}" ] && set -x || true
 
-CRATES="$(cat Cargo.toml | sed -n -e '0, /^members/d' -e '/^\]$/, $d' -e 's/.*["'\'']\(.*\)["'\''].*/\1/p')"
+CRATES="$(cat Cargo.toml | sed -n -e '1, /^members/d' -e '/^\]$/, $d' -e 's/.*["'\'']\(.*\)["'\''].*/\1/p')"
 RUST_VERSION="$(cat rust-toolchain)"
 
 retry_cargo_publish() {


### PR DESCRIPTION
### What problem does this PR solve?

The line starts at 1 in sed. While 0 also works for GNU sed, the BSD
variant sed does not recognize the line number 0.

Test cases:

```
macos$ date | sed -e '0, /./d'
Sun May  7 11:45:37 CST 2023

// brew install gnu-sed
// gnu variant outputs nothing
macos$ date | gsed -e '0, /./d'
```


### What is changed and how it works?

What's Changed: use 1 instead of 0 for the first line.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
