### PR TITLE
chore(test): add ctrl handler and fix integration test timeout issue

### DIFF
--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -51,7 +51,7 @@ case $GITHUB_WORKFLOW in
     if [[ $github_workflow_os == 'macos' ]]; then
       export CKB_FEATURES="deadlock_detection,with_sentry,portable"
     fi
-    make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report" integration
+    make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report --max-time 3600 " integration
     ;;
   ci_quick_checks*)
     echo "ci_quick_check"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -38,6 +38,7 @@ lazy_static = "1.4.0"
 byteorder = "1.3.1"
 jsonrpc-core = "18.0"
 ctrlc = { version = "3.1", features = ["termination"] }
+log = "0.4"
 
 [target.'cfg(not(target_os="windows"))'.dependencies]
 nix = { version = "0.24.0", default-features = false, features = ["signal"] }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0"
 lazy_static = "1.4.0"
 byteorder = "1.3.1"
 jsonrpc-core = "18.0"
+ctrlc = { version = "3.1", features = ["termination"] }
 
 [target.'cfg(not(target_os="windows"))'.dependencies]
 nix = { version = "0.24.0", default-features = false, features = ["signal"] }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -135,8 +135,7 @@ fn main() {
         for name in cloned_running_names.lock().iter() {
             warn!("spec {} is still not finished", name);
         }
-        // sleep 1 second to wait for the log flush
-        std::thread::sleep(Duration::from_secs(1));
+        log::logger().flush();
         std::process::exit(1);
     })
     .expect("Error setting Ctrl-C handler");

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -125,7 +125,7 @@ fn main() {
 
     let (notify_tx, notify_rx) = unbounded();
 
-    let cloned_running_names = running_spec_names.clone();
+    let cloned_running_names = Arc::clone(&running_spec_names);
     ctrlc::set_handler(move || {
         std::thread::sleep(Duration::from_secs(1));
         warn!(
@@ -153,6 +153,7 @@ fn main() {
         if max_time > 0 && start_time.elapsed().as_secs() > max_time {
             // shutdown, specs running to long
             workers.shutdown();
+            break;
         }
 
         let msg = match notify_rx.recv_timeout(Duration::from_secs(5)) {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -12,6 +12,7 @@ use clap::{App, Arg};
 use rand::{seq::SliceRandom, thread_rng};
 use std::any::Any;
 use std::cmp::min;
+use std::collections::HashSet;
 use std::env;
 use std::fs::{self, read_to_string, File};
 use std::io::{self, BufRead, BufReader, Write};
@@ -113,6 +114,8 @@ fn main() {
     info!("max time: {:?}", max_time);
 
     let specs = filter_specs(all_specs(), spec_names_to_run);
+    let running_spec_names = Arc::new(Mutex::new(HashSet::new()));
+
     let total = specs.len();
     let worker_count = min(worker_count, total);
     let specs = Arc::new(Mutex::new(specs));
@@ -121,6 +124,22 @@ fn main() {
     let mut error_spec_names = Vec::new();
 
     let (notify_tx, notify_rx) = unbounded();
+
+    let cloned_running_names = running_spec_names.clone();
+    ctrlc::set_handler(move || {
+        std::thread::sleep(Duration::from_secs(1));
+        warn!(
+            "Total {} specs are not finished",
+            cloned_running_names.lock().len()
+        );
+        for name in cloned_running_names.lock().iter() {
+            warn!("spec {} is still not finished", name);
+        }
+        // sleep 1 second to wait for the log flush
+        std::thread::sleep(Duration::from_secs(1));
+        std::process::exit(1);
+    })
+    .expect("Error setting Ctrl-C handler");
 
     info!("start {} workers...", worker_count);
     let mut workers = Workers::new(worker_count, Arc::clone(&specs), notify_tx, start_port);
@@ -148,6 +167,7 @@ fn main() {
         match msg {
             Notify::Start { spec_name } => {
                 info!("[{}] Start executing", spec_name);
+                running_spec_names.lock().insert(spec_name);
             }
             Notify::Error {
                 spec_error,
@@ -166,6 +186,7 @@ fn main() {
                     workers.shutdown();
                     worker_running -= 1;
                 }
+                running_spec_names.lock().remove(&spec_name);
                 spec_errors.push(Some(spec_error));
                 if verbose {
                     info!("[{}] Error", spec_name);
@@ -189,6 +210,7 @@ fn main() {
                     worker_running -= 1;
                 }
                 spec_errors.push(None);
+                running_spec_names.lock().remove(&spec_name);
                 if verbose {
                     info!("[{}] Panic", spec_name);
                     print_panicked_logs(&node_log_paths);
@@ -204,6 +226,7 @@ fn main() {
                     status: TestResultStatus::Passed,
                     duration: seconds,
                 });
+                running_spec_names.lock().remove(&spec_name);
                 done_specs += 1;
                 info!(
                     "{}/{} .............. [{}] Done in {} seconds",
@@ -222,6 +245,7 @@ fn main() {
             }
         }
     }
+
     // join all workers threads
     workers.join_all();
 
@@ -294,8 +318,12 @@ fn clap_app() -> App<'static> {
                 .value_name("SECONDS")
                 .help("Exit when total running time exceeds this limit"),
         )
-        .arg(Arg::with_name("list-specs").long("list-specs"))
-        .arg(Arg::with_name("specs").multiple(true))
+        .arg(
+            Arg::with_name("list-specs")
+                .long("list-specs")
+                .help("list all specs"),
+        )
+        .arg(Arg::with_name("specs").multiple(true).help("Specs to run"))
         .arg(
             Arg::with_name("concurrent")
                 .short('c')
@@ -626,13 +654,13 @@ fn log_failed_specs(error_spec_names: &[String]) -> Result<(), io::Error> {
 
 fn print_results(mut test_results: Vec<TestResult>) {
     println!("{}", "-".repeat(20));
-    println!("{:50} | {:10} | {:10}", "TEST", "STATUS", "DURATION");
+    println!("{:65} | {:10} | {:10}", "TEST", "STATUS", "DURATION");
 
     test_results.sort_by(|a, b| (&a.status, a.duration).cmp(&(&b.status, b.duration)));
 
     for result in test_results.iter() {
         println!(
-            "{:50} | {:10} | {:<10}",
+            "{:65} | {:10} | {:<10}",
             result.spec_name,
             format!("{:?}", result.status),
             format!("{} s", result.duration),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::convert::Into;
 use std::fs;
 use std::path::PathBuf;
-use std::process::{self, Child, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
@@ -609,7 +609,8 @@ impl Node {
                         status,
                         self.log_path().display()
                     );
-                    process::exit(status.code().unwrap());
+                    // parent process will exit
+                    return;
                 }
                 Err(error) => {
                     error!(
@@ -617,7 +618,7 @@ impl Node {
                         error,
                         self.log_path().display()
                     );
-                    process::exit(255);
+                    return;
                 }
             }
         };


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

There is a scenario `make integration` will hang for a long time when there is a bug in a `spec`, which may happen since we have a lot functions such as `mine_with_blocking`.

Proper `ctrl` handler will print out the running spec name, so that we may narrow the scope of root cause.

There is a odd scenario `make integration` will hang forever, it's safe to add `timeout` in `CI`, there is a trivial bug for that.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

