### PR TITLE
Set ChainService process_block channel size to zero

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,7 +20,7 @@ use ckb_types::{
             ResolvedTransaction,
         },
         hardfork::HardForks,
-        service::{Request, DEFAULT_CHANNEL_SIZE},
+        service::Request,
         BlockExt, BlockNumber, BlockView, Cycle, HeaderView,
     },
     packed::{Byte32, ProposalShortId},
@@ -222,8 +222,8 @@ impl ChainService {
     /// start background single-threaded service with specified thread_name.
     pub fn start<S: ToString>(mut self, thread_name: Option<S>) -> ChainController {
         let signal_receiver = new_crossbeam_exit_rx();
-        let (process_block_sender, process_block_receiver) = channel::bounded(DEFAULT_CHANNEL_SIZE);
-        let (truncate_sender, truncate_receiver) = channel::bounded(1);
+        let (process_block_sender, process_block_receiver) = channel::bounded(0);
+        let (truncate_sender, truncate_receiver) = channel::bounded(0);
 
         // Mainly for test: give an empty thread_name
         let mut thread_builder = thread::Builder::new();


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

On the develop branch, the `ChainService`'s `process_block` channel has a capacity of `DEFAULT_CHANNEL_SIZE`(32), but it does not provide any benefit for `ckb-sync` or `ckb-chain`:
https://github.com/nervosnetwork/ckb/blob/149b5c53e2c6e089d3e4ff6013d1992b56f3b4c6/chain/src/chain.rs#L225

In a scenario where `ckb-sync` sends a block to `ChainService` through `ChainController::process_block`, and at the same time, `ChainService` receives a `Ctrl-C` exit signal.
Then `ChainService`'s `process_block_sender` have one `ProcessBlockRequest` in its buffer:

https://github.com/nervosnetwork/ckb/blob/149b5c53e2c6e089d3e4ff6013d1992b56f3b4c6/chain/src/chain.rs#L41

When `self.process_block_sender` and `self.stop_receiver` are ready at the same time, `ChainService`'s `select!` may choose to execute `self.stop_receiver`:
https://github.com/nervosnetwork/ckb/blob/149b5c53e2c6e089d3e4ff6013d1992b56f3b4c6/chain/src/chain.rs#L237-L272

then the `process_block_receiver` will be dropped.

However, the `process_block_sender` is held by the `Synchronizer`'s `ChainController`, and there is one `ProcessBlockRequest` in `process_block_sender`'s buffer, causing the `ChainController::internal_block_process` to block indefinitely.

In that case, `Synchronizer::received` will block indefinitely at this point:
https://github.com/nervosnetwork/ckb/blob/149b5c53e2c6e089d3e4ff6013d1992b56f3b4c6/sync/src/synchronizer/mod.rs#L784

### What is changed and how it works?

### Related changes

- Set `ChainService`'s process_block channel capacity size to 0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

