### PR TITLE
fix: no chain_root in 1st block of the mmr activated epoch

### DIFF
--- a/util/types/src/utilities/merkle_mountain_range.rs
+++ b/util/types/src/utilities/merkle_mountain_range.rs
@@ -209,8 +209,9 @@ impl VerifiableHeader {
     }
 
     /// Checks if the current verifiable header is valid.
-    pub fn is_valid(&self, mmr_activated_epoch: EpochNumber) -> bool {
-        let has_chain_root = self.header().epoch().number() >= mmr_activated_epoch;
+    pub fn is_valid(&self, mmr_activated_epoch_number: EpochNumber) -> bool {
+        let mmr_activated_epoch = EpochNumberWithFraction::new(mmr_activated_epoch_number, 0, 1);
+        let has_chain_root = self.header().epoch() > mmr_activated_epoch;
         if has_chain_root {
             if self.header().is_genesis() {
                 if !self.parent_chain_root().is_default() {


### PR DESCRIPTION
### What problem does this PR solve?

Since CKB enabled the MMR feature through version bits with following code:

https://github.com/nervosnetwork/ckb/blob/3d674d558e5574f0c77a52798775c903561a933a/verification/contextual/src/contextual_block_verifier.rs#L567-L569
https://github.com/nervosnetwork/ckb/blob/3d674d558e5574f0c77a52798775c903561a933a/spec/src/consensus.rs#L1031

the extension field of the first block in the MMR activated epoch, doesn't contain the chain root.

So, when check the extension fields, the first block in the MMR activated epoch should be skipped.

Ref: nervosnetwork/ckb-light-client#163

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

