### PR TITLE
Fix rpc doc generator issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -178,7 +178,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn 2.0.43",
  "which",
 ]
 
@@ -1394,7 +1394,9 @@ dependencies = [
  "ckb-rpc",
  "ckb_schemars",
  "serde_json",
+ "syn 2.0.43",
  "tera",
+ "walkdir",
 ]
 
 [[package]]
@@ -2075,7 +2077,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2092,7 +2094,7 @@ checksum = "b45506e3c66512b0a65d291a6b452128b7b1dd9841e20d1e151addbd2c00ea50"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2125,7 +2127,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2136,7 +2138,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2344,7 +2346,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "uuid",
 ]
 
@@ -2469,7 +2471,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3116,7 +3118,7 @@ checksum = "34fe3ce66f7e4909575f6be478862325559bf5b5d0a681d106aae2c9849e1857"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3291,7 +3293,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3554,7 +3556,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3710,7 +3712,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3828,7 +3830,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3923,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4301,7 +4303,7 @@ checksum = "853977598f084a492323fe2f7896b4100a86284ee8473612de60021ea341310f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4592,7 +4594,7 @@ checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4843,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4999,7 +5001,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5143,7 +5145,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5610,7 +5612,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -5644,7 +5646,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5954,7 +5956,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5974,5 +5976,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,17 @@ gen-rpc-doc: submodule-init ## Generate rpc documentation
 	./target/debug/ckb-rpc-gen --json
 	./target/debug/ckb-rpc-gen rpc/README.md
 
+.PHONY: old-gen-rpc-doc
+old-gen-rpc-doc:  ## Generate rpc documentation
+	rm -f ${CARGO_TARGET_DIR}/doc/ckb_rpc/module/trait.*.html
+	cargo doc --workspace
+	ln -nsf "${CARGO_TARGET_DIR}" "target"
+	if command -v python3 &> /dev/null; then \
+		python3 ./devtools/doc/rpc.py > rpc/old-README.md; \
+	else \
+		python ./devtools/doc/rpc.py > rpc/old-README.md; \
+	fi
+
 .PHONY: gen-hashes
 gen-hashes: ## Generate docs/hashes.toml
 	cargo run list-hashes -b > docs/hashes.toml

--- a/Makefile
+++ b/Makefile
@@ -107,17 +107,6 @@ gen-rpc-doc: submodule-init ## Generate rpc documentation
 	./target/debug/ckb-rpc-gen --json
 	./target/debug/ckb-rpc-gen rpc/README.md
 
-.PHONY: old-gen-rpc-doc
-old-gen-rpc-doc:  ## Generate rpc documentation
-	rm -f ${CARGO_TARGET_DIR}/doc/ckb_rpc/module/trait.*.html
-	cargo doc --workspace
-	ln -nsf "${CARGO_TARGET_DIR}" "target"
-	if command -v python3 &> /dev/null; then \
-		python3 ./devtools/doc/rpc.py > rpc/old-README.md; \
-	else \
-		python ./devtools/doc/rpc.py > rpc/old-README.md; \
-	fi
-
 .PHONY: gen-hashes
 gen-hashes: ## Generate docs/hashes.toml
 	cargo run list-hashes -b > docs/hashes.toml

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -13,3 +13,7 @@ ckb-rpc ={ path = "../../../rpc", version = "= 0.114.0-pre" }
 schemars = { version = "0.8.16", package = "ckb_schemars" }
 serde_json = "~1.0"
 tera = "1"
+syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }
+walkdir = "2.1.4"
+
+

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -15,5 +15,3 @@ serde_json = "~1.0"
 tera = "1"
 syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }
 walkdir = "2.1.4"
-
-

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -526,6 +526,8 @@ fn pre_defined_types() -> impl Iterator<Item = (String, String)> {
     [
         ("AlertId", "The alert identifier that is used to filter duplicated alerts.\n
 This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32)."),
+        ("AlertPriority", "Alerts are sorted by priority. Greater integers mean higher priorities.\n
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32)."),
         ("SerializedHeader", "This is a 0x-prefix hex string. It is the block header serialized by molecule using the schema `table Header`."),
         ("SerializedBlock", "This is a 0x-prefix hex string. It is the block serialized by molecule using the schema `table Block`."),
         ("U256", "The 256-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON."),

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -138,6 +138,7 @@ impl RpcDocGenerator {
                 }
             }
         }
+        types.push(("AlertId".into(), Value::String("AlertId".into())));
         types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
 
         Self {
@@ -214,10 +215,11 @@ impl RpcDocGenerator {
                     .join("\n");
 
                 // replace only the first ``` with ```json
+                let name = capitlize(name);
                 let desc = desc.replacen("```\n", "```json\n", 1);
-                let fields = gen_type_fields(ty);
+                let fields = gen_type_fields(&name, ty);
                 gen_value(&[
-                    ("name", capitlize(name).into()),
+                    ("name", name.into()),
                     ("desc", desc.into()),
                     ("fields", fields.into()),
                 ])
@@ -302,7 +304,7 @@ fn gen_type_desc(desc: &str) -> String {
     format!(" - {}\n", desc)
 }
 
-fn gen_type_fields(ty: &Value) -> String {
+fn gen_type_fields(name: &str, ty: &Value) -> String {
     if let Some(fields) = ty.get("required") {
         let res = fields
             .as_array()
@@ -319,7 +321,10 @@ fn gen_type_fields(ty: &Value) -> String {
             .collect::<Vec<_>>()
             .join("\n");
         let res = strip_prefix_space(&res);
-        format!("\n#### Fields:\n{}", res)
+        format!(
+            "\n#### Fields\n\n`{}` is a JSON object with the following fields.\n\n{}",
+            name, res
+        )
     } else {
         "".to_string()
     }

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -131,22 +131,21 @@ impl RpcDocGenerator {
         // sort rpc_methods accoring to title
         rpc_methods.sort_by(|a, b| a.title.cmp(&b.title));
 
-        let mut types: Vec<(String, Value)> = vec![];
-        for map in all_types.iter() {
+        let mut pre_defined: Vec<(String, String)> = pre_defined_types().collect();
+        pre_defined.extend(visit_for_types());
+
+        let mut types: Vec<(String, Value)> = pre_defined
+            .iter()
+            .map(|(name, desc)| (name.clone(), Value::String(desc.clone())))
+            .collect();
+        for map in all_types {
             for (name, ty) in map.iter() {
-                if !types.iter().any(|(n, _)| *n == *name) {
+                if !(types.iter().any(|(n, _)| *n == *name)
+                    || (name.starts_with("Either_for_") && name.ends_with("_JsonBytes")))
+                {
                     types.push((name.to_string(), ty.to_owned()));
                 }
             }
-        }
-
-        let mut pre_defined: Vec<(String, String)> = pre_defined_types().collect();
-        pre_defined.extend(visit_for_types());
-        for (ty, desc) in pre_defined {
-            if types.iter().any(|t| t.0 == *ty) {
-                continue;
-            }
-            types.push((ty.to_owned(), Value::String(desc)));
         }
         types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
         Self {

--- a/devtools/doc/rpc-gen/src/main.rs
+++ b/devtools/doc/rpc-gen/src/main.rs
@@ -1,5 +1,6 @@
 //! this is a tool to generate rpc doc
 mod gen;
+mod syn;
 mod utils;
 use crate::gen::RpcDocGenerator;
 use crate::utils::*;

--- a/devtools/doc/rpc-gen/src/syn.rs
+++ b/devtools/doc/rpc-gen/src/syn.rs
@@ -1,0 +1,96 @@
+//! It's bad(sad) JSON Schema currently ignore type alias,
+//! maybe it's better to fix it in schemars, but here we only do a quick hack
+//! here we use a simple syn visitor to find extra type comments
+
+use std::collections::HashMap;
+use syn::visit::Visit;
+use syn::{parse2, Expr, ItemType, Meta, MetaNameValue};
+use walkdir::WalkDir;
+
+struct CommentFinder {
+    // Store the comments here
+    type_comments: HashMap<String, String>,
+    current_type: Option<String>,
+    types: Vec<String>,
+}
+
+impl Visit<'_> for CommentFinder {
+    fn visit_attribute(&mut self, attr: &syn::Attribute) {
+        if let Some(type_name) = &self.current_type {
+            if attr.path().is_ident("doc") {
+                if let Meta::NameValue(MetaNameValue {
+                    value:
+                        Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(lit),
+                            ..
+                        }),
+                    ..
+                }) = &attr.meta
+                {
+                    let lit = lit.value();
+                    let current_type = type_name.clone();
+                    *self
+                        .type_comments
+                        .entry(current_type)
+                        .or_insert("".to_string()) += &format!("\n{}", lit.trim_start());
+                }
+            }
+        }
+    }
+
+    fn visit_item_struct(&mut self, i: &syn::ItemStruct) {
+        let ident_name = i.ident.to_string();
+        if self.types.contains(&ident_name) && !i.attrs.is_empty() {
+            self.current_type = Some(ident_name);
+            for attr in &i.attrs {
+                self.visit_attribute(attr);
+            }
+            self.current_type = None;
+        }
+    }
+
+    fn visit_item_type(&mut self, i: &ItemType) {
+        let ident_name = i.ident.to_string();
+        if !i.attrs.is_empty() {
+            self.current_type = Some(ident_name);
+            for attr in &i.attrs {
+                self.visit_attribute(attr);
+            }
+            self.current_type = None;
+        }
+    }
+}
+
+fn visit_source_file(finder: &mut CommentFinder, file_path: &std::path::Path) {
+    let code = std::fs::read_to_string(file_path).unwrap();
+    if let Ok(tokens) = code.parse() {
+        if let Ok(file) = parse2(tokens) {
+            finder.visit_file(&file);
+        }
+    }
+}
+
+pub(crate) fn visit_for_types() -> Vec<(String, String)> {
+    let mut finder = CommentFinder {
+        type_comments: Default::default(),
+        current_type: None,
+        types: vec![],
+    };
+    let dir = "util/jsonrpc-types";
+    for entry in WalkDir::new(dir).follow_links(true).into_iter() {
+        match entry {
+            Ok(ref e)
+                if !e.file_name().to_string_lossy().starts_with('.')
+                    && e.file_name().to_string_lossy().ends_with(".rs") =>
+            {
+                visit_source_file(&mut finder, e.path());
+            }
+            _ => (),
+        }
+    }
+    finder
+        .type_comments
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}

--- a/devtools/doc/rpc-gen/src/syn.rs
+++ b/devtools/doc/rpc-gen/src/syn.rs
@@ -74,7 +74,7 @@ pub(crate) fn visit_for_types() -> Vec<(String, String)> {
     let mut finder = CommentFinder {
         type_comments: Default::default(),
         current_type: None,
-        types: vec![],
+        types: vec!["JsonBytes".to_string()],
     };
     let dir = "util/jsonrpc-types";
     for entry in WalkDir::new(dir).follow_links(true).into_iter() {

--- a/devtools/doc/rpc-gen/src/syn.rs
+++ b/devtools/doc/rpc-gen/src/syn.rs
@@ -74,7 +74,10 @@ pub(crate) fn visit_for_types() -> Vec<(String, String)> {
     let mut finder = CommentFinder {
         type_comments: Default::default(),
         current_type: None,
-        types: vec!["JsonBytes".to_string()],
+        types: vec!["JsonBytes", "IndexerRange"]
+            .iter()
+            .map(|&s| s.to_owned())
+            .collect(),
     };
     let dir = "util/jsonrpc-types";
     for entry in WalkDir::new(dir).follow_links(true).into_iter() {

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -160,6 +160,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `IndexerOrder`](#type-indexerorder)
     * [Type `IndexerPagination_for_IndexerCell`](#type-indexerpagination_for_indexercell)
     * [Type `IndexerPagination_for_IndexerTx`](#type-indexerpagination_for_indexertx)
+    * [Type `IndexerRange`](#type-indexerrange)
     * [Type `IndexerScriptType`](#type-indexerscripttype)
     * [Type `IndexerSearchKey`](#type-indexersearchkey)
     * [Type `IndexerSearchKeyFilter`](#type-indexersearchkeyfilter)
@@ -5856,6 +5857,17 @@ IndexerPagination wraps objects array and last_cursor to provide paging
 * `last_cursor`: [`JsonBytes`](#type-jsonbytes) - pagination parameter
 
 * `objects`: `Array<` [`IndexerTx`](#type-indexertx) `>` - objects collection
+
+### Type `IndexerRange`
+
+A array represent (half-open) range bounded inclusively below and exclusively above [start, end).
+
+###### Examples
+
+|            JSON          |            range             |
+| -------------------------| ---------------------------- |
+| ["0x0", "0x2"]           |          [0, 2)              |
+| ["0x0", "0x174876e801"]  |          [0, 100000000001)   |
 
 ### Type `IndexerScriptType`
 ScriptType `Lock` | `Type`

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,10 +99,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
@@ -212,7 +212,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -278,7 +278,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -1918,7 +1918,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1964,7 +1964,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2118,7 +2118,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -3000,7 +3000,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3501,7 +3501,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3717,7 +3717,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4274,7 +4274,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4617,7 +4617,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -5415,6 +5415,16 @@ An enum to represent the two kinds of dao withdrawal amount calculation option. 
 ### Type `DepType`
 The dep cell type. Allowed values: "code" and "dep_group".
 
+It's an enum value from one of:
+  - code : Type "code".
+
+Use the cell itself as the dep cell.
+  - dep_group : Type "dep_group".
+
+The cell is a dep group which members are cells. These members are used as dep cells instead of the group itself.
+
+The dep group stores the array of `OutPoint`s serialized via molecule in the cell data. Each `OutPoint` points to one cell member.
+
 ### Type `Deployment`
 RFC0043 deployment params
 
@@ -5465,6 +5475,13 @@ An object containing various state info regarding deployments of consensus chang
 
 ### Type `DeploymentState`
 The possible softfork deployment state
+
+It's an enum value from one of:
+  - defined : First state that each softfork starts. The 0 epoch is by definition in this state for each deployment.
+  - started : For epochs past the `start` epoch.
+  - locked_in : For one epoch after the first epoch period with STARTED epochs of which at least `threshold` has the associated bit set in `version`.
+  - active : For all epochs after the LOCKED_IN epoch.
+  - failed : For one epoch period past the `timeout_epoch`, if LOCKED_IN was not reached.
 
 ### Type `DeploymentsInfo`
 Chain information.
@@ -5733,6 +5750,10 @@ Live cell
 ### Type `IndexerCellType`
 Cell type
 
+It's an enum value from one of:
+  - input : Input
+  - output : Output
+
 ### Type `IndexerCellsCapacity`
 Cells capacity
 
@@ -5748,6 +5769,10 @@ Cells capacity
 
 ### Type `IndexerOrder`
 Order Desc | Asc
+
+It's an enum value from one of:
+  - desc : Descending order
+  - asc : Ascending order
 
 ### Type `IndexerPagination_for_IndexerCell`
 IndexerPagination wraps objects array and last_cursor to provide paging
@@ -5774,6 +5799,10 @@ IndexerPagination wraps objects array and last_cursor to provide paging
 ### Type `IndexerScriptType`
 ScriptType `Lock` | `Type`
 
+It's an enum value from one of:
+  - lock : Lock
+  - type : Type
+
 ### Type `IndexerSearchKey`
 SearchKey represent indexer support params
 
@@ -5790,6 +5819,11 @@ IndexerSearchKeyFilter represent indexer params `filter`
 
 ### Type `IndexerSearchMode`
 IndexerSearchMode represent search mode, default is prefix search
+
+It's an enum value from one of:
+  - prefix : Mode `prefix` search with prefix
+  - exact : Mode `exact` search with exact match
+  - partial : Mode `partial` search with partial match
 
 ### Type `IndexerTip`
 Indexer tip information
@@ -5995,6 +6029,10 @@ Reference to a cell via transaction hash and output index.
 
 ### Type `OutputsValidator`
 Transaction output validators that prevent common mistakes.
+
+It's an enum value from one of:
+  - passthrough : the default validator, bypass output checking, thus allow any kind of transaction outputs.
+  - well_known_scripts_only : restricts the lock script and type script usage, see more information on <https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Default-Outputs-Validator>
 
 ### Type `PeerSyncState`
 The chain synchronization state between the local node and a remote node.
@@ -6235,6 +6273,12 @@ Refer to the section [Code Locating](https://github.com/nervosnetwork/rfcs/blob/
 
 The hash type is split into the high 7 bits and the low 1 bit, when the low 1 bit is 1, it indicates the type, when the low 1 bit is 0, it indicates the data, and then it relies on the high 7 bits to indicate that the data actually corresponds to the version.
 
+It's an enum value from one of:
+  - data : Type "data" matches script code via cell data hash, and run the script code in v0 CKB VM.
+  - type : Type "type" matches script code via cell type script hash.
+  - data1 : Type "data1" matches script code via cell data hash, and run the script code in v1 CKB VM.
+  - data2 : Type "data2" matches script code via cell data hash, and run the script code in v2 CKB VM.
+
 ### Type `SerializedBlock`
 This is a 0x-prefix hex string. It is the block serialized by molecule using the schema `table Block`.
 
@@ -6247,8 +6291,19 @@ SoftFork information
 ### Type `SoftForkStatus`
 SoftForkStatus which is either `buried` (for soft fork deployments where the activation epoch is hard-coded into the client implementation), or `rfc0043` (for soft fork deployments where activation is controlled by rfc0043 signaling).
 
+It's an enum value from one of:
+  - buried : the activation epoch is hard-coded into the client implementation
+  - rfc0043 : the activation is controlled by rfc0043 signaling
+
 ### Type `Status`
 Status for transaction
+
+It's an enum value from one of:
+  - pending : Status "pending". The transaction is in the pool, and not proposed yet.
+  - proposed : Status "proposed". The transaction is in the pool and has been proposed.
+  - committed : Status "committed". The transaction has been committed to the canonical chain.
+  - unknown : Status "unknown". The node has not seen the transaction, or it should be rejected but was cleared due to storage limitations.
+  - rejected : Status "rejected". The transaction has been recently removed from the pool. Due to storage limitations, the node can only hold the most recently removed transactions.
 
 ### Type `SyncState`
 The overall chain synchronization state of this local node.

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -110,6 +110,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `Alert`](#type-alert)
     * [Type `AlertId`](#type-alertid)
     * [Type `AlertMessage`](#type-alertmessage)
+    * [Type `AlertPriority`](#type-alertpriority)
     * [Type `AncestorsScoreSortKey`](#type-ancestorsscoresortkey)
     * [Type `BannedAddr`](#type-bannedaddr)
     * [Type `Block`](#type-block)
@@ -4939,6 +4940,11 @@ An alert sent by RPC `send_alert`.
 * `notice_until`: [`Uint64`](#type-uint64) - The alert is expired after this timestamp.
 
 * `priority`: [`Uint32`](#type-uint32) - Alerts are sorted by priority, highest first.
+
+### Type `AlertPriority`
+Alerts are sorted by priority. Greater integers mean higher priorities.
+
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32).
 
 ### Type `AncestorsScoreSortKey`
 A struct as a sorted key for tx-pool

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,10 +99,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
@@ -117,12 +117,14 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `BlockEconomicState`](#type-blockeconomicstate)
     * [Type `BlockFilter`](#type-blockfilter)
     * [Type `BlockIssuance`](#type-blockissuance)
+    * [Type `BlockNumber`](#type-blocknumber)
     * [Type `BlockResponse`](#type-blockresponse)
     * [Type `BlockTemplate`](#type-blocktemplate)
     * [Type `BlockView`](#type-blockview)
     * [Type `BlockWithCyclesResponse`](#type-blockwithcyclesresponse)
     * [Type `Buried`](#type-buried)
     * [Type `Byte32`](#type-byte32)
+    * [Type `Capacity`](#type-capacity)
     * [Type `CellData`](#type-celldata)
     * [Type `CellDep`](#type-celldep)
     * [Type `CellInfo`](#type-cellinfo)
@@ -132,6 +134,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `CellbaseTemplate`](#type-cellbasetemplate)
     * [Type `ChainInfo`](#type-chaininfo)
     * [Type `Consensus`](#type-consensus)
+    * [Type `Cycle`](#type-cycle)
     * [Type `DaoWithdrawingCalculationKind`](#type-daowithdrawingcalculationkind)
     * [Type `DepType`](#type-deptype)
     * [Type `Deployment`](#type-deployment)
@@ -141,6 +144,8 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes)
     * [Type `Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes)
     * [Type `Either_for_TransactionView_and_JsonBytes`](#type-either_for_transactionview_and_jsonbytes)
+    * [Type `EpochNumber`](#type-epochnumber)
+    * [Type `EpochNumberWithFraction`](#type-epochnumberwithfraction)
     * [Type `EpochView`](#type-epochview)
     * [Type `EstimateCycles`](#type-estimatecycles)
     * [Type `ExtraLoggerConfig`](#type-extraloggerconfig)
@@ -190,6 +195,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `SoftForkStatus`](#type-softforkstatus)
     * [Type `Status`](#type-status)
     * [Type `SyncState`](#type-syncstate)
+    * [Type `Timestamp`](#type-timestamp)
     * [Type `Transaction`](#type-transaction)
     * [Type `TransactionAndWitnessProof`](#type-transactionandwitnessproof)
     * [Type `TransactionProof`](#type-transactionproof)
@@ -208,12 +214,13 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `UncleBlock`](#type-uncleblock)
     * [Type `UncleBlockView`](#type-uncleblockview)
     * [Type `UncleTemplate`](#type-uncletemplate)
+    * [Type `Version`](#type-version)
 * [RPC Errors](#rpc-errors)
 
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -279,7 +286,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -1919,7 +1926,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1965,7 +1972,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2119,7 +2126,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -3001,7 +3008,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3502,7 +3509,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3718,7 +3725,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4275,7 +4282,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4618,7 +4625,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5ff94076d47877fb5f2663a9a9ed76e9b9eea8eb/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -5032,6 +5039,12 @@ Block base rewards.
 
 * `secondary`: [`Uint64`](#type-uint64) - The secondary base rewards.
 
+### Type `BlockNumber`
+
+Consecutive block number starting from 0.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
+
 ### Type `BlockResponse`
 The wrapper represent response of `get_block` | `get_block_by_number`, return a Block with cycles.
 
@@ -5150,6 +5163,12 @@ Represent soft fork deployments where the activation epoch is hard-coded into th
 
 ### Type `Byte32`
 
+
+### Type `Capacity`
+
+The capacity of a cell is the value of the cell in Shannons. It is also the upper limit of the cell occupied storage size where every 100,000,000 Shannons give 1-byte storage.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
 
 ### Type `CellData`
 The cell data content and hash.
@@ -5404,13 +5423,19 @@ Consensus defines various parameters that influence chain consensus
 
 * `secondary_epoch_reward`: [`Uint64`](#type-uint64) - The secondary primary_epoch_reward
 
-* `softforks`: `object` - Softforks
+* `softforks`:  - `HashMap<DeploymentPos, SoftFork>` - Softforks
 
 * `tx_proposal_window`: [`ProposalWindow`](#type-proposalwindow) - The two-step-transaction-confirmation proposal window
 
 * `tx_version`: [`Uint32`](#type-uint32) - The tx version number supported
 
 * `type_id_code_hash`: [`H256`](#type-h256) - The "TYPE_ID" in hex
+
+### Type `Cycle`
+
+Count of cycles consumed by CKB VM to run scripts.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
 
 ### Type `DaoWithdrawingCalculationKind`
 An enum to represent the two kinds of dao withdrawal amount calculation option. `DaoWithdrawingCalculationKind` is equivalent to [`H256`] `|` [`OutPoint`].
@@ -5496,7 +5521,7 @@ Chain information.
 
 `DeploymentsInfo` is a JSON object with the following fields.
 
-* `deployments`: `object` - deployments info
+* `deployments`:  - `{ [ key:` [`DeploymentPos`](#type-deploymentpos) `]: ` [`DeploymentInfo`](#type-deploymentinfo) `}` deployments info
 
 * `epoch`: [`Uint64`](#type-uint64) - requested block epoch
 
@@ -5510,6 +5535,31 @@ The enum `Either` with variants `Left` and `Right` is a general purpose sum type
 
 ### Type `Either_for_TransactionView_and_JsonBytes`
 The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
+
+### Type `EpochNumber`
+Consecutive epoch number starting from 0.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](#type-uint64).
+
+### Type `EpochNumberWithFraction`
+
+The epoch indicator of a block. It shows which epoch the block is in, and the elapsed epoch fraction after adding this block.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
+
+The lower 56 bits of the epoch field are split into 3 parts (listed in the order from higher bits to lower bits):
+
+* The highest 16 bits represent the epoch length
+* The next 16 bits represent the current block index in the epoch, starting from 0.
+* The lowest 24 bits represent the current epoch number.
+
+Assume there's a block, which number is 11555 and in epoch 50. The epoch 50 starts from block
+11000 and have 1000 blocks. The epoch field for this particular block will then be 1,099,520,939,130,930,
+which is calculated in the following way:
+
+```text
+50 | ((11555 - 11000) << 24) | (1000 << 40)
+```
 
 ### Type `EpochView`
 JSON view of an epoch.
@@ -6387,6 +6437,14 @@ The overall chain synchronization state of this local node.
 
     If this number is too high, it indicates that block download has stuck at some block.
 
+### Type `Timestamp`
+
+The Unix timestamp in milliseconds (1 second is 1000 milliseconds).
+
+For example, 1588233578000 is Thu, 30 Apr 2020 07:59:38 +0000
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
+
 ### Type `Transaction`
 The transaction.
 
@@ -6570,9 +6628,9 @@ Tx-pool entries object
 
 `TxPoolEntries` is a JSON object with the following fields.
 
-* `pending`: `object` - Pending tx verbose info
+* `pending`:  - Pending tx verbose info
 
-* `proposed`: `object` - Proposed tx verbose info
+* `proposed`:  - Proposed tx verbose info
 
 ### Type `TxPoolEntry`
 Transaction entry info
@@ -6732,6 +6790,12 @@ The uncle block template of the new block for miners.
     Miners must keep this unchanged when including this uncle in the new block.
 
 * `required`: `boolean` - Whether miners must include this uncle in the submit block.
+
+### Type `Version`
+
+The simple increasing integer version.
+
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](type.Uint32.html#examples).
 
 
 ## RPC Errors

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,16 +99,15 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
 
     * [Type `Alert`](#type-alert)
-    * [Type `AlertId`](#type-alertid)
     * [Type `AlertMessage`](#type-alertmessage)
     * [Type `AncestorsScoreSortKey`](#type-ancestorsscoresortkey)
     * [Type `BannedAddr`](#type-bannedaddr)
@@ -198,6 +197,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `TxPoolInfo`](#type-txpoolinfo)
     * [Type `TxStatus`](#type-txstatus)
     * [Type `Uint128`](#type-uint128)
+    * [Type `Uint32`](#type-uint32)
     * [Type `Uint64`](#type-uint64)
     * [Type `UncleBlock`](#type-uncleblock)
     * [Type `UncleBlockView`](#type-uncleblockview)
@@ -207,7 +207,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -273,7 +273,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -302,7 +302,7 @@ and
 #### Method `get_block`
 * `get_block(block_hash, verbosity, with_cycles)`
     * `block_hash`: [`H256`](#type-h256)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
     * `with_cycles`: `boolean` `|` `null`
 * result: [`BlockResponse`](#type-blockresponse) `|` `null`
 
@@ -434,7 +434,7 @@ When specifying with_cycles, the response object will be different like below:
 #### Method `get_block_by_number`
 * `get_block_by_number(block_number, verbosity, with_cycles)`
     * `block_number`: [`Uint64`](#type-uint64)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
     * `with_cycles`: `boolean` `|` `null`
 * result: [`BlockResponse`](#type-blockresponse) `|` `null`
 
@@ -569,7 +569,7 @@ When specifying with_cycles, the response object will be different like below:
 #### Method `get_header`
 * `get_header(block_hash, verbosity)`
     * `block_hash`: [`H256`](#type-h256)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
 * result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes) `|` `null`
 
 Returns the information about a block header by hash.
@@ -648,7 +648,7 @@ The response looks like below when `verbosity` is 0.
 #### Method `get_header_by_number`
 * `get_header_by_number(block_number, verbosity)`
     * `block_number`: [`Uint64`](#type-uint64)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
 * result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes) `|` `null`
 
 Returns the block header in the [canonical chain](#canonical-chain) with the specific block
@@ -784,7 +784,7 @@ The response looks like below when the block have block filter.
 #### Method `get_transaction`
 * `get_transaction(tx_hash, verbosity, only_committed)`
     * `tx_hash`: [`H256`](#type-h256)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
     * `only_committed`: `boolean` `|` `null`
 * result: [`TransactionWithStatusResponse`](#type-transactionwithstatusresponse)
 
@@ -959,7 +959,7 @@ Response
 <a id="chain-get_tip_header"></a>
 #### Method `get_tip_header`
 * `get_tip_header(verbosity)`
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
 * result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes)
 
 Returns the header with the highest block number in the [canonical chain](#canonical-chain).
@@ -1487,7 +1487,7 @@ Response
 #### Method `get_fork_block`
 * `get_fork_block(block_hash, verbosity)`
     * `block_hash`: [`H256`](#type-h256)
-    * `verbosity`: [`AlertId`](#type-alertid) `|` `null`
+    * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
 * result: [`Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes) `|` `null`
 
 Returns the information about a fork block by hash.
@@ -1913,7 +1913,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1959,7 +1959,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2113,7 +2113,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -2159,7 +2159,7 @@ Response
 * `get_cells(search_key, order, limit, after)`
     * `search_key`: [`IndexerSearchKey`](#type-indexersearchkey)
     * `order`: [`IndexerOrder`](#type-indexerorder)
-    * `limit`: [`AlertId`](#type-alertid)
+    * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
 * result: [`IndexerPagination_for_IndexerCell`](#type-indexerpagination_for_indexercell)
 
@@ -2517,7 +2517,7 @@ Response
 * `get_transactions(search_key, order, limit, after)`
     * `search_key`: [`IndexerSearchKey`](#type-indexersearchkey)
     * `order`: [`IndexerOrder`](#type-indexerorder)
-    * `limit`: [`AlertId`](#type-alertid)
+    * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
 * result: [`IndexerPagination_for_IndexerTx`](#type-indexerpagination_for_indexertx)
 
@@ -2995,7 +2995,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3496,7 +3496,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3508,7 +3508,7 @@ submits the found new block.
 * `get_block_template(bytes_limit, proposals_limit, max_version)`
     * `bytes_limit`: [`Uint64`](#type-uint64) `|` `null`
     * `proposals_limit`: [`Uint64`](#type-uint64) `|` `null`
-    * `max_version`: [`AlertId`](#type-alertid) `|` `null`
+    * `max_version`: [`Uint32`](#type-uint32) `|` `null`
 * result: [`BlockTemplate`](#type-blocktemplate)
 
 Returns block template for miners.
@@ -3712,7 +3712,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4269,7 +4269,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4612,7 +4612,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/5d696307edb59dfa198fb78800ae14588d4bafd8/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -4900,32 +4900,29 @@ An example in JSON
 ```
 
 #### Fields:
-* `cancel`: [`AlertId`](#type-alertid) - Cancel a previous sent alert.
+* `cancel`: [`Uint32`](#type-uint32) - Cancel a previous sent alert.
 
-* `id`: [`AlertId`](#type-alertid) - The identifier of the alert. Clients use id to filter duplicated alerts.
+* `id`: [`Uint32`](#type-uint32) - The identifier of the alert. Clients use id to filter duplicated alerts.
 
 * `message`: `string` - Alert message.
 
 * `notice_until`: [`Uint64`](#type-uint64) - The alert is expired after this timestamp.
 
-* `priority`: [`AlertId`](#type-alertid) - Alerts are sorted by priority, highest first.
+* `priority`: [`Uint32`](#type-uint32) - Alerts are sorted by priority, highest first.
 
 * `signatures`: `Array<` [`JsonBytes`](#type-jsonbytes) `>` - The list of required signatures.
-
-### Type `AlertId`
-`AlertId` is `uint32`
 
 ### Type `AlertMessage`
 An alert sent by RPC `send_alert`.
 
 #### Fields:
-* `id`: [`AlertId`](#type-alertid) - The unique alert ID.
+* `id`: [`Uint32`](#type-uint32) - The unique alert ID.
 
 * `message`: `string` - Alert message.
 
 * `notice_until`: [`Uint64`](#type-uint64) - The alert is expired after this timestamp.
 
-* `priority`: [`AlertId`](#type-alertid) - Alerts are sorted by priority, highest first.
+* `priority`: [`Uint32`](#type-uint32) - Alerts are sorted by priority, highest first.
 
 ### Type `AncestorsScoreSortKey`
 A struct as a sorted key for tx-pool
@@ -5014,7 +5011,7 @@ Miners optional pick transactions and then assemble the final block.
 
     Miners must use it as the cellbase transaction without changes in the assembled block.
 
-* `compact_target`: [`AlertId`](#type-alertid) - The compacted difficulty target for the new block.
+* `compact_target`: [`Uint32`](#type-uint32) - The compacted difficulty target for the new block.
 
     Miners must use it unchanged in the assembled block.
 
@@ -5065,7 +5062,7 @@ Miners optional pick transactions and then assemble the final block.
 
     Miners must keep the uncles count below this limit, otherwise, the CKB node will reject the block submission.
 
-* `version`: [`AlertId`](#type-alertid) - Block version.
+* `version`: [`Uint32`](#type-uint32) - Block version.
 
     Miners must use it unchanged in the assembled block.
 
@@ -5292,7 +5289,7 @@ Chain information.
 Consensus defines various parameters that influence chain consensus
 
 #### Fields:
-* `block_version`: [`AlertId`](#type-alertid) - The block version number supported
+* `block_version`: [`Uint32`](#type-uint32) - The block version number supported
 
 * `cellbase_maturity`: [`Uint64`](#type-uint64) - The Cellbase maturity
 
@@ -5332,7 +5329,7 @@ Consensus defines various parameters that influence chain consensus
 
 * `tx_proposal_window`: [`ProposalWindow`](#type-proposalwindow) - The two-step-transaction-confirmation proposal window
 
-* `tx_version`: [`AlertId`](#type-alertid) - The tx version number supported
+* `tx_version`: [`Uint32`](#type-uint32) - The tx version number supported
 
 * `type_id_code_hash`: [`H256`](#type-h256) - The "TYPE_ID" in hex
 
@@ -5426,7 +5423,7 @@ CKB adjusts difficulty based on epochs.
 ```
 
 #### Fields:
-* `compact_target`: [`AlertId`](#type-alertid) - The difficulty target for any block in this epoch.
+* `compact_target`: [`Uint32`](#type-uint32) - The difficulty target for any block in this epoch.
 
 * `length`: [`Uint64`](#type-uint64) - The number of blocks in this epoch.
 
@@ -5489,7 +5486,7 @@ The block header.
 Refer to RFC [CKB Block Structure](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0027-block-structure/0027-block-structure.md).
 
 #### Fields:
-* `compact_target`: [`AlertId`](#type-alertid) - The block difficulty target.
+* `compact_target`: [`Uint32`](#type-uint32) - The block difficulty target.
 
     It can be converted to a 256-bit target. Miners must ensure the Eaglesong of the header is within the target.
 
@@ -5534,7 +5531,7 @@ Refer to RFC [CKB Block Structure](https://github.com/nervosnetwork/rfcs/blob/ma
     * The root of a CKB Merkle Tree, which items are the transaction hashes of all the transactions in the block.
     * The root of a CKB Merkle Tree, but the items are the transaction witness hashes of all the transactions in the block.
 
-* `version`: [`AlertId`](#type-alertid) - The block version.
+* `version`: [`Uint32`](#type-uint32) - The block version.
 
     It must equal to 0 now and is reserved for future upgrades.
 
@@ -5564,7 +5561,7 @@ This structure is serialized into a JSON object with field `hash` and all the fi
 ```
 
 #### Fields:
-* `compact_target`: [`AlertId`](#type-alertid) - The block difficulty target.
+* `compact_target`: [`Uint32`](#type-uint32) - The block difficulty target.
 
     It can be converted to a 256-bit target. Miners must ensure the Eaglesong of the header is within the target.
 
@@ -5611,7 +5608,7 @@ This structure is serialized into a JSON object with field `hash` and all the fi
     * The root of a CKB Merkle Tree, which items are the transaction hashes of all the transactions in the block.
     * The root of a CKB Merkle Tree, but the items are the transaction witness hashes of all the transactions in the block.
 
-* `version`: [`AlertId`](#type-alertid) - The block version.
+* `version`: [`Uint32`](#type-uint32) - The block version.
 
     It must equal to 0 now and is reserved for future upgrades.
 
@@ -5625,7 +5622,7 @@ Live cell
 
 * `output`: [`CellOutput`](#type-celloutput) - the fields of an output cell
 
-* `tx_index`: [`AlertId`](#type-alertid) - the position index of the transaction committed in the block
+* `tx_index`: [`Uint32`](#type-uint32) - the position index of the transaction committed in the block
 
 ### Type `IndexerCellType`
 Cell type
@@ -5693,13 +5690,13 @@ Ungrouped Tx inner type
 #### Fields:
 * `block_number`: [`Uint64`](#type-uint64) - the number of the transaction committed in the block
 
-* `io_index`: [`AlertId`](#type-alertid) - the position index of the cell in the transaction inputs or outputs
+* `io_index`: [`Uint32`](#type-uint32) - the position index of the cell in the transaction inputs or outputs
 
 * `io_type`: [`IndexerCellType`](#type-indexercelltype) - io type
 
 * `tx_hash`: [`H256`](#type-h256) - transaction hash
 
-* `tx_index`: [`AlertId`](#type-alertid) - the position index of the transaction committed in the block
+* `tx_index`: [`Uint32`](#type-uint32) - the position index of the transaction committed in the block
 
 ### Type `IndexerTxWithCells`
 Grouped Tx inner type
@@ -5707,11 +5704,11 @@ Grouped Tx inner type
 #### Fields:
 * `block_number`: [`Uint64`](#type-uint64) - the number of the transaction committed in the block
 
-* `cells`: `Array<` ([`IndexerCellType`](#type-indexercelltype) , [`AlertId`](#type-alertid)) `>` - Array [(io_type, io_index)]
+* `cells`: `Array<` ([`IndexerCellType`](#type-indexercelltype) , [`Uint32`](#type-uint32)) `>` - Array [(io_type, io_index)]
 
 * `tx_hash`: [`H256`](#type-h256) - transaction hash
 
-* `tx_index`: [`AlertId`](#type-alertid) - the position index of the transaction committed in the block
+* `tx_index`: [`Uint32`](#type-uint32) - the position index of the transaction committed in the block
 
 ### Type `JsonBytes`
 
@@ -5798,7 +5795,7 @@ Proof of CKB Merkle Tree.
 CKB Merkle Tree is a [CBMT](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0006-merkle-tree/0006-merkle-tree.md) using CKB blake2b hash as the merge function.
 
 #### Fields:
-* `indices`: `Array<` [`AlertId`](#type-alertid) `>` - Leaves indices in the CBMT that are proved present in the block.
+* `indices`: `Array<` [`Uint32`](#type-uint32) `>` - Leaves indices in the CBMT that are proved present in the block.
 
     These are indices in the CBMT tree not the transaction indices in the block.
 
@@ -5847,7 +5844,7 @@ Reference to a cell via transaction hash and output index.
 ```
 
 #### Fields:
-* `index`: [`AlertId`](#type-alertid) - The output index of the cell in the transaction specified by `tx_hash`.
+* `index`: [`Uint32`](#type-uint32) - The output index of the cell in the transaction specified by `tx_hash`.
 
 * `tx_hash`: [`H256`](#type-h256) - Transaction hash in which the cell is an output.
 
@@ -6135,7 +6132,7 @@ Refer to RFC [CKB Transaction Structure](https://github.com/nervosnetwork/rfcs/b
 
     This is a parallel array of outputs. The cell capacity, lock, and type of the output i is `outputs[i]` and its data is `outputs_data[i]`.
 
-* `version`: [`AlertId`](#type-alertid) - Reserved for future usage. It must equal 0 in current version.
+* `version`: [`Uint32`](#type-uint32) - Reserved for future usage. It must equal 0 in current version.
 
 * `witnesses`: `Array<` [`JsonBytes`](#type-jsonbytes) `>` - An array of variable-length binaries.
 
@@ -6251,7 +6248,7 @@ This structure is serialized into a JSON object with field `hash` and all the fi
 
     This is a parallel array of outputs. The cell capacity, lock, and type of the output i is `outputs[i]` and its data is `outputs_data[i]`.
 
-* `version`: [`AlertId`](#type-alertid) - Reserved for future usage. It must equal 0 in current version.
+* `version`: [`Uint32`](#type-uint32) - Reserved for future usage. It must equal 0 in current version.
 
 * `witnesses`: `Array<` [`JsonBytes`](#type-jsonbytes) `>` - An array of variable-length binaries.
 
@@ -6351,6 +6348,9 @@ Transaction status and the block hash if it is committed.
 
 ### Type `Uint128`
 `Uint128` is `uint128`
+
+### Type `Uint32`
+`Uint32` is `uint64`
 
 ### Type `Uint64`
 `Uint64` is `uint64`

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,10 +99,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
@@ -212,7 +212,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -278,7 +278,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -1918,7 +1918,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1964,7 +1964,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2118,7 +2118,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -3000,7 +3000,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3501,7 +3501,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3717,7 +3717,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4274,7 +4274,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4617,7 +4617,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/6fa715b681ea79469e6988236012fd567e1f5439/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/bede8783d07523bf1d5b77da0af6d8164c2570de/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -5817,6 +5817,17 @@ SearchKey represent indexer support params
 ### Type `IndexerSearchKeyFilter`
 IndexerSearchKeyFilter represent indexer params `filter`
 
+#### Fields
+
+`IndexerSearchKeyFilter` is a JSON object with the following fields.
+
+* `block_range`: [`Uint64`](#type-uint64) filter cells by block number range
+* `output_capacity_range`: [`Uint64`](#type-uint64) filter cells by output capacity range
+* `output_data`: [`JsonBytes`](#type-jsonbytes) `|` `null` filter cells by output data
+* `output_data_filter_mode`: [`IndexerSearchMode`](#type-indexersearchmode) `|` `null` output data filter mode, optional default is `prefix`
+* `output_data_len_range`: [`Uint64`](#type-uint64) filter cells by output data len range
+* `script`: [`Script`](#type-script) `|` `null` if search script type is lock, filter cells by type script prefix, and vice versa
+* `script_len_range`: [`Uint64`](#type-uint64) filter cells by script len range
 ### Type `IndexerSearchMode`
 IndexerSearchMode represent search mode, default is prefix search
 
@@ -5956,6 +5967,36 @@ The information of a P2P protocol that is supported by the local node.
 ### Type `MainLoggerConfig`
 Runtime logger config.
 
+#### Fields
+
+`MainLoggerConfig` is a JSON object with the following fields.
+
+* `color`: `boolean` `|` `null` Whether using color when printing the logs to the process stdout.
+
+    `null` means keeping the current option unchanged.
+* `filter`: `string` `|` `null` Sets log levels for different modules.
+
+    `null` means keeping the current option unchanged.
+
+    ## Examples
+
+    Set the log level to info for all modules
+
+    ```text
+    info
+    ```
+
+    Set the log level to debug for listed modules and info for other modules.
+
+    ```text
+    info,ckb-rpc=debug,ckb-sync=debug,ckb-relay=debug,ckb-tx-pool=debug,ckb-network=debug
+    ```
+* `to_file`: `boolean` `|` `null` Whether appending the logs to the log file.
+
+    `null` means keeping the current option unchanged.
+* `to_stdout`: `boolean` `|` `null` Whether printing the logs to the process stdout.
+
+    `null` means keeping the current option unchanged.
 ### Type `MerkleProof`
 Proof of CKB Merkle Tree.
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -31,9 +31,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
 * [RPC Methods](#rpc-methods)
 
-    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/alert_rpc_doc.json)
+    * [Module Alert](#module-alert) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/alert_rpc_doc.json)
         * [Method `send_alert`](#alert-send_alert)
-    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/chain_rpc_doc.json)
+    * [Module Chain](#module-chain) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/chain_rpc_doc.json)
         * [Method `get_block`](#chain-get_block)
         * [Method `get_block_by_number`](#chain-get_block_by_number)
         * [Method `get_header`](#chain-get_header)
@@ -57,19 +57,19 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `estimate_cycles`](#chain-estimate_cycles)
         * [Method `get_fee_rate_statics`](#chain-get_fee_rate_statics)
         * [Method `get_fee_rate_statistics`](#chain-get_fee_rate_statistics)
-    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/debug_rpc_doc.json)
+    * [Module Debug](#module-debug) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/debug_rpc_doc.json)
         * [Method `jemalloc_profiling_dump`](#debug-jemalloc_profiling_dump)
         * [Method `update_main_logger`](#debug-update_main_logger)
         * [Method `set_extra_logger`](#debug-set_extra_logger)
-    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/experiment_rpc_doc.json)
+    * [Module Experiment](#module-experiment) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/experiment_rpc_doc.json)
         * [Method `dry_run_transaction`](#experiment-dry_run_transaction)
         * [Method `calculate_dao_maximum_withdraw`](#experiment-calculate_dao_maximum_withdraw)
-    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/indexer_rpc_doc.json)
+    * [Module Indexer](#module-indexer) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/indexer_rpc_doc.json)
         * [Method `get_indexer_tip`](#indexer-get_indexer_tip)
         * [Method `get_cells`](#indexer-get_cells)
         * [Method `get_transactions`](#indexer-get_transactions)
         * [Method `get_cells_capacity`](#indexer-get_cells_capacity)
-    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/integration_test_rpc_doc.json)
+    * [Module Integration_test](#module-integration_test) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/integration_test_rpc_doc.json)
         * [Method `process_block_without_verify`](#integration_test-process_block_without_verify)
         * [Method `truncate`](#integration_test-truncate)
         * [Method `generate_block`](#integration_test-generate_block)
@@ -77,10 +77,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `notify_transaction`](#integration_test-notify_transaction)
         * [Method `generate_block_with_template`](#integration_test-generate_block_with_template)
         * [Method `calculate_dao_field`](#integration_test-calculate_dao_field)
-    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/miner_rpc_doc.json)
+    * [Module Miner](#module-miner) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/miner_rpc_doc.json)
         * [Method `get_block_template`](#miner-get_block_template)
         * [Method `submit_block`](#miner-submit_block)
-    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/net_rpc_doc.json)
+    * [Module Net](#module-net) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/net_rpc_doc.json)
         * [Method `local_node_info`](#net-local_node_info)
         * [Method `get_peers`](#net-get_peers)
         * [Method `get_banned_addresses`](#net-get_banned_addresses)
@@ -91,7 +91,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `add_node`](#net-add_node)
         * [Method `remove_node`](#net-remove_node)
         * [Method `ping_peers`](#net-ping_peers)
-    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/pool_rpc_doc.json)
+    * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/pool_rpc_doc.json)
         * [Method `send_transaction`](#pool-send_transaction)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -99,10 +99,10 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
-    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/stats_rpc_doc.json)
+    * [Module Stats](#module-stats) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/stats_rpc_doc.json)
         * [Method `get_blockchain_info`](#stats-get_blockchain_info)
         * [Method `get_deployments_info`](#stats-get_deployments_info)
-    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/subscription_rpc_doc.json)
+    * [Module Subscription](#module-subscription) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Subscription&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/subscription_rpc_doc.json)
         * [Method `subscribe`](#subscription-subscribe)
         * [Method `unsubscribe`](#subscription-unsubscribe)
 * [RPC Types](#rpc-types)
@@ -176,12 +176,15 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `ProposalShortId`](#type-proposalshortid)
     * [Type `ProposalWindow`](#type-proposalwindow)
     * [Type `Ratio`](#type-ratio)
+    * [Type `RationalU256`](#type-rationalu256)
     * [Type `RawTxPool`](#type-rawtxpool)
     * [Type `RemoteNode`](#type-remotenode)
     * [Type `RemoteNodeProtocol`](#type-remotenodeprotocol)
     * [Type `Rfc0043`](#type-rfc0043)
     * [Type `Script`](#type-script)
     * [Type `ScriptHashType`](#type-scripthashtype)
+    * [Type `SerializedBlock`](#type-serializedblock)
+    * [Type `SerializedHeader`](#type-serializedheader)
     * [Type `SoftFork`](#type-softfork)
     * [Type `SoftForkStatus`](#type-softforkstatus)
     * [Type `Status`](#type-status)
@@ -197,6 +200,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `TxPoolIds`](#type-txpoolids)
     * [Type `TxPoolInfo`](#type-txpoolinfo)
     * [Type `TxStatus`](#type-txstatus)
+    * [Type `U256`](#type-u256)
     * [Type `Uint128`](#type-uint128)
     * [Type `Uint32`](#type-uint32)
     * [Type `Uint64`](#type-uint64)
@@ -208,7 +212,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 ## RPC Modules
 
 ### Module `Alert`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/alert_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Alert&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/alert_rpc_doc.json)
 
 RPC Module Alert for network alerts.
 
@@ -274,7 +278,7 @@ Response
 ```
 
 ### Module `Chain`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/chain_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Chain&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/chain_rpc_doc.json)
 
 RPC Module Chain for methods related to the canonical chain.
 
@@ -1914,7 +1918,7 @@ Response
 ```
 
 ### Module `Debug`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/debug_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Debug&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/debug_rpc_doc.json)
 
 RPC Module Debug for internal RPC methods.
 
@@ -1960,7 +1964,7 @@ they only append logs to their log files.
 Removes the logger when this is null.
 
 ### Module `Experiment`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/experiment_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Experiment&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/experiment_rpc_doc.json)
 
 RPC Module Experiment for experimenting methods.
 
@@ -2114,7 +2118,7 @@ Response
 ```
 
 ### Module `Indexer`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/indexer_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Indexer&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/indexer_rpc_doc.json)
 
 RPC Module Indexer.
 
@@ -2996,7 +3000,7 @@ Response
 ```
 
 ### Module `Integration_test`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/integration_test_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Integration_test&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/integration_test_rpc_doc.json)
 
 RPC for Integration Test.
 
@@ -3497,7 +3501,7 @@ Response
 ```
 
 ### Module `Miner`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/miner_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Miner&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/miner_rpc_doc.json)
 
 RPC Module Miner for miners.
 
@@ -3713,7 +3717,7 @@ Response
 ```
 
 ### Module `Net`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/net_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Net&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/net_rpc_doc.json)
 
 RPC Module Net for P2P network.
 
@@ -4270,7 +4274,7 @@ Response
 ```
 
 ### Module `Pool`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/pool_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/pool_rpc_doc.json)
 
 RPC Module Pool for transaction memory pool.
 
@@ -4613,7 +4617,7 @@ Response
 ```
 
 ### Module `Stats`
-- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/2e81f841216d4cf493a82e285a42f5f21206a5f0/json/stats_rpc_doc.json)
+- [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Stats&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/main/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/cryptape/ckb-rpc-resources/79197fb1524e32c2b7317763c86c4d9dd0b74aa9/json/stats_rpc_doc.json)
 
 RPC Module Stats for getting various statistic data.
 
@@ -4917,7 +4921,9 @@ An example in JSON
 * `signatures`: `Array<` [`JsonBytes`](#type-jsonbytes) `>` - The list of required signatures.
 
 ### Type `AlertId`
+The alert identifier that is used to filter duplicated alerts.
 
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32).
 
 ### Type `AlertMessage`
 An alert sent by RPC `send_alert`.
@@ -6074,6 +6080,9 @@ Represents the ratio `numerator / denominator`, where `numerator` and `denominat
 
 * `numer`: [`Uint64`](#type-uint64) - Numerator.
 
+### Type `RationalU256`
+The ratio which numerator and denominator are both 256-bit unsigned integers.
+
 ### Type `RawTxPool`
 All transactions in tx-pool.
 
@@ -6225,6 +6234,12 @@ Allowed kinds: "data", "type", "data1" and "data2"
 Refer to the section [Code Locating](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#code-locating) and [Upgradable Script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#upgradable-script) in the RFC *CKB Transaction Structure*.
 
 The hash type is split into the high 7 bits and the low 1 bit, when the low 1 bit is 1, it indicates the type, when the low 1 bit is 0, it indicates the data, and then it relies on the high 7 bits to indicate that the data actually corresponds to the version.
+
+### Type `SerializedBlock`
+This is a 0x-prefix hex string. It is the block serialized by molecule using the schema `table Block`.
+
+### Type `SerializedHeader`
+This is a 0x-prefix hex string. It is the block header serialized by molecule using the schema `table Header`.
 
 ### Type `SoftFork`
 SoftFork information
@@ -6545,11 +6560,14 @@ Transaction status and the block hash if it is committed.
 
 * `status`: [`Status`](#type-status) - The transaction status, allowed values: "pending", "proposed" "committed" "unknown" and "rejected".
 
+### Type `U256`
+The 256-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON.
+
 ### Type `Uint128`
 `Uint128` is `uint128`
 
 ### Type `Uint32`
-`Uint32` is `uint64`
+`Uint32` is `uint32`
 
 ### Type `Uint64`
 `Uint64` is `uint64`

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -108,6 +108,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 * [RPC Types](#rpc-types)
 
     * [Type `Alert`](#type-alert)
+    * [Type `AlertId`](#type-alertid)
     * [Type `AlertMessage`](#type-alertmessage)
     * [Type `AncestorsScoreSortKey`](#type-ancestorsscoresortkey)
     * [Type `BannedAddr`](#type-bannedaddr)
@@ -4899,7 +4900,10 @@ An example in JSON
  }
 ```
 
-#### Fields:
+#### Fields
+
+`Alert` is a JSON object with the following fields.
+
 * `cancel`: [`Uint32`](#type-uint32) - Cancel a previous sent alert.
 
 * `id`: [`Uint32`](#type-uint32) - The identifier of the alert. Clients use id to filter duplicated alerts.
@@ -4912,10 +4916,16 @@ An example in JSON
 
 * `signatures`: `Array<` [`JsonBytes`](#type-jsonbytes) `>` - The list of required signatures.
 
+### Type `AlertId`
+
+
 ### Type `AlertMessage`
 An alert sent by RPC `send_alert`.
 
-#### Fields:
+#### Fields
+
+`AlertMessage` is a JSON object with the following fields.
+
 * `id`: [`Uint32`](#type-uint32) - The unique alert ID.
 
 * `message`: `string` - Alert message.
@@ -4927,7 +4937,10 @@ An alert sent by RPC `send_alert`.
 ### Type `AncestorsScoreSortKey`
 A struct as a sorted key for tx-pool
 
-#### Fields:
+#### Fields
+
+`AncestorsScoreSortKey` is a JSON object with the following fields.
+
 * `ancestors_fee`: [`Uint64`](#type-uint64) - Ancestors fee
 
 * `ancestors_weight`: [`Uint64`](#type-uint64) - Ancestors weight
@@ -4939,7 +4952,10 @@ A struct as a sorted key for tx-pool
 ### Type `BannedAddr`
 A banned P2P address.
 
-#### Fields:
+#### Fields
+
+`BannedAddr` is a JSON object with the following fields.
+
 * `address`: `string` - The P2P address.
 
     Example: "/ip4/192.168.0.2/tcp/8112/p2p/QmTRHCdrRtgUzYLNCin69zEvPvLYdxUZLLfLYyHVY3DZAS"
@@ -4953,7 +4969,10 @@ A banned P2P address.
 ### Type `Block`
 The JSON view of a Block used as a parameter in the RPC.
 
-#### Fields:
+#### Fields
+
+`Block` is a JSON object with the following fields.
+
 * `header`: [`Header`](#type-header) - The block header.
 
 * `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - The proposal IDs in the block body.
@@ -4967,7 +4986,10 @@ Block Economic State.
 
 It includes the rewards details and when it is finalized.
 
-#### Fields:
+#### Fields
+
+`BlockEconomicState` is a JSON object with the following fields.
+
 * `finalized_at`: [`H256`](#type-h256) - The block hash of the block which creates the rewards as cells in its cellbase transaction.
 
 * `issuance`: [`BlockIssuance`](#type-blockissuance) - Block base rewards.
@@ -4979,7 +5001,10 @@ It includes the rewards details and when it is finalized.
 ### Type `BlockFilter`
 Block filter data and hash.
 
-#### Fields:
+#### Fields
+
+`BlockFilter` is a JSON object with the following fields.
+
 * `data`: [`JsonBytes`](#type-jsonbytes) - The the hex-encoded filter data of the block
 
 * `hash`: [`Byte32`](#type-byte32) - The filter hash, blake2b hash of the parent block filter hash and the filter data, blake2b(parent_block_filter_hash | current_block_filter_data)
@@ -4987,7 +5012,10 @@ Block filter data and hash.
 ### Type `BlockIssuance`
 Block base rewards.
 
-#### Fields:
+#### Fields
+
+`BlockIssuance` is a JSON object with the following fields.
+
 * `primary`: [`Uint64`](#type-uint64) - The primary base rewards.
 
 * `secondary`: [`Uint64`](#type-uint64) - The secondary base rewards.
@@ -5000,7 +5028,10 @@ A block template for miners.
 
 Miners optional pick transactions and then assemble the final block.
 
-#### Fields:
+#### Fields
+
+`BlockTemplate` is a JSON object with the following fields.
+
 * `bytes_limit`: [`Uint64`](#type-uint64) - The block serialized size limit.
 
     Miners must keep the block size below this limit, otherwise, the CKB node will reject the block submission.
@@ -5071,7 +5102,10 @@ Miners optional pick transactions and then assemble the final block.
 ### Type `BlockView`
 The JSON view of a Block including header and body.
 
-#### Fields:
+#### Fields
+
+`BlockView` is a JSON object with the following fields.
+
 * `header`: [`HeaderView`](#type-headerview) - The block header.
 
 * `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - The proposal IDs in the block body.
@@ -5083,13 +5117,19 @@ The JSON view of a Block including header and body.
 ### Type `BlockWithCyclesResponse`
 BlockResponse with cycles format wrapper
 
-#### Fields:
+#### Fields
+
+`BlockWithCyclesResponse` is a JSON object with the following fields.
+
 * `block`: [`Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes) - The block structure
 
 ### Type `Buried`
 Represent soft fork deployments where the activation epoch is hard-coded into the client implementation
 
-#### Fields:
+#### Fields
+
+`Buried` is a JSON object with the following fields.
+
 * `active`: `boolean` - Whether the rules are active
 
 * `epoch`: [`Uint64`](#type-uint64) - The first epoch which the rules will be enforced
@@ -5111,7 +5151,10 @@ The cell data content and hash.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellData` is a JSON object with the following fields.
+
 * `content`: [`JsonBytes`](#type-jsonbytes) - Cell content.
 
 * `hash`: [`H256`](#type-h256) - Cell content hash.
@@ -5131,7 +5174,10 @@ The cell dependency of a transaction.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellDep` is a JSON object with the following fields.
+
 * `dep_type`: [`DepType`](#type-deptype) - Dependency type.
 
 * `out_point`: [`OutPoint`](#type-outpoint) - Reference to the cell.
@@ -5159,7 +5205,10 @@ The JSON view of a cell combining the fields in cell output and cell data.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellInfo` is a JSON object with the following fields.
+
 * `output`: [`CellOutput`](#type-celloutput) - Cell fields appears in the transaction `outputs` array.
 
 ### Type `CellInput`
@@ -5177,7 +5226,10 @@ The input cell of a transaction.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellInput` is a JSON object with the following fields.
+
 * `previous_output`: [`OutPoint`](#type-outpoint) - Reference to the input cell.
 
 * `since`: [`Uint64`](#type-uint64) - Restrict when the transaction can be committed into the chain.
@@ -5201,7 +5253,10 @@ The fields of an output cell except the cell data.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellOutput` is a JSON object with the following fields.
+
 * `capacity`: [`Uint64`](#type-uint64) - The cell capacity.
 
     The capacity of a cell is the value of the cell in Shannons. It is also the upper limit of the cell occupied storage size where every 100,000,000 Shannons give 1-byte storage.
@@ -5241,7 +5296,10 @@ The JSON view of a cell with its status information.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`CellWithStatus` is a JSON object with the following fields.
+
 * `status`: `string` - Status of the cell.
 
     Allowed values: "live", "dead", "unknown".
@@ -5253,7 +5311,10 @@ The JSON view of a cell with its status information.
 ### Type `CellbaseTemplate`
 The cellbase transaction template of the new block for miners.
 
-#### Fields:
+#### Fields
+
+`CellbaseTemplate` is a JSON object with the following fields.
+
 * `data`: [`Transaction`](#type-transaction) - The cellbase transaction.
 
 * `hash`: [`H256`](#type-h256) - The cellbase transaction hash.
@@ -5261,7 +5322,10 @@ The cellbase transaction template of the new block for miners.
 ### Type `ChainInfo`
 Chain information.
 
-#### Fields:
+#### Fields
+
+`ChainInfo` is a JSON object with the following fields.
+
 * `alerts`: `Array<` [`AlertMessage`](#type-alertmessage) `>` - Active alerts stored in the local node.
 
 * `chain`: `string` - The network name.
@@ -5288,7 +5352,10 @@ Chain information.
 ### Type `Consensus`
 Consensus defines various parameters that influence chain consensus
 
-#### Fields:
+#### Fields
+
+`Consensus` is a JSON object with the following fields.
+
 * `block_version`: [`Uint32`](#type-uint32) - The block version number supported
 
 * `cellbase_maturity`: [`Uint64`](#type-uint64) - The Cellbase maturity
@@ -5345,7 +5412,10 @@ The dep cell type. Allowed values: "code" and "dep_group".
 ### Type `Deployment`
 RFC0043 deployment params
 
-#### Fields:
+#### Fields
+
+`Deployment` is a JSON object with the following fields.
+
 * `bit`: `integer` - Determines which bit in the `version` field of the block is to be used to signal the softfork lock-in and activation. It is chosen from the set {0,1,2,...,28}.
 
 * `min_activation_epoch`: [`Uint64`](#type-uint64) - Specifies the epoch at which the softfork is allowed to become active.
@@ -5361,7 +5431,10 @@ RFC0043 deployment params
 ### Type `DeploymentInfo`
 An object containing various state info regarding deployments of consensus changes
 
-#### Fields:
+#### Fields
+
+`DeploymentInfo` is a JSON object with the following fields.
+
 * `bit`: `integer` - determines which bit in the `version` field of the block is to be used to signal the softfork lock-in and activation. It is chosen from the set {0,1,2,...,28}.
 
 * `min_activation_epoch`: [`Uint64`](#type-uint64) - specifies the epoch at which the softfork is allowed to become active.
@@ -5390,7 +5463,10 @@ The possible softfork deployment state
 ### Type `DeploymentsInfo`
 Chain information.
 
-#### Fields:
+#### Fields
+
+`DeploymentsInfo` is a JSON object with the following fields.
+
 * `deployments`: `object` - deployments info
 
 * `epoch`: [`Uint64`](#type-uint64) - requested block epoch
@@ -5422,7 +5498,10 @@ CKB adjusts difficulty based on epochs.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`EpochView` is a JSON object with the following fields.
+
 * `compact_target`: [`Uint32`](#type-uint32) - The difficulty target for any block in this epoch.
 
 * `length`: [`Uint64`](#type-uint64) - The number of blocks in this epoch.
@@ -5436,13 +5515,19 @@ CKB adjusts difficulty based on epochs.
 ### Type `EstimateCycles`
 Response result of the RPC method `estimate_cycles`.
 
-#### Fields:
+#### Fields
+
+`EstimateCycles` is a JSON object with the following fields.
+
 * `cycles`: [`Uint64`](#type-uint64) - The count of cycles that the VM has consumed to verify this transaction.
 
 ### Type `ExtraLoggerConfig`
 Runtime logger config for extra loggers.
 
-#### Fields:
+#### Fields
+
+`ExtraLoggerConfig` is a JSON object with the following fields.
+
 * `filter`: `string` - Sets log levels for different modules.
 
     **Examples**
@@ -5462,7 +5547,10 @@ Runtime logger config for extra loggers.
 ### Type `FeeRateStatistics`
 The fee_rate statistics information, includes mean and median, unit: shannons per kilo-weight
 
-#### Fields:
+#### Fields
+
+`FeeRateStatistics` is a JSON object with the following fields.
+
 * `mean`: [`Uint64`](#type-uint64) - mean
 
 * `median`: [`Uint64`](#type-uint64) - median
@@ -5477,7 +5565,10 @@ In JSONRPC, it is encoded as a 0x-prefixed hex string.
 ### Type `HardForkFeature`
 The information about one hardfork feature.
 
-#### Fields:
+#### Fields
+
+`HardForkFeature` is a JSON object with the following fields.
+
 * `rfc`: `string` - The related RFC ID.
 
 ### Type `Header`
@@ -5485,7 +5576,10 @@ The block header.
 
 Refer to RFC [CKB Block Structure](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0027-block-structure/0027-block-structure.md).
 
-#### Fields:
+#### Fields
+
+`Header` is a JSON object with the following fields.
+
 * `compact_target`: [`Uint32`](#type-uint32) - The block difficulty target.
 
     It can be converted to a 256-bit target. Miners must ensure the Eaglesong of the header is within the target.
@@ -5560,7 +5654,10 @@ This structure is serialized into a JSON object with field `hash` and all the fi
  }
 ```
 
-#### Fields:
+#### Fields
+
+`HeaderView` is a JSON object with the following fields.
+
 * `compact_target`: [`Uint32`](#type-uint32) - The block difficulty target.
 
     It can be converted to a 256-bit target. Miners must ensure the Eaglesong of the header is within the target.
@@ -5615,7 +5712,10 @@ This structure is serialized into a JSON object with field `hash` and all the fi
 ### Type `IndexerCell`
 Live cell
 
-#### Fields:
+#### Fields
+
+`IndexerCell` is a JSON object with the following fields.
+
 * `block_number`: [`Uint64`](#type-uint64) - the number of the transaction committed in the block
 
 * `out_point`: [`OutPoint`](#type-outpoint) - reference to a cell via transaction hash and output index
@@ -5630,7 +5730,10 @@ Cell type
 ### Type `IndexerCellsCapacity`
 Cells capacity
 
-#### Fields:
+#### Fields
+
+`IndexerCellsCapacity` is a JSON object with the following fields.
+
 * `block_hash`: [`H256`](#type-h256) - indexed tip block hash
 
 * `block_number`: [`Uint64`](#type-uint64) - indexed tip block number
@@ -5643,7 +5746,10 @@ Order Desc | Asc
 ### Type `IndexerPagination_for_IndexerCell`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
-#### Fields:
+#### Fields
+
+`IndexerPagination_for_IndexerCell` is a JSON object with the following fields.
+
 * `last_cursor`: [`JsonBytes`](#type-jsonbytes) - pagination parameter
 
 * `objects`: `Array<` [`IndexerCell`](#type-indexercell) `>` - objects collection
@@ -5651,7 +5757,10 @@ IndexerPagination wraps objects array and last_cursor to provide paging
 ### Type `IndexerPagination_for_IndexerTx`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
-#### Fields:
+#### Fields
+
+`IndexerPagination_for_IndexerTx` is a JSON object with the following fields.
+
 * `last_cursor`: [`JsonBytes`](#type-jsonbytes) - pagination parameter
 
 * `objects`: `Array<` [`IndexerTx`](#type-indexertx) `>` - objects collection
@@ -5662,7 +5771,10 @@ ScriptType `Lock` | `Type`
 ### Type `IndexerSearchKey`
 SearchKey represent indexer support params
 
-#### Fields:
+#### Fields
+
+`IndexerSearchKey` is a JSON object with the following fields.
+
 * `script`: [`Script`](#type-script) - Script
 
 * `script_type`: [`IndexerScriptType`](#type-indexerscripttype) - Script Type
@@ -5676,7 +5788,10 @@ IndexerSearchMode represent search mode, default is prefix search
 ### Type `IndexerTip`
 Indexer tip information
 
-#### Fields:
+#### Fields
+
+`IndexerTip` is a JSON object with the following fields.
+
 * `block_hash`: [`H256`](#type-h256) - indexed tip block hash
 
 * `block_number`: [`Uint64`](#type-uint64) - indexed tip block number
@@ -5687,7 +5802,10 @@ Indexer Transaction Object
 ### Type `IndexerTxWithCell`
 Ungrouped Tx inner type
 
-#### Fields:
+#### Fields
+
+`IndexerTxWithCell` is a JSON object with the following fields.
+
 * `block_number`: [`Uint64`](#type-uint64) - the number of the transaction committed in the block
 
 * `io_index`: [`Uint32`](#type-uint32) - the position index of the cell in the transaction inputs or outputs
@@ -5701,7 +5819,10 @@ Ungrouped Tx inner type
 ### Type `IndexerTxWithCells`
 Grouped Tx inner type
 
-#### Fields:
+#### Fields
+
+`IndexerTxWithCells` is a JSON object with the following fields.
+
 * `block_number`: [`Uint64`](#type-uint64) - the number of the transaction committed in the block
 
 * `cells`: `Array<` ([`IndexerCellType`](#type-indexercelltype) , [`Uint32`](#type-uint32)) `>` - Array [(io_type, io_index)]
@@ -5753,7 +5874,10 @@ The information of the node itself.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`LocalNode` is a JSON object with the following fields.
+
 * `active`: `boolean` - Whether this node is active.
 
     An inactive node ignores incoming p2p messages and drops outgoing messages.
@@ -5777,7 +5901,10 @@ The information of the node itself.
 ### Type `LocalNodeProtocol`
 The information of a P2P protocol that is supported by the local node.
 
-#### Fields:
+#### Fields
+
+`LocalNodeProtocol` is a JSON object with the following fields.
+
 * `id`: [`Uint64`](#type-uint64) - Unique protocol ID.
 
 * `name`: `string` - Readable protocol name.
@@ -5794,7 +5921,10 @@ Proof of CKB Merkle Tree.
 
 CKB Merkle Tree is a [CBMT](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0006-merkle-tree/0006-merkle-tree.md) using CKB blake2b hash as the merge function.
 
-#### Fields:
+#### Fields
+
+`MerkleProof` is a JSON object with the following fields.
+
 * `indices`: `Array<` [`Uint32`](#type-uint32) `>` - Leaves indices in the CBMT that are proved present in the block.
 
     These are indices in the CBMT tree not the transaction indices in the block.
@@ -5804,7 +5934,10 @@ CKB Merkle Tree is a [CBMT](https://github.com/nervosnetwork/rfcs/blob/master/rf
 ### Type `MinerReward`
 Block rewards for miners.
 
-#### Fields:
+#### Fields
+
+`MinerReward` is a JSON object with the following fields.
+
 * `committed`: [`Uint64`](#type-uint64) - The transaction fees that are rewarded to miners because the transaction is committed in the block.
 
     Miners get 60% of the transaction fee for each transaction committed in the block.
@@ -5820,7 +5953,10 @@ Block rewards for miners.
 ### Type `NodeAddress`
 Node P2P address and score.
 
-#### Fields:
+#### Fields
+
+`NodeAddress` is a JSON object with the following fields.
+
 * `address`: `string` - P2P address.
 
     This is the same address used in the whitelist in ckb.toml.
@@ -5843,7 +5979,10 @@ Reference to a cell via transaction hash and output index.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`OutPoint` is a JSON object with the following fields.
+
 * `index`: [`Uint32`](#type-uint32) - The output index of the cell in the transaction specified by `tx_hash`.
 
 * `tx_hash`: [`H256`](#type-h256) - Transaction hash in which the cell is an output.
@@ -5854,7 +5993,10 @@ Transaction output validators that prevent common mistakes.
 ### Type `PeerSyncState`
 The chain synchronization state between the local node and a remote node.
 
-#### Fields:
+#### Fields
+
+`PeerSyncState` is a JSON object with the following fields.
+
 * `can_fetch_count`: [`Uint64`](#type-uint64) - The count of blocks are available for concurrency download.
 
 * `inflight_count`: [`Uint64`](#type-uint64) - The count of concurrency downloading blocks.
@@ -5866,7 +6008,10 @@ The chain synchronization state between the local node and a remote node.
 ### Type `PoolTxDetailInfo`
 A Tx details info in tx-pool.
 
-#### Fields:
+#### Fields
+
+`PoolTxDetailInfo` is a JSON object with the following fields.
+
 * `ancestors_count`: [`Uint64`](#type-uint64) - The ancestors count of tx
 
 * `descendants_count`: [`Uint64`](#type-uint64) - The descendants count of tx
@@ -5910,7 +6055,10 @@ A non-cellbase transaction is committed at height h_c if all of the following co
                              commit
 ```
 
-#### Fields:
+#### Fields
+
+`ProposalWindow` is a JSON object with the following fields.
+
 * `closest`: [`Uint64`](#type-uint64) - The closest distance between the proposal and the commitment.
 
 * `farthest`: [`Uint64`](#type-uint64) - The farthest distance between the proposal and the commitment.
@@ -5918,7 +6066,10 @@ A non-cellbase transaction is committed at height h_c if all of the following co
 ### Type `Ratio`
 Represents the ratio `numerator / denominator`, where `numerator` and `denominator` are both unsigned 64-bit integers.
 
-#### Fields:
+#### Fields
+
+`Ratio` is a JSON object with the following fields.
+
 * `denom`: [`Uint64`](#type-uint64) - Denominator.
 
 * `numer`: [`Uint64`](#type-uint64) - Numerator.
@@ -6001,7 +6152,10 @@ A remote node connects to the local node via the P2P network. It is often called
  }
 ```
 
-#### Fields:
+#### Fields
+
+`RemoteNode` is a JSON object with the following fields.
+
 * `addresses`: `Array<` [`NodeAddress`](#type-nodeaddress) `>` - The remote node addresses.
 
 * `connected_duration`: [`Uint64`](#type-uint64) - Elapsed time in milliseconds since the remote node is connected.
@@ -6021,7 +6175,10 @@ A remote node connects to the local node via the P2P network. It is often called
 ### Type `RemoteNodeProtocol`
 The information about an active running protocol.
 
-#### Fields:
+#### Fields
+
+`RemoteNodeProtocol` is a JSON object with the following fields.
+
 * `id`: [`Uint64`](#type-uint64) - Unique protocol ID.
 
 * `version`: `string` - Active protocol version.
@@ -6029,7 +6186,10 @@ The information about an active running protocol.
 ### Type `Rfc0043`
 Represent soft fork deployments where activation is controlled by rfc0043 signaling
 
-#### Fields:
+#### Fields
+
+`Rfc0043` is a JSON object with the following fields.
+
 * `rfc0043`: [`Deployment`](#type-deployment) - RFC0043 deployment params
 
 * `status`: [`SoftForkStatus`](#type-softforkstatus) - SoftFork status
@@ -6047,7 +6207,10 @@ Describes the lock script and type script for a cell.
  }
 ```
 
-#### Fields:
+#### Fields
+
+`Script` is a JSON object with the following fields.
+
 * `args`: [`JsonBytes`](#type-jsonbytes) - Arguments for script.
 
 * `code_hash`: [`H256`](#type-h256) - The hash used to match the script code.
@@ -6075,7 +6238,10 @@ Status for transaction
 ### Type `SyncState`
 The overall chain synchronization state of this local node.
 
-#### Fields:
+#### Fields
+
+`SyncState` is a JSON object with the following fields.
+
 * `best_known_block_number`: [`Uint64`](#type-uint64) - This is the best known block number observed by the local node from the P2P network.
 
     The best here means that the block leads a chain which has the best known accumulated difficulty.
@@ -6109,7 +6275,10 @@ The transaction.
 
 Refer to RFC [CKB Transaction Structure](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md).
 
-#### Fields:
+#### Fields
+
+`Transaction` is a JSON object with the following fields.
+
 * `cell_deps`: `Array<` [`CellDep`](#type-celldep) `>` - An array of cell deps.
 
     CKB locates lock script and type script code via cell deps. The script also can use syscalls to read the cells here.
@@ -6143,7 +6312,10 @@ Refer to RFC [CKB Transaction Structure](https://github.com/nervosnetwork/rfcs/b
 ### Type `TransactionAndWitnessProof`
 Merkle proof for transactions' witnesses in a block.
 
-#### Fields:
+#### Fields
+
+`TransactionAndWitnessProof` is a JSON object with the following fields.
+
 * `block_hash`: [`H256`](#type-h256) - Block hash
 
 * `transactions_proof`: [`MerkleProof`](#type-merkleproof) - Merkle proof of all transactions' hash
@@ -6153,7 +6325,10 @@ Merkle proof for transactions' witnesses in a block.
 ### Type `TransactionProof`
 Merkle proof for transactions in a block.
 
-#### Fields:
+#### Fields
+
+`TransactionProof` is a JSON object with the following fields.
+
 * `block_hash`: [`H256`](#type-h256) - Block hash
 
 * `proof`: [`MerkleProof`](#type-merkleproof) - Merkle proof of all transactions' hash
@@ -6163,7 +6338,10 @@ Merkle proof for transactions in a block.
 ### Type `TransactionTemplate`
 Transaction template which is ready to be committed in the new block.
 
-#### Fields:
+#### Fields
+
+`TransactionTemplate` is a JSON object with the following fields.
+
 * `data`: [`Transaction`](#type-transaction) - The transaction.
 
     Miners must keep it unchanged when including it in the new block.
@@ -6223,7 +6401,10 @@ This structure is serialized into a JSON object with field `hash` and all the fi
  }
 ```
 
-#### Fields:
+#### Fields
+
+`TransactionView` is a JSON object with the following fields.
+
 * `cell_deps`: `Array<` [`CellDep`](#type-celldep) `>` - An array of cell deps.
 
     CKB locates lock script and type script code via cell deps. The script also can use syscalls to read the cells here.
@@ -6259,13 +6440,19 @@ This structure is serialized into a JSON object with field `hash` and all the fi
 ### Type `TransactionWithStatusResponse`
 The JSON view of a transaction as well as its status.
 
-#### Fields:
+#### Fields
+
+`TransactionWithStatusResponse` is a JSON object with the following fields.
+
 * `tx_status`: [`TxStatus`](#type-txstatus) - The Transaction status.
 
 ### Type `TxPoolEntries`
 Tx-pool entries object
 
-#### Fields:
+#### Fields
+
+`TxPoolEntries` is a JSON object with the following fields.
+
 * `pending`: `object` - Pending tx verbose info
 
 * `proposed`: `object` - Proposed tx verbose info
@@ -6273,7 +6460,10 @@ Tx-pool entries object
 ### Type `TxPoolEntry`
 Transaction entry info
 
-#### Fields:
+#### Fields
+
+`TxPoolEntry` is a JSON object with the following fields.
+
 * `ancestors_count`: [`Uint64`](#type-uint64) - Number of in-tx-pool ancestor transactions
 
 * `ancestors_cycles`: [`Uint64`](#type-uint64) - Cycles of in-tx-pool ancestor transactions
@@ -6291,7 +6481,10 @@ Transaction entry info
 ### Type `TxPoolIds`
 Array of transaction ids
 
-#### Fields:
+#### Fields
+
+`TxPoolIds` is a JSON object with the following fields.
+
 * `pending`: `Array<` [`H256`](#type-h256) `>` - Pending transaction ids
 
 * `proposed`: `Array<` [`H256`](#type-h256) `>` - Proposed transaction ids
@@ -6299,7 +6492,10 @@ Array of transaction ids
 ### Type `TxPoolInfo`
 Transaction pool information.
 
-#### Fields:
+#### Fields
+
+`TxPoolInfo` is a JSON object with the following fields.
+
 * `last_txs_updated_at`: [`Uint64`](#type-uint64) - Last updated time. This is the Unix timestamp in milliseconds.
 
 * `max_tx_pool_size`: [`Uint64`](#type-uint64) - Total limit on the size of transactions in the tx-pool
@@ -6343,7 +6539,10 @@ Transaction pool information.
 ### Type `TxStatus`
 Transaction status and the block hash if it is committed.
 
-#### Fields:
+#### Fields
+
+`TxStatus` is a JSON object with the following fields.
+
 * `status`: [`Status`](#type-status) - The transaction status, allowed values: "pending", "proposed" "committed" "unknown" and "rejected".
 
 ### Type `Uint128`
@@ -6367,7 +6566,10 @@ A block B1 is considered to be the uncle of another block B2 if all the followin
 3. B1's parent is either B2's ancestor or an uncle embedded in B2 or any of B2's ancestors.
 4. B2 is the first block in its chain to refer to B1.
 
-#### Fields:
+#### Fields
+
+`UncleBlock` is a JSON object with the following fields.
+
 * `header`: [`Header`](#type-header) - The uncle block header.
 
 * `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - Proposal IDs in the uncle block body.
@@ -6384,7 +6586,10 @@ A block B1 is considered to be the uncle of another block B2 if all the followin
 3. B1's parent is either B2's ancestor or an uncle embedded in B2 or any of B2's ancestors.
 4. B2 is the first block in its chain to refer to B1.
 
-#### Fields:
+#### Fields
+
+`UncleBlockView` is a JSON object with the following fields.
+
 * `header`: [`HeaderView`](#type-headerview) - The uncle block header.
 
 * `proposals`: `Array<` [`ProposalShortId`](#type-proposalshortid) `>` - Proposal IDs in the uncle block body.
@@ -6392,7 +6597,10 @@ A block B1 is considered to be the uncle of another block B2 if all the followin
 ### Type `UncleTemplate`
 The uncle block template of the new block for miners.
 
-#### Fields:
+#### Fields
+
+`UncleTemplate` is a JSON object with the following fields.
+
 * `hash`: [`H256`](#type-h256) - The uncle block hash.
 
 * `header`: [`Header`](#type-header) - The header of the uncle block.

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -109,7 +109,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
 
     * [Type `Alert`](#type-alert)
     * [Type `AlertId`](#type-alertid)
+    * [Type `AlertId`](#type-alertid)
     * [Type `AlertMessage`](#type-alertmessage)
+    * [Type `AlertPriority`](#type-alertpriority)
     * [Type `AlertPriority`](#type-alertpriority)
     * [Type `AncestorsScoreSortKey`](#type-ancestorsscoresortkey)
     * [Type `BannedAddr`](#type-bannedaddr)
@@ -141,9 +143,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `DeploymentInfo`](#type-deploymentinfo)
     * [Type `DeploymentState`](#type-deploymentstate)
     * [Type `DeploymentsInfo`](#type-deploymentsinfo)
-    * [Type `Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes)
-    * [Type `Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes)
-    * [Type `Either_for_TransactionView_and_JsonBytes`](#type-either_for_transactionview_and_jsonbytes)
+    * [Type `EpochNumber`](#type-epochnumber)
     * [Type `EpochNumber`](#type-epochnumber)
     * [Type `EpochNumberWithFraction`](#type-epochnumberwithfraction)
     * [Type `EpochView`](#type-epochview)
@@ -4933,6 +4933,12 @@ The alert identifier that is used to filter duplicated alerts.
 
 This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32).
 
+### Type `AlertId`
+
+The alert identifier that is used to filter duplicated alerts.
+
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](type.Uint32.html#examples).
+
 ### Type `AlertMessage`
 An alert sent by RPC `send_alert`.
 
@@ -4952,6 +4958,12 @@ An alert sent by RPC `send_alert`.
 Alerts are sorted by priority. Greater integers mean higher priorities.
 
 This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](#type-uint32).
+
+### Type `AlertPriority`
+
+Alerts are sorted by priority. Greater integers mean higher priorities.
+
+This is a 32-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint32](type.Uint32.html#examples).
 
 ### Type `AncestorsScoreSortKey`
 A struct as a sorted key for tx-pool
@@ -5162,7 +5174,7 @@ Represent soft fork deployments where the activation epoch is hard-coded into th
 * `status`: [`SoftForkStatus`](#type-softforkstatus) - SoftFork status
 
 ### Type `Byte32`
-
+The fixed-length 32 bytes binary encoded as a 0x-prefixed hex string in JSON.
 
 ### Type `Capacity`
 
@@ -5527,19 +5539,16 @@ Chain information.
 
 * `hash`: [`H256`](#type-h256) - requested block hash
 
-### Type `Either_for_BlockView_and_JsonBytes`
-The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
-
-### Type `Either_for_HeaderView_and_JsonBytes`
-The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
-
-### Type `Either_for_TransactionView_and_JsonBytes`
-The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.
-
 ### Type `EpochNumber`
 Consecutive epoch number starting from 0.
 
 This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](#type-uint64).
+
+### Type `EpochNumber`
+
+Consecutive epoch number starting from 0.
+
+This is a 64-bit unsigned integer type encoded as the 0x-prefixed hex string in JSON. See examples of [Uint64](type.Uint64.html#examples).
 
 ### Type `EpochNumberWithFraction`
 
@@ -5635,11 +5644,7 @@ The fee_rate statistics information, includes mean and median, unit: shannons pe
 * `median`: [`Uint64`](#type-uint64) - median
 
 ### Type `H256`
-The 32-byte fixed-length binary data.
-
-The name comes from the number of bits in the data.
-
-In JSONRPC, it is encoded as a 0x-prefixed hex string.
+The 256-bit binary data encoded as a 0x-prefixed hex string in JSON.
 
 ### Type `HardForkFeature`
 The information about one hardfork feature.
@@ -5940,6 +5945,17 @@ Grouped Tx inner type
 
 ### Type `JsonBytes`
 
+Variable-length binary encoded as a 0x-prefixed hex string in JSON.
+
+###### Example
+
+| JSON       | Binary                               |
+| ---------- | ------------------------------------ |
+| "0x"       | Empty binary                         |
+| "0x00"     | Single byte 0                        |
+| "0x636b62" | 3 bytes, UTF-8 encoding of ckb       |
+| "00"       | Invalid, 0x is required              |
+| "0x0"      | Invalid, each byte requires 2 digits |
 
 ### Type `LocalNode`
 The information of the node itself.

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -179,6 +179,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `OutPoint`](#type-outpoint)
     * [Type `OutputsValidator`](#type-outputsvalidator)
     * [Type `PeerSyncState`](#type-peersyncstate)
+    * [Type `PoolTransactionReject`](#type-pooltransactionreject)
     * [Type `PoolTxDetailInfo`](#type-pooltxdetailinfo)
     * [Type `ProposalShortId`](#type-proposalshortid)
     * [Type `ProposalWindow`](#type-proposalwindow)
@@ -5869,6 +5870,8 @@ A array represent (half-open) range bounded inclusively below and exclusively ab
 | ["0x0", "0x2"]           |          [0, 2)              |
 | ["0x0", "0x174876e801"]  |          [0, 100000000001)   |
 
+
+
 ### Type `IndexerScriptType`
 ScriptType `Lock` | `Type`
 
@@ -6173,6 +6176,25 @@ The chain synchronization state between the local node and a remote node.
 * `unknown_header_list_size`: [`Uint64`](#type-uint64) - The total size of unknown header list.
 
     **Deprecated**: this is an internal state and will be removed in a future release.
+
+### Type `PoolTransactionReject`
+
+TX reject message, `PoolTransactionReject` is a JSON object with following fields.
+* `type`:  the Reject type with following enum values
+* `description`: `string` - Detailed description about why the transaction is rejected.
+
+An enum value from one of:
+  - `LowFeeRate` :  Transaction fee lower than config
+  - `ExceededMaximumAncestorsCount` :  Transaction exceeded maximum ancestors count limit
+  - `ExceededTransactionSizeLimit` :  Transaction exceeded maximum size limit
+  - `Full` :  Transaction are replaced because the pool is full
+  - `Duplicated` :  Transaction already exists in transaction_pool
+  - `Malformed` :  Malformed transaction
+  - `DeclaredWrongCycles` :  Declared wrong cycles
+  - `Resolve` :  Resolve failed
+  - `Verification` :  Verification failed
+  - `Expiry` :  Transaction expired
+  - `RBFRejected` :  RBF rejected
 
 ### Type `PoolTxDetailInfo`
 A Tx details info in tx-pool.

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -1398,7 +1398,7 @@ pub struct Consensus {
     pub permanent_difficulty_in_dummy: bool,
     /// Hardfork features
     pub hardfork_features: HardForks,
-    /// Softforks
+    /// `HashMap<DeploymentPos, SoftFork>` - Softforks
     pub softforks: HashMap<DeploymentPos, SoftFork>,
 }
 

--- a/util/jsonrpc-types/src/debug.rs
+++ b/util/jsonrpc-types/src/debug.rs
@@ -27,7 +27,7 @@ pub struct ExtraLoggerConfig {
 pub struct MainLoggerConfig {
     /// Sets log levels for different modules.
     ///
-    /// **Optional**, null means keeping the current option unchanged.
+    /// `null` means keeping the current option unchanged.
     ///
     /// ## Examples
     ///
@@ -45,14 +45,14 @@ pub struct MainLoggerConfig {
     pub filter: Option<String>,
     /// Whether printing the logs to the process stdout.
     ///
-    /// **Optional**, null means keeping the current option unchanged.
+    /// `null` means keeping the current option unchanged.
     pub to_stdout: Option<bool>,
     /// Whether appending the logs to the log file.
     ///
-    /// **Optional**, null means keeping the current option unchanged.
+    /// `null` means keeping the current option unchanged.
     pub to_file: Option<bool>,
     /// Whether using color when printing the logs to the process stdout.
     ///
-    /// **Optional**, null means keeping the current option unchanged.
+    /// `null` means keeping the current option unchanged.
     pub color: Option<bool>,
 }

--- a/util/jsonrpc-types/src/info.rs
+++ b/util/jsonrpc-types/src/info.rs
@@ -41,6 +41,7 @@ pub struct DeploymentsInfo {
     pub hash: H256,
     /// requested block epoch
     pub epoch: EpochNumber,
+    /// `{ [ key:` [`DeploymentPos`](#type-deploymentpos) `]: ` [`DeploymentInfo`](#type-deploymentinfo) `}`
     /// deployments info
     pub deployments: BTreeMap<DeploymentPos, DeploymentInfo>,
 }

--- a/util/jsonrpc-types/src/json_schema.rs
+++ b/util/jsonrpc-types/src/json_schema.rs
@@ -1,41 +1,23 @@
 use crate::{Byte32, Uint128, Uint32, Uint64};
 use schemars::JsonSchema;
 
-impl JsonSchema for Byte32 {
-    fn schema_name() -> String {
-        String::from("Byte32")
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<[u8; 32]>().into_object().into()
-    }
+macro_rules! impl_json_schema_for_type {
+    ($type:ty, $inner_ty:ty, $name:expr) => {
+        impl JsonSchema for $type {
+            fn schema_name() -> String {
+                String::from($name)
+            }
+            fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+                gen.subschema_for::<$inner_ty>().into_object().into()
+            }
+        }
+    };
 }
 
-impl JsonSchema for Uint32 {
-    fn schema_name() -> String {
-        String::from("Uint32")
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<u32>().into_object().into()
-    }
-}
-
-impl JsonSchema for Uint64 {
-    fn schema_name() -> String {
-        String::from("Uint64")
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<u64>().into_object().into()
-    }
-}
-
-impl JsonSchema for Uint128 {
-    fn schema_name() -> String {
-        String::from("Uint128")
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<u128>().into_object().into()
-    }
-}
+impl_json_schema_for_type!(Byte32, [u8; 32], "Byte32");
+impl_json_schema_for_type!(Uint32, u32, "Uint32");
+impl_json_schema_for_type!(Uint64, u64, "Uint64");
+impl_json_schema_for_type!(Uint128, u128, "Uint128");
 
 pub fn u256_json_schema(
     _schemars: &mut schemars::gen::SchemaGenerator,

--- a/util/jsonrpc-types/src/json_schema.rs
+++ b/util/jsonrpc-types/src/json_schema.rs
@@ -15,7 +15,7 @@ impl JsonSchema for Uint32 {
         String::from("Uint32")
     }
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<u64>().into_object().into()
+        gen.subschema_for::<u32>().into_object().into()
     }
 }
 

--- a/util/jsonrpc-types/src/json_schema.rs
+++ b/util/jsonrpc-types/src/json_schema.rs
@@ -1,14 +1,5 @@
-use crate::{AlertId, Byte32, Uint128, Uint64};
+use crate::{Byte32, Uint128, Uint32, Uint64};
 use schemars::JsonSchema;
-
-impl JsonSchema for AlertId {
-    fn schema_name() -> String {
-        String::from("AlertId")
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        gen.subschema_for::<u32>().into_object().into()
-    }
-}
 
 impl JsonSchema for Byte32 {
     fn schema_name() -> String {
@@ -16,6 +7,15 @@ impl JsonSchema for Byte32 {
     }
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         gen.subschema_for::<[u8; 32]>().into_object().into()
+    }
+}
+
+impl JsonSchema for Uint32 {
+    fn schema_name() -> String {
+        String::from("Uint32")
+    }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        gen.subschema_for::<u64>().into_object().into()
     }
 }
 

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -278,7 +278,9 @@ impl From<CorePoolTxDetailInfo> for PoolTxDetailInfo {
     }
 }
 
-/// TX reject message
+/// TX reject message, `PoolTransactionReject` is a JSON object with following fields.
+///    * `type`:  the Reject type with following enum values
+///    * `description`: `string` - Detailed description about why the transaction is rejected.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", content = "description")]
 pub enum PoolTransactionReject {

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -111,9 +111,9 @@ impl From<CorePoolTransactionEntry> for PoolTransactionEntry {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputsValidator {
-    /// "passthrough": the default validator, bypass output checking, thus allow any kind of transaction outputs.
+    /// the default validator, bypass output checking, thus allow any kind of transaction outputs.
     Passthrough,
-    /// "well_known_scripts_only": restricts the lock script and type script usage, see more information on <https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Default-Outputs-Validator>
+    /// restricts the lock script and type script usage, see more information on <https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Default-Outputs-Validator>
     WellKnownScriptsOnly,
 }
 

--- a/util/types/src/core/service.rs
+++ b/util/types/src/core/service.rs
@@ -5,7 +5,6 @@
 use crate::core::{Capacity, Cycle, TransactionView};
 use ckb_channel::Sender;
 use std::sync::mpsc;
-
 /// Default channel size to send control signals.
 pub const SIGNAL_CHANNEL_SIZE: usize = 1;
 /// Default channel size to send messages.


### PR DESCRIPTION

### What problem does this PR solve?

There are several issues:
- `Uint32` is wrong and replaced with `AlertId`
- Missing some fields, such as `IndexerSearchKeyFilter`, cc @EthanYuan 


### What is changed and how it works?

What's Changed:

- Fix issues in `gen.rs` 
- Add some predefined types in the doc generator, similar with `rpc.py` 

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

