### PR TITLE
`get_fee_rate_statistics` should skip first (cellbase) Transaction

### DIFF
--- a/rpc/src/tests/fee_rate.rs
+++ b/rpc/src/tests/fee_rate.rs
@@ -53,9 +53,16 @@ fn test_fee_rate_statics() {
             total_difficulty: 0u64.into(),
             total_uncles_count: 0,
             verified: None,
-            txs_fees: vec![Capacity::shannons(i * i * 100)],
-            cycles: Some(vec![i * 100]),
-            txs_sizes: Some(vec![i * 100]),
+
+            // first element in txs_fees is belong to cellbase
+            txs_fees: vec![
+                Capacity::shannons(i * 1234),
+                Capacity::shannons(i * i * 100),
+            ],
+            // first element in cycles is belong to cellbase
+            cycles: Some(vec![0, i * 100]),
+            // first element in txs_sizes is belong to cellbase
+            txs_sizes: Some(vec![i * 5678, i * 100]),
         };
         provider.append(i, ext);
     }

--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -83,15 +83,19 @@ where
         target = std::cmp::min(self.provider.max_target(), target);
 
         let mut fee_rates = self.provider.collect(target, |mut fee_rates, block_ext| {
-            if !block_ext.txs_fees.is_empty()
+            if block_ext.txs_fees.len() > 1
                 && block_ext.cycles.is_some()
                 && block_ext.txs_sizes.is_some()
             {
+                // block_ext.txs_fees, cycles, txs_sizes length is same
                 for (fee, cycles, size) in itertools::izip!(
                     block_ext.txs_fees,
                     block_ext.cycles.expect("checked"),
                     block_ext.txs_sizes.expect("checked")
-                ) {
+                )
+                // skip cellbase (first element in the Vec)
+                .skip(1)
+                {
                     let weight = get_transaction_weight(size as usize, cycles);
                     if weight > 0 {
                         fee_rates.push(FeeRate::calculate(fee, weight).as_u64());


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Want to fix #4646 and #4350

### What is changed and how it works?

### Related changes

- get_fee_rate_statistics skip first cellbase in BlockExt

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

