### PR TITLE
chore: add deprecated notes for rpc README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ version = "0.115.0-pre"
 dependencies = [
  "ckb-rpc",
  "ckb_schemars",
+ "proc-macro2",
  "serde_json",
  "syn 2.0.52",
  "tera",

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "~1.0"
 tera = "1"
 syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }
 walkdir = "2.1.4"
+proc-macro2 = "1.0"

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1866,6 +1866,9 @@ Response
     * `target`: [`Uint64`](#type-uint64) `|` `null`
 * result: [`FeeRateStatistics`](#type-feeratestatistics) `|` `null`
 
+👎Deprecated since 0.109.0: Please use the RPC method [`get_fee_rate_statistics`](#chain-get_fee_rate_statistics) instead
+
+
 Returns the fee_rate statistics of confirmed blocks on the chain
 
 ###### Params
@@ -2014,6 +2017,9 @@ The methods here may be removed or changed in future releases without prior noti
 * `dry_run_transaction(tx)`
     * `tx`: [`Transaction`](#type-transaction)
 * result: [`EstimateCycles`](#type-estimatecycles)
+
+👎Deprecated since 0.105.1: Please use the RPC method [`estimate_cycles`](#chain-estimate_cycles) instead
+
 
 Dry run a transaction and return the execution cycles.
 

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1562,7 +1562,7 @@ pub trait ChainRpc {
     /// ```
     #[deprecated(
         since = "0.109.0",
-        note = "Please use the RPC method [`get_fee_rate_statistics`](#tymethod.get_fee_rate_statistics) instead"
+        note = "Please use the RPC method [`get_fee_rate_statistics`](#chain-get_fee_rate_statistics) instead"
     )]
     #[rpc(name = "get_fee_rate_statics")]
     fn get_fee_rate_statics(&self, target: Option<Uint64>) -> Result<Option<FeeRateStatistics>>;

--- a/rpc/src/module/experiment.rs
+++ b/rpc/src/module/experiment.rs
@@ -97,7 +97,7 @@ pub trait ExperimentRpc {
     /// ```
     #[deprecated(
         since = "0.105.1",
-        note = "Please use the RPC method [`estimate_cycles`](#tymethod.estimate_cycles) instead"
+        note = "Please use the RPC method [`estimate_cycles`](#chain-estimate_cycles) instead"
     )]
     #[rpc(name = "dry_run_transaction")]
     fn dry_run_transaction(&self, tx: Transaction) -> Result<EstimateCycles>;


### PR DESCRIPTION


### What problem does this PR solve?

Problem Summary:

The new readme generator didn't add note for deprecated rpc methods.

### What is changed and how it works?

What's Changed:

- Add `syn` related code to support these notes.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

