### PR TITLE
Peer store optimization

### DIFF
--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -5,7 +5,7 @@ use ckb_chain::{start_chain_services, ChainController};
 use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::JsonBytes;
-use ckb_network::{Flags, NetworkController, NetworkService, NetworkState};
+use ckb_network::{network::TransportType, Flags, NetworkController, NetworkService, NetworkState};
 use ckb_shared::{Shared, SharedBuilder};
 use ckb_store::ChainStore;
 use ckb_types::{
@@ -77,6 +77,7 @@ fn dummy_network(shared: &Shared) -> NetworkController {
             "test".to_string(),
             Flags::COMPATIBILITY,
         ),
+        TransportType::Tcp,
     )
     .start(shared.async_handle())
     .expect("Start network service failed")

--- a/chain/src/tests/util.rs
+++ b/chain/src/tests/util.rs
@@ -4,7 +4,7 @@ use ckb_app_config::{BlockAssemblerConfig, NetworkConfig};
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::ScriptHashType;
-use ckb_network::{Flags, NetworkController, NetworkService, NetworkState};
+use ckb_network::{network::TransportType, Flags, NetworkController, NetworkService, NetworkState};
 use ckb_shared::{Shared, SharedBuilder};
 use ckb_store::ChainStore;
 use ckb_test_chain_utils::{always_success_cell, create_always_success_tx};
@@ -123,6 +123,7 @@ pub(crate) fn dummy_network(shared: &Shared) -> NetworkController {
             "test".to_string(),
             Flags::COMPATIBILITY,
         ),
+        TransportType::Tcp,
     )
     .start(shared.async_handle())
     .expect("Start network service failed")

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1531,27 +1531,13 @@ pub enum TransportType {
     Wss,
 }
 
-impl<'a> From<TransportType> for p2p::multiaddr::Protocol<'a> {
-    fn from(value: TransportType) -> Self {
-        match value {
-            TransportType::Ws => Protocol::Ws,
-            TransportType::Wss => Protocol::Wss,
-            _ => unreachable!(),
-        }
-    }
-}
-
 pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
     let mut iter = addr.iter();
 
-    iter.find_map(|proto| {
-        if let Protocol::Ws = proto {
-            Some(TransportType::Ws)
-        } else if let Protocol::Wss = proto {
-            Some(TransportType::Wss)
-        } else {
-            None
-        }
+    iter.find_map(|proto| match proto {
+        Protocol::Ws => Some(TransportType::Ws),
+        Protocol::Wss => Some(TransportType::Wss),
+        _ => None,
     })
     .unwrap_or(TransportType::Tcp)
 }

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -3,13 +3,12 @@ use crate::peer_store::types::AddrInfo;
 use p2p::{multiaddr::Multiaddr, utils::multiaddr_to_socketaddr};
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 
 /// Address manager
 #[derive(Default)]
 pub struct AddrManager {
     next_id: u64,
-    addr_to_id: HashMap<SocketAddr, u64>,
+    addr_to_id: HashMap<Multiaddr, u64>,
     id_to_info: HashMap<u64, AddrInfo>,
     random_ids: Vec<u64>,
 }
@@ -17,27 +16,25 @@ pub struct AddrManager {
 impl AddrManager {
     /// Add an address information to address manager
     pub fn add(&mut self, mut addr_info: AddrInfo) {
-        if let Some(key) = multiaddr_to_socketaddr(&addr_info.addr) {
-            if let Some(&id) = self.addr_to_id.get(&key) {
-                let (exist_last_connected_at_ms, random_id_pos) = {
-                    let info = self.id_to_info.get(&id).expect("must exists");
-                    (info.last_connected_at_ms, info.random_id_pos)
-                };
-                // Get time earlier than record time, return directly
-                if addr_info.last_connected_at_ms >= exist_last_connected_at_ms {
-                    addr_info.random_id_pos = random_id_pos;
-                    self.id_to_info.insert(id, addr_info);
-                }
-                return;
+        if let Some(&id) = self.addr_to_id.get(&addr_info.addr) {
+            let (exist_last_connected_at_ms, random_id_pos) = {
+                let info = self.id_to_info.get(&id).expect("must exists");
+                (info.last_connected_at_ms, info.random_id_pos)
+            };
+            // Get time earlier than record time, return directly
+            if addr_info.last_connected_at_ms >= exist_last_connected_at_ms {
+                addr_info.random_id_pos = random_id_pos;
+                self.id_to_info.insert(id, addr_info);
             }
-
-            let id = self.next_id;
-            self.addr_to_id.insert(key, id);
-            addr_info.random_id_pos = self.random_ids.len();
-            self.id_to_info.insert(id, addr_info);
-            self.random_ids.push(id);
-            self.next_id += 1;
+            return;
         }
+
+        let id = self.next_id;
+        self.addr_to_id.insert(addr_info.addr.clone(), id);
+        addr_info.random_id_pos = self.random_ids.len();
+        self.id_to_info.insert(id, addr_info);
+        self.random_ids.push(id);
+        self.next_id += 1;
     }
 
     /// Randomly return addrs that worth to try or connect.
@@ -55,22 +52,29 @@ impl AddrManager {
             let j = rng.gen_range(i..self.random_ids.len());
             self.swap_random_id(j, i);
             let addr_info: AddrInfo = self.id_to_info[&self.random_ids[i]].to_owned();
-            if let Some(socket_addr) = multiaddr_to_socketaddr(&addr_info.addr) {
-                let ip = socket_addr.ip();
-                let is_unique_ip = !duplicate_ips.contains(&ip);
-                // A trick to make our tests work
-                // TODO remove this after fix the network tests.
-                let is_test_ip = ip.is_unspecified() || ip.is_loopback();
-                if (is_test_ip || is_unique_ip)
-                    && addr_info.is_connectable(now_ms)
-                    && filter(&addr_info)
-                {
-                    duplicate_ips.insert(ip);
-                    addr_infos.push(addr_info);
+            match multiaddr_to_socketaddr(&addr_info.addr) {
+                Some(socket_addr) => {
+                    let ip = socket_addr.ip();
+                    let is_unique_ip = !duplicate_ips.contains(&ip);
+                    // A trick to make our tests work
+                    // TODO remove this after fix the network tests.
+                    let is_test_ip = ip.is_unspecified() || ip.is_loopback();
+                    if (is_test_ip || is_unique_ip)
+                        && addr_info.is_connectable(now_ms)
+                        && filter(&addr_info)
+                    {
+                        duplicate_ips.insert(ip);
+                        addr_infos.push(addr_info);
+                    }
                 }
-                if addr_infos.len() == count {
-                    break;
+                None => {
+                    if addr_info.is_connectable(now_ms) && filter(&addr_info) {
+                        addr_infos.push(addr_info);
+                    }
                 }
+            }
+            if addr_infos.len() == count {
+                break;
             }
         }
         addr_infos
@@ -88,34 +92,26 @@ impl AddrManager {
 
     /// Remove an address by ip and port
     pub fn remove(&mut self, addr: &Multiaddr) -> Option<AddrInfo> {
-        multiaddr_to_socketaddr(addr).and_then(|addr| {
-            self.addr_to_id.remove(&addr).and_then(|id| {
-                let random_id_pos = self.id_to_info.get(&id).expect("exists").random_id_pos;
-                // swap with last index, then remove the last index
-                self.swap_random_id(random_id_pos, self.random_ids.len() - 1);
-                self.random_ids.pop();
-                self.id_to_info.remove(&id)
-            })
+        self.addr_to_id.remove(addr).and_then(|id| {
+            let random_id_pos = self.id_to_info.get(&id).expect("exists").random_id_pos;
+            // swap with last index, then remove the last index
+            self.swap_random_id(random_id_pos, self.random_ids.len() - 1);
+            self.random_ids.pop();
+            self.id_to_info.remove(&id)
         })
     }
 
     /// Get an address information by ip and port
     pub fn get(&self, addr: &Multiaddr) -> Option<&AddrInfo> {
-        multiaddr_to_socketaddr(addr).and_then(|addr| {
-            self.addr_to_id
-                .get(&addr)
-                .and_then(|id| self.id_to_info.get(id))
-        })
+        self.addr_to_id
+            .get(addr)
+            .and_then(|id| self.id_to_info.get(id))
     }
 
     /// Get a mutable address information by ip and port
     pub fn get_mut(&mut self, addr: &Multiaddr) -> Option<&mut AddrInfo> {
-        if let Some(addr) = multiaddr_to_socketaddr(addr) {
-            if let Some(id) = self.addr_to_id.get(&addr) {
-                self.id_to_info.get_mut(id)
-            } else {
-                None
-            }
+        if let Some(id) = self.addr_to_id.get(addr) {
+            self.id_to_info.get_mut(id)
         } else {
             None
         }

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -1,6 +1,4 @@
 //! Address manager
-#[cfg(target_family = "wasm")]
-use crate::network::{find_type, TransportType};
 use crate::peer_store::types::AddrInfo;
 use p2p::{multiaddr::Multiaddr, utils::multiaddr_to_socketaddr};
 use rand::Rng;
@@ -51,10 +49,6 @@ impl AddrManager {
         let mut addr_infos = Vec::with_capacity(count);
         let mut rng = rand::thread_rng();
         let now_ms = ckb_systemtime::unix_time_as_millis();
-        #[cfg(target_family = "wasm")]
-        let filter = |peer_addr: &AddrInfo| {
-            filter(peer_addr) && matches!(find_type(&peer_addr.addr), TransportType::Ws)
-        };
         for i in 0..self.random_ids.len() {
             // reuse the for loop to shuffle random ids
             // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -65,10 +65,6 @@ impl PeerStore {
         if self.ban_list.is_addr_banned(&addr) {
             return Ok(());
         }
-        #[cfg(target_family = "wasm")]
-        if !matches!(find_type(&addr), TransportType::Ws) {
-            return Ok(());
-        }
         self.check_purge()?;
         let score = self.score_config.default_score;
         self.addr_manager
@@ -178,12 +174,6 @@ impl PeerStore {
                 && peer_addr
                     .connected(|t| t > addr_expired_ms && t <= now_ms.saturating_sub(DIAL_INTERVAL))
                 && required_flags_filter(required_flags, Flags::from_bits_truncate(peer_addr.flags))
-        };
-
-        // Any protocol expect websocket
-        #[cfg(not(target_family = "wasm"))]
-        let filter = |peer_addr: &AddrInfo| {
-            filter(peer_addr) && !matches!(find_type(&peer_addr.addr), TransportType::Ws)
         };
 
         // get addrs that can attempt.

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -1,4 +1,3 @@
-use crate::network::{find_type, TransportType};
 use crate::{
     errors::{PeerStoreError, Result},
     extract_peer_id, multiaddr_to_socketaddr,

--- a/network/src/peer_store/types.rs
+++ b/network/src/peer_store/types.rs
@@ -62,7 +62,20 @@ impl AddrInfo {
     /// Init
     pub fn new(addr: Multiaddr, last_connected_at_ms: u64, score: Score, flags: u64) -> Self {
         AddrInfo {
-            addr,
+            // only store tcp protocol
+            addr: addr
+                .iter()
+                .filter_map(|p| {
+                    if matches!(
+                        p,
+                        Protocol::Ws | Protocol::Wss | Protocol::Memory(_) | Protocol::Tls(_)
+                    ) {
+                        None
+                    } else {
+                        Some(p)
+                    }
+                })
+                .collect(),
             score,
             last_connected_at_ms,
             last_tried_at_ms: 0,

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -325,10 +325,10 @@ impl AddressManager for DiscoveryAddressManager {
 
     fn is_valid_addr(&self, addr: &Multiaddr) -> bool {
         if !self.discovery_local_address {
-            let local_or_invalid = multiaddr_to_socketaddr(addr)
-                .map(|socket_addr| !is_reachable(socket_addr.ip()))
-                .unwrap_or(true);
-            !local_or_invalid
+            match multiaddr_to_socketaddr(addr) {
+                Some(socket_addr) => is_reachable(socket_addr.ip()),
+                None => true,
+            }
         } else {
             true
         }

--- a/network/src/protocols/feeler.rs
+++ b/network/src/protocols/feeler.rs
@@ -34,11 +34,8 @@ impl ServiceProtocol for Feeler {
                 .remove(&session.address);
         } else if context.session.ty.is_outbound() {
             let flags = self.network_state.with_peer_registry(|reg| {
-                if let Some(p) = reg.get_peer(session.id) {
-                    p.identify_info
-                        .as_ref()
-                        .map(|i| i.flags)
-                        .unwrap_or(Flags::COMPATIBILITY)
+                if let Some(p) = reg.feeler_flags(&session.address) {
+                    p
                 } else {
                     Flags::COMPATIBILITY
                 }

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -462,10 +462,9 @@ impl Callback for IdentifyCallback {
                         });
                     }
 
-                    if self
-                        .network_state
-                        .with_peer_registry(|reg| reg.is_feeler(&context.session.address))
-                    {
+                    if self.network_state.with_peer_registry_mut(|reg| {
+                        reg.change_feeler_flags(&context.session.address, flags)
+                    }) {
                         let _ = context
                             .open_protocols(
                                 context.session.id,

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -139,10 +139,9 @@ impl<T: Callback> IdentifyProtocol<T> {
             let global_ip_only = self.global_ip_only;
             let reachable_addrs = listens
                 .into_iter()
-                .filter(|addr| {
-                    multiaddr_to_socketaddr(addr)
-                        .map(|socket_addr| !global_ip_only || is_reachable(socket_addr.ip()))
-                        .unwrap_or(false)
+                .filter(|addr| match multiaddr_to_socketaddr(addr) {
+                    Some(socket_addr) => !global_ip_only || is_reachable(socket_addr.ip()),
+                    None => true,
                 })
                 .collect::<Vec<_>>();
             self.callback

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -29,6 +29,7 @@ pub struct OutboundPeerService {
     try_connect_interval: Duration,
     try_identify_count: u8,
     transport_type: TransportType,
+    update_outbound_connected_count: u8,
 }
 
 impl OutboundPeerService {
@@ -44,6 +45,7 @@ impl OutboundPeerService {
             interval: None,
             try_connect_interval,
             try_identify_count: 0,
+            update_outbound_connected_count: 0,
             transport_type,
         }
     }
@@ -161,6 +163,33 @@ impl OutboundPeerService {
         self.network_state
             .try_dial_observed_addrs(&self.p2p_control);
     }
+
+    fn update_outbound_connected_ms(&mut self) {
+        if self.update_outbound_connected_count > 10 {
+            let connected_outbounds: Vec<p2p::multiaddr::Multiaddr> =
+                self.network_state.with_peer_registry(|re| {
+                    re.peers()
+                        .values()
+                        .filter_map(|p| {
+                            if p.is_outbound() {
+                                Some(p.connected_addr.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                });
+
+            self.network_state.with_peer_store_mut(|p| {
+                for addr in connected_outbounds {
+                    p.update_outbound_addr_last_connected_ms(addr)
+                }
+            });
+            self.update_outbound_connected_count = 0;
+        } else {
+            self.update_outbound_connected_count += 1;
+        }
+    }
 }
 
 impl Future for OutboundPeerService {
@@ -192,6 +221,8 @@ impl Future for OutboundPeerService {
             self.try_dial_peers();
             // try dial observed addrs
             self.try_dial_observed();
+            // Keep connected nodes up to date in the peer store
+            self.update_outbound_connected_ms();
         }
         Poll::Pending
     }

--- a/network/src/tests/mod.rs
+++ b/network/src/tests/mod.rs
@@ -20,7 +20,7 @@ fn random_addr_v6() -> crate::multiaddr::Multiaddr {
 
     multi_addr.push(crate::multiaddr::Protocol::Tcp(43));
     multi_addr.push(crate::multiaddr::Protocol::P2P(
-        crate::PeerId::random().to_base58().into_bytes().into(),
+        crate::PeerId::random().into_bytes().into(),
     ));
     multi_addr
 }

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -588,3 +588,18 @@ fn test_addr_unique() {
 
     assert_eq!(peer_store.addr_manager().addrs_iter().count(), 2);
 }
+
+#[test]
+fn test_only_tcp_store() {
+    let mut peer_store = PeerStore::default();
+    let mut addr = random_addr();
+    addr.push(p2p::multiaddr::Protocol::Ws);
+    peer_store
+        .add_addr(addr.clone(), Flags::COMPATIBILITY)
+        .unwrap();
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
+    assert_eq!(peer_store.fetch_addrs_to_feeler(1)[0].addr, {
+        addr.pop();
+        addr
+    });
+}

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -603,3 +603,21 @@ fn test_only_tcp_store() {
         addr
     });
 }
+
+#[test]
+fn test_support_dns_store() {
+    let mut peer_store = PeerStore::default();
+    let addr: Multiaddr = format!(
+        "/dns4/www.abc.com/tcp/{}/p2p/{}",
+        rand::random::<u16>(),
+        crate::PeerId::random().to_base58()
+    )
+    .parse()
+    .unwrap();
+
+    peer_store
+        .add_addr(addr.clone(), Flags::COMPATIBILITY)
+        .unwrap();
+    assert_eq!(peer_store.fetch_addrs_to_feeler(2).len(), 1);
+    assert_eq!(peer_store.fetch_addrs_to_feeler(1)[0].addr, addr);
+}

--- a/rpc/src/tests/setup.rs
+++ b/rpc/src/tests/setup.rs
@@ -9,7 +9,7 @@ use ckb_chain::start_chain_services;
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_chain_spec::versionbits::{ActiveMode, Deployment, DeploymentPos};
 use ckb_dao_utils::genesis_dao_data;
-use ckb_network::{Flags, NetworkService, NetworkState};
+use ckb_network::{network::TransportType, Flags, NetworkService, NetworkState};
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_notify::NotifyService;
 use ckb_shared::SharedBuilder;
@@ -112,6 +112,7 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
                 "0.1.0".to_string(),
                 Flags::COMPATIBILITY,
             ),
+            TransportType::Tcp,
         )
         .start(shared.async_handle())
         .expect("Start network service failed")

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -5,9 +5,9 @@ use ckb_chain_spec::consensus::{build_genesis_epoch_ext, ConsensusBuilder};
 use ckb_dao::DaoCalculator;
 use ckb_dao_utils::genesis_dao_data;
 use ckb_network::{
-    async_trait, bytes::Bytes as P2pBytes, Behaviour, CKBProtocolContext, Error, Flags,
-    NetworkController, NetworkService, NetworkState, Peer, PeerIndex, ProtocolId, SupportProtocols,
-    TargetSession,
+    async_trait, bytes::Bytes as P2pBytes, network::TransportType, Behaviour, CKBProtocolContext,
+    Error, Flags, NetworkController, NetworkService, NetworkState, Peer, PeerIndex, ProtocolId,
+    SupportProtocols, TargetSession,
 };
 use ckb_reward_calculator::RewardCalculator;
 use ckb_shared::{Shared, SharedBuilder, Snapshot};
@@ -127,6 +127,7 @@ pub(crate) fn dummy_network(shared: &Shared) -> NetworkController {
             "test".to_string(),
             Flags::COMPATIBILITY,
         ),
+        TransportType::Tcp,
     )
     .start(shared.async_handle())
     .expect("Start network service failed")

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -6,9 +6,9 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_channel::{self as channel, unbounded, Receiver, RecvTimeoutError, Sender};
 use ckb_logger::info;
 use ckb_network::{
-    async_trait, bytes::Bytes, extract_peer_id, CKBProtocol, CKBProtocolContext,
-    CKBProtocolHandler, Flags, NetworkController, NetworkService, NetworkState, PeerIndex,
-    ProtocolId, SupportProtocols,
+    async_trait, bytes::Bytes, extract_peer_id, network::TransportType, CKBProtocol,
+    CKBProtocolContext, CKBProtocolHandler, Flags, NetworkController, NetworkService, NetworkState,
+    PeerIndex, ProtocolId, SupportProtocols,
 };
 use ckb_util::Mutex;
 use std::collections::HashMap;
@@ -73,6 +73,7 @@ impl Net {
                 "0.1.0".to_string(),
                 Flags::COMPATIBILITY,
             ),
+            TransportType::Tcp,
         )
         .start(&async_handle)
         .unwrap();

--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -15,8 +15,8 @@ use ckb_light_client_protocol_server::LightClientProtocol;
 use ckb_logger::info;
 use ckb_logger::internal::warn;
 use ckb_network::{
-    observe_listen_port_occupancy, CKBProtocol, Flags, NetworkController, NetworkService,
-    NetworkState, SupportProtocols,
+    network::TransportType, observe_listen_port_occupancy, CKBProtocol, Flags, NetworkController,
+    NetworkService, NetworkState, SupportProtocols,
 };
 use ckb_network_alert::alert_relayer::AlertRelayer;
 use ckb_resource::Resource;
@@ -384,6 +384,7 @@ impl Launcher {
                 self.version.to_string(),
                 flags,
             ),
+            TransportType::Tcp,
         )
         .start(shared.async_handle())
         .expect("Start network service failed");

--- a/util/light-client-protocol-server/src/tests/utils/chain.rs
+++ b/util/light-client-protocol-server/src/tests/utils/chain.rs
@@ -8,7 +8,7 @@ use ckb_chain::{start_chain_services, ChainController};
 use ckb_chain_spec::consensus::{build_genesis_epoch_ext, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::ScriptHashType;
-use ckb_network::{Flags, NetworkController, NetworkService, NetworkState};
+use ckb_network::{network::TransportType, Flags, NetworkController, NetworkService, NetworkState};
 use ckb_shared::{Shared, SharedBuilder};
 use ckb_systemtime::unix_time_as_millis;
 use ckb_test_chain_utils::always_success_cell;
@@ -240,6 +240,7 @@ fn dummy_network(shared: &Shared) -> NetworkController {
             "test".to_string(),
             Flags::all(),
         ),
+        TransportType::Tcp,
     )
     .start(shared.async_handle())
     .expect("Start network service failed")


### PR DESCRIPTION
### What problem does this PR solve?

1. peer store only retains TCP multiaddr
2. peer store support store DNS
3. `OutboundPeerService` specifying the transport type, In wasm, user can specify ws or wss for dial operation
4. identify/discovery allows no tcp/ip multiaddr spread
5. public_listens allow no tcp/ip multiaddr
6. Keep connected nodes up to date in the peer store
7. Fix feeler flags fetch fail

### Check List 

Tests

- Unit test
- Integration test

### Release note

```release-note
Title Only: Include only the PR title in the release note.
```

