### PR TITLE
chore: 2nd hardfork mainnet activation params

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1694,8 +1694,8 @@ Response
             { "rfc": "0032", "epoch_number": "0x1526" },
             { "rfc": "0036", "epoch_number": "0x0" },
             { "rfc": "0038", "epoch_number": "0x0" },
-            { "rfc": "0048", "epoch_number": null },
-            { "rfc": "0049", "epoch_number": null }
+            { "rfc": "0048", "epoch_number": "0x3005" },
+            { "rfc": "0049", "epoch_number": "0x3005" }
          ],
         "id": "main",
         "initial_primary_epoch_reward": "0x71afd498d000",

--- a/rpc/src/module/chain.rs
+++ b/rpc/src/module/chain.rs
@@ -1359,8 +1359,8 @@ pub trait ChainRpc {
     ///             { "rfc": "0032", "epoch_number": "0x1526" },
     ///             { "rfc": "0036", "epoch_number": "0x0" },
     ///             { "rfc": "0038", "epoch_number": "0x0" },
-    ///             { "rfc": "0048", "epoch_number": null },
-    ///             { "rfc": "0049", "epoch_number": null }
+    ///             { "rfc": "0048", "epoch_number": "0x3005" },
+    ///             { "rfc": "0049", "epoch_number": "0x3005" }
     ///          ],
     ///         "id": "main",
     ///         "initial_primary_epoch_reward": "0x71afd498d000",

--- a/util/constant/src/hardfork/mainnet.rs
+++ b/util/constant/src/hardfork/mainnet.rs
@@ -7,5 +7,8 @@ pub const RFC0028_RFC0032_RFC0033_RFC0034_START_EPOCH: u64 = 5414;
 // pub const CKB2021_START_EPOCH: u64 = 5414;
 pub const CKB2021_START_EPOCH: u64 = 0;
 
-/// hardcode ckb2023 epoch
-pub const CKB2023_START_EPOCH: u64 = u64::MAX;
+/// 2025-07-01 06:32:53 utc
+/// |            hash                                                    |  number   |    timestamp    | epoch |
+/// | 0xf959f70e487bc3073374d148ef0df713e6060542b84d89a3318bf18edbacdf94 | 15,414,776  |  1739773973982  |  11,489 (1800/1800)|
+/// 1739773973982 + 804 * (4 * 60 * 60 * 1000) = 1751351573982  2024-10-25 05:43 utc
+pub const CKB2023_START_EPOCH: u64 = 12_293;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Planned CKB Edition Meepo (2024) activation on the Mainnet. Binary version 0.200 scheduled for release around Mar. 1.


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

