### PR TITLE
chore: add clippy::redundant_clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/sh
 MOLC    := moleculec
 MOLC_VERSION := 0.7.5
 VERBOSE := $(if ${CI},--verbose,)
-CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::enum_glob_use -D clippy::fallible_impl_from \
+CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::redundant_clone -D clippy::enum_glob_use -D clippy::fallible_impl_from \
 	-A clippy::mutable_key_type -A clippy::upper_case_acronyms
 CKB_TEST_ARGS := -c 4 ${CKB_TEST_ARGS}
 CKB_FEATURES ?= deadlock_detection,with_sentry

--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -48,13 +48,13 @@ pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), 
 
     let network_controller = launcher.start_network_and_rpc(
         &shared,
-        chain_controller.clone(),
+        chain_controller,
         miner_enable,
         pack.take_relay_tx_receiver(),
     );
 
     let tx_pool_builder = pack.take_tx_pool_builder();
-    tx_pool_builder.start(network_controller.clone());
+    tx_pool_builder.start(network_controller);
 
     info!("CKB service started ...");
     ctrlc::set_handler(|| {

--- a/db-migration/src/lib.rs
+++ b/db-migration/src/lib.rs
@@ -250,7 +250,7 @@ impl Migrations {
         let all_can_resume = migrations.iter().all(|(_, m)| m.can_resume());
         let tasks = Arc::new(Mutex::new(migrations));
         let (tx, rx) = unbounded();
-        let worker = MigrationWorker::new(tasks, db.clone(), rx);
+        let worker = MigrationWorker::new(tasks, db, rx);
 
         let exit_signal = ckb_stop_handler::new_crossbeam_exit_rx();
         let clone = v.to_string();

--- a/devtools/doc/rpc-gen/src/gen.rs
+++ b/devtools/doc/rpc-gen/src/gen.rs
@@ -261,7 +261,7 @@ fn capitlize(s: &str) -> String {
     if s.is_empty() {
         return s.to_owned();
     }
-    s[0..1].to_uppercase().to_string() + &s[1..]
+    s[0..1].to_uppercase() + &s[1..]
 }
 
 fn strip_prefix_space(content: &str) -> String {
@@ -440,7 +440,7 @@ fn gen_type(ty: &Value) -> String {
                         .map(|t| format!("`{}`", gen_type(t)))
                         .collect::<Vec<_>>()
                         .join(" `|` ");
-                    ty.to_string()
+                    ty
                 } else if ty.as_str() == Some("object") {
                     // json schemars bug!
                     // type is `HashMap` here

--- a/rpc/src/service_builder.rs
+++ b/rpc/src/service_builder.rs
@@ -152,7 +152,7 @@ impl<'a> ServiceBuilder<'a> {
             );
         }
         let methods = IntegrationTestRpcImpl {
-            shared: shared.clone(),
+            shared,
             network_controller,
             chain,
         };

--- a/rpc/src/tests/setup.rs
+++ b/rpc/src/tests/setup.rs
@@ -96,7 +96,7 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
 
     let network_controller = {
         let network_config = NetworkConfig {
-            path: temp_dir.path().join("network").to_path_buf(),
+            path: temp_dir.path().join("network"),
             ping_interval_secs: 1,
             ping_timeout_secs: 1,
             connect_outbound_interval_secs: 1,
@@ -221,7 +221,7 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
     let io_handler = builder.build();
     let shared_clone = shared.clone();
     let handler = shared_clone.async_handle().clone();
-    let rpc_server = RpcServer::new(rpc_config, io_handler, handler.clone());
+    let rpc_server = RpcServer::new(rpc_config, io_handler, handler);
 
     let rpc_client = reqwest::blocking::Client::new();
     let rpc_uri = format!(

--- a/test/src/specs/tx_pool/limit.rs
+++ b/test/src/specs/tx_pool/limit.rs
@@ -136,7 +136,7 @@ impl Spec for TxPoolLimitAncestorCount {
             tx_c
         };
 
-        let mut prev = tx_c.clone();
+        let mut prev = tx_c;
         // Create transaction chain
         for i in 0..2000 {
             let input =

--- a/test/src/specs/tx_pool/orphan_tx.rs
+++ b/test/src/specs/tx_pool/orphan_tx.rs
@@ -313,7 +313,7 @@ impl Spec for TxPoolOrphanDoubleSpend {
         let script = node0.always_success_script();
         let new_output1 = CellOutputBuilder::default()
             .capacity(capacity_bytes!(200).pack())
-            .lock(script.clone())
+            .lock(script)
             .build();
         let new_output2 = new_output1.clone();
         let new_output3 = new_output1.clone();

--- a/test/src/specs/tx_pool/replace.rs
+++ b/test/src/specs/tx_pool/replace.rs
@@ -961,6 +961,7 @@ impl Spec for RbfCellDepsCheck {
             tx_a
         };
 
+        #[allow(clippy::redundant_clone)]
         let mut prev = tx_a.clone();
         // Create transaction chain
         for _i in 0..2 {

--- a/tx-pool/src/component/tests/links.rs
+++ b/tx-pool/src/component/tests/links.rs
@@ -22,7 +22,7 @@ fn test_link_map() {
 
     map.add_parent(&id1, id2.clone());
     map.add_parent(&id2, id3.clone());
-    map.add_parent(&id3, id4.clone());
+    map.add_parent(&id3, id4);
     let parents = map.calc_relation_ids([id1.clone()].into(), Relation::Parents);
     assert_eq!(parents.len(), 4);
 

--- a/tx-pool/src/component/tests/orphan.rs
+++ b/tx-pool/src/component/tests/orphan.rs
@@ -36,7 +36,7 @@ fn test_orphan_duplicated() {
     let tx5 = build_tx(vec![(&tx1.hash(), 0)], 2);
     orphan.add_orphan_tx(tx1.clone(), 0.into(), 0);
     orphan.add_orphan_tx(tx2.clone(), 0.into(), 0);
-    orphan.add_orphan_tx(tx3.clone(), 0.into(), 0);
+    orphan.add_orphan_tx(tx3, 0.into(), 0);
     orphan.add_orphan_tx(tx4.clone(), 0.into(), 0);
     orphan.add_orphan_tx(tx5.clone(), 0.into(), 0);
     assert_eq!(orphan.len(), 5);

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -274,7 +274,7 @@ impl TxPoolService {
                                 "{} is resolved as Dead, but there is no conflicted tx",
                                 rtx.transaction.proposal_short_id()
                             );
-                            return Err(Reject::Resolve(OutPointError::Dead(out.clone())));
+                            return Err(Reject::Resolve(OutPointError::Dead(out)));
                         }
                         // we also return Ok here, so that the entry will be continue to be verified before submit
                         // we only want to put it into conflicts pool after the verification stage passed

--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -47,7 +47,7 @@ impl IndexerService {
             ckb_db,
             pool_service,
             &config.into(),
-            async_handle.clone(),
+            async_handle,
             config.init_tip_hash.clone(),
         );
 
@@ -1802,8 +1802,8 @@ mod tests {
             .output(
                 CellOutputBuilder::default()
                     .capacity(capacity_bytes!(1000).pack())
-                    .lock(lock_script1.clone())
-                    .type_(Some(type_script1.clone()).pack())
+                    .lock(lock_script1)
+                    .type_(Some(type_script1).pack())
                     .build(),
             )
             .output_data(Default::default())
@@ -1816,7 +1816,7 @@ mod tests {
                 CellOutputBuilder::default()
                     .capacity(capacity_bytes!(2000).pack())
                     .lock(lock_script11.clone())
-                    .type_(Some(type_script11.clone()).pack())
+                    .type_(Some(type_script11).pack())
                     .build(),
             )
             .output_data(data.to_vec().pack())
@@ -1824,8 +1824,8 @@ mod tests {
 
         let block0 = BlockBuilder::default()
             .transaction(cellbase0)
-            .transaction(tx00.clone())
-            .transaction(tx01.clone())
+            .transaction(tx00)
+            .transaction(tx01)
             .header(HeaderBuilder::default().number(0.pack()).build())
             .build();
 
@@ -2001,7 +2001,7 @@ mod tests {
         // test get_cells_capacity rpc with output_data Partial search mode
         let cells_capacity = rpc
             .get_cells_capacity(IndexerSearchKey {
-                script: lock_script11.clone().into(),
+                script: lock_script11.into(),
                 filter: Some(IndexerSearchKeyFilter {
                     output_data: Some(JsonBytes::from_vec(vec![])),
                     output_data_filter_mode: Some(IndexerSearchMode::Partial),


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary: 

When I review a performance issue, I found there are some necessary clones.
`clippy::redundant_clone` may remove them from the code.

### What is changed and how it works?

add `clippy::redundant_clone`.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

