### PR TITLE
fix: get_consensus 2023 info

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1665,7 +1665,10 @@ Response
                 { "rfc": "0036", "epoch_number": "0x0" },
                 { "rfc": "0038", "epoch_number": "0x0" }
             ],
-            "ckb2023": []
+            "ckb2023": [
+                 { "rfc": "0146", "epoch_number": null },
+                 { "rfc": "0148", "epoch_number": null }
+            ]
         },
         "id": "main",
         "initial_primary_epoch_reward": "0x71afd498d000",

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1347,7 +1347,10 @@ pub trait ChainRpc {
     ///                 { "rfc": "0036", "epoch_number": "0x0" },
     ///                 { "rfc": "0038", "epoch_number": "0x0" }
     ///             ],
-    ///             "ckb2023": []
+    ///             "ckb2023": [
+    ///                  { "rfc": "0146", "epoch_number": null },
+    ///                  { "rfc": "0148", "epoch_number": null }
+    ///             ]
     ///         },
     ///         "id": "main",
     ///         "initial_primary_epoch_reward": "0x71afd498d000",

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1402,7 +1402,10 @@ impl HardForks {
                 HardForkFeature::new("0036", convert(hardforks.ckb2021.rfc_0036())),
                 HardForkFeature::new("0038", convert(hardforks.ckb2021.rfc_0038())),
             ],
-            ckb2023: vec![],
+            ckb2023: vec![
+                HardForkFeature::new("0146", convert(hardforks.ckb2023.rfc_0146())),
+                HardForkFeature::new("0148", convert(hardforks.ckb2023.rfc_0148())),
+            ],
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The features of 2023 are not displayed correctly by rpc get_consensus


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

