### PR TITLE
Move `BlockNumberAndHash` from`ckb-sync` to `ckb-types`

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -21,7 +21,7 @@ use self::get_transactions_process::GetTransactionsProcess;
 use self::transaction_hashes_process::TransactionHashesProcess;
 use self::transactions_process::TransactionsProcess;
 use crate::block_status::BlockStatus;
-use crate::types::{ActiveChain, BlockNumberAndHash, SyncShared};
+use crate::types::{ActiveChain, SyncShared};
 use crate::utils::{
     is_internal_db_error, metric_ckb_message_bytes, send_message_to, MetricDirection,
 };
@@ -35,6 +35,7 @@ use ckb_network::{
 };
 use ckb_systemtime::unix_time_as_millis;
 use ckb_tx_pool::service::TxVerificationResult;
+use ckb_types::BlockNumberAndHash;
 use ckb_types::{
     core::{self, BlockView},
     packed::{self, Byte32, ProposalShortId},

--- a/sync/src/synchronizer/block_fetcher.rs
+++ b/sync/src/synchronizer/block_fetcher.rs
@@ -1,5 +1,5 @@
 use crate::block_status::BlockStatus;
-use crate::types::{ActiveChain, BlockNumberAndHash, HeaderIndex, HeaderIndexView, IBDState};
+use crate::types::{ActiveChain, HeaderIndex, HeaderIndexView, IBDState};
 use crate::SyncShared;
 use ckb_constant::sync::{
     BLOCK_DOWNLOAD_WINDOW, CHECK_POINT_WINDOW, INIT_BLOCKS_IN_TRANSIT_PER_PEER,
@@ -9,6 +9,7 @@ use ckb_logger::{debug, trace};
 use ckb_network::PeerIndex;
 use ckb_systemtime::unix_time_as_millis;
 use ckb_types::packed;
+use ckb_types::BlockNumberAndHash;
 use std::cmp::min;
 use std::sync::Arc;
 

--- a/sync/src/tests/inflight_blocks.rs
+++ b/sync/src/tests/inflight_blocks.rs
@@ -1,7 +1,8 @@
-use crate::types::{BlockNumberAndHash, InflightBlocks};
+use crate::types::InflightBlocks;
 use ckb_constant::sync::BLOCK_DOWNLOAD_TIMEOUT;
 use ckb_types::h256;
 use ckb_types::prelude::*;
+use ckb_types::BlockNumberAndHash;
 use std::collections::HashSet;
 
 #[test]

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -21,6 +21,7 @@ use ckb_store::{ChainDB, ChainStore};
 use ckb_systemtime::unix_time_as_millis;
 use ckb_traits::{HeaderFields, HeaderFieldsProvider};
 use ckb_tx_pool::service::TxVerificationResult;
+use ckb_types::BlockNumberAndHash;
 use ckb_types::{
     core::{self, BlockNumber, EpochExt},
     packed::{self, Byte32},
@@ -398,53 +399,6 @@ impl InflightState {
         Self {
             peer,
             timestamp: unix_time_as_millis(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BlockNumberAndHash {
-    pub number: BlockNumber,
-    pub hash: Byte32,
-}
-
-impl BlockNumberAndHash {
-    pub fn new(number: BlockNumber, hash: Byte32) -> Self {
-        Self { number, hash }
-    }
-
-    pub fn number(&self) -> BlockNumber {
-        self.number
-    }
-
-    pub fn hash(&self) -> Byte32 {
-        self.hash.clone()
-    }
-}
-
-impl From<(BlockNumber, Byte32)> for BlockNumberAndHash {
-    fn from(inner: (BlockNumber, Byte32)) -> Self {
-        Self {
-            number: inner.0,
-            hash: inner.1,
-        }
-    }
-}
-
-impl From<&core::HeaderView> for BlockNumberAndHash {
-    fn from(header: &core::HeaderView) -> Self {
-        Self {
-            number: header.number(),
-            hash: header.hash(),
-        }
-    }
-}
-
-impl From<core::HeaderView> for BlockNumberAndHash {
-    fn from(header: core::HeaderView) -> Self {
-        Self {
-            number: header.number(),
-            hash: header.hash(),
         }
     }
 }

--- a/util/types/src/block_number_and_hash.rs
+++ b/util/types/src/block_number_and_hash.rs
@@ -1,0 +1,54 @@
+//! Block Number and Hash struct
+use crate::core::BlockNumber;
+use ckb_gen_types::packed::Byte32;
+
+/// Block Number And Hash struct
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockNumberAndHash {
+    /// Block Number
+    pub number: BlockNumber,
+    /// Block Hash
+    pub hash: Byte32,
+}
+
+impl BlockNumberAndHash {
+    /// Create new BlockNumberAndHash
+    pub fn new(number: BlockNumber, hash: Byte32) -> Self {
+        Self { number, hash }
+    }
+    /// Return BlockNumber
+    pub fn number(&self) -> BlockNumber {
+        self.number
+    }
+    /// Return Hash
+    pub fn hash(&self) -> Byte32 {
+        self.hash.clone()
+    }
+}
+
+impl From<(BlockNumber, Byte32)> for BlockNumberAndHash {
+    fn from(inner: (BlockNumber, Byte32)) -> Self {
+        Self {
+            number: inner.0,
+            hash: inner.1,
+        }
+    }
+}
+
+impl From<&crate::core::HeaderView> for BlockNumberAndHash {
+    fn from(header: &crate::core::HeaderView) -> Self {
+        Self {
+            number: header.number(),
+            hash: header.hash(),
+        }
+    }
+}
+
+impl From<crate::core::HeaderView> for BlockNumberAndHash {
+    fn from(header: crate::core::HeaderView) -> Self {
+        Self {
+            number: header.number(),
+            hash: header.hash(),
+        }
+    }
+}

--- a/util/types/src/lib.rs
+++ b/util/types/src/lib.rs
@@ -4,12 +4,12 @@
 
 pub mod prelude;
 
+pub use block_number_and_hash::BlockNumberAndHash;
 pub use bytes;
 pub use ckb_fixed_hash::{h160, h256, H160, H256};
 pub use ckb_gen_types::packed;
 pub use molecule::{self, error};
 pub use numext_fixed_uint::{u256, U128, U256};
-
 pub mod core;
 pub mod global;
 
@@ -18,5 +18,6 @@ mod conversion;
 mod extension;
 pub mod utilities;
 
+mod block_number_and_hash;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

I think `BlockNumberAndHash` is more suitable to be placed in `ckb-types`. Moreover, I want to use `BlockNumberAndHash` in `ckb-db` and `ckb-db-schema`.


What's Changed:

### Related changes

- Move `struct BlockNumberAndHash` to `ckb-types`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

