### PR TITLE
Fix using `journalctl` to check the log of `ckb.service`

### DIFF
--- a/devtools/init/linux-systemd/README.md
+++ b/devtools/init/linux-systemd/README.md
@@ -61,7 +61,7 @@ sudo systemctl enable ckb.service
 If ckb doesn't seem to start properly you can view the logs to figure out the problem:
 
 ```bash
-journalctl --boot -u ckb.service
+sudo journalctl --boot -u ckb.service
 ```
 
 Following the similar instructions to start a miner:

--- a/devtools/init/linux-systemd/README.md
+++ b/devtools/init/linux-systemd/README.md
@@ -58,6 +58,12 @@ Start the node automatically on boot if you like:
 sudo systemctl enable ckb.service
 ```
 
+Check ckb's status:
+
+```bash
+sudo systemctl status ckb.service
+```
+
 If ckb doesn't seem to start properly you can view the logs to figure out the problem:
 
 ```bash


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In the documentation for starting the ckb service via systemd on [here](https://github.com/nervosnetwork/ckb/blob/develop/devtools/init/linux-systemd/README.md), it's noted that the `ckb.service` is handled by the root's systemd. Therefore, to view its logs, you'd need to use `sudo journalctl`.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

