### PR TITLE
Fix: verify worker exit when signal_exit is_cancelled

### DIFF
--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -76,6 +76,10 @@ impl Worker {
 
     async fn process_inner(&mut self) {
         loop {
+            if self.exit_signal.is_cancelled() {
+                info!("Verify worker::process_inner exit_signal is cancelled");
+                return;
+            }
             if self.status != ChunkCommand::Resume {
                 return;
             }
@@ -170,7 +174,6 @@ impl VerifyMgr {
     }
 
     fn send_child_command(&self, command: ChunkCommand) {
-        //info!("[verify-test] verify-mgr send child command: {:?}", command);
         for w in &self.workers {
             if let Err(err) = w.0.send(command.clone()) {
                 info!("send worker command failed, error: {}", err);


### PR DESCRIPTION
### What problem does this PR solve?

When there are a lot of transaction pending in verify queue, `ctrl-c` may need to wait worker finishing all of them, because of this [loop](https://github.com/chenyukang/ckb/blob/ce418075496faad44d111f2cbc25b1eb961f8d8b/tx-pool/src/verify_mgr.rs#L78-L124) in verify worker, there is no chance to update `self.status` since worker is executing `process_inner`.

### What is changed and how it works?

Worker should return from iteration when exit signal is sent.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

