### PR TITLE
bugfix: add missing crate features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
 dependencies = [
  "digest",
  "either",
+ "futures",
  "hex",
  "libc",
  "memmap2",
@@ -481,6 +482,8 @@ dependencies = [
  "ssri",
  "tempfile",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "walkdir",
 ]
 

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -10,10 +10,15 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 ckb-logger = { path = "../util/logger", version = "= 0.120.0-pre" }
-ckb-app-config  = { path = "../util/app-config", version = "= 0.120.0-pre" }
+ckb-app-config = { path = "../util/app-config", version = "= 0.120.0-pre" }
 ckb-types = { path = "../util/types", version = "= 0.120.0-pre" }
 ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.120.0-pre" }
 ckb-async-runtime = { path = "../util/runtime", version = "= 0.120.0-pre" }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { version = "1", features = ["sync"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { version = "1", features = ["sync", "process"] }
 
 [dev-dependencies]

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -25,7 +25,10 @@ ckb-traits = { path = "../traits", version = "= 0.120.0-pre" }
 ckb-logger = { path = "../util/logger", version = "= 0.120.0-pre" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-cacache = { version = "13.0.0", default-features = false, features = ["mmap"] }
+cacache = { version = "13.0.0", default-features = false, features = [
+  "tokio-runtime",
+  "mmap",
+] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -19,4 +19,4 @@ hyper = { version = "1", features = ["http1", "http2", "server"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["server-auto", "server-graceful"] }
 ckb-stop-handler = { path = "../stop-handler", version = "= 0.120.0-pre" }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "macros"] }


### PR DESCRIPTION
**Blocking** release of v0.120.0

### What problem does this PR solve?

Problem Summary: Failed to `cargo publish` because of missing features listed in `Cargo.toml`

### What is changed and how it works?

What's Changed: See commit messages

### Related changes

- Need to cherry-pick to the release branch rc/v0.120.x

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
CKB_PUBLISH_FROM=util/metrics-service devtools/release/publish-crates.sh -n
CKB_PUBLISH_FROM=spec devtools/release/publish-crates.sh -n
```

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

