### PR TITLE
script(fuzz): fixed the issue where data1 verifier always returns invalid version error

### DIFF
--- a/script/fuzz/fuzz_targets/transaction_scripts_verifier_data0.rs
+++ b/script/fuzz/fuzz_targets/transaction_scripts_verifier_data0.rs
@@ -9,6 +9,7 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMetaBuilder, ResolvedTransaction},
+        hardfork::{HardForks, CKB2021, CKB2023},
         Capacity, HeaderView, ScriptHashType, TransactionBuilder, TransactionInfo,
     },
     h256,
@@ -96,7 +97,13 @@ fn run(data: &[u8]) {
     };
 
     let provider = MockDataLoader {};
-    let consensus = ConsensusBuilder::default().build();
+    let hardfork_switch = HardForks {
+        ckb2021: CKB2021::new_dev_default(),
+        ckb2023: CKB2023::new_dev_default(),
+    };
+    let consensus = ConsensusBuilder::default()
+        .hardfork_switch(hardfork_switch)
+        .build();
     let tx_verify_env =
         TxVerifyEnv::new_submit(&HeaderView::new_advanced_builder().epoch(0.pack()).build());
     let verifier = TransactionScriptsVerifier::new(

--- a/script/fuzz/fuzz_targets/transaction_scripts_verifier_data1.rs
+++ b/script/fuzz/fuzz_targets/transaction_scripts_verifier_data1.rs
@@ -9,6 +9,7 @@ use ckb_types::{
     core::{
         capacity_bytes,
         cell::{CellMetaBuilder, ResolvedTransaction},
+        hardfork::{HardForks, CKB2021, CKB2023},
         Capacity, HeaderView, ScriptHashType, TransactionBuilder, TransactionInfo,
     },
     h256,
@@ -96,7 +97,13 @@ fn run(data: &[u8]) {
     };
 
     let provider = MockDataLoader {};
-    let consensus = ConsensusBuilder::default().build();
+    let hardfork_switch = HardForks {
+        ckb2021: CKB2021::new_dev_default(),
+        ckb2023: CKB2023::new_dev_default(),
+    };
+    let consensus = ConsensusBuilder::default()
+        .hardfork_switch(hardfork_switch)
+        .build();
     let tx_verify_env =
         TxVerifyEnv::new_submit(&HeaderView::new_advanced_builder().epoch(0.pack()).build());
     let verifier = TransactionScriptsVerifier::new(

--- a/script/fuzz/fuzz_targets/transaction_scripts_verifier_data2.rs
+++ b/script/fuzz/fuzz_targets/transaction_scripts_verifier_data2.rs
@@ -98,12 +98,8 @@ fn run(data: &[u8]) {
 
     let provider = MockDataLoader {};
     let hardfork_switch = HardForks {
-        ckb2021: CKB2021::new_mirana().as_builder().build().unwrap(),
-        ckb2023: CKB2023::new_mirana()
-            .as_builder()
-            .rfc_0049(0)
-            .build()
-            .unwrap(),
+        ckb2021: CKB2021::new_dev_default(),
+        ckb2023: CKB2023::new_dev_default(),
     };
     let consensus = ConsensusBuilder::default()
         .hardfork_switch(hardfork_switch)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Data1 verifier always returns `Err(Error { kind: Script, inner: TransactionScriptError { source: Inputs[0].Lock, cause: Invalid VM Version: 1 } })`. 

What's Changed:

Use the correct hardfork writing to make ckb2021 and ckb2023 always effective in the three fuzz targets. There are no issues with Data0 and Data2 fuzz target at the moment, but I still made same changes to them.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

