### PR TITLE
feat(rpc): Introduce the new method `generate_epochs` in the `IntegrationTest` module

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3216,8 +3216,8 @@ Response
 
 
 #### Method `fast_forward_epochs`
-* `fast_forward_epochs(epoch_count)`
-    * `epoch_count`: [`Uint64`](#type-uint64)
+* `fast_forward_epochs(epochs_to_skip)`
+    * `epochs_to_skip`: [`Uint64`](#type-uint64)
 * result: [`Uint64`](#type-uint64)
 
 Fast-forwarding epochs during development, can be useful for scenarios
@@ -3228,7 +3228,7 @@ Returns the updated epoch number after fast forwarding.
 
 ###### Params
 
-*   `epoch_count` - The number of epochs to fast forward.
+*   `epochs_to_skip` - The number of epochs to fast forward.
 
 ###### Examples
 
@@ -3240,7 +3240,7 @@ Returns the updated epoch number after fast forwarding.
   "id": 42,
   "jsonrpc": "2.0",
   "method": "fast_forward_epochs",
-  "params": "0x4"
+  "params": ["0x6"]
 }
 ```
 
@@ -3252,7 +3252,7 @@ Returns the updated epoch number after fast forwarding.
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": 0x8,
+  "result": "0x8",
   "error": null
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -68,6 +68,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.67.1.
         * [Method `process_block_without_verify`](#method-process_block_without_verify)
         * [Method `truncate`](#method-truncate)
         * [Method `generate_block`](#method-generate_block)
+        * [Method `fast_forward_epochs`](#method-fast_forward_epochs)
         * [Method `notify_transaction`](#method-notify_transaction)
         * [Method `generate_block_with_template`](#method-generate_block_with_template)
         * [Method `calculate_dao_field`](#method-calculate_dao_field)
@@ -3209,6 +3210,49 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029",
+  "error": null
+}
+```
+
+
+#### Method `fast_forward_epochs`
+* `fast_forward_epochs(epoch_count)`
+    * `epoch_count`: [`Uint64`](#type-uint64)
+* result: [`Uint64`](#type-uint64)
+
+Fast-forwarding epochs during development, can be useful for scenarios
+
+like testing DAO-related functionalities.
+
+Returns the updated epoch number after fast forwarding.
+
+###### Params
+
+*   `epoch_count` - The number of epochs to fast forward.
+
+###### Examples
+
+###### Request
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "fast_forward_epochs",
+  "params": "0x4"
+}
+```
+
+
+###### Response
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": 0x8,
   "error": null
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -68,7 +68,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.67.1.
         * [Method `process_block_without_verify`](#method-process_block_without_verify)
         * [Method `truncate`](#method-truncate)
         * [Method `generate_block`](#method-generate_block)
-        * [Method `fast_forward_epochs`](#method-fast_forward_epochs)
+        * [Method `generate_epochs`](#method-generate_epochs)
         * [Method `notify_transaction`](#method-notify_transaction)
         * [Method `generate_block_with_template`](#method-generate_block_with_template)
         * [Method `calculate_dao_field`](#method-calculate_dao_field)
@@ -3215,20 +3215,20 @@ Response
 ```
 
 
-#### Method `fast_forward_epochs`
-* `fast_forward_epochs(epochs_to_skip)`
-    * `epochs_to_skip`: [`EpochNumber`](#type-epochnumber)
+#### Method `generate_epochs`
+* `generate_epochs(num_epochs)`
+    * `num_epochs`: [`EpochNumberWithFraction`](#type-epochnumberwithfraction)
 * result: [`EpochNumberWithFraction`](#type-epochnumberwithfraction)
 
-Fast-forwarding epochs during development, can be useful for scenarios
+Generate epochs during development, can be useful for scenarios
 
 like testing DAO-related functionalities.
 
-Returns the updated epoch number after fast forwarding.
+Returns the updated epoch number after generating the specified number of epochs.
 
 ###### Params
 
-*   `epochs_to_skip` - The number of epochs to fast forward.
+*   `num_epochs` - The number of epochs to generate.
 
 ###### Examples
 
@@ -3239,8 +3239,8 @@ Returns the updated epoch number after fast forwarding.
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "method": "fast_forward_epochs",
-  "params": ["0x1"]
+  "method": "generate_epochs",
+  "params": ["0x00000000001"]
 }
 ```
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3217,8 +3217,8 @@ Response
 
 #### Method `fast_forward_epochs`
 * `fast_forward_epochs(epochs_to_skip)`
-    * `epochs_to_skip`: [`Uint64`](#type-uint64)
-* result: [`Uint64`](#type-uint64)
+    * `epochs_to_skip`: [`EpochNumber`](#type-epochnumber)
+* result: [`EpochNumberWithFraction`](#type-epochnumberwithfraction)
 
 Fast-forwarding epochs during development, can be useful for scenarios
 
@@ -3240,7 +3240,7 @@ Returns the updated epoch number after fast forwarding.
   "id": 42,
   "jsonrpc": "2.0",
   "method": "fast_forward_epochs",
-  "params": ["0x6"]
+  "params": ["0x1"]
 }
 ```
 
@@ -3252,7 +3252,7 @@ Returns the updated epoch number after fast forwarding.
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0x8",
+  "result": "0x384000c000002",
   "error": null
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3232,7 +3232,9 @@ Returns the updated epoch number after generating the specified number of epochs
 
 ###### Examples
 
-###### Request
+Request
+
+generating 2 epochs:
 
 
 ```
@@ -3240,19 +3242,32 @@ Returns the updated epoch number after generating the specified number of epochs
   "id": 42,
   "jsonrpc": "2.0",
   "method": "generate_epochs",
-  "params": ["0x00000000001"]
+  "params": ["0x2"]
 }
 ```
 
 
-###### Response
+generating 1/2 epoch:
 
 
 ```
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0x384000c000002",
+  "method": "generate_epochs",
+  "params": ["0x20001000000"]
+}
+```
+
+
+Response
+
+
+```
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": "0xa0001000003",
   "error": null
 }
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3220,9 +3220,7 @@ Response
     * `num_epochs`: [`EpochNumberWithFraction`](#type-epochnumberwithfraction)
 * result: [`EpochNumberWithFraction`](#type-epochnumberwithfraction)
 
-Generate epochs during development, can be useful for scenarios
-
-like testing DAO-related functionalities.
+Generate epochs during development, can be useful for scenarios like testing DAO-related functionalities.
 
 Returns the updated epoch number after generating the specified number of epochs.
 
@@ -3234,7 +3232,7 @@ Returns the updated epoch number after generating the specified number of epochs
 
 Request
 
-generating 2 epochs:
+Generating 2 epochs:
 
 
 ```
@@ -3247,7 +3245,9 @@ generating 2 epochs:
 ```
 
 
-generating 1/2 epoch:
+The input parameter “0x2” will be normalized to “0x10000000002”(the correct [`EpochNumberWithFraction`](#type-epochnumberwithfraction) type) within the method. Therefore, if you want to generate epochs as integers, you can simply pass an integer as long as it does not exceed 16777215 (24 bits).
+
+Generating 1/2 epoch:
 
 
 ```

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -579,10 +579,10 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
                 .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?
                 .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
             current_epoch = EpochNumberWithFraction::from_full_value(block_template.epoch.into());
-            let _ = self.process_and_announce_block(block_template.into());
+            self.process_and_announce_block(block_template.into())?;
         }
 
-        Ok(target_epoch.full_value().into())
+        Ok(current_epoch.full_value().into())
     }
 
     fn notify_transaction(&self, tx: Transaction) -> Result<H256> {

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -1,7 +1,7 @@
 use crate::error::RPCError;
 use ckb_chain::chain::ChainController;
 use ckb_dao::DaoCalculator;
-use ckb_jsonrpc_types::{Block, BlockTemplate, Byte32, Transaction};
+use ckb_jsonrpc_types::{Block, BlockTemplate, Byte32, Transaction, Uint64};
 use ckb_logger::error;
 use ckb_network::{NetworkController, SupportProtocols};
 use ckb_shared::{shared::Shared, Snapshot};
@@ -169,6 +169,42 @@ pub trait IntegrationTestRpc {
     /// ```
     #[rpc(name = "generate_block")]
     fn generate_block(&self) -> Result<H256>;
+
+    /// Fast-forwarding epochs during development, can be useful for scenarios
+    ///
+    /// like testing DAO-related functionalities.
+    ///
+    /// Returns the updated epoch number after fast forwarding.
+    ///
+    /// ## Params
+    ///
+    /// * `epoch_count` - The number of epochs to fast forward.
+    ///
+    /// ## Examples
+    ///
+    /// ### Request
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "method": "fast_forward_epochs",
+    ///   "params": "0x4"
+    /// }
+    /// ```
+    ///
+    /// ### Response
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "result": 0x8,
+    ///   "error": null
+    /// }
+    /// ```
+    #[rpc(name = "fast_forward_epochs")]
+    fn fast_forward_epochs(&self, epoch_count: Uint64) -> Result<Uint64>;
 
     /// Add transaction to tx-pool.
     ///
@@ -520,6 +556,10 @@ impl IntegrationTestRpc for IntegrationTestRpcImpl {
             .map_err(|err| RPCError::custom(RPCError::CKBInternalError, err.to_string()))?;
 
         self.process_and_announce_block(block_template.into())
+    }
+
+    fn fast_forward_epochs(&self, _epoch_count: Uint64) -> Result<Uint64> {
+        todo!()
     }
 
     fn notify_transaction(&self, tx: Transaction) -> Result<H256> {

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -182,24 +182,37 @@ pub trait IntegrationTestRpc {
     ///
     /// ## Examples
     ///
-    /// ### Request
+    /// Request
+    ///
+    /// generating 2 epochs:
     ///
     /// ```json
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "method": "generate_epochs",
-    ///   "params": ["0x00000000001"]
+    ///   "params": ["0x2"]
     /// }
     /// ```
     ///
-    /// ### Response
+    /// generating 1/2 epoch:
+    ///
+    /// ```text
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "method": "generate_epochs",
+    ///   "params": ["0x20001000000"]
+    /// }
+    /// ```
+    ///
+    /// Response
     ///
     /// ```json
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0x384000c000002",
+    ///   "result": "0xa0001000003",
     ///   "error": null
     /// }
     /// ```

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -171,7 +171,6 @@ pub trait IntegrationTestRpc {
     fn generate_block(&self) -> Result<H256>;
 
     /// Generate epochs during development, can be useful for scenarios
-    ///
     /// like testing DAO-related functionalities.
     ///
     /// Returns the updated epoch number after generating the specified number of epochs.
@@ -184,7 +183,7 @@ pub trait IntegrationTestRpc {
     ///
     /// Request
     ///
-    /// generating 2 epochs:
+    /// Generating 2 epochs:
     ///
     /// ```json
     /// {
@@ -195,7 +194,12 @@ pub trait IntegrationTestRpc {
     /// }
     /// ```
     ///
-    /// generating 1/2 epoch:
+    /// The input parameter "0x2" will be normalized to "0x10000000002"(the correct
+    /// [`EpochNumberWithFraction`](#type-epochnumberwithfraction) type) within the method.
+    /// Therefore, if you want to generate epochs as integers, you can simply pass an integer
+    /// as long as it does not exceed 16777215 (24 bits).
+    ///
+    /// Generating 1/2 epoch:
     ///
     /// ```text
     /// {

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -661,7 +661,7 @@ fn before_rpc_example(suite: &RpcTestSuite, example: &mut RpcTestExample) -> boo
             );
         }
         ("generate_block", 42) => return false,
-        ("fast_forward_epochs", 42) => return false,
+        ("generate_epochs", 42) => return false,
         ("get_fee_rate_statics", 42) => return false,
         ("get_fee_rate_statistics", 42) => return false,
         ("generate_block_with_template", 42) => return false,

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -661,6 +661,7 @@ fn before_rpc_example(suite: &RpcTestSuite, example: &mut RpcTestExample) -> boo
             );
         }
         ("generate_block", 42) => return false,
+        ("fast_forward_epochs", 42) => return false,
         ("get_fee_rate_statics", 42) => return false,
         ("get_fee_rate_statistics", 42) => return false,
         ("generate_block_with_template", 42) => return false,

--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::{RpcServer, ServiceBuilder};
 use ckb_app_config::{BlockAssemblerConfig, NetworkConfig, RpcConfig, RpcModule};
 use ckb_chain::chain::{ChainController, ChainService};
+use ckb_chain_spec::consensus::Consensus;
 use ckb_dao::DaoCalculator;
 use ckb_jsonrpc_types::ScriptHashType;
 use ckb_launcher::SharedBuilder;
@@ -8,9 +9,7 @@ use ckb_network::{Flags, NetworkService, NetworkState};
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::{Shared, Snapshot};
 use ckb_store::ChainStore;
-use ckb_test_chain_utils::{
-    always_success_cell, always_success_cellbase, always_success_consensus,
-};
+use ckb_test_chain_utils::{always_success_cell, always_success_cellbase};
 use ckb_types::{
     core::{
         cell::resolve_transaction, BlockBuilder, BlockView, HeaderView, TransactionBuilder,
@@ -206,9 +205,9 @@ fn always_success_transaction() -> TransactionView {
 
 // setup a chain with 20 blocks and enable `Chain`, `Miner` and `Pool` rpc modules for unit test
 // there is a similar fn `setup_rpc_test_suite` which enables all rpc modules, may be refactored into one fn with different paramsters in other PRs
-fn setup() -> RpcTestSuite {
+fn setup(consensus: Consensus) -> RpcTestSuite {
     let (shared, mut pack) = SharedBuilder::with_temp_db()
-        .consensus(always_success_consensus())
+        .consensus(consensus)
         .block_assembler_config(Some(BlockAssemblerConfig {
             code_hash: h256!("0x0"),
             args: Default::default(),

--- a/rpc/src/tests/module/miner.rs
+++ b/rpc/src/tests/module/miner.rs
@@ -1,6 +1,6 @@
 use crate::tests::{always_success_transaction, setup, RpcTestRequest};
 use ckb_store::ChainStore;
-use ckb_test_chain_utils::always_success_cell;
+use ckb_test_chain_utils::{always_success_cell, always_success_consensus};
 use ckb_types::{
     core::{capacity_bytes, Capacity, TransactionBuilder},
     packed::{CellDep, CellInput, CellOutputBuilder, OutPoint},
@@ -12,7 +12,7 @@ use std::{sync::Arc, thread::sleep, time::Duration};
 #[test]
 #[ignore]
 fn test_get_block_template_cache() {
-    let suite = setup();
+    let suite = setup(always_success_consensus());
     // block template cache will expire when new uncle block is added to the chain
     {
         let response_old = suite.rpc(&RpcTestRequest {

--- a/rpc/src/tests/module/mod.rs
+++ b/rpc/src/tests/module/mod.rs
@@ -1,2 +1,3 @@
 mod miner;
 mod pool;
+mod test;

--- a/rpc/src/tests/module/pool.rs
+++ b/rpc/src/tests/module/pool.rs
@@ -1,8 +1,7 @@
 use std::{thread::sleep, time::Duration};
 
 use ckb_store::ChainStore;
-use ckb_test_chain_utils::always_success_cell;
-use ckb_test_chain_utils::ckb_testnet_consensus;
+use ckb_test_chain_utils::{always_success_cell, always_success_consensus, ckb_testnet_consensus};
 use ckb_types::{
     core::{self, Capacity, TransactionBuilder},
     packed::{self, CellDep, CellInput, CellOutputBuilder, OutPoint},
@@ -139,7 +138,7 @@ fn test_default_outputs_validator() {
 #[test]
 #[ignore]
 fn test_send_transaction_exceeded_maximum_ancestors_count() {
-    let suite = setup();
+    let suite = setup(always_success_consensus());
 
     let store = suite.shared.store();
     let tip = store.get_tip_header().unwrap();

--- a/rpc/src/tests/module/test.rs
+++ b/rpc/src/tests/module/test.rs
@@ -5,7 +5,6 @@ use ckb_store::ChainStore;
 use ckb_test_chain_utils::always_success_consensus;
 use ckb_types::{
     core::{Capacity, EpochNumberWithFraction},
-    prelude::Unpack,
     utilities::DIFF_TWO,
 };
 
@@ -40,6 +39,10 @@ fn test_generate_epochs() {
         method: "generate_epochs".to_string(),
         params: vec!["0x10000000001".into()],
     });
+    assert_eq!(
+        "0x10000000001".to_string(),
+        Into::<ckb_jsonrpc_types::Uint64>::into(EpochNumberWithFraction::new(1, 0, 1)).to_string(),
+    );
     assert_eq!(
         get_current_epoch(&suite),
         EpochNumberWithFraction::new(2, 20, GENESIS_EPOCH_LENGTH)
@@ -104,9 +107,9 @@ fn setup_rpc() -> RpcTestSuite {
 
 fn get_current_epoch(suite: &RpcTestSuite) -> EpochNumberWithFraction {
     let store = suite.shared.store();
-    let tip_block_number = store.get_tip_header().unwrap().data().raw().number();
+    let tip_block_number = store.get_tip_header().unwrap().number();
     store
         .get_current_epoch_ext()
         .unwrap()
-        .number_with_fraction(tip_block_number.unpack())
+        .number_with_fraction(tip_block_number)
 }

--- a/rpc/src/tests/module/test.rs
+++ b/rpc/src/tests/module/test.rs
@@ -1,0 +1,112 @@
+#![allow(clippy::inconsistent_digit_grouping)]
+
+use ckb_chain_spec::consensus::build_genesis_epoch_ext;
+use ckb_store::ChainStore;
+use ckb_test_chain_utils::always_success_consensus;
+use ckb_types::{
+    core::{Capacity, EpochNumberWithFraction},
+    prelude::Unpack,
+    utilities::DIFF_TWO,
+};
+
+use crate::tests::{setup, RpcTestRequest, RpcTestSuite};
+
+const GENESIS_EPOCH_LENGTH: u64 = 30;
+
+#[test]
+fn test_generate_epochs() {
+    let suite = setup_rpc();
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(0, 20, GENESIS_EPOCH_LENGTH)
+    );
+
+    // generate 1 epoch
+    suite.rpc(&RpcTestRequest {
+        id: 42,
+        jsonrpc: "2.0".to_string(),
+        method: "generate_epochs".to_string(),
+        params: vec!["0x1".into()],
+    });
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(1, 20, GENESIS_EPOCH_LENGTH)
+    );
+
+    // generate 1(0/1) epoch
+    suite.rpc(&RpcTestRequest {
+        id: 42,
+        jsonrpc: "2.0".to_string(),
+        method: "generate_epochs".to_string(),
+        params: vec!["0x10000000001".into()],
+    });
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(2, 20, GENESIS_EPOCH_LENGTH)
+    );
+
+    // generate 1/2 epoch
+    suite.rpc(&RpcTestRequest {
+        id: 42,
+        jsonrpc: "2.0".to_string(),
+        method: "generate_epochs".to_string(),
+        params: vec!["0x20001000000".into()],
+    });
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(3, 5, GENESIS_EPOCH_LENGTH)
+    );
+
+    // generate 3/2 epoch
+    suite.rpc(&RpcTestRequest {
+        id: 42,
+        jsonrpc: "2.0".to_string(),
+        method: "generate_epochs".to_string(),
+        params: vec!["0x20003000000".into()],
+    });
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(4, 20, GENESIS_EPOCH_LENGTH)
+    );
+
+    // generate 0/2 epoch
+    suite.rpc(&RpcTestRequest {
+        id: 42,
+        jsonrpc: "2.0".to_string(),
+        method: "generate_epochs".to_string(),
+        params: vec!["0x20000000000".into()],
+    });
+    assert_eq!(
+        get_current_epoch(&suite),
+        EpochNumberWithFraction::new(4, 20, GENESIS_EPOCH_LENGTH)
+    );
+}
+
+// setup a chain for integration test rpc
+fn setup_rpc() -> RpcTestSuite {
+    const INITIAL_PRIMARY_EPOCH_REWARD: Capacity = Capacity::shannons(1_917_808_21917808);
+    const DEFAULT_EPOCH_DURATION_TARGET: u64 = 240;
+    const DEFAULT_ORPHAN_RATE_TARGET: (u32, u32) = (1, 40);
+    let epoch_ext = build_genesis_epoch_ext(
+        INITIAL_PRIMARY_EPOCH_REWARD,
+        DIFF_TWO,
+        GENESIS_EPOCH_LENGTH,
+        DEFAULT_EPOCH_DURATION_TARGET,
+        DEFAULT_ORPHAN_RATE_TARGET,
+    );
+    let mut consensus = always_success_consensus();
+    consensus.genesis_epoch_ext = epoch_ext;
+    consensus.epoch_duration_target = 240;
+    consensus.permanent_difficulty_in_dummy = true;
+
+    setup(consensus)
+}
+
+fn get_current_epoch(suite: &RpcTestSuite) -> EpochNumberWithFraction {
+    let store = suite.shared.store();
+    let tip_block_number = store.get_tip_header().unwrap().data().raw().number();
+    store
+        .get_current_epoch_ext()
+        .unwrap()
+        .number_with_fraction(tip_block_number.unpack())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

In the context of CKB applications, many contracts are closely tied to `epoch` processes, including ["DAO"](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md) script, ["cheque"](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0039-cheque/0039-cheque.md) script, and others. During the development process, facilitating the acceleration of epochs becomes essential.

Before this PR, there were two methods: 
1. relied on miners rapidly producing blocks
2. required multiple calls to the CKB RPC `generate_block`

Clearly, the latter is more suitable for integration testing (without requiring a miner). However, using `generate_block` poses two issues. Firstly, it requires the calling side to calculate and determine the number of times `generate_block` should be called based on the desired epochs to fast-forward. Secondly, if called too quickly, `generate_block` may produce duplicate block hashes (indicating that no new blocks were generated), necessitating deduplication on the calling side.

The newly designed RPC `generate_epochs` introduces a parameter called `num_epochs`. Upon successful execution, it will return the current epoch target (in the form of `EpochNumberWithFraction`), significantly simplifying integration testing for applications like "DAO".

### What is changed and how it works?

What's Changed:

add rpc:

```rust
#[rpc(name = "generate_epochs")]
fn generate_epochs(&self, num_epochs: EpochNumberWithFraction) -> Result<EpochNumberWithFraction>;
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  - [dao-related tests](https://github.com/EthanYuan/mercury/blob/dev-0.4-omni-0.108/integration/src/tests/build_dao_transaction.rs#L22) 
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

