### PR TITLE
feat: limit ibd orphan pool size

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4125,7 +4125,8 @@ Response
     "inflight_blocks_count": "0x0",
     "low_time": "0x5dc",
     "normal_time": "0x4e2",
-    "orphan_blocks_count": "0x0"
+    "orphan_blocks_count": "0x0",
+    "orphan_blocks_size": "0x0"
   }
 }
 ```
@@ -6511,6 +6512,8 @@ The overall chain synchronization state of this local node.
     The local node downloads multiple blocks simultaneously but blocks must be connected consecutively. If a descendant is downloaded before its ancestors, it becomes an orphan block.
 
     If this number is too high, it indicates that block download has stuck at some block.
+
+* `orphan_blocks_size`: [`Uint64`](#type-uint64) - The size of all download orphan blocks
 
 ### Type `Timestamp`
 

--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -368,7 +368,8 @@ pub trait NetRpc {
     ///     "inflight_blocks_count": "0x0",
     ///     "low_time": "0x5dc",
     ///     "normal_time": "0x4e2",
-    ///     "orphan_blocks_count": "0x0"
+    ///     "orphan_blocks_count": "0x0",
+    ///     "orphan_blocks_size": "0x0"
     ///   }
     /// }
     /// ```
@@ -723,6 +724,7 @@ impl NetRpc for NetRpcImpl {
             best_known_block_number: best_known.number().into(),
             best_known_block_timestamp: best_known.timestamp().into(),
             orphan_blocks_count: (state.orphan_pool().len() as u64).into(),
+            orphan_blocks_size: (state.orphan_pool().total_size() as u64).into(),
             inflight_blocks_count: (state.read_inflight_blocks().total_inflight_count() as u64)
                 .into(),
             fast_time: fast_time.into(),

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -12,18 +12,18 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-chain = { path = "../chain", version = "= 0.115.0-pre" }
 ckb-shared = { path = "../shared", version = "= 0.115.0-pre" }
 ckb-store = { path = "../store", version = "= 0.115.0-pre" }
-ckb-app-config = {path = "../util/app-config", version = "= 0.115.0-pre"}
-ckb-types = {path = "../util/types", version = "= 0.115.0-pre"}
+ckb-app-config = { path = "../util/app-config", version = "= 0.115.0-pre" }
+ckb-types = { path = "../util/types", version = "= 0.115.0-pre" }
 ckb-network = { path = "../network", version = "= 0.115.0-pre" }
-ckb-logger = {path = "../util/logger", version = "= 0.115.0-pre"}
-ckb-metrics = {path = "../util/metrics", version = "= 0.115.0-pre"}
+ckb-logger = { path = "../util/logger", version = "= 0.115.0-pre" }
+ckb-metrics = { path = "../util/metrics", version = "= 0.115.0-pre" }
 ckb-util = { path = "../util", version = "= 0.115.0-pre" }
 ckb-verification = { path = "../verification", version = "= 0.115.0-pre" }
 ckb-verification-traits = { path = "../verification/traits", version = "= 0.115.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.115.0-pre" }
 ckb-channel = { path = "../util/channel", version = "= 0.115.0-pre" }
 ckb-traits = { path = "../traits", version = "= 0.115.0-pre" }
-ckb-error = {path = "../error", version = "= 0.115.0-pre"}
+ckb-error = { path = "../error", version = "= 0.115.0-pre" }
 ckb-tx-pool = { path = "../tx-pool", version = "= 0.115.0-pre" }
 sentry = { version = "0.26.0", optional = true }
 ckb-constant = { path = "../util/constant", version = "= 0.115.0-pre" }
@@ -50,7 +50,7 @@ ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.115
 ckb-chain = { path = "../chain", version = "= 0.115.0-pre", features = ["mock"] }
 faux = "^0.1"
 once_cell = "1.8.0"
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.115.0-pre" , features = ["enable_faketime"]}
+ckb-systemtime = { path = "../util/systemtime", version = "= 0.115.0-pre", features = ["enable_faketime"] }
 ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.115.0-pre" }
 
 [features]

--- a/sync/src/tests/orphan_block_pool.rs
+++ b/sync/src/tests/orphan_block_pool.rs
@@ -26,17 +26,21 @@ fn test_remove_blocks_by_parent() {
     let mut blocks = Vec::new();
     let mut parent = consensus.genesis_block().header();
     let pool = OrphanBlockPool::with_capacity(200);
+    let mut total_size = 0;
     for _ in 1..block_number {
         let new_block = gen_block(&parent);
+        total_size += new_block.data().total_size();
         blocks.push(new_block.clone());
         pool.insert(new_block.clone());
         parent = new_block.header();
     }
+    assert_eq!(total_size, pool.total_size());
 
     let orphan = pool.remove_blocks_by_parent(&consensus.genesis_block().hash());
     let orphan_set: HashSet<BlockView> = orphan.into_iter().collect();
     let blocks_set: HashSet<BlockView> = blocks.into_iter().collect();
-    assert_eq!(orphan_set, blocks_set)
+    assert_eq!(orphan_set, blocks_set);
+    assert_eq!(0, pool.total_size());
 }
 
 #[test]
@@ -145,4 +149,5 @@ fn test_remove_expired_blocks() {
     let v = pool.clean_expired_blocks(20_u64);
     assert_eq!(v.len(), 19);
     assert_eq!(pool.leaders_len(), 0);
+    assert_eq!(pool.total_size(), 0)
 }

--- a/util/constant/src/sync.rs
+++ b/util/constant/src/sync.rs
@@ -53,6 +53,9 @@ pub const BLOCK_DOWNLOAD_TIMEOUT: u64 = 30 * 1000; // 30s
 // potential degree of disordering of blocks.
 pub const BLOCK_DOWNLOAD_WINDOW: u64 = 1024 * 8; // 1024 * default_outbound_peers
 
+/// Orphan block pool max size
+pub const MAX_ORPHAN_POOL_SIZE: usize = 1024 * 1024 * 256;
+
 /// Interval between repeated inquiry transactions
 pub const RETRY_ASK_TX_TIMEOUT_INCREASE: Duration = Duration::from_secs(30);
 

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -276,6 +276,8 @@ pub struct SyncState {
     ///
     /// If this number is too high, it indicates that block download has stuck at some block.
     pub orphan_blocks_count: Uint64,
+    /// The size of all download orphan blocks
+    pub orphan_blocks_size: Uint64,
     /// Count of downloading blocks.
     pub inflight_blocks_count: Uint64,
     /// The download scheduler's time analysis data, the fast is the 1/3 of the cut-off point, unit ms


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds a special download mode during ibd to limit the memory usage of the orphan pool.

### Check List

Tests

- Unit test
- Integration test


### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

