### PR TITLE
chore: delayed 2nd hardfork testnet activation

### DIFF
--- a/util/constant/src/hardfork/testnet.rs
+++ b/util/constant/src/hardfork/testnet.rs
@@ -8,8 +8,4 @@ pub const RFC0028_RFC0032_RFC0033_RFC0034_START_EPOCH: u64 = 3113;
 pub const CKB2021_START_EPOCH: u64 = 0;
 
 /// hardcode ckb2023 epoch
-/// 2024/02/05 7:44 utc
-/// |            hash                                                    |  number   |    timestamp    | epoch |
-/// | 0x4014244087d989355c1d06311f3f73582607d4c991e03296f703f9221f77aabe | 11937425  |  1704944649417  |  9074 |
-/// 1704944649417 + 151 * 4 * 60 * 60 * 1000 = 1707119049417  2024/02/05 7:44 utc
-pub const CKB2023_START_EPOCH: u64 = 9225;
+pub const CKB2023_START_EPOCH: u64 = u64::MAX;


### PR DESCRIPTION


<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This reverts commit f2890dfa7847eca36e11f8dc26e9e2214a4a0777.
 2nd hardfork still needs some tweaking:
* We need to consider whether to keep A extension
* Spawn syscall needs more time to refine its design.


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

