### PR TITLE
Generate `default.db-options` file if it not exist

### DIFF
--- a/ckb-bin/src/subcommand/run.rs
+++ b/ckb-bin/src/subcommand/run.rs
@@ -6,12 +6,15 @@ use ckb_async_runtime::{new_global_runtime, Handle};
 use ckb_build_info::Version;
 use ckb_launcher::Launcher;
 use ckb_logger::info;
+use ckb_logger::warn;
+use ckb_resource::{Resource, TemplateContext};
 
 use ckb_stop_handler::{broadcast_exit_signals, wait_all_ckb_services_exit};
 
 use ckb_types::core::cell::setup_system_cell_cache;
 
 pub fn run(args: RunArgs, version: Version, async_handle: Handle) -> Result<(), ExitCode> {
+    check_default_db_options_exists(&args)?;
     deadlock_detection();
 
     let rpc_threads_num = calc_rpc_threads_num(&args);
@@ -78,4 +81,25 @@ fn calc_rpc_threads_num(args: &RunArgs) -> usize {
     let system_parallelism: usize = available_parallelism().unwrap().into();
     let default_num = usize::max(system_parallelism, 1);
     args.config.rpc.threads.unwrap_or(default_num)
+}
+
+fn check_default_db_options_exists(args: &RunArgs) -> Result<(), ExitCode> {
+    // check is there a default.db-options file exist in args.config.root_dir, if not, create one.
+    let db_options_path = args.config.root_dir.join("default.db-options");
+
+    // Check if the default.db-options file exists, if not, create one.
+    if !db_options_path.exists() {
+        warn!(
+            "default.db-options file does not exist in {}, creating one.",
+            args.config.root_dir.display()
+        );
+        // context_for_db_options is used to generate a default default.db-options file.
+        let context_for_db_options = TemplateContext::new("", vec![]);
+
+        // Attempt to export the bundled DB options to the specified path.
+        Resource::bundled_db_options()
+            .export(&context_for_db_options, &args.config.root_dir)
+            .map_err(|_| ExitCode::Config)?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
close #4671
### Related changes

- Generate default.db-options file if it not exist

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

