### PR TITLE
Fix Unit Test: `Shared::with_temp_db` should use a non-exist path

### DIFF
--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -180,6 +180,18 @@ impl SharedBuilder {
                 .unwrap()
                 .path()
                 .to_path_buf();
+
+            if std::fs::read_dir(&db_base_dir)
+                .expect("read db_base_dir must be ok")
+                .count()
+                != 0
+            {
+                panic!(
+                    "In test code, Shared::with_temp_db created a db path should be empty: {}, db_id: {}",
+                    db_base_dir.display(), db_id,
+                );
+            }
+
             let db_dir = db_base_dir.join(format!("db_{db_id}"));
             RocksDB::open_in(db_dir, COLUMNS)
         };


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

`Shared::with_temp_db` is only used by unit test, and the rocksdb should be inited in a non exist path.

In the develop branch, if I assert that the path `db_base_dir` in `Shared::with_temp_db` does not exist, I encounter the following error:

```bash
$ make test
--- STDERR:              ckb-verification-contextual tests::uncle_verifier::test_uncle_over_count ---
thread 'tests::uncle_verifier::test_uncle_over_count' panicked at 'In test code, Shared::with_temp_db created a db path that already exist: /run/user/1000/.tmpUXdHrL, db_id: 0', shared/src/shared_builder.rs:185:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        FAIL [   0.012s] ckb-verification-contextual tests::uncle_verifier::test_uncle_proposals_hash

--- STDOUT:              ckb-verification-contextual tests::uncle_verifier::test_uncle_proposals_hash ---

running 1 test
test tests::uncle_verifier::test_uncle_proposals_hash ... FAILED

failures:

failures:
    tests::uncle_verifier::test_uncle_proposals_hash

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s


--- STDERR:              ckb-verification-contextual tests::uncle_verifier::test_uncle_proposals_hash ---
thread 'tests::uncle_verifier::test_uncle_proposals_hash' panicked at 'In test code, Shared::with_temp_db created a db path that already exist: /run/user/1000/.tmpmjLMrO, db_id: 0', shared/src/shared_builder.rs:185:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        FAIL [   0.013s] ckb-verification-contextual tests::uncle_verifier::test_uncle_with_uncle_descendant

--- STDOUT:              ckb-verification-contextual tests::uncle_verifier::test_uncle_with_uncle_descendant ---

running 1 test
test tests::uncle_verifier::test_uncle_with_uncle_descendant ... FAILED

failures:

failures:
    tests::uncle_verifier::test_uncle_with_uncle_descendant

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s


--- STDERR:              ckb-verification-contextual tests::uncle_verifier::test_uncle_with_uncle_descendant ---
thread 'tests::uncle_verifier::test_uncle_with_uncle_descendant' panicked at 'In test code, Shared::with_temp_db created a db path that already exist: /run/user/1000/.tmpYeObhI, db_id: 0', shared/src/shared_builder.rs:185:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: test run failed
make: *** [Makefile:33: test] Error 100
```

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

