### PR TITLE
fix: fix peer store random fetch

### DIFF
--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -57,7 +57,7 @@ impl AddrManager {
             let addr_info: AddrInfo = self.id_to_info[&self.random_ids[i]].to_owned();
             if let Some(socket_addr) = multiaddr_to_socketaddr(&addr_info.addr) {
                 let ip = socket_addr.ip();
-                let is_unique_ip = duplicate_ips.insert(ip);
+                let is_unique_ip = !duplicate_ips.contains(&ip);
                 // A trick to make our tests work
                 // TODO remove this after fix the network tests.
                 let is_test_ip = ip.is_unspecified() || ip.is_loopback();
@@ -65,6 +65,7 @@ impl AddrManager {
                     && addr_info.is_connectable(now_ms)
                     && filter(&addr_info)
                 {
+                    duplicate_ips.insert(ip);
                     addr_infos.push(addr_info);
                 }
                 if addr_infos.len() == count {

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -185,19 +185,15 @@ impl PeerStore {
     /// Return valid addrs that success connected, used for discovery.
     pub fn fetch_random_addrs(&mut self, count: usize, required_flags: Flags) -> Vec<AddrInfo> {
         // Get info:
-        // 1. Already connected or Connected within 7 days
+        // 1. Connected within 7 days
 
         let now_ms = ckb_systemtime::unix_time_as_millis();
         let addr_expired_ms = now_ms.saturating_sub(ADDR_TIMEOUT_MS);
-        let peers = &self.connected_peers;
         // get success connected addrs.
         self.addr_manager
             .fetch_random(count, |peer_addr: &AddrInfo| {
                 required_flags_filter(required_flags, Flags::from_bits_truncate(peer_addr.flags))
-                    && (extract_peer_id(&peer_addr.addr)
-                        .map(|peer_id| peers.contains_key(&peer_id))
-                        .unwrap_or_default()
-                        || peer_addr.connected(|t| t > addr_expired_ms))
+                    && peer_addr.connected(|t| t > addr_expired_ms)
             })
     }
 

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -16,7 +16,7 @@ use p2p::{
 use rand::seq::SliceRandom;
 
 pub use self::{
-    addr::{AddrKnown, AddressManager, MisbehaveResult, Misbehavior},
+    addr::{AddressManager, MisbehaveResult, Misbehavior},
     protocol::{DiscoveryMessage, Node, Nodes},
     state::SessionState,
 };

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -479,11 +479,14 @@ fn test_discovery_behavior() {
 
     wait_connect_state(&node2, 2);
 
-    wait_discovery(&node3, |num| num >= 2);
+    wait_discovery(&node3, |num| num >= 3);
 
+    // use node1 instead of node3 because ANNOUNCE_INTERVAL is 24 hour
+    // node2 can't announce node1 address to node3 within 24 hours
+    // but the reverse can
     let addrs = {
-        let listen_addr = &node3.listen_addr;
-        let mut locked = node3.network_state.peer_store.lock();
+        let listen_addr = &node1.listen_addr;
+        let mut locked = node1.network_state.peer_store.lock();
 
         locked
             .fetch_addrs_to_feeler(6)
@@ -508,7 +511,7 @@ fn test_discovery_behavior() {
     };
 
     for addr in addrs {
-        node3.dial_addr(
+        node1.dial_addr(
             addr,
             TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
         );

--- a/util/dao/utils/src/lib.rs
+++ b/util/dao/utils/src/lib.rs
@@ -122,12 +122,13 @@ pub fn pack_dao_data(ar: u64, c: Capacity, s: Capacity, u: Capacity) -> Byte32 {
     Byte32::from_slice(&buf).expect("impossible: fail to read array")
 }
 
+#[cfg(test)]
 mod tests {
     pub use super::{extract_dao_data, pack_dao_data};
     pub use ckb_types::core::Capacity;
+    pub use ckb_types::h256;
     pub use ckb_types::packed::Byte32;
     pub use ckb_types::prelude::Pack;
-    pub use ckb_types::{h256, H256};
 
     #[test]
     #[allow(clippy::unreadable_literal)]


### PR DESCRIPTION
### What problem does this PR solve?

Fix bug：
1. The propagation address obtained by discovery from the peer store should be one that has been connected locally within seven days, and the check of the address that keeps the connection should not be skipped.
2. To determine if the IP is duplicated, we need to confirm that the address has been selected.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

