### PR TITLE
Trivial fix for `ckb2023`

### DIFF
--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -51,7 +51,7 @@ pub enum ScriptVersion {
     V0 = 0,
     /// CKB VM 1 with Syscall version 1 and version 2.
     V1 = 1,
-    /// /// CKB VM 1 with Syscall version 1, version 2 and version 3.
+    /// CKB VM 2 with Syscall version 1, version 2 and version 3.
     V2 = 2,
 }
 

--- a/script/testdata/README.md
+++ b/script/testdata/README.md
@@ -6,8 +6,6 @@
 
   - Clone https://github.com/nervosnetwork/ckb-c-stdlib into `deps`.
 
-    Checkout the commit 6665e3a289648a0da69b818ea620aeb5e8d74e3b.
-
 - Build all scripts with `docker`.
 
   ```shell

--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -145,6 +145,7 @@ fn protocol_name(protocol_id: ProtocolId) -> String {
         100 => SupportProtocols::Sync.name(),
         101 => SupportProtocols::RelayV2.name(),
         102 => SupportProtocols::Time.name(),
+        103 => SupportProtocols::RelayV3.name(),
         110 => SupportProtocols::Alert.name(),
         120 => SupportProtocols::LightClient.name(),
         121 => SupportProtocols::Filter.name(),


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:

### Related changes

- Fix `ScriptVersion`'s comment
- Remove `ckb-c-stdlib`'s specific commit hash in `script/testdata/README.md`
- support `fn protocol_name` to check `RelayV3` for `ckb_metrics`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

