### PR TITLE
chore: add histogram metrics for relay compact block verify time

### DIFF
--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -121,7 +121,7 @@ impl<'a> CompactBlockProcess<'a> {
 
                 if let Some(metrics) = ckb_metrics::handle() {
                     metrics
-                        .ckb_relay_cb_verify_time
+                        .ckb_relay_cb_verify_duration
                         .observe(instant.elapsed().as_secs_f64());
                 }
                 Status::ok()

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -21,6 +21,7 @@ use ckb_verification::{HeaderError, HeaderVerifier};
 use ckb_verification_traits::Verifier;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 // Keeping in mind that short_ids are expected to occasionally collide.
 // On receiving compact-block message,
@@ -53,6 +54,7 @@ impl<'a> CompactBlockProcess<'a> {
     }
 
     pub fn execute(self) -> Status {
+        let instant = Instant::now();
         let shared = self.relayer.shared();
         let active_chain = shared.active_chain();
         let compact_block = self.message.to_entity();
@@ -117,6 +119,11 @@ impl<'a> CompactBlockProcess<'a> {
                 self.relayer
                     .accept_block(self.nc.as_ref(), self.peer, block);
 
+                if let Some(metrics) = ckb_metrics::handle() {
+                    metrics
+                        .ckb_relay_cb_verify_time
+                        .observe(instant.elapsed().as_secs_f64());
+                }
                 Status::ok()
             }
             ReconstructionResult::Missing(transactions, uncles) => {

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -7,8 +7,8 @@
 //! [`ckb-metrics-service`]: ../ckb_metrics_service/index.html
 
 use prometheus::{
-    register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
-    HistogramVec, IntCounter, IntGauge, IntGaugeVec,
+    register_histogram, register_histogram_vec, register_int_counter, register_int_gauge,
+    register_int_gauge_vec, Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec,
 };
 use prometheus_static_metric::make_static_metric;
 use std::cell::Cell;
@@ -48,6 +48,8 @@ pub struct Metrics {
     pub ckb_freezer_read: IntCounter,
     /// Counter for relay transaction short id collide
     pub ckb_relay_transaction_short_id_collide: IntCounter,
+    /// Histogram for relay compact block verify time
+    pub ckb_relay_cb_verify_time: Histogram,
     /// Counter for relay compact block transaction count
     pub ckb_relay_cb_transaction_count: IntCounter,
     /// Counter for relay compact block reconstruct ok
@@ -77,6 +79,11 @@ static METRICS: once_cell::sync::Lazy<Metrics> = once_cell::sync::Lazy::new(|| M
     ckb_relay_transaction_short_id_collide: register_int_counter!(
         "ckb_relay_transaction_short_id_collide",
         "The CKB relay transaction short id collide"
+    )
+    .unwrap(),
+    ckb_relay_cb_verify_time: register_histogram!(
+        "ckb_relay_cb_verify_time",
+        "The CKB relay compact block verify time"
     )
     .unwrap(),
     ckb_relay_cb_transaction_count: register_int_counter!(

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -48,8 +48,8 @@ pub struct Metrics {
     pub ckb_freezer_read: IntCounter,
     /// Counter for relay transaction short id collide
     pub ckb_relay_transaction_short_id_collide: IntCounter,
-    /// Histogram for relay compact block verify time
-    pub ckb_relay_cb_verify_time: Histogram,
+    /// Histogram for relay compact block verify duration
+    pub ckb_relay_cb_verify_duration: Histogram,
     /// Counter for relay compact block transaction count
     pub ckb_relay_cb_transaction_count: IntCounter,
     /// Counter for relay compact block reconstruct ok
@@ -81,9 +81,9 @@ static METRICS: once_cell::sync::Lazy<Metrics> = once_cell::sync::Lazy::new(|| M
         "The CKB relay transaction short id collide"
     )
     .unwrap(),
-    ckb_relay_cb_verify_time: register_histogram!(
-        "ckb_relay_cb_verify_time",
-        "The CKB relay compact block verify time"
+    ckb_relay_cb_verify_duration: register_histogram!(
+        "ckb_relay_cb_verify_duration",
+        "The CKB relay compact block verify duration"
     )
     .unwrap(),
     ckb_relay_cb_transaction_count: register_int_counter!(


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

An efficient block verification process is important for reducing the network uncle rate, especially when the relay protocol receives the latest block,  which allows the miner to update the tip faster and thus work on the latest chain quickly. User may need this metric to monitor and optimize ckb node.

### What is changed and how it works?

This PR add histogram metrics for relay protocol to record the compact block verification time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
https://github.com/nervosnetwork/ckb/blob/19f5362a82da87441daa9ba002a3c4f404cff9de/util/metrics-config/src/lib.rs#L17-L16


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

