### PR TITLE
Rename `ckb_chain::consume_unverified` to `ckb_chain::verify`

### DIFF
--- a/chain/src/init.rs
+++ b/chain/src/init.rs
@@ -2,11 +2,11 @@
 
 //! Bootstrap InitLoadUnverified, PreloadUnverifiedBlock, ChainService and ConsumeUnverified threads.
 use crate::chain_service::ChainService;
-use crate::consume_unverified::ConsumeUnverifiedBlocks;
 use crate::init_load_unverified::InitLoadUnverified;
 use crate::orphan_broker::OrphanBroker;
 use crate::preload_unverified_blocks_channel::PreloadUnverifiedBlocksChannel;
 use crate::utils::orphan_block_pool::OrphanBlockPool;
+use crate::verify::ConsumeUnverifiedBlocks;
 use crate::{chain_controller::ChainController, LonelyBlockHash, UnverifiedBlock};
 use ckb_channel::{self as channel, SendError};
 use ckb_constant::sync::BLOCK_DOWNLOAD_WINDOW;
@@ -37,7 +37,7 @@ pub fn start_chain_services(builder: ChainServicesBuilder) -> ChainController {
     let is_pending_verify: Arc<DashSet<Byte32>> = Arc::new(DashSet::new());
 
     let consumer_unverified_thread = thread::Builder::new()
-        .name("consume_unverified_blocks".into())
+        .name("verify_blocks".into())
         .spawn({
             let shared = builder.shared.clone();
             let is_pending_verify = Arc::clone(&is_pending_verify);

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 mod chain_controller;
 mod chain_service;
-pub mod consume_unverified;
 mod init;
 mod init_load_unverified;
 mod orphan_broker;
@@ -24,6 +23,7 @@ mod preload_unverified_blocks_channel;
 #[cfg(test)]
 mod tests;
 mod utils;
+pub mod verify;
 
 pub use chain_controller::ChainController;
 use ckb_logger::{error, info};

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -1,5 +1,5 @@
-use crate::consume_unverified::ConsumeUnverifiedBlockProcessor;
 use crate::utils::forkchanges::ForkChanges;
+use crate::verify::ConsumeUnverifiedBlockProcessor;
 use crate::{start_chain_services, UnverifiedBlock};
 use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
 use ckb_proposal_table::ProposalTable;

--- a/chain/src/verify.rs
+++ b/chain/src/verify.rs
@@ -103,7 +103,7 @@ impl ConsumeUnverifiedBlocks {
                     },
                 },
                 recv(self.stop_rx) -> _ => {
-                    info!("consume_unverified_blocks thread received exit signal, exit now");
+                    info!("verify_blocks thread received exit signal, exit now");
                     break;
                 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
In current develop:
The log looks like:
```
2024-08-30 02:31:18.961 +00:00 consume_unverified_blocks INFO ckb_chain::consume_unverified  [verify block] new best block found: 13721606 => 0x26ba9b2e2c562aecdb13042feab7c7c850bacd95748127a43167a104680b3044, difficulty diff = 0x34b5ec519ab53fc6, unverified_tip: 13721606
```

the `ckb_chain::consume_unverified` looks inappropriate. Changing it to `ckb_chain::verify` should be more appropriate.


Rename `ckb_chain::consume_unverified` to `ckb_chain::verify`

### What is changed and how it works?

What's Changed:

### Related changes

- Change `consume_unverified.rs` to `verify.rs` in `./chain/src/`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

