### PR TITLE
fix: fix empty git commit version of cli

### DIFF
--- a/util/build-info/src/lib.rs
+++ b/util/build-info/src/lib.rs
@@ -92,7 +92,10 @@ impl std::fmt::Display for Version {
             .chain(self.commit_date.iter())
             .map(String::as_str)
             .collect();
-        if !extra_parts.is_empty() {
+        
+        let commit_describe = self.commit_describe.clone().unwrap_or("".to_string());
+        let commit_date = self.commit_describe.clone().unwrap_or("".to_string());
+        if !commit_describe.is_empty() || !commit_date.is_empty() {
             write!(f, " ({})", extra_parts.as_slice().join(" "))?;
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4550 nervosnetwork/ckb-cli#609

Problem Summary: When no git information was found, the sub-command --version outputs a pair of empty brackets.

### What is changed and how it works?

What's Changed:
`String::from_utf8(r.stdout)` will always return a string when stdout is empty.
https://github.com/nervosnetwork/ckb/blob/2fb17ab8f4c3a5bd005cbf726e897e3201258bc9/util/build-info/src/lib.rs#L106-L124
https://github.com/nervosnetwork/ckb/blob/2fb17ab8f4c3a5bd005cbf726e897e3201258bc9/util/build-info/src/lib.rs#L129-L141

So `extra_parts.is_empty()` is always return `false`
https://github.com/nervosnetwork/ckb/blob/2fb17ab8f4c3a5bd005cbf726e897e3201258bc9/util/build-info/src/lib.rs#L95

unwrap it with default value "", check if they are empty
```rust
let commit_describe = self.commit_describe.clone().unwrap_or("".to_string());
let commit_date = self.commit_describe.clone().unwrap_or("".to_string());
if !commit_describe.is_empty() || !commit_date.is_empty() {
    write!(f, " ({})", extra_parts.as_slice().join(" "))?;
}
```

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

