### PR TITLE
Fix `ckb-hash` depends `blake2b-ref` multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,12 +204,16 @@ bench-test:
 
 .PHONY: ci
 ci: ## Run recipes for CI.
-ci: fmt clippy test bench-test check-cargotoml check-whitespaces check-dirty-rpc-doc security-audit check-crates check-licenses
+ci: fmt clippy test bench-test check-cargo-metadata check-cargotoml check-whitespaces check-dirty-rpc-doc security-audit check-crates check-licenses
 	git diff --exit-code Cargo.lock
 
 .PHONY: check-cargotoml
 check-cargotoml:
 	./devtools/ci/check-cargotoml.sh
+
+.PHONY: check-cargo-metadata
+check-cargo-metadata: ## Check cargo metadata is success
+	cargo metadata --format-version 1 --all-features --manifest-path ./Cargo.toml &> /dev/null
 
 .PHONY: check-whitespace
 check-whitespaces:

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -20,7 +20,7 @@ check-data = []
 # Enable the `serialized-size` extension for CKB contract development in `no-std` env
 serialized-size = ["calc-hash"]
 # Enable all in `std` env
-std = ["molecule/std", "ckb-hash/default", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
+std = ["molecule/std", "ckb-hash", "ckb-fixed-hash", "ckb-error", "ckb-occupied-capacity", "numext-fixed-uint"]
 
 [dependencies]
 cfg-if = "1.0"

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -9,14 +9,8 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [features]
-default = ["blake2b"]
-ckb-contract = ["blake2b-ref"] # This feature is used for CKB contract development
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-blake2b = { package = "blake2b-rs", version = "0.2", optional = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-blake2b = { package = "blake2b-ref", version = "0.3", optional = true }
+ckb-contract = [] # This feature is used for CKB contract development
 
 [dependencies]
-blake2b-ref = { version = "0.3", optional = true }
+blake2b-ref = { version = "0.3"}
+blake2b-rs = { version = "0.2", optional = true }

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -13,4 +13,4 @@ ckb-contract = [] # This feature is used for CKB contract development
 
 [dependencies]
 blake2b-ref = { version = "0.3"}
-blake2b-rs = { version = "0.2", optional = true }
+blake2b-rs = { version = "0.2" }

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -9,9 +9,13 @@
 
 #![no_std]
 
-#[cfg(feature = "default")]
-pub use blake2b::{Blake2b, Blake2bBuilder};
 #[cfg(feature = "ckb-contract")]
+pub use blake2b_ref::{Blake2b, Blake2bBuilder};
+
+#[cfg(all(not(feature = "ckb-contract"), target_arch = "wasm32"))]
+pub use blake2b_rs::{Blake2b, Blake2bBuilder};
+
+#[cfg(all(not(feature = "ckb-contract"), not(target_arch = "wasm32")))]
 pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 
 #[doc(hidden)]

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -13,10 +13,10 @@
 pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 
 #[cfg(all(not(feature = "ckb-contract"), target_arch = "wasm32"))]
-pub use blake2b_rs::{Blake2b, Blake2bBuilder};
+pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 
 #[cfg(all(not(feature = "ckb-contract"), not(target_arch = "wasm32")))]
-pub use blake2b_ref::{Blake2b, Blake2bBuilder};
+pub use blake2b_rs::{Blake2b, Blake2bBuilder};
 
 #[doc(hidden)]
 pub const BLAKE2B_KEY: &[u8] = &[];


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
In latest develop branch, we found this:
```bash
$ cargo metadata --format-version 1 --all-features --manifest-path ./Cargo.toml
error: the crate `ckb-hash v0.112.0-pre (/home/exec/Projects/github.com/nervosnetwork/ckb/util/hash)` depends on crate `blake2b-ref v0.3.1` multiple times with different names
```
This PR want to fix this error.

### What is changed and how it works?


What's Changed:

### Related changes

- Remove `ckb-hash/default` feature, and make this feature's behavior as default

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

