### PR TITLE
Remove useless `non_owning_clone` method for `ChainController` and `NetworkController`

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -99,15 +99,6 @@ impl ChainController {
                 .into())
         })
     }
-
-    /// Since a non-owning reference does not count towards ownership,
-    /// it will not prevent the value stored in the allocation from being dropped
-    pub fn non_owning_clone(&self) -> Self {
-        ChainController {
-            truncate_sender: self.truncate_sender.clone(),
-            process_block_sender: self.process_block_sender.clone(),
-        }
-    }
 }
 
 /// The struct represent fork

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -53,7 +53,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
     );
 
     let tx_pool_builder = pack.take_tx_pool_builder();
-    tx_pool_builder.start(network_controller.non_owning_clone());
+    tx_pool_builder.start(network_controller.clone());
 
     ctrlc::set_handler(|| {
         info!("Trapped exit signal, exiting...");

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -47,7 +47,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     let (network_controller, _rpc_server) = launcher.start_network_and_rpc(
         &shared,
-        chain_controller.non_owning_clone(),
+        chain_controller.clone(),
         miner_enable,
         pack.take_relay_tx_receiver(),
     );

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1386,17 +1386,6 @@ impl NetworkController {
             let _ignore = ping_controller.try_send(());
         }
     }
-
-    /// Since a non-owning reference does not count towards ownership,
-    /// it will not prevent the value stored in the allocation from being dropped
-    pub fn non_owning_clone(&self) -> Self {
-        NetworkController {
-            version: self.version.clone(),
-            network_state: Arc::clone(&self.network_state),
-            p2p_control: self.p2p_control.clone(),
-            ping_controller: self.ping_controller.clone(),
-        }
-    }
 }
 
 // Send an optional message before disconnect a peer


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

We have remove `stop_handler` from `ChainService` and `NetworkController` in #3999 : related [change](https://github.com/nervosnetwork/ckb/pull/3999/files#diff-821b94c6d358718330722e717ee1226b384b1b657262c0e42e357f621d60433aL53)

So the `non_owning_clone` become meaningless. Remove it to make code more neat. 

### What is changed and how it works?

### Related changes

- Remove useless `non_owning_clone` method for `ChainController` and `NetworkController`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

