### PR TITLE
BREAK CHANGE! Consensus: Allow `epoch_duration_target` to impact epoch length in `Dummy` mode.

### DIFF
--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: build ckb and run bats cli test
       run: |
-        make build
+        make prod
         make cli-test
       shell: bash
     env:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ doc-test: ## Run doc tests
 	cargo test --all --doc
 
 .PHONY: cli-test
-cli-test: build # Run ckb command line usage bats test
+cli-test: prod # Run ckb command line usage bats test
 	./util/app-config/src/tests/cli_test.sh
 
 .PHONY: test

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -804,12 +804,7 @@ impl Consensus {
                         let remainder_reward =
                             Capacity::shannons(primary_epoch_reward % epoch.length());
 
-                        let mut next_epoch_length = epoch.length();
-                        let epoch_length_from_param =
-                            cmp::max(self.epoch_duration_target() / MIN_BLOCK_INTERVAL, 1);
-                        if next_epoch_length != epoch_length_from_param {
-                            next_epoch_length = self.epoch_duration_target() / MIN_BLOCK_INTERVAL;
-                        }
+let next_epoch_length = (self.epoch_duration_target() + MIN_BLOCK_INTERVAL - 1) / MIN_BLOCK_INTERVAL
 
                         let dummy_epoch_ext = epoch
                             .clone()

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -804,6 +804,13 @@ impl Consensus {
                         let remainder_reward =
                             Capacity::shannons(primary_epoch_reward % epoch.length());
 
+                        let mut next_epoch_length = epoch.length();
+                        let epoch_length_from_param =
+                            cmp::max(self.epoch_duration_target() / MIN_BLOCK_INTERVAL, 1);
+                        if next_epoch_length != epoch_length_from_param {
+                            next_epoch_length = self.epoch_duration_target() / MIN_BLOCK_INTERVAL;
+                        }
+
                         let dummy_epoch_ext = epoch
                             .clone()
                             .into_builder()
@@ -812,6 +819,7 @@ impl Consensus {
                             .number(epoch.number() + 1)
                             .last_block_hash_in_previous_epoch(header.hash())
                             .start_number(header.number() + 1)
+                            .length(next_epoch_length)
                             .build();
                         NextBlockEpoch::HeadBlock(dummy_epoch_ext)
                     } else {

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -804,7 +804,9 @@ impl Consensus {
                         let remainder_reward =
                             Capacity::shannons(primary_epoch_reward % epoch.length());
 
-let next_epoch_length = (self.epoch_duration_target() + MIN_BLOCK_INTERVAL - 1) / MIN_BLOCK_INTERVAL
+                        let next_epoch_length = (self.epoch_duration_target() + MIN_BLOCK_INTERVAL
+                            - 1)
+                            / MIN_BLOCK_INTERVAL;
 
                         let dummy_epoch_ext = epoch
                             .clone()

--- a/test/src/specs/dao/dao_tx.rs
+++ b/test/src/specs/dao/dao_tx.rs
@@ -12,7 +12,7 @@ pub struct WithdrawDAO;
 impl Spec for WithdrawDAO {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.genesis_epoch_length = Some(2);
-        spec.params.epoch_duration_target = Some(2);
+        spec.params.epoch_duration_target = Some(16);
         spec.params.permanent_difficulty_in_dummy = Some(true);
     }
 

--- a/test/src/specs/dao/dao_tx.rs
+++ b/test/src/specs/dao/dao_tx.rs
@@ -40,7 +40,7 @@ pub struct WithdrawDAOWithOverflowCapacity;
 impl Spec for WithdrawDAOWithOverflowCapacity {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.genesis_epoch_length = Some(2);
-        spec.params.epoch_duration_target = Some(2);
+        spec.params.epoch_duration_target = Some(16);
         spec.params.permanent_difficulty_in_dummy = Some(true);
     }
 

--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -46,7 +46,7 @@ impl Spec for DAOWithSatoshiCellOccupied {
         let satoshi_cell = issue_satoshi_cell();
         spec.genesis.issued_cells.push(satoshi_cell);
         spec.params.genesis_epoch_length = Some(2);
-        spec.params.epoch_duration_target = Some(2);
+        spec.params.epoch_duration_target = Some(16);
         spec.params.permanent_difficulty_in_dummy = Some(true);
     }
 }
@@ -142,7 +142,7 @@ impl Spec for SpendSatoshiCell {
         spec.genesis.issued_cells.push(issue_satoshi_cell());
         spec.genesis.satoshi_gift.satoshi_cell_occupied_ratio = satoshi_cell_occupied_ratio;
         spec.params.genesis_epoch_length = Some(2);
-        spec.params.epoch_duration_target = Some(2);
+        spec.params.epoch_duration_target = Some(16);
         spec.params.permanent_difficulty_in_dummy = Some(true);
     }
 }

--- a/test/src/specs/hardfork/v2021/since.rs
+++ b/test/src/specs/hardfork/v2021/since.rs
@@ -78,6 +78,7 @@ impl Spec for CheckAbsoluteEpochSince {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
+        spec.params.epoch_duration_target = Some(8 * GENESIS_EPOCH_LENGTH);
     }
 }
 
@@ -113,6 +114,7 @@ impl Spec for CheckRelativeEpochSince {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
+        spec.params.epoch_duration_target = Some(8 * GENESIS_EPOCH_LENGTH);
     }
 }
 

--- a/test/src/specs/hardfork/v2023/vm_version2.rs
+++ b/test/src/specs/hardfork/v2023/vm_version2.rs
@@ -97,6 +97,7 @@ impl Spec for CheckVmVersion2 {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
+        spec.params.epoch_duration_target = Some(8 * GENESIS_EPOCH_LENGTH);
         if spec.params.hardfork.is_none() {
             spec.params.hardfork = Some(Default::default());
         }

--- a/util/app-config/src/tests/cli_test.sh
+++ b/util/app-config/src/tests/cli_test.sh
@@ -11,7 +11,7 @@ function cleanup {
 
 trap cleanup EXIT
 
-cp target/release/ckb ${CKB_BATS_TESTBED}
+cp target/prod/ckb ${CKB_BATS_TESTBED}
 cp util/app-config/src/tests/*.bats ${CKB_BATS_TESTBED}
 cp -r util/app-config/src/tests/later_bats_job ${CKB_BATS_TESTBED}
 cp util/app-config/src/tests/*.sh ${CKB_BATS_TESTBED}

--- a/util/app-config/src/tests/cli_test.sh
+++ b/util/app-config/src/tests/cli_test.sh
@@ -13,6 +13,7 @@ trap cleanup EXIT
 
 cp target/release/ckb ${CKB_BATS_TESTBED}
 cp util/app-config/src/tests/*.bats ${CKB_BATS_TESTBED}
+cp -r util/app-config/src/tests/later_bats_job ${CKB_BATS_TESTBED}
 cp util/app-config/src/tests/*.sh ${CKB_BATS_TESTBED}
 
 if [ ! -d "/tmp/ckb_bats_assets/" ]; then
@@ -47,9 +48,15 @@ export TMP_DIR=${CKB_BATS_TESTBED}/tmp_dir
 mkdir ${TMP_DIR}
 
 for bats_cases in *.bats; do
-  bats "$bats_cases"
+  bats --verbose-run --print-output-on-failure --show-output-of-passing-tests "$bats_cases"
   ret=$?
   if [ "$ret" -ne "0" ]; then
     exit "$ret"
   fi
 done
+
+bats --verbose-run --print-output-on-failure --show-output-of-passing-tests ./later_bats_job/change_epoch.bats
+ret=$?
+if [ "$ret" -ne "0" ]; then
+  exit "$ret"
+fi

--- a/util/app-config/src/tests/later_bats_job/change_epoch.bats
+++ b/util/app-config/src/tests/later_bats_job/change_epoch.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+set -e
+
+bats_load_library 'bats-assert'
+bats_load_library 'bats-support'
+
+NUMBER_OFFSET=0
+NUMBER_BITS=24
+NUMBER_MAXIMUM_VALUE=$((1 << NUMBER_BITS))
+NUMBER_MASK=$((NUMBER_MAXIMUM_VALUE - 1))
+
+INDEX_OFFSET=$((NUMBER_BITS))
+INDEX_BITS=16
+INDEX_MAXIMUM_VALUE=$((1 << INDEX_BITS))
+INDEX_MASK=$((INDEX_MAXIMUM_VALUE - 1))
+
+LENGTH_OFFSET=$((NUMBER_BITS + INDEX_BITS))
+LENGTH_BITS=16
+LENGTH_MAXIMUM_VALUE=$((1 << LENGTH_BITS))
+LENGTH_MASK=$((LENGTH_MAXIMUM_VALUE - 1))
+
+function extract_epoch_number() {
+    local value=$1
+    echo $(( (value >> NUMBER_OFFSET) & NUMBER_MASK ))
+}
+
+function extract_epoch_index() {
+    local value=$1
+    echo $(( (value >> INDEX_OFFSET) & INDEX_MASK ))
+}
+
+function extract_epoch_length() {
+    local value=$1
+    echo $(( (value >> LENGTH_OFFSET) & LENGTH_MASK ))
+}
+
+function tip_header_epoch() {
+  curl -s -X POST http://127.0.0.1:8114 \
+  -H 'Content-Type: application/json' \
+  -d '{ "id": 42, "jsonrpc": "2.0", "method": "get_tip_header", "params": [ ] }' \
+  | jq .result.epoch | xargs -I{} printf "%d\n" {}
+}
+
+function tip_header_number() {
+  curl -s -X POST http://127.0.0.1:8114 \
+  -H 'Content-Type: application/json' \
+  -d '{ "id": 42, "jsonrpc": "2.0", "method": "get_tip_header", "params": [ ] }' \
+  | jq .result.number | xargs -I{} printf "%d\n" {}
+}
+
+function block_kill() {
+  kill $1
+  while kill -0 $1; do
+      echo "waiting for $1 to exit"
+      sleep 1
+  done
+}
+
+function ckb_change_epoch_length_for_dumm_mode { #@test
+  ckb run -C ${CKB_DIRNAME} &> /dev/null &
+
+  CKB_NODE_PID=$!
+  sleep 5
+
+
+  TIP_EPOCH=$(tip_header_epoch)
+
+  TIP_EPOCH_NUMBER=$(extract_epoch_number ${TIP_EPOCH})
+  TIP_EPOCH_INDEX=$(extract_epoch_index ${TIP_EPOCH})
+  TIP_EPOCH_LENGTH=$(extract_epoch_length ${TIP_EPOCH})
+  TIP_NUMBER=$(tip_header_number)
+
+  echo tip_number is ${TIP_NUMBER}
+  echo tip_epoch_number is ${TIP_EPOCH_NUMBER}, tip_epoch_index is ${TIP_EPOCH_INDEX}, tip_epoch_length is ${TIP_EPOCH_LENGTH}
+
+  block_kill ${CKB_NODE_PID}
+
+  wget https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/mainnet.toml
+
+  ckb init -c dev --import-spec mainnet.toml --force
+
+  sed -i 's/Eaglesong/Dummy/g' specs/dev.toml
+  sed -i '/genesis_epoch_length = 1743/a permanent_difficulty_in_dummy = true\nepoch_duration_target = 80\n' specs/dev.toml
+
+  sed -i 's/poll_interval = 1000/poll_interval = 1/g' ckb-miner.toml
+  sed -i 's/value = 5000/value = 1/g' ckb-miner.toml
+
+  sed -i 's/# \[block_assembler\]/\[block_assembler\]/g' ckb.toml
+  sed -i 's/# code_hash =/code_hash =/g' ckb.toml
+  sed -i 's/# args = "ckb-cli util blake2b --prefix-160 <compressed-pubkey>"/args = "0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7"/g' ckb.toml
+  sed -i 's/# hash_type =/hash_type =/g' ckb.toml
+  sed -i 's/# message = "A 0x-prefixed hex string"/message = "0x"/g' ckb.toml
+
+
+
+  ckb run --skip-spec-check --overwrite-spec -C ${CKB_DIRNAME} &> /dev/null &
+  CKB_NODE_PID=$!
+
+  ckb miner -C ${CKB_DIRNAME} &> /dev/null &
+  CKB_MINER_PID=$!
+
+  sleep 5
+
+  while [ $(tip_header_number) -lt $(( ${TIP_NUMBER} + ${TIP_EPOCH_LENGTH} )) ]; do
+    echo waiting for tip_number to be $(( ${TIP_NUMBER} + ${TIP_EPOCH_LENGTH} ))
+    sleep 1
+  done
+
+  echo latest tip_header_number is $(tip_header_number)
+  echo latest tip_header_epoch length is $(extract_epoch_length $(tip_header_epoch))
+  echo latest tip_header_epoch number is $(extract_epoch_number $(tip_header_epoch))
+
+  # we specified epoch_duration_target = 80 in dev.toml, so the epoch length should be 10
+  assert [ $(extract_epoch_length $(tip_header_epoch)) -eq 10 ]
+
+  block_kill ${CKB_NODE_PID}
+  block_kill ${CKB_MINER_PID}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Related issue: #4092 

Problem Summary:


What's Changed:

### Related changes

- let `epoch_duration_target` affect epoch length when `permanent_difficulty_in_dummy` is enabled in `Dummy` mode.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: This PR introduce a break change. When the CKB is in `Dummy` mode and the `permanent_difficulty_in_dummy` option is set to `true`, the epoch length will be influenced by the `epoch_duration_target` parameter. Specifically, the epoch length will be calculated as `epoch_duration_target / 8`.
```

