### PR TITLE
fix spec of TxPoolOrphanDoubleSpend

### DIFF
--- a/test/src/specs/tx_pool/orphan_tx.rs
+++ b/test/src/specs/tx_pool/orphan_tx.rs
@@ -343,8 +343,8 @@ impl Spec for TxPoolOrphanDoubleSpend {
         );
 
         assert!(
-            run_replay_tx(&net, node0, tx12, 1, 0),
-            "tx12 is not in orphan pool"
+            run_replay_tx(&net, node0, tx12, 2, 0),
+            "tx12 in orphan pool"
         );
     }
 }

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -7,7 +7,7 @@ use crate::component::sort_key::{AncestorsScoreSortKey, EvictKey};
 use crate::error::Reject;
 use crate::TxEntry;
 
-use ckb_logger::trace;
+use ckb_logger::{debug, trace};
 use ckb_types::core::error::OutPointError;
 use ckb_types::packed::OutPoint;
 use ckb_types::prelude::*;
@@ -190,6 +190,11 @@ impl PoolMap {
 
     pub(crate) fn remove_entry(&mut self, id: &ProposalShortId) -> Option<TxEntry> {
         self.entries.remove_by_id(id).map(|entry| {
+            debug!(
+                "remove entry {} from status: {:?}",
+                entry.inner.transaction().hash(),
+                entry.status
+            );
             self.update_ancestors_index_key(&entry.inner, EntryOp::Remove);
             self.update_descendants_index_key(&entry.inner, EntryOp::Remove);
             self.remove_entry_edges(&entry.inner);
@@ -455,6 +460,7 @@ impl PoolMap {
             entry.add_ancestor_weight(&ancestor.inner);
         }
         if entry.ancestors_count > self.max_ancestors_count {
+            debug!("debug: exceeded maximum ancestors count");
             return Err(Reject::ExceededMaximumAncestorsCount);
         }
 

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -228,6 +228,7 @@ impl TxPool {
     fn remove_committed_tx(&mut self, tx: &TransactionView, callbacks: &Callbacks) {
         let short_id = tx.proposal_short_id();
         if let Some(entry) = self.pool_map.remove_entry(&short_id) {
+            debug!("remove_committed_tx for {}", tx.hash());
             callbacks.call_committed(self, &entry)
         }
         {
@@ -249,6 +250,8 @@ impl TxPool {
             .collect();
 
         for entry in removed {
+            let tx_hash = entry.transaction().hash();
+            debug!("remove_expired {} timestamp({})", tx_hash, entry.timestamp);
             self.pool_map.remove_entry(&entry.proposal_short_id());
             let reject = Reject::Expiry(entry.timestamp);
             callbacks.call_reject(self, &entry, reject);


### PR DESCRIPTION

### What problem does this PR solve?

Fix the spec failure of TxPoolOrphanDoubleSpend.

Problem Summary:

### What is changed and how it works?

https://github.com/nervosnetwork/ckb/pull/4208 was merged before https://github.com/nervosnetwork/ckb/pull/4199, maybe we should add `make intergration` when backporting.

What's Changed:

Fix the spec from https://github.com/nervosnetwork/ckb/pull/4208


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note 

```release-note
None: Exclude this PR from the release note.
```

