### PR TITLE
Don't ban remote peer when ckb_vm received Ctrl-C signal when processing chunk_tx

### DIFF
--- a/error/src/internal.rs
+++ b/error/src/internal.rs
@@ -50,6 +50,9 @@ pub enum InternalErrorKind {
     /// The feature is disabled or is conflicted with the configuration
     Config,
 
+    /// Interrupts, such as a Ctrl-C signal
+    Interrupts,
+
     /// Other system error
     Other,
 }

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -182,7 +182,12 @@ impl ScriptError {
 
 impl From<TransactionScriptError> for Error {
     fn from(error: TransactionScriptError) -> Self {
-        ErrorKind::Script.because(error)
+        match error.cause {
+            ScriptError::Other(ref reason) if reason == "stopped" => {
+                ErrorKind::Internal.because(error)
+            }
+            _ => ErrorKind::Script.because(error),
+        }
     }
 }
 

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -1,5 +1,5 @@
 use crate::types::{ScriptGroup, ScriptGroupType};
-use ckb_error::{prelude::*, Error, ErrorKind};
+use ckb_error::{prelude::*, Error, ErrorKind, InternalErrorKind};
 use ckb_types::core::{Cycle, ScriptHashType};
 use ckb_types::packed::{Byte32, Script};
 use ckb_vm::Error as VMInternalError;
@@ -43,6 +43,10 @@ pub enum ScriptError {
     /// Errors thrown by ckb-vm
     #[error("VM Internal Error: {0:?}")]
     VMInternalError(VMInternalError),
+
+    /// Interrupts, such as a Ctrl-C signal
+    #[error("VM Interrupts")]
+    Interrupts,
 
     /// Other errors raised in script execution process
     #[error("Other Error: {0}")]
@@ -183,9 +187,8 @@ impl ScriptError {
 impl From<TransactionScriptError> for Error {
     fn from(error: TransactionScriptError) -> Self {
         match error.cause {
-            ScriptError::Other(ref reason) if reason == "stopped" => {
-                ErrorKind::Internal.because(error)
-            }
+            ScriptError::Interrupts => ErrorKind::Internal
+                .because(InternalErrorKind::Interrupts.other(ScriptError::Interrupts.to_string())),
             _ => ErrorKind::Script.because(error),
         }
     }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1186,6 +1186,7 @@ where
         let mut scheduler = Scheduler::new(tx_data, version, self.syscalls_generator.clone());
         let map_vm_internal_error = |error: VMInternalError| match error {
             VMInternalError::CyclesExceeded => ScriptError::ExceededMaximumCycles(max_cycles),
+            VMInternalError::External(reason) if reason.eq("stopped") => ScriptError::Interrupts,
             _ => ScriptError::VMInternalError(error),
         };
 

--- a/script/src/verify/tests/ckb_latest/features_since_v2023.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2023.rs
@@ -540,8 +540,11 @@ async fn check_spawn_suspend_shutdown() {
         .verify_complete_async(script_version, &rtx, &mut command_rx, true)
         .await;
     assert!(res.is_err());
-    let err = res.unwrap_err().to_string();
-    assert!(err.contains("VM Internal Error: External(\"stopped\")"));
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("VM Interrupts"));
+
+    let reject = ckb_types::core::tx_pool::Reject::Verification(err);
+    assert!(!reject.is_malformed_tx());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4701 <!-- REMOVE this line if no issue to close -->

### Related changes

- let `ckb_vm::Error::External("stopped")` return `ErrorKind::Internal` instead of `ErrorKind::Script`

return `ErrorKind::Internal` then ckb will not think the tx is malformled:
https://github.com/nervosnetwork/ckb/blob/8cb49e4d727f337a2c80e210507a9e277bab3391/util/types/src/core/tx_pool.rs#L68-L84
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

