### PR TITLE
Upgrade OpenSSL from `1.1.1` to `3.1.3`

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -203,7 +203,10 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include ${{ matrix.build_target }}
+        export OPENSSL_STATIC=1
+        export OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib
+        export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include 
+        make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -288,7 +288,7 @@ jobs:
         Set-ExecutionPolicy RemoteSigned -scope CurrentUser
         iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
         .\install-scoop.ps1 -RunAsAdmin
-        scoop install llvm yasm
+        scoop install llvm yasm main/openssl
         echo ("GIT_TAG_NAME=" + $env:GITHUB_REF.replace('refs/heads/pkg/', '')) >> $env:GITHUB_ENV
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -112,6 +112,7 @@ jobs:
         cd ..
         export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-3.1.3
         export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-3.1.3/include
+        export OPENSSL_STATIC=1
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -216,7 +216,7 @@ jobs:
         
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
-        ./Configure --prefix=$(pwd)/build no-shared
+        ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
         make
         make install_sw
     - name: Build CKB and Package CKB
@@ -291,7 +291,7 @@ jobs:
         
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
-        ./Configure --prefix=$(pwd)/build no-shared
+        ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
         make
         make install_sw
         

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -197,19 +197,25 @@ jobs:
         echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
     - name: Install Dependencies
       run: |
-        if ! [ -d /opt/homebrew/opt/openssl@3.1 ]; then
-          brew install "openssl@3.1"
-        fi
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        tar -xzf openssl-3.1.3.tar.gz
+        cd openssl-3.1.3
+        ./Configure --prefix=$(pwd)/build no-shared
+        make
+        make install_sw
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
+        
+        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
+        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
-        export OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib
-        export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include 
         make ${{ matrix.build_target }}
+        
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -250,34 +250,39 @@ jobs:
         echo /opt/homebrew/bin >> $GITHUB_PATH
         echo /opt/homebrew/sbin >> $GITHUB_PATH
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
+    - uses: actions/checkout@v3
+    - name: Set Env
+      run: |
+        export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
+        echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
     - name: Install Depedencies
       run: |
-        if ! [ -d /opt/homebrew/opt/openssl@3.1 ]; then
-          brew install "openssl@3.1"
-        fi
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        tar -xzf openssl-3.1.3.tar.gz
+        cd openssl-3.1.3
+        ./Configure --prefix=$(pwd)/build no-shared
+        make
+        make install_sw
+        
         if ! type -f gpg &> /dev/null; then
           brew install gnupg
         fi
         if ! [ -f "$HOME/.cargo/bin/rustup" ]; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         fi
-
-    - uses: actions/checkout@v3
-    - name: Set Env
-      run: |
-        export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
+        
+        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
+        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
-        export OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib
-        export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include 
         make ${{ matrix.build_target }}
+        
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -61,7 +61,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu -e OPENSSL_INCLUDE_DIR=/usr/include $BUILDER_IMAGE make ${{ matrix.build_target }}
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -78,7 +78,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.71.1
+      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.71.1-openssl-3.1.3
       REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-linux-aarch64:
@@ -104,14 +104,14 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         export TOP_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-1.1.1.tar.gz
-        tar -xzf openssl-1.1.1.tar.gz
-        cd openssl-1.1.1
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        tar -xzf openssl-3.1.3.tar.gz
+        cd openssl-3.1.3
         CC=aarch64-linux-gnu-gcc ./Configure linux-aarch64 shared
         CC=aarch64-linux-gnu-gcc make
         cd ..
-        export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-1.1.1
-        export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-1.1.1/include
+        export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-3.1.3
+        export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-3.1.3/include
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
@@ -170,7 +170,7 @@ jobs:
         name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.71.1
+      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.71.1-openssl-3.1.3
       REL_PKG: ${{ matrix.rel_pkg }}
 
   package-for-mac:
@@ -189,13 +189,18 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
+    - name: Install Dependencies
+      run: |
+        if ! [ -d /opt/homebrew/opt/openssl@3.1 ]; then
+          brew install "openssl@3.1"
+        fi
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include ${{ matrix.build_target }}
+        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -233,8 +238,8 @@ jobs:
 
     - name: Install Depedencies
       run: |
-        if ! [ -d /opt/homebrew/opt/openssl@1.1 ]; then
-          brew install "openssl@1.1"
+        if ! [ -d /opt/homebrew/opt/openssl@3.1 ]; then
+          brew install "openssl@3.1"
         fi
         if ! type -f gpg &> /dev/null; then
           brew install gnupg
@@ -254,7 +259,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@1.1/lib OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@1.1/include ${{ matrix.build_target }}
+        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -94,6 +94,15 @@ jobs:
       run: rustup target add aarch64-unknown-linux-gnu
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+    - name: Install OpenSSL 
+      run: |
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        tar -xzf openssl-3.1.3.tar.gz
+        cd openssl-3.1.3
+        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        CC=aarch64-linux-gnu-gcc ./Configure --prefix=$(pwd)/openssl-3.1.3/build linux-aarch64 no-shared
+        CC=aarch64-linux-gnu-gcc make -j $(nproc)
+        CC=aarch64-linux-gnu-gcc make -j $(nproc) install_sw
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -103,19 +112,13 @@ jobs:
         SKIP_CKB_CLI: true
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        export TOP_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
-        tar -xzf openssl-3.1.3.tar.gz
-        cd openssl-3.1.3
-        export OPENSSL_DIR=${TOP_DIR}/openssl-3.1.3/build
-        CC=aarch64-linux-gnu-gcc ./Configure --prefix=${OPENSSL_DIR} linux-aarch64 no-shared
-        CC=aarch64-linux-gnu-gcc make
-        CC=aarch64-linux-gnu-gcc make install_sw
-        cd ..
+        
+        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib64
         export OPENSSL_STATIC=1
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
+        
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/aarch64-unknown-linux-gnu/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -96,6 +96,8 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Install OpenSSL 
       run: |
+        mkdir target && cd target
+        
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
         
@@ -107,7 +109,6 @@ jobs:
         
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
-        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
         CC=aarch64-linux-gnu-gcc ./Configure --prefix=$(pwd)/openssl-3.1.3/build linux-aarch64 no-shared
         CC=aarch64-linux-gnu-gcc make -j $(nproc)
         CC=aarch64-linux-gnu-gcc make -j $(nproc) install_sw
@@ -121,7 +122,7 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         
-        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib64
         export OPENSSL_STATIC=1
@@ -205,6 +206,8 @@ jobs:
         echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
     - name: Install Dependencies
       run: |
+        mkdir target && cd target
+        
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
         
@@ -226,7 +229,7 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         
-        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
@@ -280,6 +283,8 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         fi
         
+        mkdir target && cd target
+        
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
         
@@ -302,7 +307,7 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         
-        export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build
+        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -206,6 +206,14 @@ jobs:
     - name: Install Dependencies
       run: |
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
+        
+        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
+        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
+        
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
+        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
+        
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
         ./Configure --prefix=$(pwd)/build no-shared

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -340,7 +340,7 @@ jobs:
         Set-ExecutionPolicy RemoteSigned -scope CurrentUser
         iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
         .\install-scoop.ps1 -RunAsAdmin
-        scoop install llvm yasm main/openssl
+        scoop install llvm yasm
         echo ("GIT_TAG_NAME=" + $env:GITHUB_REF.replace('refs/heads/pkg/', '')) >> $env:GITHUB_ENV
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -231,7 +231,7 @@ jobs:
         
         export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
-        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/include
+        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
         make ${{ matrix.build_target }}
         

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -265,7 +265,10 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include ${{ matrix.build_target }}
+        export OPENSSL_STATIC=1
+        export OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@3.1/lib
+        export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@3.1/include 
+        make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -94,19 +94,19 @@ jobs:
       run: rustup target add aarch64-unknown-linux-gnu
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-    - name: Install OpenSSL 
+    - name: Install OpenSSL
       run: |
         mkdir target && cd target
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-        
+
         gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
         gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
         echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-        
+
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
         CC=aarch64-linux-gnu-gcc ./Configure --prefix=$(pwd)/openssl-3.1.3/build linux-aarch64 no-shared
@@ -121,13 +121,13 @@ jobs:
         SKIP_CKB_CLI: true
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        
+
         export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib64
         export OPENSSL_STATIC=1
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
-        
+
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/aarch64-unknown-linux-gnu/prod/ckb
@@ -207,16 +207,16 @@ jobs:
     - name: Install Dependencies
       run: |
         mkdir target && cd target
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-        
+
         gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
         gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
         echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-        
+
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
         ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
@@ -228,13 +228,13 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        
+
         export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
         make ${{ matrix.build_target }}
-        
+
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -282,37 +282,37 @@ jobs:
         if ! [ -f "$HOME/.cargo/bin/rustup" ]; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         fi
-        
+
         mkdir target && cd target
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-        
+
         gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
         gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-        
+
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
         echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-        
+
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
         ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
         make
         make install_sw
-        
+
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        
+
         export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
         export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
         export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
         export OPENSSL_STATIC=1
         make ${{ matrix.build_target }}
-        
+
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -97,6 +97,14 @@ jobs:
     - name: Install OpenSSL 
       run: |
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
+        
+        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
+        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
+        
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
+        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
+        
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
         export OPENSSL_DIR=$(pwd)/openssl-3.1.3/build

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -273,19 +273,28 @@ jobs:
         echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
     - name: Install Depedencies
       run: |
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
-        tar -xzf openssl-3.1.3.tar.gz
-        cd openssl-3.1.3
-        ./Configure --prefix=$(pwd)/build no-shared
-        make
-        make install_sw
-        
         if ! type -f gpg &> /dev/null; then
           brew install gnupg
         fi
         if ! [ -f "$HOME/.cargo/bin/rustup" ]; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         fi
+        
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
+        
+        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
+        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
+        
+        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
+        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
+        
+        tar -xzf openssl-3.1.3.tar.gz
+        cd openssl-3.1.3
+        ./Configure --prefix=$(pwd)/build no-shared
+        make
+        make install_sw
+        
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -107,11 +107,13 @@ jobs:
         curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
         tar -xzf openssl-3.1.3.tar.gz
         cd openssl-3.1.3
-        CC=aarch64-linux-gnu-gcc ./Configure linux-aarch64 shared
+        export OPENSSL_DIR=${TOP_DIR}/openssl-3.1.3/build
+        CC=aarch64-linux-gnu-gcc ./Configure --prefix=${OPENSSL_DIR} linux-aarch64 no-shared
         CC=aarch64-linux-gnu-gcc make
+        CC=aarch64-linux-gnu-gcc make install_sw
         cd ..
-        export OPENSSL_LIB_DIR=${TOP_DIR}/openssl-3.1.3
-        export OPENSSL_INCLUDE_DIR=${TOP_DIR}/openssl-3.1.3/include
+        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
+        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib64
         export OPENSSL_STATIC=1
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg

--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -66,15 +66,15 @@ case $GITHUB_WORKFLOW in
     sudo apt-get install -y gcc-multilib
     sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu clang
     rustup target add aarch64-unknown-linux-gnu
-    curl -LO https://www.openssl.org/source/openssl-1.1.1.tar.gz
-    tar -xvzf openssl-1.1.1.tar.gz
-    cd openssl-1.1.1
+    curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
+    tar -xvzf openssl-3.1.3.tar.gz
+    cd openssl-3.1.3
     CC=aarch64-linux-gnu-gcc ./Configure linux-aarch64 shared
     CC=aarch64-linux-gnu-gcc make
     cd ..
     export TOP
-    export OPENSSL_LIB_DIR=$(pwd)/openssl-1.1.1
-    export OPENSSL_INCLUDE_DIR=$(pwd)/openssl-1.1.1/include
+    export OPENSSL_LIB_DIR=$(pwd)/openssl-3.1.3
+    export OPENSSL_INCLUDE_DIR=$(pwd)/openssl-3.1.3/include
     export PKG_CONFIG_ALLOW_CROSS=1
     export CC=gcc
     export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,9 +1,9 @@
-FROM nervos/ckb-docker-builder:bionic-rust-1.71.1 as ckb-docker-builder
+FROM nervos/ckb-docker-builder:bionic-rust-1.71.1-openssl-3.1.3 as ckb-docker-builder
 
 WORKDIR /ckb
 COPY ./ .
 
-RUN make prod-docker
+RUN make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/lib64 OPENSSL_INCLUDE_DIR=/usr/local/include prod-docker
 
 FROM ubuntu:bionic
 LABEL description="Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network."
@@ -15,10 +15,6 @@ RUN groupadd -g 1000 ckb \
 
 WORKDIR /var/lib/ckb
 
-COPY --from=ckb-docker-builder \
-     /usr/lib/x86_64-linux-gnu/libssl.so.* \
-     /usr/lib/x86_64-linux-gnu/libcrypto.so.* \
-     /usr/lib/x86_64-linux-gnu/
 COPY --from=ckb-docker-builder /ckb/target/prod/ckb /ckb/docker/docker-entrypoint.sh /bin/
 RUN chown -R ckb:ckb /var/lib/ckb \
  && chmod 755 /var/lib/ckb


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4159 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The OpenSSL 1.1.1 series has reached its [End of Life](https://www.openssl.org/blog/blog/2023/09/11/eol-111), so it's time for us to transition to OpenSSL 3 since CKB is statically built with OpenSSL 1.1.1.
### What is changed and how it works?

What's Changed:

### Related changes

- [x] staticly linked openssl 3.1.3 on `Docker` image build
- [x] staticly linked openssl 3.1.3 on `Linux` platform release
- [x] staticly linked openssl 3.1.3 on `Macos` platform release
- [ ] ~staticly linked openssl 3.1.3 on `Windows` platform release~
- [x] test `package.yaml` CI workflow on all platform
- [x] test staticly linked openssl 3.1.3 docker image

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

