### PR TITLE
chore(scripts): update ckb-vm to v0.24.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587cf28dd1523eba5ba96f649c53d1b37bc63de364e9e882497324bc17f80def"
+checksum = "0cc004a826b9bc9319ffae0b8415690e1b5f1482266d55fbd43843aa40ddcd63"
 dependencies = [
  "byteorder",
  "bytes 1.4.0",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59166a186706e782cd10cf1f6c55fac6b5abd163ff4506198c682610368f895"
+checksum = "c4ced3ff9d79b53d93c106720f6c1f855694290e33581850e05c859500eee83f"
 dependencies = [
  "paste",
 ]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -22,7 +22,7 @@ ckb-traits = { path = "../traits", version = "= 0.112.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.112.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.112.0-pre" }
-ckb-vm = { version = "=0.24.5", default-features = false }
+ckb-vm = { version = "=0.24.6", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.112.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

There is a bug in the ckb-vm aarch64 mode that memory would not be correctly zero-initialized.

### What is changed and how it works?

What's Changed:

Update ckb-vm to v0.24.6. For detaild ChangLogs, see:

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.24.6

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

