### PR TITLE
Fix `Relayer::request_proposal_txs` dedup proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
  "ckb-util",
  "ckb-verification",
  "ckb-verification-traits",
- "itertools",
+ "itertools 0.10.5",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
@@ -1342,6 +1342,7 @@ dependencies = [
  "faux",
  "futures",
  "governor",
+ "itertools 0.11.0",
  "keyed_priority_queue",
  "lru",
  "once_cell",
@@ -1700,7 +1701,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1721,7 +1722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2736,6 +2737,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -39,6 +39,7 @@ bitflags = "1.0"
 dashmap = "4.0"
 keyed_priority_queue = "0.3"
 sled = "0.34.7"
+itertools = "0.11.0"
 
 [dev-dependencies]
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.112.0-pre" }

--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -97,10 +97,9 @@ impl<'a> BlockTransactionsProcess<'a> {
 
                 // Request proposal
                 {
-                    let proposals: Vec<_> = received_uncles
+                    let proposals = received_uncles
                         .into_iter()
-                        .flat_map(|u| u.data().proposals().into_iter())
-                        .collect();
+                        .flat_map(|u| u.data().proposals().into_iter());
                     self.relayer.request_proposal_txs(
                         self.nc.as_ref(),
                         self.peer,

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -10,6 +10,7 @@ use ckb_logger::{self, debug_target};
 use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_systemtime::unix_time_as_millis;
 use ckb_traits::{HeaderFields, HeaderFieldsProvider};
+use ckb_types::packed::ProposalShortIdVecIterator;
 use ckb_types::{
     core::{EpochNumberWithFraction, HeaderView},
     packed::{self, Byte32, CompactBlock},
@@ -76,7 +77,7 @@ impl<'a> CompactBlockProcess<'a> {
         shared.insert_valid_header(self.peer, &header);
 
         // Request proposal
-        let proposals: Vec<_> = compact_block.proposals().into_iter().collect();
+        let proposals: ProposalShortIdVecIterator = compact_block.proposals().into_iter();
         self.relayer.request_proposal_txs(
             self.nc.as_ref(),
             self.peer,

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -239,9 +239,9 @@ impl Relayer {
         nc: &dyn CKBProtocolContext,
         peer: PeerIndex,
         block_hash_and_number: BlockNumberAndHash,
-        proposals: Vec<packed::ProposalShortId>,
+        proposals: impl Iterator<Item = packed::ProposalShortId>,
     ) {
-        let proposals: Vec<ProposalShortId> = proposals.into_iter().unique().collect_vec();
+        let proposals: Vec<ProposalShortId> = proposals.unique().collect_vec();
         let tx_pool = self.shared.shared().tx_pool_controller();
         let fresh_proposals = match tx_pool.fresh_proposals_filter(proposals) {
             Err(err) => {

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -39,6 +39,7 @@ use ckb_types::{
     prelude::*,
 };
 use ckb_util::Mutex;
+use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -238,9 +239,9 @@ impl Relayer {
         nc: &dyn CKBProtocolContext,
         peer: PeerIndex,
         block_hash_and_number: BlockNumberAndHash,
-        mut proposals: Vec<packed::ProposalShortId>,
+        proposals: Vec<packed::ProposalShortId>,
     ) {
-        proposals.dedup();
+        let proposals: Vec<ProposalShortId> = proposals.into_iter().unique().collect_vec();
         let tx_pool = self.shared.shared().tx_pool_controller();
         let fresh_proposals = match tx_pool.fresh_proposals_filter(proposals) {
             Err(err) => {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

https://github.com/nervosnetwork/ckb/blob/345a88140a9f6d41d57afa76fc9ac0bc52bdd0cf/sync/src/relayer/mod.rs#L235-L243

`proposals.dedup()` only [remove consecutive repeated elements](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.dedup), this is not expected.

What's Changed:

### Related changes

- use [`iterator_tools unique()`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.unique) to remove duplicate proposals

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

