### PR TITLE
fix(light-client): could not check MMR for fork chains

### DIFF
--- a/util/light-client-protocol-server/src/components/get_last_state_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_last_state_proof.rs
@@ -204,12 +204,17 @@ impl<'a> GetLastStateProofProcess<'a> {
         let snapshot = self.protocol.shared.snapshot();
 
         let last_block_hash = self.message.last_hash().to_entity();
-        let last_block = if let Some(block) = snapshot.get_block(&last_block_hash) {
-            block
-        } else {
+        let last_block = if !snapshot.is_main_chain(&last_block_hash) {
             return self
                 .protocol
                 .reply_tip_state::<packed::SendLastStateProof>(self.peer, self.nc);
+        } else if let Some(block) = snapshot.get_block(&last_block_hash) {
+            block
+        } else {
+            let errmsg = format!(
+                "the block is in the main chain but not found, its hash is {last_block_hash:#x}"
+            );
+            return StatusCode::InternalError.with_context(errmsg);
         };
 
         let start_block_hash = self.message.start_hash().to_entity();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The MMR data are saved as key-value format and the keys are positions (`= block_number - MMR_enabled_block_number`).
https://github.com/nervosnetwork/ckb/blob/922516e967df45c08ce4a62f4c3f2fd8db88d745/store/src/transaction.rs#L371-L376
So, only the MMR data for main chain could be fetched from the storage.
https://github.com/nervosnetwork/ckb/blob/922516e967df45c08ce4a62f4c3f2fd8db88d745/util/light-client-protocol-server/src/components/get_last_state_proof.rs#L150

### What is changed and how it works?

What's Changed:

- CKB node sends the hash of block `H` to light client.
- Then CKB node changes to a fork chain which tip is block `G`.
- Light client asks CKB node for proof of the chain whose tip is block `H`.
- Difference:
  - Before the bugfix:
    - CKB node sends a proof base on block `H` with a incorrect MMR proof to light client.
    - Light client checks the incorrect MMR proof, then ban CKB node for 300 seconds.
  - After this bugfix: 
    - CKB node sends the hash of block `G` to light client.

### Check List <!--REMOVE the items that are not applicable-->

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

