### PR TITLE
chore: Fix get_version in doc gen

### DIFF
--- a/devtools/doc/rpc-gen/src/utils.rs
+++ b/devtools/doc/rpc-gen/src/utils.rs
@@ -51,7 +51,8 @@ pub(crate) fn get_version() -> String {
         .nth(1)
         .unwrap_or("0.0.0")
         .to_owned();
-    version
+    let stripped = version.split('@').nth(1).unwrap_or(&version).trim();
+    stripped.to_string()
 }
 
 pub(crate) fn get_current_git_branch() -> String {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The result from command `cargo pkgid` may have differences between different arch.

### What is changed and how it works?

Strip out the first `@` in command line output.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test



### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

