### PR TITLE
Test: remove expect in verify_mgr because process_tx may return None

### DIFF
--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -42,13 +42,13 @@ async fn verify_queue_basic() {
 
     assert!(!queue.add_tx(tx.clone(), None).unwrap());
 
-    assert_eq!(queue.pop_first(false).as_ref(), Some(&entry));
+    assert_eq!(queue.pop_front(false).as_ref(), Some(&entry));
     assert!(!queue.contains_key(&id));
 
     assert!(queue.add_tx(tx.clone(), None).unwrap());
     sleep(std::time::Duration::from_millis(100)).await;
 
-    assert_eq!(queue.pop_first(false).as_ref(), Some(&entry));
+    assert_eq!(queue.pop_front(false).as_ref(), Some(&entry));
 
     assert!(queue.add_tx(tx.clone(), None).unwrap());
     sleep(std::time::Duration::from_millis(100)).await;
@@ -60,11 +60,11 @@ async fn verify_queue_basic() {
     let counts = count.await.unwrap();
     assert_eq!(counts, 4);
 
-    let cur = queue.pop_first(false);
+    let cur = queue.pop_front(false);
     assert_eq!(cur.unwrap().tx, tx);
 
     assert!(!queue.is_empty());
-    let cur = queue.pop_first(false);
+    let cur = queue.pop_front(false);
     assert_eq!(cur.unwrap().tx, tx2);
 
     assert!(queue.is_empty());
@@ -122,24 +122,24 @@ async fn test_verify_different_cycles() {
     assert_eq!(queue.total_tx_size(), tx_size_sum);
 
     // tx0 should be the first tx in the queue
-    let cur = queue.pop_first(true);
+    let cur = queue.pop_front(true);
     assert_eq!(cur.unwrap().tx, tx0);
 
-    let cur = queue.pop_first(true);
+    let cur = queue.pop_front(true);
     assert_eq!(cur.unwrap().tx, tx2);
 
-    let cur = queue.pop_first(true);
+    let cur = queue.pop_front(true);
     assert_eq!(cur.unwrap().tx, tx3);
 
     // now there is no small cycle tx
-    let cur = queue.pop_first(true);
+    let cur = queue.pop_front(true);
     assert!(cur.is_none());
 
     // pop the tx with the large cycle
-    let cur = queue.pop_first(false);
+    let cur = queue.pop_front(false);
     assert_eq!(cur.unwrap().tx, tx1);
 
-    let cur = queue.pop_first(false);
+    let cur = queue.pop_front(false);
     assert!(cur.is_none());
 
     exit_tx.send(()).unwrap();

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -131,7 +131,7 @@ impl VerifyQueue {
     }
 
     /// Returns the first entry in the queue and remove it
-    pub fn pop_first(&mut self, only_small_cycle: bool) -> Option<Entry> {
+    pub fn pop_front(&mut self, only_small_cycle: bool) -> Option<Entry> {
         if let Some(short_id) = self.peek(only_small_cycle) {
             self.remove_tx(&short_id)
         } else {

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -88,7 +88,7 @@ impl Worker {
                 .tasks
                 .write()
                 .await
-                .pop_first(self.role == WorkerRole::OnlySmallCycleTx)
+                .pop_front(self.role == WorkerRole::OnlySmallCycleTx)
             {
                 Some(entry) => entry,
                 None => return,

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -106,6 +106,8 @@ impl Worker {
                 self.service
                     .after_process(entry.tx, entry.remote, &snapshot, &res)
                     .await;
+            } else {
+                info!("_process_tx for tx: {} returned none", entry.tx.hash());
             }
         }
     }

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -94,7 +94,7 @@ impl Worker {
                 None => return,
             };
 
-            let (res, snapshot) = self
+            if let Some((res, snapshot)) = self
                 .service
                 ._process_tx(
                     entry.tx.clone(),
@@ -102,11 +102,11 @@ impl Worker {
                     Some(&mut self.command_rx),
                 )
                 .await
-                .expect("verify worker _process_tx failed");
-
-            self.service
-                .after_process(entry.tx, entry.remote, &snapshot, &res)
-                .await;
+            {
+                self.service
+                    .after_process(entry.tx, entry.remote, &snapshot, &res)
+                    .await;
+            }
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Fix error from spec `CheckVmVersion2`.

### What is changed and how it works?

What's Changed:
It's safe to skip none and don't call `after_process` for None returned from `process_tx`.

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

