### PR TITLE
chore: Move  txpool statistics from callbacks to PoolMap

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -555,9 +555,13 @@ fn test_package_multi_best_scores() {
         TxEntry::dummy_resolve(tx2_3.clone(), 0, Capacity::shannons(150), 100),
         TxEntry::dummy_resolve(tx2_4.clone(), 0, Capacity::shannons(150), 100),
         TxEntry::dummy_resolve(tx3_1.clone(), 0, Capacity::shannons(1000), 1000),
-        TxEntry::dummy_resolve(tx4_1.clone(), 0, Capacity::shannons(300), 250),
+        TxEntry::dummy_resolve(tx4_1.clone(), 100, Capacity::shannons(300), 250),
     ];
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
+
+    let tx_pool_info = tx_pool.get_tx_pool_info().unwrap();
+    assert_eq!(tx_pool_info.total_tx_size, 2400);
+    assert_eq!(tx_pool_info.total_tx_cycles, 100);
 
     // 250 size best scored txs
     let txs = tx_pool.package_txs(Some(250)).unwrap();

--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -381,10 +381,7 @@ fn register_tx_pool_callback(tx_pool_builder: &mut TxPoolServiceBuilder, notify:
         fee: entry.fee,
         timestamp: entry.timestamp,
     };
-    tx_pool_builder.register_pending(Box::new(move |tx_pool: &mut TxPool, entry: &TxEntry| {
-        // update statics
-        tx_pool.update_statics_for_add_tx(entry.size, entry.cycles);
-
+    tx_pool_builder.register_pending(Box::new(move |_tx_pool: &mut TxPool, entry: &TxEntry| {
         // notify
         let notify_tx_entry = create_notify_entry(entry);
         notify_pending.notify_new_transaction(notify_tx_entry);
@@ -392,28 +389,16 @@ fn register_tx_pool_callback(tx_pool_builder: &mut TxPoolServiceBuilder, notify:
 
     let notify_proposed = notify.clone();
     tx_pool_builder.register_proposed(Box::new(
-        move |tx_pool: &mut TxPool, entry: &TxEntry, new: bool| {
-            // update statics
-            if new {
-                tx_pool.update_statics_for_add_tx(entry.size, entry.cycles);
-            }
-
+        move |_tx_pool: &mut TxPool, entry: &TxEntry, _new: bool| {
             // notify
             let notify_tx_entry = create_notify_entry(entry);
             notify_proposed.notify_proposed_transaction(notify_tx_entry);
         },
     ));
 
-    tx_pool_builder.register_committed(Box::new(move |tx_pool: &mut TxPool, entry: &TxEntry| {
-        tx_pool.update_statics_for_remove_tx(entry.size, entry.cycles);
-    }));
-
     let notify_reject = notify;
     tx_pool_builder.register_reject(Box::new(
         move |tx_pool: &mut TxPool, entry: &TxEntry, reject: Reject| {
-            // update statics
-            tx_pool.update_statics_for_remove_tx(entry.size, entry.cycles);
-
             let tx_hash = entry.transaction().hash();
             // record recent reject
             if matches!(reject, Reject::Resolve(..) | Reject::RBFRejected(..)) {

--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -381,20 +381,18 @@ fn register_tx_pool_callback(tx_pool_builder: &mut TxPoolServiceBuilder, notify:
         fee: entry.fee,
         timestamp: entry.timestamp,
     };
-    tx_pool_builder.register_pending(Box::new(move |_tx_pool: &mut TxPool, entry: &TxEntry| {
+    tx_pool_builder.register_pending(Box::new(move |entry: &TxEntry| {
         // notify
         let notify_tx_entry = create_notify_entry(entry);
         notify_pending.notify_new_transaction(notify_tx_entry);
     }));
 
     let notify_proposed = notify.clone();
-    tx_pool_builder.register_proposed(Box::new(
-        move |_tx_pool: &mut TxPool, entry: &TxEntry, _new: bool| {
-            // notify
-            let notify_tx_entry = create_notify_entry(entry);
-            notify_proposed.notify_proposed_transaction(notify_tx_entry);
-        },
-    ));
+    tx_pool_builder.register_proposed(Box::new(move |entry: &TxEntry| {
+        // notify
+        let notify_tx_entry = create_notify_entry(entry);
+        notify_proposed.notify_proposed_transaction(notify_tx_entry);
+    }));
 
     let notify_reject = notify;
     tx_pool_builder.register_reject(Box::new(

--- a/tx-pool/src/callback.rs
+++ b/tx-pool/src/callback.rs
@@ -13,7 +13,6 @@ pub type RejectCallback = Box<dyn Fn(&mut TxPool, &TxEntry, Reject) + Sync + Sen
 pub struct Callbacks {
     pub(crate) pending: Option<Callback>,
     pub(crate) proposed: Option<ProposedCallback>,
-    pub(crate) committed: Option<Callback>,
     pub(crate) reject: Option<RejectCallback>,
 }
 
@@ -29,7 +28,6 @@ impl Callbacks {
         Callbacks {
             pending: None,
             proposed: None,
-            committed: None,
             reject: None,
         }
     }
@@ -42,11 +40,6 @@ impl Callbacks {
     /// Register a new proposed callback
     pub fn register_proposed(&mut self, callback: ProposedCallback) {
         self.proposed = Some(callback);
-    }
-
-    /// Register a new committed callback
-    pub fn register_committed(&mut self, callback: Callback) {
-        self.committed = Some(callback);
     }
 
     /// Register a new abandon callback
@@ -65,13 +58,6 @@ impl Callbacks {
     pub fn call_proposed(&self, tx_pool: &mut TxPool, entry: &TxEntry, new: bool) {
         if let Some(call) = &self.proposed {
             call(tx_pool, entry, new)
-        }
-    }
-
-    /// Call on after proposed
-    pub fn call_committed(&self, tx_pool: &mut TxPool, entry: &TxEntry) {
-        if let Some(call) = &self.committed {
-            call(tx_pool, entry)
         }
     }
 

--- a/tx-pool/src/callback.rs
+++ b/tx-pool/src/callback.rs
@@ -3,15 +3,15 @@ use crate::error::Reject;
 use crate::pool::TxPool;
 
 /// Callback boxed fn pointer wrapper
-pub type Callback = Box<dyn Fn(&mut TxPool, &TxEntry) + Sync + Send>;
+pub type PendingCallback = Box<dyn Fn(&TxEntry) + Sync + Send>;
 /// Proposed Callback boxed fn pointer wrapper
-pub type ProposedCallback = Box<dyn Fn(&mut TxPool, &TxEntry, bool) + Sync + Send>;
+pub type ProposedCallback = Box<dyn Fn(&TxEntry) + Sync + Send>;
 /// Reject Callback boxed fn pointer wrapper
 pub type RejectCallback = Box<dyn Fn(&mut TxPool, &TxEntry, Reject) + Sync + Send>;
 
 /// Struct hold callbacks
 pub struct Callbacks {
-    pub(crate) pending: Option<Callback>,
+    pub(crate) pending: Option<PendingCallback>,
     pub(crate) proposed: Option<ProposedCallback>,
     pub(crate) reject: Option<RejectCallback>,
 }
@@ -33,7 +33,7 @@ impl Callbacks {
     }
 
     /// Register a new pending callback
-    pub fn register_pending(&mut self, callback: Callback) {
+    pub fn register_pending(&mut self, callback: PendingCallback) {
         self.pending = Some(callback);
     }
 
@@ -48,16 +48,16 @@ impl Callbacks {
     }
 
     /// Call on after pending
-    pub fn call_pending(&self, tx_pool: &mut TxPool, entry: &TxEntry) {
+    pub fn call_pending(&self, entry: &TxEntry) {
         if let Some(call) = &self.pending {
-            call(tx_pool, entry)
+            call(entry)
         }
     }
 
     /// Call on after proposed
-    pub fn call_proposed(&self, tx_pool: &mut TxPool, entry: &TxEntry, new: bool) {
+    pub fn call_proposed(&self, entry: &TxEntry) {
         if let Some(call) = &self.proposed {
-            call(tx_pool, entry, new)
+            call(entry)
         }
     }
 

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -7,8 +7,9 @@ use crate::component::links::{Relation, TxLinksMap};
 use crate::component::sort_key::{AncestorsScoreSortKey, EvictKey};
 use crate::error::Reject;
 use crate::TxEntry;
-use ckb_logger::{debug, trace};
+use ckb_logger::{debug, error, trace};
 use ckb_types::core::error::OutPointError;
+use ckb_types::core::Cycle;
 use ckb_types::packed::OutPoint;
 use ckb_types::prelude::*;
 use ckb_types::{
@@ -66,6 +67,10 @@ pub struct PoolMap {
     /// All the parent/children relationships
     pub(crate) links: TxLinksMap,
     pub(crate) max_ancestors_count: usize,
+    // sum of all tx_pool tx's virtual sizes.
+    pub(crate) total_tx_size: usize,
+    // sum of all tx_pool tx's cycles.
+    pub(crate) total_tx_cycles: Cycle,
 }
 
 impl PoolMap {
@@ -75,6 +80,8 @@ impl PoolMap {
             edges: Edges::default(),
             links: TxLinksMap::new(),
             max_ancestors_count,
+            total_tx_size: 0,
+            total_tx_cycles: 0,
         }
     }
 
@@ -217,6 +224,7 @@ impl PoolMap {
             self.update_descendants_index_key(&entry.inner, EntryOp::Remove);
             self.remove_entry_edges(&entry.inner);
             self.remove_entry_links(id);
+            self.update_statics_for_remove_tx(entry.inner.size, entry.inner.cycles);
             entry.inner
         })
     }
@@ -332,6 +340,8 @@ impl PoolMap {
         self.entries = MultiIndexPoolEntryMap::default();
         self.edges.clear();
         self.links.clear();
+        self.total_tx_size = 0;
+        self.total_tx_cycles = 0;
     }
 
     pub(crate) fn score_sorted_iter_by(
@@ -521,6 +531,7 @@ impl PoolMap {
             inner: entry.clone(),
             evict_key,
         });
+        self.update_statics_for_add_tx(entry.size, entry.cycles);
     }
 
     fn track_entry_statics(&self) {
@@ -538,5 +549,32 @@ impl PoolMap {
                 .proposed
                 .set(self.proposed_size() as i64);
         }
+    }
+
+    /// Update size and cycles statics for add tx
+    fn update_statics_for_add_tx(&mut self, tx_size: usize, cycles: Cycle) {
+        self.total_tx_size += tx_size;
+        self.total_tx_cycles += cycles;
+    }
+
+    /// Update size and cycles statics for remove tx
+    /// cycles overflow is possible, currently obtaining cycles is not accurate
+    pub fn update_statics_for_remove_tx(&mut self, tx_size: usize, cycles: Cycle) {
+        let total_tx_size = self.total_tx_size.checked_sub(tx_size).unwrap_or_else(|| {
+            error!(
+                "total_tx_size {} overflown by sub {}",
+                self.total_tx_size, tx_size
+            );
+            0
+        });
+        let total_tx_cycles = self.total_tx_cycles.checked_sub(cycles).unwrap_or_else(|| {
+            error!(
+                "total_tx_cycles {} overflown by sub {}",
+                self.total_tx_cycles, cycles
+            );
+            0
+        });
+        self.total_tx_size = total_tx_size;
+        self.total_tx_cycles = total_tx_cycles;
     }
 }

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -552,8 +552,22 @@ impl PoolMap {
 
     /// Update size and cycles statistics for add tx
     fn update_stat_for_add_tx(&mut self, tx_size: usize, cycles: Cycle) {
-        self.total_tx_size += tx_size;
-        self.total_tx_cycles += cycles;
+        let total_tx_size = self.total_tx_size.checked_add(tx_size).unwrap_or_else(|| {
+            error!(
+                "total_tx_size {} overflown by add {}",
+                self.total_tx_size, tx_size
+            );
+            self.total_tx_size
+        });
+        let total_tx_cycles = self.total_tx_cycles.checked_add(cycles).unwrap_or_else(|| {
+            error!(
+                "total_tx_cycles {} overflown by add {}",
+                self.total_tx_cycles, cycles
+            );
+            self.total_tx_cycles
+        });
+        self.total_tx_size = total_tx_size;
+        self.total_tx_cycles = total_tx_cycles;
     }
 
     /// Update size and cycles statistics for remove tx

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -196,9 +196,8 @@ impl TxPool {
 
     fn remove_committed_tx(&mut self, tx: &TransactionView, callbacks: &Callbacks) {
         let short_id = tx.proposal_short_id();
-        if let Some(entry) = self.pool_map.remove_entry(&short_id) {
+        if let Some(_entry) = self.pool_map.remove_entry(&short_id) {
             debug!("remove_committed_tx for {}", tx.hash());
-            callbacks.call_committed(self, &entry)
         }
         {
             let conflicts = self.pool_map.resolve_conflict(tx);

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -410,7 +410,7 @@ impl TxPool {
 
     pub(crate) fn drain_all_transactions(&mut self) -> Vec<TransactionView> {
         let mut txs = CommitTxsScanner::new(&self.pool_map)
-            .txs_to_commit(self.pool_map.total_tx_size, self.pool_map.total_tx_cycles)
+            .txs_to_commit(usize::MAX, Cycle::MAX)
             .0
             .into_iter()
             .map(|tx_entry| tx_entry.into_transaction())

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -200,8 +200,7 @@ impl TxPool {
             debug!("remove_committed_tx for {}", tx.hash());
         }
         {
-            let conflicts = self.pool_map.resolve_conflict(tx);
-            for (entry, reject) in conflicts {
+            for (entry, reject) in self.pool_map.resolve_conflict(tx) {
                 debug!(
                     "removed {} for commited: {}",
                     entry.transaction().hash(),

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -289,7 +289,7 @@ impl TxPool {
 
     pub(crate) fn remove_tx(&mut self, id: &ProposalShortId) -> bool {
         let entries = self.pool_map.remove_entry_and_descendants(id);
-        return !entries.is_empty();
+        !entries.is_empty()
     }
 
     pub(crate) fn check_rtx_from_pool(&self, rtx: &ResolvedTransaction) -> Result<(), Reject> {

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -1102,19 +1102,19 @@ fn _submit_entry(
         TxStatus::Fresh => {
             if tx_pool.add_pending(entry.clone())? {
                 debug!("submit_entry pending {}", tx_hash);
-                callbacks.call_pending(tx_pool, &entry);
+                callbacks.call_pending(&entry);
             }
         }
         TxStatus::Gap => {
             if tx_pool.add_gap(entry.clone())? {
                 debug!("submit_entry gap {}", tx_hash);
-                callbacks.call_pending(tx_pool, &entry);
+                callbacks.call_pending(&entry);
             }
         }
         TxStatus::Proposed => {
             if tx_pool.add_proposed(entry.clone())? {
                 debug!("submit_entry proposed {}", tx_hash);
-                callbacks.call_proposed(tx_pool, &entry, true);
+                callbacks.call_proposed(&entry);
             }
         }
     }
@@ -1174,7 +1174,7 @@ fn _update_tx_pool_for_reorg(
                 );
                 callbacks.call_reject(tx_pool, &entry, e);
             } else {
-                callbacks.call_proposed(tx_pool, &entry, false)
+                callbacks.call_proposed(&entry)
             }
         }
 

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -909,6 +909,7 @@ async fn process(mut service: TxPoolService, message: Message) {
             let max_block_cycles = service.consensus.max_block_cycles();
             let max_block_bytes = service.consensus.max_block_bytes();
             let tx_pool = service.tx_pool.read().await;
+            eprintln!("tx_pool total_size: {}", tx_pool.pool_map.total_tx_size);
             let (txs, _size, _cycles) = tx_pool.package_txs(
                 max_block_cycles,
                 bytes_limit.unwrap_or(max_block_bytes) as usize,
@@ -932,8 +933,8 @@ impl TxPoolService {
             pending_size: tx_pool.pool_map.pending_size(),
             proposed_size: tx_pool.pool_map.proposed_size(),
             orphan_size: orphan.len(),
-            total_tx_size: tx_pool.total_tx_size,
-            total_tx_cycles: tx_pool.total_tx_cycles,
+            total_tx_size: tx_pool.pool_map.total_tx_size,
+            total_tx_cycles: tx_pool.pool_map.total_tx_cycles,
             min_fee_rate: self.tx_pool_config.min_fee_rate,
             min_rbf_rate: self.tx_pool_config.min_rbf_rate,
             last_txs_updated_at: tx_pool.pool_map.get_max_update_time(),

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -451,11 +451,6 @@ impl TxPoolServiceBuilder {
         self.callbacks.register_proposed(callback);
     }
 
-    /// Register new committed callback
-    pub fn register_committed(&mut self, callback: Callback) {
-        self.callbacks.register_committed(callback);
-    }
-
     /// Register new abandon callback
     pub fn register_reject(&mut self, callback: RejectCallback) {
         self.callbacks.register_reject(callback);

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -1,7 +1,7 @@
 //! Tx-pool background service
 
 use crate::block_assembler::{self, BlockAssembler};
-use crate::callback::{Callback, Callbacks, ProposedCallback, RejectCallback};
+use crate::callback::{Callbacks, PendingCallback, ProposedCallback, RejectCallback};
 use crate::chunk_process::ChunkCommand;
 use crate::component::pool_map::{PoolEntry, Status};
 use crate::component::{chunk::ChunkQueue, orphan::OrphanPool};
@@ -437,7 +437,7 @@ impl TxPoolServiceBuilder {
     }
 
     /// Register new pending callback
-    pub fn register_pending(&mut self, callback: Callback) {
+    pub fn register_pending(&mut self, callback: PendingCallback) {
         self.callbacks.register_pending(callback);
     }
 
@@ -904,7 +904,6 @@ async fn process(mut service: TxPoolService, message: Message) {
             let max_block_cycles = service.consensus.max_block_cycles();
             let max_block_bytes = service.consensus.max_block_bytes();
             let tx_pool = service.tx_pool.read().await;
-            eprintln!("tx_pool total_size: {}", tx_pool.pool_map.total_tx_size);
             let (txs, _size, _cycles) = tx_pool.package_txs(
                 max_block_cycles,
                 bytes_limit.unwrap_or(max_block_bytes) as usize,


### PR DESCRIPTION


### What problem does this PR solve?

Problem Summary:

The `total_tx_size` and `total_tx_cycle` are zero when we use `plug_entry` to add entries into `tx_pool`, which caused some confusing when debugging.

Updating statics was implemented in callbacks because we had 3 separate queue in `txpool`, now we have refactor it to the only one `PoolMap`, it's better and cleaner to move this part to `PoolMap`.



### What is changed and how it works?

What's Changed:

Cleanup `callbacks` to move `txpool` statics part to `PoolMap`.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

