### PR TITLE
Init a temp `DATA_DIR` for `bench-test`

### DIFF
--- a/benches/benches/benchmarks/resolve.rs
+++ b/benches/benches/benchmarks/resolve.rs
@@ -5,6 +5,7 @@ use ckb_chain_spec::{ChainSpec, IssuedCell};
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_resource::Resource;
 use ckb_shared::{Shared, SharedBuilder, Snapshot};
+use ckb_types::global::DATA_DIR;
 use ckb_types::{
     bytes::Bytes,
     core::{
@@ -122,6 +123,11 @@ pub fn gen_txs_from_genesis(block: &BlockView) -> Vec<TransactionView> {
 
 fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolve");
+
+    let tmp_dir = tempfile::tempdir().expect("create tmp_dir failed");
+    DATA_DIR
+        .set(tmp_dir.path().join("data"))
+        .expect("DATA_DIR set only once");
 
     group.bench_with_input(BenchmarkId::new("resolve", SIZE), &SIZE, |b, txs_size| {
         b.iter_batched(


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4274


Problem Summary:

### What is changed and how it works?

This PR want to set `DATA_DIR` as a temporary dir for `make bench-test`.
What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

