### PR TITLE
[WIP] Debuging Github CI

### DIFF
--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -54,6 +54,8 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
     - run: |
         if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
             devtools/ci/ci_main.sh

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -58,8 +58,7 @@ jobs:
         if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
             devtools/ci/ci_main.sh
         else
-          echo "skip job"
-          exit 0
+          devtools/ci/ci_main.sh
         fi
       shell: bash
     - name: upload log files

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CKB_FEATURES ?= deadlock_detection,with_sentry
 ALL_FEATURES := deadlock_detection,with_sentry,with_dns_seeding,profiling,march-native
 CKB_BENCH_FEATURES ?= ci
 CKB_BUILD_TARGET ?=
-INTEGRATION_RUST_LOG := info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
+INTEGRATION_RUST_LOG := debug,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug
 CARGO_TARGET_DIR ?= $(shell pwd)/target
 BINARY_NAME ?= "ckb"
 COV_PROFRAW_DIR = ${CARGO_TARGET_DIR}/cov

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -395,7 +395,7 @@ fn canonicalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
 }
 
 fn all_specs() -> Vec<Box<dyn Spec>> {
-    let mut specs: Vec<Box<dyn Spec>> = vec![
+    let mut _specs: Vec<Box<dyn Spec>> = vec![
         Box::new(BlockSyncFromOne),
         Box::new(BlockSyncForks),
         Box::new(BlockSyncDuplicatedAndReconnect),
@@ -468,7 +468,6 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(ValidSince),
         Box::new(SendLowFeeRateTx),
         Box::new(SendLargeCyclesTxInBlock::new()),
-        Box::new(SendLargeCyclesTxToRelay::new()),
         Box::new(NotifyLargeCyclesTx::new()),
         Box::new(LoadProgramFailedTx::new()),
         Box::new(RelayWithWrongTx::new()),
@@ -598,6 +597,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RandomlyKill),
         Box::new(SyncChurn),
     ];
+    let mut specs: Vec<Box<dyn Spec>> = vec![Box::new(SendLargeCyclesTxToRelay::new())];
     specs.shuffle(&mut thread_rng());
     specs
 }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -597,7 +597,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(RandomlyKill),
         Box::new(SyncChurn),
     ];
-    let mut specs: Vec<Box<dyn Spec>> = vec![Box::new(SendLargeCyclesTxToRelay::new())];
+    let mut specs: Vec<Box<dyn Spec>> = vec![Box::new(DAOWithSatoshiCellOccupied)];
     specs.shuffle(&mut thread_rng());
     specs
 }

--- a/test/src/specs/tx_pool/send_large_cycles_tx.rs
+++ b/test/src/specs/tx_pool/send_large_cycles_tx.rs
@@ -106,7 +106,7 @@ impl Spec for SendLargeCyclesTxToRelay {
         info!("Generate large cycles tx");
 
         let tx = build_tx(node1, &self.random_key.privkey, self.random_key.lock_arg());
-        // send tx
+        // send tx to node1
         let ret = node1.rpc_client().send_transaction_result(tx.data().into());
         assert!(ret.is_ok());
 

--- a/test/src/specs/tx_pool/valid_since.rs
+++ b/test/src/specs/tx_pool/valid_since.rs
@@ -132,10 +132,12 @@ impl ValidSince {
         {
             let since = since_from_relative_timestamp(median_time_seconds - 1);
             let transaction = node.new_transaction_with_since(cellbase.hash(), since);
+            let res = node
+                .rpc_client()
+                .send_transaction_result(transaction.data().into());
+            info!("res test_since_relative_median_time {:?}", res);
             assert!(
-                node.rpc_client()
-                    .send_transaction_result(transaction.data().into())
-                    .is_ok(),
+                res.is_ok(),
                 "transaction's since is greater than tip's median time",
             );
         }

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -144,6 +144,7 @@ impl VerifyMgr {
         // `num_cpus::get()` will always return at least 1,
         // don't use too many cpu cores to avoid high workload on the system
         let worker_num = std::cmp::max(num_cpus::get() * 3 / 4, 1);
+        eprintln!("verify worker_num: {}", worker_num);
         let workers: Vec<_> = (0..worker_num)
             .map({
                 let tasks = Arc::clone(&service.verify_queue);

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -77,6 +77,13 @@ impl Worker {
     async fn process_inner(&mut self) {
         loop {
             if self.status != ChunkCommand::Resume {
+                info!(
+                    "Worker is not in resume status, current status: {:?}",
+                    self.status
+                );
+                // sleep a while to avoid busy loop
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                self.tasks.write().await.re_notify();
                 return;
             }
             // cheap query to check queue is not empty

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -76,8 +76,9 @@ impl Worker {
 
     async fn process_inner(&mut self) {
         loop {
+            eprintln!("Worker process_inner begin ....");
             if self.status != ChunkCommand::Resume {
-                info!(
+                eprintln!(
                     "Worker is not in resume status, current status: {:?}",
                     self.status
                 );
@@ -88,6 +89,7 @@ impl Worker {
             }
             // cheap query to check queue is not empty
             if self.tasks.read().await.is_empty() {
+                eprintln!("Worker queue is empty");
                 return;
             }
 


### PR DESCRIPTION

### What problem does this PR solve?

Spec `SendLargeCyclesTxToRelay` may be failing in MacOS CI, but it's not reproducible on local dev machine. 

There is a low chance for such a scenario, when a worker is wake up, the current status is not `Resume`, if we return directly the job is left in the queue.

### What is changed and how it works?

Renotify verify worker when status is in `Suspend`.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

