### PR TITLE
fix: wasm build

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -183,7 +183,6 @@ impl NetworkState {
             bootnodes,
             peer_registry: RwLock::new(peer_registry),
             dialing_addrs: RwLock::new(HashMap::default()),
-            pending_dns_addrs: RwLock::new(HashMap::default()),
             public_addrs: RwLock::new(public_addrs),
             listened_addrs: RwLock::new(Vec::new()),
             pending_observed_addrs: RwLock::new(HashSet::default()),


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

fix
```bash
error[E0560]: struct `NetworkState` has no field named `pending_dns_addrs`
   --> network/src/network.rs:186:13
    |
186 |             pending_dns_addrs: RwLock::new(HashMap::default()),
    |             ^^^^^^^^^^^^^^^^^ `NetworkState` does not have this field
    |
    = note: all struct fields are already assigned
```

introduced from https://github.com/nervosnetwork/ckb/pull/4812


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

