### PR TITLE
Add ckb_block_process_duration in metric for monitoring and testing

### DIFF
--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -59,6 +59,8 @@ pub struct Metrics {
     pub ckb_relay_transaction_short_id_collide: IntCounter,
     /// Histogram for relay compact block verify duration
     pub ckb_relay_cb_verify_duration: Histogram,
+    /// Histogram for block process duration
+    pub ckb_block_process_duration: Histogram,
     /// Counter for relay compact block transaction count
     pub ckb_relay_cb_transaction_count: IntCounter,
     /// Counter for relay compact block reconstruct ok
@@ -95,6 +97,11 @@ static METRICS: once_cell::sync::Lazy<Metrics> = once_cell::sync::Lazy::new(|| M
     ckb_relay_cb_verify_duration: register_histogram!(
         "ckb_relay_cb_verify_duration",
         "The CKB relay compact block verify duration"
+    )
+    .unwrap(),
+    ckb_block_process_duration: register_histogram!(
+        "ckb_block_process_duration",
+        "The CKB block process duration"
     )
     .unwrap(),
     ckb_relay_cb_transaction_count: register_int_counter!(


### PR DESCRIPTION

### What problem does this PR solve?

We need to monitor the time duration for `process_block`, this is useful to benchmark the new verify with pause, we want to compare the different results from develop branch and the new feature branch.

### What is changed and how it works?

Add `ckb_block_process_duration` in matrics.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

