### PR TITLE
Specify 20.04 to aarch64 image

### DIFF
--- a/docker/hub/Dockerfile-aarch64
+++ b/docker/hub/Dockerfile-aarch64
@@ -5,7 +5,7 @@ COPY ./ .
 
 RUN make prod-docker
 
-FROM arm64v8/ubuntu
+FROM arm64v8/ubuntu:20.04
 LABEL description="Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network."
 LABEL maintainer="Nervos Core Dev <dev@nervos.org>"
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Waiting https://github.com/nervosnetwork/ckb-docker-builder/pull/32

What's Changed:

### Related changes

- Specify 20.04 tag to aarch64 ubuntu image

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

