### PR TITLE
Remove `stop-handler`'s unit test for `Windows` platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,6 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tokio-util 0.7.8",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -21,5 +21,4 @@ tokio-util = "0.7.8"
 [dev-dependencies]
 ctrlc = { version = "3.1", features = ["termination"] }
 libc = "0.2"
-winapi = "0.3.9"
 rand = "0.8.5"

--- a/util/stop-handler/src/lib.rs
+++ b/util/stop-handler/src/lib.rs
@@ -8,5 +8,6 @@ pub use stop_register::{
 pub use tokio_util::sync::CancellationToken;
 
 mod stop_register;
-#[cfg(test)]
+
+#[cfg(all(test, unix))]
 mod tests;

--- a/util/stop-handler/src/tests.rs
+++ b/util/stop-handler/src/tests.rs
@@ -14,17 +14,7 @@ fn send_ctrlc_later(duration: Duration) {
     std::thread::spawn(move || {
         std::thread::sleep(duration);
 
-        // send CTRL_C event to myself on windows platform
-        #[cfg(windows)]
-        {
-            let pid = std::process::id();
-            unsafe {
-                winapi::um::wincon::GenerateConsoleCtrlEvent(winapi::um::wincon::CTRL_C_EVENT, pid);
-            }
-        }
-
         // send SIGINT to myself on Linux and MacOS platform
-        #[cfg(not(windows))]
         unsafe {
             libc::raise(libc::SIGINT);
             println!("[ $$ sent SIGINT to myself $$ ]");
@@ -120,6 +110,7 @@ impl TestStopMemo {
         }
     }
 }
+
 #[test]
 fn basic() {
     let (mut handle, mut stop_recv, _runtime) = new_global_runtime();


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
On `Windows` platform, `stop-handler`'s unit test will pass by `cargo test`, but failed by `cargo nextest run`.
It seems that `nextest-rs/nextest` catches the Ctrl-C signal for the `stop-handler`'s unit test. So I'd like to make the unit test only run on `unix` platform.

Ref:
1. https://github.com/nervosnetwork/ckb/pull/4070#issuecomment-1640363313
2. https://github.com/nextest-rs/nextest/issues/907

What's Changed:

### Related changes

- Make `stop-handler`'s unit test only run on `unix` platform.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

