### PR TITLE
chore: supplements `ckb-gen-types` with two type conversions that used to exist in `ckb-standalone-types`

### DIFF
--- a/util/gen-types/src/conversion/blockchain/mod.rs
+++ b/util/gen-types/src/conversion/blockchain/mod.rs
@@ -9,12 +9,30 @@ impl Pack<packed::Byte32> for [u8; 32] {
     }
 }
 
+impl<'r> Unpack<[u8; 32]> for packed::Byte32Reader<'r> {
+    fn unpack(&self) -> [u8; 32] {
+        let mut b = [0u8; 32];
+        b.copy_from_slice(self.raw_data());
+        b
+    }
+}
+impl_conversion_for_entity_unpack!([u8; 32], Byte32);
+
 impl Pack<packed::ProposalShortId> for [u8; 10] {
     fn pack(&self) -> packed::ProposalShortId {
         packed::ProposalShortId::from_slice(&self[..])
             .expect("impossible: fail to pack to ProposalShortId")
     }
 }
+
+impl<'r> Unpack<[u8; 10]> for packed::ProposalShortIdReader<'r> {
+    fn unpack(&self) -> [u8; 10] {
+        let mut b = [0u8; 10];
+        b.copy_from_slice(self.raw_data());
+        b
+    }
+}
+impl_conversion_for_entity_unpack!([u8; 10], ProposalShortId);
 
 impl Pack<packed::Bytes> for Bytes {
     fn pack(&self) -> packed::Bytes {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: 

`ckb-gen-types` complements the two type conversions that used to exist in `ckb-standalone-types`. 

User feedback from:
https://github.com/nervosnetwork/ckb-std/pull/71#issuecomment-1875026833

### What is changed and how it works?

What's Changed:

```
impl<'r> Unpack<[u8; 32]> for Byte32;
impl<'r> Unpack<[u8; 10]> for ProposalShortId;
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

