### PR TITLE
Integration Test: decrease restart times and mined blocks count on windows and macos

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -592,7 +592,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RandomlyKill),
     ];
     specs.shuffle(&mut thread_rng());
-    specs.append(&mut vec![Box::new(SyncChurn) as Box<dyn Spec>]);
+    specs.insert(0, Box::new(SyncChurn) as Box<dyn Spec>);
     specs
 }
 

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -36,6 +36,16 @@ impl Spec for SyncChurn {
 
         let (restart_stopped_tx, restart_stopped_rx) = mpsc::channel();
 
+        #[cfg(target_os = "linux")]
+        const NUM_MINED_BLOCKS: usize = 10000;
+        #[cfg(target_os = "linux")]
+        const NUM_RESTART: usize = 100;
+
+        #[cfg(not(target_os = "linux"))]
+        const NUM_MINED_BLOCKS: usize = 1000;
+        #[cfg(not(target_os = "linux"))]
+        const NUM_RESTART: usize = 20;
+
         let mining_thread = thread::spawn(move || {
             let mut rng = rand::thread_rng();
             loop {
@@ -46,7 +56,7 @@ impl Spec for SyncChurn {
                 // and the implicit waiting time is not long enough when there are too many blocks to sync,
                 // so we stop mining when the tip block number is greater than 15000.
                 // Otherwise nodes may not be able to sync within the implicit waiting time.
-                let too_many_blocks = mining_node.get_tip_block_number() > 10000;
+                let too_many_blocks = mining_node.get_tip_block_number() > NUM_MINED_BLOCKS as u64;
                 if too_many_blocks || restart_stopped_rx.try_recv().is_ok() {
                     break;
                 }
@@ -57,8 +67,7 @@ impl Spec for SyncChurn {
         let restart_thread = thread::spawn(move || {
             let mut rng = rand::thread_rng();
             // It takes about 1 second to restart a node. So restarting nodes 100 times takes about 100 seconds.
-            let num_restarts = 100;
-            for _ in 0..num_restarts {
+            for _ in 0..NUM_RESTART {
                 let node = select_random_node(&mut rng, &mut churn_nodes);
                 info!("Restarting node {}", node.node_id());
                 node.stop();


### PR DESCRIPTION


<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

### Related changes

- Decrease mined blocks count and restart count on macos and windows

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

