### PR TITLE
Fix stop-handler's unit test on `Windows` platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tokio-util 0.7.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -21,4 +21,5 @@ tokio-util = "0.7.8"
 [dev-dependencies]
 ctrlc = { version = "3.1", features = ["termination"] }
 libc = "0.2"
+winapi = "0.3.9"
 rand = "0.8.5"

--- a/util/stop-handler/src/tests.rs
+++ b/util/stop-handler/src/tests.rs
@@ -13,7 +13,18 @@ use tokio_util::sync::CancellationToken;
 fn send_ctrlc_later(duration: Duration) {
     std::thread::spawn(move || {
         std::thread::sleep(duration);
-        // send SIGINT to myself
+
+        // send CTRL_C event to myself on windows platform
+        #[cfg(windows)]
+        {
+            let pid = std::process::id();
+            unsafe {
+                winapi::um::wincon::GenerateConsoleCtrlEvent(winapi::um::wincon::CTRL_C_EVENT, pid);
+            }
+        }
+
+        // send SIGINT to myself on Linux and MacOS platform
+        #[cfg(not(windows))]
         unsafe {
             libc::raise(libc::SIGINT);
             println!("[ $$ sent SIGINT to myself $$ ]");


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to fix the CI job failed on `Windows` platform: https://github.com/nervosnetwork/ckb/actions/runs/5585546337/jobs/10208427302

Problem Summary:
The `signal-handler::basic` unit test should handle the condition when it's in the `Windows` platform:
https://github.com/nervosnetwork/ckb/blob/c666193eadc8a52ffc0bfe242318981e32a1e556/util/stop-handler/src/tests.rs#L13-L22
The above function will failed to execute on Windows platform.

What's Changed:

### Related changes

- add `winapi` to `dev-dependencies`
- Handle the `Windows` platform condition

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

