### PR TITLE
Fix `FeeOfMultipleMaxBlockProposalsLimit` failed on MacOS CI action

### DIFF
--- a/test/src/specs/mining/fee.rs
+++ b/test/src/specs/mining/fee.rs
@@ -146,7 +146,7 @@ impl Spec for FeeOfMultipleMaxBlockProposalsLimit {
         });
 
         (0..multiple).for_each(|_| {
-            let block = node.new_block(None, None, None);
+            let block = node.new_block_with_blocking(|template| template.proposals.is_empty());
             node.submit_block(&block);
             assert_eq!(
                 max_block_proposals_limit as usize,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This [CI job failed](https://github.com/nervosnetwork/ckb/actions/runs/5596018174/jobs/10232539158), and we can't reproduce it.

### What is changed and how it works?

What's Changed:

### Related changes
- Try to fix `FeeOfMultipleMaxBlockProposalsLimit` 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

