### PR TITLE
fix: fix tmp dir early drop on test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-librocksdb-sys"
-version = "7.7.3"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb64bb11f8d53b9abb526b7e9d3c5fb437a8101e4210d540d2bcee0d18055313"
+checksum = "5d9bc1ea9ab886ecbf48bc4ade6d383ba56cf3da198b6a51620736daf74b683c"
 dependencies = [
  "bindgen",
  "cc",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rocksdb"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9d412caf8a7fe9080bf2c66209e1b6d9aab336c417b336adde47e184c78c41"
+checksum = "c2331a8580072e2991e77277d2c3e999c8df0d00b16188a77e561e45a4597769"
 dependencies = [
  "ckb-librocksdb-sys",
  "libc",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -13,7 +13,7 @@ ckb-app-config = { path = "../util/app-config", version = "= 0.111.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.111.0-pre" }
 ckb-error = { path = "../error", version = "= 0.111.0-pre" }
 libc = "0.2"
-rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", features = ["snappy"], default-features = false }
+rocksdb = { package = "ckb-rocksdb", version ="=0.20.0", features = ["snappy"], default-features = false }
 ckb-db-schema = { path = "../db-schema", version = "= 0.111.0-pre" }
 
 [dev-dependencies]

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -35,6 +35,7 @@ struct Node {
     listen_addr: Multiaddr,
     control: ServiceControl,
     network_state: Arc<NetworkState>,
+    _tmp_dir: tempfile::TempDir,
 }
 
 impl Node {
@@ -110,13 +111,11 @@ fn net_service_start(
     required_flags: Flags,
     self_flags: Flags,
 ) -> Node {
+    let tmp_dir = tempdir().expect("create tempdir failed");
     let config = NetworkConfig {
         max_peers: 19,
         max_outbound_peers: 5,
-        path: tempdir()
-            .expect("create tempdir failed")
-            .path()
-            .to_path_buf(),
+        path: tmp_dir.path().to_path_buf(),
         ping_interval_secs: 15,
         ping_timeout_secs: 20,
         connect_outbound_interval_secs: 1,
@@ -259,6 +258,7 @@ fn net_service_start(
         control,
         listen_addr,
         network_state,
+        _tmp_dir: tmp_dir,
     }
 }
 

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 thiserror = "1.0"
-rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", features = ["snappy"], default-features = false }
+rocksdb = { package = "ckb-rocksdb", version ="=0.20.0", features = ["snappy"], default-features = false }
 ckb-db-schema = { path = "../../db-schema", version = "= 0.111.0-pre" }
 ckb-types = { path = "../types", version = "= 0.111.0-pre" }
 ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.111.0-pre" }


### PR DESCRIPTION
### What problem does this PR solve?

1. tmpdir must hold until the test is finished, otherwise, it may delete before the test start
2. upgrade rocksdb to [0.20](https://github.com/nervosnetwork/rust-rocksdb/pull/45)

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

