### PR TITLE
fix(scripts/spawn): always consume extra_cycles

### DIFF
--- a/script/src/syscalls/spawn.rs
+++ b/script/src/syscalls/spawn.rs
@@ -222,6 +222,8 @@ where
                     .add_cycles_no_checking(transferred_byte_cycles(size))?;
             }
             Err(_) => {
+                // If loading binary fails, we still need to consume extra_cycles.
+                machine.add_cycles_no_checking(extra_cycles)?;
                 machine.set_register(A0, Mac::REG::from_u8(WRONG_FORMAT));
                 return Ok(true);
             }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In Spawn syscall, if loading binary fails, only 500 cycles will be added. This is much lower than the actual resource consumption of the Spawn syscall.

### What is changed and how it works?

What's Changed:

Add extra_cycles even if loading fails.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

