### PR TITLE
`NetRpcImpl::get_peers` return `Remoteaddress.addresses` dedup

### DIFF
--- a/rpc/src/module/net.rs
+++ b/rpc/src/module/net.rs
@@ -11,6 +11,7 @@ use ckb_systemtime::unix_time_as_millis;
 use ckb_types::prelude::{Pack, Unpack};
 use jsonrpc_core::Result;
 use jsonrpc_utils::rpc;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 const MAX_ADDRS: usize = 50;
@@ -586,8 +587,9 @@ impl NetRpc for NetRpcImpl {
             .connected_peers()
             .iter()
             .map(|(peer_index, peer)| {
-                let mut addresses = vec![&peer.connected_addr];
-                addresses.extend(peer.listened_addrs.iter());
+                let addresses: HashSet<_> = std::iter::once(peer.connected_addr.clone())
+                    .chain(peer.listened_addrs.iter().cloned())
+                    .collect();
 
                 let node_addresses = addresses
                     .iter()


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

`get_peers` RPC returned `RemoteAddress.addresses` shouldn't contains duplicate `MultiAddr`.


### Related changes

- In `NetRpcImpl::get_peers`, use `HashSet` to remove duplicate `MultiAddr`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

