### PR TITLE
Recover possible transaction in conflicted cache when RBF

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -486,6 +486,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RbfReplaceProposedSuccess),
         Box::new(RbfConcurrency),
         Box::new(RbfCellDepsCheck),
+        Box::new(RbfCyclingAttack),
         Box::new(CompactBlockEmpty),
         Box::new(CompactBlockEmptyParentUnknown),
         Box::new(CompactBlockPrefilled),

--- a/test/src/specs/tx_pool/replace.rs
+++ b/test/src/specs/tx_pool/replace.rs
@@ -1055,8 +1055,8 @@ impl Spec for RbfCyclingAttack {
         }
 
         // Create transaction chain,  B0 -> B1
-        let mut prev = tx_b.clone();
         let mut txs_chain_b = vec![tx_b.clone()];
+        let mut prev = tx_b;
         for _i in 0..1 {
             let input =
                 CellMetaBuilder::from_cell_output(prev.output(0).unwrap(), Default::default())

--- a/test/src/specs/tx_pool/replace.rs
+++ b/test/src/specs/tx_pool/replace.rs
@@ -1013,6 +1013,142 @@ impl Spec for RbfCellDepsCheck {
     }
 }
 
+pub struct RbfCyclingAttack;
+impl Spec for RbfCyclingAttack {
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let node0 = &nodes[0];
+
+        let initial_inputs = gen_spendable(node0, 3);
+        let input_a = &initial_inputs[0];
+        let input_b = &initial_inputs[1];
+        let input_c = &initial_inputs[2];
+
+        let input_c: CellInput = CellInput::new_builder()
+            .previous_output(input_c.out_point.clone())
+            .build();
+
+        // Commit transaction root
+        let tx_a = {
+            let tx_a = always_success_transaction(node0, input_a);
+            node0.submit_transaction(&tx_a);
+            tx_a
+        };
+
+        let tx_b = {
+            let tx_b = always_success_transaction(node0, input_b);
+            node0.submit_transaction(&tx_b);
+            tx_b
+        };
+
+        let mut prev = tx_a.clone();
+        // Create transaction chain,  A0 -> A1 -> A2
+        let mut txs_chain_a = vec![tx_a];
+        for _i in 0..2 {
+            let input =
+                CellMetaBuilder::from_cell_output(prev.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(prev.hash(), 0))
+                    .build();
+            let cur = always_success_transaction(node0, &input);
+            txs_chain_a.push(cur.clone());
+            let _ = node0.rpc_client().send_transaction(cur.data().into());
+            prev = cur.clone();
+        }
+
+        // Create transaction chain,  B0 -> B1
+        let mut prev = tx_b.clone();
+        let mut txs_chain_b = vec![tx_b.clone()];
+        for _i in 0..1 {
+            let input =
+                CellMetaBuilder::from_cell_output(prev.output(0).unwrap(), Default::default())
+                    .out_point(OutPoint::new(prev.hash(), 0))
+                    .build();
+            let cur = always_success_transaction(node0, &input);
+            txs_chain_b.push(cur.clone());
+            let _ = node0.rpc_client().send_transaction(cur.data().into());
+            prev = cur.clone();
+        }
+        let tx_b1 = txs_chain_b[1].clone();
+        eprintln!("tx_b1 {:?}", tx_b1.proposal_short_id());
+
+        // Create a child transaction consume B0 and A1
+        // A0 ---> A1 ---> A2
+        //         |
+        //   ----------> B2
+        //  |
+        // B0 ---> B1
+        let tx_a1 = &txs_chain_a[1];
+        let tx_b0 = &txs_chain_b[0];
+
+        let input_a1: CellInput = CellInput::new_builder()
+            .previous_output(OutPoint::new(tx_a1.hash(), 0))
+            .build();
+        let input_b0 = CellInput::new_builder()
+            .previous_output(OutPoint::new(tx_b0.hash(), 0))
+            .build();
+
+        let tx_b2_output = CellOutputBuilder::default()
+            .capacity(capacity_bytes!(200).pack())
+            .build();
+        let tx_b2 = tx_a1
+            .as_advanced_builder()
+            .set_inputs(vec![input_a1, input_b0])
+            .set_outputs(vec![tx_b2_output])
+            .build();
+        let res = node0.rpc_client().send_transaction(tx_b2.data().into());
+        eprintln!("tx_b2 {:?}", res);
+
+        // after A2 and B1 is replaced by B2
+        // A0 ---> A1
+        //         |
+        //   ----------> B2
+        //  |
+        // B0
+        let res = node0.rpc_client().get_transaction(tx_b2.hash());
+        assert_eq!(res.tx_status.status, Status::Pending);
+        let res = node0.rpc_client().get_transaction(txs_chain_a[2].hash());
+        assert_eq!(res.tx_status.status, Status::Rejected);
+        let res = node0.rpc_client().get_transaction(txs_chain_b[1].hash());
+        assert_eq!(res.tx_status.status, Status::Rejected);
+
+        // tx_b1 is still rejected
+        let res = node0.rpc_client().get_transaction(tx_b1.hash());
+        assert_eq!(res.tx_status.status, Status::Rejected);
+
+        // Create a new transaction A3 consume A1, it will replace B2
+        let input_a1 = CellInput::new_builder()
+            .previous_output(OutPoint::new(tx_a1.hash(), 0))
+            .build();
+        let tx_a3_output = CellOutputBuilder::default()
+            .capacity(capacity_bytes!(100).pack())
+            .build();
+        let tx_a3 = tx_a1
+            .as_advanced_builder()
+            .set_inputs(vec![input_a1, input_c])
+            .set_outputs(vec![tx_a3_output])
+            .build();
+        let _res = node0.rpc_client().send_transaction(tx_a3.data().into());
+
+        // now result is:
+        // A0 ---> A1 -> A3
+        //
+        // B0 -> B1  (B1 is recovered back)
+        //
+        let res = node0.rpc_client().get_transaction(tx_a3.hash());
+        assert_eq!(res.tx_status.status, Status::Pending);
+        let res = node0.rpc_client().get_transaction(tx_b2.hash());
+        assert_eq!(res.tx_status.status, Status::Rejected);
+        eprintln!("tx_b1 {:?}", tx_b1.proposal_short_id());
+
+        // B1 is expected by recovered back
+        let res = node0.rpc_client().get_transaction(tx_b1.hash());
+        assert_eq!(res.tx_status.status, Status::Pending);
+    }
+
+    fn modify_app_config(&self, config: &mut ckb_app_config::CKBAppConfig) {
+        config.tx_pool.min_rbf_rate = ckb_types::core::FeeRate(1500);
+    }
+}
+
 fn run_spec_send_conflict_relay(nodes: &mut [Node]) {
     let node0 = &nodes[0];
     let node1 = &nodes[1];

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -133,25 +133,45 @@ impl TxPoolService {
                 }
 
                 // try to remove conflicted tx here
+                let mut available_inputs = HashSet::new();
+                let mut all_removed = vec![];
                 for id in conflicts.iter() {
-                    let removed = tx_pool.pool_map.remove_entry_and_descendants(id);
-                    for old in removed {
-                        debug!(
-                            "remove conflict tx {} for RBF by new tx {}",
-                            old.transaction().hash(),
-                            entry.transaction().hash()
-                        );
-                        let reject = Reject::RBFRejected(format!(
-                            "replaced by tx {}",
-                            entry.transaction().hash()
-                        ));
-                        // RBF replace successfully, put old transactions into conflicts pool
-                        tx_pool.record_conflict(old.transaction().clone());
-                        // after removing old tx from tx_pool, we call reject callbacks manually
-                        self.callbacks.call_reject(tx_pool, &old, reject);
+                    all_removed.extend(tx_pool.pool_map.remove_entry_and_descendants(id));
+                }
+
+                for removed in all_removed.iter() {
+                    available_inputs.extend(removed.transaction().input_pts_iter());
+                }
+
+                if !available_inputs.is_empty() {
+                    for input in entry.transaction().input_pts_iter() {
+                        available_inputs.remove(&input);
                     }
                 }
+                let may_recovered_txs =
+                    tx_pool.get_conflicted_txs_from_inputs(available_inputs.into_iter());
+
+                for old in all_removed {
+                    debug!(
+                        "remove conflict tx {} for RBF by new tx {}",
+                        old.transaction().hash(),
+                        entry.transaction().hash()
+                    );
+                    let reject = Reject::RBFRejected(format!(
+                        "replaced by tx {}",
+                        entry.transaction().hash()
+                    ));
+
+                    // RBF replace successfully, put old transactions into conflicts pool
+                    tx_pool.record_conflict(old.transaction().clone());
+                    // after removing old tx from tx_pool, we call reject callbacks manually
+                    self.callbacks.call_reject(tx_pool, &old, reject);
+                }
+
                 let evicted = _submit_entry(tx_pool, status, entry.clone(), &self.callbacks)?;
+
+                // in a corner case, a tx with lower fee rate may be rejected immediately
+                // after inserting into pool, return proper reject error here
                 for evict in evicted {
                     let reject = Reject::Invalidated(format!(
                         "invalidated by tx {}",
@@ -159,12 +179,23 @@ impl TxPoolService {
                     ));
                     self.callbacks.call_reject(tx_pool, &evict, reject);
                 }
+
                 tx_pool.remove_conflict(&entry.proposal_short_id());
-                // in a corner case, a tx with lower fee rate may be rejected immediately
-                // after inserting into pool, return proper reject error here
                 tx_pool
                     .limit_size(&self.callbacks, Some(&entry.proposal_short_id()))
                     .map_or(Ok(()), Err)?;
+
+                if !may_recovered_txs.is_empty() {
+                    let self_clone = self.clone();
+                    tokio::spawn(async move {
+                        // push the recovered txs back to verify queue, so that they can be verified and submitted again
+                        let mut queue = self_clone.verify_queue.write().await;
+                        for tx in may_recovered_txs {
+                            debug!("recover back: {:?}", tx.proposal_short_id());
+                            let _ = queue.add_tx(tx, None);
+                        }
+                    });
+                }
                 Ok(())
             })
             .await;


### PR DESCRIPTION
### What problem does this PR solve?

When we replace some transactions in RBF, some old transactions may be okay to be recovered, since there are no conflicts after removing transactions. 

If we don't recover these transactions, it may introduce a scenario of a possible cycling attack in lightning network.

### What is changed and how it works?

What's Changed:

Add `conflicts_outputs_cache` to track the relationship of `input -> tx` in RBF, then add possible transactions into the verify pool, so that they may be recovered.

This PR is based on the `new-verify` branch, one reason is we can not recursively call `submit_entry` in async. Another reason is `new-verify`'s worker-consumer model is more suitable for retrying submit transactions.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

