### PR TITLE
[WIP] Add limitation for RPC slow queries

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -5,7 +5,6 @@ use ckb_build_info::Version;
 use ckb_launcher::Launcher;
 use ckb_logger::info;
 use ckb_stop_handler::{broadcast_exit_signals, wait_all_ckb_services_exit};
-
 use ckb_types::core::cell::setup_system_cell_cache;
 
 pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), ExitCode> {

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -207,6 +207,7 @@ block_uncles_cache_size    = 30
 # cell_filter = "let script = output.type;script!=() && script.code_hash == \"0x00000000000000000000000000000000000000000000000000545950455f4944\""
 # # The initial tip can be set higher than the current indexer tip as the starting height for indexing.
 # init_tip_hash = "0x8fbd0ec887159d2814cee475911600e3589849670f5ee1ed9798b38fdeef4e44"
+# iterator_next_limit = 100000
 #
 # # CKB rich-indexer has its unique configuration.
 # [indexer_v2.rich_indexer]

--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -35,12 +35,12 @@ pub struct IndexerConfig {
     /// The init tip block hash
     #[serde(default)]
     pub init_tip_hash: Option<H256>,
-    /// Rich indexer config options
-    #[serde(default)]
-    pub rich_indexer: RichIndexerConfig,
     /// Max iterator next limit count
     #[serde(default = "default_iterator_next_limit")]
     pub iterator_next_limit: usize,
+    /// Rich indexer config options
+    #[serde(default)]
+    pub rich_indexer: RichIndexerConfig,
 }
 
 const fn default_poll_interval() -> u64 {
@@ -55,6 +55,7 @@ impl Default for IndexerConfig {
     fn default() -> Self {
         IndexerConfig {
             poll_interval: default_poll_interval(),
+            iterator_next_limit: default_iterator_next_limit(),
             index_tx_pool: false,
             store: PathBuf::new(),
             secondary_path: PathBuf::new(),
@@ -64,7 +65,6 @@ impl Default for IndexerConfig {
             db_keep_log_file_num: None,
             init_tip_hash: None,
             rich_indexer: RichIndexerConfig::default(),
-            iterator_next_limit: default_iterator_next_limit(),
         }
     }
 }

--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -38,16 +38,23 @@ pub struct IndexerConfig {
     /// Rich indexer config options
     #[serde(default)]
     pub rich_indexer: RichIndexerConfig,
+    /// Max iterator next limit count
+    #[serde(default = "default_iterator_next_limit")]
+    pub iterator_next_limit: usize,
 }
 
 const fn default_poll_interval() -> u64 {
     2
 }
 
+const fn default_iterator_next_limit() -> usize {
+    100_000
+}
+
 impl Default for IndexerConfig {
     fn default() -> Self {
         IndexerConfig {
-            poll_interval: 2,
+            poll_interval: default_poll_interval(),
             index_tx_pool: false,
             store: PathBuf::new(),
             secondary_path: PathBuf::new(),
@@ -57,6 +64,7 @@ impl Default for IndexerConfig {
             db_keep_log_file_num: None,
             init_tip_hash: None,
             rich_indexer: RichIndexerConfig::default(),
+            iterator_next_limit: default_iterator_next_limit(),
         }
     }
 }

--- a/util/indexer-sync/src/error.rs
+++ b/util/indexer-sync/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     /// Invalid params error
     #[error("Invalid params {0}")]
     Params(String),
+    /// Iterator limit exceeded
+    #[error("Iteration limit exceeded {0}, you need to increase `iterator_next_limit` in the ckb.toml or tuning the query performance.")]
+    IterLimitExceeded(usize),
 }
 
 impl Error {

--- a/util/indexer/src/lib.rs
+++ b/util/indexer/src/lib.rs
@@ -1,6 +1,7 @@
 //! CKB's built-in indexer, which shares data with the ckb node by creating secondary db instances.
 
 pub(crate) mod indexer;
+pub(crate) mod limited_iter;
 pub(crate) mod store;
 
 /// The indexer service.

--- a/util/indexer/src/limited_iter.rs
+++ b/util/indexer/src/limited_iter.rs
@@ -1,0 +1,27 @@
+pub(crate) struct LimitedIterator<I> {
+    inner: I,
+    limit: usize,
+    count: usize,
+}
+
+impl<I> LimitedIterator<I> {
+    pub fn new(inner: I, limit: usize) -> Self {
+        Self {
+            inner,
+            limit,
+            count: 0,
+        }
+    }
+}
+
+impl<I: Iterator> Iterator for LimitedIterator<I> {
+    type Item = Result<I::Item, &'static str>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count >= self.limit {
+            Some(Err("Iteration limit exceeded"))
+        } else {
+            self.count += 1;
+            self.inner.next().map(Ok)
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Currently, we have some RPC API from indexer such as `get_cells`, `get_transactions`, `get_cells_capacity` which may cost a lot of computing resources, it may occupy all the tokio tasks, and ckb can not response to other RPC APIs.

### What is changed and how it works?

This PR try to fix this issue by adding limitation on computing resources for slow queries
- [add limited count iterator for indexer · nervosnetwork/ckb@a83d416](https://github.com/nervosnetwork/ckb/commit/a83d416f353278f47a8cebf0a90c64ff79ae81c0)
- [add slow\_query\_parallelism to limit slow query · nervosnetwork/ckb@a3bf751](https://github.com/nervosnetwork/ckb/commit/a3bf7519b839fde4857cf22105a5ff6b04fce7ec)
- TODO: limit the number of batch in JSONPRC.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

