### PR TITLE
fix: fix disconnect miss await

### DIFF
--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -290,7 +290,7 @@ impl ServiceProtocol for CKBHandler {
             .network_state
             .ckb2023
             .load(std::sync::atomic::Ordering::SeqCst)
-            && version != "3"
+            && version != crate::protocols::support_protocols::LASTEST_VERSION
             && context.proto_id != SupportProtocols::RelayV2.protocol_id()
         {
             debug!(
@@ -298,7 +298,7 @@ impl ServiceProtocol for CKBHandler {
                 context.session.id, context.proto_id, version
             );
             let id = context.session.id;
-            let _ignore = context.disconnect(id);
+            let _ignore = context.disconnect(id).await;
             return;
         }
         self.network_state.with_peer_registry_mut(|reg| {

--- a/network/src/protocols/support_protocols.rs
+++ b/network/src/protocols/support_protocols.rs
@@ -6,7 +6,7 @@ use p2p::{
 };
 use tokio_util::codec::length_delimited;
 
-const LASTEST_VERSION: &str = "3";
+pub const LASTEST_VERSION: &str = "3";
 
 /// All supported protocols
 ///


### PR DESCRIPTION
### What problem does this PR solve?

fix disconnect miss `await`, it may lead to illegal node connection, but cannot be found in the node registration information

### Check List 

Tests 

- Unit test
- Integration test

### Release note
```release-note
None: Exclude this PR from the release note.
```

