### PR TITLE
clippy: fix `make clippy` failed on develop

### DIFF
--- a/util/constant/src/default_assume_valid_target.rs
+++ b/util/constant/src/default_assume_valid_target.rs
@@ -1,4 +1,4 @@
-/// Get default assume valid targets
+//! Get default assume valid targets
 
 /// mainnet
 pub mod mainnet {

--- a/util/constant/src/latest_assume_valid_target.rs
+++ b/util/constant/src/latest_assume_valid_target.rs
@@ -1,7 +1,6 @@
-/// The mod mainnet and mod testnet's codes are generated
-/// by script: ./devtools/release/update_default_valid_target.sh
-/// Please don't modify them manually.
-///
+//! The mod mainnet and mod testnet's codes are generated
+//! by script: ./devtools/release/update_default_valid_target.sh
+//! Please don't modify them manually.
 
 /// sync config related to mainnet
 pub mod mainnet {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

After v0.200.0 released, `make clippy` failed on develop since we merged master into develop: https://github.com/nervosnetwork/ckb/commit/33446e83c28e1c6f09d94de5de7efefe26dfcff5
```bash
    Checking petgraph v0.6.5
error: empty line after doc comment
 --> util/constant/src/default_assume_valid_target.rs:1:1
  |
1 | / /// Get default assume valid targets
2 | |
  | |_^
3 |   /// mainnet
4 |   pub mod mainnet {
  |   --------------- the comment documents this module
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
  = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
  = help: if the empty line is unintentional remove it
help: if the comment should document the parent module use an inner doc comment
  |
1 | //! Get default assume valid targets
  |   ~
help: if the documentation should include the empty line include it in the comment
  |
2 | ///
  |

error: empty line after doc comment
 --> util/constant/src/latest_assume_valid_target.rs:4:1
  |
4 | / ///
5 | |
  | |_^
6 |   /// sync config related to mainnet
7 |   pub mod mainnet {
  |   --------------- the comment documents this module
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
  = help: if the empty line is unintentional remove it
help: if the comment should document the parent module use an inner doc comment
  |
1 ~ //! The mod mainnet and mod testnet's codes are generated
2 ~ //! by script: ./devtools/release/update_default_valid_target.sh
3 ~ //! Please don't modify them manually.
4 ~ //!
  |
help: if the documentation should include the empty line include it in the comment
  |
5 | ///
  |

    Checking thread-id v4.2.2
error: could not compile `ckb-constant` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:192: clippy] Error 101

```
### Related changes

- Fix clippy warning

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

