### PR TITLE
script: refactored vmargs to accept a vector array

### DIFF
--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::scheduler::{Scheduler, ROOT_VM_ID};
 pub use crate::syscalls::generator::generate_ckb_syscalls;
 pub use crate::types::{
     ChunkCommand, CoreMachine, DataLocation, DataPieceId, RunMode, ScriptGroup, ScriptGroupType,
-    ScriptVersion, TransactionState, TxData, VerifyResult, VmIsa, VmState, VmVersion,
+    ScriptVersion, TransactionState, TxData, VerifyResult, VmArgs, VmIsa, VmState, VmVersion,
 };
 pub use crate::verify::TransactionScriptsVerifier;
 pub use crate::verify_env::TxVerifyEnv;

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -1015,7 +1015,7 @@ where
 /// When the vm is initialized, arguments are loaded onto the stack.
 /// This enum specifies how to locate these arguments.
 pub enum VmArgs {
-    Reader(u64, u64, u64),
+    Reader { vm_id: u64, argc: u64, argv: u64 },
     Vector(Vec<Bytes>),
 }
 

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -1014,8 +1014,18 @@ where
 
 /// When the vm is initialized, arguments are loaded onto the stack.
 /// This enum specifies how to locate these arguments.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum VmArgs {
-    Reader { vm_id: u64, argc: u64, argv: u64 },
+    /// Represents reading arguments from other vm.
+    Reader {
+        /// An identifier for the virtual machine/process.
+        vm_id: u64,
+        /// The number of arguments provided.
+        argc: u64,
+        /// The pointer of the actual arguments.
+        argv: u64,
+    },
+    /// Represents reading arguments from a vector.
     Vector(Vec<Bytes>),
 }
 

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -1012,6 +1012,13 @@ where
     }
 }
 
+/// When the vm is initialized, arguments are loaded onto the stack.
+/// This enum specifies how to locate these arguments.
+pub enum VmArgs {
+    Reader(u64, u64, u64),
+    Vector(Vec<Bytes>),
+}
+
 /// Mutable data at virtual machine level
 #[derive(Clone)]
 pub struct VmContext<DL>


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

The current approach completely prohibits the possibility of receiving external arguments to initialize the VM stack, which has led to the breakdown of some important functions in the ckb-debugger.

### What is changed and how it works?

Use an enumeration type to represent the type of the parameter. 

- `VmArgs::Reader(u64, u64, u64) == Some((u64, u64, u64))`
- `VmArgs::Vector(vec![]) == None`
- `VmArgs::Vector(vec!["a", "b", "c"]) : The new method for ckb-debugger`

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

