### PR TITLE
Change `score_sortkey`'s type from `String` to `struct AncestorsScoreSortKey`

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -105,6 +105,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `AlertId`](#type-alertid)
     * [Type `AlertMessage`](#type-alertmessage)
     * [Type `AlertPriority`](#type-alertpriority)
+    * [Type `AncestorsScoreSortKey`](#type-ancestorsscoresortkey)
     * [Type `BannedAddr`](#type-bannedaddr)
     * [Type `Block`](#type-block)
     * [Type `BlockEconomicState`](#type-blockeconomicstate)
@@ -4701,7 +4702,12 @@ Response
        "pending_count": "0x1",
        "proposed_count": "0x0",
        "rank_in_pending": "0x1",
-       "score_sortkey": "fee: 0x16923F7DCF, ancestors_fee: 0x16923F7DCF, weight: 0x112, ancestors_weight: 0x112",
+       "score_sortkey": {
+           "ancestors_fee": "0x16923f7dcf",
+           "ancestors_weight": "0x112",
+           "fee": "0x16923f7dcf",
+           "weight": "0x112"
+       },
        "timestamp": "0x18aa1baa54c"
    },
    "id": 42
@@ -5249,6 +5255,23 @@ An alert sent by RPC `send_alert`.
 Alerts are sorted by priority. Greater integers mean higher priorities.
 
 This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32).
+
+### Type `AncestorsScoreSortKey`
+
+A struct as a sorted key for tx-pool
+
+#### Fields
+
+`AncestorsScoreSortKey` is a JSON object with the following fields.
+
+*   `fee`: [`Uint64`](#type-uint64) - Fee
+
+*   `weight`: [`Uint64`](#type-uint64) - Weight
+
+*   `ancestors_fee`: [`Uint64`](#type-uint64) - Ancestors fee
+
+*   `ancestors_weight`: [`Uint64`](#type-uint64) - Ancestors weight
+
 
 ### Type `BannedAddr`
 
@@ -6565,7 +6588,7 @@ A Tx details info in tx-pool.
 
 *   `ancestors_count`: [`Uint64`](#type-uint64) - The ancestors count of tx
 
-*   `score_sortkey`: `string` - The score key details, useful to debug
+*   `score_sortkey`: [`AncestorsScoreSortKey`](#type-ancestorsscoresortkey) - The score key details, useful to debug
 
 
 ### Type `ProposalShortId`

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -289,7 +289,12 @@ pub trait PoolRpc {
     ///        "pending_count": "0x1",
     ///        "proposed_count": "0x0",
     ///        "rank_in_pending": "0x1",
-    ///        "score_sortkey": "fee: 0x16923F7DCF, ancestors_fee: 0x16923F7DCF, weight: 0x112, ancestors_weight: 0x112",
+    ///        "score_sortkey": {
+    ///            "ancestors_fee": "0x16923f7dcf",
+    ///            "ancestors_weight": "0x112",
+    ///            "fee": "0x16923f7dcf",
+    ///            "weight": "0x112"
+    ///        },
     ///        "timestamp": "0x18aa1baa54c"
     ///    },
     ///    "id": 42

--- a/tx-pool/src/component/sort_key.rs
+++ b/tx-pool/src/component/sort_key.rs
@@ -49,13 +49,13 @@ impl Ord for AncestorsScoreSortKey {
     }
 }
 
-impl Into<CoreAncestorsScoreSortKey> for AncestorsScoreSortKey {
-    fn into(self) -> CoreAncestorsScoreSortKey {
+impl From<AncestorsScoreSortKey> for CoreAncestorsScoreSortKey {
+    fn from(val: AncestorsScoreSortKey) -> Self {
         CoreAncestorsScoreSortKey {
-            fee: self.fee,
-            weight: self.weight,
-            ancestors_fee: self.ancestors_fee,
-            ancestors_weight: self.ancestors_weight,
+            fee: val.fee,
+            weight: val.weight,
+            ancestors_fee: val.ancestors_fee,
+            ancestors_weight: val.ancestors_weight,
         }
     }
 }

--- a/tx-pool/src/component/sort_key.rs
+++ b/tx-pool/src/component/sort_key.rs
@@ -1,4 +1,6 @@
-use ckb_types::core::{Capacity, FeeRate};
+use ckb_types::core::{
+    tx_pool::AncestorsScoreSortKey as CoreAncestorsScoreSortKey, Capacity, FeeRate,
+};
 use std::cmp::Ordering;
 
 /// A struct to use as a sorted key
@@ -43,6 +45,17 @@ impl Ord for AncestorsScoreSortKey {
             self.ancestors_weight.cmp(&other.ancestors_weight)
         } else {
             self_weight.cmp(&other_weight)
+        }
+    }
+}
+
+impl Into<CoreAncestorsScoreSortKey> for AncestorsScoreSortKey {
+    fn into(self) -> CoreAncestorsScoreSortKey {
+        CoreAncestorsScoreSortKey {
+            fee: self.fee,
+            weight: self.weight,
+            ancestors_fee: self.ancestors_fee,
+            ancestors_weight: self.ancestors_weight,
         }
     }
 }

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -652,7 +652,7 @@ impl TxPool {
                 proposed_count: ids.proposed.len(),
                 descendants_count: self.pool_map.calc_descendants(id).len(),
                 ancestors_count: self.pool_map.calc_ancestors(id).len(),
-                score_sortkey: entry.inner.as_score_key().to_string(),
+                score_sortkey: entry.inner.as_score_key().into(),
             };
             Some(res)
         } else {

--- a/util/jsonrpc-types/src/lib.rs
+++ b/util/jsonrpc-types/src/lib.rs
@@ -44,8 +44,8 @@ pub use self::net::{
     RemoteNodeProtocol, SyncState,
 };
 pub use self::pool::{
-    OutputsValidator, PoolTransactionEntry, PoolTransactionReject, PoolTxDetailInfo, RawTxPool,
-    TxPoolEntries, TxPoolEntry, TxPoolIds, TxPoolInfo,
+    AncestorsScoreSortKey, OutputsValidator, PoolTransactionEntry, PoolTransactionReject,
+    PoolTxDetailInfo, RawTxPool, TxPoolEntries, TxPoolEntry, TxPoolIds, TxPoolInfo,
 };
 pub use self::proposal_short_id::ProposalShortId;
 pub use self::subscription::Topic;

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -218,9 +218,13 @@ pub enum RawTxPool {
 /// A struct as a sorted key for tx-pool
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct AncestorsScoreSortKey {
+    /// Fee
     pub fee: Uint64,
+    /// Weight
     pub weight: Uint64,
+    /// Ancestors fee
     pub ancestors_fee: Uint64,
+    /// Ancestors weight
     pub ancestors_weight: Uint64,
 }
 

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -8,7 +8,6 @@ use ckb_types::prelude::Unpack;
 use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Ancestors;
 
 /// Transaction pool information.
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -1,13 +1,14 @@
 use crate::{BlockNumber, Capacity, Cycle, Timestamp, TransactionView, Uint64};
 use ckb_types::core::service::PoolTransactionEntry as CorePoolTransactionEntry;
 use ckb_types::core::tx_pool::{
-    PoolTxDetailInfo as CorePoolTxDetailInfo, Reject, TxEntryInfo, TxPoolEntryInfo,
-    TxPoolIds as CoreTxPoolIds, TxPoolInfo as CoreTxPoolInfo,
+    AncestorsScoreSortKey as CoreAncestorsScoreSortKey, PoolTxDetailInfo as CorePoolTxDetailInfo,
+    Reject, TxEntryInfo, TxPoolEntryInfo, TxPoolIds as CoreTxPoolIds, TxPoolInfo as CoreTxPoolInfo,
 };
 use ckb_types::prelude::Unpack;
 use ckb_types::H256;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::Ancestors;
 
 /// Transaction pool information.
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
@@ -215,6 +216,26 @@ pub enum RawTxPool {
     Verbose(TxPoolEntries),
 }
 
+/// A struct as a sorted key for tx-pool
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct AncestorsScoreSortKey {
+    pub fee: Uint64,
+    pub weight: Uint64,
+    pub ancestors_fee: Uint64,
+    pub ancestors_weight: Uint64,
+}
+
+impl From<CoreAncestorsScoreSortKey> for AncestorsScoreSortKey {
+    fn from(value: CoreAncestorsScoreSortKey) -> Self {
+        Self {
+            fee: value.fee.into(),
+            weight: value.weight.into(),
+            ancestors_fee: value.ancestors_fee.into(),
+            ancestors_weight: value.ancestors_weight.into(),
+        }
+    }
+}
+
 /// A Tx details info in tx-pool.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct PoolTxDetailInfo {
@@ -233,7 +254,7 @@ pub struct PoolTxDetailInfo {
     /// The ancestors count of tx
     pub ancestors_count: Uint64,
     /// The score key details, useful to debug
-    pub score_sortkey: String,
+    pub score_sortkey: AncestorsScoreSortKey,
 }
 
 impl From<CorePoolTxDetailInfo> for PoolTxDetailInfo {
@@ -246,7 +267,7 @@ impl From<CorePoolTxDetailInfo> for PoolTxDetailInfo {
             proposed_count: (info.proposed_count as u64).into(),
             descendants_count: (info.descendants_count as u64).into(),
             ancestors_count: (info.ancestors_count as u64).into(),
-            score_sortkey: info.score_sortkey,
+            score_sortkey: info.score_sortkey.into(),
         }
     }
 }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -345,6 +345,15 @@ pub struct TxPoolInfo {
     pub max_tx_pool_size: u64,
 }
 
+/// A struct as a sorted key in tx-pool
+#[derive(Eq, PartialEq, Clone, Debug, Default)]
+pub struct AncestorsScoreSortKey {
+    pub fee: Capacity,
+    pub weight: u64,
+    pub ancestors_fee: Capacity,
+    pub ancestors_weight: u64,
+}
+
 /// A Tx details info in tx-pool.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct PoolTxDetailInfo {
@@ -363,7 +372,7 @@ pub struct PoolTxDetailInfo {
     /// The ancestors count of tx
     pub ancestors_count: usize,
     /// The score key details, useful to debug
-    pub score_sortkey: String,
+    pub score_sortkey: AncestorsScoreSortKey,
 }
 
 impl PoolTxDetailInfo {

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -348,9 +348,13 @@ pub struct TxPoolInfo {
 /// A struct as a sorted key in tx-pool
 #[derive(Eq, PartialEq, Clone, Debug, Default)]
 pub struct AncestorsScoreSortKey {
+    /// fee
     pub fee: Capacity,
+    /// weight
     pub weight: u64,
+    /// ancestors_fee
     pub ancestors_fee: Capacity,
+    /// ancestors_weight
     pub ancestors_weight: u64,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR updated the type of `struct PoolTxDetailInfo::score_sortkey` from `String` to `struct AncestorsScoreSortKey`. This change makes it easier to parse and work with.

What's Changed:

### Related changes

- Change `score_sortkey`'s type from `String` to `struct AncestorsScoreSortKey`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

