### PR TITLE
[rc/v0.119.x] chore: lock tentacle

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -37,20 +37,20 @@ ckb-spawn = { path = "../util/spawn", version = "= 0.119.0" }
 socket2 = "0.5"
 bitflags = "1.0"
 
-p2p = { version = "0.6.1", package = "tentacle", features = [
-    "upnp",
-    "parking_lot",
-    "openssl-vendored",
+p2p = { version = "= 0.6.1", package = "tentacle", features = [
+  "upnp",
+  "parking_lot",
+  "openssl-vendored",
 ] }
 
 [features]
 with_sentry = ["sentry"]
 with_dns_seeding = [
-    "lazy_static",
-    "bs58",
-    "faster-hex",
-    "trust-dns-resolver",
-    "secp256k1",
+  "lazy_static",
+  "bs58",
+  "faster-hex",
+  "trust-dns-resolver",
+  "secp256k1",
 ]
 fuzz = []
 
@@ -61,7 +61,7 @@ proptest = "1.0"
 num_cpus = "1.10"
 once_cell = "1.8.0"
 ckb-systemtime = { path = "../util/systemtime", version = "= 0.119.0", features = [
-    "enable_faketime",
+  "enable_faketime",
 ] }
 
 [[bench]]


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Tentacle 0.6.2 introduces changes that require Rust 1.80.0 where ckb 0.119.0 minimum supported rust version is 1.75.0. So lock the tentacle to 0.6.1 in the `Cargo.toml` file for future possible patch releases. This only affects crates publish which does not use the `Cargo.lock` file.

### What is changed and how it works?

What's Changed: Lock tentacle to 0.6.1 using `= 0.6.1`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

