### PR TITLE
Fix bats test, `ckb_run` should wait ckb process exit

### DIFF
--- a/util/app-config/src/tests/ckb_run_replay.bats
+++ b/util/app-config/src/tests/ckb_run_replay.bats
@@ -3,12 +3,18 @@ bats_load_library 'bats-assert'
 bats_load_library 'bats-support'
 
 _ckb_run() {
-  ckb run -C ${CKB_DIRNAME} 1>${TMP_DIR}/ckb_run.log 2>&1 &
-  echo $! >${TMP_DIR}/ckb_run.pid
+  ckb run -C ${CKB_DIRNAME} &> ${TMP_DIR}/ckb_run.log &
+  PID=$!
   sleep 5
-  kill "$(<"${TMP_DIR}/ckb_run.pid")"
+  kill ${PID}
+
+  while kill -0 ${PID}; do
+      echo "waiting for ckb to exit"
+      sleep 1
+  done
   tail -n 50 ${TMP_DIR}/ckb_run.log
 }
+
 _ckb_replay() {
   # from 1 to 2500 enough to trigger profile action
   CKB_LOG=err ckb replay -C ${CKB_DIRNAME} --tmp-target ${TMP_DIR} --profile 1 2500


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In the current implementation: 
https://github.com/nervosnetwork/ckb/blob/860d56c94c386a5d82be6d7f9f50e38420892f88/util/app-config/src/tests/ckb_run_replay.bats#L5-L11

We should wait ckb process exit before get the tail of the log.

What's Changed:

### Related changes

- wait ckb process exit before get the tail of the log.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

