### PR TITLE
wasm: fix `make wasm` build failed by `error[E0521]: borrowed data escapes outside of closure`

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1538,6 +1538,7 @@ pub enum TransportType {
     Wss,
 }
 
+#[allow(dead_code)]
 pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
     let mut iter = addr.iter();
 

--- a/network/src/peer_store/peer_store_db.rs
+++ b/network/src/peer_store/peer_store_db.rs
@@ -196,7 +196,10 @@ impl PeerStore {
     }
 
     #[cfg(target_family = "wasm")]
-    pub fn dump_to_idb<P: AsRef<Path>>(&self, path: P) -> impl std::future::Future<Output = ()> {
+    pub fn dump_to_idb<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> impl std::future::Future<Output = ()> + use<P> {
         use crate::peer_store::browser::get_db;
         let ban_list = self.ban_list().dump_data();
         let addr_manager = self.addr_manager().dump_data();


### PR DESCRIPTION

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to fix: `make wasn` error on latest develop branch:
```bash
error[E0521]: borrowed data escapes outside of closure
  --> network/src/services/dump_peer_store.rs:43:24
   |
42 |         self.network_state.with_peer_store_mut(|peer_store| {
   |                                                 ----------
   |                                                 |
   |                                                 `peer_store` is a reference that is only valid in the closure body
   |                                                 has type `&'1 mut PeerStore`
43 |             let task = peer_store.dump_to_idb(path);
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |                        |
   |                        `peer_store` escapes the closure body here
   |                        argument requires that `'1` must outlive `'static`

```

### What is changed and how it works?
### Related changes

- change dump_to_idb from a method to a function, remove `&self` param

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

