### PR TITLE
chore: Fix macos proxy issue in development env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3939,9 +3939,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64",
  "bytes 1.5.0",
@@ -3964,7 +3964,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -4490,27 +4489,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -47,7 +47,7 @@ itertools.workspace = true
 tokio = "1"
 
 [dev-dependencies]
-reqwest = { version = "0.11.4", features = ["blocking", "json"] }
+reqwest = { version = "=0.11.20", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 ckb-launcher = { path = "../util/launcher", version = "= 0.113.0-pre" }
 ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.113.0-pre" }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -30,7 +30,7 @@ ckb-logger-service = { path = "../util/logger-service", version = "= 0.113.0-pre
 ckb-error = { path = "../error", version = "= 0.113.0-pre" }
 ckb-constant = { path = "../util/constant", version = "= 0.113.0-pre" }
 tempfile = "3"
-reqwest = { version = "0.11.4", features = ["blocking", "json"] }
+reqwest = { version = "=0.11.20", features = ["blocking", "json"] }
 rand = "0.7"
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.113.0-pre" }
 serde_json = "1.0"

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 ckb-types = { path = "../util/types", version = "= 0.113.0-pre" }
-ckb-logger = {path = "../util/logger", version = "= 0.113.0-pre"}
+ckb-logger = { path = "../util/logger", version = "= 0.113.0-pre" }
 ckb-verification = { path = "../verification", version = "= 0.113.0-pre" }
-ckb-systemtime = {path = "../util/systemtime", version = "= 0.113.0-pre"}
+ckb-systemtime = { path = "../util/systemtime", version = "= 0.113.0-pre" }
 lru = "0.7.1"
 ckb-dao = { path = "../util/dao", version = "= 0.113.0-pre" }
 ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.113.0-pre" }
@@ -50,5 +50,5 @@ ckb-systemtime = {path = "../util/systemtime", version = "= 0.113.0-pre", featur
 default = []
 internal = []
 with_sentry = ["sentry"]
-portable = ["ckb-db/portable", "ckb-store/portable","ckb-snapshot/portable"]
-march-native = ["ckb-db/march-native", "ckb-store/march-native","ckb-snapshot/march-native"]
+portable = ["ckb-db/portable", "ckb-store/portable", "ckb-snapshot/portable"]
+march-native = ["ckb-db/march-native", "ckb-store/march-native", "ckb-snapshot/march-native"]


### PR DESCRIPTION
### What problem does this PR solve?

`make test` and `make intergration` on MacOs will fail because of https://github.com/nervosnetwork/ckb/commit/28631e15ab235eb86743a5223e50ed844ec834f5,
in that commit we updated `reqwest` to the latest version, which contains a commit to [respect MacOS proxy settings](https://github.com/seanmonstar/reqwest/pull/1955).

It's inconvenient for devs who use `vpn` most of the time, and there is no feature option for it, so let's don't use the latest version right now.

Problem Summary:

### What is changed and how it works?

Lock `reqwest` to version `0.11.20`

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

