### PR TITLE
Add `assume_valid_target_reached: bool` to `NetRpc::sync_state` 

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -17,7 +17,7 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
     info!("ckb version: {}", version);
     info!("run rpc server with {} threads", rpc_threads_num);
     let (mut rpc_handle, _rpc_stop_rx, _runtime) = new_global_runtime(Some(rpc_threads_num));
-    let mut launcher = Launcher::new(args, version, async_handle, rpc_handle.clone());
+    let launcher = Launcher::new(args, version, async_handle, rpc_handle.clone());
 
     let block_assembler_config = launcher.sanitize_block_assembler_config()?;
     let miner_enable = block_assembler_config.is_some();
@@ -44,8 +44,6 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
         launcher.args.config.memory_tracker.interval,
         Some(shared.store().db().inner()),
     );
-
-    launcher.check_assume_valid_target(&shared);
 
     let chain_controller = launcher.start_chain_service(&shared, pack.take_proposal_table());
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4138,12 +4138,16 @@ Response
   "id": 42,
   "jsonrpc": "2.0",
   "result": {
+    "assume_valid_target": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "assume_valid_target_reached": true,
     "best_known_block_number": "0x400",
     "best_known_block_timestamp": "0x5cd2b117",
     "fast_time": "0x3e8",
     "ibd": true,
     "inflight_blocks_count": "0x0",
     "low_time": "0x5dc",
+    "min_chain_work": "0x0",
+    "min_chain_work_reached": true,
     "normal_time": "0x4e2",
     "orphan_blocks_count": "0x0",
     "orphan_blocks_size": "0x0"
@@ -6833,6 +6837,10 @@ The overall chain synchronization state of this local node.
 
 `SyncState` is a JSON object with the following fields.
 
+* `assume_valid_target`: [`Byte32`](#type-byte32) - The assume_valid_target specified by ckb, if no assume_valid_target, this will be all zero.
+
+* `assume_valid_target_reached`: `boolean` - Is ckb reached the assume_valid_target? If no assume_valid_target, this will be true.
+
 * `best_known_block_number`: [`Uint64`](#type-uint64) - This is the best known block number observed by the local node from the P2P network.
 
     The best here means that the block leads a chain which has the best known accumulated difficulty.
@@ -6852,6 +6860,10 @@ The overall chain synchronization state of this local node.
 * `inflight_blocks_count`: [`Uint64`](#type-uint64) - Count of downloading blocks.
 
 * `low_time`: [`Uint64`](#type-uint64) - The download scheduler's time analysis data, the low is the 9/10 of the cut-off point, unit ms
+
+* `min_chain_work`: [`Uint128`](#type-uint128) - This field acts as a security measure to ensure that a node only synchronizes with other nodes that have a significant amount of computational work invested in them, thereby preventing certain types of attacks and ensuring network integrity. Only the mainnet uses a hardcoded value for this field.
+
+* `min_chain_work_reached`: `boolean` - Is ckb reached the min_chain_work?
 
 * `normal_time`: [`Uint64`](#type-uint64) - The download scheduler's time analysis data, the normal is the 4/5 of the cut-off point, unit ms
 

--- a/util/jsonrpc-types/src/net.rs
+++ b/util/jsonrpc-types/src/net.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumber, Byte32, Timestamp, Uint64};
+use crate::{BlockNumber, Byte32, Timestamp, Uint128, Uint64};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -258,6 +258,18 @@ pub struct SyncState {
     /// During IBD, the local node only synchronizes the chain with one selected remote node and
     /// stops responding to most P2P requests.
     pub ibd: bool,
+    /// Is ckb reached the assume_valid_target? If no assume_valid_target, this will be true.
+    pub assume_valid_target_reached: bool,
+    /// The assume_valid_target specified by ckb, if no assume_valid_target, this will be all zero.
+    pub assume_valid_target: Byte32,
+    /// Is ckb reached the min_chain_work?
+    pub min_chain_work_reached: bool,
+    /// This field acts as a security measure to ensure that a node only
+    /// synchronizes with other nodes that have a significant amount of
+    /// computational work invested in them, thereby preventing certain types
+    /// of attacks and ensuring network integrity. Only the mainnet uses a
+    /// hardcoded value for this field.
+    pub min_chain_work: Uint128,
     /// This is the best known block number observed by the local node from the P2P network.
     ///
     /// The best here means that the block leads a chain which has the best known accumulated

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -26,7 +26,7 @@ use ckb_rpc::ServiceBuilder;
 use ckb_shared::Shared;
 
 use ckb_shared::shared_builder::{SharedBuilder, SharedPackage};
-use ckb_store::{ChainDB, ChainStore};
+use ckb_store::ChainDB;
 use ckb_sync::{BlockFilter, NetTimeProtocol, Relayer, SyncShared, Synchronizer};
 use ckb_tx_pool::service::TxVerificationResult;
 use ckb_types::prelude::*;
@@ -217,16 +217,6 @@ impl Launcher {
         self.check_spec(&shared)?;
 
         Ok((shared, pack))
-    }
-
-    /// Check whether the data already exists in the database before starting
-    pub fn check_assume_valid_target(&mut self, shared: &Shared) {
-        if let Some(ref target) = self.args.config.network.sync.assume_valid_target {
-            if shared.snapshot().block_exists(&target.pack()) {
-                info!("assume valid target is already in db, CKB will do full verification from now on");
-                self.args.config.network.sync.assume_valid_target.take();
-            }
-        }
     }
 
     /// Start chain service, return ChainController


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4485 <!-- REMOVE this line if no issue to close -->

What's Changed:

### Related changes

- Add `assume_valid_target_reached: bool` and `min_chain_work_reached: bool` to `sync_state` RPC
- let `check_assume_valid_target` don't reset `SyncConfig::assume_valid_target` to `None` if the assume target has found in `Snapshot`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

