### PR TITLE
Use standalone runtime for RPC service

### DIFF
--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -121,7 +121,7 @@ fn run_app_inner(
     matches: &ArgMatches,
 ) -> Result<(), ExitCode> {
     let is_silent_logging = is_silent_logging(cmd);
-    let (mut handle, mut handle_stop_rx, _runtime) = new_global_runtime();
+    let (mut handle, mut handle_stop_rx, _runtime) = new_global_runtime(None);
     let setup = Setup::from_matches(bin_name, cmd, matches)?;
     let _guard = SetupGuard::from_setup(&setup, &version, handle.clone(), is_silent_logging)?;
 

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -1,6 +1,8 @@
+use std::thread::available_parallelism;
+
 use crate::helper::deadlock_detection;
 use ckb_app_config::{ExitCode, RunArgs};
-use ckb_async_runtime::Handle;
+use ckb_async_runtime::{new_global_runtime, Handle};
 use ckb_build_info::Version;
 use ckb_launcher::Launcher;
 use ckb_logger::info;
@@ -11,8 +13,11 @@ use ckb_types::core::cell::setup_system_cell_cache;
 pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), ExitCode> {
     deadlock_detection();
 
+    let rpc_threads_num = calc_rpc_threads_num(&args);
     info!("ckb version: {}", version);
-    let mut launcher = Launcher::new(args, version, async_handle);
+    info!("run rpc server with {} threads", rpc_threads_num);
+    let (mut rpc_handle, _rpc_stop_rx, _runtime) = new_global_runtime(Some(rpc_threads_num));
+    let mut launcher = Launcher::new(args, version, async_handle, rpc_handle.clone());
 
     let block_assembler_config = launcher.sanitize_block_assembler_config()?;
     let miner_enable = block_assembler_config.is_some();
@@ -63,7 +68,14 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
     })
     .expect("Error setting Ctrl-C handler");
 
+    rpc_handle.drop_guard();
     wait_all_ckb_services_exit();
 
     Ok(())
+}
+
+fn calc_rpc_threads_num(args: &RunArgs) -> usize {
+    let system_parallelism: usize = available_parallelism().unwrap().into();
+    let default_num = usize::max(system_parallelism - 1, 1);
+    args.config.rpc.threads.unwrap_or(default_num)
 }

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -76,6 +76,6 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
 fn calc_rpc_threads_num(args: &RunArgs) -> usize {
     let system_parallelism: usize = available_parallelism().unwrap().into();
-    let default_num = usize::max(system_parallelism - 1, 1);
+    let default_num = usize::max(system_parallelism, 1);
     args.config.rpc.threads.unwrap_or(default_num)
 }

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -63,7 +63,7 @@ impl Net {
                 )
             })
             .collect();
-        let (async_handle, _handle_recv, async_runtime) = new_global_runtime();
+        let (async_handle, _handle_recv, async_runtime) = new_global_runtime(None);
         let controller = NetworkService::new(
             Arc::clone(&network_state),
             ckb_protocols,

--- a/test/template/ckb.toml
+++ b/test/template/ckb.toml
@@ -76,6 +76,10 @@ reject_ill_transactions = true
 # By default deprecated rpc methods are disabled.
 enable_deprecated_rpc = true
 
+# threads number for RPC service,
+# default it's equal to the number of CPU cores minus one
+# threads = 4
+
 [tx_pool]
 max_tx_pool_size = 180_000_000 # 180mb
 min_fee_rate = 0 # Here fee_rate are calculated directly using size in units of shannons/KB

--- a/test/template/ckb.toml
+++ b/test/template/ckb.toml
@@ -76,8 +76,7 @@ reject_ill_transactions = true
 # By default deprecated rpc methods are disabled.
 enable_deprecated_rpc = true
 
-# threads number for RPC service,
-# default it's equal to the number of CPU cores minus one
+# threads number for RPC service, default value is the number of CPU cores
 # threads = 4
 
 [tx_pool]

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -43,15 +43,18 @@ pub struct Launcher {
     pub version: Version,
     /// ckb global runtime handle
     pub async_handle: Handle,
+    /// rpc global runtime handle
+    pub rpc_handle: Handle,
 }
 
 impl Launcher {
     /// Construct new Launcher from cli args
-    pub fn new(args: RunArgs, version: Version, async_handle: Handle) -> Self {
+    pub fn new(args: RunArgs, version: Version, async_handle: Handle, rpc_handle: Handle) -> Self {
         Launcher {
             args,
             version,
             async_handle,
+            rpc_handle,
         }
     }
 
@@ -427,8 +430,7 @@ impl Launcher {
         builder.enable_subscription(shared.clone());
         let io_handler = builder.build();
 
-        let async_handle = shared.async_handle();
-        let _rpc = RpcServer::new(rpc_config, io_handler, async_handle.clone());
+        let _rpc = RpcServer::new(rpc_config, io_handler, self.rpc_handle.clone());
 
         network_controller
     }

--- a/util/stop-handler/src/tests.rs
+++ b/util/stop-handler/src/tests.rs
@@ -113,7 +113,7 @@ impl TestStopMemo {
 
 #[test]
 fn basic() {
-    let (mut handle, mut stop_recv, _runtime) = new_global_runtime();
+    let (mut handle, mut stop_recv, _runtime) = new_global_runtime(None);
 
     ctrlc::set_handler(move || {
         broadcast_exit_signals();


### PR DESCRIPTION
### What problem does this PR solve?

Currently, we have some RPC API from indexer such as `get_cells`, `get_transactions`, `get_cells_capacity` which may cost a lot of computing resources, it may occupy all the tokio tasks, and `ckb` can not process blocks in extreme scenarios.

### What is changed and how it works?

RPC will run in a standalone tokio runtime, so that we can process block even in extreme scenario.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

