### PR TITLE
Remove `#[derive(Clone)]` from `Synchronizer`

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -80,7 +80,7 @@ enum FetchCMD {
 }
 
 struct BlockFetchCMD {
-    sync: Synchronizer,
+    sync_shared: Arc<SyncShared>,
     p2p_control: ServiceControl,
     recv: channel::Receiver<FetchCMD>,
     can_start: CanStart,
@@ -93,7 +93,9 @@ impl BlockFetchCMD {
             FetchCMD::Fetch((peers, state)) => match self.can_start() {
                 CanStart::Ready => {
                     for peer in peers {
-                        if let Some(fetch) = BlockFetcher::new(&self.sync, peer, state).fetch() {
+                        if let Some(fetch) =
+                            BlockFetcher::new(Arc::clone(&self.sync_shared), peer, state).fetch()
+                        {
                             for item in fetch {
                                 BlockFetchCMD::send_getblocks(item, &self.p2p_control, peer);
                             }
@@ -101,7 +103,7 @@ impl BlockFetchCMD {
                     }
                 }
                 CanStart::MinWorkNotReach => {
-                    let best_known = self.sync.shared.state().shared_best_header_ref();
+                    let best_known = self.sync_shared.state().shared_best_header_ref();
                     let number = best_known.number();
                     if number != self.number && (number - self.number) % 10000 == 0 {
                         self.number = number;
@@ -111,12 +113,12 @@ impl BlockFetchCMD {
                                  then start to download block",
                             number,
                             best_known.total_difficulty(),
-                            self.sync.shared.state().min_chain_work()
+                            self.sync_shared.state().min_chain_work()
                         );
                     }
                 }
                 CanStart::AssumeValidNotFound => {
-                    let state = self.sync.shared.state();
+                    let state = self.sync_shared.state();
                     let best_known = state.shared_best_header_ref();
                     let number = best_known.number();
                     let assume_valid_target: Byte32 = state
@@ -161,7 +163,7 @@ impl BlockFetchCMD {
             return self.can_start;
         }
 
-        let state = self.sync.shared.state();
+        let state = self.sync_shared.state();
 
         let min_work_reach = |flag: &mut CanStart| {
             if state.min_chain_work_ready() {
@@ -230,7 +232,6 @@ impl BlockFetchCMD {
 }
 
 /// Sync protocol handle
-#[derive(Clone)]
 pub struct Synchronizer {
     pub(crate) chain: ChainController,
     /// Sync shared state
@@ -364,7 +365,7 @@ impl Synchronizer {
         peer: PeerIndex,
         ibd: IBDState,
     ) -> Option<Vec<Vec<packed::Byte32>>> {
-        BlockFetcher::new(self, peer, ibd).fetch()
+        BlockFetcher::new(Arc::to_owned(self.shared()), peer, ibd).fetch()
     }
 
     pub(crate) fn on_connected(&self, nc: &dyn CKBProtocolContext, peer: PeerIndex) {
@@ -632,7 +633,6 @@ impl Synchronizer {
                 }
                 None => {
                     let p2p_control = raw.clone();
-                    let sync = self.clone();
                     let (sender, recv) = channel::bounded(2);
                     let peers = self.get_peers_to_fetch(ibd, &disconnect_list);
                     sender.send(FetchCMD::Fetch((peers, ibd))).unwrap();
@@ -640,12 +640,13 @@ impl Synchronizer {
                     let thread = ::std::thread::Builder::new();
                     let number = self.shared.state().shared_best_header_ref().number();
                     const THREAD_NAME: &str = "BlockDownload";
+                    let sync_shared: Arc<SyncShared> = Arc::to_owned(self.shared());
                     let blockdownload_jh = thread
                         .name(THREAD_NAME.into())
                         .spawn(move || {
                             let stop_signal = new_crossbeam_exit_rx();
                             BlockFetchCMD {
-                                sync,
+                                sync_shared,
                                 p2p_control,
                                 recv,
                                 number,

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -1139,7 +1139,7 @@ fn test_fix_last_common_header() {
         }
 
         let expected = fix_last_common.map(|mark| mark.to_string());
-        let actual = BlockFetcher::new(&synchronizer, peer, IBDState::In)
+        let actual = BlockFetcher::new(Arc::clone(&synchronizer.shared), peer, IBDState::In)
             .update_last_common_header(&best_known_header.number_and_hash())
             .map(|header| {
                 if graph


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
I submit this PR for 2 reason:
1. I think there should be **only one** `Synchronizer` instance in CKB process. And `struct BlockFetchCMD` should depend on `SyncState` instead of `Synchronizer`
2. In #3958 , when `ChainService` verify a failed block, ChainService should transfer the `VerifyFailedBlockInfo`  to `Synchronizer`, then `Synchronizer` must ban the malicious peer. 

So I want to add a new field: `tokio::sync::mpsc::UnboundedReceiver<VerifyFailedBlockInfo>` field to the `Synchronizer` struct: 
https://github.com/nervosnetwork/ckb/pull/3958/files#diff-66d6800da6ed28c35f087178b6e0f1b31d6fea529dd97a86f6b5ce5dda26bbfcR884-R903

But `UnboundedReceiver` cannot be cloned, and `UnboundedReceiver`'s `fn recv(&mut self)` method need **mutable** self. Then I have to use `Arc<Mutex< ... >>` to wrap `UnboundedReceiver`, this is not good:

```rust
#[derive(Clone)]
pub struct Synchronizer {
    ...

    pub(crate) verify_failed_blocks_rx:
        Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<VerifyFailedBlockInfo>>>,
}

...

#[async_trait]
impl CKBProtocolHandler for Synchronizer {
    async fn poll(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>) -> Option<()> {
        let mut have_malformed_peers = false;
        while let Some(malformed_peer_info) = self.verify_failed_blocks_rx.lock().recv().await {
            // ban peer
        }
    }
}
```

By removing `#[derive(Clone)]` attribute from `Synchronizer`, this code can be improved to this:
```rust
/// we remove derive Cone
pub struct Synchronizer {
   ...

    pub(crate) verify_failed_blocks_rx: tokio::sync::mpsc::UnboundedReceiver<VerifyFailedBlockInfo>,
}


#[async_trait]
impl CKBProtocolHandler for Synchronizer {
    async fn poll(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>) -> Option<()> {
        let mut have_malformed_peers = false;
        while let Some(malformed_peer_info) = self.verify_failed_blocks_rx.recv().await {            
            // ban peer
        }
    }
}

```

### What is changed and how it works?

What's Changed:

### Related changes

- Remove `#[derive(Clone)]` from `Synchronizer`
- Make `BlockFetchCMD` depend on `SyncState` instead of `Synchronizer`. This means that the initialization of `BlockFetchCMD` will no longer require cloning the `Synchronizer`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

