### PR TITLE
chore(scripts): update ckb-vm to v0.24.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816e61367594b83f86d6100d1c940a62658f364fcfb8e81f2296440ebcb6e28e"
+checksum = "8332997ee3beacb0c1b9e2489e17b33af855a0ec28d7c08a81170fae6b204340"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd940885b250d3bc14b1d2b9fb45ceafdc857b2c5c43610cf9bf944f08dc511f"
+checksum = "27f6fa54fd079938807cce5b11b4fbb9b21984568b887204ea96a02dbd907c2f"
 dependencies = [
  "paste",
 ]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -22,7 +22,7 @@ ckb-traits = { path = "../traits", version = "= 0.114.0-pre" }
 byteorder = "1.3.1"
 ckb-types = { path = "../util/types", version = "= 0.114.0-pre" }
 ckb-hash = { path = "../util/hash", version = "= 0.114.0-pre" }
-ckb-vm = { version = "=0.24.7", default-features = false }
+ckb-vm = { version = "=0.24.8", default-features = false }
 faster-hex = "0.6"
 ckb-logger = { path = "../util/logger", version = "= 0.114.0-pre", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

There is a small issue in the old version of ckb-vm that leads to a slight performance decrease.

### What is changed and how it works?

What's Changed:

Update ckb-vm to v0.24.8. For detaild ChangLogs, see:

https://github.com/nervosnetwork/ckb-vm/releases/tag/v0.24.8

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

