### PR TITLE
chore: add `make docker-publish-rc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ docker-publish:
 	docker tag nervos/ckb:$$(git describe) nervos/ckb:latest
 	docker push nervos/ckb:latest
 
+.PHONY: docker-publish-rc
+docker-publish-rc:
+	docker push nervos/ckb:$$(git describe)
+
 ##@ Code Quality
 .PHONY: fmt
 fmt: setup-ckb-test ## Check Rust source code format to keep to the same style.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The command `make docker-publish` will overwrite the `latest` tag in Docker Hub, even for rc versions.

### What is changed and how it works?

What's Changed:

Push the latest version as the image tag only. Skip the `latest` image
tag.

This will be used to push the rc version, which should not become the
latest image in Docker.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

