### PR TITLE
Fix send Ctrl-C signal on Windows integration test'

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -43,6 +43,9 @@ log = "0.4"
 [target.'cfg(not(target_os="windows"))'.dependencies]
 nix = { version = "0.24.0", default-features = false, features = ["signal"] }
 
+[target.'cfg(target_os="windows")'.dependencies]
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_System_Console"] }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
 
     let cloned_running_names = Arc::clone(&running_spec_names);
     ctrlc::set_handler(move || {
-        std::thread::sleep(Duration::from_secs(1));
+        std::thread::sleep(Duration::from_secs(10));
         warn!(
             "Total {} specs are not finished",
             cloned_running_names.lock().len()

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -8,7 +8,7 @@ use ckb_chain_spec::ChainSpec;
 use ckb_error::AnyError;
 use ckb_jsonrpc_types::{BlockFilter, BlockTemplate, TxPoolInfo};
 use ckb_jsonrpc_types::{PoolTxDetailInfo, TxStatus};
-use ckb_logger::{debug, error, info};
+use ckb_logger::{debug, error};
 use ckb_resource::Resource;
 use ckb_types::{
     bytes,


### PR DESCRIPTION


<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
On latest develop branch, Windows CI failed: https://github.com/nervosnetwork/ckb/actions/runs/8718279015/job/23915178721


What's Changed:

### Related changes

- Use `windows_sys` to send `Ctrl-C` signal to process on Windows platform

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

