### PR TITLE
Limit txpool size when inserting an Entry 

### DIFF
--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -51,11 +51,10 @@ impl Spec for SizeLimit {
         });
 
         info!("The next tx reach size limit");
-        let tx = node.new_transaction(hash);
-        let _hash = node.rpc_client().send_transaction(tx.data().into());
-        node.assert_tx_pool_serialized_size((max_tx_num + 1) * one_tx_size);
-        let last = node
-            .mine_with_blocking(|template| template.proposals.len() != (max_tx_num + 1) as usize);
+        let _tx = node.new_transaction(hash);
+        node.assert_tx_pool_serialized_size((max_tx_num) * one_tx_size);
+        let last =
+            node.mine_with_blocking(|template| template.proposals.len() != max_tx_num as usize);
         node.assert_tx_pool_serialized_size(max_tx_num * one_tx_size);
         node.mine_with_blocking(|template| template.number.value() != (last + 1));
         node.mine_with_blocking(|template| template.transactions.len() != max_tx_num as usize);


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

Currently, the `limit_size` is only invoked by `_update_tx_pool_for_reorg`, so we only shrink tx_pool size when generating a new block. Ideally, we should also limit size when inserting a new Entry into pool.

### What is changed and how it works?

What's Changed:
Invoke `limit_size` in `submit_entry`.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

