### PR TITLE
Fix bats tests failed for rc version like `ckb 0.111.0-rc6`

### DIFF
--- a/util/app-config/src/tests/cli.bats
+++ b/util/app-config/src/tests/cli.bats
@@ -31,7 +31,7 @@ _full_help() {
 function short_version { #@test
   run _short
   assert_success
-  assert_output --regexp "^ckb [0-9.]+[-]?[a-z]*$"
+  assert_output --regexp "^ckb [0-9.]+[-]?[a-z0-9]*$"
 }
 
 #@test "ckb --version" {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to fix: https://github.com/nervosnetwork/ckb/actions/runs/5398930496/jobs/9805391563?pr=4048

Current regex can match `ckb 0.112.0-pre`, but it can't match `ckb 0.111.0-rc6`, so this CI action failed.
https://github.com/nervosnetwork/ckb/blob/1271cdf75ab1f1577b835259815619b0aa58bc19/util/app-config/src/tests/cli.bats#L30-L35


Problem Summary:

### What is changed and how it works?


What's Changed:

### Related changes

- fix bats test's `short_version` match rc version like `ckb 0.111.0-rc6`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

