### PR TITLE
Fix `CheckCellDeps` transaction fee not enough

### DIFF
--- a/test/src/specs/hardfork/v2021/cell_deps.rs
+++ b/test/src/specs/hardfork/v2021/cell_deps.rs
@@ -152,6 +152,7 @@ impl Spec for CheckCellDeps {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
+        spec.params.epoch_duration_target = Some(GENESIS_EPOCH_LENGTH * 8);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This PR want to fix https://github.com/nervosnetwork/ckb/actions/runs/6847588555/job/18616144298 :
```
2023-11-16 04:18:03.847 +00:00 main INFO ckb_test  [CheckCellDeps] Start executing
2023-11-16 04:18:03.847 +00:00 *unnamed* INFO ckb_test::node  working_dir "/var/folders/_m/f2pp9dy135ng8gb3z154mgkh0000gn/T/ckb-it-CheckCellDeps-node0-Ie8GHW"
2023-11-16 04:18:05.384 +00:00 *unnamed* ERROR panic  thread 'unnamed' panicked at 'rpc call send_transaction: {"code":-1108,"message":"PoolRejectedMalformedTransaction: Malformed Overflow transaction","data":"Malformed(\"Overflow\", \"expect (outputs capacity) <= (inputs capacity)\")"}': src/rpc.rs:197   0: backtrace::capture::Backtrace::create
   1: backtrace::capture::Backtrace::new
```

Problem Summary:

### What is changed and how it works?
In `Dummy` mode, `epoch_length_target` will affect the epoch length, the epoch length will [affect `block_reward` and `remainder_reward`](https://github.com/nervosnetwork/ckb/pull/4227). 
So in `CheckCellDeps`, we should specify `spec.params.epoch_duration_target` with `Some(GENESIS_EPOCH_LENGTH * 8)` to let `epoch_length` be `GENESIS_EPOCH_LENGTH` forever.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

