### PR TITLE
`make prod-test` should specify prod features and use `nextest` instead of `cargo test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ prod-docker:
 
 .PHONY: prod-test
 prod-test:
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" cargo test ${VERBOSE} --all -- --nocapture
+	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" CKB_FEATURES="with_sentry,with_dns_seeding" $(MAKE) test
 
 .PHONY: prod-with-debug
 prod-with-debug:


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
`make prod-test` should specify `with_sentry,with_dns_seeding` features, and use `nextest-rs/nextest` instead of `cargo test`.

What's Changed:

### Related changes

- specify `with_sentry,with_dns_seeding` features for `make prod-test`
- use `nextest` to run `prod-test`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

