### PR TITLE
chore: package ckb-cli for aarch64 linux

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -104,7 +104,6 @@ jobs:
           QINIU_ACCESS_KEY: ${{ secrets.QINIU_ACCESS_KEY }}
           QINIU_SECRET_KEY: ${{ secrets.QINIU_SECRET_KEY }}
           GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
-          SKIP_CKB_CLI: true
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4745 

It was disabled before because ckb-cli aarch64 package was not available when ckb started to package aarch64 binary.

### What is changed and how it works?

What's Changed: Enable packaging ckb-cli for aarch64 linux

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    - Run package workflow 

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

