### PR TITLE
feat: Suspend support in spawn syscalls

### DIFF
--- a/script/src/syscalls/mod.rs
+++ b/script/src/syscalls/mod.rs
@@ -12,7 +12,7 @@ mod load_script_hash;
 mod load_tx;
 mod load_witness;
 mod set_content;
-mod spawn;
+pub(crate) mod spawn;
 mod utils;
 mod vm_version;
 

--- a/script/src/syscalls/spawn.rs
+++ b/script/src/syscalls/spawn.rs
@@ -297,7 +297,7 @@ pub fn build_child_machine<
         script_version,
         script_group,
         callee_peak_memory,
-        context.clone(),
+        Arc::clone(context),
     )));
     let mut machine_child = Machine::new(machine_builder.build());
     set_vm_max_cycles(&mut machine_child, cycles_limit);

--- a/script/src/syscalls/spawn.rs
+++ b/script/src/syscalls/spawn.rs
@@ -206,6 +206,10 @@ where
             argv_vec.push(cstr);
             addr += 8;
         }
+        // Deduct cycles used to build the child machine
+        let extra_cycles =
+            SPAWN_EXTRA_CYCLES_BASE + memory_limit * SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE;
+        machine_child.machine.add_cycles_no_checking(extra_cycles)?;
         // Load program into child machine.
         match machine_child.load_program(&program, &argv_vec) {
             Ok(size) => {
@@ -218,10 +222,6 @@ where
                 return Ok(true);
             }
         }
-        // Deduct cycles used to build the child machine
-        let extra_cycles =
-            SPAWN_EXTRA_CYCLES_BASE + memory_limit * SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE;
-        machine_child.machine.add_cycles_no_checking(extra_cycles)?;
         // Run the child machine and check result.
         match machine_child.run() {
             Ok(data) => {

--- a/script/src/syscalls/spawn.rs
+++ b/script/src/syscalls/spawn.rs
@@ -6,7 +6,9 @@ use crate::syscalls::{
     SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE, SPAWN_MAX_CONTENT_LENGTH, SPAWN_MAX_MEMORY,
     SPAWN_MAX_PEAK_MEMORY, SPAWN_MEMORY_PAGE_SIZE, SPAWN_WRONG_MEMORY_LIMIT, WRONG_FORMAT,
 };
-use crate::types::{set_vm_max_cycles, CoreMachineType, Machine};
+use crate::types::{
+    set_vm_max_cycles, CoreMachineType, Machine, MachineContext, ResumableMachine, ResumeData,
+};
 use crate::TransactionScriptsSyscallsGenerator;
 use crate::{ScriptGroup, ScriptVersion};
 use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
@@ -23,6 +25,7 @@ pub struct Spawn<DL> {
     script_version: ScriptVersion,
     syscalls_generator: TransactionScriptsSyscallsGenerator<DL>,
     peak_memory: u64,
+    context: Arc<Mutex<MachineContext>>,
 }
 
 impl<DL: CellDataProvider + Clone + HeaderProvider + Send + Sync + 'static> Spawn<DL> {
@@ -31,12 +34,14 @@ impl<DL: CellDataProvider + Clone + HeaderProvider + Send + Sync + 'static> Spaw
         script_version: ScriptVersion,
         syscalls_generator: TransactionScriptsSyscallsGenerator<DL>,
         peak_memory: u64,
+        context: Arc<Mutex<MachineContext>>,
     ) -> Self {
         Self {
             script_group,
             script_version,
             syscalls_generator,
             peak_memory,
+            context,
         }
     }
 
@@ -142,47 +147,23 @@ where
             return Ok(true);
         }
         // Build child machine.
-        let machine_content = Arc::new(Mutex::new(Vec::<u8>::new()));
-        let mut machine_child = {
-            let machine_isa = self.script_version.vm_isa();
-            let machine_version = self.script_version.vm_version();
-            let machine_core = CoreMachineType::new_with_memory(
-                machine_isa,
-                machine_version,
-                cycles_limit,
-                (memory_limit * SPAWN_MEMORY_PAGE_SIZE) as usize,
-            );
-            let machine_builder = DefaultMachineBuilder::new(machine_core)
-                .instruction_cycle_func(Box::new(estimate_cycles));
-            let machine_syscalls = self
-                .syscalls_generator
-                .generate_same_syscalls(self.script_version, &self.script_group);
-            let machine_builder = machine_syscalls
-                .into_iter()
-                .fold(machine_builder, |builder, syscall| builder.syscall(syscall));
-            let machine_builder = machine_builder.syscall(Box::new(
-                self.syscalls_generator.build_get_memory_limit(memory_limit),
-            ));
-            let machine_builder = machine_builder.syscall(Box::new(
-                self.syscalls_generator
-                    .build_set_content(Arc::clone(&machine_content), content_length.to_u64()),
-            ));
-            let machine_builder =
-                machine_builder.syscall(Box::new(self.syscalls_generator.build_spawn(
-                    self.script_version,
-                    &self.script_group,
-                    self.peak_memory + memory_limit,
-                )));
-            let mut machine_child = Machine::new(machine_builder.build());
-            set_vm_max_cycles(&mut machine_child, cycles_limit);
-            machine_child
+        let resume_data = ResumeData::Spawn {
+            callee_peak_memory: self.peak_memory + memory_limit,
+            callee_memory_limit: memory_limit,
+            content: Arc::new(Mutex::new(Vec::<u8>::new())),
+            content_length: content_length.to_u64(),
+            caller_exit_code_addr: exit_code_addr.to_u64(),
+            caller_content_addr: content_addr.to_u64(),
+            caller_content_length_addr: content_length_addr.to_u64(),
         };
-
-        // Deduct cycles used to build the machine
-        let extra_cycles =
-            SPAWN_EXTRA_CYCLES_BASE + memory_limit * SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE;
-        machine_child.machine.add_cycles_no_checking(extra_cycles)?;
-
+        let mut machine_child = build_child_machine(
+            &self.script_group,
+            self.script_version,
+            &self.syscalls_generator,
+            cycles_limit,
+            &resume_data,
+            &self.context,
+        )?;
         // Get binary.
         let program = {
             let cell = self.fetch_cell(source, index as usize);
@@ -225,7 +206,7 @@ where
             argv_vec.push(cstr);
             addr += 8;
         }
-        // Run child machine.
+        // Load program into child machine.
         match machine_child.load_program(&program, &argv_vec) {
             Ok(size) => {
                 machine_child
@@ -237,24 +218,128 @@ where
                 return Ok(true);
             }
         }
-        // Check result.
+        // Deduct cycles used to build the child machine
+        let extra_cycles =
+            SPAWN_EXTRA_CYCLES_BASE + memory_limit * SPAWN_EXTRA_CYCLES_PER_MEMORY_PAGE;
+        machine_child.machine.add_cycles_no_checking(extra_cycles)?;
+        // Run the child machine and check result.
         match machine_child.run() {
             Ok(data) => {
-                machine.set_register(A0, Mac::REG::from_u32(0));
-                machine
-                    .memory_mut()
-                    .store8(&exit_code_addr, &Mac::REG::from_i8(data))?;
-                machine
-                    .memory_mut()
-                    .store_bytes(content_addr.to_u64(), &machine_content.lock().unwrap())?;
-                machine.memory_mut().store64(
-                    &content_length_addr,
-                    &Mac::REG::from_u64(machine_content.lock().unwrap().len() as u64),
-                )?;
-                machine.add_cycles_no_checking(machine_child.machine.cycles())?;
+                update_caller_machine(machine, data, machine_child.machine.cycles(), &resume_data)?;
                 Ok(true)
+            }
+            Err(VMError::CyclesExceeded) => {
+                let mut context = self
+                    .context
+                    .lock()
+                    .map_err(|e| VMError::Unexpected(format!("Failed to acquire lock: {}", e)))?;
+                context
+                    .suspended_machines
+                    .push(ResumableMachine::new(machine_child, resume_data));
+                Err(VMError::CyclesExceeded)
             }
             Err(err) => Err(err),
         }
     }
+}
+
+pub fn build_child_machine<
+    DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + Clone + 'static,
+>(
+    script_group: &ScriptGroup,
+    script_version: ScriptVersion,
+    syscalls_generator: &TransactionScriptsSyscallsGenerator<DL>,
+    cycles_limit: u64,
+    resume_data: &ResumeData,
+    context: &Arc<Mutex<MachineContext>>,
+) -> Result<Machine, VMError> {
+    let (callee_peak_memory, callee_memory_limit, content, content_length) = match resume_data {
+        ResumeData::Spawn {
+            callee_peak_memory,
+            callee_memory_limit,
+            content,
+            content_length,
+            ..
+        } => (
+            *callee_peak_memory,
+            *callee_memory_limit,
+            content,
+            *content_length,
+        ),
+        _ => {
+            return Err(VMError::Unexpected(
+                "Building child machine requires Spawn variant of ResumeData!".to_string(),
+            ))
+        }
+    };
+
+    let machine_isa = script_version.vm_isa();
+    let machine_version = script_version.vm_version();
+    let machine_core = CoreMachineType::new_with_memory(
+        machine_isa,
+        machine_version,
+        cycles_limit,
+        (callee_memory_limit * SPAWN_MEMORY_PAGE_SIZE) as usize,
+    );
+    let machine_builder =
+        DefaultMachineBuilder::new(machine_core).instruction_cycle_func(Box::new(estimate_cycles));
+    let machine_syscalls = syscalls_generator.generate_same_syscalls(script_version, script_group);
+    let machine_builder = machine_syscalls
+        .into_iter()
+        .fold(machine_builder, |builder, syscall| builder.syscall(syscall));
+    let machine_builder = machine_builder.syscall(Box::new(
+        syscalls_generator.build_get_memory_limit(callee_memory_limit),
+    ));
+    let machine_builder = machine_builder.syscall(Box::new(
+        syscalls_generator.build_set_content(Arc::clone(content), content_length),
+    ));
+    let machine_builder = machine_builder.syscall(Box::new(syscalls_generator.build_spawn(
+        script_version,
+        script_group,
+        callee_peak_memory,
+        context.clone(),
+    )));
+    let mut machine_child = Machine::new(machine_builder.build());
+    set_vm_max_cycles(&mut machine_child, cycles_limit);
+    Ok(machine_child)
+}
+
+pub fn update_caller_machine<Mac: SupportMachine>(
+    caller: &mut Mac,
+    callee_exit_code: i8,
+    callee_cycles: u64,
+    resume_data: &ResumeData,
+) -> Result<(), VMError> {
+    let (content, caller_exit_code_addr, caller_content_addr, caller_content_length_addr) =
+        match resume_data {
+            ResumeData::Spawn {
+                content,
+                caller_exit_code_addr,
+                caller_content_addr,
+                caller_content_length_addr,
+                ..
+            } => (
+                content,
+                *caller_exit_code_addr,
+                *caller_content_addr,
+                *caller_content_length_addr,
+            ),
+            _ => return Ok(()),
+        };
+
+    caller.set_register(A0, Mac::REG::from_u32(0));
+    caller.memory_mut().store8(
+        &Mac::REG::from_u64(caller_exit_code_addr),
+        &Mac::REG::from_i8(callee_exit_code),
+    )?;
+    caller
+        .memory_mut()
+        .store_bytes(caller_content_addr.to_u64(), &content.lock().unwrap())?;
+    caller.memory_mut().store64(
+        &Mac::REG::from_u64(caller_content_length_addr),
+        &Mac::REG::from_u64(content.lock().unwrap().len() as u64),
+    )?;
+    caller.add_cycles_no_checking(callee_cycles)?;
+
+    Ok(())
 }

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -340,6 +340,23 @@ pub struct TransactionState {
 }
 
 impl TransactionState {
+    /// Creates a new TransactionState struct
+    pub fn new(
+        vms: Vec<ResumableMachine>,
+        machine_context: Arc<Mutex<MachineContext>>,
+        current: usize,
+        current_cycles: Cycle,
+        limit_cycles: Cycle,
+    ) -> Self {
+        TransactionState {
+            current,
+            vms,
+            machine_context,
+            current_cycles,
+            limit_cycles,
+        }
+    }
+
     /// Return next limit cycles according to max_cycles and step_cycles
     pub fn next_limit_cycles(&self, step_cycles: Cycle, max_cycles: Cycle) -> (Cycle, bool) {
         let remain = max_cycles - self.current_cycles;

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -114,7 +114,7 @@ pub(crate) type Machine = TraceMachine<CoreMachine>;
 
 /// Common data that would be shared amongst multiple VM instances.
 /// One sample usage right now, is to capture suspended machines in
-/// a chain of spanwed machines.
+/// a chain of spawned machines.
 #[derive(Default)]
 pub struct MachineContext {
     pub(crate) suspended_machines: Vec<ResumableMachine>,

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1094,7 +1094,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             // is reached, the error would be raised when executing the first instruction
             // after the syscall. What's more, when spawn is loading a program
             // to its child machine, it also uses +add_cycles_no_checking+ so it
-            // won't generate errors immediately. This means that all spanwed machines
+            // won't generate errors immediately. This means that all spawned machines
             // will be in a state that a program is loaded, regardless of the fact if
             // loading a program in spawn reaches the cycle limit or not. As a
             // result, we definitely want to pull the trigger, so we can have unified

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1132,8 +1132,7 @@ fn run_vms(
         _ => ScriptError::VMInternalError(format!("{error:?}")),
     };
 
-    while !machines.is_empty() {
-        let mut machine = machines.pop().unwrap();
+    while let Some(mut machine) = machines.pop() {
 
         if let (Some((callee_exit_code, callee_cycles)), Some(callee_spawn_data)) =
             (callee_data, &spawn_data)

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1078,7 +1078,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             // one, we won't generate any snapshots. Starting from this version,
             // we will remove this distinction: when loading program exceeds
             // maximum cycles, the error will be triggered when executing the
-            // first instruction. As as result, now all ResumableMachine will
+            // first instruction. As a result, now all ResumableMachine will
             // be transformed to snapshots. This is due to several considerations:
             //
             // * Let's do a little bit math: right now CKB has a block limit of

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1133,7 +1133,6 @@ fn run_vms(
     };
 
     while let Some(mut machine) = machines.pop() {
-
         if let (Some((callee_exit_code, callee_cycles)), Some(callee_spawn_data)) =
             (callee_data, &spawn_data)
         {
@@ -1166,10 +1165,7 @@ fn run_vms(
                     new_suspended_machines.reverse();
                     machines.push(machine);
                     machines.append(&mut new_suspended_machines);
-                    return Ok(ChunkState::suspended(
-                        machines,
-                        Arc::clone(context),
-                    ));
+                    return Ok(ChunkState::suspended(machines, Arc::clone(context)));
                 }
                 _ => return Err(ScriptError::VMInternalError(format!("{error:?}"))),
             },

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1093,7 +1093,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             // * If you pay attention to the code now, we already have this behavior
             // in the code: most syscalls use +add_cycles_no_checking+ in the code,
             // meaning an error would not be immediately generated when cycle limit
-            // is reached, the error would be raise when executing the first instruction
+            // is reached, the error would be raised when executing the first instruction
             // after the syscall. What's more, when spawn is loading a program
             // to its child machine, it also uses +add_cycles_no_checking+ so it
             // won't generate errors immediately. This means that all spanwed machines

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1165,11 +1165,10 @@ fn run_vms(
                     // The inner most machine lives at the top of the vector,
                     // reverse the list for natural order.
                     new_suspended_machines.reverse();
-                    let mut suspended_machines: Vec<_> = machines.drain(..).collect();
-                    suspended_machines.push(machine);
-                    suspended_machines.append(&mut new_suspended_machines);
+                    machines.push(machine);
+                    machines.append(&mut new_suspended_machines);
                     return Ok(ChunkState::suspended(
-                        suspended_machines,
+                        machines,
                         Arc::clone(context),
                     ));
                 }

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -532,10 +532,7 @@ fn _check_type_id_one_in_one_out_resume(step_cycles: Cycle) -> Result<(), TestCa
             }
 
             while let Some((ty, _, group)) = groups.front().cloned() {
-                match verifier
-                    .verify_group_with_chunk(group, limit, None)
-                    .unwrap()
-                {
+                match verifier.verify_group_with_chunk(group, limit, &[]).unwrap() {
                     ChunkState::Completed(used_cycles) => {
                         cycles += used_cycles;
                         groups.pop_front();
@@ -731,10 +728,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_chunk(step_cycles: Cycle
                 }
             }
             while let Some((_, _, group)) = groups.pop() {
-                match verifier
-                    .verify_group_with_chunk(group, limit, None)
-                    .unwrap()
-                {
+                match verifier.verify_group_with_chunk(group, limit, &[]).unwrap() {
                     ChunkState::Completed(used_cycles) => {
                         cycles += used_cycles;
                     }


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes a bug that when suspend happens when a child machine created by the spawn syscall is running, CKB cannot correctly suspend & resume the VM.

### What is changed and how it works?

What's Changed: the bug relating spawn syscall and suspend / resume feature is fixed.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

