### PR TITLE
Fix security-audit, upgrade ahash to 0.8.6 and 0.7.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom 0.2.10",
  "once_cell",
@@ -46,15 +46,16 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if 1.0.0",
  "const-random",
  "getrandom 0.2.10",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2449,7 +2450,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -3952,7 +3953,7 @@ version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206cee941730eaf90a22c84235b25193df661393688162e15551164f92f09eca"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "bitflags 2.4.0",
  "instant",
  "num-traits",
@@ -5378,6 +5379,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c48d63854f77746c68a5fbb4aa17f3997ece1cb301689a257af8cb80610d21"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c258c1040279e4f88763a113de72ce32dde2d50e2a94573f15dd534cea36a16d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "zeroize"


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
```
cargo deny check --hide-inclusion-graph --show-stats advisories sources
warning[unmaintained]: `net2` crate has been deprecated; use `socket2` instead
    ┌─ /home/runner/work/ckb/ckb/Cargo.lock:269:1
    │
269 │ net2 0.2.39 registry+https://github.com/rust-lang/crates.io-index
    │ ----------------------------------------------------------------- unmaintained advisory detected
 advisories FAILED: 2 errors, 2 warnings, 0 notes
        sources ok: 0 errors, 0 warnings, 0 notes
    │
    = ID: RUSTSEC-2020-0016
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0016
    = The [`net2`](https://crates.io/crates/net2) crate has been deprecated
      and users are encouraged to considered [`socket2`](https://crates.io/crates/socket2) instead.
    = Announcement: https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091
    = Solution: No safe upgrade is available!

error[yanked]: detected yanked crate (try `cargo update -p ahash`)
  ┌─ /home/runner/work/ckb/ckb/Cargo.lock:5:1
  │
5 │ ahash 0.7.6 registry+https://github.com/rust-lang/crates.io-index
  │ ----------------------------------------------------------------- yanked version

error[yanked]: detected yanked crate (try `cargo update -p ahash`)
  ┌─ /home/runner/work/ckb/ckb/Cargo.lock:6:1
  │
6 │ ahash 0.8.3 registry+https://github.com/rust-lang/crates.io-index
  │ ----------------------------------------------------------------- yanked version

warning[advisory-not-detected]: advisory was not encountered
  ┌─ /home/runner/work/ckb/ckb/deny.toml:8:5
  │
8 │     "RUSTSEC-2021-0145"
  │     ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria

make: *** [Makefile:189: security-audit] Error 1
Error: Process completed with exit code 2.
```
There is a security-audit error occured on #4201's merge queue. We need to update `ahash`
### What is changed and how it works?

### Related changes

- updata `ahash` version
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

