### PR TITLE
chore: include latest_assume_valid_target.rs when merging master

### DIFF
--- a/devtools/git/merge-master.sh
+++ b/devtools/git/merge-master.sh
@@ -3,4 +3,8 @@
 set -eu
 
 git merge --no-ff --no-commit -s ours master
-git checkout master -- CHANGELOG.md src/main.rs resource/specs/testnet.toml resource/specs/mainnet.toml resource/specs/mainnet.toml.asc .github/workflows/package.yaml util/constant/src/default_assume_valid_target.rs
+git checkout master -- \
+    CHANGELOG.md src/main.rs resource/specs/testnet.toml resource/specs/mainnet.toml \
+    resource/specs/mainnet.toml.asc .github/workflows/package.yaml \
+    util/constant/src/default_assume_valid_target.rs \
+    util/constant/src/latest_assume_valid_target.rs


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: util/constant/src/latest_assume_valid_target.rs should be merged from master into develop

### What is changed and how it works?

What's Changed: include util/constant/src/latest_assume_valid_target.rs when merging master in the script devtools/git/merge-master.sh

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

