### PR TITLE
Fix the regex expression for ckb's version test

### DIFF
--- a/util/app-config/src/tests/cli.bats
+++ b/util/app-config/src/tests/cli.bats
@@ -31,14 +31,14 @@ _full_help() {
 function short_version { #@test
   run _short
   assert_success
-  assert_output --regexp "^ckb [0-9.]+[-]?[a-z0-9]*$"
+  assert_output --regexp "^ckb [0-9.]+[-[a-z0-9]*]?$"
 }
 
 #@test "ckb --version" {
 function long_version { #@test
   run _long
   assert_success
-  assert_output --regexp "^ckb [0-9.]+-.*\([0-9a-z-]+ [0-9]{4}-[0-9]{2}-[0-9]{2}\)$"
+  assert_output --regexp "^ckb [0-9.]+[-[a-z0-9]*]? \([0-9a-z-]+ [0-9]{4}-[0-9]{2}-[0-9]{2}\)$"
 }
 
 function help { #@test


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

What's Changed:


- Fix the regex expression to match ckb version string like `ckb 0.113.0 (82871a3 2024-01-09)` or `ckb 0.113.0-rc3 (3287c63 2024-01-02)`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

