### PR TITLE
Fix(`TxPoolService`): set `started` to `true` before `load_persisted_data`

### DIFF
--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -618,10 +618,10 @@ impl TxPoolServiceBuilder {
                 }
             }
         });
+        self.started.store(true, Ordering::Relaxed);
         if let Err(err) = self.tx_pool_controller.load_persisted_data(txs) {
             error!("Failed to import persisted txs, cause: {}", err);
         }
-        self.started.store(true, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4032

Problem Summary:
### What is changed and how it works?


### Related changes

- set `tx_pool_service.started` to `true` before `tx_pool_controller.load_persisted_data`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

