### PR TITLE
chore(RPC): add PRC to clear verify queue 

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -109,6 +109,7 @@ The crate `ckb-rpc`'s minimum supported rustc version is 1.71.1.
         * [Method `remove_transaction`](#pool-remove_transaction)
         * [Method `tx_pool_info`](#pool-tx_pool_info)
         * [Method `clear_tx_pool`](#pool-clear_tx_pool)
+        * [Method `clear_tx_verify_queue`](#pool-clear_tx_verify_queue)
         * [Method `get_raw_tx_pool`](#pool-get_raw_tx_pool)
         * [Method `get_pool_tx_detail_info`](#pool-get_pool_tx_detail_info)
         * [Method `tx_pool_ready`](#pool-tx_pool_ready)
@@ -4734,6 +4735,37 @@ Request
   "id": 42,
   "jsonrpc": "2.0",
   "method": "clear_tx_pool",
+  "params": []
+}
+```
+
+Response
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": null
+}
+```
+
+<a id="pool-clear_tx_verify_queue"></a>
+#### Method `clear_tx_verify_queue`
+* `clear_tx_verify_queue()`
+
+* result: `null`
+
+Removes all transactions from the verification queue.
+
+###### Examples
+
+Request
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "clear_tx_verify_queue",
   "params": []
 }
 ```

--- a/rpc/src/module/pool.rs
+++ b/rpc/src/module/pool.rs
@@ -322,6 +322,33 @@ pub trait PoolRpc {
     #[rpc(name = "clear_tx_pool")]
     fn clear_tx_pool(&self) -> Result<()>;
 
+    /// Removes all transactions from the verification queue.
+    ///
+    /// ## Examples
+    ///
+    /// Request
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "method": "clear_tx_verify_queue",
+    ///   "params": []
+    /// }
+    /// ```
+    ///
+    /// Response
+    ///
+    /// ```json
+    /// {
+    ///   "id": 42,
+    ///   "jsonrpc": "2.0",
+    ///   "result": null
+    /// }
+    /// ```
+    #[rpc(name = "clear_tx_verify_queue")]
+    fn clear_tx_verify_queue(&self) -> Result<()>;
+
     /// Returns all transaction ids in tx pool as a json array of string transaction ids.
     /// ## Params
     ///
@@ -657,6 +684,15 @@ impl PoolRpc for PoolRpcImpl {
         let tx_pool = self.shared.tx_pool_controller();
         tx_pool
             .clear_pool(snapshot)
+            .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
+
+        Ok(())
+    }
+
+    fn clear_tx_verify_queue(&self) -> Result<()> {
+        let tx_pool = self.shared.tx_pool_controller();
+        tx_pool
+            .clear_verify_queue()
             .map_err(|err| RPCError::custom(RPCError::Invalid, err.to_string()))?;
 
         Ok(())


### PR DESCRIPTION
### What problem does this PR solve?

With the new verify queue in PR https://github.com/nervosnetwork/ckb/pull/4291, the verify-queue may contain a lot of transactions in the extreme scenario, similar as `clear_tx_pool` we need a RPC to clear it.

### What is changed and how it works?

Add a RPC `clear_tx_verify_queue` in the txpool RPC module.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

