### PR TITLE
Fix Unit Test and Integration Test on MacOS and Windows platform

### DIFF
--- a/sync/src/tests/synchronizer/basic_sync.rs
+++ b/sync/src/tests/synchronizer/basic_sync.rs
@@ -121,6 +121,10 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
 
     let chain_controller = start_chain_services(pack.take_chain_services_builder());
 
+    while chain_controller.is_verifying_unverified_blocks_on_startup() {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
     for _i in 0..height {
         let number = block.header().number() + 1;
         let timestamp = block.header().timestamp() + 1;

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -681,6 +681,9 @@ impl Node {
                         status,
                         self.log_path().display()
                     );
+                    info!("Last 200 lines of log:");
+                    self.print_last_500_lines_log(&self.log_path());
+                    info!("End of last 200 lines of log");
                     // parent process will exit
                     return;
                 }
@@ -703,6 +706,20 @@ impl Node {
             killed: false,
         });
         self.set_node_id(node_info.node_id.as_str());
+    }
+
+    fn print_last_500_lines_log(&self, log_file: &Path) {
+        let file = File::open(log_file).expect("open log file");
+        let reader = BufReader::new(file);
+        let lines: Vec<String> = reader.lines().map(|line| line.unwrap()).collect();
+        let start = if lines.len() > 500 {
+            lines.len() - 500
+        } else {
+            0
+        };
+        for line in lines.iter().skip(start) {
+            info!("{}", line);
+        }
     }
 
     pub(crate) fn set_process_guard(&mut self, guard: ProcessGuard) {

--- a/test/src/specs/sync/invalid_block.rs
+++ b/test/src/specs/sync/invalid_block.rs
@@ -26,6 +26,10 @@ impl Spec for ChainContainsInvalidBlock {
         let good_node = nodes.pop().unwrap();
         let fresh_node = nodes.pop().unwrap();
 
+        // wait a few seconds to let find_unverified_block thread finish
+        #[cfg(target_os = "macos")]
+        std::thread::sleep(Duration::from_secs(3));
+
         // Build invalid chain on bad_node
         bad_node.mine(3);
         let invalid_block = bad_node


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Want to fix: 
https://github.com/nervosnetwork/ckb/actions/runs/10256636258/job/28376143614
https://github.com/nervosnetwork/ckb/actions/runs/10256636255/job/28376145250

In Integration Test, when node crash, print last 500 lines of log.
In Unit test `fn basic_sync`, wait init_load_unverified thread exit before process bad block

### Related changes

- Unit test: wait init_load_unverified thread finish before insert block
- Integration Test: print last 500 lines log when node crash
- Integration Test: wait init_load_unverified thread exit before process block on MacOS platform

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

