### PR TITLE
enlarge DEFAULT_MAX_TX_POOL_SIZE to 500mb for more capacity

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -132,7 +132,7 @@ enable_deprecated_rpc = false # {{
 # }}
 
 [tx_pool]
-max_tx_pool_size = 180_000_000 # 180mb
+max_tx_pool_size = 500_000_000 # 500mb
 min_fee_rate = 1_000 # Here fee_rate are calculated directly using size in units of shannons/KB
 # min_rbf_rate > min_fee_rate means RBF is enabled
 min_rbf_rate = 1_500 # Here fee_rate are calculated directly using size in units of shannons/KB

--- a/test/template/ckb.toml
+++ b/test/template/ckb.toml
@@ -77,7 +77,7 @@ reject_ill_transactions = true
 enable_deprecated_rpc = true
 
 [tx_pool]
-max_tx_pool_size = 180_000_000 # 180mb
+max_tx_pool_size = 500_000_000 # 500mb
 min_fee_rate = 0 # Here fee_rate are calculated directly using size in units of shannons/KB
 min_rbf_rate = 0 # Here rbf_rate are calculated directly using size in units of shannons/KB
 max_tx_verify_cycles = 70_000_000

--- a/util/app-config/src/legacy/tx_pool.rs
+++ b/util/app-config/src/legacy/tx_pool.rs
@@ -15,8 +15,8 @@ const DEFAULT_MAX_TX_VERIFY_CYCLES: Cycle = TWO_IN_TWO_OUT_CYCLES * 20;
 const DEFAULT_MAX_ANCESTORS_COUNT: usize = 125;
 // Default expiration time for pool transactions in hours
 const DEFAULT_EXPIRY_HOURS: u8 = 12;
-// Default max_tx_pool_size 180mb
-const DEFAULT_MAX_TX_POOL_SIZE: usize = 180_000_000;
+// Default max_tx_pool_size 500mb
+const DEFAULT_MAX_TX_POOL_SIZE: usize = 500_000_000;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION

### What problem does this PR solve?

`DEFAULT_MAX_TX_POOL_SIZE` is not enough for new scenarios like mint.


Problem Summary:

### What is changed and how it works?

Enlarge `DEFAULT_MAX_TX_POOL_SIZE` to 500mb

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

