### PR TITLE
doc: add link to rpc proxy projects

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6,6 +6,8 @@ Allowing arbitrary machines to access the JSON-RPC port (using the `rpc.listen_a
 
 CKB JSON-RPC only supports HTTP now. If you need SSL, please set up a proxy via Nginx or other HTTP servers.
 
+See [list of projects](https://github.com/topics/ckb-rpc-proxy) to setup the proxy for the RPC server.
+
 Subscriptions require a full duplex connection. CKB offers such connections in the form of TCP (enable with `rpc.tcp_listen_address` configuration option) and WebSockets (enable with `rpc.ws_listen_address`).
 
 ## JSONRPC Deprecation Process


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3513

### What is changed and how it works?

What's Changed:

Add the link to a GitHub topic as mentioned in the issue <https://github.com/nervosnetwork/ckb/issues/3513>

### Check List

Tests

- Integration test: CI that covers RPC doc generation

### Release note

```release-note
None: Exclude this PR from the release note.
```
