### PR TITLE
fix: incorrect and inadequate checks of sync message

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -716,7 +716,7 @@ impl CKBProtocolHandler for Synchronizer {
             Ok(msg) => {
                 let item = msg.to_enum();
                 if let packed::SyncMessageUnionReader::SendBlock(ref reader) = item {
-                    if reader.count_extra_fields() > 1 {
+                    if reader.has_extra_fields() || reader.block().count_extra_fields() > 1 {
                         info!(
                             "Peer {} sends us a malformed message: \
                              too many fields in SendBlock",


### PR DESCRIPTION
### What problem does this PR solve?

The checks of sync message are incorrect and inadequate since CKB2021.

https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/sync/src/synchronizer/mod.rs#L718-L733

- `SendBlock` is the same before and after CKB2021, so the result of checks is always be `true`.

  https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/util/gen-types/schemas/extensions.mol#L264-L266

- The `Block` could have 1 more field after CKB2021.

  https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/util/gen-types/schemas/blockchain.mol#L94-L99

  https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/util/gen-types/schemas/blockchain.mol#L101-L107

- As a comparison, the checks of relay message are correct.

  https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/sync/src/relayer/mod.rs#L780-L781

  https://github.com/nervosnetwork/ckb/blob/5dadcbffbfcb7877fdf4f366fdec958d9838ff4e/util/gen-types/schemas/extensions.mol#L138-L153

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

