### PR TITLE
Ignore RUSTSEC-2024-0370 : https://rustsec.org/advisories/RUSTSEC-2024-0370

### DIFF
--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -64,7 +64,7 @@ jobs:
       shell: bash
     - name: upload log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}_integration.log
         path: ${{ env.CKB_INTEGRATION_TEST_TMP }}/integration.log

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -72,7 +72,7 @@ jobs:
       shell: bash
     - name: upload log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}_integration.log
         path: ${{ env.CKB_INTEGRATION_TEST_TMP }}/integration.log

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -76,7 +76,7 @@ jobs:
       shell: bash
     - name: upload log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}_integration.log
         path: ${{ env.CKB_INTEGRATION_TEST_TMP }}/integration.log

--- a/deny.toml
+++ b/deny.toml
@@ -79,7 +79,10 @@ ignore = [
   "RUSTSEC-2022-0090",
 # https://rustsec.org/advisories/RUSTSEC-2024-0336
 # `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
-  "RUSTSEC-2024-0336"
+  "RUSTSEC-2024-0336",
+# Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
+# proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.
+  "RUSTSEC-2024-0370"
 #"RUSTSEC-0000-0000",
 #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
 #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Want to fix:
![image](https://github.com/user-attachments/assets/dd95faef-e148-43f2-acf0-e8136f5c63f4)

![image](https://github.com/user-attachments/assets/11ea304d-30c3-40c9-8595-74e5ac5b390a)


### Related changes
- Inogre  https://rustsec.org/advisories/RUSTSEC-2024-0370
- Upgrade actions/upload-artifact to v4: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

