### PR TITLE
Skip storing all zero cycles in db when disable script

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -802,11 +802,20 @@ impl ChainService {
                                     mmr.push(b.digest())
                                         .map_err(|e| InternalErrorKind::MMR.other(e))?;
 
+                                    // when `disable_script` is true, `cache_entries` is a array with all `0`
+                                    // there is no need to store them in db
+                                    let verify_entries: Option<&[Completed]> =
+                                        if switch.disable_script() {
+                                            None
+                                        } else {
+                                            Some(&cache_entries)
+                                        };
+
                                     self.insert_ok_ext(
                                         &txn,
                                         &b.header().hash(),
                                         ext.clone(),
-                                        Some(&cache_entries),
+                                        verify_entries,
                                         Some(txs_sizes),
                                     )?;
 


### PR DESCRIPTION
### What problem does this PR solve?

When run `ckb run` without disabling `assume-valid-target`, all the cycles in blocks are zero, since we skipped verification in this scenario.

### What is changed and how it works?
Don't store all zeros in db, set `ext.cycles` to None.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

