### PR TITLE
Add `tx_index` to `TxStatus` for `get_transaction` RPC

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -926,6 +926,7 @@ Response
       "block_hash": null,
       "block_number": null,
       "status": "pending",
+      "tx_index": null,
       "reason": null
     }
   }
@@ -946,6 +947,7 @@ The response looks like below when `verbosity` is 0.
       "block_hash": null,
       "block_number": null,
       "status": "pending",
+      "tx_index": null,
       "reason": null
     }
   }

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -625,6 +625,7 @@ pub trait ChainRpc {
     ///       "block_hash": null,
     ///       "block_number": null,
     ///       "status": "pending",
+    ///       "tx_index": null,
     ///       "reason": null
     ///     }
     ///   }
@@ -645,6 +646,7 @@ pub trait ChainRpc {
     ///       "block_hash": null,
     ///       "block_number": null,
     ///       "status": "pending",
+    ///       "tx_index": null,
     ///       "reason": null
     ///     }
     ///   }
@@ -2159,6 +2161,7 @@ impl ChainRpcImpl {
                 None,
                 tx_info.block_number,
                 tx_info.block_hash.unpack(),
+                tx_info.index as u32,
                 cycles,
                 None,
             ));
@@ -2207,6 +2210,7 @@ impl ChainRpcImpl {
                 Some(tx),
                 tx_info.block_number,
                 tx_info.block_hash.unpack(),
+                tx_info.index as u32,
                 cycles,
                 None,
             ));

--- a/util/jsonrpc-types/src/blockchain.rs
+++ b/util/jsonrpc-types/src/blockchain.rs
@@ -593,6 +593,8 @@ pub struct TxStatus {
     pub block_number: Option<BlockNumber>,
     /// The block hash of the block which has committed this transaction in the canonical chain.
     pub block_hash: Option<H256>,
+    /// The transaction index in the block.
+    pub tx_index: Option<Uint32>,
     /// The reason why the transaction is rejected
     pub reason: Option<String>,
 }
@@ -602,7 +604,9 @@ impl From<tx_pool::TxStatus> for TxStatus {
         match tx_pool_status {
             tx_pool::TxStatus::Pending => TxStatus::pending(),
             tx_pool::TxStatus::Proposed => TxStatus::proposed(),
-            tx_pool::TxStatus::Committed(number, hash) => TxStatus::committed(number.into(), hash),
+            tx_pool::TxStatus::Committed(number, hash, tx_index) => {
+                TxStatus::committed(number.into(), hash, tx_index.into())
+            }
             tx_pool::TxStatus::Rejected(reason) => TxStatus::rejected(reason),
             tx_pool::TxStatus::Unknown => TxStatus::unknown(),
         }
@@ -616,6 +620,7 @@ impl TxStatus {
             status: Status::Pending,
             block_number: None,
             block_hash: None,
+            tx_index: None,
             reason: None,
         }
     }
@@ -626,6 +631,7 @@ impl TxStatus {
             status: Status::Proposed,
             block_number: None,
             block_hash: None,
+            tx_index: None,
             reason: None,
         }
     }
@@ -635,11 +641,12 @@ impl TxStatus {
     /// ## Params
     ///
     /// * `hash` - the block hash in which the transaction is committed.
-    pub fn committed(number: BlockNumber, hash: H256) -> Self {
+    pub fn committed(number: BlockNumber, hash: H256, tx_index: Uint32) -> Self {
         Self {
             status: Status::Committed,
             block_number: Some(number),
             block_hash: Some(hash),
+            tx_index: Some(tx_index),
             reason: None,
         }
     }
@@ -654,6 +661,7 @@ impl TxStatus {
             status: Status::Rejected,
             block_number: None,
             block_hash: None,
+            tx_index: None,
             reason: Some(reason),
         }
     }
@@ -664,6 +672,7 @@ impl TxStatus {
             status: Status::Unknown,
             block_number: None,
             block_hash: None,
+            tx_index: None,
             reason: None,
         }
     }

--- a/util/types/src/core/tx_pool.rs
+++ b/util/types/src/core/tx_pool.rs
@@ -122,7 +122,7 @@ pub enum TxStatus {
     /// Status "proposed". The transaction is in the pool and has been proposed.
     Proposed,
     /// Status "committed". The transaction has been committed to the canonical chain.
-    Committed(BlockNumber, H256),
+    Committed(BlockNumber, H256, u32),
     /// Status "unknown". The node has not seen the transaction,
     /// or it should be rejected but was cleared due to storage limitations.
     Unknown,
@@ -216,11 +216,12 @@ impl TransactionWithStatus {
         tx: Option<core::TransactionView>,
         number: BlockNumber,
         hash: H256,
+        tx_index: u32,
         cycles: Option<core::Cycle>,
         fee: Option<Capacity>,
     ) -> Self {
         Self {
-            tx_status: TxStatus::Committed(number, hash),
+            tx_status: TxStatus::Committed(number, hash, tx_index),
             transaction: tx,
             cycles,
             fee,


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


### Related changes

- Add tx_index for TxStatus for get_transaction RPC

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

