### PR TITLE
Remove `ActiveChain`'s `state: SyncState` field, reuse `ActiveChain#shared#state` instead

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1355,7 +1355,6 @@ impl SyncShared {
         ActiveChain {
             shared: self.clone(),
             snapshot: Arc::clone(&self.shared.snapshot()),
-            state: Arc::clone(&self.state),
         }
     }
 
@@ -2048,7 +2047,6 @@ impl SyncState {
 pub struct ActiveChain {
     shared: SyncShared,
     snapshot: Arc<Snapshot>,
-    state: Arc<SyncState>,
 }
 
 #[doc(hidden)]

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -2300,6 +2300,7 @@ impl ActiveChain {
         block_number_and_hash: BlockNumberAndHash,
     ) {
         if let Some(last_time) = self
+            .shared()
             .state
             .pending_get_headers
             .write()
@@ -2318,7 +2319,8 @@ impl ActiveChain {
                 );
             }
         }
-        self.state
+        self.shared()
+            .state()
             .pending_get_headers
             .write()
             .put((peer, block_number_and_hash.hash()), Instant::now());
@@ -2338,10 +2340,10 @@ impl ActiveChain {
     }
 
     pub fn get_block_status(&self, block_hash: &Byte32) -> BlockStatus {
-        match self.state.block_status_map.get(block_hash) {
+        match self.shared().state().block_status_map.get(block_hash) {
             Some(status_ref) => *status_ref.value(),
             None => {
-                if self.state.header_map.contains_key(block_hash) {
+                if self.shared().state().header_map.contains_key(block_hash) {
                     BlockStatus::HEADER_VALID
                 } else {
                     let verified = self


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
`ActiveChain#shared#state` and `ActiveChain#state` are duplicated. Should reuse `ActiveChain#shared#state` only.

### Related changes

- Remove `ActiveChain`'s `state` field

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

