### PR TITLE
feat: introduce `init tip` setting for indexer to skip previous block synchronization

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -205,5 +205,5 @@ block_uncles_cache_size    = 30
 # cell_filter = "let script = output.type;script!=() && script.code_hash == \"0x00000000000000000000000000000000000000000000000000545950455f4944\""
 # # The initial tip number and hash can be set as the starting height for building indexes in indexer-r. Effective only during the initial index creation.
 # init_tip_number = 10000
-# # The initial tip hash must match the tip number; otherwise, it will result in a rollback.
+# # The initial tip hash must match the tip number; otherwise, it will result in a rollback to empty.
 # init_tip_hash = "0x8fbd0ec887159d2814cee475911600e3589849670f5ee1ed9798b38fdeef4e44"

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -199,3 +199,11 @@ block_uncles_cache_size    = 30
 # [indexer_v2]
 # # Indexing the pending txs in the ckb tx-pool
 # index_tx_pool = false
+# # Customize block filtering rules to index only retained blocks
+# block_filter = "block.header.number.to_uint() >= \"0x0\".to_uint()"
+# # Customize cell filtering rules to index only retained cells
+# cell_filter = "let script = output.type;script!=() && script.code_hash == \"0x00000000000000000000000000000000000000000000000000545950455f4944\""
+# # The initial tip number and hash can be set as the starting height for building indexes in indexer-r. Effective only during the initial index creation.
+# init_tip_number = 10000
+# # The initial tip hash must match the tip number; otherwise, it will result in a rollback.
+# init_tip_hash = "0x8fbd0ec887159d2814cee475911600e3589849670f5ee1ed9798b38fdeef4e44"

--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -1,3 +1,4 @@
+use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -28,6 +29,12 @@ pub struct IndexerConfig {
     /// Maximal db info log files to be kept.
     #[serde(default)]
     pub db_keep_log_file_num: Option<NonZeroUsize>,
+    /// The init tip block number
+    #[serde(default)]
+    pub init_tip_number: Option<u64>,
+    /// The init tip block hash
+    #[serde(default)]
+    pub init_tip_hash: Option<H256>,
 }
 
 const fn default_poll_interval() -> u64 {
@@ -45,6 +52,8 @@ impl Default for IndexerConfig {
             cell_filter: None,
             db_background_jobs: None,
             db_keep_log_file_num: None,
+            init_tip_number: None,
+            init_tip_hash: None,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

CKB-indexer supports building indexes only for interested blocks. This can be done by setting `block_filter` before this PR. But the filter can only traverse the block from 0 and for the uninterested block also need to save its `Header(BlockNumber, &'a Byte32, bool)`. 

### What is changed and how it works?

 This pr introduces the `init tip` setting, which can be set directly when the indexer initializes the database for the first time, which brings two benefits:

1. synchronization can be started instantly from any height
2. the previous block does not need to save any data

What's Changed:

- Added commented out configuration item to ckb.toml template (as an example)
- Implement `apply_init_tip` function, which is called in `IndexerService::new`
- Necessary unit tests

### Related changes

This feature will also be used for index-r: 

- #4224  

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test
  - general: the indexer can skip the synchronization of the block before the init tip, and the init tip block only saves the block `Header(BlockNumber, &'a Byte32, bool)`
  - tip hash doesn't match, it rolls back to empty
  - when the init tip is set greater than the current node tip, there are no side effects, it waits for the node to synchronize

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

