### PR TITLE
(chore): Add cargo shear to check crates

### DIFF
--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -24,3 +24,6 @@ ckb-system-scripts = { version = "= 0.5.4" }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[package.metadata.cargo-shear]
+ignored = ["phf"]

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -16,3 +16,6 @@ ckb-fixed-hash-core = { path = "../core", version = "= 0.116.0-pre" }
 quote = "1.0"
 syn = "1.0"
 proc-macro2 = "1.0"
+
+[package.metadata.cargo-shear]
+ignored = ["ckb-fixed-hash-core"]

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -30,3 +30,6 @@ paste = "1.0"
 
 [dev-dependencies]
 proptest = "1.0"
+
+[package.metadata.cargo-shear]
+ignored = ["bytes"]


### PR DESCRIPTION
### What problem does this PR solve?

Use bash script with pattern match to check unused crates seems slow and not easy to maintain, [cargo-shear](https://github.com/Boshen/cargo-shear) is a better tool for this task.

While it has false positive warnings caused by macros, we can add them to the ignored list.

### What is changed and how it works?

What's Changed:
- Add `cargo-shear` into `devtools/ci/check-cargotoml.sh`
- Trivial cleanup for performance

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

