### PR TITLE
Remove anyhow's backtrace from RPC response

### DIFF
--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -121,6 +121,14 @@ pub enum RPCError {
     Indexer = -1200,
 }
 
+/// Removes the backtrace portion from an error string.
+fn remove_backtrace(err_str: &str) -> &str {
+    match err_str.find("\nStack backtrace:") {
+        Some(idx) => &err_str[..idx],
+        None => err_str,
+    }
+}
+
 impl RPCError {
     /// Invalid method parameter(s).
     pub fn invalid_params<T: Display>(message: T) -> Error {
@@ -158,10 +166,12 @@ impl RPCError {
     /// The parameter `err` is usually an std error. The Display form is used as the error message,
     /// and the Debug form is used as the data.
     pub fn custom_with_error<T: Display + Debug>(error_code: RPCError, err: T) -> Error {
+        let err_str_with_backtrace = format!("{err:?}");
+        let err_str = remove_backtrace(&err_str_with_backtrace);
         Error {
             code: ErrorCode::ServerError(error_code as i64),
             message: format!("{error_code:?}: {err}"),
-            data: Some(Value::String(format!("{err:?}"))),
+            data: Some(Value::String(err_str.to_string())),
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #4698

Problem Summary:

### What is changed and how it works?

- use remove_backtrace to remove backtrace from error message

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

