### PR TITLE
Increase integration CI timeout to `2 hours`

### DIFF
--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -51,7 +51,7 @@ case $GITHUB_WORKFLOW in
     if [[ $github_workflow_os == 'macos' ]]; then
       export CKB_FEATURES="deadlock_detection,with_sentry,portable"
     fi
-    make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report --max-time 3600 " integration
+    make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report --max-time 7200 " integration
     ;;
   ci_quick_checks*)
     echo "ci_quick_check"


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Set `make integration`'s timneout to `1 hour` [is not enough](https://github.com/nervosnetwork/ckb/actions/runs/5736150087/job/15545163278), it may cost more than 1 hour on MacOS runner.
![image](https://github.com/nervosnetwork/ckb/assets/46400566/49f8aafe-b283-4dc3-b2f1-ce3476be5882)

![image](https://github.com/nervosnetwork/ckb/assets/46400566/778b8246-b71d-4cb1-b4e4-01f1ada92ca1)


What's Changed:

### Related changes

- Increase `make integrations`'s timeout to `2 hour`
- Print ckb process' Spec name when kill the node, this may help to debug integration test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

