### PR TITLE
Print duration needed to reach assume_valid_target in the Header Sync phase.

### DIFF
--- a/devtools/release/update_default_valid_target.sh
+++ b/devtools/release/update_default_valid_target.sh
@@ -69,6 +69,8 @@ pub mod ${network} {
     /// you can view this block in ${EXPLORER_URL}
     pub const DEFAULT_ASSUME_VALID_TARGET: &str =
         "${ASSUME_TARGET_HASH}";
+    /// Default assume valid target's height
+    pub const DEFAULT_ASSUME_VALID_TARGET_HEIGHT: u64 = ${ASSUME_TARGET_HEIGHT_DECIMAL};
 }
 END_HEREDOC
 )

--- a/util/constant/src/default_assume_valid_target.rs
+++ b/util/constant/src/default_assume_valid_target.rs
@@ -15,6 +15,8 @@ pub mod mainnet {
     /// you can view this block in https://explorer.nervos.org/block/0xc394fa4c5e5032c49f3502d4fd8054ead76ff693a54ac90757e441b5119afcaf
     pub const DEFAULT_ASSUME_VALID_TARGET: &str =
         "0xc394fa4c5e5032c49f3502d4fd8054ead76ff693a54ac90757e441b5119afcaf";
+    /// Default assume valid target's height
+    pub const DEFAULT_ASSUME_VALID_TARGET_HEIGHT: u64 = 12051310;
 }
 /// sync config related to testnet
 pub mod testnet {
@@ -28,4 +30,6 @@ pub mod testnet {
     /// you can view this block in https://pudge.explorer.nervos.org/block/0xb60b1fbe31f02ad58234dee525400c161c604e851c4ef839e4ef4b9422cfb445
     pub const DEFAULT_ASSUME_VALID_TARGET: &str =
         "0xb60b1fbe31f02ad58234dee525400c161c604e851c4ef839e4ef4b9422cfb445";
+    /// Default assume valid target's height
+    pub const DEFAULT_ASSUME_VALID_TARGET_HEIGHT: u64 = 12069984;
 }


### PR DESCRIPTION
- **Add DEFAULT_ASSUME_VALID_TARGET_HEIGHT to calculate duration need to reach the target**
- **Print duration to reach assume_valid_target in log msg**

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This PR let CKB print duration needed to reach to `DEFAULT_ASSUME_VALID_TARGET` in log
```
2024-04-28 06:12:02.343 +00:00 BlockDownload INFO ckb_sync::synchronizer  best known header number: 8760000, hash: Byte32(0x323b52e2309b15bb5d1bc0e3497da2905b14e2014313e1d01c8cea816b55e361), CKB is reaching the assume valid target: Byte32(0xc394fa4c5e5032c49f3502d4fd8054ead76ff693a54ac90757e441b5119afcaf) Please wait. It will take about 7.7 minutes to reach the assume valid target
2024-04-28 06:12:03.727 +00:00 BlockDownload INFO ckb_sync::synchronizer  best known header number: 8770000, hash: Byte32(0xd383dacd15a1db0b746f1af2c20b845cc89222485f975a4084990c74da6904af), CKB is reaching the assume valid target: Byte32(0xc394fa4c5e5032c49f3502d4fd8054ead76ff693a54ac90757e441b5119afcaf) Please wait. It will take about 7.6 minutes to reach the assume valid target
2024-04-28 06:12:05.104 +00:00 BlockDownload INFO ckb_sync::synchronizer  best known header number: 8780000, hash: Byte32(0x1e16b3079422c122acd30eaef0525a17f9828be5a3ceba79c72e9c7d69b75245), CKB is reaching the assume valid target: Byte32(0xc394fa4c5e5032c49f3502d4fd8054ead76ff693a54ac90757e441b5119afcaf) Please wait. It will take about 7.5 minutes to reach the assume valid target
```

https://github.com/nervosnetwork/ckb/pull/4254#issuecomment-1840263490

print duration need to reach `DEFAULT_ASSUME_VALID_TARGET` in Header Sync phase

If `ckb run` is specified with a custom `--assume-valid-target`, the corresponding height of this target is not known temporarily, so it is currently not possible to calculate the time needed to reach this target.



### Related changes

- print duration need to reach `DEFAULT_ASSUME_VALID_TARGET` in Header Sync phase


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

