### PR TITLE
[RPC CHANGE] : Add `block_number` to `TxStatus` for `get_transaction` RPC

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -889,6 +889,7 @@ Response
     "min_replace_fee": "0x16923f7f6a",
     "tx_status": {
       "block_hash": null,
+      "block_number": null,
       "status": "pending",
       "reason": null
     }
@@ -909,6 +910,7 @@ The response looks like below when `verbosity` is 0.
     "cycles": "0x219",
     "tx_status": {
       "block_hash": null,
+      "block_number": null,
       "status": "pending",
       "reason": null
     }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -7210,6 +7210,8 @@ Transaction status and the block hash if it is committed.
 
 *   `status`: [`Status`](#type-status) - The transaction status, allowed values: “pending”, “proposed” “committed” “unknown” and “rejected”.
 
+*   `block_number`: [`BlockNumber`](#type-blocknumber) `|` `null` - The block number of the block which has committed this transaction in the canonical chain.
+
 *   `block_hash`: [`H256`](#type-h256) `|` `null` - The block hash of the block which has committed this transaction in the canonical chain.
 
 *   `reason`: `string` `|` `null` - The reason why the transaction is rejected

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -2138,6 +2138,7 @@ impl ChainRpcImpl {
             };
             return Ok(TransactionWithStatus::with_committed(
                 None,
+                tx_info.block_number,
                 tx_info.block_hash.unpack(),
                 cycles,
                 None,
@@ -2185,6 +2186,7 @@ impl ChainRpcImpl {
 
             return Ok(TransactionWithStatus::with_committed(
                 Some(tx),
+                tx_info.block_number,
                 tx_info.block_hash.unpack(),
                 cycles,
                 None,

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -623,6 +623,7 @@ pub trait ChainRpc {
     ///     "min_replace_fee": "0x16923f7f6a",
     ///     "tx_status": {
     ///       "block_hash": null,
+    ///       "block_number": null,
     ///       "status": "pending",
     ///       "reason": null
     ///     }
@@ -642,6 +643,7 @@ pub trait ChainRpc {
     ///     "cycles": "0x219",
     ///     "tx_status": {
     ///       "block_hash": null,
+    ///       "block_number": null,
     ///       "status": "pending",
     ///       "reason": null
     ///     }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -601,7 +601,7 @@ impl From<tx_pool::TxStatus> for TxStatus {
         match tx_pool_status {
             tx_pool::TxStatus::Pending => TxStatus::pending(),
             tx_pool::TxStatus::Proposed => TxStatus::proposed(),
-            tx_pool::TxStatus::Committed(hash) => TxStatus::committed(hash),
+            tx_pool::TxStatus::Committed(number, hash) => TxStatus::committed(number.into(), hash),
             tx_pool::TxStatus::Rejected(reason) => TxStatus::rejected(reason),
             tx_pool::TxStatus::Unknown => TxStatus::unknown(),
         }
@@ -613,6 +613,7 @@ impl TxStatus {
     pub fn pending() -> Self {
         Self {
             status: Status::Pending,
+            block_number: None,
             block_hash: None,
             reason: None,
         }
@@ -622,6 +623,7 @@ impl TxStatus {
     pub fn proposed() -> Self {
         Self {
             status: Status::Proposed,
+            block_number: None,
             block_hash: None,
             reason: None,
         }
@@ -632,9 +634,10 @@ impl TxStatus {
     /// ## Params
     ///
     /// * `hash` - the block hash in which the transaction is committed.
-    pub fn committed(hash: H256) -> Self {
+    pub fn committed(number: BlockNumber, hash: H256) -> Self {
         Self {
             status: Status::Committed,
+            block_number: Some(number),
             block_hash: Some(hash),
             reason: None,
         }
@@ -648,6 +651,7 @@ impl TxStatus {
     pub fn rejected(reason: String) -> Self {
         Self {
             status: Status::Rejected,
+            block_number: None,
             block_hash: None,
             reason: Some(reason),
         }
@@ -657,6 +661,7 @@ impl TxStatus {
     pub fn unknown() -> Self {
         Self {
             status: Status::Unknown,
+            block_number: None,
             block_hash: None,
             reason: None,
         }

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -588,6 +588,8 @@ pub enum Status {
 pub struct TxStatus {
     /// The transaction status, allowed values: "pending", "proposed" "committed" "unknown" and "rejected".
     pub status: Status,
+    /// The block number of the block which has committed this transaction in the canonical chain.
+    pub block_number: Option<BlockNumber>,
     /// The block hash of the block which has committed this transaction in the canonical chain.
     pub block_hash: Option<H256>,
     /// The reason why the transaction is rejected

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -113,7 +113,7 @@ pub enum TxStatus {
     /// Status "proposed". The transaction is in the pool and has been proposed.
     Proposed,
     /// Status "committed". The transaction has been committed to the canonical chain.
-    Committed(H256),
+    Committed(BlockNumber, H256),
     /// Status "unknown". The node has not seen the transaction,
     /// or it should be rejected but was cleared due to storage limitations.
     Unknown,
@@ -203,12 +203,13 @@ impl TransactionWithStatus {
     /// Build with committed status
     pub fn with_committed(
         tx: Option<core::TransactionView>,
+        number: BlockNumber,
         hash: H256,
         cycles: Option<core::Cycle>,
         fee: Option<Capacity>,
     ) -> Self {
         Self {
-            tx_status: TxStatus::Committed(hash),
+            tx_status: TxStatus::Committed(number, hash),
             transaction: tx,
             cycles,
             fee,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

### Related changes

- Add `block_number` to `TxStatus` for `get_transaction` RPC.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

