### PR TITLE
Reduce `PeerStore::load_from_dir_or_default`'s timecost

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -113,6 +113,7 @@ impl NetworkState {
                     })
             })
             .collect();
+        info!("loading the peer store, which may take a few seconds to complete");
         let peer_store = Mutex::new(PeerStore::load_from_dir_or_default(
             config.peer_store_path(),
         ));

--- a/network/src/peer_store/peer_store_db.rs
+++ b/network/src/peer_store/peer_store_db.rs
@@ -78,7 +78,7 @@ impl PeerStore {
                 )
             })
             .and_then(|file| {
-                AddrManager::load(file).map_err(|err| {
+                AddrManager::load(std::io::BufReader::new(file)).map_err(|err| {
                     error!(
                         "Failed to load AddrManager db, file: {:?}, error: {:?}",
                         addr_manager_path, err
@@ -95,7 +95,7 @@ impl PeerStore {
                 )
             })
             .and_then(|file| {
-                BanList::load(file).map_err(|err| {
+                BanList::load(std::io::BufReader::new(file)).map_err(|err| {
                     error!(
                         "Failed to load BanList db, file: {:?}, error: {:?}",
                         ban_list_path, err


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?
In `AddrManager::load`, using `BufReader` reduces the time cost of `serde_json::from_reader(r)` from `8.77s` to `2.25s`, resulting in a `75%` improvement.

What's Changed:

### Related changes

- Use `BufReader` in `PeerStore::load_from_dir_or_default`
- Add info-level log message during startup process to inform about peer store loading.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

