### PR TITLE
Modify the method `Relayer::accept_block` to return `StatusCode::BlockIsInvalid` when `shared.insert_new_block()` produces an error.

### DIFF
--- a/sync/src/relayer/block_transactions_process.rs
+++ b/sync/src/relayer/block_transactions_process.rs
@@ -116,9 +116,10 @@ impl<'a> BlockTransactionsProcess<'a> {
                 match ret {
                     ReconstructionResult::Block(block) => {
                         pending.remove();
-                        self.relayer
+                        let status = self
+                            .relayer
                             .accept_block(self.nc.as_ref(), self.peer, block);
-                        return Status::ok();
+                        return status;
                     }
                     ReconstructionResult::Missing(transactions, uncles) => {
                         // We need to get all transactions and uncles that do not exist locally

--- a/sync/src/relayer/compact_block_process.rs
+++ b/sync/src/relayer/compact_block_process.rs
@@ -116,7 +116,8 @@ impl<'a> CompactBlockProcess<'a> {
                         >= block.epoch().number()
                 });
                 shrink_to_fit!(pending_compact_blocks, 20);
-                self.relayer
+                let status = self
+                    .relayer
                     .accept_block(self.nc.as_ref(), self.peer, block);
 
                 if let Some(metrics) = ckb_metrics::handle() {
@@ -124,7 +125,7 @@ impl<'a> CompactBlockProcess<'a> {
                         .ckb_relay_cb_verify_duration
                         .observe(instant.elapsed().as_secs_f64());
                 }
-                Status::ok()
+                status
             }
             ReconstructionResult::Missing(transactions, uncles) => {
                 let missing_transactions: Vec<u32> =

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -299,83 +299,92 @@ impl Relayer {
             .insert_new_block(&self.chain, Arc::clone(&boxed))
             .unwrap_or(false)
         {
+            self.broadcast_compact_block(nc, peer, &boxed)
+        }
+    }
+
+    fn broadcast_compact_block(
+        &self,
+        nc: &dyn CKBProtocolContext,
+        peer: PeerIndex,
+        boxed: &Arc<BlockView>,
+    ) {
+        debug_target!(
+            crate::LOG_TARGET_RELAY,
+            "[block_relay] relayer accept_block {} {}",
+            boxed.header().hash(),
+            unix_time_as_millis()
+        );
+        let block_hash = boxed.hash();
+        self.shared().state().remove_header_view(&block_hash);
+        let cb = packed::CompactBlock::build_from_block(&boxed, &HashSet::new());
+        let message = packed::RelayMessage::new_builder().set(cb).build();
+
+        let selected_peers: Vec<PeerIndex> = nc
+            .connected_peers()
+            .into_iter()
+            .filter(|target_peer| peer != *target_peer)
+            .take(MAX_RELAY_PEERS)
+            .collect();
+        if let Err(err) = nc.quick_filter_broadcast(
+            TargetSession::Multi(Box::new(selected_peers.into_iter())),
+            message.as_bytes(),
+        ) {
             debug_target!(
                 crate::LOG_TARGET_RELAY,
-                "[block_relay] relayer accept_block {} {}",
-                boxed.header().hash(),
-                unix_time_as_millis()
+                "relayer send block when accept block error: {:?}",
+                err,
             );
-            let block_hash = boxed.hash();
-            self.shared().state().remove_header_view(&block_hash);
-            let cb = packed::CompactBlock::build_from_block(&boxed, &HashSet::new());
-            let message = packed::RelayMessage::new_builder().set(cb).build();
+        }
 
-            let selected_peers: Vec<PeerIndex> = nc
+        if let Some(p2p_control) = nc.p2p_control() {
+            let snapshot = self.shared.shared().snapshot();
+            let parent_chain_root = {
+                let mmr = snapshot.chain_root_mmr(boxed.header().number() - 1);
+                match mmr.get_root() {
+                    Ok(root) => root,
+                    Err(err) => {
+                        error_target!(
+                            crate::LOG_TARGET_RELAY,
+                            "Generate last state to light client failed: {:?}",
+                            err
+                        );
+                        return;
+                    }
+                }
+            };
+
+            let tip_header = packed::VerifiableHeader::new_builder()
+                .header(boxed.header().data())
+                .uncles_hash(boxed.calc_uncles_hash())
+                .extension(Pack::pack(&boxed.extension()))
+                .parent_chain_root(parent_chain_root)
+                .build();
+            let light_client_message = {
+                let content = packed::SendLastState::new_builder()
+                    .last_header(tip_header)
+                    .build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            };
+            let light_client_peers: HashSet<PeerIndex> = nc
                 .connected_peers()
                 .into_iter()
-                .filter(|target_peer| peer != *target_peer)
-                .take(MAX_RELAY_PEERS)
+                .filter_map(|index| nc.get_peer(index).map(|peer| (index, peer)))
+                .filter(|(_id, peer)| peer.if_lightclient_subscribed)
+                .map(|(id, _)| id)
                 .collect();
-            if let Err(err) = nc.quick_filter_broadcast(
-                TargetSession::Multi(Box::new(selected_peers.into_iter())),
-                message.as_bytes(),
+            if let Err(err) = p2p_control.filter_broadcast(
+                TargetSession::Filter(Box::new(move |id| light_client_peers.contains(id))),
+                SupportProtocols::LightClient.protocol_id(),
+                light_client_message.as_bytes(),
             ) {
                 debug_target!(
                     crate::LOG_TARGET_RELAY,
-                    "relayer send block when accept block error: {:?}",
+                    "relayer send last state to light client when accept block, error: {:?}",
                     err,
                 );
-            }
-
-            if let Some(p2p_control) = nc.p2p_control() {
-                let snapshot = self.shared.shared().snapshot();
-                let parent_chain_root = {
-                    let mmr = snapshot.chain_root_mmr(boxed.header().number() - 1);
-                    match mmr.get_root() {
-                        Ok(root) => root,
-                        Err(err) => {
-                            error_target!(
-                                crate::LOG_TARGET_RELAY,
-                                "Generate last state to light client failed: {:?}",
-                                err
-                            );
-                            return;
-                        }
-                    }
-                };
-
-                let tip_header = packed::VerifiableHeader::new_builder()
-                    .header(boxed.header().data())
-                    .uncles_hash(boxed.calc_uncles_hash())
-                    .extension(Pack::pack(&boxed.extension()))
-                    .parent_chain_root(parent_chain_root)
-                    .build();
-                let light_client_message = {
-                    let content = packed::SendLastState::new_builder()
-                        .last_header(tip_header)
-                        .build();
-                    packed::LightClientMessage::new_builder()
-                        .set(content)
-                        .build()
-                };
-                let light_client_peers: HashSet<PeerIndex> = nc
-                    .connected_peers()
-                    .into_iter()
-                    .filter_map(|index| nc.get_peer(index).map(|peer| (index, peer)))
-                    .filter(|(_id, peer)| peer.if_lightclient_subscribed)
-                    .map(|(id, _)| id)
-                    .collect();
-                if let Err(err) = p2p_control.filter_broadcast(
-                    TargetSession::Filter(Box::new(move |id| light_client_peers.contains(id))),
-                    SupportProtocols::LightClient.protocol_id(),
-                    light_client_message.as_bytes(),
-                ) {
-                    debug_target!(
-                        crate::LOG_TARGET_RELAY,
-                        "relayer send last state to light client when accept block, error: {:?}",
-                        err,
-                    );
-                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Let `Relayer::accept_block` return `Status`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

