### PR TITLE
Exec/backport/4654

### DIFF
--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -83,20 +83,16 @@ where
         target = std::cmp::min(self.provider.max_target(), target);
 
         let mut fee_rates = self.provider.collect(target, |mut fee_rates, block_ext| {
-            if block_ext.txs_fees.len() > 1
-                && block_ext.cycles.is_some()
-                && block_ext.txs_sizes.is_some()
-            {
-                // block_ext.txs_fees, cycles, txs_sizes length is same
+            let txs_sizes = block_ext.txs_sizes.expect("expect txs_size's length >= 1");
+            if txs_sizes.len() > 1 && block_ext.cycles.is_some() && !block_ext.txs_fees.is_empty() {
+                // block_ext.txs_fees's length == block_ext.cycles's length
+                // block_ext.txs_fees's length + 1 == txs_sizes's length
                 for (fee, cycles, size) in itertools::izip!(
                     block_ext.txs_fees,
                     block_ext.cycles.expect("checked"),
-                    block_ext.txs_sizes.expect("checked")
-                )
-                // skip cellbase (first element in the Vec)
-                .skip(1)
-                {
-                    let weight = get_transaction_weight(size as usize, cycles);
+                    txs_sizes.iter().skip(1) // skip cellbase (first element in the Vec)
+                ) {
+                    let weight = get_transaction_weight(*size as usize, cycles);
                     if weight > 0 {
                         fee_rates.push(FeeRate::calculate(fee, weight).as_u64());
                     }

--- a/util/types/src/core/extras.rs
+++ b/util/types/src/core/extras.rs
@@ -10,7 +10,15 @@ use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-/// TODO(doc): @quake
+/// Represents a block's additional information.
+///
+/// It is crucial to ensure that `txs_sizes` has one more element than `txs_fees`, and that `cycles` has the same length as `txs_fees`.
+///
+/// `BlockTxsVerifier::verify()` skips the first transaction (the cellbase) in the block. Therefore, `txs_sizes` must have a length equal to `txs_fees` length + 1.
+///
+/// Refer to: https://github.com/nervosnetwork/ckb/blob/44afc93cd88a1b52351831dce788d3023c52f37e/verification/contextual/src/contextual_block_verifier.rs#L455
+///
+/// Additionally, the `get_fee_rate_statistics` RPC function requires accurate `txs_sizes` and `txs_fees` data from `BlockExt`.
 #[derive(Clone, PartialEq, Default, Debug, Eq)]
 pub struct BlockExt {
     /// TODO(doc): @quake
@@ -21,11 +29,14 @@ pub struct BlockExt {
     pub total_uncles_count: u64,
     /// TODO(doc): @quake
     pub verified: Option<bool>,
-    /// TODO(doc): @quake
+    /// Transaction fees for each transaction except the cellbase.
+    /// The length of `txs_fees` is equal to the length of `cycles`.
     pub txs_fees: Vec<Capacity>,
-    /// block txs consumed cycles
+    /// Execution cycles for each transaction except the cellbase.
+    /// The length of `cycles` is equal to the length of `txs_fees`.
     pub cycles: Option<Vec<Cycle>>,
-    /// block txs serialized sizes
+    /// Sizes of each transaction including the cellbase.
+    /// The length of `txs_sizes` is `txs_fees` length + 1.
     pub txs_sizes: Option<Vec<u64>>,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->
backport #4654 
### What problem does this PR solve?
https://github.com/nervosnetwork/ckb/pull/4647 didn't do the right fix.

### What is changed and how it works?

We should take aware:
https://github.com/nervosnetwork/ckb/blob/44afc93cd88a1b52351831dce788d3023c52f37e/util/types/src/core/extras.rs#L13-L30

1. `BlockExt.cycles`'s length is equal to `BlockExt.txs_fees`'s length.
2. `BlockExt.cycles`'s length + 1 is equal to `BlockExt.txs_sizes`'s length.

https://github.com/nervosnetwork/ckb/blob/44afc93cd88a1b52351831dce788d3023c52f37e/verification/contextual/src/contextual_block_verifier.rs#L455

### Related changes

- `get_fee_rate_statistics` should aware `block_ext.txs_sizes`'s length is `block_ext.cycles`'s length + 1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

