### PR TITLE
Enable the `openssl-vendored` feature for the `tentacle` package to allow CKB to statically link with OpenSSL.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -61,7 +61,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include $BUILDER_IMAGE make ${{ matrix.build_target }}
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -94,24 +94,6 @@ jobs:
       run: rustup target add aarch64-unknown-linux-gnu
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-    - name: Install OpenSSL
-      run: |
-        mkdir target && cd target
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-
-        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
-        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
-        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-
-        tar -xzf openssl-3.1.3.tar.gz
-        cd openssl-3.1.3
-        CC=aarch64-linux-gnu-gcc ./Configure --prefix=$(pwd)/openssl-3.1.3/build linux-aarch64 no-shared
-        CC=aarch64-linux-gnu-gcc make -j $(nproc)
-        CC=aarch64-linux-gnu-gcc make -j $(nproc) install_sw
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -122,10 +104,6 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
 
-        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
-        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
-        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib64
-        export OPENSSL_STATIC=1
         PKG_CONFIG_ALLOW_CROSS=1 CC=gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CKB_BUILD_TARGET="--target=aarch64-unknown-linux-gnu" make prod_portable
 
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
@@ -168,7 +146,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb -v $(pwd):/ckb -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include $BUILDER_IMAGE make ${{ matrix.build_target }}
+        docker run --rm -i -w /ckb -v $(pwd):/ckb -e $BUILDER_IMAGE make ${{ matrix.build_target }}
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/prod/ckb
@@ -204,24 +182,6 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
-    - name: Install Dependencies
-      run: |
-        mkdir target && cd target
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-
-        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
-        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
-        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-
-        tar -xzf openssl-3.1.3.tar.gz
-        cd openssl-3.1.3
-        ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
-        make
-        make install_sw
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -229,10 +189,6 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
 
-        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
-        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
-        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
-        export OPENSSL_STATIC=1
         make ${{ matrix.build_target }}
 
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
@@ -282,24 +238,6 @@ jobs:
         if ! [ -f "$HOME/.cargo/bin/rustup" ]; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         fi
-
-        mkdir target && cd target
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.asc
-
-        gpg --keyserver keys.openpgp.org --recv-keys EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5
-        gpg --verify openssl-3.1.3.tar.gz.asc openssl-3.1.3.tar.gz
-
-        curl -LO https://www.openssl.org/source/openssl-3.1.3.tar.gz.sha256
-        echo $(cat openssl-3.1.3.tar.gz.sha256) openssl-3.1.3.tar.gz | sha256sum --check
-
-        tar -xzf openssl-3.1.3.tar.gz
-        cd openssl-3.1.3
-        ./Configure --prefix=$(pwd)/openssl-3.1.3/build no-shared
-        make
-        make install_sw
-
     - name: Build CKB and Package CKB
       env:
         LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -307,10 +245,6 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
 
-        export OPENSSL_DIR=$(pwd)/target/openssl-3.1.3/build
-        export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib
-        export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include
-        export OPENSSL_STATIC=1
         make ${{ matrix.build_target }}
 
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,6 +3319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.1+3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3335,7 @@ checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -36,7 +36,7 @@ ckb-spawn = { path = "../util/spawn", version = "= 0.114.0-pre" }
 socket2 = "0.4"
 bitflags = "1.0"
 
-p2p = { version="0.4.0", package="tentacle", features = ["upnp", "parking_lot"] }
+p2p = { version="0.4.0", package="tentacle", features = ["upnp", "parking_lot", "openssl-vendored"] }
 
 [features]
 with_sentry = ["sentry"]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
The easiest way to make ckb binary statically link SSL is to enable the `openssl-vendored` feature of the `tentacle` package.
Previously, we needed to compile OpenSSL dependencies in `ckb-docker-builder` which was cumbersome. Enabling `openssl-vendored` in CKB's `tentacle` dependency simplifies this. It makes our maintenance much easier.


What's Changed:

- Enable `openssl-vendored` feature for tentacle
- Delete "compile openssl from source code" part for CKB's release script

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- make CKB binary staticlly linked with OpenSSL.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

