### PR TITLE
Ensure that `block_assembler`'s `Snapshot.tip_number` reaches  `shared.snapshot().tip_number` before `tx_pool.plug_entry`

### DIFF
--- a/chain/src/tests/block_assembler.rs
+++ b/chain/src/tests/block_assembler.rs
@@ -557,6 +557,19 @@ fn test_package_multi_best_scores() {
         TxEntry::dummy_resolve(tx3_1.clone(), 0, Capacity::shannons(1000), 1000),
         TxEntry::dummy_resolve(tx4_1.clone(), 0, Capacity::shannons(300), 250),
     ];
+
+    let shared_tip_number = shared.snapshot().tip_number().into();
+    while {
+        let template_tip_number = tx_pool
+            .get_block_template(None, None, None)
+            .expect("must fetch block template result")
+            .expect("must have block template")
+            .number;
+        template_tip_number <= shared_tip_number
+    } {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
     tx_pool.plug_entry(entries, PlugTarget::Proposed).unwrap();
 
     // 250 size best scored txs


### PR DESCRIPTION
`shared.Snapshot.tip_number` before `tx_pool.plug_entry`

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This PR want to fix https://github.com/nervosnetwork/ckb/issues/4252

Issue Number: close #4252 <!-- REMOVE this line if no issue to close -->

Problem Summary:

In the `fn test_package_multi_best_scores` function, we generate three blocks in quick succession. This could potentially lead to the `snapshot.tip_number` of the `block_assembler` lagging behind `shared.snapshot.tip_number`.

Consequently, in the `BlockAssembler::calc_dao` function, the following scenario may occur:
The `snapshot.tip_number` is 3, but `calc_dao` is processing a transaction that is packed in block 4. As a result, the transactions in block 4 fail to be resolved.

So, I want to make sure the block_assembler's snapshot.tip_number is larger than shared.snapshot.tip_number before `tx_pool.plug_entry`.


### What is changed and how it works?

What's Changed:

### Related changes

- Wait `block_assembler`'s snapshot.tip_number reach over `shared.snapshot().tip_number()` before executing `tx_pool.plug_entry`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None
### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

