### PR TITLE
Enable cargo build cache for `ckb-librocksdb-sys` on CI workflows, fix #4792

### DIFF
--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -34,6 +34,11 @@ jobs:
       runner_label: ${{ steps.prologue.outputs.runner_label }}
     steps:
       - uses: actions/checkout@v3
+      # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+      # 'ckb-librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
       - name: prologue
         id: prologue
         uses: ./.github/actions/ci_prologue

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -34,6 +34,11 @@ jobs:
       linux_runner_label: ${{ steps.prologue.outputs.linux_runner_label }}
     steps:
     - uses: actions/checkout@v3
+    # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+    # 'ckb-librocksdb-sys' src directory which is managed by cargo
+    - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      with:
+        path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
     - name: prologue
       id: prologue
       uses: ./.github/actions/ci_prologue

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -34,6 +34,11 @@ jobs:
       runner_label: ${{ steps.prologue.outputs.runner_label }}
     steps:
       - uses: actions/checkout@v3
+      # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+      # 'ckb-librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
       - name: prologue
         id: prologue
         uses: ./.github/actions/ci_prologue

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -45,6 +45,11 @@ jobs:
         LABELS: "${{ toJson(github.event.pull_request.labels.*.name) }}"
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_WORKFLOW: ${{ github.workflow }}
+    # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+    # 'ckb-librocksdb-sys' src directory which is managed by cargo
+    - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      with:
+        path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
   ci_quick_checks_ubuntu:
     name: ci_quick_checks_ubuntu
     needs: prologue

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -34,6 +34,11 @@ jobs:
       runner_label: ${{ steps.prologue.outputs.runner_label }}
     steps:
       - uses: actions/checkout@v3
+      # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+      # 'ckb-librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
       - name: prologue
         id: prologue
         uses: ./.github/actions/ci_prologue

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -34,6 +34,11 @@ jobs:
       linux_runner_label: ${{ steps.prologue.outputs.linux_runner_label }}
     steps:
     - uses: actions/checkout@v3
+    # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+    # 'ckb-librocksdb-sys' src directory which is managed by cargo
+    - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      with:
+        path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
     - name: prologue
       id: prologue
       uses: ./.github/actions/ci_prologue

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -34,6 +34,11 @@ jobs:
       windows_runner_label: ${{ steps.prologue.outputs.windows_runner_label }}
     steps:
     - uses: actions/checkout@v3
+    # Enable caching of the 'ckb-librocksdb-sys' crate by additionally caching the
+    # 'ckb-librocksdb-sys' src directory which is managed by cargo
+    - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      with:
+        path: ~/.cargo/registry/src/**/ckb-librocksdb-sys-*
     - name: prologue
       id: prologue
       uses: ./.github/actions/ci_prologue


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4792


### Related changes

- Enable cache in linter/unit test/integration test for ckb-librocksdb-sys on CI workflows

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

