### PR TITLE
fix: dummy block reward

### DIFF
--- a/spec/src/consensus.rs
+++ b/spec/src/consensus.rs
@@ -824,16 +824,15 @@ impl Consensus {
                     epoch_duration_in_milliseconds,
                 } => {
                     if self.permanent_difficulty() {
-                        let primary_epoch_reward =
-                            self.primary_epoch_reward_of_next_epoch(&epoch).as_u64();
-                        let block_reward =
-                            Capacity::shannons(primary_epoch_reward / epoch.length());
-                        let remainder_reward =
-                            Capacity::shannons(primary_epoch_reward % epoch.length());
-
                         let next_epoch_length = (self.epoch_duration_target() + MIN_BLOCK_INTERVAL
                             - 1)
                             / MIN_BLOCK_INTERVAL;
+                        let primary_epoch_reward =
+                            self.primary_epoch_reward_of_next_epoch(&epoch).as_u64();
+                        let block_reward =
+                            Capacity::shannons(primary_epoch_reward / next_epoch_length);
+                        let remainder_reward =
+                            Capacity::shannons(primary_epoch_reward % next_epoch_length);
 
                         let dummy_epoch_ext = epoch
                             .clone()


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In dummy mode, block reward is incorrectly calculated using the length of the previous epoch.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

