### PR TITLE
RPC: Set `jsonrpc::Ratio` as the type of  `threshold` field for  `DeploymentsInfo` and `Deployment` 

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1692,8 +1692,8 @@ Response
                     "period": "0xa",
                     "start": "0x0",
                     "threshold": {
-                        "denom": 4,
-                        "numer": 3
+                        "denom": "0x4",
+                        "numer": "0x3"
                     },
                     "timeout": "0x0"
                 }
@@ -4730,8 +4730,8 @@ Response
                "state": "failed",
                "timeout": "0x0",
                "threshold": {
-                    "numer": 3,
-                    "denom": 4
+                    "numer": "0x3",
+                    "denom": "0x4"
                 }
            }
        }
@@ -6494,6 +6494,13 @@ A non-cellbase transaction is committed at height h_c if all of the following co
 
 Represents the ratio `numerator / denominator`, where `numerator` and `denominator` are both unsigned 64-bit integers.
 
+#### Fields
+
+`Ratio` is a JSON object with the following fields.
+
+*   `numer`: [`Uint64`](#type-uint64) - Numerator.
+
+*   `denom`: [`Uint64`](#type-uint64) - Denominator.
 
 
 ### Type `RationalU256`

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1374,8 +1374,8 @@ pub trait ChainRpc {
     ///                     "period": "0xa",
     ///                     "start": "0x0",
     ///                     "threshold": {
-    ///                         "denom": 4,
-    ///                         "numer": 3
+    ///                         "denom": "0x4",
+    ///                         "numer": "0x3"
     ///                     },
     ///                     "timeout": "0x0"
     ///                 }

--- a/rpc/src/module/stats.rs
+++ b/rpc/src/module/stats.rs
@@ -87,8 +87,8 @@ pub trait StatsRpc {
     ///                "state": "failed",
     ///                "timeout": "0x0",
     ///                "threshold": {
-    ///                     "numer": 3,
-    ///                     "denom": 4
+    ///                     "numer": "0x3",
+    ///                     "denom": "0x4"
     ///                 }
     ///            }
     ///        }

--- a/spec/src/versionbits/convert.rs
+++ b/spec/src/versionbits/convert.rs
@@ -23,7 +23,7 @@ impl From<Deployment> for DeploymentInfo {
             timeout: deployment.timeout.into(),
             min_activation_epoch: deployment.min_activation_epoch.into(),
             period: deployment.period.into(),
-            threshold: deployment.threshold,
+            threshold: deployment.threshold.into(),
             state: DeploymentState::Defined,
             since: 0.into(),
         }
@@ -38,7 +38,7 @@ impl From<Deployment> for ckb_jsonrpc_types::Deployment {
             timeout: deployment.timeout.into(),
             min_activation_epoch: deployment.min_activation_epoch.into(),
             period: deployment.period.into(),
-            threshold: deployment.threshold,
+            threshold: deployment.threshold.into(),
         }
     }
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1438,6 +1438,25 @@ pub struct Rfc0043 {
     pub rfc0043: Deployment,
 }
 
+/// Represents the ratio `numerator / denominator`, where `numerator` and `denominator` are both
+/// unsigned 64-bit integers.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Ratio {
+    /// Numerator.
+    pub numer: Uint64,
+    /// Denominator.
+    pub denom: Uint64,
+}
+
+impl From<core::Ratio> for Ratio {
+    fn from(value: core::Ratio) -> Self {
+        Ratio {
+            numer: value.numer().into(),
+            denom: value.denom().into(),
+        }
+    }
+}
+
 /// RFC0043 deployment params
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Deployment {
@@ -1456,7 +1475,7 @@ pub struct Deployment {
     pub period: EpochNumber,
     /// Specifies the minimum ratio of block per `period`,
     /// which indicate the locked_in of the softfork during the `period`.
-    pub threshold: core::Ratio,
+    pub threshold: Ratio,
 }
 
 fn convert(number: core::EpochNumber) -> Option<EpochNumber> {

--- a/util/jsonrpc-types/src/info.rs
+++ b/util/jsonrpc-types/src/info.rs
@@ -1,5 +1,5 @@
-use crate::{AlertMessage, EpochNumber, EpochNumberWithFraction, Timestamp};
-use ckb_types::{core::Ratio, H256, U256};
+use crate::{AlertMessage, EpochNumber, EpochNumberWithFraction, Ratio, Timestamp};
+use ckb_types::{H256, U256};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::blockchain::{
     Block, BlockEconomicState, BlockFilter, BlockIssuance, BlockResponse, BlockView,
     BlockWithCyclesResponse, CellDep, CellInput, CellOutput, Consensus, DepType, Deployment,
     EpochView, FeeRateStatistics, HardForkFeature, Header, HeaderView, MerkleProof, MinerReward,
-    OutPoint, ProposalWindow, Script, ScriptHashType, SoftFork, Status, Transaction,
+    OutPoint, ProposalWindow, Ratio, Script, ScriptHashType, SoftFork, Status, Transaction,
     TransactionAndWitnessProof, TransactionProof, TransactionView, TransactionWithStatusResponse,
     TxStatus, UncleBlock, UncleBlockView,
 };


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #3978 

Problem Summary:

### What is changed and how it works?

What's Changed:

### Related changes

- Add `Ratio` struct in `ckb-jsonrpc` crate
- Set `jsonrpc::Ratio` as the type of `threshold` field for `DeploymentsInfo` and `Deployment`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- It's a break change

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

