### PR TITLE
fix: add missing features for tokio

### DIFF
--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -28,7 +28,7 @@ ckb-logger = { path = "../util/logger", version = "= 0.120.0-pre", optional = tr
 serde = { version = "1.0", features = ["derive"] }
 ckb-error = { path = "../error", version = "= 0.120.0-pre" }
 ckb-chain-spec = { path = "../spec", version = "= 0.120.0-pre" }
-tokio = { version = "1.35.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.35.0", features = ["sync", "macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 proptest = "1.0"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Failed to publish ckb-script because of the missing features.

### What is changed and how it works?

What's Changed: Add missing features of "tokio" in the Cargo.toml of ckb-script

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

-   Integration test
-   Manual test
    `cargo publish` in directory `script/`.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
