### PR TITLE
Remove useless `--cfg disable_faketime` from `RUSTFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,19 +140,19 @@ build-for-profiling: ## Build binary with for profiling.
 
 .PHONY: prod
 prod: ## Build binary for production release.
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" cargo build ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding"
+	cargo build ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod_portable
 prod_portable: ## Build binary for portable production release.
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" cargo build ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding,portable"
+	cargo build ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding,portable"
 
 .PHONY: prod-docker
 prod-docker:
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime --cfg docker" cargo build --verbose ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding"
+	RUSTFLAGS="$${RUSTFLAGS} --cfg docker" cargo build --verbose ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding"
 
 .PHONY: prod-test
 prod-test:
-	RUSTFLAGS="$${RUSTFLAGS} --cfg disable_faketime" RUSTDOCFLAGS="--cfg disable_faketime" CKB_FEATURES="with_sentry,with_dns_seeding" $(MAKE) test
+	CKB_FEATURES="with_sentry,with_dns_seeding" $(MAKE) test
 
 .PHONY: prod-with-debug
 prod-with-debug:

--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -128,7 +128,6 @@ fn create_cellbase(number: BlockNumber, epoch: &EpochExt) -> TransactionView {
         .build()
 }
 
-
 #[test]
 fn test_block_template_timestamp() {
     let mut _faketime_guard = ckb_systemtime::faketime();

--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -128,7 +128,7 @@ fn create_cellbase(number: BlockNumber, epoch: &EpochExt) -> TransactionView {
         .build()
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_block_template_timestamp() {
     let mut _faketime_guard = ckb_systemtime::faketime();

--- a/devtools/windows/make.ps1
+++ b/devtools/windows/make.ps1
@@ -57,7 +57,7 @@ function Disable-DebugSymbols {
 }
 
 function run-prod {
-  Set-Env RUSTFLAGS "--cfg disable_faketime"
+  Set-Env RUSTFLAGS ""
   cargo build @Verbose --release
 }
 

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -82,7 +82,6 @@ fn test_update_status() {
     );
 }
 
-
 #[test]
 fn test_ban_peer() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -122,7 +121,6 @@ fn test_ban_peer() {
     assert_eq!(peer_store.ban_list().count(), 1)
 }
 
-
 #[test]
 fn test_attempt_ban() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -156,7 +154,6 @@ fn test_attempt_ban() {
     );
 }
 
-
 #[test]
 fn test_fetch_addrs_to_attempt() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -189,7 +186,6 @@ fn test_fetch_addrs_to_attempt() {
         .is_empty());
 }
 
-
 #[test]
 fn test_fetch_addrs_to_attempt_or_feeler() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -216,7 +212,6 @@ fn test_fetch_addrs_to_attempt_or_feeler() {
         .is_empty());
     assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
 }
-
 
 #[test]
 fn test_fetch_addrs_to_attempt_in_last_minutes() {

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -82,7 +82,7 @@ fn test_update_status() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_ban_peer() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -122,7 +122,7 @@ fn test_ban_peer() {
     assert_eq!(peer_store.ban_list().count(), 1)
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_attempt_ban() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -156,7 +156,7 @@ fn test_attempt_ban() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_fetch_addrs_to_attempt() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -189,7 +189,7 @@ fn test_fetch_addrs_to_attempt() {
         .is_empty());
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_fetch_addrs_to_attempt_or_feeler() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -217,7 +217,7 @@ fn test_fetch_addrs_to_attempt_or_feeler() {
     assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_fetch_addrs_to_attempt_in_last_minutes() {
     let _faketime_guard = ckb_systemtime::faketime();

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -87,7 +87,7 @@ fn inflight_blocks_state() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn inflight_blocks_timeout() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -140,7 +140,7 @@ fn inflight_blocks_timeout() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn inflight_trace_number_state() {
     let _faketime_guard = ckb_systemtime::faketime();

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -87,7 +87,6 @@ fn inflight_blocks_state() {
     );
 }
 
-
 #[test]
 fn inflight_blocks_timeout() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -139,7 +138,6 @@ fn inflight_blocks_timeout() {
         Some(4.into())
     );
 }
-
 
 #[test]
 fn inflight_trace_number_state() {

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -17,7 +17,7 @@ mod inflight_blocks;
 mod net_time_checker;
 mod orphan_block_pool;
 mod sync_shared;
-#[cfg(not(disable_faketime))]
+
 mod synchronizer;
 mod types;
 mod util;

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -695,7 +695,7 @@ fn test_sync_process() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_header_sync_timeout() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -747,7 +747,7 @@ fn test_header_sync_timeout() {
     )
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_chain_sync_timeout() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -945,7 +945,7 @@ fn test_chain_sync_timeout() {
     }
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_n_sync_started() {
     let _faketime_guard = ckb_systemtime::faketime();

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -695,7 +695,6 @@ fn test_sync_process() {
     );
 }
 
-
 #[test]
 fn test_header_sync_timeout() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -746,7 +745,6 @@ fn test_header_sync_timeout() {
         &vec![0, 1, 2].into_iter().map(Into::into).collect()
     )
 }
-
 
 #[test]
 fn test_chain_sync_timeout() {
@@ -944,7 +942,6 @@ fn test_chain_sync_timeout() {
         )
     }
 }
-
 
 #[test]
 fn test_n_sync_started() {

--- a/verification/contextual/src/tests/mod.rs
+++ b/verification/contextual/src/tests/mod.rs
@@ -1,3 +1,3 @@
 mod contextual_block_verifier;
-#[cfg(not(disable_faketime))]
+
 mod uncle_verifier;

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -61,7 +61,7 @@ pub fn test_version() {
     assert!(verifier.verify().is_ok());
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_timestamp() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -82,7 +82,7 @@ fn test_timestamp() {
     assert!(timestamp_verifier.verify().is_ok());
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_timestamp_too_old() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -111,7 +111,7 @@ fn test_timestamp_too_old() {
     );
 }
 
-#[cfg(not(disable_faketime))]
+
 #[test]
 fn test_timestamp_too_new() {
     let _faketime_guard = ckb_systemtime::faketime();

--- a/verification/src/tests/header_verifier.rs
+++ b/verification/src/tests/header_verifier.rs
@@ -61,7 +61,6 @@ pub fn test_version() {
     assert!(verifier.verify().is_ok());
 }
 
-
 #[test]
 fn test_timestamp() {
     let _faketime_guard = ckb_systemtime::faketime();
@@ -81,7 +80,6 @@ fn test_timestamp() {
 
     assert!(timestamp_verifier.verify().is_ok());
 }
-
 
 #[test]
 fn test_timestamp_too_old() {
@@ -110,7 +108,6 @@ fn test_timestamp_too_old() {
         },
     );
 }
-
 
 #[test]
 fn test_timestamp_too_new() {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
We have removed the [`faketime`](https://crates.io/crates/faketime) crate from https://github.com/nervosnetwork/ckb/pull/3777. As a result, the `#[cfg(not(disable_faketime))]` is now meaningless and can be removed.


What's Changed:

### Related changes

- Remove useless `--cfg disable_faketime` from `RUSTFLAGS`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- NOne

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

