### PR TITLE
Remove `assume_valid_target`'s `Mutex` wrapper to improve `ckb-sync`'s performance 

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -117,7 +117,6 @@ impl BlockFetchCMD {
                 let number = best_known.number();
                 let assume_valid_target: Byte32 = state
                     .assume_valid_target()
-                    .as_ref()
                     .map(Pack::pack)
                     .expect("assume valid target must exist");
 
@@ -167,7 +166,7 @@ impl BlockFetchCMD {
 
         let assume_valid_target_find = |flag: &mut CanStart| {
             let mut assume_valid_target = state.assume_valid_target();
-            if let Some(ref target) = *assume_valid_target {
+            if let Some(target) = assume_valid_target {
                 match state.header_map().get(&target.pack()) {
                     Some(header) => {
                         *flag = CanStart::Ready;

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1463,9 +1463,10 @@ impl SyncShared {
     ) -> Result<bool, CKBError> {
         let ret = {
             let mut assume_valid_target = self.state.assume_valid_target();
-            if let Some(ref target) = *assume_valid_target {
+            if let Some(target) = assume_valid_target {
                 // if the target has been reached, delete it
-                let switch = if target == &Unpack::<H256>::unpack(&core::BlockView::hash(&block)) {
+                let block_hash: H256 = Unpack::<H256>::unpack(&core::BlockView::hash(&block));
+                let switch = if target.eq(&block_hash) {
                     assume_valid_target.take();
                     Switch::NONE
                 } else {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1695,7 +1695,7 @@ pub struct SyncState {
 
     /* cached for sending bulk */
     tx_relay_receiver: Receiver<TxVerificationResult>,
-    assume_valid_target: Mutex<Option<H256>>,
+    assume_valid_target: Option<H256>,
     min_chain_work: U256,
 }
 

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1700,8 +1700,8 @@ pub struct SyncState {
 }
 
 impl SyncState {
-    pub fn assume_valid_target(&self) -> MutexGuard<Option<H256>> {
-        self.assume_valid_target.lock()
+    pub fn assume_valid_target(&self) -> Option<&H256> {
+        self.assume_valid_target.as_ref()
     }
 
     pub fn min_chain_work(&self) -> &U256 {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1335,7 +1335,7 @@ impl SyncShared {
             inflight_blocks: RwLock::new(InflightBlocks::default()),
             pending_get_headers: RwLock::new(LruCache::new(GET_HEADERS_CACHE_SIZE)),
             tx_relay_receiver,
-            assume_valid_target: Mutex::new(sync_config.assume_valid_target),
+            assume_valid_target: sync_config.assume_valid_target,
             min_chain_work: sync_config.min_chain_work,
         };
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

I have discovered that there is no need to use the `Mutex` to protect `SyncState::assume_valid_target`. Therefore, this pull request changes its type from `Mutex<Option<H256>>` to `Option<H256>`.


What's Changed:

### Related changes

- change `SyncState::assume_valid_target`'s type from `Mutex<Option<H256>>` to `Option<H256>`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

