### PR TITLE
Fix `Relayer::notify`'s `remove_notify`'s log when `RelaySwitch` is `Ckb2023RelayV2`

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -904,13 +904,13 @@ impl CKBProtocolHandler for Relayer {
                     trace_target!(crate::LOG_TARGET_RELAY, "remove v2 relay notify fail");
                 }
                 if nc.remove_notify(ASK_FOR_TXS_TOKEN).await.is_err() {
-                    trace_target!(crate::LOG_TARGET_RELAY, "remove v1 relay notify fail");
+                    trace_target!(crate::LOG_TARGET_RELAY, "remove v2 relay notify fail");
                 }
                 if nc.remove_notify(TX_HASHES_TOKEN).await.is_err() {
-                    trace_target!(crate::LOG_TARGET_RELAY, "remove v1 relay notify fail");
+                    trace_target!(crate::LOG_TARGET_RELAY, "remove v2 relay notify fail");
                 }
                 if nc.remove_notify(SEARCH_ORPHAN_POOL_TOKEN).await.is_err() {
-                    trace_target!(crate::LOG_TARGET_RELAY, "remove v1 relay notify fail");
+                    trace_target!(crate::LOG_TARGET_RELAY, "remove v2 relay notify fail");
                 }
                 for kv_pair in self.shared().state().peers().state.iter() {
                     let (peer, state) = kv_pair.pair();


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
When `RelaySwitch` is `RelaySwitch::Ckb2023RelayV2`, the log message should be `v2` instead of `v1`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

