### PR TITLE
Make `Header Map Statistics` table align well

### DIFF
--- a/sync/src/types/header_map/kernel_lru.rs
+++ b/sync/src/types/header_map/kernel_lru.rs
@@ -157,7 +157,7 @@ where
                 "Header Map Statistics\
             \n>\t| storage | length  |  limit  | contain |   select   | insert  | delete  |\
             \n>\t|---------+---------+---------+---------+------------+---------+---------|\
-            \n>\t| memory |{:>9}|{:>9}|{:>9}|{:>12}|{:>9}|{:>9}|\
+            \n>\t| memory  |{:>9}|{:>9}|{:>9}|{:>12}|{:>9}|{:>9}|\
             \n>\t| backend |{:>9}|{:>9}|{:>9}|{:>12}|{:>9}|{:>9}|\
             ",
                 self.memory.len(),


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
`Header Map Statistics` not align well, should add `one` space behind `memory` to make the table align well.
before:
```bash
$ cat tmp/data_dir/data/logs/run.log | grep -A4  "Header Map Statistics$"
2023-10-31 09:12:40.492 +00:00 GlobalRt-1 INFO ckb_shared::types::header_map::kernel_lru  Header Map Statistics
>       | storage | length  |  limit  | contain |   select   | insert  | delete  |
>       |---------+---------+---------+---------+------------+---------+---------|
>       | memory |  1488390|  1684210|  7684430|   416695468|  1744195|   255805|
>       | backend |        0|        -|        0|           -|        -|        0|
```
This PR:
```bash
$ cat tmp/data_dir/data/logs/run.log | grep -A4  "Header Map Statistics$"
2023-10-31 09:12:40.492 +00:00 GlobalRt-1 INFO ckb_shared::types::header_map::kernel_lru  Header Map Statistics
>       | storage | length  |  limit  | contain |   select   | insert  | delete  |
>       |---------+---------+---------+---------+------------+---------+---------|
>       | memory  |  1488390|  1684210|  7684430|   416695468|  1744195|   255805|
>       | backend |        0|        -|        0|           -|        -|        0|
```
What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

