### PR TITLE
Fix parse `RelayV3`'s message name for metrics service

### DIFF
--- a/sync/src/utils.rs
+++ b/sync/src/utils.rs
@@ -93,7 +93,9 @@ fn message_name<Message: Entity>(protocol_id: ProtocolId, message: &Message) -> 
             .to_enum()
             .item_name()
             .to_owned()
-    } else if protocol_id == SupportProtocols::RelayV2.protocol_id() {
+    } else if protocol_id == SupportProtocols::RelayV2.protocol_id()
+        || protocol_id == SupportProtocols::RelayV3.protocol_id()
+    {
         RelayMessageReader::new_unchecked(message.as_slice())
             .to_enum()
             .item_name()


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

We should parse `Relayv3`'s message name to metrics service.

What's Changed:

### Related changes

- Parse `RelayV3`'s message name

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

