### PR TITLE
Integration Test: Increase wait timeout for LastCommonHeaderForPeerWithWorseChain

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -772,6 +772,22 @@ impl Node {
         Ok(config)
     }
 
+    pub fn wait_find_unverified_blocks_finished(&self) {
+        // wait for node[0] to find unverified blocks finished
+
+        let now = std::time::Instant::now();
+        while !self
+            .access_log(|line: &str| line.contains("find unverified blocks finished"))
+            .expect("node[0] must have log")
+        {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if now.elapsed() > Duration::from_secs(60) {
+                panic!("node[0] should find unverified blocks finished in 60s");
+            }
+            info!("waiting for node[0] to find unverified blocks finished");
+        }
+    }
+
     pub fn access_log<F>(&self, line_checker: F) -> io::Result<bool>
     where
         F: Fn(&str) -> bool,

--- a/test/src/specs/sync/last_common_header.rs
+++ b/test/src/specs/sync/last_common_header.rs
@@ -32,7 +32,7 @@ impl Spec for LastCommonHeaderForPeerWithWorseChain {
         }
 
         // peer.last_common_header is expect to be advanced to peer.best_known_header
-        let last_common_header_synced = wait_until(10, || {
+        let last_common_header_synced = wait_until(20, || {
             let sync_state = node0
                 .rpc_client()
                 .get_peers()

--- a/test/src/specs/sync/sync_invalid.rs
+++ b/test/src/specs/sync/sync_invalid.rs
@@ -17,20 +17,9 @@ impl Spec for SyncInvalid {
     fn run(&self, nodes: &mut Vec<Node>) {
         nodes[0].mine(20);
 
-        {
-            // wait for node[0] to find unverified blocks finished
+        // wait for node[0] to find unverified blocks finished
+        nodes[0].wait_find_unverified_blocks_finished();
 
-            let now = std::time::Instant::now();
-            while !nodes[0]
-                .access_log(|line: &str| line.contains("find unverified blocks finished"))
-                .expect("node[0] must have log")
-            {
-                if now.elapsed() > Duration::from_secs(60) {
-                    panic!("node[0] should find unverified blocks finished in 60s");
-                }
-                info!("waiting for node[0] to find unverified blocks finished");
-            }
-        }
         nodes[1].mine(1);
 
         nodes[0].connect(&nodes[1]);


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to increase wait timeout for LastCommonHeaderForPeerWithWorseChain, fix https://github.com/nervosnetwork/ckb/actions/runs/10259218824/job/28436471337 on MacOS


### Related changes

- **Integration Test: Extract wait_find_unverified_blocks_finished as independent method**
- **Integration Test: Increase wait timeout for LastCommonHeaderForPeerWithWorseChain**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

