### PR TITLE
[WIP] Add invalidated_tx_count to fix cell dep and cell consume issues

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,10 +99,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
@@ -207,7 +207,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -273,7 +273,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -1913,7 +1913,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1959,7 +1959,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2113,7 +2113,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -2995,7 +2995,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3496,7 +3496,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3712,7 +3712,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4269,7 +4269,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4612,7 +4612,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/baa73b6f8a1ea1fd4ace127e6766b9c37c7ee50f/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -5875,6 +5875,8 @@ A Tx details info in tx-pool.
 * `descendants_count`: [`Uint64`](#type-uint64) - The descendants count of tx
 
 * `entry_status`: `string` - The detailed status in tx-pool, `pending`, `gap`, `proposed`
+
+* `invalidated_tx_count`: [`Uint64`](#type-uint64) - the invalidated transactions count
 
 * `pending_count`: [`Uint64`](#type-uint64) - The pending(`pending` and `gap`) count
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -566,6 +566,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RelayTooNewBlock),
         Box::new(LastCommonHeaderForPeerWithWorseChain),
         Box::new(BlockTransactionsRelayParentOfOrphanBlock),
+        Box::new(SendTxCellRefCellConsume),
         Box::new(CellBeingSpentThenCellDepInSameBlockTestSubmitBlock),
         Box::new(CellBeingCellDepThenSpentInSameBlockTestSubmitBlock),
         Box::new(CellBeingCellDepAndSpentInSameBlockTestGetBlockTemplate),

--- a/test/src/specs/tx_pool/dead_cell_deps.rs
+++ b/test/src/specs/tx_pool/dead_cell_deps.rs
@@ -397,7 +397,7 @@ impl Spec for SendTxCellRefCellConsume {
         let details = node0.get_pool_tx_detail_info(tx_b2.hash());
         let invalidated_tx_count: u64 = details.invalidated_tx_count.into();
         let ancestors_count: u64 = details.ancestors_count.into();
-        assert_eq!(invalidated_tx_count, 3); // child's invalidated_tx_count >= parent tx's invalidated_tx_count
+        assert_eq!(invalidated_tx_count, 0); // child's invalidated_tx_count is not inherit from parent
         assert_eq!(ancestors_count, 1);
     }
 

--- a/tx-pool/src/component/commit_txs_scanner.rs
+++ b/tx-pool/src/component/commit_txs_scanner.rs
@@ -176,6 +176,11 @@ impl<'a> CommitTxsScanner<'a> {
 
             self.update_modified_entries(&ancestors);
         }
+        // sort by invalid_tx_count, from small to large
+        // for A, B, if A.invalidated_tx_count < B.invalidated_tx_count
+        // then B is the tx consumed a cell dep, and A is the tx that cell dep
+        // so the result in order will be [A, B]
+        self.entries.sort_by_key(|entry| entry.invalidated_tx_count);
         (self.entries, size, cycles)
     }
 

--- a/tx-pool/src/component/commit_txs_scanner.rs
+++ b/tx-pool/src/component/commit_txs_scanner.rs
@@ -153,8 +153,9 @@ impl<'a> CommitTxsScanner<'a> {
                 .cloned()
                 .collect::<Vec<TxEntry>>();
 
-            // sort ancestors by ancestors_count,
+            // sort ancestors by ancestors_count, from small to large
             // if A is an ancestor of B, B.ancestors_count must large than A
+            // so that the result in order will be A, B
             ancestors.sort_unstable_by_key(|entry| entry.ancestors_count);
             ancestors.push(tx_entry.to_owned());
 

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -39,8 +39,10 @@ pub struct TxEntry {
     pub descendants_cycles: Cycle,
     /// descendants txs count
     pub descendants_count: usize,
-    /// dicrect ancestors txs count
-    pub direct_ancestors_count: usize,
+    /// invalidated transactions count
+    /// if this tx is invalid, invalidated_tx_count of transactions will be invalidated
+    /// it will be used order in transaction packaging stage
+    pub invalidated_tx_count: usize,
     /// The unix timestamp when entering the Txpool, unit: Millisecond
     pub timestamp: u64,
 }
@@ -73,7 +75,7 @@ impl TxEntry {
             descendants_cycles: cycles,
             descendants_count: 1,
             ancestors_count: 1,
-            direct_ancestors_count: 1,
+            invalidated_tx_count: 0,
         }
     }
 

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -5,14 +5,12 @@ use std::collections::{HashMap, HashSet};
 pub struct TxLinks {
     pub parents: HashSet<ProposalShortId>,
     pub children: HashSet<ProposalShortId>,
-    pub direct_parents: HashSet<ProposalShortId>,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Relation {
     Parents,
     Children,
-    DirectParents,
 }
 
 impl TxLinks {
@@ -20,7 +18,6 @@ impl TxLinks {
         match relation {
             Relation::Parents => &self.parents,
             Relation::Children => &self.children,
-            Relation::DirectParents => &self.direct_parents,
         }
     }
 }
@@ -70,11 +67,6 @@ impl TxLinksMap {
             }
             stage.remove(&id);
             relation_ids.insert(id);
-        }
-        // for direct parents, we don't store children in links map
-        // so filter those not in links map, they maybe removed from tx-pool now
-        if relation == Relation::DirectParents {
-            relation_ids.retain(|id| self.inner.contains_key(id));
         }
         relation_ids
     }
@@ -141,16 +133,6 @@ impl TxLinksMap {
         self.inner
             .get_mut(short_id)
             .map(|links| links.parents.insert(parent))
-    }
-
-    pub fn add_direct_parent(
-        &mut self,
-        short_id: &ProposalShortId,
-        parent: ProposalShortId,
-    ) -> Option<bool> {
-        self.inner
-            .get_mut(short_id)
-            .map(|links| links.direct_parents.insert(parent))
     }
 
     pub fn clear(&mut self) {

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -5,12 +5,15 @@ use std::collections::{HashMap, HashSet};
 pub struct TxLinks {
     pub parents: HashSet<ProposalShortId>,
     pub children: HashSet<ProposalShortId>,
+    pub invalidators: HashSet<ProposalShortId>,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Relation {
     Parents,
     Children,
+    #[allow(dead_code)]
+    Invalidators,
 }
 
 impl TxLinks {
@@ -18,6 +21,7 @@ impl TxLinks {
         match relation {
             Relation::Parents => &self.parents,
             Relation::Children => &self.children,
+            Relation::Invalidators => &self.invalidators,
         }
     }
 }
@@ -91,6 +95,13 @@ impl TxLinksMap {
         self.inner.get(short_id).map(|link| &link.parents)
     }
 
+    pub fn get_invalidators(
+        &self,
+        short_id: &ProposalShortId,
+    ) -> Option<&HashSet<ProposalShortId>> {
+        self.inner.get(short_id).map(|link| &link.invalidators)
+    }
+
     pub fn remove(&mut self, short_id: &ProposalShortId) -> Option<TxLinks> {
         self.inner.remove(short_id)
     }
@@ -123,6 +134,16 @@ impl TxLinksMap {
         self.inner
             .get_mut(short_id)
             .map(|links| links.children.insert(child))
+    }
+
+    pub fn add_invalidator(
+        &mut self,
+        short_id: &ProposalShortId,
+        invalidator: ProposalShortId,
+    ) -> Option<bool> {
+        self.inner
+            .get_mut(short_id)
+            .map(|links| links.invalidators.insert(invalidator))
     }
 
     pub fn add_parent(

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -500,7 +500,7 @@ impl PoolMap {
             // cell deps don't accord into ancestors
             entry.add_ancestor_weight(&ancestor.inner);
         }
-        entry.ancestors_count = ancestors.len();
+        entry.ancestors_count = ancestors.len() + 1;
         if entry.ancestors_count > self.max_ancestors_count {
             // the `ancestors_count` only account for direct ancestors now.
             // here we still does not changed anything in pool_map,

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -504,6 +504,8 @@ impl PoolMap {
         }
         entry.direct_ancestors_count = direct_ancestors.len() + 1;
         if entry.direct_ancestors_count > self.max_ancestors_count {
+            // here we still does not changed anything in pool_map,
+            // so return Err is safe and we don't need to rollback anything.
             return Err(Reject::ExceededMaximumAncestorsCount);
         }
 

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -429,25 +429,17 @@ impl PoolMap {
         let tx_short_id: ProposalShortId = entry.proposal_short_id();
         let outputs = entry.transaction().output_pts();
         let mut children = HashSet::new();
-        let mut direct_children = HashSet::new();
 
         // collect children
         for o in outputs {
             if let Some(ids) = self.edges.get_deps_ref(&o).cloned() {
                 children.extend(ids);
             }
-            if let Some(id) = self.edges.get_input_ref(&o).cloned() {
-                children.insert(id.clone());
-                direct_children.insert(id);
-            }
         }
         // update children
         if !children.is_empty() {
             for child in &children {
                 self.links.add_parent(child, tx_short_id.clone());
-            }
-            for child in &direct_children {
-                self.links.add_direct_parent(child, tx_short_id.clone());
             }
             if let Some(links) = self.links.inner.get_mut(&tx_short_id) {
                 links.children.extend(children);
@@ -463,21 +455,18 @@ impl PoolMap {
         let mut parents: HashSet<ProposalShortId> = HashSet::with_capacity(
             entry.transaction().inputs().len() + entry.transaction().cell_deps().len(),
         );
-        let mut direct_parents: HashSet<ProposalShortId> =
-            HashSet::with_capacity(entry.transaction().inputs().len());
-
+        let mut invalidated = HashSet::default();
         let short_id = entry.proposal_short_id();
         for input in entry.transaction().inputs() {
             let input_pt = input.previous_output();
             if let Some(deps) = self.edges.deps.get(&input_pt) {
-                parents.extend(deps.iter().cloned());
+                invalidated.extend(deps.iter().cloned());
             }
 
             let parent_hash = &input_pt.tx_hash();
             let id = ProposalShortId::from_tx_hash(parent_hash);
             if self.links.inner.contains_key(&id) {
                 parents.insert(id.clone());
-                direct_parents.insert(id);
             }
         }
         for cell_dep in entry.transaction().cell_deps() {
@@ -491,19 +480,14 @@ impl PoolMap {
         let ancestors = self
             .links
             .calc_relation_ids(parents.clone(), Relation::Parents);
-
-        let direct_ancestors = self
-            .links
-            .calc_relation_ids(direct_parents.clone(), Relation::DirectParents);
-
         // update parents references
         for ancestor_id in &ancestors {
             let ancestor = self.get_by_id_checked(ancestor_id);
             // cell deps don't accord into ancestors
             entry.add_ancestor_weight(&ancestor.inner);
         }
-        entry.direct_ancestors_count = direct_ancestors.len() + 1;
-        if entry.direct_ancestors_count > self.max_ancestors_count {
+        if entry.ancestors_count > self.max_ancestors_count {
+            // the `ancestors_count` only account for direct ancestors now.
             // here we still does not changed anything in pool_map,
             // so return Err is safe and we don't need to rollback anything.
             return Err(Reject::ExceededMaximumAncestorsCount);
@@ -513,11 +497,16 @@ impl PoolMap {
             self.links.add_child(parent, short_id.clone());
         }
 
+        // all the descendants of the invalidated tx are also invalidated
+        let all_invalidated = self
+            .links
+            .calc_relation_ids(invalidated, Relation::Children);
+        entry.invalidated_tx_count = all_invalidated.len();
+
         self.links.add_link(
             short_id,
             TxLinks {
                 parents,
-                direct_parents,
                 children: Default::default(),
             },
         );

--- a/tx-pool/src/component/tests/links.rs
+++ b/tx-pool/src/component/tests/links.rs
@@ -20,13 +20,14 @@ fn test_link_map() {
     let expect: HashSet<ProposalShortId> = vec![id2.clone()].into_iter().collect();
     assert_eq!(map.get_parents(&id1).unwrap(), &expect);
 
-    map.add_direct_parent(&id1, id2.clone());
-    map.add_direct_parent(&id2, id3.clone());
-    map.add_direct_parent(&id3, id4.clone());
-    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
-    assert_eq!(direct_parents.len(), 4);
+    map.add_parent(&id1, id2.clone());
+    map.add_parent(&id2, id3.clone());
+    map.add_parent(&id3, id4.clone());
+    let parents = map.calc_relation_ids([id1.clone()].into(), Relation::Parents);
+    assert_eq!(parents.len(), 4);
 
     map.remove(&id3);
-    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
-    assert_eq!(direct_parents.len(), 2);
+    map.remove_parent(&id2, &id3);
+    let parents = map.calc_relation_ids([id1.clone()].into(), Relation::Parents);
+    assert_eq!(parents.len(), 2);
 }

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -171,12 +171,12 @@ fn test_add_entry_from_detached() {
         assert!(pool.links.get_parents(&id1).unwrap().is_empty());
         assert_eq!(
             pool.links.get_children(&id1).unwrap(),
-            &HashSet::from_iter(vec![].into_iter())
+            &HashSet::from_iter(vec![id2.clone()].into_iter())
         );
 
         assert_eq!(
             pool.links.get_parents(&id2).unwrap(),
-            &HashSet::from_iter(vec![].into_iter())
+            &HashSet::from_iter(vec![id1].into_iter())
         );
         assert_eq!(
             pool.links

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -83,6 +83,10 @@ fn test_add_entry_from_detached() {
     let tx2_hash = tx2.hash();
     let tx3 = build_tx_with_dep(vec![(&Byte32::zero(), 0)], vec![(&tx2_hash, 0)], 1);
 
+    //        tx1
+    //       /
+    //     tx2 --->(cell dep)  tx3
+
     let entry1 = TxEntry::new(dummy_resolve(tx1.clone(), |_| None), 1, MOCK_FEE, 1);
     let entry2 = TxEntry::new(dummy_resolve(tx2, |_| None), 1, MOCK_FEE, 1);
     let entry3 = TxEntry::new(dummy_resolve(tx3, |_| None), 1, MOCK_FEE, 1);
@@ -167,12 +171,12 @@ fn test_add_entry_from_detached() {
         assert!(pool.links.get_parents(&id1).unwrap().is_empty());
         assert_eq!(
             pool.links.get_children(&id1).unwrap(),
-            &HashSet::from_iter(vec![id2.clone()].into_iter())
+            &HashSet::from_iter(vec![].into_iter())
         );
 
         assert_eq!(
             pool.links.get_parents(&id2).unwrap(),
-            &HashSet::from_iter(vec![id1].into_iter())
+            &HashSet::from_iter(vec![].into_iter())
         );
         assert_eq!(
             pool.links

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -616,6 +616,7 @@ impl TxPool {
                 proposed_count: ids.proposed.len(),
                 descendants_count: self.pool_map.calc_descendants(id).len(),
                 ancestors_count: self.pool_map.calc_ancestors(id).len(),
+                invalidated_tx_count: entry.inner.invalidated_tx_count,
                 score_sortkey: entry.inner.as_score_key().into(),
             };
             Some(res)

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -259,6 +259,8 @@ pub struct PoolTxDetailInfo {
     pub descendants_count: Uint64,
     /// The ancestors count of tx
     pub ancestors_count: Uint64,
+    /// the invalidated transactions count
+    pub invalidated_tx_count: Uint64,
     /// The score key details, useful to debug
     pub score_sortkey: AncestorsScoreSortKey,
 }
@@ -272,6 +274,7 @@ impl From<CorePoolTxDetailInfo> for PoolTxDetailInfo {
             pending_count: (info.pending_count as u64).into(),
             proposed_count: (info.proposed_count as u64).into(),
             descendants_count: (info.descendants_count as u64).into(),
+            invalidated_tx_count: (info.invalidated_tx_count as u64).into(),
             ancestors_count: (info.ancestors_count as u64).into(),
             score_sortkey: info.score_sortkey.into(),
         }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -376,6 +376,8 @@ pub struct PoolTxDetailInfo {
     pub descendants_count: usize,
     /// The ancestors count of tx
     pub ancestors_count: usize,
+    /// the invalidated transactions count
+    pub invalidated_tx_count: usize,
     /// The score key details, useful to debug
     pub score_sortkey: AncestorsScoreSortKey,
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The are conflicts rule between cell dep reference and cell consume relationships.

Assume there are 3 transactions, B cell dep A(and there may be many transactions also cell dep A), C consumes A. 

- If C is committed first, B and all other transactions will be invalidated.
- If there are too many transactions all cell dep A, transaction C can not be submitted to `txpool`.

### What is changed and how it works?

In this PR, we introduce these changes:

- add a new `invalidated_tx_count` to Entry, marked as how many transactions will be invalidated if by this transaction entry.
- Add `invalidators` to store all transactions which may invalidate the current transaction
- Remove `DirectParents` and  `direct_ancestors_count`, it's now replaced by `Parents` and `ancestors_count`
- Fix order based on the relationships of invalidators and parents.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

