### PR TITLE
chore: add comment to header sync with empty

### DIFF
--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -97,8 +97,16 @@ impl<'a> BlockFetcher<'a> {
             }
         }
 
-        // This peer has nothing interesting.
-        let best_known = self.peer_best_known_header()?;
+        let best_known = match self.peer_best_known_header() {
+            Some(t) => t,
+            None => {
+                debug!(
+                    "peer {} doesn't have best known header, ignore it",
+                    self.peer
+                );
+                return None;
+            }
+        };
         if !best_known.is_better_than(self.active_chain.total_difficulty()) {
             // Advancing this peer's last_common_header is unnecessary for block-sync mechanism.
             // However, RPC `get_peers`, returns peers information which includes

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -108,6 +108,11 @@ impl<'a> HeadersProcess<'a> {
         }
 
         if headers.is_empty() {
+            // Empty means that the other peer's tip may be consistent with our own best known,
+            // but empty cannot 100% confirm this, so it does not set the other peer's best header
+            // to the shared best known.
+            // This action means that if the newly connected node has not been sync with headers,
+            // it cannot be used as a synchronization node.
             debug!("HeadersProcess is_empty (synchronized)");
             if let Some(mut state) = self.synchronizer.peers().state.get_mut(&self.peer) {
                 self.synchronizer


### PR DESCRIPTION
### What problem does this PR solve?

add comment to header sync with empty

### Check List

Tests

- Unit test
- Integration test

### Release note
```release-note
None: Exclude this PR from the release note.
```

