### PR TITLE
chore: ix windows ci error failed for daemon option

### DIFF
--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -57,6 +57,7 @@ pub struct RunArgs {
     /// Whether start indexer, default false
     pub indexer: bool,
     /// Whether start in daemon mode
+    #[cfg(not(target_os = "windows"))]
     pub daemon: bool,
 }
 

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -98,6 +98,7 @@ impl Setup {
             overwrite_chain_spec: matches.get_flag(cli::ARG_OVERWRITE_CHAIN_SPEC),
             chain_spec_hash,
             indexer: matches.get_flag(cli::ARG_INDEXER),
+            #[cfg(not(target_os = "windows"))]
             daemon: matches.get_flag(cli::ARG_DAEMON),
         })
     }


### PR DESCRIPTION
### What problem does this PR solve?

The CI is failing because of an cfg error in #4237 , we may need to investigate why CI failure may still get the PR was merged successfully.

https://github.com/nervosnetwork/ckb/actions/runs/7354769222/job/20022410084

Problem Summary:

### What is changed and how it works?

Windows don't have daemon option.

What's Changed:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

