### PR TITLE
doc: update RPC doc related to block extension

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -5248,6 +5248,10 @@ The JSON view of a Block used as a parameter in the RPC.
 
 *   `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - The proposal IDs in the block body.
 
+*   `extension`: [`JsonBytes`](#type-jsonbytes) `|` `null` - The extension in the block body.
+
+    This is a field introduced in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md). Since the activation of [CKB RFC 0044](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md), this field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is defined in the RFC 0044.
+
 
 ### Type `BlockEconomicState`
 
@@ -5400,7 +5404,7 @@ Miners optional pick transactions and then assemble the final block.
 
 *   `extension`: [`JsonBytes`](#type-jsonbytes) `|` `null` - The extension for the new block.
 
-    This field is optional. It’s a reserved field, please leave it blank. More details can be found in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md).
+    This is a field introduced in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md). Since the activation of [CKB RFC 0044](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md), this field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is defined in the RFC 0044.
 
 
 ### Type `BlockView`
@@ -5418,6 +5422,10 @@ The JSON view of a Block including header and body.
 *   `transactions`: `Array<` [`TransactionView`](#type-transactionview) `>` - The transactions in the block body.
 
 *   `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - The proposal IDs in the block body.
+
+*   `extension`: [`JsonBytes`](#type-jsonbytes) `|` `null` - The extension in the block body.
+
+    This is a field introduced in [CKB RFC 0031](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md). Since the activation of [CKB RFC 0044](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md), this field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is defined in the RFC 0044.
 
 
 ### Type `Byte32`

--- a/util/jsonrpc-types/src/block_template.rs
+++ b/util/jsonrpc-types/src/block_template.rs
@@ -86,10 +86,12 @@ pub struct BlockTemplate {
     pub dao: Byte32,
     /// The extension for the new block.
     ///
-    /// This field is optional. It's a reserved field, please leave it blank.
-    /// More details can be found in [CKB RFC 0031].
+    /// This is a field introduced in [CKB RFC 0031]. Since the activation of [CKB RFC 0044], this
+    /// field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is
+    /// defined in the RFC 0044.
     ///
     /// [CKB RFC 0031]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md
+    /// [CKB RFC 0044]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md
     #[serde(default)]
     pub extension: Option<JsonBytes>,
 }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -924,8 +924,12 @@ pub struct Block {
     pub proposals: Vec<ProposalShortId>,
     /// The extension in the block body.
     ///
-    /// This field is optional. It's a reserved field, please leave it blank.
-    #[doc(hidden)]
+    /// This is a field introduced in [CKB RFC 0031]. Since the activation of [CKB RFC 0044], this
+    /// field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is
+    /// defined in the RFC 0044.
+    ///
+    /// [CKB RFC 0031]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md
+    /// [CKB RFC 0044]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension: Option<JsonBytes>,
 }
@@ -981,8 +985,12 @@ pub struct BlockView {
     pub proposals: Vec<ProposalShortId>,
     /// The extension in the block body.
     ///
-    /// This field is optional. It's a reserved field, please leave it blank.
-    #[doc(hidden)]
+    /// This is a field introduced in [CKB RFC 0031]. Since the activation of [CKB RFC 0044], this
+    /// field is at least 32 bytes, and at most 96 bytes. The consensus rule of first 32 bytes is
+    /// defined in the RFC 0044.
+    ///
+    /// [CKB RFC 0031]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0031-variable-length-header-field/0031-variable-length-header-field.md
+    /// [CKB RFC 0044]: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0044-ckb-light-client/0044-ckb-light-client.md
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension: Option<JsonBytes>,
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: the extension in `submit_block` is hidden and the doc is outdated.

### What is changed and how it works?

What's Changed: show `extension` in Block structure and update the documentation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test: RPC test
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

