### PR TITLE
Allow the `PoolPersisted` integration test to run on Windows.

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -438,7 +438,6 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(PoolResurrect),
         Box::new(PoolResolveConflictAfterReorg),
         Box::new(InvalidHeaderDep),
-        #[cfg(not(target_os = "windows"))]
         Box::new(PoolPersisted),
         Box::new(TransactionRelayBasic),
         Box::new(TransactionRelayLowFeeRate),

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -690,20 +690,36 @@ impl Node {
         drop(self.guard.take())
     }
 
-    #[cfg(not(target_os = "windows"))]
     pub fn stop_gracefully(&mut self) {
         if let Some(mut guard) = self.guard.take() {
             if !guard.killed {
-                // send SIGINT to the child
-                nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(guard.child.id() as i32),
-                    nix::sys::signal::Signal::SIGINT,
-                )
-                .expect("cannot send ctrl-c");
+                // on nix: send SIGINT to the child
+                // on windows: use taskkill to kill the child gracefully
+                Self::kill_gracefully(guard.child.id());
                 let _ = guard.child.wait();
                 guard.killed = true;
             }
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn kill_gracefully(pid: u32) {
+        // taskkill /pid 1234
+        let kill_output = std::process::Command::new("taskkill")
+            .arg("/pid")
+            .arg(format!("{}", pid))
+            .output()
+            .expect("kill process on windows");
+        info!("kill process {}, output: {}", pid, kill_output)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn kill_gracefully(pid: u32) {
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGINT,
+        )
+        .expect("cannot send ctrl-c");
     }
 
     pub fn export(&self, target: String) {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
In the current integration test, `PoolPersisted` is only permitted to be executed on non-Windows platforms, as there is no `stop_gracefully` implementation for the Node used in the integration test.

What's Changed:

### Related changes

- Implement graceful termination for the integration test on the Windows platform.
- Allow `PoolPersisted` to be executed on Windows.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

