### PR TITLE
fix(scripts): set_debug_printer should updates generator's debug_printer

### DIFF
--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -336,8 +336,6 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
 pub struct TransactionScriptsVerifier<DL> {
     data_loader: DL,
 
-    debug_printer: DebugPrinter,
-
     rtx: Arc<ResolvedTransaction>,
 
     binaries_by_data_hash: HashMap<Byte32, LazyData>,
@@ -464,7 +462,6 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             rtx,
             lock_groups,
             type_groups,
-            debug_printer,
             #[cfg(test)]
             skip_pause,
             consensus,
@@ -483,7 +480,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
     /// * `hash: &Byte32`: this is the script hash of currently running script group.
     /// * `message: &str`: message passed to the debug syscall.
     pub fn set_debug_printer<F: Fn(&Byte32, &str) + Sync + Send + 'static>(&mut self, func: F) {
-        self.debug_printer = Arc::new(func);
+        self.generator.debug_printer = Arc::new(func);
     }
 
     #[cfg(test)]


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Calling `set_debug_printer` will have no effect.

The bug was introduced by this PR: https://github.com/nervosnetwork/ckb/commit/80b3d2177b9ffc45bf1219f7e2e1ac297d3c4660#diff-7e2ff24bf0a62c374be4d4f63d0cbf77a8ca525883575b9ce4609cff1c7e81b8R441-R459

### What is changed and how it works?

What's Changed:

1. Remove TransactionScriptsVerifier's debug_printer member
2. `set_debug_printer` now updates TransactionScriptsSyscallsGenerator's debug_printer

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

