### PR TITLE
Evict possible cell ref txs before submitting cell consuming transaction

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6969,5 +6969,7 @@ For example, a cellbase transaction is not allowed in `send_transaction` RPC.
 (-1110): The transaction exceeded maximum size limit.
 ### ERROR `PoolRejectedRBF`
 (-1111): The transaction is rejected for RBF checking.
+### ERROR `PoolRejectedInvalidated`
+(-1112): The transaction is rejected for ref cell consuming.
 ### ERROR `Indexer`
 (-1200): The indexer error.

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6216,6 +6216,7 @@ An enum value from one of:
   - `Verification` :  Verification failed
   - `Expiry` :  Transaction expired
   - `RBFRejected` :  RBF rejected
+  - `Invalidated` :  Invalidated rejected
 
 ### Type `PoolTxDetailInfo`
 A Tx details info in tx-pool.

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -115,6 +115,8 @@ pub enum RPCError {
     PoolRejectedTransactionBySizeLimit = -1110,
     /// (-1111): The transaction is rejected for RBF checking.
     PoolRejectedRBF = -1111,
+    /// (-1112): The transaction is rejected for ref cell consuming.
+    PoolRejectedInvalidated = -1112,
     /// (-1200): The indexer error.
     Indexer = -1200,
 }
@@ -177,6 +179,7 @@ impl RPCError {
             Reject::Resolve(_) => RPCError::TransactionFailedToResolve,
             Reject::Verification(_) => RPCError::TransactionFailedToVerify,
             Reject::RBFRejected(_) => RPCError::PoolRejectedRBF,
+            Reject::Invalidated(_) => RPCError::PoolRejectedInvalidated,
             Reject::ExceededTransactionSizeLimit(_, _) => {
                 RPCError::PoolRejectedTransactionBySizeLimit
             }

--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -416,7 +416,10 @@ fn register_tx_pool_callback(tx_pool_builder: &mut TxPoolServiceBuilder, notify:
         move |tx_pool: &mut TxPool, entry: &TxEntry, reject: Reject| {
             let tx_hash = entry.transaction().hash();
             // record recent reject
-            if matches!(reject, Reject::Resolve(..) | Reject::RBFRejected(..)) {
+            if matches!(
+                reject,
+                Reject::Resolve(..) | Reject::RBFRejected(..) | Reject::Invalidated(..)
+            ) {
                 if let Some(ref mut recent_reject) = tx_pool.recent_reject {
                     if let Err(e) = recent_reject.put(&tx_hash, reject.clone()) {
                         error!("record recent_reject failed {} {} {}", tx_hash, reject, e);

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -1,8 +1,15 @@
-use crate::{Node, Spec};
-
+use crate::{
+    util::{cell::gen_spendable, transaction::always_success_transaction},
+    Node, Spec,
+};
 use ckb_logger::info;
-use ckb_types::core::FeeRate;
+use ckb_types::{
+    core::{cell::CellMetaBuilder, DepType, FeeRate},
+    packed::CellDepBuilder,
+};
 use std::{thread::sleep, time::Duration};
+
+use ckb_types::{packed::OutPoint, prelude::*};
 
 pub struct SizeLimit;
 

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -107,8 +107,10 @@ impl Spec for TxPoolLimitAncestorCount {
             .build();
         let last = always_success_transaction(node0, &input);
 
-        // now there are 252 ancestors in the pool, 252 = 250 ref cell + 1 parent + 1 for self
-        // to make sure this consume cell dep transaction submitted, we need to evict 2 cell ref transactions
+        // now there are 252 ancestors for the last tx in the pool:
+        // 252 = 250 ref cell + 1 parent + 1 for self
+        // to make sure this consuming cell dep transaction submitted,
+        // we need to evict 127 = 252 - 125 cell ref transactions
         let res = node0
             .rpc_client()
             .send_transaction_result(last.data().into());

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -1,15 +1,8 @@
-use crate::{
-    util::{cell::gen_spendable, transaction::always_success_transaction},
-    Node, Spec,
-};
-use ckb_logger::info;
-use ckb_types::{
-    core::{cell::CellMetaBuilder, DepType, FeeRate},
-    packed::CellDepBuilder,
-};
-use std::{thread::sleep, time::Duration};
+use crate::{Node, Spec};
 
-use ckb_types::{packed::OutPoint, prelude::*};
+use ckb_logger::info;
+use ckb_types::core::FeeRate;
+use std::{thread::sleep, time::Duration};
 
 pub struct SizeLimit;
 

--- a/tx-pool/src/component/entry.rs
+++ b/tx-pool/src/component/entry.rs
@@ -39,8 +39,6 @@ pub struct TxEntry {
     pub descendants_cycles: Cycle,
     /// descendants txs count
     pub descendants_count: usize,
-    /// dicrect ancestors txs count
-    pub direct_ancestors_count: usize,
     /// The unix timestamp when entering the Txpool, unit: Millisecond
     pub timestamp: u64,
 }
@@ -73,7 +71,6 @@ impl TxEntry {
             descendants_cycles: cycles,
             descendants_count: 1,
             ancestors_count: 1,
-            direct_ancestors_count: 1,
         }
     }
 

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -7,7 +7,7 @@ pub struct TxLinks {
     pub children: HashSet<ProposalShortId>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Relation {
     Parents,
     Children,

--- a/tx-pool/src/component/links.rs
+++ b/tx-pool/src/component/links.rs
@@ -5,14 +5,12 @@ use std::collections::{HashMap, HashSet};
 pub struct TxLinks {
     pub parents: HashSet<ProposalShortId>,
     pub children: HashSet<ProposalShortId>,
-    pub direct_parents: HashSet<ProposalShortId>,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub enum Relation {
     Parents,
     Children,
-    DirectParents,
 }
 
 impl TxLinks {
@@ -20,7 +18,6 @@ impl TxLinks {
         match relation {
             Relation::Parents => &self.parents,
             Relation::Children => &self.children,
-            Relation::DirectParents => &self.direct_parents,
         }
     }
 }
@@ -70,11 +67,6 @@ impl TxLinksMap {
             }
             stage.remove(&id);
             relation_ids.insert(id);
-        }
-        // for direct parents, we don't store children in links map
-        // so filter those not in links map, they maybe removed from tx-pool now
-        if relation == Relation::DirectParents {
-            relation_ids.retain(|id| self.inner.contains_key(id));
         }
         relation_ids
     }
@@ -141,16 +133,6 @@ impl TxLinksMap {
         self.inner
             .get_mut(short_id)
             .map(|links| links.parents.insert(parent))
-    }
-
-    pub fn add_direct_parent(
-        &mut self,
-        short_id: &ProposalShortId,
-        parent: ProposalShortId,
-    ) -> Option<bool> {
-        self.inner
-            .get_mut(short_id)
-            .map(|links| links.direct_parents.insert(parent))
     }
 
     pub fn clear(&mut self) {

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -569,16 +569,17 @@ impl PoolMap {
                     break;
                 }
             }
+        } else {
+            return Err(Reject::ExceededMaximumAncestorsCount);
         }
 
-        // if ancestors count is still larger than limitation,
-        // return ExceededMaximumAncestorsCount error directly
+        // some txs in `parents` are removed, now `ancestors` need to re-caculate,
         let ancestors = self
             .links
             .calc_relation_ids(parents.clone(), Relation::Parents);
-        if ancestors.len() + 1 > self.max_ancestors_count {
-            return Err(Reject::ExceededMaximumAncestorsCount);
-        }
+
+        // we can assume the number now is less than `max_ancestors_count`
+        assert!(ancestors.len() < self.max_ancestors_count);
 
         self._record_ancestors(entry, ancestors, parents);
         Ok(evicted)

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -565,10 +565,11 @@ impl PoolMap {
         }
 
         // why we move ExceededMaximumAncestorsCount to here?
-        // in the scenario that a transaction passed all RBF rules,
-        // and then removed the conflicted transaction in txpool,
-        // then failed with max ancestor limits, we now need to rollback the removing.
-        // so it's safer to report an error before any writing kind of operation,
+        // in the scenario that a transaction passed all RBF rules, and then removed the conflicted
+        // transaction in txpool, then failed with max ancestor limits, we now need to rollback the removing.
+        // this is not an issue currently, because RBF have a rule that not allow any unknown inputs except
+        // the conflicted inputs, so the new transcation can not be in a long transaction chain.
+        // but it's still safer to report an error before any writing kind of operation,
         // here is the place will be invoked before commiting transaction into the pool.
         if ancestors_count > self.max_ancestors_count {
             return Err(Reject::ExceededMaximumAncestorsCount);

--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -456,7 +456,6 @@ impl PoolMap {
 
     // return (ancestors, parents, cell_ref_ancestors)
     // `cell_ref_ancestors` may be invalidate when the tx consuming the cell is submitted
-    // FIXME(yukang): submit an Entry to invoking this function 2 times, how to optimize it?
     fn get_tx_ancenstors(
         &self,
         entry: &TransactionView,

--- a/tx-pool/src/component/tests/links.rs
+++ b/tx-pool/src/component/tests/links.rs
@@ -20,13 +20,14 @@ fn test_link_map() {
     let expect: HashSet<ProposalShortId> = vec![id2.clone()].into_iter().collect();
     assert_eq!(map.get_parents(&id1).unwrap(), &expect);
 
-    map.add_direct_parent(&id1, id2.clone());
-    map.add_direct_parent(&id2, id3.clone());
-    map.add_direct_parent(&id3, id4.clone());
-    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
-    assert_eq!(direct_parents.len(), 4);
+    map.add_parent(&id1, id2.clone());
+    map.add_parent(&id2, id3.clone());
+    map.add_parent(&id3, id4.clone());
+    let parents = map.calc_relation_ids([id1.clone()].into(), Relation::Parents);
+    assert_eq!(parents.len(), 4);
 
     map.remove(&id3);
-    let direct_parents = map.calc_relation_ids([id1.clone()].into(), Relation::DirectParents);
-    assert_eq!(direct_parents.len(), 2);
+    map.remove_parent(&id2, &id3);
+    let parents = map.calc_relation_ids([id1.clone()].into(), Relation::Parents);
+    assert_eq!(parents.len(), 2);
 }

--- a/tx-pool/src/component/tests/pending.rs
+++ b/tx-pool/src/component/tests/pending.rs
@@ -23,8 +23,8 @@ fn test_basic() {
     );
     let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry2 = TxEntry::dummy_resolve(tx2.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry1.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
     assert!(pool.size() == 2);
     assert!(pool.contains_key(&tx1.proposal_short_id()));
     assert!(pool.contains_key(&tx2.proposal_short_id()));
@@ -70,9 +70,9 @@ fn test_resolve_conflict() {
     let entry1 = TxEntry::dummy_resolve(tx1, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry2 = TxEntry::dummy_resolve(tx2, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry3 = TxEntry::dummy_resolve(tx3, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry1.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3.clone(), Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3.clone(), Status::Pending).is_ok());
 
     let conflicts = pool.resolve_conflict(&tx4);
     assert_eq!(
@@ -99,9 +99,9 @@ fn test_resolve_conflict_descendants() {
     let entry1 = TxEntry::dummy_resolve(tx1, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry3 = TxEntry::dummy_resolve(tx3, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry4 = TxEntry::dummy_resolve(tx4, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry4.clone(), Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry4.clone(), Status::Pending).is_ok());
 
     let conflicts = pool.resolve_conflict(&tx2);
     assert_eq!(
@@ -124,8 +124,8 @@ fn test_resolve_conflict_header_dep() {
 
     let entry = TxEntry::dummy_resolve(tx, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry1 = TxEntry::dummy_resolve(tx1, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry1.clone(), Status::Pending).unwrap());
+    assert!(pool.add_entry(entry.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry1.clone(), Status::Pending).is_ok());
 
     assert_eq!(pool.inputs_len(), 3);
     assert_eq!(pool.header_deps_len(), 1);
@@ -149,8 +149,8 @@ fn test_remove_entry() {
 
     let entry1 = TxEntry::dummy_resolve(tx1.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
     let entry2 = TxEntry::dummy_resolve(tx2.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry1.clone(), Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2.clone(), Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1.clone(), Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2.clone(), Status::Pending).is_ok());
 
     let removed = pool.remove_entry(&tx1.proposal_short_id());
     assert_eq!(removed, Some(entry1));
@@ -182,9 +182,9 @@ fn test_fill_proposals() {
     std::thread::sleep(Duration::from_millis(1));
 
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     assert_eq!(pool.inputs_len(), 5);
     assert_eq!(pool.deps_len(), 1);
@@ -234,9 +234,9 @@ fn test_fill_proposals_with_high_score() {
     std::thread::sleep(Duration::from_millis(1));
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), 2, Capacity::shannons(100), 2);
 
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     let id1 = tx1.proposal_short_id();
     let id2 = tx2.proposal_short_id();
@@ -301,9 +301,9 @@ fn test_pool_evict() {
     std::thread::sleep(Duration::from_millis(1));
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), MOCK_CYCLES, MOCK_FEE, MOCK_SIZE);
 
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     let e1 = pool.next_evict_entry(Status::Pending).unwrap();
     assert_eq!(e1, tx1.proposal_short_id());
@@ -339,9 +339,9 @@ fn test_pool_min_weight_evict() {
     std::thread::sleep(Duration::from_millis(1));
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), 2, Capacity::shannons(10), 2);
 
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     let e1 = pool.next_evict_entry(Status::Pending).unwrap();
     assert_eq!(e1, tx3.proposal_short_id());
@@ -377,9 +377,9 @@ fn test_pool_max_size_evict() {
     std::thread::sleep(Duration::from_millis(1));
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), 2, Capacity::shannons(100), 1);
 
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     let e1 = pool.next_evict_entry(Status::Pending).unwrap();
     assert_eq!(e1, tx1.proposal_short_id());
@@ -408,9 +408,9 @@ fn test_pool_min_descendants_evict() {
     std::thread::sleep(Duration::from_millis(1));
     let entry3 = TxEntry::dummy_resolve(tx3.clone(), 2, Capacity::shannons(100), 1);
 
-    assert!(pool.add_entry(entry1, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry2, Status::Pending).unwrap());
-    assert!(pool.add_entry(entry3, Status::Pending).unwrap());
+    assert!(pool.add_entry(entry1, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry2, Status::Pending).is_ok());
+    assert!(pool.add_entry(entry3, Status::Pending).is_ok());
 
     let e1 = pool.next_evict_entry(Status::Pending).unwrap();
     assert_eq!(e1, tx3.proposal_short_id());

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -128,17 +128,17 @@ impl TxPool {
 
     /// Add tx with pending status
     /// If did have this value present, false is returned.
-    pub(crate) fn add_pending(&mut self, entry: TxEntry) -> Result<bool, Reject> {
+    pub(crate) fn add_pending(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
         self.pool_map.add_entry(entry, Status::Pending)
     }
 
     /// Add tx which proposed but still uncommittable to gap
-    pub(crate) fn add_gap(&mut self, entry: TxEntry) -> Result<bool, Reject> {
+    pub(crate) fn add_gap(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
         self.pool_map.add_entry(entry, Status::Gap)
     }
 
     /// Add tx with proposed status
-    pub(crate) fn add_proposed(&mut self, entry: TxEntry) -> Result<bool, Reject> {
+    pub(crate) fn add_proposed(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
         self.pool_map.add_entry(entry, Status::Proposed)
     }
 

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -128,17 +128,23 @@ impl TxPool {
 
     /// Add tx with pending status
     /// If did have this value present, false is returned.
-    pub(crate) fn add_pending(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
+    pub(crate) fn add_pending(
+        &mut self,
+        entry: TxEntry,
+    ) -> Result<(bool, HashSet<TxEntry>), Reject> {
         self.pool_map.add_entry(entry, Status::Pending)
     }
 
     /// Add tx which proposed but still uncommittable to gap
-    pub(crate) fn add_gap(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
+    pub(crate) fn add_gap(&mut self, entry: TxEntry) -> Result<(bool, HashSet<TxEntry>), Reject> {
         self.pool_map.add_entry(entry, Status::Gap)
     }
 
     /// Add tx with proposed status
-    pub(crate) fn add_proposed(&mut self, entry: TxEntry) -> Result<HashSet<TxEntry>, Reject> {
+    pub(crate) fn add_proposed(
+        &mut self,
+        entry: TxEntry,
+    ) -> Result<(bool, HashSet<TxEntry>), Reject> {
         self.pool_map.add_entry(entry, Status::Proposed)
     }
 

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -492,16 +492,9 @@ impl TxPool {
     ) -> Result<HashSet<ProposalShortId>, Reject> {
         assert!(self.enable_rbf());
         let tx_inputs: Vec<OutPoint> = entry.transaction().input_pts_iter().collect();
-        let mut conflict_ids = self.pool_map.find_conflict_tx(entry.transaction());
+        let conflict_ids = self.pool_map.find_conflict_tx(entry.transaction());
 
-        // If current new transaction is a cell consuming transaction,
-        // find out old transactions maybe invalidated by this new transaction,
-        // we need to evict them before inserting new transaction.
-        let conflicted_cell_ref_txs = self
-            .pool_map
-            .check_entry_ancestors_limit(entry.transaction())?;
-
-        if conflict_ids.is_empty() && conflicted_cell_ref_txs.is_empty() {
+        if conflict_ids.is_empty() {
             return Ok(HashSet::new());
         }
 
@@ -579,11 +572,6 @@ impl TxPool {
                 ));
             }
         }
-
-        // we want to make sure new transaction's fee is higher than those ref cell transactions
-        // so we extend them to `all_conflicted` so that fee rules check applied.
-        conflict_ids.extend(conflicted_cell_ref_txs.iter().map(|e| e.id.clone()));
-        all_conflicted.extend(conflicted_cell_ref_txs);
 
         // Rule #4, new tx's fee need to higher than min_rbf_fee computed from the tx_pool configuration
         // Rule #3, new tx's fee need to higher than conflicts, here we only check the all conflicted txs fee

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -1106,17 +1106,17 @@ fn _submit_entry(
 ) -> Result<HashSet<TxEntry>, Reject> {
     let tx_hash = entry.transaction().hash();
     debug!("submit_entry {:?} {}", status, tx_hash);
-    let evicts = match status {
+    let (succ, evicts) = match status {
         TxStatus::Fresh => tx_pool.add_pending(entry.clone())?,
         TxStatus::Gap => tx_pool.add_gap(entry.clone())?,
         TxStatus::Proposed => tx_pool.add_proposed(entry.clone())?,
     };
-    match status {
-        TxStatus::Fresh => callbacks.call_pending(&entry),
-
-        TxStatus::Gap => callbacks.call_pending(&entry),
-
-        TxStatus::Proposed => callbacks.call_proposed(&entry),
+    if succ {
+        match status {
+            TxStatus::Fresh => callbacks.call_pending(&entry),
+            TxStatus::Gap => callbacks.call_pending(&entry),
+            TxStatus::Proposed => callbacks.call_proposed(&entry),
+        }
     }
     Ok(evicts)
 }

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -112,7 +112,7 @@ impl TxPoolService {
                 } else {
                     tx_pool
                         .pool_map
-                        .cell_ref_conflicted_candidates(entry.transaction())
+                        .check_entry_ancestors_limit(entry.transaction())?
                         .iter()
                         .map(|e| e.id.clone())
                         .collect()

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -110,7 +110,12 @@ impl TxPoolService {
                 let conflicts = if tx_pool.enable_rbf() {
                     tx_pool.check_rbf(&snapshot, &entry)?
                 } else {
-                    HashSet::new()
+                    tx_pool
+                        .pool_map
+                        .cell_ref_conflicted_candidates(entry.transaction())
+                        .iter()
+                        .map(|e| e.id.clone())
+                        .collect()
                 };
 
                 // if snapshot changed by context switch we need redo time_relative verify

--- a/util/jsonrpc-types/src/pool.rs
+++ b/util/jsonrpc-types/src/pool.rs
@@ -316,6 +316,9 @@ pub enum PoolTransactionReject {
 
     /// RBF rejected
     RBFRejected(String),
+
+    /// Invalidated rejected
+    Invalidated(String),
 }
 
 impl From<Reject> for PoolTransactionReject {
@@ -336,6 +339,7 @@ impl From<Reject> for PoolTransactionReject {
             Reject::Verification(_) => Self::Verification(format!("{reject}")),
             Reject::Expiry(_) => Self::Expiry(format!("{reject}")),
             Reject::RBFRejected(_) => Self::RBFRejected(format!("{reject}")),
+            Reject::Invalidated(_) => Self::Invalidated(format!("{reject}")),
         }
     }
 }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -59,6 +59,10 @@ pub enum Reject {
     /// RBF rejected
     #[error("RBF rejected: {0}")]
     RBFRejected(String),
+
+    /// Invalidated by cell consuming Tx
+    #[error("Invalidated: {0}")]
+    Invalidated(String),
 }
 
 fn is_malformed_from_verification(error: &Error) -> bool {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The are conflicts rule between cell dep reference and cell consume relationships.

Assume there are 3 transactions, B cell dep A(and there may be many transactions also cell dep A), C consumes A. 

- If C is committed first, B and all other transactions will be invalidated.
- If there are too many transactions all cell dep A, transaction C can not be submitted to `txpool`.

### What is changed and how it works?

This is an alternative solution with https://github.com/nervosnetwork/ckb/pull/4352
In this PR, we introduce these changes:

- Add a new `check_entry_ancestors_limit ` to find all candidates needed to evict due to cell ref conflicts, based on `evict_score`. 
- Remove `DirectParents` and  `direct_ancestors_count`, we make sure an entry's ancestors number is valid after evicting conflicted cell ref transactions.
- Move `ExceededMaximumAncestorsCount` check to place before inserting, so that we can assume there will no error report when committing a entry.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

