### PR TITLE
test: fix script test error caused by rand step cycles

### DIFF
--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -835,10 +835,12 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_state(step_cycles: Cycle
     let mut cycles = 0;
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
+        #[allow(unused_assignments)]
         let mut init_state: Option<TransactionState> = None;
 
-        if let VerifyResult::Suspended(state) = verifier.resumable_verify(step_cycles).unwrap() {
-            init_state = Some(state);
+        match verifier.resumable_verify(step_cycles).unwrap() {
+            VerifyResult::Suspended(state) => init_state = Some(state),
+            VerifyResult::Completed(cycle) => return Ok(cycle),
         }
 
         loop {

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -950,12 +950,12 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap(step_cycles: Cycle)
     if script_version == crate::ScriptVersion::V2 {
         assert!(
             cycles >= TWO_IN_TWO_OUT_CYCLES - V2_CYCLE_BOUND,
-            "step_cycles {step_cycles}"
+            "cycles {cycles} step_cycles {step_cycles}"
         );
     } else {
         assert!(
             cycles >= TWO_IN_TWO_OUT_CYCLES - CYCLE_BOUND,
-            "step_cycles {step_cycles}"
+            "cycles {cycles} step_cycles {step_cycles}"
         );
     }
     assert_eq!(cycles, cycles_once, "step_cycles {step_cycles}");

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -117,7 +117,7 @@ impl Spec for SendLargeCyclesTxToRelay {
         });
         assert!(result, "node0 can't sync with node1");
 
-        let result = wait_until(60, || {
+        let result = wait_until(120, || {
             node0
                 .rpc_client()
                 .get_transaction(tx.hash())


### PR DESCRIPTION
### What problem does this PR solve?

`step_cycles` is randomly generated, which may introduce different VM execution results.
cc PR #4546

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

