### PR TITLE
feat: let crate `ckb-hash` support `no-std`

### DIFF
--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -6,6 +6,9 @@
 //! * personalization: ckb-default-hash
 //!
 //! [blake2b]: https://blake2.net/blake2.pdf
+
+#![no_std]
+
 #[cfg(target_arch = "wasm32")]
 pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### What problem does this PR solve?

Let `ckb-hash` support `no-std`, so developers don't have to copy constants again and again when write CKB contracts with Rust, such as `CKB_HASH_PERSONALIZATION`, to avoid typos.

For examples:
- [`axonweb3/ckb-type-id`](https://github.com/axonweb3/ckb-type-id/blob/c84032254ede96566e4d490d74c80520032bb92e/src/lib.rs#L81)
- [`synapseweb3/ibc-ckb-contracts`](https://github.com/synapseweb3/ibc-ckb-contracts/blob/c397ab2d586302760f6bccb071db055652561fc0/contracts/eth_light_client/client_type_lock/src/utils/type_id.rs#L5)

### What is changed and how it works?

Both [`blake2b-rs` (when `cfg(not(target_arch = "wasm32"))`)](https://github.com/nervosnetwork/blake2b-rs/blob/807a40354867530d134c9b4cb3c3a77688938045/src/lib.rs#L1) and [`blake2b-ref` (when `cfg(target_arch = "wasm32")`)](https://github.com/jjyr/blake2b-ref.rs/blob/c2b28ecf1334e3fe3a2a6275ba7c99e329b615e9/src/lib.rs#L1) are support `no-std` with default features.

So, just adding `#![no_std]` is enough.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note

```release-note
Title Only: Include only the PR title in the release note.
```