### PR TITLE
Fix `PoolRpc::send_transaction` param `outputs_validator` default value should be `passthrough`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4399,7 +4399,7 @@ Please note that `send_transaction` is an asynchronous process. The return of `s
 
 *   `transaction` - The transaction.
 
-*   `outputs_validator` - Validates the transaction outputs before entering the tx-pool. (**Optional**, default is “well_known_scripts_only”).
+*   `outputs_validator` - Validates the transaction outputs before entering the tx-pool. (**Optional**, default is “passthrough”).
 
 ###### Errors
 

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -27,7 +27,7 @@ pub trait PoolRpc {
     /// ## Params
     ///
     /// * `transaction` - The transaction.
-    /// * `outputs_validator` - Validates the transaction outputs before entering the tx-pool. (**Optional**, default is "well_known_scripts_only").
+    /// * `outputs_validator` - Validates the transaction outputs before entering the tx-pool. (**Optional**, default is "passthrough").
     ///
     /// ## Errors
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

### Related changes

- Fix send_transaction's doc

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

