### PR TITLE
scripts(spawn): deduct cycls used to build the machine

### DIFF
--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -85,6 +85,8 @@ pub const SPAWN_MAX_MEMORY: u64 = 8;
 pub const SPAWN_MAX_PEAK_MEMORY: u64 = 64; // 64 * 0.5M = 32M
 pub const SPAWN_MEMORY_PAGE_SIZE: u64 = 512 * 1024; // 0.5M
 pub const SPAWN_MAX_CONTENT_LENGTH: u64 = 256 * 1024; // 256K
+pub const SPAWN_EXTRA_CYCLES_BASE: u64 = 100_000;
+pub const SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE: u64 = 8192;
 
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
 enum CellField {


### PR DESCRIPTION
### What problem does this PR solve?

A spawn's cycles consumption does not match its actual resource consumption.

### What is changed and how it works?

After build the machine, deduct an extra cycls.

```text
extra_cycles = 100_000 + memory_size_in_bytes / 64
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

