### PR TITLE
Fix RPC cors issue of preflight request

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,7 +45,7 @@ async-trait = "0.1"
 axum = "0.6.20"
 tokio-util = { version = "0.7.3", features = ["codec"] }
 futures-util = { version = "0.3.21" }
-tower-http = { version = "0.3.5", features = ["timeout"] }
+tower-http = { version = "0.3.5", features = ["timeout", "cors"] }
 async-stream = "0.3.3"
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.114.0-pre" }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -85,10 +85,9 @@ impl RpcServer {
         enable_websocket: bool,
     ) -> Result<SocketAddr, AnyError> {
         let stream_config = StreamServerConfig::default()
+            .with_keep_alive(true)
             .with_channel_size(4)
             .with_pipeline_size(4);
-
-        let cors = CorsLayer::permissive();
 
         // HTTP and WS server.
         let method_router =
@@ -97,7 +96,7 @@ impl RpcServer {
             .route("/", method_router.clone())
             .route("/*path", method_router)
             .layer(Extension(Arc::clone(rpc)))
-            .layer(cors)
+            .layer(CorsLayer::permissive())
             .layer(TimeoutLayer::new(Duration::from_secs(30)));
 
         if enable_websocket {


### PR DESCRIPTION

### What problem does this PR solve?

Because `Axum` cors setting, if we send request from browser console, we met this issue:

```console
Access to fetch at 'http://127.0.0.1:8114/' from origin 'null' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

Problem Summary:

### What is changed and how it works?

Add `CorsLayer::permissive()` for a permissive setting for `cors`.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

