### PR TITLE
Fix type name issue caused from schemars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "ckb_schemars"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160bd7cb5051a4bd6fe80a3c3e794cd26864dba70360d0e5ea34e21a71d7e4a3"
+checksum = "f21f99fca82a4eb8708e406e99246987b087ecc1e1babeece1a0b1d5238b1750"
 dependencies = [
  "ckb_schemars_derive",
  "dyn-clone",
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "ckb_schemars_derive"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4003e04a097903cf2d96d20f5c587c5f744cdef972ce8029bd30a4674634c9"
+checksum = "40c813b4fadbdd9f33b1cf02a1ddfa9537d955c8d2fbe150d1fc1684dbf78e73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 ckb-rpc ={ path = "../../../rpc", version = "= 0.115.0-pre" }
-schemars = { version = "0.8.16", package = "ckb_schemars" }
+schemars = { version = "0.8.19", package = "ckb_schemars" }
 serde_json = "~1.0"
 tera = "1"
 syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -218,8 +218,19 @@ impl RpcDocGenerator {
                 let name = capitlize(name);
                 let desc = desc.replacen("```\n", "```json\n", 1);
                 let fields = gen_type_fields(&name, ty);
+                let fixed_name = fix_type_name(&name);
+                let sub_title = if fixed_name != name {
+                    format!(
+                        "<a id=\"type-{}\"></a>\n### Type `{}`",
+                        name.to_lowercase(),
+                        fixed_name
+                    )
+                } else {
+                    format!("### Type `{}`", fixed_name)
+                };
                 gen_value(&[
-                    ("name", fix_type_name(&name).into()),
+                    ("sub_title", sub_title.into()),
+                    ("name", fixed_name.into()),
                     ("desc", desc.into()),
                     ("fields", fields.into()),
                 ])

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -100,7 +100,7 @@ pub(crate) struct RpcDocGenerator {
 impl RpcDocGenerator {
     pub fn new(all_rpc: &Vec<Value>, readme_path: String) -> Self {
         let mut rpc_methods = vec![];
-        let mut all_types: Vec<&Map<String, Value>> = vec![];
+        let mut types: Vec<&Map<String, Value>> = vec![];
         for rpc in all_rpc {
             if let serde_json::Value::Object(map) = rpc {
                 let title = capitlize(
@@ -111,8 +111,8 @@ impl RpcDocGenerator {
                 );
                 let description = get_description(&map["info"]["description"]);
                 let methods = map["methods"].as_array().unwrap();
-                let types = map["components"]["schemas"].as_object().unwrap();
-                all_types.push(types);
+                let pair = map["components"]["schemas"].as_object().unwrap();
+                types.push(pair);
                 rpc_methods.push(RpcModule {
                     title,
                     description,
@@ -127,23 +127,24 @@ impl RpcDocGenerator {
         let mut pre_defined: Vec<(String, String)> = pre_defined_types().collect();
         pre_defined.extend(visit_for_types());
 
-        let mut types: Vec<(String, Value)> = pre_defined
+        let mut all_types: Vec<(String, Value)> = pre_defined
             .iter()
             .map(|(name, desc)| (name.clone(), Value::String(desc.clone())))
             .collect();
-        for map in all_types {
+        for map in types {
             for (name, ty) in map.iter() {
-                if !(types.iter().any(|(n, _)| *n == *name)
+                if !(all_types.iter().any(|(n, _)| *n == *name)
                     || (name.starts_with("Either_for_") && name.ends_with("_JsonBytes")))
                 {
-                    types.push((name.to_string(), ty.to_owned()));
+                    all_types.push((name.to_string(), ty.to_owned()));
                 }
             }
         }
-        types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+
+        all_types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
         Self {
             rpc_methods,
-            types,
+            types: all_types,
             file_path: readme_path,
         }
     }
@@ -169,7 +170,7 @@ impl RpcDocGenerator {
         let type_menus: Value = self
             .types
             .iter()
-            .map(|(name, _)| vec![capitlize(name).into(), name.to_lowercase().into()])
+            .map(|(name, _)| vec![fix_type_name(name).into(), name.to_lowercase().into()])
             .collect::<Vec<Vec<Value>>>()
             .into();
 
@@ -218,7 +219,7 @@ impl RpcDocGenerator {
                 let desc = desc.replacen("```\n", "```json\n", 1);
                 let fields = gen_type_fields(&name, ty);
                 gen_value(&[
-                    ("name", name.into()),
+                    ("name", fix_type_name(&name).into()),
                     ("desc", desc.into()),
                     ("fields", fields.into()),
                 ])
@@ -261,6 +262,23 @@ fn strip_prefix_space(content: &str) -> String {
     } else {
         content.to_string()
     }
+}
+
+// Fix type name issue caused by: https://github.com/GREsau/schemars/issues/193
+fn fix_type_name(type_name: &str) -> String {
+    let elems: Vec<_> = type_name.split("_for_").collect();
+    let type_name = if elems.len() == 2 {
+        format!("{}<{}>", fix_type_name(elems[0]), fix_type_name(elems[1]))
+    } else {
+        type_name.to_owned()
+    };
+    let elems: Vec<_> = type_name.split("_and_").collect();
+    let type_name = if elems.len() == 2 {
+        format!("{} | {}", fix_type_name(elems[0]), fix_type_name(elems[1]))
+    } else {
+        type_name.to_owned()
+    };
+    capitlize(&type_name)
 }
 
 fn get_description(value: &Value) -> String {
@@ -306,7 +324,8 @@ fn gen_type_desc(desc: &str) -> String {
 fn format_fields(name: &str, fields: &str) -> String {
     format!(
         "\n#### Fields\n\n`{}` is a JSON object with the following fields.\n\n{}",
-        name, fields
+        fix_type_name(name),
+        fields
     )
 }
 
@@ -418,7 +437,7 @@ fn gen_type(ty: &Value) -> String {
                 format!("\nIt's an enum value from one of:\n{}\n", res)
             } else if let Some(link) = map.get("$ref") {
                 let link = link.as_str().unwrap().split('/').last().unwrap();
-                format!("[`{}`](#type-{})", link, link.to_lowercase())
+                format!("[`{}`](#type-{})", fix_type_name(link), link.to_lowercase())
             } else {
                 "".to_owned()
             }

--- a/devtools/doc/rpc-gen/templates/markdown.tera
+++ b/devtools/doc/rpc-gen/templates/markdown.tera
@@ -22,7 +22,7 @@
 
 ## RPC Types
 {% for ty in types %}
-### Type `{{ ty["name"] }}`
+{{ ty["sub_title"]}}
 {{ ty["desc"] }}
 {{ ty["fields"] }}
 {%- endfor %}

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -51,7 +51,7 @@ tower-http = { version = "0.3.5", features = ["timeout", "cors"] }
 async-stream = "0.3.3"
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.115.0-pre" }
 # issue tracking: https://github.com/GREsau/schemars/pull/251
-schemars = { version = "0.8.16", package = "ckb_schemars" }
+schemars = { version = "0.8.19", package = "ckb_schemars" }
 
 [dev-dependencies]
 reqwest = { version = "=0.11.20", features = ["blocking", "json"] }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -6037,6 +6037,7 @@ It's an enum value from one of:
   - desc : Descending order
   - asc : Ascending order
 
+<a id="type-indexerpagination_for_indexercell"></a>
 ### Type `IndexerPagination<IndexerCell>`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
@@ -6048,6 +6049,7 @@ IndexerPagination wraps objects array and last_cursor to provide paging
 
 * `objects`: `Array<` [`IndexerCell`](#type-indexercell) `>` - objects collection
 
+<a id="type-indexerpagination_for_indexertx"></a>
 ### Type `IndexerPagination<IndexerTx>`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
@@ -6578,6 +6580,7 @@ The information about an active running protocol.
 
 * `version`: `string` - Active protocol version.
 
+<a id="type-responseformat_for_blockview"></a>
 ### Type `ResponseFormat<BlockView>`
 This is a wrapper for JSON serialization to select the format between Json and Hex.
 
@@ -6591,6 +6594,7 @@ This is a wrapper for JSON serialization to select the format between Json and H
 
 * `inner`: [`Either<BlockView | JsonBytes>`](#type-either_for_blockview_and_jsonbytes) - The inner value.
 
+<a id="type-responseformat_for_headerview"></a>
 ### Type `ResponseFormat<HeaderView>`
 This is a wrapper for JSON serialization to select the format between Json and Hex.
 
@@ -6604,6 +6608,7 @@ This is a wrapper for JSON serialization to select the format between Json and H
 
 * `inner`: [`Either<HeaderView | JsonBytes>`](#type-either_for_headerview_and_jsonbytes) - The inner value.
 
+<a id="type-responseformat_for_transactionview"></a>
 ### Type `ResponseFormat<TransactionView>`
 This is a wrapper for JSON serialization to select the format between Json and Hex.
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -171,14 +171,15 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `FeeRateStatistics`](#type-feeratestatistics)
     * [Type `H256`](#type-h256)
     * [Type `HardForkFeature`](#type-hardforkfeature)
+    * [Type `HardForks`](#type-hardforks)
     * [Type `Header`](#type-header)
     * [Type `HeaderView`](#type-headerview)
     * [Type `IndexerCell`](#type-indexercell)
     * [Type `IndexerCellType`](#type-indexercelltype)
     * [Type `IndexerCellsCapacity`](#type-indexercellscapacity)
     * [Type `IndexerOrder`](#type-indexerorder)
-    * [Type `IndexerPagination_for_IndexerCell`](#type-indexerpagination_for_indexercell)
-    * [Type `IndexerPagination_for_IndexerTx`](#type-indexerpagination_for_indexertx)
+    * [Type `IndexerPagination<IndexerCell>`](#type-indexerpagination_for_indexercell)
+    * [Type `IndexerPagination<IndexerTx>`](#type-indexerpagination_for_indexertx)
     * [Type `IndexerRange`](#type-indexerrange)
     * [Type `IndexerScriptType`](#type-indexerscripttype)
     * [Type `IndexerSearchKey`](#type-indexersearchkey)
@@ -207,6 +208,9 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Type `RawTxPool`](#type-rawtxpool)
     * [Type `RemoteNode`](#type-remotenode)
     * [Type `RemoteNodeProtocol`](#type-remotenodeprotocol)
+    * [Type `ResponseFormat<BlockView>`](#type-responseformat_for_blockview)
+    * [Type `ResponseFormat<HeaderView>`](#type-responseformat_for_headerview)
+    * [Type `ResponseFormat<TransactionView>`](#type-responseformat_for_transactionview)
     * [Type `Rfc0043`](#type-rfc0043)
     * [Type `Script`](#type-script)
     * [Type `ScriptHashType`](#type-scripthashtype)
@@ -606,7 +610,7 @@ When specifying with_cycles, the response object will be different like below:
 * `get_header(block_hash, verbosity)`
     * `block_hash`: [`H256`](#type-h256)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes) `|` `null`
+* result: [`ResponseFormat<HeaderView>`](#type-responseformat_for_headerview) `|` `null`
 
 Returns the information about a block header by hash.
 
@@ -685,7 +689,7 @@ The response looks like below when `verbosity` is 0.
 * `get_header_by_number(block_number, verbosity)`
     * `block_number`: [`Uint64`](#type-uint64)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes) `|` `null`
+* result: [`ResponseFormat<HeaderView>`](#type-responseformat_for_headerview) `|` `null`
 
 Returns the block header in the [canonical chain](#canonical-chain) with the specific block
 number.
@@ -996,7 +1000,7 @@ Response
 #### Method `get_tip_header`
 * `get_tip_header(verbosity)`
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`Either_for_HeaderView_and_JsonBytes`](#type-either_for_headerview_and_jsonbytes)
+* result: [`ResponseFormat<HeaderView>`](#type-responseformat_for_headerview)
 
 Returns the header with the highest block number in the [canonical chain](#canonical-chain).
 
@@ -1524,7 +1528,7 @@ Response
 * `get_fork_block(block_hash, verbosity)`
     * `block_hash`: [`H256`](#type-h256)
     * `verbosity`: [`Uint32`](#type-uint32) `|` `null`
-* result: [`Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes) `|` `null`
+* result: [`ResponseFormat<BlockView>`](#type-responseformat_for_blockview) `|` `null`
 
 Returns the information about a fork block by hash.
 
@@ -2200,7 +2204,7 @@ Response
     * `order`: [`IndexerOrder`](#type-indexerorder)
     * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
-* result: [`IndexerPagination_for_IndexerCell`](#type-indexerpagination_for_indexercell)
+* result: [`IndexerPagination<IndexerCell>`](#type-indexerpagination_for_indexercell)
 
 Returns the live cells collection by the lock or type script.
 
@@ -2558,7 +2562,7 @@ Response
     * `order`: [`IndexerOrder`](#type-indexerorder)
     * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
-* result: [`IndexerPagination_for_IndexerTx`](#type-indexerpagination_for_indexertx)
+* result: [`IndexerPagination<IndexerTx>`](#type-indexerpagination_for_indexertx)
 
 Returns the transactions collection by the lock or type script.
 
@@ -4685,7 +4689,7 @@ Same as CKB Indexer.
     * `order`: [`IndexerOrder`](#type-indexerorder)
     * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
-* result: [`IndexerPagination_for_IndexerCell`](#type-indexerpagination_for_indexercell)
+* result: [`IndexerPagination<IndexerCell>`](#type-indexerpagination_for_indexercell)
 
 Returns the live cells collection by the lock or type script.
 
@@ -4733,7 +4737,7 @@ Same as CKB Indexer.
     * `order`: [`IndexerOrder`](#type-indexerorder)
     * `limit`: [`Uint32`](#type-uint32)
     * `after`: [`JsonBytes`](#type-jsonbytes) `|` `null`
-* result: [`IndexerPagination_for_IndexerTx`](#type-indexerpagination_for_indexertx)
+* result: [`IndexerPagination<IndexerTx>`](#type-indexerpagination_for_indexertx)
 
 Returns the transactions collection by the lock or type script.
 
@@ -5348,7 +5352,7 @@ BlockResponse with cycles format wrapper
 
 `BlockWithCyclesResponse` is a JSON object with the following fields.
 
-* `block`: [`Either_for_BlockView_and_JsonBytes`](#type-either_for_blockview_and_jsonbytes) - The block structure
+* `block`: [`ResponseFormat<BlockView>`](#type-responseformat_for_blockview) - The block structure
 
 ### Type `Buried`
 Represent soft fork deployments where the activation epoch is hard-coded into the client implementation
@@ -5599,7 +5603,7 @@ Consensus defines various parameters that influence chain consensus
 
 * `genesis_hash`: [`H256`](#type-h256) - The genesis block hash
 
-* `hardfork_features`: `Array<` [`HardForkFeature`](#type-hardforkfeature) `>` - Hardfork features
+* `hardfork_features`: [`HardForks`](#type-hardforks) - Hardfork features
 
 * `id`: `string` - Names the network.
 
@@ -5845,6 +5849,14 @@ The information about one hardfork feature.
 
 * `rfc`: `string` - The related RFC ID.
 
+### Type `HardForks`
+Hardfork information
+
+#### Fields
+
+`HardForks` is a JSON object with the following fields.
+
+* `inner`: `Array<` [`HardForkFeature`](#type-hardforkfeature) `>`
 ### Type `Header`
 The block header.
 
@@ -6025,23 +6037,23 @@ It's an enum value from one of:
   - desc : Descending order
   - asc : Ascending order
 
-### Type `IndexerPagination_for_IndexerCell`
+### Type `IndexerPagination<IndexerCell>`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
 #### Fields
 
-`IndexerPagination_for_IndexerCell` is a JSON object with the following fields.
+`IndexerPagination<IndexerCell>` is a JSON object with the following fields.
 
 * `last_cursor`: [`JsonBytes`](#type-jsonbytes) - pagination parameter
 
 * `objects`: `Array<` [`IndexerCell`](#type-indexercell) `>` - objects collection
 
-### Type `IndexerPagination_for_IndexerTx`
+### Type `IndexerPagination<IndexerTx>`
 IndexerPagination wraps objects array and last_cursor to provide paging
 
 #### Fields
 
-`IndexerPagination_for_IndexerTx` is a JSON object with the following fields.
+`IndexerPagination<IndexerTx>` is a JSON object with the following fields.
 
 * `last_cursor`: [`JsonBytes`](#type-jsonbytes) - pagination parameter
 
@@ -6085,13 +6097,13 @@ IndexerSearchKeyFilter represent indexer params `filter`
 
 `IndexerSearchKeyFilter` is a JSON object with the following fields.
 
-* `block_range`: [`Uint64`](#type-uint64) filter cells by block number range
-* `output_capacity_range`: [`Uint64`](#type-uint64) filter cells by output capacity range
+* `block_range`: [`IndexerRange`](#type-indexerrange) `|` `null` filter cells by block number range
+* `output_capacity_range`: [`IndexerRange`](#type-indexerrange) `|` `null` filter cells by output capacity range
 * `output_data`: [`JsonBytes`](#type-jsonbytes) `|` `null` filter cells by output data
 * `output_data_filter_mode`: [`IndexerSearchMode`](#type-indexersearchmode) `|` `null` output data filter mode, optional default is `prefix`
-* `output_data_len_range`: [`Uint64`](#type-uint64) filter cells by output data len range
+* `output_data_len_range`: [`IndexerRange`](#type-indexerrange) `|` `null` filter cells by output data len range
 * `script`: [`Script`](#type-script) `|` `null` if search script type is lock, filter cells by type script prefix, and vice versa
-* `script_len_range`: [`Uint64`](#type-uint64) filter cells by script len range
+* `script_len_range`: [`IndexerRange`](#type-indexerrange) `|` `null` filter cells by script len range
 ### Type `IndexerSearchMode`
 IndexerSearchMode represent search mode, default is prefix search
 
@@ -6565,6 +6577,45 @@ The information about an active running protocol.
 * `id`: [`Uint64`](#type-uint64) - Unique protocol ID.
 
 * `version`: `string` - Active protocol version.
+
+### Type `ResponseFormat<BlockView>`
+This is a wrapper for JSON serialization to select the format between Json and Hex.
+
+###### Examples
+
+`ResponseFormat<BlockView>` returns the block in its Json format or molecule serialized Hex format.
+
+#### Fields
+
+`ResponseFormat<BlockView>` is a JSON object with the following fields.
+
+* `inner`: [`Either<BlockView | JsonBytes>`](#type-either_for_blockview_and_jsonbytes) - The inner value.
+
+### Type `ResponseFormat<HeaderView>`
+This is a wrapper for JSON serialization to select the format between Json and Hex.
+
+###### Examples
+
+`ResponseFormat<BlockView>` returns the block in its Json format or molecule serialized Hex format.
+
+#### Fields
+
+`ResponseFormat<HeaderView>` is a JSON object with the following fields.
+
+* `inner`: [`Either<HeaderView | JsonBytes>`](#type-either_for_headerview_and_jsonbytes) - The inner value.
+
+### Type `ResponseFormat<TransactionView>`
+This is a wrapper for JSON serialization to select the format between Json and Hex.
+
+###### Examples
+
+`ResponseFormat<BlockView>` returns the block in its Json format or molecule serialized Hex format.
+
+#### Fields
+
+`ResponseFormat<TransactionView>` is a JSON object with the following fields.
+
+* `inner`: [`Either<TransactionView | JsonBytes>`](#type-either_for_transactionview_and_jsonbytes) - The inner value.
 
 ### Type `Rfc0043`
 Represent soft fork deployments where activation is controlled by rfc0043 signaling

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 thiserror = "1.0.22"
 serde = { version = "1.0", features = ["derive"] }
 faster-hex = "0.6"
-schemars = { version = "0.8.16", package = "ckb_schemars" }
+schemars = { version = "0.8.19", package = "ckb_schemars" }
 
 
 

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -13,7 +13,7 @@ ckb-types = { path = "../types", version = "= 0.115.0-pre" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 faster-hex = "0.6"
-schemars = { version = "0.8.16", package = "ckb_schemars" }
+schemars = { version = "0.8.19", package = "ckb_schemars" }
 
 
 [dev-dependencies]


### PR DESCRIPTION
### What problem does this PR solve?

There is an issue from schemars: https://github.com/GREsau/schemars/issues/193, which may insert `_and_` and `_for_` in types, we don't want this.

### What is changed and how it works?

Add a wrapper function `fix_type_name` to workaround it, it will cost much more time to wait schemars fix its issue, or we need to dig into schemars by ourself which will also cost time.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

