### PR TITLE
Upgrade CI workflow's docker image to `1.71.1`

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -78,7 +78,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.67.1
+      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.71.1
       REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-linux-aarch64:
@@ -170,7 +170,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.67.1
+      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.71.1
       REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-mac:


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
We have published `nervos/ckb-docker-builder:centos-7-rust-1.71.1` and `nervos/ckb-docker-builder:bionic-rust-1.71.1`, then let CI workflow use `1.71.1`

### What is changed and how it works?

What's Changed:

### Related changes

- Upgrade CI workflow's docker image to `1.71.1`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

