### PR TITLE
Remove `Consensus.dao_type_hash`'s `Option` wrapper

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1654,7 +1654,7 @@ Response
   "result": {
         "block_version": "0x0",
         "cellbase_maturity": "0x10000000000",
-        "dao_type_hash": null,
+        "dao_type_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "epoch_duration_target": "0x3840",
         "genesis_hash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
         "hardfork_features": [
@@ -5703,7 +5703,7 @@ Consensus defines various parameters that influence chain consensus
 
 *   `genesis_hash`: [`H256`](#type-h256) - The genesis block hash
 
-*   `dao_type_hash`: [`H256`](#type-h256) `|` `null` - The dao type hash
+*   `dao_type_hash`: [`H256`](#type-h256) - The dao type hash
 
 *   `secp256k1_blake160_sighash_all_type_hash`: [`H256`](#type-h256) `|` `null` - The secp256k1_blake160_sighash_all_type_hash
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1336,7 +1336,7 @@ pub trait ChainRpc {
     ///   "result": {
     ///         "block_version": "0x0",
     ///         "cellbase_maturity": "0x10000000000",
-    ///         "dao_type_hash": null,
+    ///         "dao_type_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     ///         "epoch_duration_target": "0x3840",
     ///         "genesis_hash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
     ///         "hardfork_features": [

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -616,9 +616,7 @@ impl<'a> WellKnownScriptsOnlyValidator<'a> {
             Some(script) => {
                 if !script.is_hash_type_type() {
                     Err(DefaultOutputsValidatorError::HashType)
-                } else if script.code_hash()
-                    != self.consensus.dao_type_hash().expect("No dao system cell")
-                {
+                } else if script.code_hash() != self.consensus.dao_type_hash() {
                     Err(DefaultOutputsValidatorError::CodeHash)
                 } else if output.lock().args().len() == BLAKE160_LEN + SINCE_LEN {
                     // https://github.com/nervosnetwork/ckb/wiki/Common-Gotchas#nervos-dao

--- a/rpc/src/tests/module/pool.rs
+++ b/rpc/src/tests/module/pool.rs
@@ -37,7 +37,7 @@ fn test_default_outputs_validator() {
 
         // invalid code hash
         let tx = build_tx(
-            &consensus.dao_type_hash().unwrap(),
+            &consensus.dao_type_hash(),
             core::ScriptHashType::Type,
             vec![1; 20],
         );
@@ -76,7 +76,7 @@ fn test_default_outputs_validator() {
         let lock_type_hash = consensus
             .secp256k1_blake160_multisig_all_type_hash()
             .unwrap();
-        let type_type_hash = consensus.dao_type_hash().unwrap();
+        let type_type_hash = consensus.dao_type_hash();
         // valid output lock
         let tx = build_tx_with_type(
             &lock_type_hash,

--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -276,7 +276,7 @@ impl ConsensusBuilder {
                 median_time_block_count: MEDIAN_TIME_BLOCK_COUNT,
                 max_block_cycles: MAX_BLOCK_CYCLES,
                 max_block_bytes: MAX_BLOCK_BYTES,
-                dao_type_hash: None,
+                dao_type_hash: Byte32::default(),
                 secp256k1_blake160_sighash_all_type_hash: None,
                 secp256k1_blake160_multisig_all_type_hash: None,
                 genesis_epoch_ext,
@@ -347,7 +347,7 @@ impl ConsensusBuilder {
             "genesis block must contain the witness for cellbase"
         );
 
-        self.inner.dao_type_hash = self.get_type_hash(OUTPUT_INDEX_DAO);
+        self.inner.dao_type_hash = self.get_type_hash(OUTPUT_INDEX_DAO).unwrap_or_default();
         self.inner.secp256k1_blake160_sighash_all_type_hash =
             self.get_type_hash(OUTPUT_INDEX_SECP256K1_BLAKE160_SIGHASH_ALL);
         self.inner.secp256k1_blake160_multisig_all_type_hash =
@@ -514,7 +514,7 @@ pub struct Consensus {
     /// The dao type hash
     ///
     /// [nervos-dao](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md#nervos-dao)
-    pub dao_type_hash: Option<Byte32>,
+    pub dao_type_hash: Byte32,
     /// The secp256k1_blake160_sighash_all_type_hash
     ///
     /// [SECP256K1/blake160](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md#secp256k1blake160)
@@ -626,7 +626,7 @@ impl Consensus {
     /// The dao type hash
     ///
     /// [nervos-dao](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md#nervos-dao)
-    pub fn dao_type_hash(&self) -> Option<Byte32> {
+    pub fn dao_type_hash(&self) -> Byte32 {
         self.dao_type_hash.clone()
     }
 
@@ -1111,7 +1111,7 @@ impl From<Consensus> for ckb_jsonrpc_types::Consensus {
         Self {
             id: consensus.id,
             genesis_hash: consensus.genesis_hash.unpack(),
-            dao_type_hash: consensus.dao_type_hash.map(|h| h.unpack()),
+            dao_type_hash: consensus.dao_type_hash.unpack(),
             secp256k1_blake160_sighash_all_type_hash: consensus
                 .secp256k1_blake160_sighash_all_type_hash
                 .map(|h| h.unpack()),

--- a/test/src/specs/dao/dao_user.rs
+++ b/test/src/specs/dao/dao_user.rs
@@ -187,7 +187,7 @@ impl<'a> DAOUser<'a> {
 
     pub fn dao_type_script(&self) -> Script {
         Script::new_builder()
-            .code_hash(self.node.consensus().dao_type_hash().unwrap())
+            .code_hash(self.node.consensus().dao_type_hash())
             .hash_type(ScriptHashType::Type.into())
             .build()
     }

--- a/test/src/specs/dao/dao_verifier.rs
+++ b/test/src/specs/dao/dao_verifier.rs
@@ -257,7 +257,7 @@ impl DAOVerifier {
             return false;
         }
 
-        let dao_type_hash = self.consensus.dao_type_hash().unwrap();
+        let dao_type_hash = self.consensus.dao_type_hash();
         self.get_output(out_point)
             .type_()
             .to_opt()

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -221,8 +221,7 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
                     let is_dao_type_script = |type_script: Script| {
                         Into::<u8>::into(type_script.hash_type())
                             == Into::<u8>::into(ScriptHashType::Type)
-                            && type_script.code_hash()
-                                == self.consensus.dao_type_hash().expect("No dao system cell")
+                            && type_script.code_hash() == self.consensus.dao_type_hash()
                     };
                     let is_withdrawing_input =
                         |cell_meta: &CellMeta| match self.data_loader.load_cell_data(cell_meta) {

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1339,7 +1339,7 @@ pub struct Consensus {
     /// The genesis block hash
     pub genesis_hash: H256,
     /// The dao type hash
-    pub dao_type_hash: Option<H256>,
+    pub dao_type_hash: H256,
     /// The secp256k1_blake160_sighash_all_type_hash
     pub secp256k1_blake160_sighash_all_type_hash: Option<H256>,
     /// The secp256k1_blake160_multisig_all_type_hash

--- a/verification/src/tests/transaction_verifier.rs
+++ b/verification/src/tests/transaction_verifier.rs
@@ -104,7 +104,7 @@ pub fn test_capacity_outofbound() {
         resolved_dep_groups: vec![],
     });
     let dao_type_hash = build_genesis_type_id_script(OUTPUT_INDEX_DAO).calc_script_hash();
-    let verifier = CapacityVerifier::new(rtx, Some(dao_type_hash));
+    let verifier = CapacityVerifier::new(rtx, dao_type_hash);
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
@@ -136,7 +136,7 @@ pub fn test_skip_dao_capacity_check() {
         resolved_inputs: vec![],
         resolved_dep_groups: vec![],
     });
-    let verifier = CapacityVerifier::new(rtx, Some(dao_type_script.calc_script_hash()));
+    let verifier = CapacityVerifier::new(rtx, dao_type_script.calc_script_hash());
 
     assert!(verifier.verify().is_ok());
 }
@@ -329,7 +329,7 @@ pub fn test_capacity_invalid() {
         resolved_dep_groups: vec![],
     });
     let dao_type_hash = build_genesis_type_id_script(OUTPUT_INDEX_DAO).calc_script_hash();
-    let verifier = CapacityVerifier::new(rtx, Some(dao_type_hash));
+    let verifier = CapacityVerifier::new(rtx, dao_type_hash);
 
     assert_error_eq!(
         verifier.verify().unwrap_err(),
@@ -808,7 +808,7 @@ fn build_consensus_with_dao_limiting_block(block_number: u64) -> (Arc<Consensus>
     // the dao script. For simplicity, we are hacking consensus here with
     // a dao_type_hash value, a proper way should be creating a proper genesis
     // block here, but we will leave it till we really need it.
-    consensus.dao_type_hash = Some(dao_script.calc_script_hash());
+    consensus.dao_type_hash = dao_script.calc_script_hash();
 
     let dao_type_script = Script::new_builder()
         .code_hash(dao_script.calc_script_hash())

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -523,7 +523,6 @@ impl<'a> DuplicateDepsVerifier<'a> {
 /// Perform inputs and outputs `capacity` field related verification
 pub struct CapacityVerifier {
     resolved_transaction: Arc<ResolvedTransaction>,
-    // It's Option because special genesis block do not have dao system cell
     dao_type_hash: Byte32,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
The `Consensus.dao_type_hash` will not be `None` on `mainnet`, `testnet`, and `devnet`. Removing the `Option` wrapper will resolve the CI failure on the latest develop branch : https://github.com/nervosnetwork/ckb/commits/develop/.


### What is changed and how it works?

- Remove the `Option` wrapper for `Consensus.dao_type_hash`
- In unit tests: `Consensus.dao_type_hash` will be `Byte32::default()`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

