### PR TITLE
fix(script): remove isa a in version 2

### DIFF
--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -5,7 +5,7 @@ use ckb_types::{
 };
 use ckb_vm::{
     machine::{VERSION0, VERSION1, VERSION2},
-    ISA_A, ISA_B, ISA_IMC, ISA_MOP,
+    ISA_B, ISA_IMC, ISA_MOP,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -81,7 +81,7 @@ impl ScriptVersion {
         match self {
             Self::V0 => ISA_IMC,
             Self::V1 => ISA_IMC | ISA_B | ISA_MOP,
-            Self::V2 => ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            Self::V2 => ISA_IMC | ISA_B | ISA_MOP,
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

ISA_A should not be contained in version 2.

### What is changed and how it works?

What's Changed:

Remove ISA_A flag.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Add a note under the PR title in the release note.
```

