### PR TITLE
Ensure `random_2_in_2_out_rtx()` suspends on first execution

### DIFF
--- a/script/src/verify/tests/utils.rs
+++ b/script/src/verify/tests/utils.rs
@@ -35,7 +35,7 @@ use tempfile::TempDir;
 use crate::verify::*;
 
 pub(crate) const ALWAYS_SUCCESS_SCRIPT_CYCLE: u64 = 537;
-pub(crate) const CYCLE_BOUND: Cycle = 200_000;
+pub(crate) const CYCLE_BOUND: Cycle = 250_000;
 pub(crate) const V2_CYCLE_BOUND: Cycle = 300_000;
 
 fn sha3_256<T: AsRef<[u8]>>(s: T) -> [u8; 32] {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This [CI action](https://github.com/nervosnetwork/ckb/actions/runs/5320745322/jobs/9634931777) failed, because the `2_in_2_out_rtx` may completed after first run.
And we didn't handle the else case:
https://github.com/nervosnetwork/ckb/blob/dbbca4e252f183b53237d286fee5ba31e342f171/script/src/verify/tests/ckb_latest/features_since_v2021.rs#L851-L853
Then `init_state` will be `None`, and panic will happen.

Since the `random_2_in_2_out_rtx` will consume `3276322` cycles, increase `CYCLE_BOUND` from `200_000` to `250_000` will make sure suspend/resume will happen in verification.


What's Changed:

### Related changes

- Increase `CYCLE_BOUND` to `250_000`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

