### PR TITLE
ci: `ckb_replay` more blocks to avoid CI failure

### DIFF
--- a/util/app-config/src/tests/ckb_run_replay.bats
+++ b/util/app-config/src/tests/ckb_run_replay.bats
@@ -10,8 +10,8 @@ _ckb_run() {
   tail -n 50 ${TMP_DIR}/ckb_run.log
 }
 _ckb_replay() {
-  # from 1 to 2000 enough to trigger profile action
-  CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} --profile 1 2000
+  # from 1 to 2500 enough to trigger profile action
+  CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} --profile 1 2500
 }
 
 function ckb_run { #@test


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
`ckb2023` branch got a ci failure:
https://github.com/nervosnetwork/ckb/actions/runs/4989131088/jobs/8933105360?pr=3917

https://github.com/nervosnetwork/ckb/blob/c63e2f3671892a47f2663542a47cb5223e15bbbf/util/app-config/src/tests/ckb_run_replay.bats#L13-L14

`ckb_replay` bat test only profile 2000 blocks, this may cause bat test failure.

### Related changes

- Increase blocks count in ckb_replay test.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

