### PR TITLE
RBF will also replace tx not in Pending

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -474,6 +474,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RbfContainInvalidInput),
         Box::new(RbfContainInvalidCells),
         Box::new(RbfRejectReplaceProposed),
+        Box::new(RbfReplaceProposedSuccess),
         Box::new(CompactBlockEmpty),
         Box::new(CompactBlockEmptyParentUnknown),
         Box::new(CompactBlockPrefilled),

--- a/test/src/specs/tx_pool/replace.rs
+++ b/test/src/specs/tx_pool/replace.rs
@@ -564,7 +564,7 @@ impl Spec for RbfRejectReplaceProposed {
             .set_outputs(vec![output2])
             .build();
 
-        eprintln!("begin to RBF ......");
+        // begin to RBF
         let res = node0
             .rpc_client()
             .send_transaction_result(tx2.data().into());
@@ -605,6 +605,125 @@ impl Spec for RbfRejectReplaceProposed {
             .unwrap()
             .to_string()
             .contains("TransactionFailedToResolve: Resolve failed Unknown"));
+    }
+
+    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
+        config.tx_pool.min_rbf_rate = ckb_types::core::FeeRate(1500);
+    }
+}
+
+pub struct RbfReplaceProposedSuccess;
+
+// RBF Rule #6
+// We removed rule #6, this spec testing that we can replace tx in `Gap` and `Proposed` successfully.
+impl Spec for RbfReplaceProposedSuccess {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        node0.mine_until_out_bootstrap_period();
+
+        // build txs chain
+        let tx0 = node0.new_transaction_spend_tip_cellbase();
+        let mut txs = vec![tx0];
+        let max_count = 5;
+        while txs.len() <= max_count {
+            let parent = txs.last().unwrap();
+            let child = parent
+                .as_advanced_builder()
+                .set_inputs(vec![{
+                    CellInput::new_builder()
+                        .previous_output(OutPoint::new(parent.hash(), 0))
+                        .build()
+                }])
+                .set_outputs(vec![parent.output(0).unwrap()])
+                .build();
+            txs.push(child);
+        }
+        assert_eq!(txs.len(), max_count + 1);
+        // send Tx chain
+        for tx in txs[..=max_count - 1].iter() {
+            let ret = node0.rpc_client().send_transaction_result(tx.data().into());
+            assert!(ret.is_ok());
+        }
+
+        let proposed = node0.mine_with_blocking(|template| template.proposals.len() != max_count);
+        let ret = node0.rpc_client().get_transaction(txs[2].hash());
+        assert!(
+            matches!(ret.tx_status.status, Status::Pending),
+            "tx1 should be pending"
+        );
+
+        node0.mine_with_blocking(|template| template.number.value() != (proposed + 1));
+
+        let rpc_client0 = node0.rpc_client();
+        let ret = wait_until(20, || {
+            let res = rpc_client0.get_transaction(txs[2].hash());
+            res.tx_status.status == Status::Proposed
+        });
+        assert!(ret, "tx1 should be proposed");
+
+        let clone_tx = txs[2].clone();
+        // Set tx2 fee to a higher value
+        let output2 = CellOutputBuilder::default()
+            .capacity(capacity_bytes!(70).pack())
+            .build();
+
+        let tx1_hash = txs[2].hash();
+        let tx2 = clone_tx
+            .as_advanced_builder()
+            .set_outputs(vec![output2])
+            .build();
+
+        // begin to RBF
+        let res = node0
+            .rpc_client()
+            .send_transaction_result(tx2.data().into());
+        assert!(res.is_ok());
+
+        let old_tx_status = node0.rpc_client().get_transaction(tx1_hash).tx_status;
+        assert_eq!(old_tx_status.status, Status::Rejected);
+        assert!(old_tx_status.reason.unwrap().contains("RBFRejected"));
+
+        let tx2_status = node0.rpc_client().get_transaction(tx2.hash()).tx_status;
+        assert_eq!(tx2_status.status, Status::Pending);
+
+        // submit a black block
+        let example = node0.new_block(None, None, None);
+        let blank_block = example
+            .as_advanced_builder()
+            .set_proposals(vec![])
+            .set_transactions(vec![example.transaction(0).unwrap()])
+            .build();
+        node0.submit_block(&blank_block);
+
+        wait_until(10, move || node0.get_tip_block() == blank_block);
+
+        let window_count = node0.consensus().tx_proposal_window().closest();
+        node0.mine(window_count);
+
+        let ret = wait_until(20, || {
+            let res = rpc_client0.get_transaction(tx2.hash());
+            res.tx_status.status == Status::Proposed
+        });
+        assert!(ret, "tx2 should be proposed");
+        let tx1_status = node0.rpc_client().get_transaction(txs[2].hash()).tx_status;
+        assert_eq!(tx1_status.status, Status::Rejected);
+
+        let window_count = node0.consensus().tx_proposal_window().closest();
+        node0.mine(window_count);
+        // since old tx is already in BlockAssembler,
+        // tx1 will be committed, even it is not in tx_pool and with `Rejected` status now
+        let ret = wait_until(20, || {
+            let res = rpc_client0.get_transaction(tx2.hash());
+            res.tx_status.status == Status::Committed
+        });
+        assert!(ret, "tx2 should be committed");
+
+        // the same tx2 can not be sent again
+        let res = node0
+            .rpc_client()
+            .send_transaction_result(tx2.data().into());
+        assert!(res.is_err(), "tx2 should be rejected");
     }
 
     fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {


### PR DESCRIPTION

### What problem does this PR solve?

To keep it consistent, now `RBF` will also can replace `tx` not in `Pending`.

Problem Summary:

### What is changed and how it works?

Drop Rule #6 and fix tests.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

