### PR TITLE
chore(test): Fix the unstable spec ForksContainSameUncle caused by block hash collision 

### DIFF
--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -361,7 +361,7 @@ impl Node {
         let timestamp = block.timestamp();
         let uncle = block
             .as_advanced_builder()
-            .timestamp((timestamp + 1).pack())
+            .timestamp((timestamp - 1).pack())
             .build();
         (block, uncle)
     }


### PR DESCRIPTION
### What problem does this PR solve?

`ForksContainSameUncle` has the chance of 1/10 to fail in my local machine with error `Uncles(DoubleInclusion)`, after debugging I found the [`uncle` block hash](https://github.com/chenyukang/ckb/blob/dc20e94885256617675edab4f71f828ff23c47ed/test/src/specs/sync/chain_forks.rs#L565) is same with new block hash in [node_b.mine(1)](https://github.com/chenyukang/ckb/blob/dc20e94885256617675edab4f71f828ff23c47ed/test/src/specs/sync/chain_forks.rs#L567).

This issue if fixed in https://github.com/nervosnetwork/ckb/commit/0dc63c2c0cc947b0f1916579a15a27f3d2054421

But it's reverted in the following changes, I believe it is unintentional.

### What is changed and how it works?

Make sure the uncle block timestamp is different from the next block timestamp in main fork


What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

