### PR TITLE
fix: resolve empty filter related message bug

### DIFF
--- a/sync/src/filter/get_block_filter_check_points_process.rs
+++ b/sync/src/filter/get_block_filter_check_points_process.rs
@@ -34,11 +34,11 @@ impl<'a> GetBlockFilterCheckPointsProcess<'a> {
     pub fn execute(self) -> Status {
         let active_chain = self.filter.shared.active_chain();
         let start_number: BlockNumber = self.message.to_entity().start_number().unpack();
-        let tip_number: BlockNumber = active_chain.tip_number();
+        let latest: BlockNumber = active_chain.get_latest_built_filter_block_number();
 
         let mut block_filter_hashes = Vec::new();
 
-        if tip_number >= start_number {
+        if latest >= start_number {
             for block_number in (start_number..start_number + BATCH_SIZE * CHECK_POINT_INTERVAL)
                 .step_by(CHECK_POINT_INTERVAL as usize)
             {
@@ -59,9 +59,9 @@ impl<'a> GetBlockFilterCheckPointsProcess<'a> {
             let message = packed::BlockFilterMessage::new_builder()
                 .set(content)
                 .build();
-            attempt!(send_message_to(self.nc.as_ref(), self.peer, &message));
+            attempt!(send_message_to(self.nc.as_ref(), self.peer, &message))
+        } else {
+            Status::ignored()
         }
-
-        Status::ok()
     }
 }

--- a/sync/src/filter/get_block_filter_hashes_process.rs
+++ b/sync/src/filter/get_block_filter_hashes_process.rs
@@ -32,11 +32,11 @@ impl<'a> GetBlockFilterHashesProcess<'a> {
     pub fn execute(self) -> Status {
         let active_chain = self.filter.shared.active_chain();
         let start_number: BlockNumber = self.message.to_entity().start_number().unpack();
-        let tip_number: BlockNumber = active_chain.tip_number();
+        let latest: BlockNumber = active_chain.get_latest_built_filter_block_number();
 
         let mut block_filter_hashes = Vec::new();
 
-        if tip_number >= start_number {
+        if latest >= start_number {
             let parent_block_filter_hash = if start_number > 0 {
                 match active_chain
                     .get_block_hash(start_number - 1)

--- a/sync/src/filter/get_block_filters_process.rs
+++ b/sync/src/filter/get_block_filters_process.rs
@@ -33,8 +33,9 @@ impl<'a> GetBlockFiltersProcess<'a> {
     pub fn execute(self) -> Status {
         let active_chain = self.filter.shared.active_chain();
         let start_number: BlockNumber = self.message.to_entity().start_number().unpack();
-        let tip_number: BlockNumber = active_chain.tip_number();
-        if tip_number >= start_number {
+        let latest: BlockNumber = active_chain.get_latest_built_filter_block_number();
+
+        if latest >= start_number {
             let mut block_hashes = Vec::new();
             let mut filters = Vec::new();
             for block_number in start_number..start_number + BATCH_SIZE {
@@ -58,9 +59,9 @@ impl<'a> GetBlockFiltersProcess<'a> {
             let message = packed::BlockFilterMessage::new_builder()
                 .set(content)
                 .build();
-            attempt!(send_message_to(self.nc.as_ref(), self.peer, &message));
+            attempt!(send_message_to(self.nc.as_ref(), self.peer, &message))
+        } else {
+            Status::ignored()
         }
-
-        Status::ok()
     }
 }

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -2085,6 +2085,13 @@ impl ActiveChain {
         self.store().get_block_filter_hash(hash)
     }
 
+    pub fn get_latest_built_filter_block_number(&self) -> BlockNumber {
+        self.snapshot
+            .get_latest_built_filter_data_block_hash()
+            .and_then(|hash| self.snapshot.get_block_number(&hash))
+            .unwrap_or_default()
+    }
+
     pub fn shared(&self) -> &SyncShared {
         &self.shared
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

ckb full node may generate an empty filter related message and send it to light client since the filter data are built asynchronously, this may cause the light client to ban the ckb node.

### What is changed and how it works?

change to use `latest_built_filter_block_number` to replace the tip number when building filter message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

