### PR TITLE
`VerifyQueue`: re_notify other Worker when `OnlySmallCycleTx` received a large cycle tx

### DIFF
--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -55,7 +55,7 @@ pub(crate) struct VerifyQueue {
     /// inner tx entry
     inner: MultiIndexVerifyEntryMap,
     /// subscribe this notify to get be notified when there is item in the queue
-    ready_rx: Arc<Notify>,
+    pub(crate) ready_rx: Arc<Notify>,
     /// total tx size in the queue, will reject new transaction if exceed the limit
     total_tx_size: usize,
     /// large cycle threshold, from `pool_config.max_tx_verify_cycles`

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -55,7 +55,7 @@ pub(crate) struct VerifyQueue {
     /// inner tx entry
     inner: MultiIndexVerifyEntryMap,
     /// subscribe this notify to get be notified when there is item in the queue
-    pub(crate) ready_rx: Arc<Notify>,
+    ready_rx: Arc<Notify>,
     /// total tx size in the queue, will reject new transaction if exceed the limit
     total_tx_size: usize,
     /// large cycle threshold, from `pool_config.max_tx_verify_cycles`
@@ -184,6 +184,11 @@ impl VerifyQueue {
         });
         self.ready_rx.notify_one();
         Ok(true)
+    }
+
+    /// When OnlySmallCycleTx Worker is wakeup, but found the tx is large cycle tx, notify other workers.
+    pub fn re_notify(&self) {
+        self.ready_rx.notify_one();
     }
 
     /// Clears the map, removing all elements.

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -1,7 +1,7 @@
 extern crate num_cpus;
 use crate::component::verify_queue::VerifyQueue;
 use crate::service::TxPoolService;
-use ckb_logger::info;
+use ckb_logger::{debug, info};
 use ckb_script::ChunkCommand;
 use ckb_stop_handler::CancellationToken;
 use std::sync::Arc;
@@ -83,15 +83,21 @@ impl Worker {
             if self.tasks.read().await.is_empty() {
                 return;
             }
+
             // pick a entry to run verify
-            let entry = match self
-                .tasks
-                .write()
-                .await
-                .pop_front(self.role == WorkerRole::OnlySmallCycleTx)
-            {
-                Some(entry) => entry,
-                None => return,
+            let entry = {
+                let mut tasks = self.tasks.write().await;
+                match tasks.pop_front(self.role == WorkerRole::OnlySmallCycleTx) {
+                    Some(entry) => entry,
+                    None => {
+                        tasks.ready_rx.notify_one();
+                        debug!(
+                            "Worker (role: {:?}) queue is empty after pop_front, notify others now",
+                            self.role
+                        );
+                        return;
+                    }
+                }
             };
 
             if let Some((res, snapshot)) = self

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -90,11 +90,13 @@ impl Worker {
                 match tasks.pop_front(self.role == WorkerRole::OnlySmallCycleTx) {
                     Some(entry) => entry,
                     None => {
-                        tasks.ready_rx.notify_one();
-                        debug!(
-                            "Worker (role: {:?}) queue is empty after pop_front, notify others now",
+                        if !tasks.is_empty() {
+                            tasks.re_notify();
+                            debug!(
+                                "Worker (role: {:?}) didn't got tx after pop_front, but tasks is not empty, notify other Workers now",
                             self.role
                         );
+                        }
                         return;
                     }
                 }


### PR DESCRIPTION

### What problem does this PR solve?

we found `SendLargeCyclesTxToRelay` is not stable, seems some large cycle tx is not properly processed when replay.

The root cause is when `verify_queue` wake up a `OnlySmallCycleTx` to large cycle tx, the worker will directly return, then other worker also miss the chance to pick it up.

### Related changes

- Let `Worker::process_inner` re_notify other workers if current worker is a `OnlySmallCycleTx` Worker, but there is large cycle tx in `VerifyQueue`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

