### PR TITLE
Fix concurrency issue for RBF 

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -476,6 +476,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RbfContainInvalidCells),
         Box::new(RbfRejectReplaceProposed),
         Box::new(RbfReplaceProposedSuccess),
+        Box::new(RbfConcurrency),
         Box::new(CompactBlockEmpty),
         Box::new(CompactBlockEmptyParentUnknown),
         Box::new(CompactBlockPrefilled),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -52,6 +52,7 @@ pub struct Node {
     consensus: Consensus,
     p2p_listen: String,
     rpc_client: RpcClient,
+    rpc_listen: String,
 
     node_id: Option<String>,     // initialize when starts node
     guard: Option<ProcessGuard>, // initialize when starts node
@@ -134,8 +135,8 @@ impl Node {
         };
 
         let p2p_listen = app_config.network.listen_addresses[0].to_string();
-        let rpc_address = app_config.rpc.listen_address;
-        let rpc_client = RpcClient::new(&format!("http://{rpc_address}/"));
+        let rpc_listen = format!("http://{}/", app_config.rpc.listen_address);
+        let rpc_client = RpcClient::new(&rpc_listen);
         let consensus = {
             // Ensure the data path is available because chain_spec.build_consensus() needs to access the
             // system-cell data.
@@ -154,6 +155,7 @@ impl Node {
             consensus,
             p2p_listen,
             rpc_client,
+            rpc_listen,
             node_id: None,
             guard: None,
         }
@@ -182,6 +184,10 @@ impl Node {
 
     pub fn p2p_listen(&self) -> String {
         self.p2p_listen.clone()
+    }
+
+    pub fn rpc_listen(&self) -> String {
+        self.rpc_listen.clone()
     }
 
     pub fn p2p_address(&self) -> String {

--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -306,7 +306,8 @@ impl RpcClient {
     }
 }
 
-jsonrpc!(pub struct Inner {
+jsonrpc!(
+    pub struct Inner {
     pub fn get_block(&self, _hash: H256) -> Option<BlockView>;
     pub fn get_fork_block(&self, _hash: H256) -> Option<BlockView>;
     pub fn get_block_by_number(&self, _number: BlockNumber) -> Option<BlockView>;

--- a/tx-pool/src/chunk_process.rs
+++ b/tx-pool/src/chunk_process.rs
@@ -218,8 +218,7 @@ impl ChunkProcess {
         let tx_hash = tx.hash();
 
         let (ret, snapshot) = self.service.pre_check(&tx).await;
-        let (tip_hash, rtx, status, fee, tx_size, conflicts) =
-            try_or_return_with_snapshot!(ret, snapshot);
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
 
         let cached = self.service.fetch_tx_verify_cache(&tx_hash).await;
 
@@ -244,10 +243,8 @@ impl ChunkProcess {
                     let completed = try_or_return_with_snapshot!(ret, snapshot);
 
                     let entry = TxEntry::new(rtx, completed.cycles, fee, tx_size);
-                    let (ret, submit_snapshot) = self
-                        .service
-                        .submit_entry(tip_hash, entry, status, conflicts)
-                        .await;
+                    let (ret, submit_snapshot) =
+                        self.service.submit_entry(tip_hash, entry, status).await;
                     try_or_return_with_snapshot!(ret, submit_snapshot);
                     self.service
                         .after_process(tx, remote, &submit_snapshot, &Ok(completed))
@@ -325,10 +322,7 @@ impl ChunkProcess {
         }
 
         let entry = TxEntry::new(rtx, completed.cycles, fee, tx_size);
-        let (ret, submit_snapshot) = self
-            .service
-            .submit_entry(tip_hash, entry, status, conflicts)
-            .await;
+        let (ret, submit_snapshot) = self.service.submit_entry(tip_hash, entry, status).await;
         try_or_return_with_snapshot!(ret, snapshot);
 
         self.service.notify_block_assembler(status).await;

--- a/tx-pool/src/component/edges.rs
+++ b/tx-pool/src/component/edges.rs
@@ -1,3 +1,4 @@
+use ckb_logger::error;
 use ckb_types::packed::{Byte32, OutPoint, ProposalShortId};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
@@ -28,9 +29,11 @@ impl Edges {
     }
 
     pub(crate) fn insert_input(&mut self, out_point: OutPoint, txid: ProposalShortId) {
-        let res = self.inputs.insert(out_point, txid);
         // inputs is occupied means double speanding happened here
-        assert!(res.is_none());
+        if self.inputs.contains_key(&out_point) {
+            error!("double spending happened {:?} {:?}", out_point, txid);
+        }
+        self.inputs.insert(out_point, txid);
     }
 
     pub(crate) fn remove_input(&mut self, out_point: &OutPoint) -> Option<ProposalShortId> {

--- a/tx-pool/src/component/edges.rs
+++ b/tx-pool/src/component/edges.rs
@@ -28,7 +28,9 @@ impl Edges {
     }
 
     pub(crate) fn insert_input(&mut self, out_point: OutPoint, txid: ProposalShortId) {
-        self.inputs.insert(out_point, txid);
+        let res = self.inputs.insert(out_point, txid);
+        // inputs is occupied means double speanding happened here
+        assert!(res.is_none());
     }
 
     pub(crate) fn remove_input(&mut self, out_point: &OutPoint) -> Option<ProposalShortId> {

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -189,8 +189,8 @@ impl PoolMap {
         }
         trace!("pool_map.add_{:?} {}", status, entry.transaction().hash());
         self.check_and_record_ancestors(&mut entry)?;
+        self.record_entry_edges(&entry)?;
         self.insert_entry(&entry, status);
-        self.record_entry_edges(&entry);
         self.record_entry_descendants(&entry);
         self.track_entry_statics();
         Ok(true)
@@ -263,10 +263,9 @@ impl PoolMap {
         conflicts
     }
 
-    pub(crate) fn find_conflict_tx(&self, tx_inputs: &[OutPoint]) -> HashSet<ProposalShortId> {
-        tx_inputs
-            .iter()
-            .filter_map(|out_point| self.edges.get_input_ref(out_point).cloned())
+    pub(crate) fn find_conflict_tx(&self, tx: &TransactionView) -> HashSet<ProposalShortId> {
+        tx.input_pts_iter()
+            .filter_map(|out_point| self.edges.get_input_ref(&out_point).cloned())
             .collect()
     }
 
@@ -390,7 +389,7 @@ impl PoolMap {
         }
     }
 
-    fn record_entry_edges(&mut self, entry: &TxEntry) {
+    fn record_entry_edges(&mut self, entry: &TxEntry) -> Result<(), Reject> {
         let tx_short_id: ProposalShortId = entry.proposal_short_id();
         let header_deps = entry.transaction().header_deps();
         let related_dep_out_points: Vec<_> = entry.related_dep_out_points().cloned().collect();
@@ -399,7 +398,7 @@ impl PoolMap {
         // if input reference a in-pool output, connect it
         // otherwise, record input for conflict check
         for i in inputs {
-            self.edges.insert_input(i.to_owned(), tx_short_id.clone());
+            self.edges.insert_input(i.to_owned(), tx_short_id.clone())?;
         }
 
         // record dep-txid
@@ -412,6 +411,7 @@ impl PoolMap {
                 .header_deps
                 .insert(tx_short_id, header_deps.into_iter().collect());
         }
+        Ok(())
     }
 
     fn record_entry_descendants(&mut self, entry: &TxEntry) {

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -263,9 +263,10 @@ impl PoolMap {
         conflicts
     }
 
-    pub(crate) fn find_conflict_tx(&self, tx: &TransactionView) -> HashSet<ProposalShortId> {
-        tx.input_pts_iter()
-            .filter_map(|out_point| self.edges.get_input_ref(&out_point).cloned())
+    pub(crate) fn find_conflict_tx(&self, tx_inputs: &[OutPoint]) -> HashSet<ProposalShortId> {
+        tx_inputs
+            .iter()
+            .filter_map(|out_point| self.edges.get_input_ref(out_point).cloned())
             .collect()
     }
 

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -524,6 +524,11 @@ impl TxPool {
         (entries, size, cycles)
     }
 
+    pub(crate) fn find_conflict_tx(&self, txv: &TransactionView) -> HashSet<ProposalShortId> {
+        let tx_inputs: Vec<OutPoint> = txv.input_pts_iter().collect();
+        self.pool_map.find_conflict_tx(&tx_inputs)
+    }
+
     pub(crate) fn check_rbf(
         &self,
         snapshot: &Snapshot,

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -102,11 +102,19 @@ impl TxPoolService {
         pre_resolve_tip: Byte32,
         entry: TxEntry,
         mut status: TxStatus,
-        conflicts: HashSet<ProposalShortId>,
     ) -> (Result<(), Reject>, Arc<Snapshot>) {
         let (ret, snapshot) = self
             .with_tx_pool_write_lock(move |tx_pool, snapshot| {
+                // the invoking of check_rbf in pre_check only holds read lock
+                // so here we double confirm RBF rules before insert entry
+                let mut conflicts = HashSet::new();
+                if tx_pool.enable_rbf() {
+                    conflicts =
+                        tx_pool.check_rbf(&snapshot, entry.transaction(), entry.fee, entry.size)?;
+                }
+
                 // if snapshot changed by context switch we need redo time_relative verify
+                // if snapshot changed by context switch
                 let tip_hash = snapshot.tip_hash();
                 if pre_resolve_tip != tip_hash {
                     debug!(
@@ -231,21 +239,21 @@ impl TxPoolService {
                 match res {
                     Ok((rtx, status)) => {
                         let fee = check_tx_fee(tx_pool, &snapshot, &rtx, tx_size)?;
-                        Ok((tip_hash, rtx, status, fee, tx_size, HashSet::new()))
+                        Ok((tip_hash, rtx, status, fee, tx_size))
                     }
                     Err(err) => {
                         if tx_pool.enable_rbf()
                             && matches!(err, Reject::Resolve(OutPointError::Dead(_)))
                         {
                             // Try RBF check
-                            let conflicts = tx_pool.pool_map.find_conflict_tx(tx);
+                            let (rtx, status) = resolve_tx(tx_pool, &snapshot, tx.clone(), true)?;
+                            let fee = check_tx_fee(tx_pool, &snapshot, &rtx, tx_size)?;
+                            let conflicts =
+                                tx_pool.check_rbf(&snapshot, &rtx.transaction, fee, tx_size)?;
                             if conflicts.is_empty() {
                                 return Err(err);
                             }
-                            let (rtx, status) = resolve_tx(tx_pool, &snapshot, tx.clone(), true)?;
-                            let fee = check_tx_fee(tx_pool, &snapshot, &rtx, tx_size)?;
-                            tx_pool.check_rbf(&snapshot, &rtx, &conflicts, fee, tx_size)?;
-                            Ok((tip_hash, rtx, status, fee, tx_size, conflicts))
+                            Ok((tip_hash, rtx, status, fee, tx_size))
                         } else {
                             Err(err)
                         }
@@ -624,8 +632,7 @@ impl TxPoolService {
         let tx_hash = tx.hash();
 
         let (ret, snapshot) = self.pre_check(&tx).await;
-        let (tip_hash, rtx, status, fee, tx_size, conflicts) =
-            try_or_return_with_snapshot!(ret, snapshot);
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
 
         if self.is_in_delay_window(&snapshot) {
             let mut delay = self.delay.write().await;
@@ -718,7 +725,7 @@ impl TxPoolService {
 
         let entry = TxEntry::new(rtx, completed.cycles, fee, tx_size);
 
-        let (ret, submit_snapshot) = self.submit_entry(tip_hash, entry, status, conflicts).await;
+        let (ret, submit_snapshot) = self.submit_entry(tip_hash, entry, status).await;
         try_or_return_with_snapshot!(ret, submit_snapshot);
 
         self.notify_block_assembler(status).await;
@@ -763,8 +770,7 @@ impl TxPoolService {
 
         let (ret, snapshot) = self.pre_check(&tx).await;
 
-        let (tip_hash, rtx, status, fee, tx_size, conflicts) =
-            try_or_return_with_snapshot!(ret, snapshot);
+        let (tip_hash, rtx, status, fee, tx_size) = try_or_return_with_snapshot!(ret, snapshot);
 
         if self.is_in_delay_window(&snapshot) {
             let mut delay = self.delay.write().await;
@@ -800,7 +806,7 @@ impl TxPoolService {
 
         let entry = TxEntry::new(rtx, verified.cycles, fee, tx_size);
 
-        let (ret, submit_snapshot) = self.submit_entry(tip_hash, entry, status, conflicts).await;
+        let (ret, submit_snapshot) = self.submit_entry(tip_hash, entry, status).await;
         try_or_return_with_snapshot!(ret, submit_snapshot);
 
         self.notify_block_assembler(status).await;
@@ -1044,9 +1050,6 @@ type PreCheckedTx = (
     TxStatus,                 // status
     Capacity,                 // tx fee
     usize,                    // tx size
-    // the conflicted txs, used for latter `check_rbf`
-    // the root txs for removing from `tx-pool` when RBF is checked
-    HashSet<ProposalShortId>,
 );
 
 type ResolveResult = Result<(Arc<ResolvedTransaction>, TxStatus), Reject>;

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -108,7 +108,7 @@ impl TxPoolService {
                 // here we double confirm RBF rules before insert entry
                 // check_rbf must be invoked in `write` lock to avoid concurrent issues.
                 let conflicts = if tx_pool.enable_rbf() {
-                    tx_pool.check_rbf(&snapshot, entry.transaction(), entry.fee, entry.size)?
+                    tx_pool.check_rbf(&snapshot, &entry)?
                 } else {
                     HashSet::new()
                 };
@@ -249,7 +249,7 @@ impl TxPoolService {
                             // Try an RBF cheap check, here if the tx is resolved as Dead,
                             // we assume there must be conflicted happened in txpool now,
                             // if there is no conflicted transactions reject it
-                            let conflicts = tx_pool.find_conflict_tx(&rtx.transaction);
+                            let conflicts = tx_pool.pool_map.find_conflict_tx(&rtx.transaction);
                             if conflicts.is_empty() {
                                 error!(
                                     "{} is resolved as Dead, but there is no conflicted tx",


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When multiple conflicted `tx` are added into `txpool` at the same time, because multiple threads may access same old data, `resolve_tx` may not resolve the conflicted tx to `Dead`, then `check_rbf` will be skipped, spec test `RbfConcurrency` is added to reproduce this scenario.


### What is changed and how it works?

In this PR, `check_rbf` is moved to `submit_entry`, which will be guarded with a `write` lock, this change will make sure there is no double-spending tx in `Pending`, and with an extra benefit that only `tx` passed `verify_rtx` may invoke `check_rbf`.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

