### PR TITLE
performance: tuning rocksdb bloom filter

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -72,14 +72,16 @@ impl RocksDB {
         for cf in cf_descriptors.iter_mut() {
             let mut block_opts = BlockBasedOptions::default();
             block_opts.set_ribbon_filter(10.0);
-            block_opts.set_cache_index_and_filter_blocks(true);
-            block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
             block_opts.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
             block_opts.set_partition_filters(true);
             block_opts.set_metadata_block_size(4096);
             block_opts.set_pin_top_level_index_and_filter(true);
             match cache {
-                Some(ref cache) => block_opts.set_block_cache(cache),
+                Some(ref cache) => {
+                    block_opts.set_block_cache(cache);
+                    block_opts.set_cache_index_and_filter_blocks(true);
+                    block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+                }
                 None => block_opts.disable_cache(),
             }
             // only COLUMN_BLOCK_BODY column family use prefix seek

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -11,8 +11,9 @@ use rocksdb::ops::{
     Put, SetOptions, WriteOps,
 };
 use rocksdb::{
-    ffi, ColumnFamily, ColumnFamilyDescriptor, DBPinnableSlice, FullOptions, IteratorMode,
-    OptimisticTransactionDB, OptimisticTransactionOptions, Options, WriteBatch, WriteOptions,
+    ffi, BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor,
+    DBPinnableSlice, FullOptions, IteratorMode, OptimisticTransactionDB,
+    OptimisticTransactionOptions, Options, SliceTransform, WriteBatch, WriteOptions,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -25,20 +26,28 @@ pub struct RocksDB {
     pub(crate) inner: Arc<OptimisticTransactionDB>,
 }
 
-const DEFAULT_CACHE_SIZE: usize = 128 << 20;
+const DEFAULT_CACHE_SIZE: usize = 256 << 20;
+const DEFAULT_CACHE_ENTRY_CHARGE_SIZE: usize = 4096;
 
 impl RocksDB {
     pub(crate) fn open_with_check(config: &DBConfig, columns: u32) -> Result<Self> {
         let cf_names: Vec<_> = (0..columns).map(|c| c.to_string()).collect();
+        let mut cache = None;
 
-        let (mut opts, cf_descriptors) = if let Some(ref file) = config.options_file {
-            let cache_size = match config.cache_size {
+        let (mut opts, mut cf_descriptors) = if let Some(ref file) = config.options_file {
+            cache = match config.cache_size {
                 Some(0) => None,
-                Some(size) => Some(size),
-                None => Some(DEFAULT_CACHE_SIZE),
+                Some(size) => Some(Cache::new_hyper_clock_cache(
+                    size,
+                    DEFAULT_CACHE_ENTRY_CHARGE_SIZE,
+                )),
+                None => Some(Cache::new_hyper_clock_cache(
+                    DEFAULT_CACHE_SIZE,
+                    DEFAULT_CACHE_ENTRY_CHARGE_SIZE,
+                )),
             };
 
-            let mut full_opts = FullOptions::load_from_file(file, cache_size, false)
+            let mut full_opts = FullOptions::load_from_file_with_cache(file, cache.clone(), false)
                 .map_err(|err| internal_error(format!("failed to load the options file: {err}")))?;
             let cf_names_str: Vec<&str> = cf_names.iter().map(|s| s.as_str()).collect();
             full_opts
@@ -60,8 +69,31 @@ impl RocksDB {
             (opts, cf_descriptors)
         };
 
+        for cf in cf_descriptors.iter_mut() {
+            let mut block_opts = BlockBasedOptions::default();
+            block_opts.set_ribbon_filter(10.0);
+            block_opts.set_cache_index_and_filter_blocks(true);
+            block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+            block_opts.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
+            block_opts.set_partition_filters(true);
+            block_opts.set_metadata_block_size(4096);
+            block_opts.set_pin_top_level_index_and_filter(true);
+            match cache {
+                Some(ref cache) => block_opts.set_block_cache(cache),
+                None => block_opts.disable_cache(),
+            }
+            // only COLUMN_BLOCK_BODY column family use prefix seek
+            if cf.name() == "2" {
+                block_opts.set_whole_key_filtering(false);
+                cf.options
+                    .set_prefix_extractor(SliceTransform::create_fixed_prefix(32));
+            }
+            cf.options.set_block_based_table_factory(&block_opts);
+        }
+
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.enable_statistics();
 
         let db = OptimisticTransactionDB::open_cf_descriptors(&opts, &config.path, cf_descriptors)
             .map_err(|err| internal_error(format!("failed to open database: {err}")))?;

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -48,11 +48,11 @@ dsn = "" # {{
 # interval = 600
 
 [db]
-# The capacity of RocksDB cache, which caches uncompressed data blocks, indexes and filters, default is 128MB.
-# Rocksdb will automatically create and use an 8MB internal cache if you set this value to 0.
+# The capacity of RocksDB cache, which caches uncompressed data blocks, indexes and filters, default is 256MB.
+# Rocksdb will automatically create and use an 32MB internal cache for each column family by default if you set this value to 0.
 # To turning off cache, you need to set this value to 0 and set `no_block_cache = true` in the options_file,
 # however, we strongly discourage this setting, it may lead to severe performance degradation.
-cache_size = 134217728
+cache_size = 268435456
 
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).

--- a/resource/default.db-options
+++ b/resource/default.db-options
@@ -16,7 +16,3 @@ write_buffer_size=8388608
 min_write_buffer_number_to_merge=1
 max_write_buffer_number=2
 max_write_buffer_size_to_maintain=-1
-
-[TableOptions/BlockBasedTable "default"]
-cache_index_and_filter_blocks=true
-pin_l0_filter_and_index_blocks_in_cache=true


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

We previously used a global lru cache as rocksdb cache (default 128M) and setting the `cache_index_and_filter_blocks` parameter to true, the rocksdb's `IndexBlock` is placed in the cache also (note, we did not use `FilterBlock` in current code). With the increasing of stored data, `DataBlock` and `IndexBlock` will compete for cache expiration, there will be more cache misses, resulting in read performance degradation. 

rocksdb statistics log
```
Block cache LRUCache@0x7f41c443d3d0#3747917 capacity: 128.00 MB seed: 886014176 usage: 117.24 MB table_size: 32768 occupancy: 5795 collections: 155 last_copies: 19 last_secs: 0.001642 secs_since: 0
Block cache entry stats(count,size,portion): DataBlock(5543,23.49 MB,18.3507%) IndexBlock(251,93.22 MB,72.8312%) Misc(1,0.00 KB,0%)
```

### What is changed and how it works?

This PR tries to adjust the cache configuration, and also uses a bloom filter to improve the performance of prefix seek.

through the mainnet synchronization test, the overall performance has been improved by about 6%.

<img width="1507" alt="QQ20231013-110427@2x" src="https://github.com/nervosnetwork/ckb/assets/8990/bb528db8-7a73-484b-bd62-ba9bd2a8920a">

and memory usage has also decreased
<img width="1497" alt="QQ20231013-110228@2x" src="https://github.com/nervosnetwork/ckb/assets/8990/a5254705-91b3-4485-a29a-e1c2f8bd71df">


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

