### PR TITLE
fix: keep peer store address unique

### DIFF
--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -46,7 +46,7 @@ impl PeerStore {
             .entry(extract_peer_id(&addr).expect("connected addr should have peer id"))
         {
             Entry::Occupied(mut entry) => {
-                let mut peer = entry.get_mut();
+                let peer = entry.get_mut();
                 peer.connected_addr = addr;
                 peer.last_connected_at_ms = now_ms;
                 peer.session_type = session_type;

--- a/network/src/tests/mod.rs
+++ b/network/src/tests/mod.rs
@@ -6,7 +6,8 @@ mod peer_store_db;
 
 fn random_addr() -> crate::multiaddr::Multiaddr {
     format!(
-        "/ip4/127.0.0.1/tcp/42/p2p/{}",
+        "/ip4/127.0.0.1/tcp/{}/p2p/{}",
+        rand::random::<u16>(),
         crate::PeerId::random().to_base58()
     )
     .parse()

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -533,3 +533,22 @@ fn test_eviction() {
         .unwrap();
     assert!(peer_store.mut_addr_manager().get(&new_peer_addr).is_some());
 }
+
+#[test]
+fn test_addr_unique() {
+    let mut peer_store = PeerStore::default();
+    let addr = random_addr();
+    let addr_1 = random_addr();
+
+    peer_store
+        .add_addr(addr.clone(), Flags::COMPATIBILITY)
+        .unwrap();
+    peer_store.add_addr(addr_1, Flags::COMPATIBILITY).unwrap();
+    assert_eq!(peer_store.addr_manager().addrs_iter().count(), 2);
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 2);
+
+    peer_store.add_addr(addr, Flags::COMPATIBILITY).unwrap();
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 2);
+
+    assert_eq!(peer_store.addr_manager().addrs_iter().count(), 2);
+}


### PR DESCRIPTION
### What problem does this PR solve?

When the same address enters the peer store, we need to reset the random id and ensure that the address is unique

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

