### PR TITLE
Fix `CheckVmBExtension` failed on CI

### DIFF
--- a/test/src/specs/hardfork/v2021/vm_b_extension.rs
+++ b/test/src/specs/hardfork/v2021/vm_b_extension.rs
@@ -74,6 +74,7 @@ impl Spec for CheckVmBExtension {
     fn modify_chain_spec(&self, spec: &mut ckb_chain_spec::ChainSpec) {
         spec.params.permanent_difficulty_in_dummy = Some(true);
         spec.params.genesis_epoch_length = Some(GENESIS_EPOCH_LENGTH);
+        spec.params.epoch_duration_target = Some(GENESIS_EPOCH_LENGTH * 8);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Same as #4234
Fix https://github.com/nervosnetwork/ckb/actions/runs/6926449286/job/18838627516 :
```
2023-11-20 07:05:35.977 +00:00 *unnamed* ERROR panic  thread 'unnamed' panicked at 'rpc call send_transaction: {"code":-1108,"message":"PoolRejectedMalformedTransaction: Malformed Overflow transaction","data":"Malformed(\"Overflow\", \"expect (outputs capacity) <= (inputs capacity)\")"}': src/rpc.rs:197   0: ckb_logger_service::setup_panic_logger::{{closure}}
             at /runner/_work/ckb/ckb/util/logger-service/src/lib.rs:508:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1999:9
      std::panicking::rust_panic_with_hook
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:709:13
   2: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:597:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:151:18
   4: rust_begin_unwind
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
   5: core::panicking::panic_fmt
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
   6: core::result::unwrap_failed
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/result.rs:1651:5
   7: core::result::Result<T,E>::expect
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/result.rs:1033:23
   8: ckb_test::rpc::RpcClient::send_transaction
             at src/rpc.rs:196:9
   9: ckb_test::node::Node::submit_transaction
             at src/node.rs:364:9
  10: ckb_test::specs::hardfork::v2021::vm_b_extension::BExtScript::deploy
             at src/specs/hardfork/v2021/vm_b_extension.rs:116:9
  11: ckb_test::specs::hardfork::v2021::vm_b_extension::BExtScript::new
             at src/specs/hardfork/v2021/vm_b_extension.rs:83:18
  12: <ckb_test::specs::hardfork::v2021::vm_b_extension::CheckVmBExtension as ckb_test::specs::Spec>::run
             at src/specs/hardfork/v2021/vm_b_extension.rs:55:22
  13: ckb_test::worker::Worker::run_spec::{{closure}}
             at src/worker.rs:125:13
  14: core::ops::function::FnOnce::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:250:5
  15: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:271:9
  16: std::panicking::try::do_call
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  17: __rust_try
  18: std::panicking::try
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  19: std::panic::catch_unwind
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  20: ckb_test::worker::Worker::run_spec
             at src/worker.rs:124:22
  21: ckb_test::worker::Worker::start::{{closure}}
             at src/worker.rs:104:17
  22: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:135:18
  23: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/mod.rs:529:17
  24: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:271:9
  25: std::panicking::try::do_call
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  26: __rust_try
  27: std::panicking::try
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  28: std::panic::catch_unwind
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
      std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/mod.rs:528:30
  29: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:250:5
  30: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
      <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/thread.rs:108:17
  31: start_thread
  32: clone

2023-11-20 07:05:35.978 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (CheckVmBExtension_node0)
2023-11-20 07:05:36.212 +00:00 GlobalRt-24 DEBUG ckb_network::services::dump_peer_store  dump peer store before exit
2023-11-20 07:05:36.212 +00:00 GlobalRt-24 DEBUG ckb_network::peer_store::peer_store_db  dump 1 addrs
2023-11-20 07:05:36.214 +00:00 GlobalRt-24 DEBUG ckb_network::peer_store::peer_store_db  dump 0 banned addrs
2023-11-20 07:05:36.215 +00:00 GlobalRt-24 DEBUG ckb_network::services::dump_peer_store  Dump peer store to "/runner/_work/ckb/ckb/test/target/ckb-test/20231120-070211/ckb-it-orphan_tx_test-net-30NABh/peer_store"
2023-11-20 07:05:36.216 +00:00 main INFO ckb_test  13/159 .............. [TxPoolOrphanUnordered] Done in 6 seconds
2023-11-20 07:05:36.216 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (TxPoolOrphanUnordered_node0)
2023-11-20 07:05:37.405 +00:00 *unnamed* INFO ckb_test::specs::tx_pool::send_large_cycles_tx  Wait block relay to node1
2023-11-20 07:05:37.407 +00:00 main INFO ckb_test  14/159 .............. [SendLargeCyclesTxInBlock] Done in 8 seconds
2023-11-20 07:05:37.407 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (SendLargeCyclesTxInBlock_node0)
2023-11-20 07:05:37.416 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (SendLargeCyclesTxInBlock_node1)
2023-11-20 07:05:45.402 +00:00 GlobalRt-30 DEBUG ckb_network::services::dump_peer_store  dump peer store before exit
2023-11-20 07:05:45.403 +00:00 GlobalRt-30 DEBUG ckb_network::peer_store::peer_store_db  dump 1 addrs
2023-11-20 07:05:45.404 +00:00 GlobalRt-30 DEBUG ckb_network::peer_store::peer_store_db  dump 0 banned addrs
2023-11-20 07:05:45.406 +00:00 GlobalRt-30 DEBUG ckb_network::services::dump_peer_store  Dump peer store to "/runner/_work/ckb/ckb/test/target/ckb-test/20231120-070211/ckb-it-RequestUnverifiedBlocks-net-Uj1nEK/peer_store"
2023-11-20 07:05:45.407 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (RequestUnverifiedBlocks_node0)
2023-11-20 07:05:45.415 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (RequestUnverifiedBlocks_node1)
2023-11-20 07:05:45.423 +00:00 *unnamed* DEBUG ckb_test::node  Successfully killed ckb process (RequestUnverifiedBlocks_node2)
2023-11-20 07:05:45.431 +00:00 main ERROR ckb_test  ckb-test failed on spec CheckVmBExtension
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

