### PR TITLE
Update ckb-vm to v0.24.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40894adbde925bfc6584d324a06228e19d78bd877146fc7df085927552d29f50"
+checksum = "587cf28dd1523eba5ba96f649c53d1b37bc63de364e9e882497324bc17f80def"
 dependencies = [
  "byteorder",
  "bytes 1.4.0",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0253bdea8dc20db90b58fe54e01392f71989e0567d42e09e7f8e588f156551db"
+checksum = "f59166a186706e782cd10cf1f6c55fac6b5abd163ff4506198c682610368f895"
 dependencies = [
  "paste",
 ]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -22,7 +22,7 @@ ckb-traits = { path = "../traits", version = "= 0.112.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.112.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.112.0-pre" }
-ckb-vm = { version = "=0.24.4", default-features = false }
+ckb-vm = { version = "=0.24.5", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.112.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

There is a bug in the A extension that may cause suspend/resume to fail in rare cases.

### What is changed and how it works?

What's Changed:

Update ckb-vm to v0.24.5. For detaild ChangLogs, see:

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.24.5

For bug descriptions, see:

https://github.com/nervosnetwork/ckb-vm/pull/373

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

