### PR TITLE
Early return process_fetch_cmd if ckb received exit signal

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -89,10 +89,17 @@ impl BlockFetchCMD {
         match self.can_start() {
             CanStart::Ready => {
                 for peer in peers {
+                    if ckb_stop_handler::has_received_stop_signal() {
+                        return;
+                    }
+
                     if let Some(fetch) =
                         BlockFetcher::new(Arc::clone(&self.sync_shared), peer, ibd_state).fetch()
                     {
                         for item in fetch {
+                            if ckb_stop_handler::has_received_stop_signal() {
+                                return;
+                            }
                             BlockFetchCMD::send_getblocks(item, &self.p2p_control, peer);
                         }
                     }


### PR DESCRIPTION


<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

### Related changes

- Early return `BlockFetchCMD::process_fetch_cmd` if ckb has received exit signal

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

