### PR TITLE
[WIP] add test-bin to workspace for better dev exp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ version = "0.112.0-pre"
 dependencies = [
  "ckb-bin",
  "ckb-build-info",
+ "ckb-test",
  "tikv-jemallocator",
 ]
 
@@ -1375,6 +1376,43 @@ name = "ckb-systemtime"
 version = "0.112.0-pre"
 
 [[package]]
+name = "ckb-test"
+version = "0.112.0-pre"
+dependencies = [
+ "byteorder",
+ "ckb-app-config",
+ "ckb-async-runtime",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-constant",
+ "ckb-crypto",
+ "ckb-dao-utils",
+ "ckb-error",
+ "ckb-hash",
+ "ckb-jsonrpc-types",
+ "ckb-logger",
+ "ckb-logger-config",
+ "ckb-logger-service",
+ "ckb-network",
+ "ckb-resource",
+ "ckb-systemtime",
+ "ckb-test-chain-utils",
+ "ckb-types",
+ "ckb-util",
+ "clap 3.2.21",
+ "ctrlc",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "nix 0.24.3",
+ "rand 0.7.3",
+ "reqwest",
+ "serde_json",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "ckb-test-chain-utils"
 version = "0.112.0-pre"
 dependencies = [
@@ -1566,13 +1604,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_lex 0.2.3",
  "indexmap",
+ "strsim",
+ "termcolor",
  "textwrap",
 ]
 
@@ -1707,7 +1748,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.23",
+ "clap 3.2.21",
  "criterion-plot",
  "itertools 0.10.5",
  "lazy_static",
@@ -1810,7 +1851,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
- "nix",
+ "nix 0.23.1",
  "winapi 0.3.9",
 ]
 
@@ -3186,6 +3227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ckb-build-info = { path = "util/build-info", version = "= 0.112.0-pre" }
 ckb-bin = { path = "ckb-bin", version = "= 0.112.0-pre" }
 
 [dev-dependencies]
+ckb-test = { path = "test", version = "= 0.112.0-pre" }
 
 [workspace]
 # To get a list sorted by dependencies, run devtools/ci/check-cyclic-dependencies.py

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,6 @@ gen-hashes: ## Generate docs/hashes.toml
 .PHONY: check
 check: setup-ckb-test ## Runs all of the compiler's checks.
 	cargo check ${VERBOSE} --all --all-targets --features ${ALL_FEATURES}
-	cd test && cargo check ${VERBOSE} --all --all-targets --all-features
 
 .PHONY: build
 build: ## Build binary with release profile.
@@ -176,12 +175,10 @@ docker-publish-rc:
 .PHONY: fmt
 fmt: setup-ckb-test ## Check Rust source code format to keep to the same style.
 	cargo fmt ${VERBOSE} --all -- --check
-	cd test && cargo fmt ${VERBOSE} --all -- --check
 
 .PHONY: clippy
 clippy: setup-ckb-test ## Run linter to examine Rust source codes.
 	cargo clippy ${VERBOSE} --all --all-targets --features ${ALL_FEATURES} -- ${CLIPPY_OPTS} -D missing_docs
-	cd test && cargo clippy ${VERBOSE} --all --all-targets --all-features -- ${CLIPPY_OPTS}
 
 .PHONY: security-audit
 security-audit: ## Use cargo-deny to audit Cargo.lock for crates with security vulnerabilities.

--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -158,6 +158,10 @@ function check_dependencies_for() {
       fi
       if [ "${depcnt}" -eq 0 ]; then
         case "${dependency}" in
+          ckb_test)
+            printf "Warn: [%s::%s] in <%s>\n" \
+              "${deptype}" "${dependency}" "${pkgroot}"
+            ;;
           phf)
             # We cann't handle these crates.
             printf "Warn: [%s::%s] in <%s>\n" \

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -43,16 +43,6 @@ log = "0.4"
 [target.'cfg(not(target_os="windows"))'.dependencies]
 nix = { version = "0.24.0", default-features = false, features = ["signal"] }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
-[profile.release.build-override]
-opt-level = 3
-
-[profile.bench.build-override]
-opt-level = 3
-
 [features]
 default = []
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 extern crate core;
 
 pub mod assertion;

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use ckb_channel::unbounded;
 use ckb_logger::{error, info, warn};
 use ckb_test::specs::*;


### PR DESCRIPTION

### What problem does this PR solve?


Problem Summary:
`test` is now a standalone crate compared with root crate, this make `rust-analyzer` not working in one VsCode instance, so for coding or browser source code in `test`, I may need to open another VsCode.

### What is changed and how it works?
This PR add `test-bin` as a dev-dependency.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

