### PR TITLE
chore: Wrap help message with max width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -4603,6 +4604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-clap = { version = "4", features = ["string"] }
+clap = { version = "4", features = ["string", "wrap_help"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_plain = "0.3.0"
 serde_json = "1.0"

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -122,6 +122,7 @@ pub fn basic_app() -> Command {
         .about("Nervos CKB - The Common Knowledge Base")
         .subcommand_required(true)
         .arg_required_else_help(true)
+        .term_width(110)
         .arg(
             Arg::new(ARG_CONFIG_DIR)
                 .global(true)
@@ -186,13 +187,13 @@ fn run() -> Command {
             .help("This parameter specifies the hash of a block. \
             When the height does not reach this block's height, the execution of the script will be disabled, \
             that is, skip verifying the script content. \
-            \
-            It should be noted that when this option is enabled, the header is first synchronized to \
+            \n\nIt should be noted that when this option is enabled, the header is first synchronized to \
             the highest currently found. During this period, if the assume valid target is found, \
             the download of the block starts; If the assume valid target is not found or it's \
             timestamp within 24 hours of the current time, the target will automatically become invalid, \
             and the download of the block will be started with verify")
-        ).arg(
+        )
+        .arg(
             Arg::new(ARG_INDEXER)
             .long(ARG_INDEXER)
             .action(clap::ArgAction::SetTrue)


### PR DESCRIPTION
### What problem does this PR solve?

`ckb run --help` seems overwhelming since the help message for `--assume-valid-target` is so long.

Problem Summary:

### What is changed and how it works?

Wrap help message with an option from `clap`.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

