### PR TITLE
`IndexerService::apply_init_tip` should stop after received exit signal.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ version = "0.114.0-pre"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
+ "ckb-channel",
  "ckb-db-schema",
  "ckb-jsonrpc-types",
  "ckb-logger",

--- a/util/app-config/src/tests/graceful_shutdown.bats
+++ b/util/app-config/src/tests/graceful_shutdown.bats
@@ -26,7 +26,7 @@ function ckb_graceful_shutdown { #@test
   assert_output --regexp "INFO ckb_tx_pool::chunk_process  TxPool chunk_command service received exit signal, exit now"
   assert_output --regexp "INFO ckb_tx_pool::service  TxPool is saving, please wait..."
   assert_output --regexp "INFO ckb_tx_pool::service  TxPool reorg process service received exit signal, exit now"
-  assert_output --regexp "INFO ckb_indexer::service  Indexer received exit signal, exit now"
+  assert_output --regexp "INFO ckb_indexer::service  Indexer received exit signal, cancel new_block_watcher task, exit now"
   assert_output --regexp "INFO ckb_notify  NotifyService received exit signal, exit now"
   assert_output --regexp "INFO ckb_block_filter::filter  BlockFilter received exit signal, exit now"
   assert_output --regexp "INFO ckb_sync::types::header_map  HeaderMap limit_memory received exit signal, exit now"

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -22,6 +22,7 @@ ckb-notify = { path = "../../notify", version = "= 0.114.0-pre" }
 ckb-store = { path = "../../store", version = "= 0.114.0-pre" }
 ckb-stop-handler = { path = "../stop-handler", version = "= 0.114.0-pre" }
 ckb-async-runtime = { path = "../runtime", version = "= 0.114.0-pre" }
+ckb-channel = { path = "../channel", version = "= 0.114.0-pre" }
 rhai = { version = "1.10.0", features = ["no_function", "no_float", "no_module", "sync"]}
 serde_json = "1.0"
 numext-fixed-uint = "0.1"

--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -18,7 +18,7 @@ use ckb_jsonrpc_types::{
 };
 use ckb_logger::{error, info};
 use ckb_notify::NotifyController;
-use ckb_stop_handler::{new_tokio_exit_rx, CancellationToken};
+use ckb_stop_handler::{new_crossbeam_exit_rx, new_tokio_exit_rx, CancellationToken};
 use ckb_store::ChainStore;
 use ckb_types::{
     core::{self, BlockNumber},
@@ -153,7 +153,16 @@ impl IndexerService {
                     }
                 }
             }
+            let stop_rx = new_crossbeam_exit_rx();
             loop {
+                ckb_channel::select! {
+                    recv(stop_rx) -> _ =>{
+                        info!("apply_init_tip received exit signal, exit now");
+                        break;
+                    },
+                    default() => {},
+                }
+
                 if let Err(e) = self.secondary_db.try_catch_up_with_primary() {
                     error!("secondary_db try_catch_up_with_primary error {}", e);
                 }
@@ -228,6 +237,16 @@ impl IndexerService {
         let poll_service = self.clone();
         self.async_handle.spawn(async move {
             let _initial_finished = initial_syncing.await;
+            info!("initial_syncing finished");
+
+            tokio::select! {
+                _ = stop.cancelled() => {
+                    info!("Indexer received exit signal, cancel new_block_watcher task, exit now");
+                    return;
+                },
+                else => {},
+            }
+
             let mut new_block_watcher = notify_controller
                 .watch_new_block(SUBSCRIBER_NAME.to_string())
                 .await;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4311

Problem Summary:

In the `apply_init_tip` function, there is a loop that should take into account the exit signal:
https://github.com/nervosnetwork/ckb/blob/1ee9c985d61285749128adbbb916ede7742404aa/util/indexer/src/service.rs#L156-L172

 Additionally, once `initial_syncing` is finished and CKB receives an exit signal, there is no need to spawn the `new_block_watcher` polling job.


What's Changed:

### Related changes

- handle exit signal in `apply_init_tip`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

