### PR TITLE
Remove empty entry for `OrphanPool`

### DIFF
--- a/tx-pool/src/component/orphan.rs
+++ b/tx-pool/src/component/orphan.rs
@@ -75,9 +75,13 @@ impl OrphanPool {
         self.entries.remove(id).map(|entry| {
             debug!("remove orphan tx {}", entry.tx.hash());
             for out_point in entry.tx.input_pts_iter() {
-                self.by_out_point
-                    .get_mut(&out_point)
-                    .map(|set| set.remove(id));
+                if let Some(ids_set) = self.by_out_point.get_mut(&out_point) {
+                    ids_set.remove(id);
+
+                    if ids_set.is_empty() {
+                        self.by_out_point.remove(&out_point);
+                    }
+                }
             }
             entry
         })


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
When an entry in `OrphanPool` is empty, it should be removed.

### What is changed and how it works?

What's Changed:

### Related changes

- Remove empty entry in `OrphanPool`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

