### PR TITLE
Add aarch64 docker image  for ckb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,18 +156,25 @@ prod-with-debug:
 
 .PHONY: docker
 docker: ## Build docker image
-	docker build -f docker/hub/Dockerfile -t nervos/ckb:$$(git describe) .
+	docker build -f docker/hub/Dockerfile -t nervos/ckb:x64-$$(git describe) .
 	docker run --rm -it nervos/ckb:$$(git describe) --version
+
+docker-aarch64:
+	docker build -f docker/hub/Dockerfile-aarch64 -t nervos/ckb:aarch64-$$(git describe) .
 
 .PHONY: docker-publish
 docker-publish:
-	docker push nervos/ckb:$$(git describe)
-	docker tag nervos/ckb:$$(git describe) nervos/ckb:latest
-	docker push nervos/ckb:latest
+	docker push nervos/ckb:x64-$$(git describe)
+	docker push nervos/ckb:aarch64-$$(git describe)
+	docker manifest create nervos/ckb:latest nervos/ckb:x64-$$(git describe) nervos/ckb:aarch64-$$(git describe)
+	docker manifest push nervos/ckb:latest
 
 .PHONY: docker-publish-rc
 docker-publish-rc:
-	docker push nervos/ckb:$$(git describe)
+	docker push nervos/ckb:x64-$$(git describe)
+	docker push nervos/ckb:aarch64-$$(git describe)
+	docker manifest create nervos/ckb:$$(git describe) nervos/ckb:x64-$$(git describe) nervos/ckb:aarch64-$$(git describe)
+	docker manifest push nervos/ckb:$$(git describe)
 
 ##@ Code Quality
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,12 @@ prod-with-debug:
 .PHONY: docker
 docker: ## Build docker image
 	docker build -f docker/hub/Dockerfile -t nervos/ckb:x64-$$(git describe) .
-	docker run --rm -it nervos/ckb:$$(git describe) --version
+	docker run --rm -it nervos/ckb:x64-$$(git describe) --version
 
+.PHONY: docker-aarch64
 docker-aarch64:
 	docker build -f docker/hub/Dockerfile-aarch64 -t nervos/ckb:aarch64-$$(git describe) .
+	docker run --rm -it nervos/ckb:aarch64-$$(git describe) --version
 
 .PHONY: docker-publish
 docker-publish:

--- a/docker/hub/Dockerfile-aarch64
+++ b/docker/hub/Dockerfile-aarch64
@@ -1,0 +1,31 @@
+FROM nervos/ckb-docker-builder:aarch64-rust-1.71.1 as ckb-docker-builder
+
+WORKDIR /ckb
+COPY ./ .
+
+RUN make prod-docker
+
+FROM arm64v8/ubuntu
+LABEL description="Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network."
+LABEL maintainer="Nervos Core Dev <dev@nervos.org>"
+
+RUN groupadd -g 1000 ckb \
+ && useradd -m -u 1000 -g ckb -s /bin/sh ckb \
+ && mkdir -p /var/lib/ckb
+
+WORKDIR /var/lib/ckb
+
+COPY --from=ckb-docker-builder \
+     /usr/lib/aarch64-linux-gnu/libssl.so.* \
+     /usr/lib/aarch64-linux-gnu/libcrypto.so.* \
+     /usr/lib/aarch64-linux-gnu/
+COPY --from=ckb-docker-builder /ckb/target/prod/ckb /ckb/docker/docker-entrypoint.sh /bin/
+RUN chown -R ckb:ckb /var/lib/ckb \
+ && chmod 755 /var/lib/ckb
+
+USER ckb
+ENV CKB_CHAIN=mainnet
+
+EXPOSE 8114 8115
+VOLUME ["/var/lib/ckb"]
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4206
For MacOS, if users follow the [guide](https://docs.nervos.org/docs/basics/guides/run-ckb-with-docker/) to run `ckb`, there will be an error:

```console
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Illegal instruction
```
This PR add arm arch docker image for ckb.

Problem Summary:

### What is changed and how it works?

Pair PR: https://github.com/nervosnetwork/ckb-docker-builder/pull/18

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

