### PR TITLE
fix: data2 value

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6681,9 +6681,11 @@ Describes the lock script and type script for a cell.
 
 Specifies how the script `code_hash` is used to match the script code and how to run the code.
 
-Allowed kinds: “data”, “type” and “data1”.
+Allowed kinds: “data”, “type”, “data1” and “data2”
 
 Refer to the section [Code Locating](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#code-locating) and [Upgradable Script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#upgradable-script) in the RFC *CKB Transaction Structure*.
+
+The hash type is split into the high 7 bits and the low 1 bit, when the low 1 bit is 1, it indicates the type, when the low 1 bit is 0, it indicates the data, and then it relies on the high 7 bits to indicate that the data actually corresponds to the version.
 
 `ScriptHashType` is equivalent to `"data" | "type" | "data1" | "data2"`.
 

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -13,11 +13,17 @@ use std::fmt;
 
 /// Specifies how the script `code_hash` is used to match the script code and how to run the code.
 ///
-/// Allowed kinds: "data", "type" and "data1".
+/// Allowed kinds: "data", "type", "data1" and “data2”
 ///
 /// Refer to the section [Code Locating](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#code-locating)
 /// and [Upgradable Script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#upgradable-script)
 /// in the RFC *CKB Transaction Structure*.
+///
+/// The hash type is split into the high 7 bits and the low 1 bit,
+/// when the low 1 bit is 1, it indicates the type,
+/// when the low 1 bit is 0, it indicates the data,
+/// and then it relies on the high 7 bits to indicate
+/// that the data actually corresponds to the version.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ScriptHashType {
@@ -28,7 +34,7 @@ pub enum ScriptHashType {
     /// Type "data1" matches script code via cell data hash, and run the script code in v1 CKB VM.
     Data1 = 2,
     /// Type "data2" matches script code via cell data hash, and run the script code in v2 CKB VM.
-    Data2 = 3,
+    Data2 = 4,
 }
 
 impl Default for ScriptHashType {

--- a/util/types/src/core/blockchain.rs
+++ b/util/types/src/core/blockchain.rs
@@ -3,6 +3,11 @@ use ckb_error::OtherError;
 use crate::packed;
 
 /// Specifies how the script `code_hash` is used to match the script code and how to run the code.
+/// The hash type is split into the high 7 bits and the low 1 bit,
+/// when the low 1 bit is 1, it indicates the type,
+/// when the low 1 bit is 0, it indicates the data,
+///  and then it relies on the high 7 bits to indicate
+/// that the data actually corresponds to the version.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum ScriptHashType {
     /// Type "data" matches script code via cell data hash, and run the script code in v0 CKB VM.
@@ -12,7 +17,7 @@ pub enum ScriptHashType {
     /// Type "data1" matches script code via cell data hash, and run the script code in v1 CKB VM.
     Data1 = 2,
     /// Type "data2" matches script code via cell data hash, and run the script code in v2 CKB VM.
-    Data2 = 3,
+    Data2 = 4,
 }
 
 impl Default for ScriptHashType {
@@ -29,7 +34,7 @@ impl TryFrom<u8> for ScriptHashType {
             0 => Ok(ScriptHashType::Data),
             1 => Ok(ScriptHashType::Type),
             2 => Ok(ScriptHashType::Data1),
-            3 => Ok(ScriptHashType::Data2),
+            4 => Ok(ScriptHashType::Data2),
             _ => Err(OtherError::new(format!("Invalid script hash type {v}"))),
         }
     }
@@ -46,7 +51,7 @@ impl TryFrom<packed::Byte> for ScriptHashType {
 impl ScriptHashType {
     #[inline]
     pub(crate) fn verify_value(v: u8) -> bool {
-        v <= 3
+        v <= 4 && v != 3
     }
 }
 
@@ -57,7 +62,7 @@ impl Into<u8> for ScriptHashType {
             Self::Data => 0,
             Self::Type => 1,
             Self::Data1 => 2,
-            Self::Data2 => 3,
+            Self::Data2 => 4,
         }
     }
 }

--- a/util/types/src/core/tests/blockchain.rs
+++ b/util/types/src/core/tests/blockchain.rs
@@ -10,10 +10,10 @@ fn test_script_hash_type() {
     let default_value: u8 = default.into();
     assert_eq!(default_value, 0);
 
-    let max_value = 3u8;
+    let max_value = 4u8;
     for v in 0..32 {
         let res = ScriptHashType::try_from(v);
-        if v <= max_value {
+        if v <= max_value && v != 3 {
             let value: u8 = res.unwrap().into();
             assert_eq!(value, v);
         } else {

--- a/util/types/src/extension/tests/check_data.rs
+++ b/util/types/src/extension/tests/check_data.rs
@@ -29,74 +29,81 @@ fn test_check_data_via_transaction(
 #[test]
 fn check_data() {
     for ht in 0..4 {
-        for dt in 0..2 {
-            let ht_right = ht.into();
-            let dt_right = dt.into();
-            let ht_error = 4.into();
-            let dt_error = 2.into();
+        if ht != 3 {
+            for dt in 0..2 {
+                let ht_right = ht.into();
+                let dt_right = dt.into();
+                let ht_error = 3.into();
+                let dt_error = 2.into();
 
-            let script_right = packed::Script::new_builder().hash_type(ht_right).build();
-            let script_error = packed::Script::new_builder().hash_type(ht_error).build();
+                let script_right = packed::Script::new_builder().hash_type(ht_right).build();
+                let script_error = packed::Script::new_builder().hash_type(ht_error).build();
 
-            let script_opt_right = packed::ScriptOpt::new_builder()
-                .set(Some(script_right.clone()))
-                .build();
-            let script_opt_error = packed::ScriptOpt::new_builder()
-                .set(Some(script_error.clone()))
-                .build();
+                let script_opt_right = packed::ScriptOpt::new_builder()
+                    .set(Some(script_right.clone()))
+                    .build();
+                let script_opt_error = packed::ScriptOpt::new_builder()
+                    .set(Some(script_error.clone()))
+                    .build();
 
-            let output_right1 = packed::CellOutput::new_builder()
-                .lock(script_right.clone())
-                .build();
-            let output_right2 = packed::CellOutput::new_builder()
-                .type_(script_opt_right.clone())
-                .build();
-            let output_error1 = packed::CellOutput::new_builder()
-                .lock(script_error.clone())
-                .build();
-            let output_error2 = packed::CellOutput::new_builder()
-                .type_(script_opt_error.clone())
-                .build();
-            let output_error3 = packed::CellOutput::new_builder()
-                .lock(script_right)
-                .type_(script_opt_error)
-                .build();
-            let output_error4 = packed::CellOutput::new_builder()
-                .lock(script_error)
-                .type_(script_opt_right)
-                .build();
+                let output_right1 = packed::CellOutput::new_builder()
+                    .lock(script_right.clone())
+                    .build();
+                let output_right2 = packed::CellOutput::new_builder()
+                    .type_(script_opt_right.clone())
+                    .build();
+                let output_error1 = packed::CellOutput::new_builder()
+                    .lock(script_error.clone())
+                    .build();
+                let output_error2 = packed::CellOutput::new_builder()
+                    .type_(script_opt_error.clone())
+                    .build();
+                let output_error3 = packed::CellOutput::new_builder()
+                    .lock(script_right)
+                    .type_(script_opt_error)
+                    .build();
+                let output_error4 = packed::CellOutput::new_builder()
+                    .lock(script_error)
+                    .type_(script_opt_right)
+                    .build();
 
-            let cell_dep_right = packed::CellDep::new_builder().dep_type(dt_right).build();
-            let cell_dep_error = packed::CellDep::new_builder().dep_type(dt_error).build();
+                let cell_dep_right = packed::CellDep::new_builder().dep_type(dt_right).build();
+                let cell_dep_error = packed::CellDep::new_builder().dep_type(dt_error).build();
 
-            test_check_data_via_transaction(true, &[], &[], &[]);
-            test_check_data_via_transaction(true, &[&output_right1], &[&[]], &[&cell_dep_right]);
-            test_check_data_via_transaction(
-                true,
-                &[&output_right1, &output_right2],
-                &[&[], &[]],
-                &[&cell_dep_right, &cell_dep_right],
-            );
-            test_check_data_via_transaction(false, &[&output_error1], &[&[]], &[]);
-            test_check_data_via_transaction(false, &[&output_error2], &[&[]], &[]);
-            test_check_data_via_transaction(false, &[&output_error3], &[&[]], &[]);
-            test_check_data_via_transaction(false, &[&output_error4], &[&[]], &[]);
-            test_check_data_via_transaction(false, &[], &[], &[&cell_dep_error]);
-            test_check_data_via_transaction(
-                false,
-                &[
-                    &output_right1,
-                    &output_right2,
-                    &output_error1,
-                    &output_error2,
-                    &output_error3,
-                    &output_error4,
-                ],
-                &[&[], &[], &[], &[], &[], &[]],
-                &[&cell_dep_right, &cell_dep_error],
-            );
-            test_check_data_via_transaction(false, &[&output_right1], &[], &[&cell_dep_right]);
-            test_check_data_via_transaction(false, &[], &[&[]], &[&cell_dep_right]);
+                test_check_data_via_transaction(true, &[], &[], &[]);
+                test_check_data_via_transaction(
+                    true,
+                    &[&output_right1],
+                    &[&[]],
+                    &[&cell_dep_right],
+                );
+                test_check_data_via_transaction(
+                    true,
+                    &[&output_right1, &output_right2],
+                    &[&[], &[]],
+                    &[&cell_dep_right, &cell_dep_right],
+                );
+                test_check_data_via_transaction(false, &[&output_error1], &[&[]], &[]);
+                test_check_data_via_transaction(false, &[&output_error2], &[&[]], &[]);
+                test_check_data_via_transaction(false, &[&output_error3], &[&[]], &[]);
+                test_check_data_via_transaction(false, &[&output_error4], &[&[]], &[]);
+                test_check_data_via_transaction(false, &[], &[], &[&cell_dep_error]);
+                test_check_data_via_transaction(
+                    false,
+                    &[
+                        &output_right1,
+                        &output_right2,
+                        &output_error1,
+                        &output_error2,
+                        &output_error3,
+                        &output_error4,
+                    ],
+                    &[&[], &[], &[], &[], &[], &[]],
+                    &[&cell_dep_right, &cell_dep_error],
+                );
+                test_check_data_via_transaction(false, &[&output_right1], &[], &[&cell_dep_right]);
+                test_check_data_via_transaction(false, &[], &[&[]], &[&cell_dep_right]);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->


### What is changed and how it works?

The hash type is split into the high 7 bits and the low 1 bit, when the low 1 bit is 1, it indicates the type, when the low 1 bit is 0, it indicates the data, and then it relies on the high 7 bits to indicate that the data actually corresponds to the version.
So data2 should be 4.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

