### PR TITLE
chore: lock cargo-deny version

### DIFF
--- a/devtools/ci/ci_main.sh
+++ b/devtools/ci/ci_main.sh
@@ -83,7 +83,7 @@ case $GITHUB_WORKFLOW in
     ;;
   ci_cargo_deny*)
     echo "ci_security_audit_licenses"
-    cargo deny --version || cargo +stable install cargo-deny --locked
+    cargo deny --version || cargo +stable install cargo-deny --locked --version 0.17.0
     make security-audit
     make check-crates
     make check-licenses


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

fix
```bash
error: cannot install package `cargo-deny 0.18.0`, it requires rustc 1.85.0 or newer, while the currently active rustc version is 1.84.1
```

### What is changed and how it works?

Temporarily lock the version of cargo-deny until CKB upgrades the toolchain. https://github.com/nervosnetwork/ckb/issues/4816



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

