### PR TITLE
chore: bump openssl to 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,9 +4049,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Failed to build OpenSSL 3.3 in CentOS 7 because of this issue:

https://github.com/openssl/openssl/issues/25366

### What is changed and how it works?

What's Changed:

```
cargo update openssl-sys
```

### Related changes

- Publish new release of [nervosnetwork/ckb-docker-builder](https://github.com/nervosnetwork/ckb-docker-builder)
- Skip v0.120.0-rc1 and start to release v0.120.0-rc2

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

