### PR TITLE
Remove `CKB_TEST_SEC_COEFFICIENT` on windows ci integration

### DIFF
--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -51,7 +51,7 @@ case $GITHUB_WORKFLOW in
     if [[ $github_workflow_os == 'macos' ]]; then
       export CKB_FEATURES="deadlock_detection,with_sentry,portable"
     fi
-    make CKB_TEST_SEC_COEFFICIENT=5 CKB_TEST_ARGS="-c 4 --no-report --max-time 7200 " integration
+    make CKB_TEST_ARGS="-c 4 --no-report --max-time 7200 " integration
     ;;
   ci_quick_checks*)
     echo "ci_quick_check"


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

I beleave we shouldn't set `CKB_TEST_SEC_COEFFICIENT=5` on windows's integration test script.

### What is changed and how it works?
### Related changes

- Remove `CKB_TEST_SEC_COEFFICIENT=5` on windows's integration test script.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

