### PR TITLE
fix(script/spawn): calucate the correct cycles_base

### DIFF
--- a/script/src/syscalls/spawn.rs
+++ b/script/src/syscalls/spawn.rs
@@ -25,6 +25,7 @@ pub struct Spawn<DL> {
     script_version: ScriptVersion,
     syscalls_generator: TransactionScriptsSyscallsGenerator<DL>,
     peak_memory: u64,
+    cycles_base: u64,
     context: Arc<Mutex<MachineContext>>,
 }
 
@@ -34,6 +35,7 @@ impl<DL: CellDataProvider + Clone + HeaderProvider + Send + Sync + 'static> Spaw
         script_version: ScriptVersion,
         syscalls_generator: TransactionScriptsSyscallsGenerator<DL>,
         peak_memory: u64,
+        cycles_base: u64,
         context: Arc<Mutex<MachineContext>>,
     ) -> Self {
         Self {
@@ -41,6 +43,7 @@ impl<DL: CellDataProvider + Clone + HeaderProvider + Send + Sync + 'static> Spaw
             script_version,
             syscalls_generator,
             peak_memory,
+            cycles_base,
             context,
         }
     }
@@ -155,7 +158,7 @@ where
             caller_exit_code_addr: exit_code_addr.to_u64(),
             caller_content_addr: content_addr.to_u64(),
             caller_content_length_addr: content_length_addr.to_u64(),
-            cycles_base: machine.cycles(),
+            cycles_base: self.cycles_base + machine.cycles(),
         };
         let mut machine_child = build_child_machine(
             &self.script_group,
@@ -290,6 +293,7 @@ pub fn build_child_machine<
         script_version,
         script_group,
         *callee_peak_memory,
+        *cycles_base,
         Arc::clone(context),
     )));
     let machine_builder = machine_builder.syscall(Box::new(

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -246,6 +246,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
         script_version: ScriptVersion,
         script_group: &ScriptGroup,
         peak_memory: u64,
+        cycles_base: u64,
         context: Arc<Mutex<MachineContext>>,
     ) -> Spawn<DL> {
         Spawn::new(
@@ -253,6 +254,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             script_version,
             self.clone(),
             peak_memory,
+            cycles_base,
             context,
         )
     }
@@ -329,7 +331,7 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             syscalls.append(&mut vec![
                 Box::new(self.build_get_memory_limit(8)),
                 Box::new(self.build_set_content(Arc::new(Mutex::new(vec![])), 0)),
-                Box::new(self.build_spawn(script_version, script_group, 8, Arc::clone(&context))),
+                Box::new(self.build_spawn(script_version, script_group, 8, 0, Arc::clone(&context))),
                 Box::new(self.build_current_memory(8)),
             ])
         }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -331,7 +331,13 @@ impl<DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + C
             syscalls.append(&mut vec![
                 Box::new(self.build_get_memory_limit(8)),
                 Box::new(self.build_set_content(Arc::new(Mutex::new(vec![])), 0)),
-                Box::new(self.build_spawn(script_version, script_group, 8, 0, Arc::clone(&context))),
+                Box::new(self.build_spawn(
+                    script_version,
+                    script_group,
+                    8,
+                    0,
+                    Arc::clone(&context),
+                )),
                 Box::new(self.build_current_memory(8)),
             ])
         }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When current_cycles is called in spawn, only the sum of the cycles of the parent script and the current script is returned, and the grandpa script is not included.

### What is changed and how it works?

What's Changed:

Add a `cycles_base` parameter to spawn. Make child script's `cycles_base` equal to `parent script's cycles_base + parent script's machine.cycles()`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

