### PR TITLE
chore: lock cargo shear version

### DIFF
--- a/devtools/ci/check-cargotoml.sh
+++ b/devtools/ci/check-cargotoml.sh
@@ -94,7 +94,8 @@ function check_cargo_publish() {
 function check_dependencies() {
   if ! type cargo-shear &> /dev/null
   then
-      cargo install cargo-shear
+      # lock version to avoid breaking building now
+      cargo install cargo-shear --version 0.0.24
   fi
   cargo shear
 }


### PR DESCRIPTION
### What problem does this PR solve?

The latest version of `cargo-shear` requires rustc 1.76.0 or newer, while the currently active rustc version is 1.75.0.

### What is changed and how it works?

Lock the version of `cargo-shear` to 0.024.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

