### PR TITLE
fix: should only return main chain data

### DIFF
--- a/util/light-client-protocol-server/src/components/get_last_state_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_last_state_proof.rs
@@ -204,18 +204,14 @@ impl<'a> GetLastStateProofProcess<'a> {
         let snapshot = self.protocol.shared.snapshot();
 
         let last_block_hash = self.message.last_hash().to_entity();
-        let last_block = if !snapshot.is_main_chain(&last_block_hash) {
+        if !snapshot.is_main_chain(&last_block_hash) {
             return self
                 .protocol
                 .reply_tip_state::<packed::SendLastStateProof>(self.peer, self.nc);
-        } else if let Some(block) = snapshot.get_block(&last_block_hash) {
-            block
-        } else {
-            let errmsg = format!(
-                "the block is in the main chain but not found, its hash is {last_block_hash:#x}"
-            );
-            return StatusCode::InternalError.with_context(errmsg);
-        };
+        }
+        let last_block = snapshot
+            .get_block(&last_block_hash)
+            .expect("block should be in store");
 
         let start_block_hash = self.message.start_hash().to_entity();
         let start_block_number: BlockNumber = self.message.start_number().unpack();

--- a/util/light-client-protocol-server/src/components/get_transactions_proof.rs
+++ b/util/light-client-protocol-server/src/components/get_transactions_proof.rs
@@ -40,107 +40,83 @@ impl<'a> GetTransactionsProofProcess<'a> {
 
         let snapshot = self.protocol.shared.snapshot();
 
-        let last_hash = self.message.last_hash().to_entity();
-        let last_block = if let Some(block) = snapshot.get_block(&last_hash) {
-            block
-        } else {
+        let last_block_hash = self.message.last_hash().to_entity();
+        if !snapshot.is_main_chain(&last_block_hash) {
             return self
                 .protocol
                 .reply_tip_state::<packed::SendTransactionsProof>(self.peer, self.nc);
-        };
+        }
+        let last_block = snapshot
+            .get_block(&last_block_hash)
+            .expect("block should be in store");
 
-        let (txs_in_blocks, missing_txs) = self
+        let (found, missing): (Vec<_>, Vec<_>) = self
             .message
             .tx_hashes()
             .to_entity()
             .into_iter()
-            .map(|tx_hash| {
-                let tx_with_info = snapshot.get_transaction_with_info(&tx_hash);
-                (tx_hash, tx_with_info)
-            })
-            .fold(
-                (HashMap::new(), Vec::new()),
-                |(mut found, mut missing_txs), (tx_hash, tx_with_info)| {
-                    if let Some((tx, tx_info)) = tx_with_info {
-                        found
-                            .entry(tx_info.block_hash)
-                            .or_insert_with(Vec::new)
-                            .push((tx, tx_info.index));
-                    } else {
-                        missing_txs.push(tx_hash);
-                    }
-                    (found, missing_txs)
-                },
-            );
-
-        let (positions, filtered_blocks, missing_txs) = txs_in_blocks
-            .into_iter()
-            .map(|(block_hash, txs_and_tx_indices)| {
+            .partition(|tx_hash| {
                 snapshot
-                    .get_block_header(&block_hash)
-                    .map(|header| header.number())
-                    .filter(|number| *number != last_block.number())
-                    .and_then(|number| snapshot.get_ancestor(&last_hash, number))
-                    .filter(|header| header.hash() == block_hash)
-                    .and_then(|_| snapshot.get_block(&block_hash))
-                    .map(|block| (block, txs_and_tx_indices.clone()))
-                    .ok_or_else(|| {
-                        txs_and_tx_indices
-                            .into_iter()
-                            .map(|(tx, _)| tx.hash())
-                            .collect::<Vec<_>>()
-                    })
-            })
-            .fold(
-                (Vec::new(), Vec::new(), missing_txs),
-                |(mut positions, mut filtered_blocks, mut missing_txs), result| {
-                    match result {
-                        Ok((block, txs_and_tx_indices)) => {
-                            let merkle_proof = CBMT::build_merkle_proof(
-                                &block
-                                    .transactions()
-                                    .iter()
-                                    .map(|tx| tx.hash())
-                                    .collect::<Vec<_>>(),
-                                &txs_and_tx_indices
-                                    .iter()
-                                    .map(|(_, index)| *index as u32)
-                                    .collect::<Vec<_>>(),
-                            )
-                            .expect("build proof with verified inputs should be OK");
+                    .get_transaction_info(tx_hash)
+                    .map(|tx_info| snapshot.is_main_chain(&tx_info.block_hash))
+                    .unwrap_or_default()
+            });
 
-                            let txs: Vec<_> = txs_and_tx_indices
-                                .into_iter()
-                                .map(|(tx, _)| tx.data())
-                                .collect();
+        let mut txs_in_blocks = HashMap::new();
+        for tx_hash in found {
+            let (tx, tx_info) = snapshot
+                .get_transaction_with_info(&tx_hash)
+                .expect("tx exists");
+            txs_in_blocks
+                .entry(tx_info.block_hash)
+                .or_insert_with(Vec::new)
+                .push((tx, tx_info.index));
+        }
 
-                            let filtered_block = packed::FilteredBlock::new_builder()
-                                .header(block.header().data())
-                                .witnesses_root(block.calc_witnesses_root())
-                                .transactions(txs.pack())
-                                .proof(
-                                    packed::MerkleProof::new_builder()
-                                        .indices(merkle_proof.indices().to_owned().pack())
-                                        .lemmas(merkle_proof.lemmas().to_owned().pack())
-                                        .build(),
-                                )
-                                .build();
+        let mut positions = Vec::with_capacity(txs_in_blocks.len());
+        let mut filtered_blocks = Vec::with_capacity(txs_in_blocks.len());
+        for (block_hash, txs_and_tx_indices) in txs_in_blocks.into_iter() {
+            let block = snapshot
+                .get_block(&block_hash)
+                .expect("block should be in store");
+            let merkle_proof = CBMT::build_merkle_proof(
+                &block
+                    .transactions()
+                    .iter()
+                    .map(|tx| tx.hash())
+                    .collect::<Vec<_>>(),
+                &txs_and_tx_indices
+                    .iter()
+                    .map(|(_, index)| *index as u32)
+                    .collect::<Vec<_>>(),
+            )
+            .expect("build proof with verified inputs should be OK");
 
-                            positions.push(leaf_index_to_pos(block.number()));
-                            filtered_blocks.push(filtered_block);
-                        }
-                        Err(tx_hashes) => {
-                            missing_txs.extend(tx_hashes);
-                        }
-                    }
-                    (positions, filtered_blocks, missing_txs)
-                },
-            );
+            let txs: Vec<_> = txs_and_tx_indices
+                .into_iter()
+                .map(|(tx, _)| tx.data())
+                .collect();
+
+            let filtered_block = packed::FilteredBlock::new_builder()
+                .header(block.header().data())
+                .witnesses_root(block.calc_witnesses_root())
+                .transactions(txs.pack())
+                .proof(
+                    packed::MerkleProof::new_builder()
+                        .indices(merkle_proof.indices().to_owned().pack())
+                        .lemmas(merkle_proof.lemmas().to_owned().pack())
+                        .build(),
+                )
+                .build();
+
+            positions.push(leaf_index_to_pos(block.number()));
+            filtered_blocks.push(filtered_block);
+        }
 
         let proved_items = packed::FilteredBlockVec::new_builder()
             .set(filtered_blocks)
             .build();
-        let missing_items = missing_txs.pack();
+        let missing_items = missing.pack();
 
         self.protocol.reply_proof::<packed::SendTransactionsProof>(
             self.peer,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

same as #4171 , when ckb node received `GetBlocksProof` and `GetTransactionsProof` message, it should return main chain data only.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

