### PR TITLE
deps(script): update ckb-vm to v0.24.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5747a877a71ff164fa0f17daf6e9abca036c2381b8576679fb3ac07ae77bbc"
+checksum = "40894adbde925bfc6584d324a06228e19d78bd877146fc7df085927552d29f50"
 dependencies = [
  "byteorder",
  "bytes 1.4.0",
@@ -1546,9 +1546,12 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83869c9d322de1ddbfde5b54b7376f9a1ac32273c50e21cdd5e8a1bd1a1cf632"
+checksum = "0253bdea8dc20db90b58fe54e01392f71989e0567d42e09e7f8e588f156551db"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "clang-sys"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -22,7 +22,7 @@ ckb-traits = { path = "../traits", version = "= 0.112.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.112.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.112.0-pre" }
-ckb-vm = { version = "=0.24.3", default-features = false }
+ckb-vm = { version = "=0.24.4", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.112.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When using ckb-vm in interpreter mode, the fllowing test case will fail due to stack overflow.
```
$ cargo test -- --nocapture verify::tests::ckb_2023::features_since_v2023::check_peak_memory_512k_to_32m
```

### What is changed and how it works?

What's Changed:

The reason for the problem is that a huge function is used in ckb-vm, which consumes too much stack space.


For detaild ChangLogs, see:

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.24.4

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

