### PR TITLE
docs: remove an outdated wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Nervos CKB is released under the terms of the MIT license. See [COPYING](COPYING
 - Testnet Pudge: Use the [latest release](https://github.com/nervosnetwork/ckb/releases/latest) and run `ckb init --chain testnet` to initialize the node.
     - Pudge is active since the epoch 3113.
 
-See more networks to join in the [wiki](https://github.com/nervosnetwork/ckb/wiki/Chains).
-
 
 ## Mining
 


### PR DESCRIPTION
### Reason

1. https://github.com/nervosnetwork/ckb/wiki/Chains said `The wiki is deprecated by docs site.`

2. `wiki/Chains` is still using old network names: Lina and Aggron.

## Related discussion
- https://github.com/sporeprotocol/spore-sdk/pull/79#discussion_r1462934127

