### PR TITLE
backport: Don't account for cell dep for MAX_ANCESTORS_COUNT

### DIFF
--- a/rpc/src/tests/module/pool.rs
+++ b/rpc/src/tests/module/pool.rs
@@ -184,7 +184,8 @@ fn test_send_transaction_exceeded_maximum_ancestors_count() {
         });
     }
 
-    // the default value of pool config `max_ancestors_count` is 125, only 125 txs will be added to committed list of the block template
+    // the default value of pool config `max_ancestors_count` is 125,
+    // only 125 txs will be added to committed list of the block template
     suite.wait_block_template_array_ge("transactions", 1);
 
     let response = suite.rpc(&RpcTestRequest {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -490,6 +490,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(CompactBlockRelayLessThenSharedBestKnown),
         Box::new(InvalidLocatorSize),
         Box::new(SizeLimit),
+        Box::new(TxPoolLimitAncestorCount),
         Box::new(SendDefectedBinary::new(
             "send_defected_binary_reject_known_bugs",
             true,

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -1,8 +1,15 @@
-use crate::{Node, Spec};
-
+use crate::{
+    util::{cell::gen_spendable, transaction::always_success_transaction},
+    Node, Spec,
+};
 use ckb_logger::info;
-use ckb_types::core::FeeRate;
+use ckb_types::{
+    core::{cell::CellMetaBuilder, DepType, FeeRate},
+    packed::CellDepBuilder,
+};
 use std::{thread::sleep, time::Duration};
+
+use ckb_types::{packed::OutPoint, prelude::*};
 
 pub struct SizeLimit;
 
@@ -57,5 +64,75 @@ impl Spec for SizeLimit {
     fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
         config.tx_pool.max_tx_pool_size = MAX_MEM_SIZE_FOR_SIZE_LIMIT;
         config.tx_pool.min_fee_rate = FeeRate::zero();
+    }
+}
+
+pub struct TxPoolLimitAncestorCount;
+impl Spec for TxPoolLimitAncestorCount {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        let initial_inputs = gen_spendable(node0, 130);
+        let input_a = &initial_inputs[0];
+
+        // Commit transaction root
+        let tx_a = {
+            let tx_a = always_success_transaction(node0, input_a);
+            node0.submit_transaction(&tx_a);
+            tx_a
+        };
+
+        let cell_dep = CellDepBuilder::default()
+            .dep_type(DepType::Code.into())
+            .out_point(OutPoint::new(tx_a.hash(), 0))
+            .build();
+
+        // Create 125 transactions cell dep on tx_a
+        for i in 1..=125 {
+            let cur = always_success_transaction(node0, initial_inputs.get(i).unwrap());
+            let cur = cur.as_advanced_builder().cell_dep(cell_dep.clone()).build();
+            let _ = node0.rpc_client().send_transaction(cur.data().into());
+        }
+
+        // Create a new transaction consume the cell dep, it will be succeed in submit
+        let input = CellMetaBuilder::from_cell_output(tx_a.output(0).unwrap(), Default::default())
+            .out_point(OutPoint::new(tx_a.hash(), 0))
+            .build();
+        let last = always_success_transaction(node0, &input);
+
+        let res = node0
+            .rpc_client()
+            .send_transaction_result(last.data().into());
+        assert!(res.is_ok());
+
+        // create a transaction chain
+        let input_c = &initial_inputs[129];
+        // Commit transaction root
+        let tx_c = {
+            let tx_c = always_success_transaction(node0, input_c);
+            node0.submit_transaction(&tx_c);
+            tx_c
+        };
+
+        let mut prev = tx_c.clone();
+        // Create transaction chain
+        for i in 0..125 {
+            let input =
+                CellMetaBuilder::from_cell_output(prev.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(prev.hash(), 0))
+                    .build();
+            let cur = always_success_transaction(node0, &input);
+            let res = node0
+                .rpc_client()
+                .send_transaction_result(cur.data().into());
+            prev = cur.clone();
+            if i >= 124 {
+                assert!(res.is_err());
+                let msg = res.err().unwrap().to_string();
+                assert!(msg.contains("PoolRejectedTransactionByMaxAncestorsCountLimit"));
+            } else {
+                assert!(res.is_ok());
+            }
+        }
     }
 }

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -39,6 +39,8 @@ pub struct TxEntry {
     pub descendants_cycles: Cycle,
     /// descendants txs count
     pub descendants_count: usize,
+    /// dicrect ancestors txs count
+    pub direct_ancestors_count: usize,
     /// The unix timestamp when entering the Txpool, unit: Millisecond
     pub timestamp: u64,
 }
@@ -71,6 +73,7 @@ impl TxEntry {
             descendants_cycles: cycles,
             descendants_count: 1,
             ancestors_count: 1,
+            direct_ancestors_count: 1,
         }
     }
 

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -72,11 +72,15 @@ impl TxLinksMap {
             relation_ids.insert(id);
         }
         // for direct parents, we don't store children in links map
-        // so filter those not in links map now, they maybe removed from tx-pool now
+        // so filter those not in links map, they maybe removed from tx-pool now
         if relation == Relation::DirectParents {
             relation_ids.retain(|id| self.inner.contains_key(id));
         }
         relation_ids
+    }
+
+    pub fn add_link(&mut self, short_id: ProposalShortId, links: TxLinks) {
+        self.inner.insert(short_id, links);
     }
 
     pub fn calc_ancestors(&self, short_id: &ProposalShortId) -> HashSet<ProposalShortId> {

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -5,12 +5,14 @@ use std::collections::{HashMap, HashSet};
 pub struct TxLinks {
     pub parents: HashSet<ProposalShortId>,
     pub children: HashSet<ProposalShortId>,
+    pub direct_parents: HashSet<ProposalShortId>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Relation {
     Parents,
     Children,
+    DirectParents,
 }
 
 impl TxLinks {
@@ -18,6 +20,7 @@ impl TxLinks {
         match relation {
             Relation::Parents => &self.parents,
             Relation::Children => &self.children,
+            Relation::DirectParents => &self.direct_parents,
         }
     }
 }
@@ -67,6 +70,11 @@ impl TxLinksMap {
             }
             stage.remove(&id);
             relation_ids.insert(id);
+        }
+        // for direct parents, we don't store children in links map
+        // so filter those not in links map now, they maybe removed from tx-pool now
+        if relation == Relation::DirectParents {
+            relation_ids.retain(|id| self.inner.contains_key(id));
         }
         relation_ids
     }
@@ -129,6 +137,16 @@ impl TxLinksMap {
         self.inner
             .get_mut(short_id)
             .map(|links| links.parents.insert(parent))
+    }
+
+    pub fn add_direct_parent(
+        &mut self,
+        short_id: &ProposalShortId,
+        parent: ProposalShortId,
+    ) -> Option<bool> {
+        self.inner
+            .get_mut(short_id)
+            .map(|links| links.direct_parents.insert(parent))
     }
 
     pub fn clear(&mut self) {

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -500,12 +500,14 @@ impl PoolMap {
             self.links.add_child(parent, short_id.clone());
         }
 
-        let links = TxLinks {
-            parents,
-            direct_parents,
-            children: Default::default(),
-        };
-        self.links.inner.insert(short_id, links);
+        self.links.add_link(
+            short_id,
+            TxLinks {
+                parents,
+                direct_parents,
+                children: Default::default(),
+            },
+        );
 
         Ok(true)
     }

--- a/tx-pool/src/component/tests/links.rs
+++ b/tx-pool/src/component/tests/links.rs
@@ -1,0 +1,32 @@
+use crate::component::links::{Relation, TxLinks, TxLinksMap};
+use ckb_types::packed::ProposalShortId;
+use ckb_types::prelude::Entity;
+use std::collections::HashSet;
+
+#[test]
+fn test_link_map() {
+    let mut map = TxLinksMap::default();
+    let id1 = ProposalShortId::from_slice(&[1; 10]).unwrap();
+    let id2 = ProposalShortId::from_slice(&[2; 10]).unwrap();
+    let id3 = ProposalShortId::from_slice(&[3; 10]).unwrap();
+    let id4 = ProposalShortId::from_slice(&[4; 10]).unwrap();
+
+    map.add_link(id1.clone(), TxLinks::default());
+    map.add_link(id2.clone(), TxLinks::default());
+    map.add_link(id3.clone(), TxLinks::default());
+    map.add_link(id4.clone(), TxLinks::default());
+
+    map.add_parent(&id1, id2.clone());
+    let expect: HashSet<ProposalShortId> = vec![id2.clone()].into_iter().collect();
+    assert_eq!(map.get_parents(&id1).unwrap(), &expect);
+
+    map.add_direct_parent(&id1, id2.clone());
+    map.add_direct_parent(&id2, id3.clone());
+    map.add_direct_parent(&id3, id4.clone());
+    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
+    assert_eq!(direct_parents.len(), 4);
+
+    map.remove(&id3);
+    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
+    assert_eq!(direct_parents.len(), 2);
+}

--- a/tx-pool/src/component/tests/mod.rs
+++ b/tx-pool/src/component/tests/mod.rs
@@ -1,5 +1,6 @@
 mod chunk;
 mod entry;
+mod links;
 mod orphan;
 mod pending;
 mod proposed;


### PR DESCRIPTION
### What problem does this PR solve?

We met a scenario that a `cell dep` may have many transactions as descendants, and we can not  submit a new transaction to consume the dep cell.

Problem Summary:

### What is changed and how it works?

`cell dep` should be handled specially when calculating the entry's `ancestors_count`.
In this PR, we add a `direct_ancestors_count` to store the directed parent-child relationship between transactions.

This is a short-term solution.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

