### PR TITLE
fix: get_consensus compatibility

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -138,7 +138,6 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.67.1.
     * [Type `EstimateCycles`](#type-estimatecycles)
     * [Type `FeeRateStatistics`](#type-feeratestatistics)
     * [Type `H256`](#type-h256)
-    * [Type `HardForkFeature`](#type-hardforkfeature)
     * [Type `HardForks`](#type-hardforks)
     * [Type `Header`](#type-header)
     * [Type `HeaderView`](#type-headerview)
@@ -1655,21 +1654,17 @@ Response
         "dao_type_hash": null,
         "epoch_duration_target": "0x3840",
         "genesis_hash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
-        "hardfork_features": {
-            "ckb2021": [
-                { "rfc": "0028", "epoch_number": "0x1526" },
-                { "rfc": "0029", "epoch_number": "0x0" },
-                { "rfc": "0030", "epoch_number": "0x0" },
-                { "rfc": "0031", "epoch_number": "0x0" },
-                { "rfc": "0032", "epoch_number": "0x0" },
-                { "rfc": "0036", "epoch_number": "0x0" },
-                { "rfc": "0038", "epoch_number": "0x0" }
-            ],
-            "ckb2023": [
-                 { "rfc": "0048", "epoch_number": null },
-                 { "rfc": "0049", "epoch_number": null }
-            ]
-        },
+        "hardfork_features": [
+            { "rfc": "0028", "epoch_number": "0x1526" },
+            { "rfc": "0029", "epoch_number": "0x0" },
+            { "rfc": "0030", "epoch_number": "0x0" },
+            { "rfc": "0031", "epoch_number": "0x0" },
+            { "rfc": "0032", "epoch_number": "0x0" },
+            { "rfc": "0036", "epoch_number": "0x0" },
+            { "rfc": "0038", "epoch_number": "0x0" },
+            { "rfc": "0048", "epoch_number": null },
+            { "rfc": "0049", "epoch_number": null }
+         ],
         "id": "main",
         "initial_primary_epoch_reward": "0x71afd498d000",
         "max_block_bytes": "0x91c08",
@@ -5902,30 +5897,10 @@ The fee_rate statistics information, includes mean and median, unit: shannons pe
 
 The 256-bit binary data encoded as a 0x-prefixed hex string in JSON.
 
-### Type `HardForkFeature`
-
-The information about one hardfork feature.
-
-#### Fields
-
-`HardForkFeature` is a JSON object with the following fields.
-
-*   `rfc`: `string` - The related RFC ID.
-
-*   `epoch_number`: [`EpochNumber`](#type-epochnumber) `|` `null` - The first epoch when the feature is enabled, `null` indicates that the RFC has never been enabled.
-
-
 ### Type `HardForks`
 
 Hardfork information
 
-#### Fields
-
-`HardForks` is a JSON object with the following fields.
-
-*   `ckb2021`: `Array<` [`HardForkFeature`](#type-hardforkfeature) `>` - ckb2021 information
-
-*   `ckb2023`: `Array<` [`HardForkFeature`](#type-hardforkfeature) `>` - ckb2023 information
 
 
 ### Type `Header`

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1337,21 +1337,17 @@ pub trait ChainRpc {
     ///         "dao_type_hash": null,
     ///         "epoch_duration_target": "0x3840",
     ///         "genesis_hash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
-    ///         "hardfork_features": {
-    ///             "ckb2021": [
-    ///                 { "rfc": "0028", "epoch_number": "0x1526" },
-    ///                 { "rfc": "0029", "epoch_number": "0x0" },
-    ///                 { "rfc": "0030", "epoch_number": "0x0" },
-    ///                 { "rfc": "0031", "epoch_number": "0x0" },
-    ///                 { "rfc": "0032", "epoch_number": "0x0" },
-    ///                 { "rfc": "0036", "epoch_number": "0x0" },
-    ///                 { "rfc": "0038", "epoch_number": "0x0" }
-    ///             ],
-    ///             "ckb2023": [
-    ///                  { "rfc": "0048", "epoch_number": null },
-    ///                  { "rfc": "0049", "epoch_number": null }
-    ///             ]
-    ///         },
+    ///         "hardfork_features": [
+    ///             { "rfc": "0028", "epoch_number": "0x1526" },
+    ///             { "rfc": "0029", "epoch_number": "0x0" },
+    ///             { "rfc": "0030", "epoch_number": "0x0" },
+    ///             { "rfc": "0031", "epoch_number": "0x0" },
+    ///             { "rfc": "0032", "epoch_number": "0x0" },
+    ///             { "rfc": "0036", "epoch_number": "0x0" },
+    ///             { "rfc": "0038", "epoch_number": "0x0" },
+    ///             { "rfc": "0048", "epoch_number": null },
+    ///             { "rfc": "0049", "epoch_number": null }
+    ///          ],
     ///         "id": "main",
     ///         "initial_primary_epoch_reward": "0x71afd498d000",
     ///         "max_block_bytes": "0x91c08",

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1382,18 +1382,16 @@ pub struct Consensus {
 
 /// Hardfork information
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(transparent)]
 pub struct HardForks {
-    /// ckb2021 information
-    pub ckb2021: Vec<HardForkFeature>,
-    /// ckb2023 information
-    pub ckb2023: Vec<HardForkFeature>,
+    inner: Vec<HardForkFeature>,
 }
 
 impl HardForks {
     /// Returns a list of hardfork features from a hardfork switch.
     pub fn new(hardforks: &core::hardfork::HardForks) -> Self {
         HardForks {
-            ckb2021: vec![
+            inner: vec![
                 HardForkFeature::new("0028", convert(hardforks.ckb2021.rfc_0028())),
                 HardForkFeature::new("0029", convert(hardforks.ckb2021.rfc_0029())),
                 HardForkFeature::new("0030", convert(hardforks.ckb2021.rfc_0030())),
@@ -1401,8 +1399,6 @@ impl HardForks {
                 HardForkFeature::new("0032", convert(hardforks.ckb2021.rfc_0032())),
                 HardForkFeature::new("0036", convert(hardforks.ckb2021.rfc_0036())),
                 HardForkFeature::new("0038", convert(hardforks.ckb2021.rfc_0038())),
-            ],
-            ckb2023: vec![
                 HardForkFeature::new("0048", convert(hardforks.ckb2023.rfc_0048())),
                 HardForkFeature::new("0049", convert(hardforks.ckb2023.rfc_0049())),
             ],


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->


### What is changed and how it works?

Revert the formatting changes to get_consensus to make it compatible with the previous version

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

