### PR TITLE
Remove non-exist `error` field from `IntegrationTestImpl` rpc doc

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3134,7 +3134,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
-  "error": null
 }
 ```
 
@@ -3210,7 +3209,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029",
-  "error": null
 }
 ```
 
@@ -3268,7 +3266,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0xa0001000003",
-  "error": null
 }
 ```
 
@@ -3342,7 +3339,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
-  "error": null
 }
 ```
 
@@ -3455,7 +3451,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75",
-  "error": null
 }
 ```
 
@@ -3566,7 +3561,6 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000",
-  "error": null
 }
 ```
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -3133,7 +3133,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+  "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
 }
 ```
 
@@ -3208,7 +3208,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029",
+  "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029"
 }
 ```
 
@@ -3265,7 +3265,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0xa0001000003",
+  "result": "0xa0001000003"
 }
 ```
 
@@ -3338,7 +3338,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
+  "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
 }
 ```
 
@@ -3450,7 +3450,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75",
+  "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75"
 }
 ```
 
@@ -3560,7 +3560,7 @@ Response
 {
   "id": 42,
   "jsonrpc": "2.0",
-  "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000",
+  "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000"
 }
 ```
 

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -100,7 +100,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+    ///   "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40"
     /// }
     /// ```
     #[rpc(name = "process_block_without_verify")]
@@ -162,7 +162,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029",
+    ///   "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029"
     /// }
     /// ```
     #[rpc(name = "generate_block")]
@@ -214,7 +214,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0xa0001000003",
+    ///   "result": "0xa0001000003"
     /// }
     /// ```
     #[rpc(name = "generate_epochs")]
@@ -283,7 +283,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
+    ///   "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
     /// }
     /// ```
     #[rpc(name = "notify_transaction")]
@@ -388,7 +388,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75",
+    ///   "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75"
     /// }
     /// ```
     #[rpc(name = "generate_block_with_template")]
@@ -491,7 +491,7 @@ pub trait IntegrationTestRpc {
     /// {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
-    ///   "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000",
+    ///   "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000"
     /// }
     /// ```
     #[rpc(name = "calculate_dao_field")]

--- a/rpc/src/module/test.rs
+++ b/rpc/src/module/test.rs
@@ -101,7 +101,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "process_block_without_verify")]
@@ -164,7 +163,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0x60dd3fa0e81db3ee3ad41cf4ab956eae7e89eb71cd935101c26c4d0652db3029",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "generate_block")]
@@ -217,7 +215,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0xa0001000003",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "generate_epochs")]
@@ -287,7 +284,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "notify_transaction")]
@@ -393,7 +389,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0x899541646ae412a99fdbefc081e1a782605a7815998a096af16e51d4df352c75",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "generate_block_with_template")]
@@ -497,7 +492,6 @@ pub trait IntegrationTestRpc {
     ///   "id": 42,
     ///   "jsonrpc": "2.0",
     ///   "result": "0xd495a106684401001e47c0ae1d5930009449d26e32380000000721efd0030000",
-    ///   "error": null
     /// }
     /// ```
     #[rpc(name = "calculate_dao_field")]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
The example response in `IntegrationTestImpl` are successful, then the `"error": null` won't appear in the response, remove them.
### Related changes

- Remove non-exist `error` field from `IntegrationTestImpl` rpc doc

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

