### PR TITLE
Add --include-background to include background migrations in migrate subcommand

### DIFF
--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -15,7 +15,7 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
         })?;
 
         if let Some(db) = read_only_db {
-            let db_status = migrate.check(&db);
+            let db_status = migrate.check(&db, args.include_background);
             if matches!(db_status, Ordering::Greater) {
                 eprintln!(
                     "The database was created by a higher version CKB executable binary \n\
@@ -37,14 +37,7 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
                 return Ok(());
             }
 
-            if migrate.can_run_in_background(&db) && !args.force {
-                eprintln!("The pending migrations are all background migrations.\n\
-                           You can skip migration and start CKB directly, the migration will be done in the background.\n\
-                           If you want to migrate the data manually, please use --force to migrate without interactive prompt.");
-                return Ok(());
-            }
-
-            if migrate.require_expensive(&db) && !args.force {
+            if migrate.require_expensive(&db, args.include_background) && !args.force {
                 if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
                     let input = prompt("\
                     \n\

--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -37,6 +37,13 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
                 return Ok(());
             }
 
+            if migrate.can_run_in_background(&db) && !args.force {
+                eprintln!("The pending migrations are all background migrations.\n\
+                           You can skip migration and start CKB directly, the migration will be done in the background.\n\
+                           If you want to migrate the data manually, please use --force to migrate without interactive prompt.");
+                return Ok(());
+            }
+
             if migrate.require_expensive(&db) && !args.force {
                 if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
                     let input = prompt("\

--- a/ckb-bin/src/subcommand/migrate.rs
+++ b/ckb-bin/src/subcommand/migrate.rs
@@ -15,7 +15,9 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
         })?;
 
         if let Some(db) = read_only_db {
-            let db_status = migrate.check(&db, args.include_background);
+            // if there are only pending background migrations, they will run automatically
+            // so here we check with `include_background` as true
+            let db_status = migrate.check(&db, true);
             if matches!(db_status, Ordering::Greater) {
                 eprintln!(
                     "The database was created by a higher version CKB executable binary \n\
@@ -25,8 +27,12 @@ pub fn migrate(args: MigrateArgs) -> Result<(), ExitCode> {
                 return Err(ExitCode::Failure);
             }
 
+            // `include_background` is default to false
+            let db_status = migrate.check(&db, args.include_background);
             if args.check {
                 if matches!(db_status, Ordering::Less) {
+                    // special for bash usage, return 0 means need run migration
+                    // if ckb migrate --check; then ckb migrate --force; fi
                     return Ok(());
                 } else {
                     return Err(ExitCode::Cli);

--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -62,7 +62,7 @@ pub fn open_or_create_db(
     })?;
 
     if let Some(db) = read_only_db {
-        match migrate.check(&db) {
+        match migrate.check(&db, true) {
             Ordering::Greater => {
                 eprintln!(
                     "The database was created by a higher version CKB executable binary \n\
@@ -74,8 +74,7 @@ pub fn open_or_create_db(
             Ordering::Equal => Ok(RocksDB::open(config, COLUMNS)),
             Ordering::Less => {
                 let can_run_in_background = migrate.can_run_in_background(&db);
-                eprintln!("can_run_in_background: {}", can_run_in_background);
-                if migrate.require_expensive(&db) && !can_run_in_background {
+                if migrate.require_expensive(&db, false) && !can_run_in_background {
                     eprintln!(
                         "For optimal performance, CKB recommends migrating your data into a new format.\n\
                         If you prefer to stick with the older version, \n\

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -202,6 +202,8 @@ pub struct MigrateArgs {
     pub check: bool,
     /// Do migration without interactive prompt.
     pub force: bool,
+    /// Whether include background migrations
+    pub include_background: bool,
 }
 
 impl CustomizeSpec {

--- a/util/app-config/src/cli.rs
+++ b/util/app-config/src/cli.rs
@@ -60,6 +60,8 @@ pub const ARG_P2P_PORT: &str = "p2p-port";
 pub const ARG_RPC_PORT: &str = "rpc-port";
 /// Command line argument `--force`.
 pub const ARG_FORCE: &str = "force";
+/// Command line argument `--include-background`.
+pub const ARG_INCLUDE_BACKGROUND: &str = "include-background";
 /// Command line argument `--log-to`.
 pub const ARG_LOG_TO: &str = "log-to";
 /// Command line argument `--bundled`.
@@ -399,6 +401,12 @@ fn migrate() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with(ARG_MIGRATE_CHECK)
                 .help("Migrate without interactive prompt"),
+        )
+        .arg(
+            Arg::new(ARG_INCLUDE_BACKGROUND)
+                .long(ARG_INCLUDE_BACKGROUND)
+                .action(clap::ArgAction::SetTrue)
+                .help("Whether include background migrations"),
         )
 }
 

--- a/util/app-config/src/lib.rs
+++ b/util/app-config/src/lib.rs
@@ -109,12 +109,14 @@ impl Setup {
         let config = self.config.into_ckb()?;
         let check = matches.get_flag(cli::ARG_MIGRATE_CHECK);
         let force = matches.get_flag(cli::ARG_FORCE);
+        let include_background = matches.get_flag(cli::ARG_INCLUDE_BACKGROUND);
 
         Ok(MigrateArgs {
             config,
             consensus,
             check,
             force,
+            include_background,
         })
     }
 

--- a/util/migrate/src/migrate.rs
+++ b/util/migrate/src/migrate.rs
@@ -53,13 +53,13 @@ impl Migrate {
     /// - Equal: The database version is matched with the executable binary version.
     /// - Greater: The database version is greater than the matched version of the executable binary.
     ///   Requires upgrade the executable binary.
-    pub fn check(&self, db: &ReadOnlyDB) -> Ordering {
-        self.migrations.check(db)
+    pub fn check(&self, db: &ReadOnlyDB, include_background: bool) -> Ordering {
+        self.migrations.check(db, include_background)
     }
 
     /// Check whether database requires expensive migrations.
-    pub fn require_expensive(&self, db: &ReadOnlyDB) -> bool {
-        self.migrations.expensive(db)
+    pub fn require_expensive(&self, db: &ReadOnlyDB, include_background: bool) -> bool {
+        self.migrations.expensive(db, include_background)
     }
 
     /// Check whether the pending migrations are all background migrations.

--- a/util/migrate/src/tests.rs
+++ b/util/migrate/src/tests.rs
@@ -161,5 +161,5 @@ fn test_mock_migration() {
 
     let rdb = mg2.open_read_only_db().unwrap().unwrap();
 
-    assert_eq!(mg2.check(&rdb), std::cmp::Ordering::Equal)
+    assert_eq!(mg2.check(&rdb, false), std::cmp::Ordering::Equal)
 }

--- a/util/migrate/src/tests.rs
+++ b/util/migrate/src/tests.rs
@@ -161,5 +161,5 @@ fn test_mock_migration() {
 
     let rdb = mg2.open_read_only_db().unwrap().unwrap();
 
-    assert_eq!(mg2.check(&rdb, false), std::cmp::Ordering::Equal)
+    assert_eq!(mg2.check(&rdb, true), std::cmp::Ordering::Equal)
 }


### PR DESCRIPTION
### What problem does this PR solve?

If all the migrations can be run in background, user don't need to manually run `ckb migrate --force`.

We should make it's transparent when all migrations can run in background.


### What is changed and how it works?

Add `--include-background` to check all migrations include background ones.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

