### PR TITLE
fix: fix sync relayer collaboration

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -8,13 +8,13 @@ mod get_block_proposal_process;
 mod get_block_transactions_process;
 mod get_transactions_process;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 mod transaction_hashes_process;
 mod transactions_process;
 
 use self::block_proposal_process::BlockProposalProcess;
 use self::block_transactions_process::BlockTransactionsProcess;
-use self::compact_block_process::CompactBlockProcess;
+pub(crate) use self::compact_block_process::CompactBlockProcess;
 use self::get_block_proposal_process::GetBlockProposalProcess;
 use self::get_block_transactions_process::GetBlockTransactionsProcess;
 use self::get_transactions_process::GetTransactionsProcess;

--- a/sync/src/relayer/tests/mod.rs
+++ b/sync/src/relayer/tests/mod.rs
@@ -6,5 +6,5 @@ mod compact_block_process;
 mod compact_block_verifier;
 mod get_block_proposal_process;
 mod get_transactions_process;
-mod helper;
+pub(crate) mod helper;
 mod reconstruct_block;


### PR DESCRIPTION
### What problem does this PR solve?

`HeaderProcess` uses the current snapshot to process the one-time message, During the entire processing process, the changes in the db itself are imperceptible. Normally, there is no problem here. But during this process, if a compact block message is received and processed successfully, the chain inserts a new block, and the block's header is in the previous header process message, there will be a concurrency problem.

I use a simple diagram to describe the time series problem here：

```bash
sync thread   |          process headers         |

relay thread    |  compact block process  |
```
The time series here is that the header process holds the old snapshot longer than the compact block process completion time.

This will cause the block status in the old snapshot to differ from the actual status.

https://github.com/nervosnetwork/ckb/blob/f3efbf24f893b9a45531a8863c549d70ec2f3d9b/sync/src/types/mod.rs#L2315-L2335

The actual status should be `BLOCK_VALID`, but because the block cannot be seen in the old snapshot, the returned status will be `UNKNOWN`

https://github.com/nervosnetwork/ckb/blob/f3efbf24f893b9a45531a8863c549d70ec2f3d9b/sync/src/synchronizer/headers_process.rs#L290-L336

The `UNKNOWN` status will cause the header to be reinserted into the header map, which will cause the block's status to become `HEADER_VALID`, the compact blocks received later will all be put into the orphan block pool due to this abnormal state. This will cause synchronization to pause until no compact block messages are received for a while. The sync protocol can then resume synchronization by re-downloading the abnormal block.

This PR forcefully reset the snapshot in get block status to obtain the latest status

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

