### PR TITLE
Support easy run daemon mode for Linux/MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "ckb-verification-traits",
  "clap",
  "ctrlc",
+ "daemonize",
  "fdlimit",
  "is-terminal",
  "rayon",
@@ -1926,6 +1927,15 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,10 +592,12 @@ dependencies = [
  "ckb-util",
  "ckb-verification-traits",
  "clap",
+ "colored",
  "ctrlc",
  "daemonize",
  "fdlimit",
  "is-terminal",
+ "nix 0.24.3",
  "rayon",
  "sentry",
  "serde",
@@ -1723,6 +1725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,7 +1919,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "windows-sys 0.48.0",
 ]
 
@@ -3119,6 +3132,17 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 clap = { version = "4" }
+daemonize = { version = "0.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_plain = "0.3.0"

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 clap = { version = "4" }
-daemonize = { version = "0.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_plain = "0.3.0"
@@ -46,7 +45,9 @@ sentry = { version = "0.26.0", optional = true }
 is-terminal = "0.4.7"
 fdlimit = "0.2.1"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.114.0-pre" }
+
 [target.'cfg(not(target_os="windows"))'.dependencies]
+daemonize = { version = "0.5.0" }
 nix = { version = "0.24.0", default-features = false, features = ["signal"] }
 colored = "2.0"
 

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -46,6 +46,9 @@ sentry = { version = "0.26.0", optional = true }
 is-terminal = "0.4.7"
 fdlimit = "0.2.1"
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.114.0-pre" }
+[target.'cfg(not(target_os="windows"))'.dependencies]
+nix = { version = "0.24.0", default-features = false, features = ["signal"] }
+colored = "2.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]

--- a/ckb-bin/src/helper.rs
+++ b/ckb-bin/src/helper.rs
@@ -1,4 +1,4 @@
-use ckb_logger::info;
+use ckb_logger::{debug, info};
 
 use std::io::{stdin, stdout, Write};
 
@@ -73,6 +73,6 @@ pub fn prompt(msg: &str) -> String {
 /// on the number of cores available.
 pub fn raise_fd_limit() {
     if let Some(limit) = fdlimit::raise_fd_limit() {
-        info!("raise_fd_limit newly-increased limit: {}", limit);
+        debug!("raise_fd_limit newly-increased limit: {}", limit);
     }
 }

--- a/ckb-bin/src/helper.rs
+++ b/ckb-bin/src/helper.rs
@@ -1,4 +1,4 @@
-use ckb_logger::{debug, info};
+use ckb_logger::debug;
 
 use std::io::{stdin, stdout, Write};
 

--- a/ckb-bin/src/helper.rs
+++ b/ckb-bin/src/helper.rs
@@ -8,7 +8,7 @@ pub fn deadlock_detection() {}
 #[cfg(feature = "deadlock_detection")]
 pub fn deadlock_detection() {
     use ckb_channel::select;
-    use ckb_logger::warn;
+    use ckb_logger::{info, warn};
     use ckb_stop_handler::{new_crossbeam_exit_rx, register_thread};
     use ckb_util::parking_lot::deadlock;
     use std::{thread, time::Duration};

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -7,7 +7,7 @@ mod subcommand;
 use ckb_app_config::{cli, ExitCode, Setup};
 use ckb_async_runtime::new_global_runtime;
 use ckb_build_info::Version;
-use ckb_logger::info;
+use ckb_logger::{debug, info};
 use ckb_network::tokio;
 use clap::ArgMatches;
 use colored::Colorize;
@@ -63,14 +63,14 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
         .expect("SubcommandRequiredElseHelp");
 
     if run_deamon(cmd, matches) {
-        run_in_daemon(version, bin_name, cmd, matches)
+        run_app_in_daemon(version, bin_name, cmd, matches)
     } else {
         debug!("ckb version: {}", version);
         run_app_inner(version, bin_name, cmd, matches)
     }
 }
 
-fn run_in_daemon(
+fn run_app_in_daemon(
     version: Version,
     bin_name: String,
     cmd: &str,
@@ -83,7 +83,7 @@ fn run_in_daemon(
     assert!(matches!(cmd, cli::CMD_RUN));
     let root_dir = Setup::root_dir_from_matches(matches)?;
     let daemon_dir = root_dir.join("data/daemon");
-    let pid_file = Setup::pid_file_path_from_matches(matches)?;
+    let pid_file = Setup::daemon_pid_file_path(matches)?;
 
     if check_process(&pid_file).is_ok() {
         eprintln!("{}", "ckb is already running".red());

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -166,6 +166,11 @@ type Silent = bool;
 fn is_silent_logging(cmd: &str) -> Silent {
     matches!(
         cmd,
-        cli::CMD_EXPORT | cli::CMD_IMPORT | cli::CMD_STATS | cli::CMD_MIGRATE | cli::CMD_RESET_DATA
+        cli::CMD_EXPORT
+            | cli::CMD_IMPORT
+            | cli::CMD_STATS
+            | cli::CMD_MIGRATE
+            | cli::CMD_RESET_DATA
+            | cli::CMD_DAEMON
     )
 }

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -14,6 +14,8 @@ use colored::Colorize;
 use daemonize::Daemonize;
 use helper::raise_fd_limit;
 use setup_guard::SetupGuard;
+
+#[cfg(not(target_os = "windows"))]
 use subcommand::check_process;
 
 #[cfg(feature = "with_sentry")]
@@ -127,6 +129,7 @@ fn run_app_inner(
         cli::CMD_STATS => subcommand::stats(setup.stats(matches)?, handle.clone()),
         cli::CMD_RESET_DATA => subcommand::reset_data(setup.reset_data(matches)?),
         cli::CMD_MIGRATE => subcommand::migrate(setup.migrate(matches)?),
+        #[cfg(not(target_os = "windows"))]
         cli::CMD_DAEMON => subcommand::daemon(setup.daemon(matches)?),
         _ => unreachable!(),
     };
@@ -144,13 +147,10 @@ fn run_app_inner(
     ret
 }
 
-#[cfg(target_os = "windows")]
-fn run_deamon(_cmd: &str, _matches: &ArgMatches) -> bool {
-    false
-}
-
-#[cfg(not(target_os = "windows"))]
 fn run_deamon(cmd: &str, matches: &ArgMatches) -> bool {
+    #[cfg(target_os = "windows")]
+    return false;
+
     match cmd {
         cli::CMD_RUN | cli::CMD_MINER => matches.get_flag(cli::ARG_DAEMON),
         _ => false,

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -83,6 +83,8 @@ fn run_app_in_daemon(
     assert!(matches!(cmd, cli::CMD_RUN));
     let root_dir = Setup::root_dir_from_matches(matches)?;
     let daemon_dir = root_dir.join("data/daemon");
+    // make sure daemon dir exists
+    std::fs::create_dir_all(daemon_dir)?;
     let pid_file = Setup::daemon_pid_file_path(matches)?;
 
     if check_process(&pid_file).is_ok() {
@@ -90,9 +92,6 @@ fn run_app_in_daemon(
         return Ok(());
     }
     eprintln!("no ckb process, starting ...");
-
-    // make sure daemon dir exists
-    std::fs::create_dir_all(daemon_dir)?;
 
     let pwd = std::env::current_dir()?;
     let daemon = Daemonize::new()

--- a/ckb-bin/src/subcommand/daemon.rs
+++ b/ckb-bin/src/subcommand/daemon.rs
@@ -55,10 +55,21 @@ fn kill_process(pid_file: &PathBuf, name: &str) -> Result<(), ExitCode> {
     );
     // Send a SIGTERM signal to the process
     let _ = kill(Pid::from_raw(pid), Some(Signal::SIGTERM)).map_err(|_| ExitCode::Failure);
-    // sleep 3 seconds and check if the process is still running
-    std::thread::sleep(std::time::Duration::from_secs(3));
+    std::thread::sleep(std::time::Duration::from_secs(20));
     match check_process(pid_file) {
-        Ok(_) => kill(Pid::from_raw(pid), Some(Signal::SIGKILL)).map_err(|_| ExitCode::Failure),
-        _ => Ok(()),
+        Ok(_) => {
+            eprintln!(
+                "{}",
+                format!(
+                "ckb daemon service is is still running with pid {}..., stop it now forcefully ...",
+                pid
+            )
+                .red()
+            );
+            kill(Pid::from_raw(pid), Some(Signal::SIGKILL)).map_err(|_| ExitCode::Failure)?;
+        }
+        _ => {}
     }
+    eprintln!("{}", "cbk daemon service stopped successfully".green());
+    Ok(())
 }

--- a/ckb-bin/src/subcommand/daemon.rs
+++ b/ckb-bin/src/subcommand/daemon.rs
@@ -1,0 +1,66 @@
+use ckb_app_config::{DaemonArgs, ExitCode};
+use colored::*;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use std::fs;
+
+pub fn daemon(args: DaemonArgs) -> Result<(), ExitCode> {
+    let ckb_pid_file = "/tmp/ckb-run.pid";
+    let miner_pid_file = "/tmp/ckb-miner.pid";
+
+    if args.check {
+        // find the pid file and check if the process is running
+        daemon_check(ckb_pid_file, "ckb");
+        daemon_check(miner_pid_file, "miner");
+    } else if args.stop {
+        let _ = kill_process(ckb_pid_file, "ckb");
+        let _ = kill_process(miner_pid_file, "miner");
+    }
+    Ok(())
+}
+
+fn daemon_check(pid_file: &str, name: &str) {
+    match check_process(pid_file) {
+        Ok(pid) => {
+            eprintln!("{:>10} : {:<12} pid - {}", name, "running".green(), pid);
+        }
+        _ => {
+            eprintln!("{:>10} : {:<12}", name, "not running".red());
+        }
+    }
+}
+
+pub fn check_process(pid_file: &str) -> Result<i32, ExitCode> {
+    let pid_str = fs::read_to_string(pid_file).map_err(|_| ExitCode::Failure)?;
+    let pid = pid_str
+        .trim()
+        .parse::<i32>()
+        .map_err(|_| ExitCode::Failure)?;
+
+    // Check if the process is running
+    match kill(Pid::from_raw(pid), None) {
+        Ok(_) => Ok(pid),
+        Err(_) => Err(ExitCode::Failure),
+    }
+}
+
+fn kill_process(pid_file: &str, name: &str) -> Result<(), ExitCode> {
+    if check_process(pid_file).is_err() {
+        eprintln!("{} is not running", name);
+        return Ok(());
+    }
+    let pid_str = fs::read_to_string(pid_file).map_err(|_| ExitCode::Failure)?;
+    let pid = pid_str
+        .trim()
+        .parse::<i32>()
+        .map_err(|_| ExitCode::Failure)?;
+    eprintln!("kill {} process {} ...", name, pid.to_string().red());
+    // Send a SIGTERM signal to the process
+    let _ = kill(Pid::from_raw(pid), Some(Signal::SIGTERM)).map_err(|_| ExitCode::Failure);
+    // sleep 3 seconds and check if the process is still running
+    std::thread::sleep(std::time::Duration::from_secs(3));
+    match check_process(pid_file) {
+        Ok(_) => kill(Pid::from_raw(pid), Some(Signal::SIGKILL)).map_err(|_| ExitCode::Failure),
+        _ => Ok(()),
+    }
+}

--- a/ckb-bin/src/subcommand/daemon.rs
+++ b/ckb-bin/src/subcommand/daemon.rs
@@ -6,23 +6,20 @@ use std::fs;
 use std::path::PathBuf;
 
 pub fn daemon(args: DaemonArgs) -> Result<(), ExitCode> {
-    let name = "ckb";
     let pid_file = &args.pid_file;
     if args.check {
         // find the pid file and check if the process is running
         match check_process(pid_file) {
             Ok(pid) => {
-                eprintln!("{:>10} : {:<12} pid - {}", name, "running".green(), pid);
+                eprintln!("{}, pid - {}", "ckb daemon service is running".green(), pid);
             }
             _ => {
-                eprintln!("{:>10} : {:<12}", name, "not running".red());
+                eprintln!("{}", "ckb daemon service is not running".red());
             }
         }
     } else if args.stop {
         kill_process(pid_file, "ckb")?;
         fs::remove_file(pid_file).map_err(|_| ExitCode::Failure)?;
-    } else {
-        unimplemented!()
     }
     Ok(())
 }
@@ -51,7 +48,11 @@ fn kill_process(pid_file: &PathBuf, name: &str) -> Result<(), ExitCode> {
         .trim()
         .parse::<i32>()
         .map_err(|_| ExitCode::Failure)?;
-    eprintln!("kill {} process {} ...", name, pid.to_string().red());
+    eprintln!(
+        "stopping {} deamon service {} ...",
+        name,
+        pid.to_string().red()
+    );
     // Send a SIGTERM signal to the process
     let _ = kill(Pid::from_raw(pid), Some(Signal::SIGTERM)).map_err(|_| ExitCode::Failure);
     // sleep 3 seconds and check if the process is still running

--- a/ckb-bin/src/subcommand/daemon.rs
+++ b/ckb-bin/src/subcommand/daemon.rs
@@ -56,7 +56,7 @@ fn kill_process(pid_file: &PathBuf, name: &str) -> Result<(), ExitCode> {
     );
     // Send a SIGTERM signal to the process
     let _ = kill(Pid::from_raw(pid), Some(Signal::SIGTERM)).map_err(|_| ExitCode::Failure);
-    let mut wait_time = 15;
+    let mut wait_time = 60;
     eprintln!("{}", "waiting ckb service to stop ...".yellow());
     loop {
         let res = check_process(pid_file);

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -11,7 +11,7 @@ mod reset_data;
 mod run;
 mod stats;
 
-pub use self::daemon::daemon;
+pub use self::daemon::{check_process, daemon};
 pub use self::export::export;
 pub use self::import::import;
 pub use self::init::init;

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -1,3 +1,4 @@
+mod daemon;
 mod export;
 mod import;
 mod init;
@@ -10,6 +11,7 @@ mod reset_data;
 mod run;
 mod stats;
 
+pub use self::daemon::daemon;
 pub use self::export::export;
 pub use self::import::import;
 pub use self::init::init;

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "windows"))]
 mod daemon;
 mod export;
 mod import;
@@ -11,6 +12,7 @@ mod reset_data;
 mod run;
 mod stats;
 
+#[cfg(not(target_os = "windows"))]
 pub use self::daemon::{check_process, daemon};
 pub use self::export::export;
 pub use self::import::import;

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -13,7 +13,6 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     info!("ckb version: {}", version);
     let mut launcher = Launcher::new(args, version, async_handle);
-    info!("ckb finished launcher new ...");
 
     let block_assembler_config = launcher.sanitize_block_assembler_config()?;
     let miner_enable = block_assembler_config.is_some();
@@ -55,7 +54,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
     let tx_pool_builder = pack.take_tx_pool_builder();
     tx_pool_builder.start(network_controller.clone());
 
-    eprintln!("CKB service started ...");
+    info!("CKB service started ...");
     ctrlc::set_handler(|| {
         info!("Trapped exit signal, exiting...");
         broadcast_exit_signals();

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -13,6 +13,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     info!("ckb version: {}", version);
     let mut launcher = Launcher::new(args, version, async_handle);
+    info!("ckb finished launcher new ...");
 
     let block_assembler_config = launcher.sanitize_block_assembler_config()?;
     let miner_enable = block_assembler_config.is_some();
@@ -54,6 +55,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
     let tx_pool_builder = pack.take_tx_pool_builder();
     tx_pool_builder.start(network_controller.clone());
 
+    eprintln!("CKB service started ...");
     ctrlc::set_handler(|| {
         info!("Trapped exit signal, exiting...");
         broadcast_exit_signals();

--- a/devtools/init/README.md
+++ b/devtools/init/README.md
@@ -1,11 +1,35 @@
-# Init/Service Scripts
+# CKB Init Scripts
+
+## Run CKB in deamon mode
+
+CKB has a builtin deamon mode, command to run CKB in deamon mode(only for Linux/MacOS):
+
+```bash
+ckb run --deamon
+```
+
+Check deamon satus:
+
+```bash
+ckb deamon --check
+```
+
+Stop deamon process:
+
+```bash
+ckb deamon --stop
+```
+
+The deamon mode is only for Linux/MacOS, and the CKB service will not be started automatically after reboot.
+
+## Init/Service Scripts
 
 This folder provides the init/service scripts to start CKB node and miner as
 daemons on various Unix like distributions.
 
 See the README in each folder for the detailed instructions.
 
-## Disclaimer
+### Disclaimer
 
 Users are expected to know how to administer their system, and these files
 should be considered as only a guide or suggestion to setup CKB.

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -24,6 +24,8 @@ pub struct DaemonArgs {
     pub check: bool,
     /// Stop daemon process
     pub stop: bool,
+    /// The pid file path
+    pub pid_file: PathBuf,
 }
 
 /// Parsed command line arguments for `ckb import`.

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -17,6 +17,15 @@ pub struct ExportArgs {
     pub target: PathBuf,
 }
 
+#[derive(Debug)]
+/// Parsed command line arguments for `ckb daemon`.
+pub struct DaemonArgs {
+    /// Check the daemon status
+    pub check: bool,
+    /// Stop daemon process
+    pub stop: bool,
+}
+
 /// Parsed command line arguments for `ckb import`.
 pub struct ImportArgs {
     /// Parsed `ckb.toml`.

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -45,6 +45,8 @@ pub struct RunArgs {
     pub chain_spec_hash: Byte32,
     /// Whether start indexer, default false
     pub indexer: bool,
+    /// Whether start in daemon mode
+    pub daemon: bool,
 }
 
 /// Enable profile on blocks in the range `[from, to]`.

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -73,6 +73,8 @@ pub const ARG_BA_HASH_TYPE: &str = "ba-hash-type";
 pub const ARG_BA_MESSAGE: &str = "ba-message";
 /// Command line argument `--ba-advanced`.
 pub const ARG_BA_ADVANCED: &str = "ba-advanced";
+/// Command line argument `--daemon`
+pub const ARG_DAEMON: &str = "daemon";
 /// Command line argument `--indexer`.
 pub const ARG_INDEXER: &str = "indexer";
 /// Command line argument `--from`.
@@ -168,6 +170,13 @@ fn run() -> Command {
                 .long(ARG_BA_ADVANCED)
                 .action(clap::ArgAction::SetTrue)
                 .help("Allow any block assembler code hash and args"),
+        )
+        .arg(
+            Arg::new(ARG_DAEMON)
+            .long(ARG_DAEMON)
+            .action(clap::ArgAction::SetTrue)
+            .help("Starts ckb as a daemon, \
+                which will run in the background and output logs to the specified log file"),
         )
         .arg(
             Arg::new(ARG_SKIP_CHAIN_SPEC_CHECK)

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -32,7 +32,8 @@ pub const CMD_GEN_SECRET: &str = "gen";
 pub const CMD_FROM_SECRET: &str = "from-secret";
 /// Subcommand `migrate`.
 pub const CMD_MIGRATE: &str = "migrate";
-
+/// Subcommand `daemon`
+pub const CMD_DAEMON: &str = "daemon";
 /// Command line argument `--config-dir`.
 pub const ARG_CONFIG_DIR: &str = "config-dir";
 /// Command line argument `--format`.
@@ -113,6 +114,10 @@ pub const ARG_OVERWRITE_CHAIN_SPEC: &str = "overwrite-spec";
 pub const ARG_ASSUME_VALID_TARGET: &str = "assume-valid-target";
 /// Command line argument `--check`.
 pub const ARG_MIGRATE_CHECK: &str = "check";
+/// Command line argument `daemon --check`
+pub const ARG_DAEMON_CHECK: &str = "check";
+/// Command line argument `daemon --stop`
+pub const ARG_DAEMON_STOP: &str = "stop";
 
 /// Command line arguments group `ba` for block assembler.
 const GROUP_BA: &str = "ba";
@@ -146,6 +151,7 @@ pub fn basic_app() -> Command {
         .subcommand(reset_data())
         .subcommand(peer_id())
         .subcommand(migrate())
+        .subcommand(daemon())
 }
 
 /// Parse the command line arguments by supplying the version information.
@@ -211,18 +217,29 @@ fn run() -> Command {
 }
 
 fn miner() -> Command {
-    Command::new(CMD_MINER).about("Run CKB miner").arg(
-        Arg::new(ARG_LIMIT)
-            .short('l')
-            .long(ARG_LIMIT)
-            .action(clap::ArgAction::Set)
-            .value_parser(clap::value_parser!(u128))
-            .default_value("0")
-            .help(
-                "Exit after finding this specific number of nonces; \
+    Command::new(CMD_MINER)
+        .about("Runs ckb miner")
+        .arg(
+            Arg::new(ARG_LIMIT)
+                .short('l')
+                .long(ARG_LIMIT)
+                .action(clap::ArgAction::Set)
+                .value_parser(clap::value_parser!(u128))
+                .default_value("0")
+                .help(
+                    "Exit after finding this specific number of nonces; \
             0 means the miner will never exit. [default: 0]",
-            ),
-    )
+                ),
+        )
+        .arg(
+            Arg::new(ARG_DAEMON)
+                .long(ARG_DAEMON)
+                .action(clap::ArgAction::SetTrue)
+                .help(
+                    "Starts ckb as a daemon, \
+        which will run in the background and output logs to the specified log file",
+                ),
+        )
 }
 
 fn reset_data() -> Command {
@@ -378,6 +395,24 @@ fn migrate() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with(ARG_MIGRATE_CHECK)
                 .help("Migrate without interactive prompt"),
+        )
+}
+
+fn daemon() -> Command {
+    Command::new(CMD_DAEMON)
+        .about("Runs ckb daemon command")
+        .arg(
+            Arg::new(ARG_DAEMON_CHECK)
+                .long(ARG_DAEMON_CHECK)
+                .action(clap::ArgAction::SetTrue)
+                .help("Check the daemon status"),
+        )
+        .arg(
+            Arg::new(ARG_DAEMON_STOP)
+                .long(ARG_DAEMON_STOP)
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with(ARG_DAEMON_CHECK)
+                .help("Stop the daemon process, both the miner and the node"),
         )
 }
 

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -221,29 +221,18 @@ fn run() -> Command {
 }
 
 fn miner() -> Command {
-    Command::new(CMD_MINER)
-        .about("Runs ckb miner")
-        .arg(
-            Arg::new(ARG_LIMIT)
-                .short('l')
-                .long(ARG_LIMIT)
-                .action(clap::ArgAction::Set)
-                .value_parser(clap::value_parser!(u128))
-                .default_value("0")
-                .help(
-                    "Exit after finding this specific number of nonces; \
+    Command::new(CMD_MINER).about("Runs ckb miner").arg(
+        Arg::new(ARG_LIMIT)
+            .short('l')
+            .long(ARG_LIMIT)
+            .action(clap::ArgAction::Set)
+            .value_parser(clap::value_parser!(u128))
+            .default_value("0")
+            .help(
+                "Exit after finding this specific number of nonces; \
             0 means the miner will never exit. [default: 0]",
-                ),
-        )
-        .arg(
-            Arg::new(ARG_DAEMON)
-                .long(ARG_DAEMON)
-                .action(clap::ArgAction::SetTrue)
-                .help(
-                    "Starts ckb as a daemon, \
-        which will run in the background and output logs to the specified log file",
-                ),
-        )
+            ),
+    )
 }
 
 fn reset_data() -> Command {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -124,7 +124,7 @@ const GROUP_BA: &str = "ba";
 
 /// return root clap Command
 pub fn basic_app() -> Command {
-    Command::new(BIN_NAME)
+    let command = Command::new(BIN_NAME)
         .author("Nervos Core Dev <dev@nervos.org>")
         .about("Nervos CKB - The Common Knowledge Base")
         .subcommand_required(true)
@@ -150,8 +150,12 @@ pub fn basic_app() -> Command {
         .subcommand(stats())
         .subcommand(reset_data())
         .subcommand(peer_id())
-        .subcommand(migrate())
-        .subcommand(daemon())
+        .subcommand(migrate());
+
+    #[cfg(not(target_os = "windows"))]
+    let command = command.subcommand(daemon());
+
+    command
 }
 
 /// Parse the command line arguments by supplying the version information.
@@ -398,6 +402,7 @@ fn migrate() -> Command {
         )
 }
 
+#[cfg(not(target_os = "windows"))]
 fn daemon() -> Command {
     Command::new(CMD_DAEMON)
         .about("Runs ckb daemon command")

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -173,20 +173,13 @@ pub fn get_bin_name_and_matches(version: &Version) -> (String, ArgMatches) {
 }
 
 fn run() -> Command {
-    Command::new(CMD_RUN)
+    let command = Command::new(CMD_RUN)
         .about("Run CKB node")
         .arg(
             Arg::new(ARG_BA_ADVANCED)
                 .long(ARG_BA_ADVANCED)
                 .action(clap::ArgAction::SetTrue)
                 .help("Allow any block assembler code hash and args"),
-        )
-        .arg(
-            Arg::new(ARG_DAEMON)
-            .long(ARG_DAEMON)
-            .action(clap::ArgAction::SetTrue)
-            .help("Starts ckb as a daemon, \
-                which will run in the background and output logs to the specified log file"),
         )
         .arg(
             Arg::new(ARG_SKIP_CHAIN_SPEC_CHECK)
@@ -217,7 +210,19 @@ fn run() -> Command {
             .long(ARG_INDEXER)
             .action(clap::ArgAction::SetTrue)
             .help("Start the built-in indexer service"),
-        )
+        );
+
+    #[cfg(not(target_os = "windows"))]
+    let command = command.arg(
+        Arg::new(ARG_DAEMON)
+            .long(ARG_DAEMON)
+            .action(clap::ArgAction::SetTrue)
+            .help(
+                "Starts ckb as a daemon, \
+                which will run in the background and output logs to the specified log file",
+            ),
+    );
+    command
 }
 
 fn miner() -> Command {

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -98,6 +98,7 @@ impl Setup {
             overwrite_chain_spec: matches.get_flag(cli::ARG_OVERWRITE_CHAIN_SPEC),
             chain_spec_hash,
             indexer: matches.get_flag(cli::ARG_INDEXER),
+            daemon: matches.get_flag(cli::ARG_DAEMON),
         })
     }
 

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -223,8 +223,12 @@ impl Setup {
     pub fn daemon(self, matches: &ArgMatches) -> Result<DaemonArgs, ExitCode> {
         let check = matches.get_flag(cli::ARG_DAEMON_CHECK);
         let stop = matches.get_flag(cli::ARG_DAEMON_STOP);
-
-        Ok(DaemonArgs { check, stop })
+        let pid_file = Setup::pid_file_path_from_matches(matches)?;
+        Ok(DaemonArgs {
+            check,
+            stop,
+            pid_file,
+        })
     }
 
     /// Executes `ckb init`.
@@ -354,6 +358,12 @@ impl Setup {
         };
         std::fs::create_dir_all(&config_dir)?;
         Ok(config_dir)
+    }
+
+    /// Resolves the pid file path for ckb from the command line arguments.
+    pub fn pid_file_path_from_matches(matches: &ArgMatches) -> Result<PathBuf, ExitCode> {
+        let root_dir = Self::root_dir_from_matches(matches)?;
+        Ok(root_dir.join("data/daemon/ckb-run.pid"))
     }
 
     /// Loads the chain spec.

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -223,7 +223,7 @@ impl Setup {
     pub fn daemon(self, matches: &ArgMatches) -> Result<DaemonArgs, ExitCode> {
         let check = matches.get_flag(cli::ARG_DAEMON_CHECK);
         let stop = matches.get_flag(cli::ARG_DAEMON_STOP);
-        let pid_file = Setup::pid_file_path_from_matches(matches)?;
+        let pid_file = Setup::daemon_pid_file_path(matches)?;
         Ok(DaemonArgs {
             check,
             stop,
@@ -361,7 +361,7 @@ impl Setup {
     }
 
     /// Resolves the pid file path for ckb from the command line arguments.
-    pub fn pid_file_path_from_matches(matches: &ArgMatches) -> Result<PathBuf, ExitCode> {
+    pub fn daemon_pid_file_path(matches: &ArgMatches) -> Result<PathBuf, ExitCode> {
         let root_dir = Self::root_dir_from_matches(matches)?;
         Ok(root_dir.join("data/daemon/ckb-run.pid"))
     }

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -15,7 +15,7 @@ pub use app_config::{
     AppConfig, CKBAppConfig, ChainConfig, LogConfig, MetricsConfig, MinerAppConfig,
 };
 pub use args::{
-    ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, ReplayArgs,
+    DaemonArgs, ExportArgs, ImportArgs, InitArgs, MigrateArgs, MinerArgs, PeerIDArgs, ReplayArgs,
     ResetDataArgs, RunArgs, StatsArgs,
 };
 pub use configs::*;
@@ -217,6 +217,14 @@ impl Setup {
             consensus,
             target,
         })
+    }
+
+    /// Executes `ckb daemon`.
+    pub fn daemon(self, matches: &ArgMatches) -> Result<DaemonArgs, ExitCode> {
+        let check = matches.get_flag(cli::ARG_DAEMON_CHECK);
+        let stop = matches.get_flag(cli::ARG_DAEMON_STOP);
+
+        Ok(DaemonArgs { check, stop })
     }
 
     /// Executes `ckb init`.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4237

Problem Summary:

### What is changed and how it works?

- use crate `daemonize` for supporting daemon 
- use crate `colored` for better terminal UX
- Note: `new_global_runtime` need to be invoked after daemonize success

Command line:
- `ckb run --daemon` - run ckb in daemon 
- `ckb daemon --check` - check the status of service
- `ckb daemon --stop` - stop the daemon process

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

