### PR TITLE
Early return init_load_unverified thread when no unverified blocks found after tip

### DIFF
--- a/chain/src/init_load_unverified.rs
+++ b/chain/src/init_load_unverified.rs
@@ -93,6 +93,15 @@ impl InitLoadUnverified {
             let unverified_hashes: Vec<packed::Byte32> =
                 self.find_unverified_block_hashes(check_unverified_number);
 
+            if check_unverified_number > tip_number && unverified_hashes.is_empty() {
+                info!(
+                    "no unverified blocks found after tip, current tip: {}-{}",
+                    tip_number,
+                    self.shared.snapshot().tip_hash()
+                );
+                return;
+            }
+
             for unverified_hash in unverified_hashes {
                 f(&unverified_hash);
             }

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -60,6 +60,11 @@ impl Spec for SyncChurn {
                 if too_many_blocks || restart_stopped_rx.try_recv().is_ok() {
                     break;
                 }
+                info!(
+                    "mining_node {}, tip: {}",
+                    mining_node.node_id(),
+                    mining_node.get_tip_block_number()
+                );
                 waiting_for_sync(&mining_nodes);
             }
         });


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


### Related changes

- In init_load_unverified thread, if no unverified blocks found after tip, early return

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

