### PR TITLE
PeerStore: do not show error when AddrManager db not exist

### DIFF
--- a/network/src/peer_store/peer_store_db.rs
+++ b/network/src/peer_store/peer_store_db.rs
@@ -72,10 +72,17 @@ impl PeerStore {
 
         let addr_manager = File::open(&addr_manager_path)
             .map_err(|err| {
-                debug!(
-                    "Failed to open AddrManager db, file: {:?}, error: {:?}",
-                    addr_manager_path, err
-                )
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    debug!(
+                        "AddrManager db {:?} not found: {:?}",
+                        addr_manager_path, err
+                    )
+                } else {
+                    error!(
+                        "Failed to open AddrManager db, file: {:?}, error: {:?}",
+                        addr_manager_path, err
+                    )
+                }
             })
             .and_then(|file| {
                 AddrManager::load(std::io::BufReader::new(file)).map_err(|err| {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

### Related changes

- Don't show `error` word when AddressManager db not exist on startup.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

