### PR TITLE
IndexerService should use `is_cancelled()` to check if ckb received Ctrl-C signal

### DIFF
--- a/util/app-config/src/tests/graceful_shutdown.bats
+++ b/util/app-config/src/tests/graceful_shutdown.bats
@@ -26,7 +26,7 @@ function ckb_graceful_shutdown { #@test
   assert_output --regexp "INFO ckb_tx_pool::chunk_process  TxPool chunk_command service received exit signal, exit now"
   assert_output --regexp "INFO ckb_tx_pool::service  TxPool is saving, please wait..."
   assert_output --regexp "INFO ckb_tx_pool::service  TxPool reorg process service received exit signal, exit now"
-  assert_output --regexp "INFO ckb_indexer::service  Indexer received exit signal, cancel new_block_watcher task, exit now"
+  assert_output --regexp "INFO ckb_indexer::service  Indexer received exit signal, exit now"
   assert_output --regexp "INFO ckb_notify  NotifyService received exit signal, exit now"
   assert_output --regexp "INFO ckb_block_filter::filter  BlockFilter received exit signal, exit now"
   assert_output --regexp "INFO ckb_sync::types::header_map  HeaderMap limit_memory received exit signal, exit now"

--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -238,13 +238,9 @@ impl IndexerService {
         self.async_handle.spawn(async move {
             let _initial_finished = initial_syncing.await;
             info!("initial_syncing finished");
-
-            tokio::select! {
-                _ = stop.cancelled() => {
-                    info!("Indexer received exit signal, cancel new_block_watcher task, exit now");
-                    return;
-                },
-                else => {},
+            if stop.is_cancelled() {
+                info!("Indexer received exit signal, cancel new_block_watcher task, exit now");
+                return;
             }
 
             let mut new_block_watcher = notify_controller


### PR DESCRIPTION
…trl-c signal

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


Problem Summary:
In #4345, the `tokio::select!` will stuck forever if ckb doesn't received ctrl-C signal. Should use `stop.is_canceled()`.

What's Changed:

### Related changes

- use `stop.is_canceled()` to check if ckb has received exit signal.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None
### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

