### PR TITLE
feat: add estimate_fee_rate rpc

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -104,6 +104,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
     * [Module Pool](#module-pool) [👉 OpenRPC spec](http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=CKB-Pool&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:logoUrl]=https://raw.githubusercontent.com/nervosnetwork/ckb-rpc-resources/develop/ckb-logo.jpg&schemaUrl=https://raw.githubusercontent.com/nervosnetwork/ckb-rpc-resources/develop/json/pool_rpc_doc.json)
 
         * [Method `send_transaction`](#pool-send_transaction)
+        * [Method `estimate_fee_rate`](#pool-estimate_fee_rate)
         * [Method `test_tx_pool_accept`](#pool-test_tx_pool_accept)
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
@@ -4419,6 +4420,53 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": "0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3"
+}
+```
+
+<a id="pool-estimate_fee_rate"></a>
+#### Method `estimate_fee_rate`
+* `estimate_fee_rate(target_to_be_committed)`
+    * `target_to_be_committed`: [`Uint64`](#type-uint64)
+* result: [`Uint64`](#type-uint64)
+
+Estimate fee rate for a transaction to be committed within target block number by using a simple strategy.
+
+Since CKB transaction confirmation involves a two-step process—1) propose and 2) commit, it is complex to
+predict the transaction fee accurately with the expectation that it will be included within a certain block height.
+
+This method relies on two assumptions and uses a simple strategy to estimate the transaction fee: 1) all transactions
+in the pool are waiting to be proposed, and 2) no new transactions will be added to the pool.
+
+In practice, this simple method should achieve good accuracy fee rate and running performance.
+
+###### Params
+
+* `target_to_be_committed` - The target block number to be committed, minimum value is 3 and maximum value is 131.
+
+###### Returns
+
+The estimated fee rate in shannons per kilobyte.
+
+###### Examples
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "estimate_fee_rate",
+  "params": [
+    "0x4"
+  ]
+}
+```
+
+Response
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": "0x3e8"
 }
 ```
 

--- a/tx-pool/src/component/tests/estimate.rs
+++ b/tx-pool/src/component/tests/estimate.rs
@@ -1,0 +1,56 @@
+use crate::component::tests::util::build_tx;
+use crate::component::{
+    entry::TxEntry,
+    pool_map::{PoolMap, Status},
+};
+use ckb_types::core::{Capacity, Cycle, FeeRate};
+
+#[test]
+fn test_estimate_fee_rate() {
+    let mut pool = PoolMap::new(1000);
+    for i in 0..1024 {
+        let tx = build_tx(vec![(&Default::default(), i as u32)], 1);
+        let entry = TxEntry::dummy_resolve(tx, i + 1, Capacity::shannons(i + 1), 1000);
+        pool.add_entry(entry, Status::Pending).unwrap();
+    }
+
+    assert_eq!(
+        FeeRate::from_u64(42),
+        pool.estimate_fee_rate(1, usize::MAX, Cycle::MAX, FeeRate::from_u64(42))
+    );
+
+    assert_eq!(
+        FeeRate::from_u64(1024),
+        pool.estimate_fee_rate(1, 1000, Cycle::MAX, FeeRate::from_u64(1))
+    );
+    assert_eq!(
+        FeeRate::from_u64(1023),
+        pool.estimate_fee_rate(1, 2000, Cycle::MAX, FeeRate::from_u64(1))
+    );
+    assert_eq!(
+        FeeRate::from_u64(1016),
+        pool.estimate_fee_rate(2, 5000, Cycle::MAX, FeeRate::from_u64(1))
+    );
+
+    assert_eq!(
+        FeeRate::from_u64(1024),
+        pool.estimate_fee_rate(1, usize::MAX, 1, FeeRate::from_u64(1))
+    );
+    assert_eq!(
+        FeeRate::from_u64(1023),
+        pool.estimate_fee_rate(1, usize::MAX, 2047, FeeRate::from_u64(1))
+    );
+    assert_eq!(
+        FeeRate::from_u64(1015),
+        pool.estimate_fee_rate(2, usize::MAX, 5110, FeeRate::from_u64(1))
+    );
+
+    assert_eq!(
+        FeeRate::from_u64(624),
+        pool.estimate_fee_rate(100, 5000, 5110, FeeRate::from_u64(1))
+    );
+    assert_eq!(
+        FeeRate::from_u64(1),
+        pool.estimate_fee_rate(1000, 5000, 5110, FeeRate::from_u64(1))
+    );
+}

--- a/tx-pool/src/component/tests/mod.rs
+++ b/tx-pool/src/component/tests/mod.rs
@@ -1,5 +1,6 @@
 mod chunk;
 mod entry;
+mod estimate;
 mod links;
 mod orphan;
 mod pending;

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -12,7 +12,7 @@ use ckb_logger::{debug, error, warn};
 use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_types::core::tx_pool::PoolTxDetailInfo;
-use ckb_types::core::CapacityError;
+use ckb_types::core::{BlockNumber, CapacityError, FeeRate};
 use ckb_types::packed::OutPoint;
 use ckb_types::{
     core::{
@@ -526,6 +526,16 @@ impl TxPool {
             );
         }
         (entries, size, cycles)
+    }
+
+    pub(crate) fn estimate_fee_rate(&self, target_to_be_committed: BlockNumber) -> FeeRate {
+        self.pool_map.estimate_fee_rate(
+            (target_to_be_committed - self.snapshot.consensus().tx_proposal_window().closest())
+                as usize,
+            self.snapshot.consensus().max_block_bytes() as usize,
+            self.snapshot.consensus().max_block_cycles(),
+            self.config.min_fee_rate,
+        )
     }
 
     pub(crate) fn check_rbf(

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -20,6 +20,7 @@ use ckb_snapshot::Snapshot;
 use ckb_store::data_loader_wrapper::AsDataLoader;
 use ckb_store::ChainStore;
 use ckb_types::core::error::OutPointError;
+use ckb_types::core::{BlockNumber, FeeRate};
 use ckb_types::{
     core::{cell::ResolvedTransaction, BlockView, Capacity, Cycle, HeaderView, TransactionView},
     packed::{Byte32, ProposalShortId},
@@ -337,6 +338,11 @@ impl TxPoolService {
         } else {
             Ok(())
         }
+    }
+
+    pub(crate) async fn estimate_fee_rate(&self, target_to_be_committed: BlockNumber) -> FeeRate {
+        let pool = self.tx_pool.read().await;
+        pool.estimate_fee_rate(target_to_be_committed)
     }
 
     pub(crate) async fn test_accept_tx(&self, tx: TransactionView) -> Result<Completed, Reject> {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

resolve https://github.com/nervosnetwork/ckb/issues/3673

### What is changed and how it works?

Since CKB transaction confirmation involves a two-step process: 1) propose and 2) commit, it is complex to predict the transaction fee accurately with the expectation that it will be included within a certain block height.

This PR relies on two assumptions and uses a simple strategy to estimate the transaction fee: 1) all transactions in the pool are waiting to be proposed, and 2) no new transactions will be added to the pool. In practice, this simple method should achieve good accuracy fee rate and running performance.

The rpc parameter `target_to_be_committed` is limited to 3~131, because the minimum value of the proposal window is 2, which is equivalent to predicting the height of current_tip + 1 ~ 128.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

