### PR TITLE
Revert "Skip storing all zero cycles in db when disable script"

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -802,20 +802,11 @@ impl ChainService {
                                     mmr.push(b.digest())
                                         .map_err(|e| InternalErrorKind::MMR.other(e))?;
 
-                                    // when `disable_script` is true, `cache_entries` is a array with all `0`
-                                    // there is no need to store them in db
-                                    let verify_entries: Option<&[Completed]> =
-                                        if switch.disable_script() {
-                                            None
-                                        } else {
-                                            Some(&cache_entries)
-                                        };
-
                                     self.insert_ok_ext(
                                         &txn,
                                         &b.header().hash(),
                                         ext.clone(),
-                                        verify_entries,
+                                        Some(&cache_entries),
                                         Some(txs_sizes),
                                     )?;
 


### PR DESCRIPTION
### What problem does this PR solve?


Reverts nervosnetwork/ckb#4452

I think #4452 introduced a bug:
```bash
./ckb run -C /tmp/a --assume-valid-target 0xb72f4d9758a36a2f9d4b8aea5a11d232e3e48332b76ec350f0a375fac10317a4
...
...
...

2024-05-12 18:16:13.895 +00:00 GlobalRt-0 ERROR ckb_sync::types  accept block BlockView { data: Block(0x3602000014000000e4000000e800000032020000000000007ea9081ac4e403716e01000014000000000000000000001400cf0600218cf6b29f5ffb1582387c587d79d1cded15f8aa72c5171875442cd228572cb5c2139e3b25f6a1574202374f54c4ee699e3b6cefd88b815e7243e72dc1e888ee00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000288ff8cff820a12e5942acecf28623000c66038e9300000000f656c8ccfefe06000539030000000073000000b4fc2dea040000004a01000008000000420100000c000000d9000000cd0000001c00000020000000240000002800000058000000c10000000000000000000000000000000100000014000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffff690000000800000061000000100000001800000061000000137d8b4e1d000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000dde7801c073dfb3464c7b1f05b806bb2bbb84e990c000000080000000000000069000000080000005d0000005d0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000dde7801c073dfb3464c7b1f05b806bb2bbb84e99040000000000000000000000), hash: Byte32(0x07686ea1bf00c78da082d83bb09d7f4349cbb54475f25c8d765b316c2de6a091), uncle_hashes: Byte32Vec(0x00000000), tx_hashes: [Byte32(0xb307facd11c63639a2ead93e6b77716124d3c2d351037474a010dedcaaf41613)], tx_witness_hashes: [Byte32(0x19e48bcb5c57bf3b7b2da4ae55b9e43844335a0a3976e13b1cbdc968a1f06995)] } Block(Cellbase(InvalidRewardAmount))
2024-05-12 18:16:13.895 +00:00 GlobalRt-0 ERROR ckb_sync::synchronizer  Receive SendBlock from SessionId(109). Ban 300s for BlockIsInvalid(401): Byte32(0x07686ea1bf00c78da082d83bb09d7f4349cbb54475f25c8d765b316c2de6a091), error: Block(Cellbase(InvalidRewardAmount))
2024-05-12 18:16:13.895 +00:00 GlobalRt-0 INFO ckb_network::network  Ban peer "/ip4/162.19.139.183/tcp/18115/p2p/QmRuYiMNmqgo4TeKPRoMTi81CHWC6gmTDT1RyJWzatz6Mh" for 300 seconds, reason: BlockIsInvalid(401): Byte32(0x07686ea1bf00c78da082d83bb09d7f4349cbb54475f25c8d765b316c2de6a091), error: Block(Cellbase(InvalidRewardAmount))
2024-05-12 18:16:13.895 +00:00 GlobalRt-6 INFO ckb_relay  RelayProtocol.disconnected peer=SessionId(109)
2024-05-12 18:16:13.895 +00:00 GlobalRt-1 INFO ckb_filter  FilterProtocol.disconnected peer=SessionId(109)
2024-05-12 18:16:13.895 +00:00 GlobalRt-5 INFO ckb_light_client_protocol_server  LightClient.disconnected peer=SessionId(109)
2024-05-12 18:16:13.895 +00:00 GlobalRt-1 INFO ckb_relay  RelayProtocol.disconnected peer=SessionId(109)
2024-05-12 18:16:14.590 +00:00 ChainService ERROR ckb_chain::chain  Block verify error. Block number: 20, hash: Byte32(0x07686ea1bf00c78da082d83bb09d7f4349cbb54475f25c8d765b316c2de6a091), error: Error { kind: Block, inner: Cellbase(InvalidRewardAmount)

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: ckb_verification::convert::<impl core::convert::From<ckb_verification::error::CellbaseError> for ckb_error::Error>::from
   2: ckb_verification_contextual::contextual_block_verifier::ContextualBlockVerifier<CS,MS>::verify
   3: ckb_chain::chain::ChainService::reconcile_main_chain
   4: ckb_chain::chain::ChainService::insert_block
   5: ckb_chain::chain::ChainService::process_block
   6: ckb_chain::chain::ChainService::start::{{closure}}
   7: std::sys_common::backtrace::__rust_begin_short_backtrace
   8: core::ops::function::FnOnce::call_once{{vtable.shim}}
   9: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  10: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  11: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys/unix/thread.rs:108:17
  12: start_thread
             at ./glibc-2.38/nptl/pthread_create.c:444:8
  13: clone3
             at ./glibc-2.38/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78 }

```
This bug may be related to the `BlockExt.txs_fees`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```



