### PR TITLE
fix(indexer): The end in `script_len_range` parameter of `IndexerSearchKeyFilter` is not inclusive

### DIFF
--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -368,7 +368,7 @@ impl IndexerHandle {
                     match filter_script_type {
                         IndexerScriptType::Lock => {
                             let script_len = extract_raw_data(&output.lock()).len();
-                            if script_len < r0 || script_len > r1 {
+                            if script_len < r0 || script_len >= r1 {
                                 return None;
                             }
                         }
@@ -378,7 +378,7 @@ impl IndexerHandle {
                                 .to_opt()
                                 .map(|script| extract_raw_data(&script).len())
                                 .unwrap_or_default();
-                            if script_len < r0 || script_len > r1 {
+                            if script_len < r0 || script_len >= r1 {
                                 return None;
                             }
                         }


### PR DESCRIPTION
### What problem does this PR solve?

Fix the issue：the end in `script_len_range` parameter of `IndexerSearchKeyFilter` is not inclusive.

```
 *   script_len_range: [u64; 2], filter cells by script len range, [inclusive, exclusive]
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

