### PR TITLE
Modify the record scope of tx-pool reject record and fix rule for orphan tx.

### DIFF
--- a/shared/src/shared_builder.rs
+++ b/shared/src/shared_builder.rs
@@ -416,10 +416,7 @@ fn register_tx_pool_callback(tx_pool_builder: &mut TxPoolServiceBuilder, notify:
         move |tx_pool: &mut TxPool, entry: &TxEntry, reject: Reject| {
             let tx_hash = entry.transaction().hash();
             // record recent reject
-            if matches!(
-                reject,
-                Reject::Resolve(..) | Reject::RBFRejected(..) | Reject::Invalidated(..)
-            ) {
+            if reject.should_recorded() {
                 if let Some(ref mut recent_reject) = tx_pool.recent_reject {
                     if let Err(e) = recent_reject.put(&tx_hash, reject.clone()) {
                         error!("record recent_reject failed {} {} {}", tx_hash, reject, e);

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -752,6 +752,17 @@ impl Relayer {
                     TxVerificationResult::Reject { tx_hash } => {
                         self.shared.state().remove_from_known_txs(&tx_hash);
                     }
+                    TxVerificationResult::UnknownParents { peer, parents } => {
+                        let tx_hashes: Vec<_> = {
+                            let mut tx_filter = self.shared.state().tx_filter();
+                            tx_filter.remove_expired();
+                            parents
+                                .into_iter()
+                                .filter(|tx_hash| !tx_filter.contains(tx_hash))
+                                .collect()
+                        };
+                        self.shared.state().add_ask_for_txs(peer, tx_hashes);
+                    }
                 }
             }
         }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -431,6 +431,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(TxPoolOrphanNormal),
         Box::new(TxPoolOrphanReverse),
         Box::new(TxPoolOrphanUnordered),
+        Box::new(TxPoolOrphanPartialInputUnknown),
         Box::new(TxPoolOrphanDoubleSpend),
         Box::new(OrphanTxRejected),
         Box::new(GetRawTxPool),

--- a/test/src/util/transaction.rs
+++ b/test/src/util/transaction.rs
@@ -47,6 +47,26 @@ pub fn always_success_transactions_with_rand_data(
         .build()
 }
 
+pub fn send_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
+    let relay_tx = packed::RelayTransaction::new_builder()
+        .cycles(cycles.pack())
+        .transaction(tx.data())
+        .build();
+
+    let tx_msg = packed::RelayMessage::new_builder()
+        .set(
+            packed::RelayTransactions::new_builder()
+                .transactions(
+                    packed::RelayTransactionVec::new_builder()
+                        .set(vec![relay_tx])
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    net.send(node, SupportProtocols::RelayV3, tx_msg.as_bytes());
+}
+
 pub fn relay_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
     let tx_hashes_msg = packed::RelayMessage::new_builder()
         .set(

--- a/tx-pool/src/component/orphan.rs
+++ b/tx-pool/src/component/orphan.rs
@@ -151,6 +151,7 @@ impl OrphanPool {
                 .insert(tx.proposal_short_id());
         }
 
+         // DoS prevention: do not allow OrphanPool to grow unbounded
         self.limit_size()
     }
 

--- a/tx-pool/src/component/orphan.rs
+++ b/tx-pool/src/component/orphan.rs
@@ -151,7 +151,7 @@ impl OrphanPool {
                 .insert(tx.proposal_short_id());
         }
 
-         // DoS prevention: do not allow OrphanPool to grow unbounded
+        // DoS prevention: do not allow OrphanPool to grow unbounded
         self.limit_size()
     }
 

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -480,13 +480,7 @@ impl TxPoolService {
                                 tx_hash: tx_hash.clone(),
                             });
                         }
-
-                        if matches!(
-                            reject,
-                            Reject::Resolve(..)
-                                | Reject::Verification(..)
-                                | Reject::RBFRejected(..)
-                        ) {
+                        if reject.should_recorded() {
                             self.put_recent_reject(&tx_hash, reject).await;
                         }
                     }
@@ -514,12 +508,7 @@ impl TxPoolService {
                     }
                     Err(reject) => {
                         debug!("after_process {} reject: {} ", tx_hash, reject);
-                        if matches!(
-                            reject,
-                            Reject::Resolve(..)
-                                | Reject::Verification(..)
-                                | Reject::RBFRejected(..)
-                        ) {
+                        if reject.should_recorded() {
                             self.put_recent_reject(&tx_hash, reject).await;
                         }
                     }
@@ -628,12 +617,7 @@ impl TxPoolService {
                                         tx_hash: orphan.tx.hash(),
                                     });
                                 }
-                                if matches!(
-                                    reject,
-                                    Reject::Resolve(..)
-                                        | Reject::Verification(..)
-                                        | Reject::RBFRejected(..)
-                                ) {
+                                if reject.should_recorded() {
                                     self.put_recent_reject(&orphan.tx.hash(), &reject).await;
                                 }
                             }

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -458,7 +458,10 @@ impl TxPoolService {
         match remote {
             Some((declared_cycle, peer)) => match ret {
                 Ok(_) => {
-                    debug!("after_process remote send_result_to_relayer {}", tx_hash);
+                    debug!(
+                        "after_process remote send_result_to_relayer {} {}",
+                        tx_hash, peer
+                    );
                     self.send_result_to_relayer(TxVerificationResult::Ok {
                         original_peer: Some(peer),
                         with_vm_2023,
@@ -467,7 +470,10 @@ impl TxPoolService {
                     self.process_orphan_tx(&tx).await;
                 }
                 Err(reject) => {
-                    debug!("after_process {} remote reject: {} ", tx_hash, reject);
+                    debug!(
+                        "after_process {} {} remote reject: {} ",
+                        tx_hash, peer, reject
+                    );
                     if is_missing_input(reject) {
                         self.send_result_to_relayer(TxVerificationResult::UnknownParents {
                             peer,

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -3,7 +3,6 @@
 use crate::block_assembler::{self, BlockAssembler};
 use crate::callback::{Callbacks, PendingCallback, ProposedCallback, RejectCallback};
 use crate::chunk_process::ChunkCommand;
-use crate::component::entry;
 use crate::component::pool_map::{PoolEntry, Status};
 use crate::component::{chunk::ChunkQueue, orphan::OrphanPool};
 use crate::error::{handle_recv_error, handle_send_cmd_error, handle_try_send_error};
@@ -679,6 +678,13 @@ pub enum TxVerificationResult {
         with_vm_2023: bool,
         /// transaction hash
         tx_hash: Byte32,
+    },
+    /// tx parent is unknown
+    UnknownParents {
+        /// original peer
+        peer: PeerIndex,
+        /// parents hashes
+        parents: HashSet<Byte32>,
     },
     /// tx is rejected
     Reject {

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -95,6 +95,11 @@ impl Reject {
         }
     }
 
+    /// Returns true if the reject should be recorded.
+    pub fn should_recorded(&self) -> bool {
+        !matches!(self, Reject::Duplicated(..))
+    }
+
     /// Returns true if tx can be resubmitted, allowing relay
     /// * Declared wrong cycles should allow relay with the correct cycles
     /// * Reject but is not malformed and the fee rate reached the threshold,

--- a/util/types/src/core/views.rs
+++ b/util/types/src/core/views.rs
@@ -422,6 +422,13 @@ impl TransactionView {
     pub fn proposal_short_id(&self) -> packed::ProposalShortId {
         packed::ProposalShortId::from_tx_hash(&self.hash())
     }
+
+    /// return deduplicate parent tx_hashes
+    pub fn unique_parents(&self) -> HashSet<packed::Byte32> {
+        self.input_pts_iter()
+            .map(|outpoint| outpoint.tx_hash())
+            .collect()
+    }
 }
 
 impl ExtraHashView {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

* Modify the record scope of tx-pool reject record, Now that all rejects are record except Duplicate (which gets rebroadcast)
* Fixed the case where some inputs of a transaction are unknown will not add to the orphan pool.
* Now actively fetches unknown transactions from node broadcasting orphan tx



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

