### PR TITLE
Fix error message when sent HTTP GET to RPC

### DIFF
--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -103,6 +103,7 @@ impl RpcServer {
         let mut app = Router::new()
             .route("/", method_router.clone())
             .route("/*path", method_router)
+            .route("/ping", get(ping_handler))
             .layer(Extension(Arc::clone(rpc)))
             .layer(CorsLayer::permissive())
             .layer(TimeoutLayer::new(Duration::from_secs(30)))
@@ -187,6 +188,11 @@ impl RpcServer {
         });
         Ok(tcp_address)
     }
+}
+
+/// used for compatible with old health endpoint
+async fn ping_handler() -> impl IntoResponse {
+    "pong"
 }
 
 /// used for compatible with old PRC error responce for GET

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,11 +1,13 @@
 use crate::IoHandler;
-use axum::routing::post;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
 use axum::{Extension, Router};
 use ckb_app_config::RpcConfig;
 use ckb_async_runtime::Handle;
 use ckb_error::AnyError;
 use ckb_logger::info;
 
+use axum::http::StatusCode;
 use ckb_stop_handler::{new_tokio_exit_rx, CancellationToken};
 use futures_util::{SinkExt, TryStreamExt};
 use jsonrpc_core::MetaIoHandler;
@@ -90,14 +92,21 @@ impl RpcServer {
             .with_pipeline_size(4);
 
         // HTTP and WS server.
-        let method_router =
-            post(handle_jsonrpc::<Option<Session>>).get(handle_jsonrpc_ws::<Option<Session>>);
+        let post_router = post(handle_jsonrpc::<Option<Session>>);
+        let get_router = if enable_websocket {
+            get(handle_jsonrpc_ws::<Option<Session>>)
+        } else {
+            get(get_error_handler)
+        };
+        let method_router = post_router.merge(get_router);
+
         let mut app = Router::new()
             .route("/", method_router.clone())
             .route("/*path", method_router)
             .layer(Extension(Arc::clone(rpc)))
             .layer(CorsLayer::permissive())
-            .layer(TimeoutLayer::new(Duration::from_secs(30)));
+            .layer(TimeoutLayer::new(Duration::from_secs(30)))
+            .layer(Extension(stream_config.clone()));
 
         if enable_websocket {
             let ws_config: StreamServerConfig =
@@ -178,4 +187,12 @@ impl RpcServer {
         });
         Ok(tcp_address)
     }
+}
+
+/// used for compatible with old PRC error responce for GET
+async fn get_error_handler() -> impl IntoResponse {
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        "Used HTTP Method is not allowed. POST or OPTIONS is required",
+    )
 }


### PR DESCRIPTION
### What problem does this PR solve?

After RPC framework changed, if we sent an GET request to RPC endpoint, the error message has changed to:

```console
Missing request extension: Extension of type `jsonrpc_utils::stream::StreamServerConfig` was not found. Perhaps you forgot to add it? See `axum::Extension`.%
```

Let's keep the same message with the old version.

Issue Number: close #4309

Problem Summary:

### What is changed and how it works?

Add a special handler for RPC endpoint, distinguished from the Websockets configuration.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

