### PR TITLE
fix: ckb-hash feature `ckb-contract` is invalid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b-ref"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95916998c798756098a4eb1b3f2cd510659705a9817bf203d61abd30fbec3e7b"
+checksum = "294d17c72e0ba59fad763caa112368d0672083779cdebbb97164f4bb4c1e339a"
 
 [[package]]
 name = "blake2b-rs"

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dev-dependencies]
-ckb-hash = {path = "../hash", version = "= 0.112.0-pre"}
+ckb-hash = { path = "../hash", version = "= 0.112.0-pre" }
 
 [features]
 default = ["std"]
@@ -20,12 +20,12 @@ check-data = []
 # Enable the `serialized-size` extension for CKB contract development in `no-std` env
 serialized-size = ["calc-hash"]
 # Enable all in `std` env
-std = ["molecule/std", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
+std = ["molecule/std", "ckb-hash", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
 
 [dependencies]
 cfg-if = "1.0"
-ckb-hash = { path = "../hash", version = "= 0.112.0-pre" }
 molecule = { version = "0.7.5", default-features = false }
+ckb-hash = { path = "../hash", version = "= 0.112.0-pre", optional = true }
 ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.112.0-pre", optional = true }
 ckb-error = { path = "../../error", version = "= 0.112.0-pre", optional = true }
 ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.112.0-pre", optional = true }

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -20,12 +20,12 @@ check-data = []
 # Enable the `serialized-size` extension for CKB contract development in `no-std` env
 serialized-size = ["calc-hash"]
 # Enable all in `std` env
-std = ["molecule/std", "ckb-hash", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
+std = ["molecule/std", "ckb-hash/default", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
 
 [dependencies]
 cfg-if = "1.0"
 molecule = { version = "0.7.5", default-features = false }
-ckb-hash = { path = "../hash", version = "= 0.112.0-pre", optional = true }
+ckb-hash = { path = "../hash", version = "= 0.112.0-pre", default-features = false, optional = true }
 ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.112.0-pre", optional = true }
 ckb-error = { path = "../../error", version = "= 0.112.0-pre", optional = true }
 ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.112.0-pre", optional = true }

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -9,11 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [features]
-default = []
-ckb-contract = [] # This feature is used for CKB contract development
+default = ["blake2b"]
+ckb-contract = ["blake2b-ref"] # This feature is used for CKB contract development
 
-[target.'cfg(not(any(target_arch = "wasm32", features = "ckb-contract")))'.dependencies]
-blake2b = { package = "blake2b-rs", version = "0.2" }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+blake2b = { package = "blake2b-rs", version = "0.2", optional = true }
 
-[target.'cfg(any(target_arch = "wasm32", features = "ckb-contract"))'.dependencies]
-blake2b = { package = "blake2b-ref", version = "0.2.0" }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+blake2b = { package = "blake2b-ref", version = "0.3", optional = true }
+
+[dependencies]
+blake2b-ref = { version = "0.3", optional = true }

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -9,7 +9,10 @@
 
 #![no_std]
 
+#[cfg(feature = "default")]
 pub use blake2b::{Blake2b, Blake2bBuilder};
+#[cfg(feature = "ckb-contract")]
+pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 
 #[doc(hidden)]
 pub const BLAKE2B_KEY: &[u8] = &[];


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Due to a Rust [issue](https://github.com/rust-lang/cargo/issues/8170), `the features = "ckb-contract"` in `ckb-hash` crate Cargo.toml below did not actually work as expected：

```toml
[target.'cfg(not(any(target_arch = "wasm32", features = "ckb-contract")))'.dependencies]
blake2b = { package = "blake2b-rs", version = "0.2" }

[target.'cfg(any(target_arch = "wasm32", features = "ckb-contract"))'.dependencies]
blake2b = { package = "blake2b-ref", version = "0.2.0" }
```

This will result in the following two CI failures of the PR [refactor: Replace ckb-standalone-types with ckb-gen-types](https://github.com/nervosnetwork/ckb-std/pull/71) for the `ckb-std` CI:

```yml
cargo build --target=riscv64imac-unknown-none-elf --no-default-features --features=ckb-types,allocator
```

```yml
cargo build --verbose --target=riscv64imac-unknown-none-elf --features=build-with-clang
```

### What is changed and how it works?

What's Changed:

1. Implemented a workaround to bypass the [issue](https://github.com/nervosnetwork/ckb/commit/312709fe048018f511ee5753af650ab43306e6c6)

```toml
[features]
default = ["blake2b"]
ckb-contract = ["blake2b-ref"] # This feature is used for CKB contract development

[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
blake2b = { package = "blake2b-rs", version = "0.2", optional = true }

[target.'cfg(target_arch = "wasm32")'.dependencies]
blake2b = { package = "blake2b-ref", version = "0.3", optional = true }

[dependencies]
blake2b-ref = { version = "0.3", optional = true }
```

2. update `blake2b-ref` version to `0.3`. 

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test: make the CI tests of `ckb-std` pass：

- [rust](https://github.com/EthanYuan/ckb-std/blob/update/.github/workflows/rust.yml)
- [build-with-clang](https://github.com/EthanYuan/ckb-std/blob/update/.github/workflows/build-with-clang.yml)

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

