### PR TITLE
refactor: Remove TransactionSnapshot structure

### DIFF
--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::error::{ScriptError, TransactionScriptError};
 pub use crate::scheduler::{Scheduler, ROOT_VM_ID};
 pub use crate::types::{
     ChunkCommand, CoreMachine, DataPieceId, RunMode, ScriptGroup, ScriptGroupType, ScriptVersion,
-    TransactionSnapshot, TransactionState, TxData, VerifyResult, VmIsa, VmState, VmVersion,
+    TransactionState, TxData, VerifyResult, VmIsa, VmState, VmVersion,
 };
 pub use crate::verify::{TransactionScriptsSyscallsGenerator, TransactionScriptsVerifier};
 pub use crate::verify_env::TxVerifyEnv;

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -15,7 +15,7 @@ use crate::{
     type_id::TypeIdSystemScript,
     types::{
         CoreMachine, DebugPrinter, Indices, ScriptGroup, ScriptGroupType, ScriptVersion,
-        TransactionSnapshot, TransactionState, VerifyResult,
+        TransactionState, VerifyResult,
     },
     verify_env::TxVerifyEnv,
 };
@@ -730,7 +730,7 @@ where
     ///
     /// ## Params
     ///
-    /// * `snap` - Captured transaction verification snapshot.
+    /// * `snap` - Captured transaction verification state.
     ///
     /// * `limit_cycles` - Maximum allowed cycles to run the scripts. The verification quits early
     ///   when the consumed cycles exceed the limit.
@@ -741,7 +741,7 @@ where
     /// If verify is suspended, a borrowed state will returned.
     pub fn resume_from_snap(
         &self,
-        snap: &TransactionSnapshot,
+        snap: &TransactionState,
         limit_cycles: Cycle,
     ) -> Result<VerifyResult, Error> {
         let mut cycles = snap.current_cycles;
@@ -881,7 +881,7 @@ where
     ///
     /// ## Params
     ///
-    /// * `snap` - Captured transaction verification snapshot.
+    /// * `snap` - Captured transaction verification state.
     ///
     /// * `max_cycles` - Maximum allowed cycles to run the scripts. The verification quits early
     ///   when the consumed cycles exceed the limit.
@@ -889,7 +889,7 @@ where
     /// ## Returns
     ///
     /// It returns the total consumed cycles on completed, Otherwise it returns the verification error.
-    pub fn complete(&self, snap: &TransactionSnapshot, max_cycles: Cycle) -> Result<Cycle, Error> {
+    pub fn complete(&self, snap: &TransactionState, max_cycles: Cycle) -> Result<Cycle, Error> {
         let mut cycles = snap.current_cycles;
 
         let (_hash, current_group) = self.groups().nth(snap.current).ok_or_else(|| {

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -894,11 +894,11 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap(step_cycles: Cycle)
 
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
         #[allow(unused_assignments)]
-        let mut init_snap: Option<TransactionSnapshot> = None;
+        let mut init_snap: Option<TransactionState> = None;
         let mut init_state: Option<TransactionState> = None;
 
         match verifier.resumable_verify(step_cycles).unwrap() {
-            VerifyResult::Suspended(state) => init_snap = Some(state.try_into().unwrap()),
+            VerifyResult::Suspended(state) => init_snap = Some(state),
             VerifyResult::Completed(cycle) => return Ok(cycle),
         }
 
@@ -911,7 +911,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap(step_cycles: Cycle)
                 match verifier.resume_from_snap(&snap, limit_cycles).unwrap() {
                     VerifyResult::Suspended(state) => {
                         if count % 500 == 0 {
-                            init_snap = Some(state.try_into().unwrap());
+                            init_snap = Some(state);
                         } else {
                             init_state = Some(state);
                         }
@@ -928,7 +928,7 @@ fn _check_typical_secp256k1_blake160_2_in_2_out_tx_with_snap(step_cycles: Cycle)
                 match verifier.resume_from_state(state, limit_cycles).unwrap() {
                     VerifyResult::Suspended(state) => {
                         if count % 500 == 0 {
-                            init_snap = Some(state.try_into().unwrap());
+                            init_snap = Some(state);
                         } else {
                             init_state = Some(state);
                         }
@@ -983,13 +983,13 @@ fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_complete() {
     let mut cycles = 0;
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut init_snap: Option<TransactionSnapshot> = None;
+        let mut init_snap: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier
             .resumable_verify(TWO_IN_TWO_OUT_CYCLES / 10)
             .unwrap()
         {
-            init_snap = Some(state.try_into().unwrap());
+            init_snap = Some(state);
         }
 
         for _ in 0..2 {
@@ -997,7 +997,7 @@ fn check_typical_secp256k1_blake160_2_in_2_out_tx_with_complete() {
             let (limit_cycles, _last) =
                 snap.next_limit_cycles(TWO_IN_TWO_OUT_CYCLES / 10, TWO_IN_TWO_OUT_CYCLES);
             match verifier.resume_from_snap(&snap, limit_cycles).unwrap() {
-                VerifyResult::Suspended(state) => init_snap = Some(state.try_into().unwrap()),
+                VerifyResult::Suspended(state) => init_snap = Some(state),
                 VerifyResult::Completed(_) => {
                     unreachable!()
                 }
@@ -1133,10 +1133,10 @@ fn load_code_with_snapshot() {
     let max_cycles = Cycle::MAX;
     let verifier = TransactionScriptsVerifierWithEnv::new();
     let result = verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut init_snap: Option<TransactionSnapshot> = None;
+        let mut init_snap: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(max_cycles).unwrap() {
-            init_snap = Some(state.try_into().unwrap());
+            init_snap = Some(state);
         }
 
         let snap = init_snap.take().unwrap();
@@ -1232,10 +1232,10 @@ fn load_code_with_snapshot_more_times() {
     let verifier = TransactionScriptsVerifierWithEnv::new();
 
     verifier.verify_map(script_version, &rtx, |verifier| {
-        let mut init_snap: Option<TransactionSnapshot> = None;
+        let mut init_snap: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(max_cycles).unwrap() {
-            init_snap = Some(state.try_into().unwrap());
+            init_snap = Some(state);
         }
 
         loop {
@@ -1244,7 +1244,7 @@ fn load_code_with_snapshot_more_times() {
 
             match result.unwrap() {
                 VerifyResult::Suspended(state) => {
-                    init_snap = Some(state.try_into().unwrap());
+                    init_snap = Some(state);
                 }
                 VerifyResult::Completed(cycle) => {
                     cycles = cycle;

--- a/script/src/verify/tests/ckb_latest/features_since_v2023.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2023.rs
@@ -597,8 +597,7 @@ fn check_spawn_state() {
 
             loop {
                 times += 1;
-                let state: TransactionSnapshot =
-                    init_state.take().unwrap().try_into().expect("no snapshot");
+                let state: TransactionState = init_state.take().unwrap();
                 match verifier.resume_from_snap(&state, max_cycles).unwrap() {
                     VerifyResult::Suspended(state) => {
                         init_state = Some(state);

--- a/script/src/verify/tests/utils.rs
+++ b/script/src/verify/tests/utils.rs
@@ -29,7 +29,7 @@ use ckb_types::{
 };
 use faster_hex::hex_encode;
 use std::sync::Arc;
-use std::{convert::TryInto as _, fs::File, path::Path};
+use std::{fs::File, path::Path};
 use tempfile::TempDir;
 
 use crate::verify::*;
@@ -236,7 +236,7 @@ impl TransactionScriptsVerifierWithEnv {
             times += 1;
 
             let mut init_snap = match verifier.resumable_verify(max_cycles).unwrap() {
-                VerifyResult::Suspended(state) => Some(state.try_into().unwrap()),
+                VerifyResult::Suspended(state) => Some(state),
                 VerifyResult::Completed(cycle) => {
                     cycles = cycle;
                     return Ok((cycles, times));
@@ -248,7 +248,7 @@ impl TransactionScriptsVerifierWithEnv {
                 let snap = init_snap.take().unwrap();
                 match verifier.resume_from_snap(&snap, max_cycles) {
                     Ok(VerifyResult::Suspended(state)) => {
-                        init_snap = Some(state.try_into().unwrap());
+                        init_snap = Some(state);
                     }
                     Ok(VerifyResult::Completed(cycle)) => {
                         cycles = cycle;

--- a/tx-pool/src/chunk_process.rs
+++ b/tx-pool/src/chunk_process.rs
@@ -16,7 +16,7 @@ use ckb_verification::cache::TxVerificationCache;
 use ckb_verification::{
     cache::{CacheEntry, Completed},
     ContextualWithoutScriptTransactionVerifier, DaoScriptSizeVerifier, ScriptError, ScriptVerifier,
-    ScriptVerifyResult, ScriptVerifyState, TimeRelativeTransactionVerifier, TransactionSnapshot,
+    ScriptVerifyResult, ScriptVerifyState, TimeRelativeTransactionVerifier, TransactionState,
     TxVerifyEnv,
 };
 use std::sync::Arc;
@@ -37,7 +37,7 @@ pub(crate) enum ChunkCommand {
 
 enum State {
     Stopped,
-    Suspended(Arc<TransactionSnapshot>),
+    Suspended(Arc<TransactionState>),
     Completed(Cycle),
 }
 
@@ -133,7 +133,7 @@ impl ChunkProcess {
         &mut self,
         rtx: Arc<ResolvedTransaction>,
         data_loader: DL,
-        mut init_snap: Option<Arc<TransactionSnapshot>>,
+        mut init_snap: Option<Arc<TransactionState>>,
         max_cycles: Cycle,
         consensus: Arc<Consensus>,
         tx_env: Arc<TxVerifyEnv>,

--- a/verification/src/cache.rs
+++ b/verification/src/cache.rs
@@ -1,6 +1,6 @@
 //! TX verification cache
 
-use ckb_script::TransactionSnapshot;
+use ckb_script::TransactionState;
 use ckb_types::{
     core::{Capacity, Cycle, EntryCompleted},
     packed::Byte32,
@@ -25,8 +25,8 @@ pub type CacheEntry = Completed;
 pub struct Suspended {
     /// Cached tx fee
     pub fee: Capacity,
-    /// Snapshot
-    pub snap: Arc<TransactionSnapshot>,
+    /// State
+    pub state: Arc<TransactionState>,
 }
 
 /// Completed entry

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -26,8 +26,8 @@ pub use crate::transaction_verifier::{
     TimeRelativeTransactionVerifier,
 };
 pub use ckb_script::{
-    ScriptError, ScriptGroupType, TransactionSnapshot, TransactionState as ScriptVerifyState,
-    TxVerifyEnv, VerifyResult as ScriptVerifyResult,
+    ScriptError, ScriptGroupType, TransactionState as ScriptVerifyState, TxVerifyEnv,
+    VerifyResult as ScriptVerifyResult,
 };
 
 /// Maximum amount of time that a block timestamp is allowed to exceed the

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -7,7 +7,7 @@ use ckb_dao_utils::DaoError;
 use ckb_error::Error;
 #[cfg(not(target_family = "wasm"))]
 use ckb_script::ChunkCommand;
-use ckb_script::{TransactionScriptsVerifier, TransactionSnapshot};
+use ckb_script::{TransactionScriptsVerifier, TransactionState};
 use ckb_traits::{
     CellDataProvider, EpochProvider, ExtensionProvider, HeaderFieldsProvider, HeaderProvider,
 };
@@ -201,7 +201,7 @@ where
         &self,
         max_cycles: Cycle,
         skip_script_verify: bool,
-        snapshot: &TransactionSnapshot,
+        state: &TransactionState,
     ) -> Result<Completed, Error> {
         self.compatible.verify()?;
         self.time_relative.verify()?;
@@ -209,7 +209,7 @@ where
         let cycles = if skip_script_verify {
             0
         } else {
-            self.script.complete(snapshot, max_cycles)?
+            self.script.complete(state, max_cycles)?
         };
         let fee = self.fee_calculator.transaction_fee()?;
         Ok(Completed { cycles, fee })


### PR DESCRIPTION
As of now, TransactionSnapshot and TransactionState from ckb-script package are exactly the same. There is no need to keep them both.

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

