### PR TITLE
fix: update the RPC `generate_block` method comments

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3182,19 +3182,9 @@ Response
 * `generate_block()`
 * result: [`H256`](#type-h256)
 
-Generate block with block_assembler_config, process the block(with verification)
+Generate block(with verification) and broadcast the block.
 
-and broadcast the block.
-
-###### Params
-
-*
-    `block_assembler_script` - specified block assembler script
-
-
-*
-    `block_assembler_message` - specified block assembler message
-
+Note that if called concurrently, it may return the hash of the same block.
 
 ###### Examples
 

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -140,15 +140,9 @@ pub trait IntegrationTestRpc {
     #[rpc(name = "truncate")]
     fn truncate(&self, target_tip_hash: H256) -> Result<()>;
 
-    /// Generate block with block_assembler_config, process the block(with verification)
+    /// Generate block(with verification) and broadcast the block.
     ///
-    /// and broadcast the block.
-    ///
-    /// ## Params
-    ///
-    /// * `block_assembler_script` - specified block assembler script
-    ///
-    /// * `block_assembler_message` - specified block assembler message
+    /// Note that if called concurrently, it may return the hash of the same block.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

There are deprecated parameters in the comments of RPC method `generate_block`.

### What is changed and how it works?

What's Changed:

- removed deprecated parameters
- added a note about concurrent calling

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

