### PR TITLE
Fix: `ckb init` creates config files even when an unsupported spec is specified.

### DIFF
--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -1,6 +1,6 @@
 //! CKB command line arguments parser.
 use ckb_build_info::Version;
-use ckb_resource::{DEFAULT_P2P_PORT, DEFAULT_RPC_PORT, DEFAULT_SPEC};
+use ckb_resource::{AVAILABLE_SPECS, DEFAULT_P2P_PORT, DEFAULT_RPC_PORT, DEFAULT_SPEC};
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 
 /// binary file name(ckb)
@@ -414,6 +414,12 @@ fn init() -> Command {
             Arg::new(ARG_CHAIN)
                 .short('c')
                 .long(ARG_CHAIN)
+                .value_parser(
+                    AVAILABLE_SPECS
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>(),
+                )
                 .default_value(DEFAULT_SPEC)
                 .help("Initializes CKB directory for <chain>"),
         )


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


Problem Summary:

In the current ckb implementation: `ckb init --chain unsupported_spec` will create config files:
![image](https://github.com/nervosnetwork/ckb/assets/46400566/d572543c-1446-448e-81ef-b95d35d39af6)

![image](https://github.com/nervosnetwork/ckb/assets/46400566/e458476d-1300-4d29-8a7a-4bb15dbefdb7)



### What is changed and how it works?

I think config files should NOT be created if `ckb init --chain` got an unsupported spec name.

So I make some change:

What's Changed:

### Related changes

- Add possible values to `ckb init --chain`'s 


![image](https://github.com/nervosnetwork/ckb/assets/46400566/c4789be2-80bf-474f-b285-815c4ef601d1)

![image](https://github.com/nervosnetwork/ckb/assets/46400566/08ffb11d-f010-42d0-98d3-b9aeb3c3e31b)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

