### PR TITLE
Centralize dependencies with `cargo autoinherit` to improve CKB workspace maintainability

### DIFF
--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -52,8 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          brew install grep gnu-sed
+          brew unlink yq
+          brew install grep gnu-sed bash python-yq
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
+              echo bash version:
+              bash --version
               devtools/ci/ci_main.sh
           else
             echo "skip job"

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -58,9 +58,14 @@ jobs:
     - uses: actions/checkout@v3
     - run: cargo fmt --all -- --check
     - run: rustup component add clippy
-    - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y
+    - run: pip install yq
+    - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev jq -y
     - run: |
         if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
+            echo tomlq path: $(which tomlq)
+            echo jq path: $(which jq)
+            tomlq --version
+            jq --version
             devtools/ci/ci_main.sh
         else
           echo "skip job"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,11 +239,11 @@ merkle-cbt = "0.3"
 minstant = "0.1.4"
 molecule = { version = "0.8.0", default-features = false }
 multi_index_map = "0.6.0"
-multiaddr = "0.3.0"
+multiaddr = { version = "0.3.0", package = "tentacle-multiaddr" }
 num-bigint = "0.4"
 num_cpus = "1.16.0"
 numext-fixed-uint = "0.1"
-p2p = { version = "0.6.2", default-features = false }
+p2p = { version = "0.6.2", package = "tentacle", default-features = false }
 parking_lot = "0.12"
 paste = "1.0"
 path-clean = "0.1.0"
@@ -262,7 +262,7 @@ reqwest = "0.12"
 rhai = "1.16.0"
 rocksdb = { version = "=0.21.1", default-features = false }
 rustc-hash = "1.1"
-secio = "0.6"
+secio = { version = "0.6", package = "tentacle-secio" }
 secp256k1 = "0.30"
 semver = "1.0"
 sentry = "0.34.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ members = [
     "ckb-bin",
 ]
 
+[workspace.package]
+version = "0.201.0-pre"
+
 [workspace.dependencies]
 tempfile = "3"
 itertools = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/nervosnetwork/ckb"
 rust-version = "1.85.0"
 
 [build-dependencies]
-ckb-build-info = { workspace = true }
+ckb-build-info.workspace = true
 
 [dependencies]
-ckb-build-info = { workspace = true }
-ckb-bin = { workspace = true }
+ckb-build-info.workspace = true
+ckb-bin.workspace = true
 console-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,7 @@ rayon = "1.0"
 regex = "1.1.6"
 reqwest = "0.12"
 rhai = "1.16.0"
-rocksdb = { version = "=0.21.1", default-features = false }
+rocksdb = { version = "=0.21.1", package = "ckb-rocksdb", default-features = false }
 rustc-hash = "1.1"
 secio = { version = "0.6", package = "tentacle-secio" }
 secp256k1 = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,78 +120,78 @@ bs58 = "0.5.0"
 byteorder = "1.3.1"
 bytes = "1"
 cfg-if = "1.0"
-ckb-app-config = { path = "util/app-config" }
-ckb-async-runtime = { path = "util/runtime" }
-ckb-bin = { path = "ckb-bin" }
-ckb-block-filter = { path = "block-filter" }
-ckb-build-info = { path = "util/build-info" }
-ckb-chain = { path = "chain" }
-ckb-chain-iter = { path = "util/chain-iter" }
-ckb-chain-spec = { path = "spec" }
-ckb-channel = { path = "util/channel" }
-ckb-constant = { path = "util/constant" }
-ckb-crypto = { path = "util/crypto" }
-ckb-dao = { path = "util/dao" }
-ckb-dao-utils = { path = "util/dao/utils" }
-ckb-db = { path = "db" }
-ckb-db-migration = { path = "db-migration" }
-ckb-db-schema = { path = "db-schema" }
-ckb-error = { path = "error" }
-ckb-fee-estimator = { path = "util/fee-estimator" }
-ckb-fixed-hash = { path = "util/fixed-hash" }
-ckb-fixed-hash-core = { path = "util/fixed-hash/core" }
-ckb-fixed-hash-macros = { path = "util/fixed-hash/macros" }
-ckb-freezer = { path = "freezer" }
-ckb-gen-types = { path = "util/gen-types" }
-ckb-hash = { path = "util/hash", default-features = false }
-ckb-indexer = { path = "util/indexer" }
-ckb-indexer-sync = { path = "util/indexer-sync" }
-ckb-instrument = { path = "util/instrument" }
-ckb-jsonrpc-types = { path = "util/jsonrpc-types" }
-ckb-launcher = { path = "util/launcher" }
-ckb-light-client-protocol-server = { path = "util/light-client-protocol-server" }
-ckb-logger = { path = "util/logger" }
-ckb-logger-config = { path = "util/logger-config" }
-ckb-logger-service = { path = "util/logger-service" }
-ckb-memory-tracker = { path = "util/memory-tracker" }
+ckb-app-config = { path = "util/app-config", version = "=0.201.0-pre" }
+ckb-async-runtime = { path = "util/runtime", version = "=0.201.0-pre" }
+ckb-bin = { path = "ckb-bin", version = "=0.201.0-pre" }
+ckb-block-filter = { path = "block-filter", version = "=0.201.0-pre" }
+ckb-build-info = { path = "util/build-info", version = "=0.201.0-pre" }
+ckb-chain = { path = "chain", version = "=0.201.0-pre" }
+ckb-chain-iter = { path = "util/chain-iter", version = "=0.201.0-pre" }
+ckb-chain-spec = { path = "spec", version = "=0.201.0-pre" }
+ckb-channel = { path = "util/channel", version = "=0.201.0-pre" }
+ckb-constant = { path = "util/constant", version = "=0.201.0-pre" }
+ckb-crypto = { path = "util/crypto", version = "=0.201.0-pre" }
+ckb-dao = { path = "util/dao", version = "=0.201.0-pre" }
+ckb-dao-utils = { path = "util/dao/utils", version = "=0.201.0-pre" }
+ckb-db = { path = "db", version = "=0.201.0-pre" }
+ckb-db-migration = { path = "db-migration", version = "=0.201.0-pre" }
+ckb-db-schema = { path = "db-schema", version = "=0.201.0-pre" }
+ckb-error = { path = "error", version = "=0.201.0-pre" }
+ckb-fee-estimator = { path = "util/fee-estimator", version = "=0.201.0-pre" }
+ckb-fixed-hash = { path = "util/fixed-hash", version = "=0.201.0-pre" }
+ckb-fixed-hash-core = { path = "util/fixed-hash/core", version = "=0.201.0-pre" }
+ckb-fixed-hash-macros = { path = "util/fixed-hash/macros", version = "=0.201.0-pre" }
+ckb-freezer = { path = "freezer", version = "=0.201.0-pre" }
+ckb-gen-types = { path = "util/gen-types", version = "=0.201.0-pre" }
+ckb-hash = { path = "util/hash", default-features = false, version = "=0.201.0-pre" }
+ckb-indexer = { path = "util/indexer", version = "=0.201.0-pre" }
+ckb-indexer-sync = { path = "util/indexer-sync", version = "=0.201.0-pre" }
+ckb-instrument = { path = "util/instrument", version = "=0.201.0-pre" }
+ckb-jsonrpc-types = { path = "util/jsonrpc-types", version = "=0.201.0-pre" }
+ckb-launcher = { path = "util/launcher", version = "=0.201.0-pre" }
+ckb-light-client-protocol-server = { path = "util/light-client-protocol-server", version = "=0.201.0-pre" }
+ckb-logger = { path = "util/logger", version = "=0.201.0-pre" }
+ckb-logger-config = { path = "util/logger-config", version = "=0.201.0-pre" }
+ckb-logger-service = { path = "util/logger-service", version = "=0.201.0-pre" }
+ckb-memory-tracker = { path = "util/memory-tracker", version = "=0.201.0-pre" }
 ckb-merkle-mountain-range = "0.5.2"
-ckb-metrics = { path = "util/metrics" }
-ckb-metrics-config = { path = "util/metrics-config" }
-ckb-metrics-service = { path = "util/metrics-service" }
-ckb-migrate = { path = "util/migrate" }
-ckb-migration-template = { path = "util/migrate/migration-template" }
-ckb-miner = { path = "miner" }
-ckb-multisig = { path = "util/multisig" }
-ckb-network = { path = "network" }
-ckb-network-alert = { path = "util/network-alert" }
-ckb-notify = { path = "notify" }
-ckb-occupied-capacity = { path = "util/occupied-capacity" }
-ckb-occupied-capacity-core = { path = "util/occupied-capacity/core" }
-ckb-occupied-capacity-macros = { path = "util/occupied-capacity/macros" }
-ckb-pow = { path = "pow" }
-ckb-proposal-table = { path = "util/proposal-table" }
-ckb-rational = { path = "util/rational" }
-ckb-resource = { path = "resource" }
-ckb-reward-calculator = { path = "util/reward-calculator" }
-ckb-rich-indexer = { path = "util/rich-indexer" }
-ckb-rpc = { path = "rpc" }
-ckb-script = { path = "script" }
-ckb-shared = { path = "shared" }
-ckb-snapshot = { path = "util/snapshot" }
-ckb-spawn = { path = "util/spawn" }
-ckb-stop-handler = { path = "util/stop-handler" }
-ckb-store = { path = "store" }
-ckb-sync = { path = "sync" }
+ckb-metrics = { path = "util/metrics", version = "=0.201.0-pre" }
+ckb-metrics-config = { path = "util/metrics-config", version = "=0.201.0-pre" }
+ckb-metrics-service = { path = "util/metrics-service", version = "=0.201.0-pre" }
+ckb-migrate = { path = "util/migrate", version = "=0.201.0-pre" }
+ckb-migration-template = { path = "util/migrate/migration-template", version = "=0.201.0-pre" }
+ckb-miner = { path = "miner", version = "=0.201.0-pre" }
+ckb-multisig = { path = "util/multisig", version = "=0.201.0-pre" }
+ckb-network = { path = "network", version = "=0.201.0-pre" }
+ckb-network-alert = { path = "util/network-alert", version = "=0.201.0-pre" }
+ckb-notify = { path = "notify", version = "=0.201.0-pre" }
+ckb-occupied-capacity = { path = "util/occupied-capacity", version = "=0.201.0-pre" }
+ckb-occupied-capacity-core = { path = "util/occupied-capacity/core", version = "=0.201.0-pre" }
+ckb-occupied-capacity-macros = { path = "util/occupied-capacity/macros", version = "=0.201.0-pre" }
+ckb-pow = { path = "pow", version = "=0.201.0-pre" }
+ckb-proposal-table = { path = "util/proposal-table", version = "=0.201.0-pre" }
+ckb-rational = { path = "util/rational", version = "=0.201.0-pre" }
+ckb-resource = { path = "resource", version = "=0.201.0-pre" }
+ckb-reward-calculator = { path = "util/reward-calculator", version = "=0.201.0-pre" }
+ckb-rich-indexer = { path = "util/rich-indexer", version = "=0.201.0-pre" }
+ckb-rpc = { path = "rpc", version = "=0.201.0-pre" }
+ckb-script = { path = "script", version = "=0.201.0-pre" }
+ckb-shared = { path = "shared", version = "=0.201.0-pre" }
+ckb-snapshot = { path = "util/snapshot", version = "=0.201.0-pre" }
+ckb-spawn = { path = "util/spawn", version = "=0.201.0-pre" }
+ckb-stop-handler = { path = "util/stop-handler", version = "=0.201.0-pre" }
+ckb-store = { path = "store", version = "=0.201.0-pre" }
+ckb-sync = { path = "sync", version = "=0.201.0-pre" }
 ckb-system-scripts = "=0.5.4"
-ckb-systemtime = { path = "util/systemtime" }
-ckb-test-chain-utils = { path = "util/test-chain-utils" }
-ckb-traits = { path = "traits" }
-ckb-tx-pool = { path = "tx-pool" }
-ckb-types = { path = "util/types" }
-ckb-util = { path = "util" }
-ckb-verification = { path = "verification" }
-ckb-verification-contextual = { path = "verification/contextual" }
-ckb-verification-traits = { path = "verification/traits" }
+ckb-systemtime = { path = "util/systemtime", version = "=0.201.0-pre" }
+ckb-test-chain-utils = { path = "util/test-chain-utils", version = "=0.201.0-pre" }
+ckb-traits = { path = "traits", version = "=0.201.0-pre" }
+ckb-tx-pool = { path = "tx-pool", version = "=0.201.0-pre" }
+ckb-types = { path = "util/types", version = "=0.201.0-pre" }
+ckb-util = { path = "util", version = "=0.201.0-pre" }
+ckb-verification = { path = "verification", version = "=0.201.0-pre" }
+ckb-verification-contextual = { path = "verification/contextual", version = "=0.201.0-pre" }
+ckb-verification-traits = { path = "verification/traits", version = "=0.201.0-pre" }
 ckb-vm = { version = "=0.24.13", default-features = false }
 clap = "=4.4"
 console = ">=0.9.1, <1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/nervosnetwork/ckb"
 rust-version = "1.85.0"
 
 [build-dependencies]
-ckb-build-info = { path = "util/build-info", version = "= 0.201.0-pre" }
+ckb-build-info = { workspace = true }
 
 [dependencies]
-ckb-build-info = { path = "util/build-info", version = "= 0.201.0-pre" }
-ckb-bin = { path = "ckb-bin", version = "= 0.201.0-pre" }
-console-subscriber = { version = "0.4.0", optional = true }
+ckb-build-info = { workspace = true }
+ckb-bin = { workspace = true }
+console-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
 
@@ -102,6 +102,186 @@ tempfile = "3"
 itertools = "0.11.0"
 # issue tracking: https://github.com/GREsau/schemars/pull/251
 schemars = { package = "ckb_schemars", version="0.8.22" }
+anyhow = "1.0.34"
+arc-swap = "1.3"
+async-stream = "0.3.3"
+async-trait = "0.1"
+axum = "0.7"
+backtrace = "0.3"
+base64 = "0.21.0"
+bit-vec = "0.6.3"
+bitflags = "1.0"
+blake2b-ref = "0.3"
+bloom-filters = "0.1"
+bs58 = "0.5.0"
+byteorder = "1.3.1"
+bytes = "1"
+cfg-if = "1.0"
+ckb-app-config = { version = "=0.201.0-pre", path = "util/app-config" }
+ckb-async-runtime = { version = "=0.201.0-pre", path = "util/runtime" }
+ckb-bin = { version = "=0.201.0-pre", path = "ckb-bin" }
+ckb-block-filter = { version = "=0.201.0-pre", path = "block-filter" }
+ckb-build-info = { version = "=0.201.0-pre", path = "util/build-info" }
+ckb-chain = { version = "=0.201.0-pre", path = "chain" }
+ckb-chain-iter = { version = "=0.201.0-pre", path = "util/chain-iter" }
+ckb-chain-spec = { version = "=0.201.0-pre", path = "spec" }
+ckb-channel = { version = "=0.201.0-pre", path = "util/channel" }
+ckb-constant = { version = "=0.201.0-pre", path = "util/constant" }
+ckb-crypto = { version = "=0.201.0-pre", path = "util/crypto" }
+ckb-dao = { version = "=0.201.0-pre", path = "util/dao" }
+ckb-dao-utils = { version = "=0.201.0-pre", path = "util/dao/utils" }
+ckb-db = { version = "=0.201.0-pre", path = "db" }
+ckb-db-migration = { version = "=0.201.0-pre", path = "db-migration" }
+ckb-db-schema = { version = "=0.201.0-pre", path = "db-schema" }
+ckb-error = { version = "=0.201.0-pre", path = "error" }
+ckb-fee-estimator = { version = "=0.201.0-pre", path = "util/fee-estimator" }
+ckb-fixed-hash = { version = "=0.201.0-pre", path = "util/fixed-hash" }
+ckb-fixed-hash-core = { version = "=0.201.0-pre", path = "util/fixed-hash/core" }
+ckb-fixed-hash-macros = { version = "=0.201.0-pre", path = "util/fixed-hash/macros" }
+ckb-freezer = { version = "=0.201.0-pre", path = "freezer" }
+ckb-gen-types = { version = "=0.201.0-pre", path = "util/gen-types" }
+ckb-hash = { version = "=0.201.0-pre", path = "util/hash", default-features = false }
+ckb-indexer = { version = "=0.201.0-pre", path = "util/indexer" }
+ckb-indexer-sync = { version = "=0.201.0-pre", path = "util/indexer-sync" }
+ckb-instrument = { version = "=0.201.0-pre", path = "util/instrument" }
+ckb-jsonrpc-types = { version = "=0.201.0-pre", path = "util/jsonrpc-types" }
+ckb-launcher = { version = "=0.201.0-pre", path = "util/launcher" }
+ckb-light-client-protocol-server = { version = "=0.201.0-pre", path = "util/light-client-protocol-server" }
+ckb-logger = { version = "=0.201.0-pre", path = "util/logger" }
+ckb-logger-config = { version = "=0.201.0-pre", path = "util/logger-config" }
+ckb-logger-service = { version = "=0.201.0-pre", path = "util/logger-service" }
+ckb-memory-tracker = { version = "=0.201.0-pre", path = "util/memory-tracker" }
+ckb-merkle-mountain-range = "0.5.2"
+ckb-metrics = { version = "=0.201.0-pre", path = "util/metrics" }
+ckb-metrics-config = { version = "=0.201.0-pre", path = "util/metrics-config" }
+ckb-metrics-service = { version = "=0.201.0-pre", path = "util/metrics-service" }
+ckb-migrate = { version = "=0.201.0-pre", path = "util/migrate" }
+ckb-migration-template = { version = "=0.201.0-pre", path = "util/migrate/migration-template" }
+ckb-miner = { version = "=0.201.0-pre", path = "miner" }
+ckb-multisig = { version = "=0.201.0-pre", path = "util/multisig" }
+ckb-network = { version = "=0.201.0-pre", path = "network" }
+ckb-network-alert = { version = "=0.201.0-pre", path = "util/network-alert" }
+ckb-notify = { version = "=0.201.0-pre", path = "notify" }
+ckb-occupied-capacity = { version = "=0.201.0-pre", path = "util/occupied-capacity" }
+ckb-occupied-capacity-core = { version = "=0.201.0-pre", path = "util/occupied-capacity/core" }
+ckb-occupied-capacity-macros = { version = "=0.201.0-pre", path = "util/occupied-capacity/macros" }
+ckb-pow = { version = "=0.201.0-pre", path = "pow" }
+ckb-proposal-table = { version = "=0.201.0-pre", path = "util/proposal-table" }
+ckb-rational = { version = "=0.201.0-pre", path = "util/rational" }
+ckb-resource = { version = "=0.201.0-pre", path = "resource" }
+ckb-reward-calculator = { version = "=0.201.0-pre", path = "util/reward-calculator" }
+ckb-rich-indexer = { version = "=0.201.0-pre", path = "util/rich-indexer" }
+ckb-rpc = { version = "=0.201.0-pre", path = "rpc" }
+ckb-script = { version = "=0.201.0-pre", path = "script" }
+ckb-shared = { version = "=0.201.0-pre", path = "shared" }
+ckb-snapshot = { version = "=0.201.0-pre", path = "util/snapshot" }
+ckb-spawn = { version = "=0.201.0-pre", path = "util/spawn" }
+ckb-stop-handler = { version = "=0.201.0-pre", path = "util/stop-handler" }
+ckb-store = { version = "=0.201.0-pre", path = "store" }
+ckb-sync = { version = "=0.201.0-pre", path = "sync" }
+ckb-system-scripts = "=0.5.4"
+ckb-systemtime = { version = "=0.201.0-pre", path = "util/systemtime" }
+ckb-test-chain-utils = { version = "=0.201.0-pre", path = "util/test-chain-utils" }
+ckb-traits = { version = "=0.201.0-pre", path = "traits" }
+ckb-tx-pool = { version = "=0.201.0-pre", path = "tx-pool" }
+ckb-types = { version = "=0.201.0-pre", path = "util/types" }
+ckb-util = { version = "=0.201.0-pre", path = "util" }
+ckb-verification = { version = "=0.201.0-pre", path = "verification" }
+ckb-verification-contextual = { version = "=0.201.0-pre", path = "verification/contextual" }
+ckb-verification-traits = { version = "=0.201.0-pre", path = "verification/traits" }
+ckb-vm = { version = "=0.24.13", default-features = false }
+clap = "=4.4"
+console = ">=0.9.1, <1.0.0"
+console-subscriber = "0.4.0"
+criterion = "0.5"
+crossbeam = "0.8.2"
+crossbeam-channel = "0.5.1"
+ctrlc = "3.1"
+daggy = "0.8.0"
+dashmap = "4.0"
+derive_more = { version = "1", default-features = false }
+eaglesong = "0.1"
+env_logger = "0.10"
+fail = "0.4"
+faster-hex = "0.6"
+faux = "0.1"
+fdlimit = "0.2.1"
+fs2 = "0.4.3"
+futures = "0.3"
+futures-util = "0.3.21"
+golomb-coded-set = "0.2.0"
+governor = "0.3.1"
+hex = "0.4"
+hickory-resolver = "0.24.2"
+http-body-util = "0.1"
+hyper = "1"
+hyper-tls = "0.6"
+hyper-util = "0.1"
+include_dir = "0.7"
+includedir = "0.6.0"
+includedir_codegen = "0.6.0"
+indicatif = "0.16"
+ipnetwork = "0.20"
+is-terminal = "0.4.7"
+is_sorted = "0.1.1"
+jsonrpc-core = "18.0"
+jsonrpc-utils = "0.3"
+keyed_priority_queue = "0.3"
+libc = "0.2"
+linked-hash-map = "0.5"
+log = "0.4"
+lru = "0.7.1"
+memchr = "2.7"
+merkle-cbt = "0.3"
+minstant = "0.1.4"
+molecule = { version = "0.8.0", default-features = false }
+multi_index_map = "0.6.0"
+multiaddr = "0.3.0"
+num-bigint = "0.4"
+num_cpus = "1.16.0"
+numext-fixed-uint = "0.1"
+p2p = { version = "0.6.2", default-features = false }
+parking_lot = "0.12"
+paste = "1.0"
+path-clean = "0.1.0"
+phf = "0.8.0"
+pretty_assertions = "1.3.0"
+proc-macro2 = "1.0"
+prometheus = "0.13.3"
+prometheus-static-metric = "0.5.1"
+proptest = "1.0"
+quote = "1.0"
+rand = "0.8.5"
+rand_distr = "0.4"
+rayon = "1.0"
+regex = "1.1.6"
+reqwest = "0.12"
+rhai = "1.16.0"
+rocksdb = { version = "=0.21.1", default-features = false }
+rustc-hash = "1.1"
+secio = "0.6"
+secp256k1 = "0.30"
+semver = "1.0"
+sentry = "0.34.0"
+serde = "1.0"
+serde_plain = "0.3.0"
+slab = "0.4"
+sled = "0.34.7"
+snap = "1"
+sql-builder = "3.1"
+sqlx = "0.8.2"
+tera = "1"
+thiserror = "1.0.22"
+time = "0.3.36"
+tiny-keccak = "2.0"
+tokio = "1.35.0"
+tokio-util = "0.7.8"
+toml = "0.5"
+tower-http = "0.6"
+ubyte = "0.10"
+url = "2.2.2"
+walkdir = "2.1.4"
+yansi = "0.5"
 
 [profile.release]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,78 +117,78 @@ bs58 = "0.5.0"
 byteorder = "1.3.1"
 bytes = "1"
 cfg-if = "1.0"
-ckb-app-config = { version = "=0.201.0-pre", path = "util/app-config" }
-ckb-async-runtime = { version = "=0.201.0-pre", path = "util/runtime" }
-ckb-bin = { version = "=0.201.0-pre", path = "ckb-bin" }
-ckb-block-filter = { version = "=0.201.0-pre", path = "block-filter" }
-ckb-build-info = { version = "=0.201.0-pre", path = "util/build-info" }
-ckb-chain = { version = "=0.201.0-pre", path = "chain" }
-ckb-chain-iter = { version = "=0.201.0-pre", path = "util/chain-iter" }
-ckb-chain-spec = { version = "=0.201.0-pre", path = "spec" }
-ckb-channel = { version = "=0.201.0-pre", path = "util/channel" }
-ckb-constant = { version = "=0.201.0-pre", path = "util/constant" }
-ckb-crypto = { version = "=0.201.0-pre", path = "util/crypto" }
-ckb-dao = { version = "=0.201.0-pre", path = "util/dao" }
-ckb-dao-utils = { version = "=0.201.0-pre", path = "util/dao/utils" }
-ckb-db = { version = "=0.201.0-pre", path = "db" }
-ckb-db-migration = { version = "=0.201.0-pre", path = "db-migration" }
-ckb-db-schema = { version = "=0.201.0-pre", path = "db-schema" }
-ckb-error = { version = "=0.201.0-pre", path = "error" }
-ckb-fee-estimator = { version = "=0.201.0-pre", path = "util/fee-estimator" }
-ckb-fixed-hash = { version = "=0.201.0-pre", path = "util/fixed-hash" }
-ckb-fixed-hash-core = { version = "=0.201.0-pre", path = "util/fixed-hash/core" }
-ckb-fixed-hash-macros = { version = "=0.201.0-pre", path = "util/fixed-hash/macros" }
-ckb-freezer = { version = "=0.201.0-pre", path = "freezer" }
-ckb-gen-types = { version = "=0.201.0-pre", path = "util/gen-types" }
-ckb-hash = { version = "=0.201.0-pre", path = "util/hash", default-features = false }
-ckb-indexer = { version = "=0.201.0-pre", path = "util/indexer" }
-ckb-indexer-sync = { version = "=0.201.0-pre", path = "util/indexer-sync" }
-ckb-instrument = { version = "=0.201.0-pre", path = "util/instrument" }
-ckb-jsonrpc-types = { version = "=0.201.0-pre", path = "util/jsonrpc-types" }
-ckb-launcher = { version = "=0.201.0-pre", path = "util/launcher" }
-ckb-light-client-protocol-server = { version = "=0.201.0-pre", path = "util/light-client-protocol-server" }
-ckb-logger = { version = "=0.201.0-pre", path = "util/logger" }
-ckb-logger-config = { version = "=0.201.0-pre", path = "util/logger-config" }
-ckb-logger-service = { version = "=0.201.0-pre", path = "util/logger-service" }
-ckb-memory-tracker = { version = "=0.201.0-pre", path = "util/memory-tracker" }
+ckb-app-config = { path = "util/app-config" }
+ckb-async-runtime = { path = "util/runtime" }
+ckb-bin = { path = "ckb-bin" }
+ckb-block-filter = { path = "block-filter" }
+ckb-build-info = { path = "util/build-info" }
+ckb-chain = { path = "chain" }
+ckb-chain-iter = { path = "util/chain-iter" }
+ckb-chain-spec = { path = "spec" }
+ckb-channel = { path = "util/channel" }
+ckb-constant = { path = "util/constant" }
+ckb-crypto = { path = "util/crypto" }
+ckb-dao = { path = "util/dao" }
+ckb-dao-utils = { path = "util/dao/utils" }
+ckb-db = { path = "db" }
+ckb-db-migration = { path = "db-migration" }
+ckb-db-schema = { path = "db-schema" }
+ckb-error = { path = "error" }
+ckb-fee-estimator = { path = "util/fee-estimator" }
+ckb-fixed-hash = { path = "util/fixed-hash" }
+ckb-fixed-hash-core = { path = "util/fixed-hash/core" }
+ckb-fixed-hash-macros = { path = "util/fixed-hash/macros" }
+ckb-freezer = { path = "freezer" }
+ckb-gen-types = { path = "util/gen-types" }
+ckb-hash = { path = "util/hash", default-features = false }
+ckb-indexer = { path = "util/indexer" }
+ckb-indexer-sync = { path = "util/indexer-sync" }
+ckb-instrument = { path = "util/instrument" }
+ckb-jsonrpc-types = { path = "util/jsonrpc-types" }
+ckb-launcher = { path = "util/launcher" }
+ckb-light-client-protocol-server = { path = "util/light-client-protocol-server" }
+ckb-logger = { path = "util/logger" }
+ckb-logger-config = { path = "util/logger-config" }
+ckb-logger-service = { path = "util/logger-service" }
+ckb-memory-tracker = { path = "util/memory-tracker" }
 ckb-merkle-mountain-range = "0.5.2"
-ckb-metrics = { version = "=0.201.0-pre", path = "util/metrics" }
-ckb-metrics-config = { version = "=0.201.0-pre", path = "util/metrics-config" }
-ckb-metrics-service = { version = "=0.201.0-pre", path = "util/metrics-service" }
-ckb-migrate = { version = "=0.201.0-pre", path = "util/migrate" }
-ckb-migration-template = { version = "=0.201.0-pre", path = "util/migrate/migration-template" }
-ckb-miner = { version = "=0.201.0-pre", path = "miner" }
-ckb-multisig = { version = "=0.201.0-pre", path = "util/multisig" }
-ckb-network = { version = "=0.201.0-pre", path = "network" }
-ckb-network-alert = { version = "=0.201.0-pre", path = "util/network-alert" }
-ckb-notify = { version = "=0.201.0-pre", path = "notify" }
-ckb-occupied-capacity = { version = "=0.201.0-pre", path = "util/occupied-capacity" }
-ckb-occupied-capacity-core = { version = "=0.201.0-pre", path = "util/occupied-capacity/core" }
-ckb-occupied-capacity-macros = { version = "=0.201.0-pre", path = "util/occupied-capacity/macros" }
-ckb-pow = { version = "=0.201.0-pre", path = "pow" }
-ckb-proposal-table = { version = "=0.201.0-pre", path = "util/proposal-table" }
-ckb-rational = { version = "=0.201.0-pre", path = "util/rational" }
-ckb-resource = { version = "=0.201.0-pre", path = "resource" }
-ckb-reward-calculator = { version = "=0.201.0-pre", path = "util/reward-calculator" }
-ckb-rich-indexer = { version = "=0.201.0-pre", path = "util/rich-indexer" }
-ckb-rpc = { version = "=0.201.0-pre", path = "rpc" }
-ckb-script = { version = "=0.201.0-pre", path = "script" }
-ckb-shared = { version = "=0.201.0-pre", path = "shared" }
-ckb-snapshot = { version = "=0.201.0-pre", path = "util/snapshot" }
-ckb-spawn = { version = "=0.201.0-pre", path = "util/spawn" }
-ckb-stop-handler = { version = "=0.201.0-pre", path = "util/stop-handler" }
-ckb-store = { version = "=0.201.0-pre", path = "store" }
-ckb-sync = { version = "=0.201.0-pre", path = "sync" }
+ckb-metrics = { path = "util/metrics" }
+ckb-metrics-config = { path = "util/metrics-config" }
+ckb-metrics-service = { path = "util/metrics-service" }
+ckb-migrate = { path = "util/migrate" }
+ckb-migration-template = { path = "util/migrate/migration-template" }
+ckb-miner = { path = "miner" }
+ckb-multisig = { path = "util/multisig" }
+ckb-network = { path = "network" }
+ckb-network-alert = { path = "util/network-alert" }
+ckb-notify = { path = "notify" }
+ckb-occupied-capacity = { path = "util/occupied-capacity" }
+ckb-occupied-capacity-core = { path = "util/occupied-capacity/core" }
+ckb-occupied-capacity-macros = { path = "util/occupied-capacity/macros" }
+ckb-pow = { path = "pow" }
+ckb-proposal-table = { path = "util/proposal-table" }
+ckb-rational = { path = "util/rational" }
+ckb-resource = { path = "resource" }
+ckb-reward-calculator = { path = "util/reward-calculator" }
+ckb-rich-indexer = { path = "util/rich-indexer" }
+ckb-rpc = { path = "rpc" }
+ckb-script = { path = "script" }
+ckb-shared = { path = "shared" }
+ckb-snapshot = { path = "util/snapshot" }
+ckb-spawn = { path = "util/spawn" }
+ckb-stop-handler = { path = "util/stop-handler" }
+ckb-store = { path = "store" }
+ckb-sync = { path = "sync" }
 ckb-system-scripts = "=0.5.4"
-ckb-systemtime = { version = "=0.201.0-pre", path = "util/systemtime" }
-ckb-test-chain-utils = { version = "=0.201.0-pre", path = "util/test-chain-utils" }
-ckb-traits = { version = "=0.201.0-pre", path = "traits" }
-ckb-tx-pool = { version = "=0.201.0-pre", path = "tx-pool" }
-ckb-types = { version = "=0.201.0-pre", path = "util/types" }
-ckb-util = { version = "=0.201.0-pre", path = "util" }
-ckb-verification = { version = "=0.201.0-pre", path = "verification" }
-ckb-verification-contextual = { version = "=0.201.0-pre", path = "verification/contextual" }
-ckb-verification-traits = { version = "=0.201.0-pre", path = "verification/traits" }
+ckb-systemtime = { path = "util/systemtime" }
+ckb-test-chain-utils = { path = "util/test-chain-utils" }
+ckb-traits = { path = "traits" }
+ckb-tx-pool = { path = "tx-pool" }
+ckb-types = { path = "util/types" }
+ckb-util = { path = "util" }
+ckb-verification = { path = "verification" }
+ckb-verification-contextual = { path = "verification/contextual" }
+ckb-verification-traits = { path = "verification/traits" }
 ckb-vm = { version = "=0.24.13", default-features = false }
 clap = "=4.4"
 console = ">=0.9.1, <1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,6 @@ p2p = { version = "0.6.2", package = "tentacle", default-features = false }
 parking_lot = "0.12"
 paste = "1.0"
 path-clean = "0.1.0"
-phf = "0.8.0"
 pretty_assertions = "1.3.0"
 proc-macro2 = "1.0"
 prometheus = "0.13.3"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-benches"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,25 +12,25 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 
 [dev-dependencies]
-criterion = { workspace = true }
-ckb-chain = { workspace = true }
-ckb-types = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-store = { workspace = true }
-ckb-chain-spec = { workspace = true }
-rand = { workspace = true }
-ckb-hash = { workspace = true }
-ckb-test-chain-utils = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-system-scripts = { workspace = true }
-ckb-crypto = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-resource = { workspace = true }
-ckb-network = { workspace = true }
+criterion.workspace = true
+ckb-chain.workspace = true
+ckb-types.workspace = true
+ckb-shared.workspace = true
+ckb-store.workspace = true
+ckb-chain-spec.workspace = true
+rand.workspace = true
+ckb-hash.workspace = true
+ckb-test-chain-utils.workspace = true
+ckb-dao-utils.workspace = true
+ckb-dao.workspace = true
+ckb-system-scripts.workspace = true
+ckb-crypto.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-verification.workspace = true
+ckb-verification-traits.workspace = true
+ckb-app-config.workspace = true
+ckb-resource.workspace = true
+ckb-network.workspace = true
 tempfile.workspace = true
 
 [[bench]]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,25 +12,25 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 
 [dev-dependencies]
-criterion = "0.5"
-ckb-chain = { path = "../chain", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-rand = "0.8"
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.201.0-pre" }
-ckb-system-scripts = { version = "= 0.5.4" }
-ckb-crypto = { path = "../util/crypto", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
+criterion = { workspace = true }
+ckb-chain = { workspace = true }
+ckb-types = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-store = { workspace = true }
+ckb-chain-spec = { workspace = true }
+rand = { workspace = true }
+ckb-hash = { workspace = true }
+ckb-test-chain-utils = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-system-scripts = { workspace = true }
+ckb-crypto = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-network = { workspace = true }
 tempfile.workspace = true
 
 [[bench]]

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
+ckb-store = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-types = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-async-runtime = { workspace = true }

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-block-filter"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-store = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-types = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-async-runtime = { workspace = true }
+ckb-store.workspace = true
+ckb-shared.workspace = true
+ckb-logger.workspace = true
+ckb-types.workspace = true
+ckb-stop-handler.workspace = true
+ckb-async-runtime.workspace = true

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -9,48 +9,44 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-verification-contextual = { path = "../verification/contextual", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
-faux = { version = "^0.1", optional = true }
-ckb-merkle-mountain-range = "0.5.2"
-is_sorted = "0.1.1"
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-crossbeam = "0.8.2"
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.201.0-pre" }
-minstant = "0.1.4"
-dashmap = "4.0"
+ckb-logger = { workspace = true }
+ckb-metrics = { workspace = true }
+ckb-types = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-store = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-verification-contextual = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-systemtime = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-proposal-table = { workspace = true }
+ckb-error = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-db = { workspace = true }
+ckb-db-schema = { workspace = true }
+faux = { workspace = true, optional = true }
+ckb-merkle-mountain-range = { workspace = true }
+is_sorted = { workspace = true }
+ckb-constant = { workspace = true }
+ckb-util = { workspace = true }
+crossbeam = { workspace = true }
+ckb-network = { workspace = true }
+ckb-tx-pool = { workspace = true }
+minstant = { workspace = true }
+dashmap = { workspace = true }
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.201.0-pre", features = [
-    "internal",
-] }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
+ckb-test-chain-utils = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-reward-calculator = { workspace = true }
+ckb-tx-pool = { workspace = true, features = ["internal"] }
+ckb-jsonrpc-types = { workspace = true }
+ckb-network = { workspace = true }
 tempfile.workspace = true
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.201.0-pre" }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
+ckb-logger-service = { workspace = true }
 
 [features]
 default = []

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -9,44 +9,44 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-metrics = { workspace = true }
-ckb-types = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-store = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-verification-contextual = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-systemtime = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-proposal-table = { workspace = true }
-ckb-error = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-db = { workspace = true }
-ckb-db-schema = { workspace = true }
+ckb-logger.workspace = true
+ckb-metrics.workspace = true
+ckb-types.workspace = true
+ckb-shared.workspace = true
+ckb-chain-spec.workspace = true
+ckb-store.workspace = true
+ckb-verification.workspace = true
+ckb-verification-contextual.workspace = true
+ckb-verification-traits.workspace = true
+ckb-systemtime.workspace = true
+ckb-stop-handler.workspace = true
+ckb-proposal-table.workspace = true
+ckb-error.workspace = true
+ckb-app-config.workspace = true
+ckb-channel.workspace = true
+ckb-db.workspace = true
+ckb-db-schema.workspace = true
 faux = { workspace = true, optional = true }
-ckb-merkle-mountain-range = { workspace = true }
-is_sorted = { workspace = true }
-ckb-constant = { workspace = true }
-ckb-util = { workspace = true }
-crossbeam = { workspace = true }
-ckb-network = { workspace = true }
-ckb-tx-pool = { workspace = true }
-minstant = { workspace = true }
-dashmap = { workspace = true }
+ckb-merkle-mountain-range.workspace = true
+is_sorted.workspace = true
+ckb-constant.workspace = true
+ckb-util.workspace = true
+crossbeam.workspace = true
+ckb-network.workspace = true
+ckb-tx-pool.workspace = true
+minstant.workspace = true
+dashmap.workspace = true
 
 [dev-dependencies]
-ckb-test-chain-utils = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-reward-calculator = { workspace = true }
+ckb-test-chain-utils.workspace = true
+ckb-dao-utils.workspace = true
+ckb-reward-calculator.workspace = true
 ckb-tx-pool = { workspace = true, features = ["internal"] }
-ckb-jsonrpc-types = { workspace = true }
-ckb-network = { workspace = true }
+ckb-jsonrpc-types.workspace = true
+ckb-network.workspace = true
 tempfile.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
-ckb-logger-service = { workspace = true }
+ckb-logger-service.workspace = true
 
 [features]
 default = []

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -9,46 +9,44 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-clap = { version = "=4.4", features = ["string", "wrap_help"] }
-serde = { version = "1.0", features = ["derive"] }
+clap = { workspace = true, features = ["string", "wrap_help"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0" }
-serde_plain = "0.3.0"
-toml = "0.5"
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.201.0-pre" }
-ckb-metrics-service = { path = "../util/metrics-service", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-miner = { path = "../miner", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.201.0-pre" }
-ctrlc = { version = "3.1", features = ["termination"] }
-ckb-instrument = { path = "../util/instrument", version = "= 0.201.0-pre", features = [
-    "progress_bar",
-] }
-ckb-build-info = { path = "../util/build-info", version = "= 0.201.0-pre" }
-ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.201.0-pre" }
-ckb-chain-iter = { path = "../util/chain-iter", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
-ckb-migrate = { path = "../util/migrate", version = "= 0.201.0-pre" }
-ckb-launcher = { path = "../util/launcher", version = "= 0.201.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-base64 = "0.21.0"
+serde_plain = { workspace = true }
+toml = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-logger-service = { workspace = true }
+ckb-metrics-service = { workspace = true }
+ckb-util = { workspace = true }
+ckb-types = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-chain = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-store = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-miner = { workspace = true }
+ckb-network = { workspace = true }
+ckb-resource = { workspace = true }
+ctrlc = { workspace = true, features = ["termination"] }
+ckb-instrument = { workspace = true, features = ["progress_bar"] }
+ckb-build-info = { workspace = true }
+ckb-memory-tracker = { workspace = true }
+ckb-chain-iter = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-migrate = { workspace = true }
+ckb-launcher = { workspace = true }
+ckb-constant = { workspace = true }
+base64 = { workspace = true }
 tempfile.workspace = true
-rayon = "1.0"
-sentry = { version = "0.34.0", optional = true }
-is-terminal = "0.4.7"
-fdlimit = "0.2.1"
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync"] }
+rayon = { workspace = true }
+sentry = { workspace = true, optional = true }
+is-terminal = { workspace = true }
+fdlimit = { workspace = true }
+ckb-stop-handler = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(not(target_os="windows"))'.dependencies]
 daemonize = { version = "0.5.0" }

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-bin"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -12,40 +12,40 @@ repository = "https://github.com/nervosnetwork/ckb"
 clap = { workspace = true, features = ["string", "wrap_help"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0" }
-serde_plain = { workspace = true }
-toml = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-logger-service = { workspace = true }
-ckb-metrics-service = { workspace = true }
-ckb-util = { workspace = true }
-ckb-types = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-chain = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-store = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-miner = { workspace = true }
-ckb-network = { workspace = true }
-ckb-resource = { workspace = true }
+serde_plain.workspace = true
+toml.workspace = true
+ckb-app-config.workspace = true
+ckb-logger.workspace = true
+ckb-logger-service.workspace = true
+ckb-metrics-service.workspace = true
+ckb-util.workspace = true
+ckb-types.workspace = true
+ckb-channel.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-chain.workspace = true
+ckb-shared.workspace = true
+ckb-store.workspace = true
+ckb-chain-spec.workspace = true
+ckb-miner.workspace = true
+ckb-network.workspace = true
+ckb-resource.workspace = true
 ctrlc = { workspace = true, features = ["termination"] }
 ckb-instrument = { workspace = true, features = ["progress_bar"] }
-ckb-build-info = { workspace = true }
-ckb-memory-tracker = { workspace = true }
-ckb-chain-iter = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-migrate = { workspace = true }
-ckb-launcher = { workspace = true }
-ckb-constant = { workspace = true }
-base64 = { workspace = true }
+ckb-build-info.workspace = true
+ckb-memory-tracker.workspace = true
+ckb-chain-iter.workspace = true
+ckb-verification-traits.workspace = true
+ckb-async-runtime.workspace = true
+ckb-migrate.workspace = true
+ckb-launcher.workspace = true
+ckb-constant.workspace = true
+base64.workspace = true
 tempfile.workspace = true
-rayon = { workspace = true }
+rayon.workspace = true
 sentry = { workspace = true, optional = true }
-is-terminal = { workspace = true }
-fdlimit = { workspace = true }
-ckb-stop-handler = { workspace = true }
+is-terminal.workspace = true
+fdlimit.workspace = true
+ckb-stop-handler.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(not(target_os="windows"))'.dependencies]

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-migration"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -11,18 +11,18 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-db = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-error = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-stop-handler = { workspace = true }
-indicatif = { workspace = true }
-console = { workspace = true }
+ckb-db.workspace = true
+ckb-logger.workspace = true
+ckb-error.workspace = true
+ckb-db-schema.workspace = true
+ckb-channel.workspace = true
+ckb-stop-handler.workspace = true
+indicatif.workspace = true
+console.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-ckb-app-config = { workspace = true }
+ckb-app-config.workspace = true
 
 [features]
 portable = ["ckb-db/portable"]

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -11,18 +11,18 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-indicatif = "0.16"
-console = ">=0.9.1, <1.0.0"
+ckb-db = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-error = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-stop-handler = { workspace = true }
+indicatif = { workspace = true }
+console = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
+ckb-app-config = { workspace = true }
 
 [features]
 portable = ["ckb-db/portable"]

--- a/db-schema/Cargo.toml
+++ b/db-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-schema"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -13,7 +13,7 @@ ckb-app-config.workspace = true
 ckb-logger.workspace = true
 ckb-error.workspace = true
 libc.workspace = true
-rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
+rocksdb = { workspace = true, features = [
     "snappy",
     "lz4",
 ], default-features = false }

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-libc = "0.2"
+ckb-app-config = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-error = { workspace = true }
+libc = { workspace = true }
 rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
     "snappy",
     "lz4",
 ], default-features = false }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
+ckb-db-schema = { workspace = true }
 
 
 [dev-dependencies]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-app-config = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-error = { workspace = true }
-libc = { workspace = true }
+ckb-app-config.workspace = true
+ckb-logger.workspace = true
+ckb-error.workspace = true
+libc.workspace = true
 rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
     "snappy",
     "lz4",
 ], default-features = false }
-ckb-db-schema = { workspace = true }
+ckb-db-schema.workspace = true
 
 
 [dev-dependencies]

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -9,10 +9,10 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-rpc ={ path = "../../../rpc", version = "= 0.201.0-pre" }
+ckb-rpc ={ workspace = true }
 schemars.workspace = true
 serde_json = "~1.0"
-tera = "1"
+tera = { workspace = true }
 syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }
-walkdir = "2.1.4"
-proc-macro2 = "1.0"
+walkdir = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nervosnetwork/ckb"
 ckb-rpc ={ workspace = true }
 schemars.workspace = true
 serde_json = "~1.0"
-tera = { workspace = true }
+tera.workspace = true
 syn = { version = "2.0.39", features = ["extra-traits", "full", "parsing", "visit"] }
-walkdir = { workspace = true }
-proc-macro2 = { workspace = true }
+walkdir.workspace = true
+proc-macro2.workspace = true

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rpc-gen"
-version = "0.201.0-pre"
+version.workspace = true
 edition = "2024"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-thiserror = { workspace = true }
-anyhow = { workspace = true }
-ckb-occupied-capacity = { workspace = true }
+thiserror.workspace = true
+anyhow.workspace = true
+ckb-occupied-capacity.workspace = true
 derive_more = { workspace = true, features = ["display"] }

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-error"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -9,9 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-thiserror = "1.0.22"
-anyhow = "1.0.34"
-ckb-occupied-capacity = { path = "../util/occupied-capacity", version = "= 0.201.0-pre" }
-derive_more = { version = "1", default-features = false, features = [
-    "display",
-] }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+ckb-occupied-capacity = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-fs2 = "0.4.3"
-fail = "0.4"
-snap = "1"
-lru = "0.7.1"
+ckb-types = { workspace = true }
+ckb-error = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-util = { workspace = true }
+ckb-metrics = { workspace = true }
+fs2 = { workspace = true }
+fail = { workspace = true }
+snap = { workspace = true }
+lru = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-error = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-util = { workspace = true }
-ckb-metrics = { workspace = true }
-fs2 = { workspace = true }
-fail = { workspace = true }
-snap = { workspace = true }
-lru = { workspace = true }
+ckb-types.workspace = true
+ckb-error.workspace = true
+ckb-logger.workspace = true
+ckb-util.workspace = true
+ckb-metrics.workspace = true
+fs2.workspace = true
+fail.workspace = true
+snap.workspace = true
+lru.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-freezer"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -9,28 +9,28 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-types = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-hash = { workspace = true }
-ckb-pow = { workspace = true }
-rand = { workspace = true }
-rand_distr = { workspace = true }
+ckb-logger.workspace = true
+ckb-app-config.workspace = true
+ckb-types.workspace = true
+ckb-channel.workspace = true
+ckb-hash.workspace = true
+ckb-pow.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-ckb-jsonrpc-types = { workspace = true }
+ckb-jsonrpc-types.workspace = true
 hyper = { workspace = true, features = ["client", "http2", "http1", "server"] }
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "client-legacy"] }
-http-body-util = { workspace = true }
-hyper-tls = { workspace = true }
-futures = { workspace = true }
-lru = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-async-runtime = { workspace = true }
-indicatif = { workspace = true }
-console = { workspace = true }
-eaglesong = { workspace = true }
-base64 = { workspace = true }
-jsonrpc-core = { workspace = true }
+http-body-util.workspace = true
+hyper-tls.workspace = true
+futures.workspace = true
+lru.workspace = true
+ckb-stop-handler.workspace = true
+ckb-async-runtime.workspace = true
+indicatif.workspace = true
+console.workspace = true
+eaglesong.workspace = true
+base64.workspace = true
+jsonrpc-core.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -9,32 +9,28 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.201.0-pre" }
-rand = "0.8"
-rand_distr = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+ckb-logger = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-types = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-hash = { workspace = true }
+ckb-pow = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-hyper = { version = "1", features = ["client", "http2", "http1", "server"] }
-hyper-util = { version = "0.1", features = [
-    "server-auto",
-    "server-graceful",
-    "client-legacy",
-] }
-http-body-util = "0.1"
-hyper-tls = "0.6"
-futures = "0.3"
-lru = "0.7.1"
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
-indicatif = "0.16"
-console = ">=0.9.1, <1.0.0"
-eaglesong = "0.1"
-base64 = "0.21.0"
-jsonrpc-core = "18.0"
-tokio = { version = "1", features = ["sync"] }
+ckb-jsonrpc-types = { workspace = true }
+hyper = { workspace = true, features = ["client", "http2", "http1", "server"] }
+hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "client-legacy"] }
+http-body-util = { workspace = true }
+hyper-tls = { workspace = true }
+futures = { workspace = true }
+lru = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-async-runtime = { workspace = true }
+indicatif = { workspace = true }
+console = { workspace = true }
+eaglesong = { workspace = true }
+base64 = { workspace = true }
+jsonrpc-core = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-miner"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -34,10 +34,10 @@ serde_json = "1.0"
 bloom-filters.workspace = true
 ckb-spawn.workspace = true
 bitflags.workspace = true
-p2p = { version = "0.6.2", package = "tentacle", default-features = false }
+p2p = { workspace = true, default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-p2p = { version = "0.6.2", package = "tentacle", default-features = false, features = [
+p2p = { workspace = true, default-features = false, features = [
     "upnp",
     "parking_lot",
     "openssl-vendored",
@@ -48,7 +48,7 @@ p2p = { version = "0.6.2", package = "tentacle", default-features = false, featu
 socket2 = "0.5"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-p2p = { version = "0.6.2", package = "tentacle", default-features = false, features = [
+p2p = { workspace = true, default-features = false, features = [
     "wasm-timer",
 ] }
 idb = "0.6"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -10,30 +10,30 @@ repository = "https://github.com/nervosnetwork/ckb"
 exclude = ["fuzz"]
 
 [dependencies]
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync", "macros"] }
-tokio-util = { version = "0.7", features = ["codec"] }
-futures = "0.3"
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-bs58 = { version = "0.5.0", optional = true }
-sentry = { version = "0.34.0", optional = true }
-faster-hex = { version = "0.6", optional = true }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-secp256k1 = { version = "0.30", features = ["recovery"], optional = true }
-hickory-resolver = { version = "0.24.2", optional = true }
-snap = "1"
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ipnetwork = "0.20"
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+ckb-util = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-metrics = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }
+tokio-util = { workspace = true, features = ["codec"] }
+futures = { workspace = true }
+ckb-systemtime = { workspace = true }
+bs58 = { workspace = true, optional = true }
+sentry = { workspace = true, optional = true }
+faster-hex = { workspace = true, optional = true }
+ckb-hash = { workspace = true }
+secp256k1 = { workspace = true, features = ["recovery"], optional = true }
+hickory-resolver = { workspace = true, optional = true }
+snap = { workspace = true }
+ckb-types = { workspace = true }
+ipnetwork = { workspace = true }
 serde_json = "1.0"
-bloom-filters = "0.1"
-ckb-spawn = { path = "../util/spawn", version = "= 0.201.0-pre" }
-bitflags = "1.0"
+bloom-filters = { workspace = true }
+ckb-spawn = { workspace = true }
+bitflags = { workspace = true }
 p2p = { version = "0.6.2", package = "tentacle", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -62,12 +62,10 @@ fuzz = []
 
 [dev-dependencies]
 tempfile.workspace = true
-criterion = "0.5"
-proptest = "1.0"
-num_cpus = "1.10"
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+criterion = { workspace = true }
+proptest = { workspace = true }
+num_cpus = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [[bench]]
 name = "peer_store"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -10,30 +10,30 @@ repository = "https://github.com/nervosnetwork/ckb"
 exclude = ["fuzz"]
 
 [dependencies]
-rand = { workspace = true }
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
-ckb-util = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-metrics = { workspace = true }
+ckb-util.workspace = true
+ckb-stop-handler.workspace = true
+ckb-logger.workspace = true
+ckb-app-config.workspace = true
+ckb-metrics.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 tokio-util = { workspace = true, features = ["codec"] }
-futures = { workspace = true }
-ckb-systemtime = { workspace = true }
+futures.workspace = true
+ckb-systemtime.workspace = true
 bs58 = { workspace = true, optional = true }
 sentry = { workspace = true, optional = true }
 faster-hex = { workspace = true, optional = true }
-ckb-hash = { workspace = true }
+ckb-hash.workspace = true
 secp256k1 = { workspace = true, features = ["recovery"], optional = true }
 hickory-resolver = { workspace = true, optional = true }
-snap = { workspace = true }
-ckb-types = { workspace = true }
-ipnetwork = { workspace = true }
+snap.workspace = true
+ckb-types.workspace = true
+ipnetwork.workspace = true
 serde_json = "1.0"
-bloom-filters = { workspace = true }
-ckb-spawn = { workspace = true }
-bitflags = { workspace = true }
+bloom-filters.workspace = true
+ckb-spawn.workspace = true
+bitflags.workspace = true
 p2p = { version = "0.6.2", package = "tentacle", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -62,9 +62,9 @@ fuzz = []
 
 [dev-dependencies]
 tempfile.workspace = true
-criterion = { workspace = true }
-proptest = { workspace = true }
-num_cpus = { workspace = true }
+criterion.workspace = true
+proptest.workspace = true
+num_cpus.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [[bench]]

--- a/network/fuzz/Cargo.toml
+++ b/network/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network-fuzz"
-version.workspace = true
+version = "0.201.0-pre"
 publish = false
 edition = "2024"
 license = "MIT"

--- a/network/fuzz/Cargo.toml
+++ b/network/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network-fuzz"
-version = "0.201.0-pre"
+version.workspace = true
 publish = false
 edition = "2024"
 license = "MIT"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
+ckb-logger = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-types = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-async-runtime = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { version = "1", features = ["sync"] }

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-notify"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-types = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-async-runtime = { workspace = true }
+ckb-logger.workspace = true
+ckb-app-config.workspace = true
+ckb-types.workspace = true
+ckb-stop-handler.workspace = true
+ckb-async-runtime.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { version = "1", features = ["sync"] }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = { workspace = true }
-ckb-types = { workspace = true }
-ckb-hash = { workspace = true }
+byteorder.workspace = true
+ckb-types.workspace = true
+ckb-hash.workspace = true
 serde = { workspace = true, features = ["derive"] }
-eaglesong = { workspace = true }
-log = { workspace = true }
+eaglesong.workspace = true
+log.workspace = true

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-pow"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = "1.3.1"
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre"}
-serde = { version = "1.0", features = ["derive"] }
-eaglesong = "0.1"
-log = "0.4"
+byteorder = { workspace = true }
+ckb-types = { workspace = true }
+ckb-hash = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+eaglesong = { workspace = true }
+log = { workspace = true }

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-resource"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -10,17 +10,17 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-phf = "0.8.0"
-includedir = "0.6.0"
-serde = { version = "1.0", features = ["derive"] }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-system-scripts = { version = "= 0.5.4" }
+phf = { workspace = true }
+includedir = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+ckb-types = { workspace = true }
+ckb-system-scripts = { workspace = true }
 
 [build-dependencies]
-includedir_codegen = "0.6.0"
-walkdir = "2.1.4"
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-system-scripts = { version = "= 0.5.4" }
+includedir_codegen = { workspace = true }
+walkdir = { workspace = true }
+ckb-types = { workspace = true }
+ckb-system-scripts = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-phf.workspace = true
+phf = "0.8.0" # ckb-resource's build script need this, and cargo shear think ckb don't need this
 includedir.workspace = true
 serde = { workspace = true, features = ["derive"] }
 ckb-types.workspace = true

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -10,17 +10,17 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-phf = { workspace = true }
-includedir = { workspace = true }
+phf.workspace = true
+includedir.workspace = true
 serde = { workspace = true, features = ["derive"] }
-ckb-types = { workspace = true }
-ckb-system-scripts = { workspace = true }
+ckb-types.workspace = true
+ckb-system-scripts.workspace = true
 
 [build-dependencies]
-includedir_codegen = { workspace = true }
-walkdir = { workspace = true }
-ckb-types = { workspace = true }
-ckb-system-scripts = { workspace = true }
+includedir_codegen.workspace = true
+walkdir.workspace = true
+ckb-types.workspace = true
+ckb-system-scripts.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,54 +9,54 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../notify", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-sync = { path = "../sync", version = "= 0.201.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.201.0-pre" }
-ckb-network-alert = { path = "../util/network-alert", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-jsonrpc-core = "18.0"
+ckb-chain-spec = { workspace = true }
+ckb-types = { workspace = true }
+ckb-network = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-store = { workspace = true }
+ckb-sync = { workspace = true }
+ckb-chain = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-logger-service = { workspace = true }
+ckb-network-alert = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-constant = { workspace = true }
+jsonrpc-core = { workspace = true }
 serde_json = "1.0"
-jsonrpc-utils = { version = "0.3", features = ["server", "macros", "axum"] }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.201.0-pre" }
-ckb-memory-tracker = { path = "../util/memory-tracker", version = "= 0.201.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.201.0-pre" }
-ckb-indexer = { path = "../util/indexer", version = "= 0.201.0-pre" }
-ckb-indexer-sync = { path = "../util/indexer-sync", version = "= 0.201.0-pre" }
-ckb-rich-indexer = { path = "../util/rich-indexer", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
+jsonrpc-utils = { workspace = true, features = ["server", "macros", "axum"] }
+ckb-jsonrpc-types = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-util = { workspace = true }
+ckb-systemtime = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-error = { workspace = true }
+ckb-reward-calculator = { workspace = true }
+ckb-tx-pool = { workspace = true }
+ckb-memory-tracker = { workspace = true }
+ckb-pow = { workspace = true }
+ckb-indexer = { workspace = true }
+ckb-indexer-sync = { workspace = true }
+ckb-rich-indexer = { workspace = true }
+ckb-stop-handler = { workspace = true }
 itertools.workspace = true
-tokio = "1"
-async-trait = "0.1"
-axum = "0.7"
-tokio-util = { version = "0.7.3", features = ["codec"] }
-futures-util = { version = "0.3.21" }
-tower-http = { version = "0.6", features = ["timeout", "cors"] }
-async-stream = "0.3.3"
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
+futures-util = { workspace = true }
+tower-http = { workspace = true, features = ["timeout", "cors"] }
+async-stream = { workspace = true }
+ckb-async-runtime = { workspace = true }
 schemars.workspace = true
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["blocking", "json"] }
-serde = { version = "1.0", features = ["derive"] }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde = { workspace = true, features = ["derive"] }
+ckb-shared = { workspace = true }
+ckb-test-chain-utils = { workspace = true }
 tempfile.workspace = true
-pretty_assertions = "1.3.0"
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
+pretty_assertions = { workspace = true }
+ckb-dao-utils = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rpc"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,54 +9,54 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain-spec = { workspace = true }
-ckb-types = { workspace = true }
-ckb-network = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-store = { workspace = true }
-ckb-sync = { workspace = true }
-ckb-chain = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-logger-service = { workspace = true }
-ckb-network-alert = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-constant = { workspace = true }
-jsonrpc-core = { workspace = true }
+ckb-chain-spec.workspace = true
+ckb-types.workspace = true
+ckb-network.workspace = true
+ckb-notify.workspace = true
+ckb-shared.workspace = true
+ckb-store.workspace = true
+ckb-sync.workspace = true
+ckb-chain.workspace = true
+ckb-logger.workspace = true
+ckb-logger-service.workspace = true
+ckb-network-alert.workspace = true
+ckb-app-config.workspace = true
+ckb-constant.workspace = true
+jsonrpc-core.workspace = true
 serde_json = "1.0"
 jsonrpc-utils = { workspace = true, features = ["server", "macros", "axum"] }
-ckb-jsonrpc-types = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-util = { workspace = true }
-ckb-systemtime = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-error = { workspace = true }
-ckb-reward-calculator = { workspace = true }
-ckb-tx-pool = { workspace = true }
-ckb-memory-tracker = { workspace = true }
-ckb-pow = { workspace = true }
-ckb-indexer = { workspace = true }
-ckb-indexer-sync = { workspace = true }
-ckb-rich-indexer = { workspace = true }
-ckb-stop-handler = { workspace = true }
+ckb-jsonrpc-types.workspace = true
+ckb-verification.workspace = true
+ckb-verification-traits.workspace = true
+ckb-traits.workspace = true
+ckb-util.workspace = true
+ckb-systemtime.workspace = true
+ckb-dao.workspace = true
+ckb-error.workspace = true
+ckb-reward-calculator.workspace = true
+ckb-tx-pool.workspace = true
+ckb-memory-tracker.workspace = true
+ckb-pow.workspace = true
+ckb-indexer.workspace = true
+ckb-indexer-sync.workspace = true
+ckb-rich-indexer.workspace = true
+ckb-stop-handler.workspace = true
 itertools.workspace = true
-tokio = { workspace = true }
-async-trait = { workspace = true }
-axum = { workspace = true }
+tokio.workspace = true
+async-trait.workspace = true
+axum.workspace = true
 tokio-util = { workspace = true, features = ["codec"] }
-futures-util = { workspace = true }
+futures-util.workspace = true
 tower-http = { workspace = true, features = ["timeout", "cors"] }
-async-stream = { workspace = true }
-ckb-async-runtime = { workspace = true }
+async-stream.workspace = true
+ckb-async-runtime.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking", "json"] }
 serde = { workspace = true, features = ["derive"] }
-ckb-shared = { workspace = true }
-ckb-test-chain-utils = { workspace = true }
+ckb-shared.workspace = true
+ckb-test-chain-utils.workspace = true
 tempfile.workspace = true
-pretty_assertions = { workspace = true }
-ckb-dao-utils = { workspace = true }
+pretty_assertions.workspace = true
+ckb-dao-utils.workspace = true

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -18,33 +18,33 @@ logging = ["ckb-logger"]
 flatmemory = []
 
 [dependencies]
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-byteorder = "1.3.1"
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-vm = { version = "= 0.24.13", default-features = false }
-faster-hex = "0.6"
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre", optional = true }
-serde = { version = "1.0", features = ["derive"] }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-tokio = { version = "1.35.0", features = ["sync", "macros"] }
+ckb-traits = { workspace = true }
+byteorder = { workspace = true }
+ckb-types = { workspace = true }
+ckb-hash = { workspace = true }
+ckb-vm = { workspace = true }
+faster-hex = { workspace = true }
+ckb-logger = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+ckb-error = { workspace = true }
+ckb-chain-spec = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.35.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-proptest = "1.0"
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-tiny-keccak = { version = "2.0", features = ["sha3"] }
-ckb-crypto = { path = "../util/crypto", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
+proptest = { workspace = true }
+ckb-db = { workspace = true }
+ckb-store = { workspace = true }
+ckb-test-chain-utils = { workspace = true }
+tiny-keccak = { workspace = true, features = ["sha3"] }
+ckb-crypto = { workspace = true }
+ckb-db-schema = { workspace = true }
 tempfile.workspace = true
-rand = "0.8.4"
-daggy = "0.8.0"
-molecule = "0.8.0"
+rand = { workspace = true }
+daggy = { workspace = true }
+molecule = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_asm)'] }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -18,33 +18,33 @@ logging = ["ckb-logger"]
 flatmemory = []
 
 [dependencies]
-ckb-traits = { workspace = true }
-byteorder = { workspace = true }
-ckb-types = { workspace = true }
-ckb-hash = { workspace = true }
-ckb-vm = { workspace = true }
-faster-hex = { workspace = true }
+ckb-traits.workspace = true
+byteorder.workspace = true
+ckb-types.workspace = true
+ckb-hash.workspace = true
+ckb-vm.workspace = true
+faster-hex.workspace = true
 ckb-logger = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-ckb-error = { workspace = true }
-ckb-chain-spec = { workspace = true }
+ckb-error.workspace = true
+ckb-chain-spec.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.35.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-proptest = { workspace = true }
-ckb-db = { workspace = true }
-ckb-store = { workspace = true }
-ckb-test-chain-utils = { workspace = true }
+proptest.workspace = true
+ckb-db.workspace = true
+ckb-store.workspace = true
+ckb-test-chain-utils.workspace = true
 tiny-keccak = { workspace = true, features = ["sha3"] }
-ckb-crypto = { workspace = true }
-ckb-db-schema = { workspace = true }
+ckb-crypto.workspace = true
+ckb-db-schema.workspace = true
 tempfile.workspace = true
-rand = { workspace = true }
-daggy = { workspace = true }
-molecule = { workspace = true }
+rand.workspace = true
+daggy.workspace = true
+molecule.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_asm)'] }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-script"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/script/fuzz/Cargo.toml
+++ b/script/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-script-fuzz"
-version.workspace = true
+version = "0.201.0-pre"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/script/fuzz/Cargo.toml
+++ b/script/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-script-fuzz"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/script/fuzz/Cargo.toml
+++ b/script/fuzz/Cargo.toml
@@ -15,10 +15,10 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = { version="0.4.0", features=["arbitrary-derive"] }
-ckb-traits = { path = "../../traits", version = "= 0.201.0-pre" }
-ckb-types = { path = "../../util/types", version = "= 0.201.0-pre" }
-ckb-script = { path = "../../script", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
+ckb-traits = { path = "../../traits" }
+ckb-types = { path = "../../util/types" }
+ckb-script = { path = "../../script" }
+ckb-chain-spec = { path = "../../spec" }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,39 +9,37 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.201.0-pre" }
-arc-swap = "1.3"
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-snapshot = { path = "../util/snapshot", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../notify", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-migrate = { path = "../util/migrate", version = "= 0.201.0-pre" }
-ckb-fee-estimator = { path = "../util/fee-estimator", version = "= 0.201.0-pre"}
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-bitflags = "1.0"
-tokio = { version = "1", features = ["sync"] }
+ckb-types = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-store = { workspace = true }
+ckb-db = { workspace = true }
+ckb-proposal-table = { workspace = true }
+arc-swap = { workspace = true }
+ckb-error = { workspace = true }
+ckb-snapshot = { workspace = true }
+ckb-tx-pool = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-constant = { workspace = true }
+ckb-systemtime = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-migrate = { workspace = true }
+ckb-fee-estimator = { workspace = true }
+ckb-util = { workspace = true }
+ckb-metrics = { workspace = true }
+bitflags = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tempfile.workspace = true
-sled = "0.34.7"
-dashmap = "4.0"
+sled = { workspace = true }
+dashmap = { workspace = true }
 
 [dev-dependencies]
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [features]
 portable = [

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,34 +9,34 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-store = { workspace = true }
-ckb-db = { workspace = true }
-ckb-proposal-table = { workspace = true }
-arc-swap = { workspace = true }
-ckb-error = { workspace = true }
-ckb-snapshot = { workspace = true }
-ckb-tx-pool = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-constant = { workspace = true }
-ckb-systemtime = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-migrate = { workspace = true }
-ckb-fee-estimator = { workspace = true }
-ckb-util = { workspace = true }
-ckb-metrics = { workspace = true }
-bitflags = { workspace = true }
+ckb-types.workspace = true
+ckb-chain-spec.workspace = true
+ckb-store.workspace = true
+ckb-db.workspace = true
+ckb-proposal-table.workspace = true
+arc-swap.workspace = true
+ckb-error.workspace = true
+ckb-snapshot.workspace = true
+ckb-tx-pool.workspace = true
+ckb-verification.workspace = true
+ckb-notify.workspace = true
+ckb-logger.workspace = true
+ckb-db-schema.workspace = true
+ckb-async-runtime.workspace = true
+ckb-stop-handler.workspace = true
+ckb-constant.workspace = true
+ckb-systemtime.workspace = true
+ckb-channel.workspace = true
+ckb-app-config.workspace = true
+ckb-migrate.workspace = true
+ckb-fee-estimator.workspace = true
+ckb-util.workspace = true
+ckb-metrics.workspace = true
+bitflags.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tempfile.workspace = true
-sled = { workspace = true }
-dashmap = { workspace = true }
+sled.workspace = true
+dashmap.workspace = true
 
 [dev-dependencies]
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-shared"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-toml = { workspace = true }
-ckb-constant = { workspace = true }
-ckb-types = { workspace = true }
-ckb-pow = { workspace = true }
-ckb-resource = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-rational = { workspace = true }
-ckb-crypto = { workspace = true }
-ckb-hash = { workspace = true }
-ckb-error = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-logger = { workspace = true }
+toml.workspace = true
+ckb-constant.workspace = true
+ckb-types.workspace = true
+ckb-pow.workspace = true
+ckb-resource.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-dao-utils.workspace = true
+ckb-rational.workspace = true
+ckb-crypto.workspace = true
+ckb-hash.workspace = true
+ckb-error.workspace = true
+ckb-traits.workspace = true
+ckb-logger.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 cacache = { version = "13.0.0", default-features = false, features = [

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -9,20 +9,20 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-rational = { path = "../util/rational", version = "= 0.201.0-pre" }
-ckb-crypto = { path = "../util/crypto", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+ckb-constant = { workspace = true }
+ckb-types = { workspace = true }
+ckb-pow = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-rational = { workspace = true }
+ckb-crypto = { workspace = true }
+ckb-hash = { workspace = true }
+ckb-error = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-logger = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 cacache = { version = "13.0.0", default-features = false, features = [

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-spec"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -9,17 +9,17 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-lru = "0.7.1"
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../db-schema", version = "= 0.201.0-pre" }
-ckb-freezer = { path = "../freezer", version = "= 0.201.0-pre" }
-ckb-merkle-mountain-range = "0.5.2"
+ckb-types = { workspace = true }
+ckb-db = { workspace = true }
+ckb-chain-spec = { workspace = true }
+lru = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-util = { workspace = true }
+ckb-error = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-freezer = { workspace = true }
+ckb-merkle-mountain-range = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -9,17 +9,17 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-db = { workspace = true }
-ckb-chain-spec = { workspace = true }
-lru = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-util = { workspace = true }
-ckb-error = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-freezer = { workspace = true }
-ckb-merkle-mountain-range = { workspace = true }
+ckb-types.workspace = true
+ckb-db.workspace = true
+ckb-chain-spec.workspace = true
+lru.workspace = true
+ckb-traits.workspace = true
+ckb-util.workspace = true
+ckb-error.workspace = true
+ckb-app-config.workspace = true
+ckb-db-schema.workspace = true
+ckb-freezer.workspace = true
+ckb-merkle-mountain-range.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-store"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sync"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -9,50 +9,46 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain = { path = "../chain", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../verification/traits", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../tx-pool", version = "= 0.201.0-pre" }
-sentry = { version = "0.34.0", optional = true }
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync"] }
-lru = "0.7.1"
-futures = "0.3"
-governor = "0.3.1"
+ckb-chain = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-store = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-types = { workspace = true }
+ckb-network = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-metrics = { workspace = true }
+ckb-util = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-error = { workspace = true }
+ckb-tx-pool = { workspace = true }
+sentry = { workspace = true, optional = true }
+ckb-constant = { workspace = true }
+ckb-stop-handler = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+lru = { workspace = true }
+futures = { workspace = true }
+governor = { workspace = true }
 tempfile.workspace = true
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-dashmap = "4.0"
-keyed_priority_queue = "0.3"
+ckb-systemtime = { workspace = true }
+dashmap = { workspace = true }
+keyed_priority_queue = { workspace = true }
 itertools.workspace = true
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-rand = "0.8"
-ckb-dao = { path = "../util/dao", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.201.0-pre" }
-ckb-chain = { path = "../chain", version = "= 0.201.0-pre", features = [
-    "mock",
-] }
-faux = "^0.1"
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
-ckb-proposal-table = { path = "../util/proposal-table", version = "= 0.201.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.201.0-pre" }
+ckb-test-chain-utils = { workspace = true }
+rand = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-reward-calculator = { workspace = true }
+ckb-chain = { workspace = true, features = ["mock"] }
+faux = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
+ckb-proposal-table = { workspace = true }
+ckb-logger-service = { workspace = true }
 
 [features]
 default = []

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -9,46 +9,46 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-chain = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-store = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-types = { workspace = true }
-ckb-network = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-metrics = { workspace = true }
-ckb-util = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-error = { workspace = true }
-ckb-tx-pool = { workspace = true }
+ckb-chain.workspace = true
+ckb-shared.workspace = true
+ckb-store.workspace = true
+ckb-app-config.workspace = true
+ckb-types.workspace = true
+ckb-network.workspace = true
+ckb-logger.workspace = true
+ckb-metrics.workspace = true
+ckb-util.workspace = true
+ckb-verification.workspace = true
+ckb-verification-traits.workspace = true
+ckb-chain-spec.workspace = true
+ckb-channel.workspace = true
+ckb-traits.workspace = true
+ckb-error.workspace = true
+ckb-tx-pool.workspace = true
 sentry = { workspace = true, optional = true }
-ckb-constant = { workspace = true }
-ckb-stop-handler = { workspace = true }
+ckb-constant.workspace = true
+ckb-stop-handler.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-lru = { workspace = true }
-futures = { workspace = true }
-governor = { workspace = true }
+lru.workspace = true
+futures.workspace = true
+governor.workspace = true
 tempfile.workspace = true
-ckb-systemtime = { workspace = true }
-dashmap = { workspace = true }
-keyed_priority_queue = { workspace = true }
+ckb-systemtime.workspace = true
+dashmap.workspace = true
+keyed_priority_queue.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-ckb-test-chain-utils = { workspace = true }
-rand = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-reward-calculator = { workspace = true }
+ckb-test-chain-utils.workspace = true
+rand.workspace = true
+ckb-dao.workspace = true
+ckb-dao-utils.workspace = true
+ckb-reward-calculator.workspace = true
 ckb-chain = { workspace = true, features = ["mock"] }
-faux = { workspace = true }
+faux.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
-ckb-proposal-table = { workspace = true }
-ckb-logger-service = { workspace = true }
+ckb-proposal-table.workspace = true
+ckb-logger-service.workspace = true
 
 [features]
 default = []

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,31 +11,31 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 clap = { version = "4" }
 toml = "0.5.0"
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-crypto = { path = "../util/crypto", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-logger-config = { path = "../util/logger-config", version = "= 0.201.0-pre" }
-ckb-logger-service = { path = "../util/logger-service", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-ckb-constant = { path = "../util/constant", version = "= 0.201.0-pre" }
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../shared", version = "= 0.201.0-pre" }
+ckb-jsonrpc-types = { path = "../util/jsonrpc-types" }
+ckb-app-config = { path = "../util/app-config" }
+ckb-network = { path = "../network" }
+ckb-channel = { path = "../util/channel" }
+ckb-types = { path = "../util/types" }
+ckb-hash = { path = "../util/hash" }
+ckb-util = { path = "../util" }
+ckb-chain-spec = { path = "../spec" }
+ckb-crypto = { path = "../util/crypto" }
+ckb-dao-utils = { path = "../util/dao/utils" }
+ckb-test-chain-utils = { path = "../util/test-chain-utils" }
+ckb-resource = { path = "../resource" }
+ckb-async-runtime = { path = "../util/runtime" }
+ckb-logger = { path = "../util/logger" }
+ckb-logger-config = { path = "../util/logger-config" }
+ckb-logger-service = { path = "../util/logger-service" }
+ckb-error = { path = "../error" }
+ckb-constant = { path = "../util/constant" }
+ckb-db = { path = "../db" }
+ckb-store = { path = "../store" }
+ckb-shared = { path = "../shared" }
 tempfile = "3"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 rand = "0.8"
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
+ckb-systemtime = { path = "../util/systemtime" }
 serde_json = "1.0"
 byteorder = "1.3.1"
 jsonrpc-core = "18.0"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
+ckb-types.workspace = true

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-traits"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -11,48 +11,46 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../util/logger", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../verification", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-lru = "0.7.1"
-num_cpus = "1.16.0"
+ckb-types = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-systemtime = { workspace = true }
+lru = { workspace = true }
+num_cpus = { workspace = true }
 
-ckb-dao = { path = "../util/dao", version = "= 0.201.0-pre" }
-ckb-reward-calculator = { path = "../util/reward-calculator", version = "= 0.201.0-pre" }
-ckb-store = { path = "../store", version = "= 0.201.0-pre" }
-ckb-util = { path = "../util", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../util/jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-snapshot = { path = "../util/snapshot", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../util/metrics", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync", "process"] }
-ckb-async-runtime = { path = "../util/runtime", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../util/stop-handler", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../util/app-config", version = "= 0.201.0-pre" }
-ckb-network = { path = "../network", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../util/channel", version = "= 0.201.0-pre" }
-ckb-db = { path = "../db", version = "= 0.201.0-pre" }
-ckb-script = { path = "../script", version = "= 0.201.0-pre" }
-sentry = { version = "0.34.0", optional = true }
+ckb-dao = { workspace = true }
+ckb-reward-calculator = { workspace = true }
+ckb-store = { workspace = true }
+ckb-util = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-snapshot = { workspace = true }
+ckb-metrics = { workspace = true }
+ckb-error = { workspace = true }
+tokio = { workspace = true, features = ["sync", "process"] }
+ckb-async-runtime = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-network = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-db = { workspace = true }
+ckb-script = { workspace = true }
+sentry = { workspace = true, optional = true }
 serde_json = "1.0"
-rand = "0.8.4"
-hyper = { version = "1", features = ["http1", "http2", "client"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2"] }
-http-body-util = "0.1"
-multi_index_map = "0.6.0"
-slab = "0.4"
-rustc-hash = "1.1"
-tokio-util = "0.7.8"
-ckb-fee-estimator = { path = "../util/fee-estimator", version = "= 0.201.0-pre" }
+rand = { workspace = true }
+hyper = { workspace = true, features = ["http1", "http2", "client"] }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"] }
+http-body-util = { workspace = true }
+multi_index_map = { workspace = true }
+slab = { workspace = true }
+rustc-hash = { workspace = true }
+tokio-util = { workspace = true }
+ckb-fee-estimator = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
-ckb-hash = { path = "../util/hash", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+ckb-hash = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [features]
 default = []

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -11,45 +11,45 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-systemtime = { workspace = true }
-lru = { workspace = true }
-num_cpus = { workspace = true }
+ckb-types.workspace = true
+ckb-logger.workspace = true
+ckb-verification.workspace = true
+ckb-systemtime.workspace = true
+lru.workspace = true
+num_cpus.workspace = true
 
-ckb-dao = { workspace = true }
-ckb-reward-calculator = { workspace = true }
-ckb-store = { workspace = true }
-ckb-util = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-snapshot = { workspace = true }
-ckb-metrics = { workspace = true }
-ckb-error = { workspace = true }
+ckb-dao.workspace = true
+ckb-reward-calculator.workspace = true
+ckb-store.workspace = true
+ckb-util.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-chain-spec.workspace = true
+ckb-snapshot.workspace = true
+ckb-metrics.workspace = true
+ckb-error.workspace = true
 tokio = { workspace = true, features = ["sync", "process"] }
-ckb-async-runtime = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-network = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-db = { workspace = true }
-ckb-script = { workspace = true }
+ckb-async-runtime.workspace = true
+ckb-stop-handler.workspace = true
+ckb-app-config.workspace = true
+ckb-network.workspace = true
+ckb-channel.workspace = true
+ckb-db.workspace = true
+ckb-script.workspace = true
 sentry = { workspace = true, optional = true }
 serde_json = "1.0"
-rand = { workspace = true }
+rand.workspace = true
 hyper = { workspace = true, features = ["http1", "http2", "client"] }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"] }
-http-body-util = { workspace = true }
-multi_index_map = { workspace = true }
-slab = { workspace = true }
-rustc-hash = { workspace = true }
-tokio-util = { workspace = true }
-ckb-fee-estimator = { workspace = true }
+http-body-util.workspace = true
+multi_index_map.workspace = true
+slab.workspace = true
+rustc-hash.workspace = true
+tokio-util.workspace = true
+ckb-fee-estimator.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-ckb-hash = { workspace = true }
+ckb-hash.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [features]

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-tx-pool"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-parking_lot = "0.12"
-linked-hash-map = { version = "0.5", features = ["serde_impl"] }
-regex = "1.1.6"
+parking_lot = { workspace = true }
+linked-hash-map = { workspace = true, features = ["serde_impl"] }
+regex = { workspace = true }
 
 [dev-dependencies]
-ckb-fixed-hash = { path = "fixed-hash", version = "= 0.201.0-pre" }
+ckb-fixed-hash = { workspace = true }
 
 [features]
 deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-util"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-parking_lot = { workspace = true }
+parking_lot.workspace = true
 linked-hash-map = { workspace = true, features = ["serde_impl"] }
-regex = { workspace = true }
+regex.workspace = true
 
 [dev-dependencies]
-ckb-fixed-hash = { workspace = true }
+ckb-fixed-hash.workspace = true
 
 [features]
 deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-app-config"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -9,32 +9,30 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-toml = "0.5"
-path-clean = "0.1.0"
-ckb-logger = { path = "../../util/logger", version = "= 0.201.0-pre" }
-ckb-logger-config = { path = "../../util/logger-config", version = "= 0.201.0-pre" }
-ckb-metrics-config = { path = "../../util/metrics-config", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-pow = { path = "../../pow", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../../resource", version = "= 0.201.0-pre" }
-ckb-build-info = { path = "../build-info", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
+toml = { workspace = true }
+path-clean = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-logger-config = { workspace = true }
+ckb-metrics-config = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-pow = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-build-info = { workspace = true }
+ckb-types = { workspace = true }
 secio = { version = "0.6", package = "tentacle-secio" }
 multiaddr = { version = "0.3.0", package = "tentacle-multiaddr" }
-rand = "0.8"
-sentry = { version = "0.34.0", optional = true }
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre" }
-url = { version = "2.2.2", features = ["serde"] }
-ubyte = { version = "0.10", features = ["serde"] }
+rand = { workspace = true }
+sentry = { workspace = true, optional = true }
+ckb-systemtime = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+ubyte = { workspace = true, features = ["serde"] }
 
 [features]
 with_sentry = ["sentry"]
 
 [dev-dependencies]
 tempfile.workspace = true
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -22,8 +22,8 @@ ckb-pow.workspace = true
 ckb-resource.workspace = true
 ckb-build-info.workspace = true
 ckb-types.workspace = true
-secio = { version = "0.6", package = "tentacle-secio" }
-multiaddr = { version = "0.3.0", package = "tentacle-multiaddr" }
+secio.workspace = true
+multiaddr.workspace = true
 rand.workspace = true
 sentry = { workspace = true, optional = true }
 ckb-systemtime.workspace = true

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -11,22 +11,22 @@ repository = "https://github.com/nervosnetwork/ckb"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-toml = { workspace = true }
-path-clean = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-logger-config = { workspace = true }
-ckb-metrics-config = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-pow = { workspace = true }
-ckb-resource = { workspace = true }
-ckb-build-info = { workspace = true }
-ckb-types = { workspace = true }
+toml.workspace = true
+path-clean.workspace = true
+ckb-logger.workspace = true
+ckb-logger-config.workspace = true
+ckb-metrics-config.workspace = true
+ckb-chain-spec.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-pow.workspace = true
+ckb-resource.workspace = true
+ckb-build-info.workspace = true
+ckb-types.workspace = true
 secio = { version = "0.6", package = "tentacle-secio" }
 multiaddr = { version = "0.3.0", package = "tentacle-multiaddr" }
-rand = { workspace = true }
+rand.workspace = true
 sentry = { workspace = true, optional = true }
-ckb-systemtime = { workspace = true }
+ckb-systemtime.workspace = true
 url = { workspace = true, features = ["serde"] }
 ubyte = { workspace = true, features = ["serde"] }
 

--- a/util/build-info/Cargo.toml
+++ b/util/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-build-info"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-iter"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
+ckb-types.workspace = true
+ckb-store.workspace = true

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-channel"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = { workspace = true }
+crossbeam-channel.workspace = true

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = "0.5.1"
+crossbeam-channel = { workspace = true }

--- a/util/constant/Cargo.toml
+++ b/util/constant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-constant"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash = { workspace = true }
+ckb-fixed-hash.workspace = true
 secp256k1 = { workspace = true, features = ["recovery"], optional = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
-faster-hex = { workspace = true }
+faster-hex.workspace = true
 
 [features]
 default = ["secp"]

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.201.0-pre" }
-secp256k1 = { version = "0.30", features = ["recovery"], optional = true }
-thiserror = "1.0.22"
-rand = { version = "0.8", features = ["small_rng"] }
-faster-hex = "0.6"
+ckb-fixed-hash = { workspace = true }
+secp256k1 = { workspace = true, features = ["recovery"], optional = true }
+thiserror = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
+faster-hex = { workspace = true }
 
 [features]
 default = ["secp"]

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-crypto"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = "1.3.1"
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "./utils", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.201.0-pre" }
+byteorder = { workspace = true }
+ckb-types = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-traits = { workspace = true }
 
 [dev-dependencies]
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
+ckb-db = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-store = { workspace = true }
 tempfile.workspace = true

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = { workspace = true }
-ckb-types = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-traits = { workspace = true }
+byteorder.workspace = true
+ckb-types.workspace = true
+ckb-chain-spec.workspace = true
+ckb-dao-utils.workspace = true
+ckb-traits.workspace = true
 
 [dev-dependencies]
-ckb-db = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-store = { workspace = true }
+ckb-db.workspace = true
+ckb-db-schema.workspace = true
+ckb-store.workspace = true
 tempfile.workspace = true

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao-utils"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -9,6 +9,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = "1.3.1"
-ckb-types = { path = "../../types", version = "= 0.201.0-pre" }
-ckb-error = { path = "../../../error", version = "= 0.201.0-pre" }
+byteorder = { workspace = true }
+ckb-types = { workspace = true }
+ckb-error = { workspace = true }

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -9,6 +9,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-byteorder = { workspace = true }
-ckb-types = { workspace = true }
-ckb-error = { workspace = true }
+byteorder.workspace = true
+ckb-types.workspace = true
+ckb-error.workspace = true

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-util = { path = "../../util", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-thiserror = "1.0"
+ckb-logger = { workspace = true }
+ckb-types = { workspace = true }
+ckb-util = { workspace = true }
+ckb-chain-spec = { workspace = true }
+thiserror = { workspace = true }

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-types = { workspace = true }
-ckb-util = { workspace = true }
-ckb-chain-spec = { workspace = true }
-thiserror = { workspace = true }
+ckb-logger.workspace = true
+ckb-types.workspace = true
+ckb-util.workspace = true
+ckb-chain-spec.workspace = true
+thiserror.workspace = true

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fee-estimator"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash-core = { path = "core", version = "= 0.201.0-pre" }
-ckb-fixed-hash-macros = { path = "macros", version = "= 0.201.0-pre" }
+ckb-fixed-hash-core = { workspace = true }
+ckb-fixed-hash-macros = { workspace = true }

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-fixed-hash-core = { workspace = true }
-ckb-fixed-hash-macros = { workspace = true }
+ckb-fixed-hash-core.workspace = true
+ckb-fixed-hash-macros.workspace = true

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-thiserror = { workspace = true }
+thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }
-faster-hex = { workspace = true }
+faster-hex.workspace = true
 schemars.workspace = true
 
 

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-core"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-thiserror = "1.0.22"
-serde = { version = "1.0", features = ["derive"] }
-faster-hex = "0.6"
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+faster-hex = { workspace = true }
 schemars.workspace = true
 
 

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-ckb-fixed-hash-core = { path = "../core", version = "= 0.201.0-pre" }
-quote = "1.0"
+ckb-fixed-hash-core = { workspace = true }
+quote = { workspace = true }
 syn = "1.0"
-proc-macro2 = "1.0"
+proc-macro2 = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["ckb-fixed-hash-core"]

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-ckb-fixed-hash-core = { workspace = true }
-quote = { workspace = true }
+ckb-fixed-hash-core.workspace = true
+quote.workspace = true
 syn = "1.0"
-proc-macro2 = { workspace = true }
+proc-macro2.workspace = true
 
 [package.metadata.cargo-shear]
 ignored = ["ckb-fixed-hash-core"]

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-macros"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dev-dependencies]
-ckb-hash = { workspace = true }
+ckb-hash.workspace = true
 
 [features]
 default = ["std"]
@@ -30,8 +30,8 @@ std = [
 ]
 
 [dependencies]
-cfg-if = { workspace = true }
-molecule = { workspace = true }
+cfg-if.workspace = true
+molecule.workspace = true
 ckb-hash = { workspace = true, optional = true }
 ckb-fixed-hash = { workspace = true, optional = true }
 ckb-error = { workspace = true, optional = true }

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dev-dependencies]
-ckb-hash = { path = "../hash", version = "= 0.201.0-pre" }
+ckb-hash = { workspace = true }
 
 [features]
 default = ["std"]
@@ -30,14 +30,10 @@ std = [
 ]
 
 [dependencies]
-cfg-if = "1.0"
-molecule = { version = "0.8", default-features = false }
-ckb-hash = { path = "../hash", version = "= 0.201.0-pre", default-features = false, optional = true }
-ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.201.0-pre", optional = true }
-ckb-error = { path = "../../error", version = "= 0.201.0-pre", optional = true }
-ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.201.0-pre", optional = true }
-numext-fixed-uint = { version = "0.1", features = [
-    "support_rand",
-    "support_heapsize",
-    "support_serde",
-], optional = true }
+cfg-if = { workspace = true }
+molecule = { workspace = true }
+ckb-hash = { workspace = true, optional = true }
+ckb-fixed-hash = { workspace = true, optional = true }
+ckb-error = { workspace = true, optional = true }
+ckb-occupied-capacity = { workspace = true, optional = true }
+numext-fixed-uint = { workspace = true, features = ["support_rand", "support_heapsize", "support_serde"], optional = true }

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-gen-types"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -21,4 +21,4 @@ blake2b-rs = { version = "0.2", optional = true }
 blake2b-ref = { version = "0.3", optional = true }
 
 [dependencies]
-blake2b-ref = { version = "0.3", optional = true }
+blake2b-ref = { workspace = true, optional = true }

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-hash"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -11,17 +11,17 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-app-config = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-stop-handler = { workspace = true }
-ckb-store = { workspace = true }
-ckb-types = { workspace = true }
-numext-fixed-uint = { workspace = true }
+ckb-app-config.workspace = true
+ckb-async-runtime.workspace = true
+ckb-db-schema.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-logger.workspace = true
+ckb-notify.workspace = true
+ckb-stop-handler.workspace = true
+ckb-store.workspace = true
+ckb-types.workspace = true
+numext-fixed-uint.workspace = true
 rhai = { workspace = true, features = ["no_function", "no_float", "no_module", "sync"] }
 rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
 serde_json = "1.0"
-thiserror = { workspace = true }
+thiserror.workspace = true

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -11,17 +11,17 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.201.0-pre" }
-ckb-stop-handler = { path = "../stop-handler", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-numext-fixed-uint = "0.1"
-rhai = { version = "1.16.0", features = ["no_function", "no_float", "no_module", "sync"]}
+ckb-app-config = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-stop-handler = { workspace = true }
+ckb-store = { workspace = true }
+ckb-types = { workspace = true }
+numext-fixed-uint = { workspace = true }
+rhai = { workspace = true, features = ["no_function", "no_float", "no_module", "sync"] }
 rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = { workspace = true }

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -22,6 +22,6 @@ ckb-store.workspace = true
 ckb-types.workspace = true
 numext-fixed-uint.workspace = true
 rhai = { workspace = true, features = ["no_function", "no_float", "no_module", "sync"] }
-rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
+rocksdb = { workspace = true, features = ["snappy"], default-features = false }
 serde_json = "1.0"
 thiserror.workspace = true

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-indexer-sync"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-indexer-sync = { path = "../indexer-sync", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-indexer-sync = { workspace = true }
 rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
-memchr = "2.7"
+memchr = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
-rand = "0.8"
-faster-hex = "0.6"
+rand = { workspace = true }
+faster-hex = { workspace = true }

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-indexer-sync = { workspace = true }
+ckb-types.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-app-config.workspace = true
+ckb-notify.workspace = true
+ckb-async-runtime.workspace = true
+ckb-indexer-sync.workspace = true
 rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
-memchr = { workspace = true }
+memchr.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-rand = { workspace = true }
-faster-hex = { workspace = true }
+rand.workspace = true
+faster-hex.workspace = true

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -17,7 +17,7 @@ ckb-app-config.workspace = true
 ckb-notify.workspace = true
 ckb-async-runtime.workspace = true
 ckb-indexer-sync.workspace = true
-rocksdb = { package = "ckb-rocksdb", version ="=0.21.1", features = ["snappy"], default-features = false }
+rocksdb = { workspace = true, features = ["snappy"], default-features = false }
 memchr.workspace = true
 
 [dev-dependencies]

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-indexer"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-chain = { workspace = true }
-ckb-chain-iter = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
+ckb-types.workspace = true
+ckb-chain.workspace = true
+ckb-chain-iter.workspace = true
+ckb-shared.workspace = true
+ckb-jsonrpc-types.workspace = true
 serde_json = "1.0"
 indicatif = { workspace = true, optional = true }
 

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -9,13 +9,13 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-chain = { path = "../../chain", version = "= 0.201.0-pre" }
-ckb-chain-iter = { path = "../chain-iter", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }
+ckb-chain = { workspace = true }
+ckb-chain-iter = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
 serde_json = "1.0"
-indicatif = { version = "0.16", optional = true }
+indicatif = { workspace = true, optional = true }
 
 [features]
 progress_bar = ["indicatif"]

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-instrument"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -9,13 +9,13 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-serde = { version = "1.0", features = ["derive"] }
+ckb-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-faster-hex = "0.6"
+faster-hex = { workspace = true }
 schemars.workspace = true
 
 
 [dev-dependencies]
-proptest = "1.0"
-regex = "1.1"
+proptest = { workspace = true }
+regex = { workspace = true }

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -9,13 +9,13 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
+ckb-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-faster-hex = { workspace = true }
+faster-hex.workspace = true
 schemars.workspace = true
 
 
 [dev-dependencies]
-proptest = { workspace = true }
-regex = { workspace = true }
+proptest.workspace = true
+regex.workspace = true

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-jsonrpc-types"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-launcher"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -11,26 +11,26 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-build-info = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-chain = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-network = { workspace = true }
-ckb-rpc = { workspace = true }
-ckb-resource = { workspace = true }
-ckb-network-alert = { workspace = true }
-ckb-sync = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-tx-pool = { workspace = true }
-ckb-light-client-protocol-server = { workspace = true }
-ckb-block-filter = { workspace = true }
+ckb-types.workspace = true
+ckb-store.workspace = true
+ckb-app-config.workspace = true
+ckb-logger.workspace = true
+ckb-build-info.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-chain.workspace = true
+ckb-shared.workspace = true
+ckb-network.workspace = true
+ckb-rpc.workspace = true
+ckb-resource.workspace = true
+ckb-network-alert.workspace = true
+ckb-sync.workspace = true
+ckb-verification.workspace = true
+ckb-verification-traits.workspace = true
+ckb-async-runtime.workspace = true
+ckb-channel.workspace = true
+ckb-tx-pool.workspace = true
+ckb-light-client-protocol-server.workspace = true
+ckb-block-filter.workspace = true
 
 [features]
 with_sentry = [

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -11,26 +11,26 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-build-info = { path = "../build-info", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-chain = { path = "../../chain", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.201.0-pre" }
-ckb-network = { path = "../../network", version = "= 0.201.0-pre" }
-ckb-rpc = { path = "../../rpc", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../../resource", version = "= 0.201.0-pre" }
-ckb-network-alert = { path = "../network-alert", version = "= 0.201.0-pre" }
-ckb-sync = { path = "../../sync", version = "= 0.201.0-pre" }
-ckb-verification = { path = "../../verification", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../../verification/traits", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../../tx-pool", version = "= 0.201.0-pre" }
-ckb-light-client-protocol-server = { path = "../light-client-protocol-server", version = "= 0.201.0-pre" }
-ckb-block-filter = { path = "../../block-filter", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-build-info = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-chain = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-network = { workspace = true }
+ckb-rpc = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-network-alert = { workspace = true }
+ckb-sync = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-tx-pool = { workspace = true }
+ckb-light-client-protocol-server = { workspace = true }
+ckb-block-filter = { workspace = true }
 
 [features]
 with_sentry = [

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -9,22 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-network = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
-ckb-merkle-mountain-range = { workspace = true }
-ckb-systemtime = { workspace = true }
+ckb-network.workspace = true
+ckb-shared.workspace = true
+ckb-logger.workspace = true
+ckb-types.workspace = true
+ckb-store.workspace = true
+ckb-merkle-mountain-range.workspace = true
+ckb-systemtime.workspace = true
 
 [dev-dependencies]
-ckb-chain = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-tx-pool = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-test-chain-utils = { workspace = true }
+ckb-chain.workspace = true
+ckb-chain-spec.workspace = true
+ckb-tx-pool.workspace = true
+ckb-app-config.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-dao-utils.workspace = true
+ckb-test-chain-utils.workspace = true
 tempfile.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
-tokio = { workspace = true }
+tokio.workspace = true

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client-protocol-server"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -9,22 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-network = { path = "../../network", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-merkle-mountain-range = "0.5.2"
-ckb-systemtime = {path = "../systemtime", version = "= 0.201.0-pre"}
+ckb-network = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }
+ckb-merkle-mountain-range = { workspace = true }
+ckb-systemtime = { workspace = true }
 
 [dev-dependencies]
-ckb-chain = { path = "../../chain", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-tx-pool = { path = "../../tx-pool", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../dao/utils", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../test-chain-utils", version = "= 0.201.0-pre" }
+ckb-chain = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-tx-pool = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-test-chain-utils = { workspace = true }
 tempfile.workspace = true
-ckb-systemtime = {path = "../systemtime", version = "= 0.201.0-pre", features = ["enable_faketime"]}
-tokio = "1.20"
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
+tokio = { workspace = true }

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/nervosnetwork/ckb"
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-toml = { workspace = true }
+toml.workspace = true

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-toml = "0.5"
+toml = { workspace = true }

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-config"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -9,19 +9,19 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-util = { path = "..", version = "= 0.201.0-pre" }
-ckb-logger-config = { path = "../logger-config", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.201.0-pre" }
-yansi = "0.5"
-log = "0.4"
-env_logger = "0.10"
-regex = "1.1.6"
-backtrace = "0.3"
-sentry = { version = "0.34.0", optional = true, features = ["log"] }
-time = { version = "0.3.36", features = ["formatting"] }
+ckb-util = { workspace = true }
+ckb-logger-config = { workspace = true }
+ckb-channel = { workspace = true }
+yansi = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+regex = { workspace = true }
+backtrace = { workspace = true }
+sentry = { workspace = true, features = ["log"], optional = true }
+time = { workspace = true, features = ["formatting"] }
 
 [dev-dependencies]
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
+ckb-logger = { workspace = true }
 tempfile.workspace = true
 
 [features]

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -9,19 +9,19 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-util = { workspace = true }
-ckb-logger-config = { workspace = true }
-ckb-channel = { workspace = true }
-yansi = { workspace = true }
-log = { workspace = true }
-env_logger = { workspace = true }
-regex = { workspace = true }
-backtrace = { workspace = true }
+ckb-util.workspace = true
+ckb-logger-config.workspace = true
+ckb-channel.workspace = true
+yansi.workspace = true
+log.workspace = true
+env_logger.workspace = true
+regex.workspace = true
+backtrace.workspace = true
 sentry = { workspace = true, features = ["log"], optional = true }
 time = { workspace = true, features = ["formatting"] }
 
 [dev-dependencies]
-ckb-logger = { workspace = true }
+ckb-logger.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-service"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-log = { workspace = true }
+log.workspace = true

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-log = "0.4"
+log = { workspace = true }

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-memory-tracker"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-metrics = { workspace = true }
-ckb-db = { workspace = true }
+ckb-logger.workspace = true
+ckb-metrics.workspace = true
+ckb-db.workspace = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.5.0" }

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../metrics", version = "= 0.201.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
+ckb-logger = { workspace = true }
+ckb-metrics = { workspace = true }
+ckb-db = { workspace = true }
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.5.0" }

--- a/util/metrics-config/Cargo.toml
+++ b/util/metrics-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-config"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics-config/Cargo.toml
+++ b/util/metrics-config/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-service"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-metrics-config = { workspace = true }
-ckb-metrics = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-util = { workspace = true }
-prometheus = { workspace = true }
+ckb-metrics-config.workspace = true
+ckb-metrics.workspace = true
+ckb-logger.workspace = true
+ckb-async-runtime.workspace = true
+ckb-util.workspace = true
+prometheus.workspace = true
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
-http-body-util = { workspace = true }
+http-body-util.workspace = true
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful"] }
-ckb-stop-handler = { workspace = true }
+ckb-stop-handler.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-metrics-config = { path = "../metrics-config", version = "= 0.201.0-pre" }
-ckb-metrics = { path = "../metrics", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-util = { path = "..", version = "= 0.201.0-pre" }
-prometheus = "0.13.3"
-hyper = { version = "1", features = ["http1", "http2", "server"] }
-http-body-util = "0.1"
-hyper-util = { version = "0.1", features = ["server-auto", "server-graceful"] }
-ckb-stop-handler = { path = "../stop-handler", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync", "macros"] }
+ckb-metrics-config = { workspace = true }
+ckb-metrics = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-util = { workspace = true }
+prometheus = { workspace = true }
+hyper = { workspace = true, features = ["http1", "http2", "server"] }
+http-body-util = { workspace = true }
+hyper-util = { workspace = true, features = ["server-auto", "server-graceful"] }
+ckb-stop-handler = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-prometheus = "0.13.3"
-prometheus-static-metric = "0.5.1"
+prometheus = { workspace = true }
+prometheus-static-metric = { workspace = true }

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-prometheus = { workspace = true }
-prometheus-static-metric = { workspace = true }
+prometheus.workspace = true
+prometheus-static-metric.workspace = true

--- a/util/migrate/Cargo.toml
+++ b/util/migrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-migrate"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/migrate/Cargo.toml
+++ b/util/migrate/Cargo.toml
@@ -11,18 +11,18 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-migration-template = { workspace = true }
-ckb-db = { workspace = true }
-ckb-error = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-db-migration = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-hash = { workspace = true }
+ckb-migration-template.workspace = true
+ckb-db.workspace = true
+ckb-error.workspace = true
+ckb-db-schema.workspace = true
+ckb-db-migration.workspace = true
+ckb-app-config.workspace = true
+ckb-types.workspace = true
+ckb-store.workspace = true
+ckb-chain-spec.workspace = true
+ckb-hash.workspace = true
 tempfile.workspace = true
-num_cpus = { workspace = true }
+num_cpus.workspace = true
 
 [dev-dependencies]
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/util/migrate/Cargo.toml
+++ b/util/migrate/Cargo.toml
@@ -11,21 +11,21 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-migration-template = { path = "migration-template", version = "= 0.201.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
-ckb-db-migration = { path = "../../db-migration", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../hash", version = "= 0.201.0-pre" }
+ckb-migration-template = { workspace = true }
+ckb-db = { workspace = true }
+ckb-error = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-db-migration = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-hash = { workspace = true }
 tempfile.workspace = true
-num_cpus = "1.10"
+num_cpus = { workspace = true }
 
 [dev-dependencies]
-ckb-systemtime = {path = "../systemtime", version = "= 0.201.0-pre", features = ["enable_faketime"]  }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 
 [features]
 portable = ["ckb-db/portable", "ckb-db-migration/portable"]

--- a/util/migrate/migration-template/Cargo.toml
+++ b/util/migrate/migration-template/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-quote = { workspace = true }
+quote.workspace = true
 syn = { version = "1.0", features = ["full", "printing"] }

--- a/util/migrate/migration-template/Cargo.toml
+++ b/util/migrate/migration-template/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
+quote = { workspace = true }
 syn = { version = "1.0", features = ["full", "printing"] }

--- a/util/migrate/migration-template/Cargo.toml
+++ b/util/migrate/migration-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-migration-template"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-multisig"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-crypto = { path = "../crypto", version = "= 0.201.0-pre" }
+ckb-error = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-crypto = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { workspace = true }

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-error = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-crypto = { workspace = true }
+ckb-error.workspace = true
+ckb-logger.workspace = true
+ckb-crypto.workspace = true
 
 [dev-dependencies]
-rand = { workspace = true }
+rand.workspace = true

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -9,24 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-multisig = { path = "../multisig", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-util = { path = "..", version = "= 0.201.0-pre" }
-ckb-network = { path = "../../network", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre" }
-lru = "0.7.1"
-semver = "1.0"
+ckb-multisig = { workspace = true }
+ckb-types = { workspace = true }
+ckb-util = { workspace = true }
+ckb-network = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-error = { workspace = true }
+ckb-systemtime = { workspace = true }
+lru = { workspace = true }
+semver = { workspace = true }
 
 [dev-dependencies]
-ckb-crypto = { path = "../crypto", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
-faster-hex = "0.6"
+ckb-crypto = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
+faster-hex = { workspace = true }
 serde_json = "1.0"

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -9,22 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-multisig = { workspace = true }
-ckb-types = { workspace = true }
-ckb-util = { workspace = true }
-ckb-network = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-error = { workspace = true }
-ckb-systemtime = { workspace = true }
-lru = { workspace = true }
-semver = { workspace = true }
+ckb-multisig.workspace = true
+ckb-types.workspace = true
+ckb-util.workspace = true
+ckb-network.workspace = true
+ckb-notify.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-logger.workspace = true
+ckb-app-config.workspace = true
+ckb-error.workspace = true
+ckb-systemtime.workspace = true
+lru.workspace = true
+semver.workspace = true
 
 [dev-dependencies]
-ckb-crypto = { workspace = true }
-ckb-async-runtime = { workspace = true }
+ckb-crypto.workspace = true
+ckb-async-runtime.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
-faster-hex = { workspace = true }
+faster-hex.workspace = true
 serde_json = "1.0"

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network-alert"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-occupied-capacity-macros = { workspace = true }
-ckb-occupied-capacity-core = { workspace = true }
+ckb-occupied-capacity-macros.workspace = true
+ckb-occupied-capacity-core.workspace = true

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-occupied-capacity-macros = { path = "macros", version = "= 0.201.0-pre" }
-ckb-occupied-capacity-core = { path = "core", version = "= 0.201.0-pre" }
+ckb-occupied-capacity-macros = { workspace = true }
+ckb-occupied-capacity-core = { workspace = true }

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-core"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-macros"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-quote = { workspace = true }
+quote.workspace = true
 syn = "1.0"
-ckb-occupied-capacity-core = { workspace = true }
+ckb-occupied-capacity-core.workspace = true

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/nervosnetwork/ckb"
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
+quote = { workspace = true }
 syn = "1.0"
-ckb-occupied-capacity-core = { path = "../core", version = "= 0.201.0-pre" }
+ckb-occupied-capacity-core = { workspace = true }

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -10,6 +10,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
+ckb-logger = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-types = { workspace = true }

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -10,6 +10,6 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-types = { workspace = true }
+ckb-logger.workspace = true
+ckb-chain-spec.workspace = true
+ckb-types.workspace = true

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-proposal-table"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
-serde = { version = "1.0", features = ["derive"] }
+numext-fixed-uint = { workspace = true, features = ["support_rand", "support_heapsize", "support_serde"] }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rational"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -15,4 +15,4 @@ numext-fixed-uint = { workspace = true, features = ["support_rand", "support_hea
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-proptest = { workspace = true }
+proptest.workspace = true

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-reward-calculator"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../dao", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../dao/utils", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-chain-spec = {path = "../../spec", version = "= 0.201.0-pre"}
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-chain-spec = { workspace = true }
 
 [dev-dependencies]
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
-ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
+ckb-db = { workspace = true }
+ckb-occupied-capacity = { workspace = true }
+ckb-db-schema = { workspace = true }
 tempfile.workspace = true

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-chain-spec = { workspace = true }
+ckb-types.workspace = true
+ckb-store.workspace = true
+ckb-dao.workspace = true
+ckb-dao-utils.workspace = true
+ckb-logger.workspace = true
+ckb-chain-spec.workspace = true
 
 [dev-dependencies]
-ckb-db = { workspace = true }
-ckb-occupied-capacity = { workspace = true }
-ckb-db-schema = { workspace = true }
+ckb-db.workspace = true
+ckb-occupied-capacity.workspace = true
+ckb-db-schema.workspace = true
 tempfile.workspace = true

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rich-indexer"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -11,23 +11,23 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
-ckb-app-config = { workspace = true }
-ckb-async-runtime = { workspace = true }
-ckb-indexer-sync = { workspace = true }
-ckb-jsonrpc-types = { workspace = true }
-ckb-notify = { workspace = true }
-ckb-types = { workspace = true }
-futures = { workspace = true }
-log = { workspace = true }
-num-bigint = { workspace = true }
-sql-builder = { workspace = true }
+anyhow.workspace = true
+ckb-app-config.workspace = true
+ckb-async-runtime.workspace = true
+ckb-indexer-sync.workspace = true
+ckb-jsonrpc-types.workspace = true
+ckb-notify.workspace = true
+ckb-types.workspace = true
+futures.workspace = true
+log.workspace = true
+num-bigint.workspace = true
+sql-builder.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "any", "sqlite", "postgres"] }
-include_dir = { workspace = true }
+include_dir.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
-hex = { workspace = true }
-rand = { workspace = true }
+hex.workspace = true
+rand.workspace = true
 serde_json = "1.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -11,28 +11,23 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.34"
-ckb-app-config = { path = "../app-config", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-ckb-indexer-sync = { path = "../indexer-sync", version = "= 0.201.0-pre" }
-ckb-jsonrpc-types = { path = "../jsonrpc-types", version = "= 0.201.0-pre" }
-ckb-notify = { path = "../../notify", version = "= 0.201.0-pre" }
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-futures = "0.3"
-log = "0.4"
-num-bigint = "0.4"
-sql-builder = "3.1"
-sqlx = { version = "0.8.2", features = [
-    "runtime-tokio-rustls",
-    "any",
-    "sqlite",
-    "postgres",
-] }
-include_dir = "0.7"
+anyhow = { workspace = true }
+ckb-app-config = { workspace = true }
+ckb-async-runtime = { workspace = true }
+ckb-indexer-sync = { workspace = true }
+ckb-jsonrpc-types = { workspace = true }
+ckb-notify = { workspace = true }
+ckb-types = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+num-bigint = { workspace = true }
+sql-builder = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "any", "sqlite", "postgres"] }
+include_dir = { workspace = true }
 tempfile.workspace = true
 
 [dev-dependencies]
-hex = "0.4"
-rand = "0.8"
+hex = { workspace = true }
+rand = { workspace = true }
 serde_json = "1.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-async-runtime"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }
-ckb-logger = { workspace = true }
-ckb-spawn = { workspace = true }
+ckb-logger.workspace = true
+ckb-spawn.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-tokio = { version = "1", features = ["rt", "sync"] }
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-ckb-spawn = { path = "../spawn", version = "= 0.201.0-pre" }
+tokio = { workspace = true, features = ["rt", "sync"] }
+ckb-logger = { workspace = true }
+ckb-spawn = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.201.0-pre" }
-ckb-proposal-table = { path = "../proposal-table", version = "= 0.201.0-pre" }
-arc-swap = "1.3"
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
-ckb-freezer = { path = "../../freezer", version = "= 0.201.0-pre" }
-ckb-merkle-mountain-range = "0.5.2"
+ckb-types = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-store = { workspace = true }
+ckb-db = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-proposal-table = { workspace = true }
+arc-swap = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-freezer = { workspace = true }
+ckb-merkle-mountain-range = { workspace = true }
 
 [features]
 portable = ["ckb-db/portable", "ckb-store/portable"]

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/nervosnetwork/ckb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-store = { workspace = true }
-ckb-db = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-proposal-table = { workspace = true }
-arc-swap = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-freezer = { workspace = true }
-ckb-merkle-mountain-range = { workspace = true }
+ckb-types.workspace = true
+ckb-chain-spec.workspace = true
+ckb-store.workspace = true
+ckb-db.workspace = true
+ckb-traits.workspace = true
+ckb-proposal-table.workspace = true
+arc-swap.workspace = true
+ckb-db-schema.workspace = true
+ckb-freezer.workspace = true
+ckb-merkle-mountain-range.workspace = true
 
 [features]
 portable = ["ckb-db/portable", "ckb-store/portable"]

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-snapshot"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/spawn/Cargo.toml
+++ b/util/spawn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-spawn"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { path = "../logger", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync"] }
-ckb-channel = { path = "../channel", version = "= 0.201.0-pre" }
-ckb-util = { path = "..", version = "= 0.201.0-pre" }
-ckb-async-runtime = { path = "../runtime", version = "= 0.201.0-pre" }
-tokio-util = "0.7.8"
+ckb-logger = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+ckb-channel = { workspace = true }
+ckb-util = { workspace = true }
+ckb-async-runtime = { workspace = true }
+tokio-util = { workspace = true }
 
 
 [dev-dependencies]
-ctrlc = { version = "3.1", features = ["termination"] }
-libc = "0.2"
-rand = "0.8.5"
+ctrlc = { workspace = true, features = ["termination"] }
+libc = { workspace = true }
+rand = { workspace = true }

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-stop-handler"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-logger = { workspace = true }
+ckb-logger.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-ckb-channel = { workspace = true }
-ckb-util = { workspace = true }
-ckb-async-runtime = { workspace = true }
-tokio-util = { workspace = true }
+ckb-channel.workspace = true
+ckb-util.workspace = true
+ckb-async-runtime.workspace = true
+tokio-util.workspace = true
 
 
 [dev-dependencies]
 ctrlc = { workspace = true, features = ["termination"] }
-libc = { workspace = true }
-rand = { workspace = true }
+libc.workspace = true
+rand.workspace = true

--- a/util/systemtime/Cargo.toml
+++ b/util/systemtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-systemtime"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -9,20 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../types", version = "= 0.201.0-pre" }
-ckb-db = { path = "../../db", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../dao/utils", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../dao", version = "= 0.201.0-pre" }
-ckb-traits = { path = "../../traits", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../../resource", version = "= 0.201.0-pre" }
-ckb-db-schema = { path = "../../db-schema", version = "= 0.201.0-pre" }
-ckb-util = { path = "..", version = "= 0.201.0-pre" }
+ckb-types = { workspace = true }
+ckb-db = { workspace = true }
+ckb-store = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-systemtime = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-db-schema = { workspace = true }
+ckb-util = { workspace = true }
 tempfile.workspace = true
 
 [dev-dependencies]
-ckb-systemtime = { path = "../systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -9,17 +9,17 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-db = { workspace = true }
-ckb-store = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-systemtime = { workspace = true }
-ckb-resource = { workspace = true }
-ckb-db-schema = { workspace = true }
-ckb-util = { workspace = true }
+ckb-types.workspace = true
+ckb-db.workspace = true
+ckb-store.workspace = true
+ckb-chain-spec.workspace = true
+ckb-dao-utils.workspace = true
+ckb-dao.workspace = true
+ckb-traits.workspace = true
+ckb-systemtime.workspace = true
+ckb-resource.workspace = true
+ckb-db-schema.workspace = true
+ckb-util.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-test-chain-utils"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -9,26 +9,26 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-molecule = { workspace = true }
-ckb-fixed-hash = { workspace = true }
+molecule.workspace = true
+ckb-fixed-hash.workspace = true
 numext-fixed-uint = { workspace = true, features = ["support_rand", "support_heapsize", "support_serde"] }
 bytes = { workspace = true, features = ["serde"] }
-merkle-cbt = { workspace = true }
-ckb-occupied-capacity = { workspace = true }
-ckb-hash = { workspace = true }
-ckb-channel = { workspace = true }
-ckb-constant = { workspace = true }
-ckb-gen-types = { workspace = true }
-bit-vec = { workspace = true }
-ckb-error = { workspace = true }
-ckb-rational = { workspace = true }
+merkle-cbt.workspace = true
+ckb-occupied-capacity.workspace = true
+ckb-hash.workspace = true
+ckb-channel.workspace = true
+ckb-constant.workspace = true
+ckb-gen-types.workspace = true
+bit-vec.workspace = true
+ckb-error.workspace = true
+ckb-rational.workspace = true
 derive_more = { workspace = true, features = ["display"] }
-ckb-merkle-mountain-range = { workspace = true }
-golomb-coded-set = { workspace = true }
-paste = { workspace = true }
+ckb-merkle-mountain-range.workspace = true
+golomb-coded-set.workspace = true
+paste.workspace = true
 
 [dev-dependencies]
-proptest = { workspace = true }
+proptest.workspace = true
 
 [package.metadata.cargo-shear]
 ignored = ["bytes"]

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -29,6 +29,3 @@ paste.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-
-[package.metadata.cargo-shear]
-ignored = ["bytes"]

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-types"
-version = "0.201.0-pre"
+version.workspace = true
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -9,32 +9,26 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-molecule = "0.8"
-ckb-fixed-hash = { path = "../fixed-hash", version = "= 0.201.0-pre" }
-numext-fixed-uint = { version = "0.1", features = [
-    "support_rand",
-    "support_heapsize",
-    "support_serde",
-] }
-bytes = { version = "1", features = ["serde"] }
-merkle-cbt = "0.3"
-ckb-occupied-capacity = { path = "../occupied-capacity", version = "= 0.201.0-pre" }
-ckb-hash = { path = "../hash", version = "= 0.201.0-pre" }
-ckb-channel = { path = "../channel", version = "= 0.201.0-pre" }
-ckb-constant = { path = "../constant", version = "= 0.201.0-pre" }
-ckb-gen-types = { path = "../gen-types", version = "= 0.201.0-pre" }
-bit-vec = "0.6.3"
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
-ckb-rational = { path = "../rational", version = "= 0.201.0-pre" }
-derive_more = { version = "1", default-features = false, features = [
-    "display",
-] }
-ckb-merkle-mountain-range = "0.5.2"
-golomb-coded-set = "0.2.0"
-paste = "1.0"
+molecule = { workspace = true }
+ckb-fixed-hash = { workspace = true }
+numext-fixed-uint = { workspace = true, features = ["support_rand", "support_heapsize", "support_serde"] }
+bytes = { workspace = true, features = ["serde"] }
+merkle-cbt = { workspace = true }
+ckb-occupied-capacity = { workspace = true }
+ckb-hash = { workspace = true }
+ckb-channel = { workspace = true }
+ckb-constant = { workspace = true }
+ckb-gen-types = { workspace = true }
+bit-vec = { workspace = true }
+ckb-error = { workspace = true }
+ckb-rational = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
+ckb-merkle-mountain-range = { workspace = true }
+golomb-coded-set = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bytes"]

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -9,26 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../util/types", version = "= 0.201.0-pre" }
-ckb-script = { path = "../script", version = "= 0.201.0-pre" }
-ckb-pow = { path = "../pow", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre" }
-lru = "0.7.1"
-ckb-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../spec", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../util/dao", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-error = { path = "../error", version = "= 0.201.0-pre" }
-derive_more = { version = "1", default-features = false, features = [
-    "display",
-] }
-ckb-verification-traits = { path = "./traits", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync", "macros"] }
+ckb-types = { workspace = true }
+ckb-script = { workspace = true }
+ckb-pow = { workspace = true }
+ckb-systemtime = { workspace = true }
+lru = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-error = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
+ckb-verification-traits = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }
 
 
 [dev-dependencies]
-ckb-test-chain-utils = { path = "../util/test-chain-utils", version = "= 0.201.0-pre" }
-ckb-resource = { path = "../resource", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
+ckb-test-chain-utils = { workspace = true }
+ckb-resource = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -9,22 +9,22 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-script = { workspace = true }
-ckb-pow = { workspace = true }
-ckb-systemtime = { workspace = true }
-lru = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-error = { workspace = true }
+ckb-types.workspace = true
+ckb-script.workspace = true
+ckb-pow.workspace = true
+ckb-systemtime.workspace = true
+lru.workspace = true
+ckb-traits.workspace = true
+ckb-chain-spec.workspace = true
+ckb-dao.workspace = true
+ckb-dao-utils.workspace = true
+ckb-error.workspace = true
 derive_more = { workspace = true, features = ["display"] }
-ckb-verification-traits = { workspace = true }
+ckb-verification-traits.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 
 
 [dev-dependencies]
-ckb-test-chain-utils = { workspace = true }
-ckb-resource = { workspace = true }
+ckb-test-chain-utils.workspace = true
+ckb-resource.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-contextual"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -9,26 +9,26 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { workspace = true }
-ckb-store = { workspace = true }
-ckb-systemtime = { workspace = true }
-rayon = { workspace = true }
-ckb-traits = { workspace = true }
-ckb-chain-spec = { workspace = true }
-ckb-dao = { workspace = true }
-ckb-dao-utils = { workspace = true }
-ckb-logger = { workspace = true }
-ckb-reward-calculator = { workspace = true }
-ckb-error = { workspace = true }
+ckb-types.workspace = true
+ckb-store.workspace = true
+ckb-systemtime.workspace = true
+rayon.workspace = true
+ckb-traits.workspace = true
+ckb-chain-spec.workspace = true
+ckb-dao.workspace = true
+ckb-dao-utils.workspace = true
+ckb-logger.workspace = true
+ckb-reward-calculator.workspace = true
+ckb-error.workspace = true
 tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
-ckb-async-runtime = { workspace = true }
-ckb-verification-traits = { workspace = true }
-ckb-verification = { workspace = true }
-ckb-merkle-mountain-range = { workspace = true }
+ckb-async-runtime.workspace = true
+ckb-verification-traits.workspace = true
+ckb-verification.workspace = true
+ckb-merkle-mountain-range.workspace = true
 
 [dev-dependencies]
-ckb-chain = { workspace = true }
-ckb-shared = { workspace = true }
-ckb-test-chain-utils = { workspace = true }
+ckb-chain.workspace = true
+ckb-shared.workspace = true
+ckb-test-chain-utils.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
-rand = { workspace = true }
+rand.workspace = true

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -9,28 +9,26 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-ckb-types = { path = "../../util/types", version = "= 0.201.0-pre" }
-ckb-store = { path = "../../store", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../../util/systemtime", version = "= 0.201.0-pre" }
-rayon = "1.0"
-ckb-traits = { path = "../../traits", version = "= 0.201.0-pre" }
-ckb-chain-spec = { path = "../../spec", version = "= 0.201.0-pre" }
-ckb-dao = { path = "../../util/dao", version = "= 0.201.0-pre" }
-ckb-dao-utils = { path = "../../util/dao/utils", version = "= 0.201.0-pre" }
-ckb-logger = { path = "../../util/logger", version = "= 0.201.0-pre" }
-ckb-reward-calculator = { path = "../../util/reward-calculator", version = "= 0.201.0-pre" }
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
-tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
-ckb-async-runtime = { path = "../../util/runtime", version = "= 0.201.0-pre" }
-ckb-verification-traits = { path = "../traits", version = "= 0.201.0-pre" }
-ckb-verification = { path = "..", version = "= 0.201.0-pre" }
-ckb-merkle-mountain-range = "0.5.2"
+ckb-types = { workspace = true }
+ckb-store = { workspace = true }
+ckb-systemtime = { workspace = true }
+rayon = { workspace = true }
+ckb-traits = { workspace = true }
+ckb-chain-spec = { workspace = true }
+ckb-dao = { workspace = true }
+ckb-dao-utils = { workspace = true }
+ckb-logger = { workspace = true }
+ckb-reward-calculator = { workspace = true }
+ckb-error = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
+ckb-async-runtime = { workspace = true }
+ckb-verification-traits = { workspace = true }
+ckb-verification = { workspace = true }
+ckb-merkle-mountain-range = { workspace = true }
 
 [dev-dependencies]
-ckb-chain = { path = "../../chain", version = "= 0.201.0-pre" }
-ckb-shared = { path = "../../shared", version = "= 0.201.0-pre" }
-ckb-test-chain-utils = { path = "../../util/test-chain-utils", version = "= 0.201.0-pre" }
-ckb-systemtime = { path = "../../util/systemtime", version = "= 0.201.0-pre", features = [
-    "enable_faketime",
-] }
-rand = "0.8"
+ckb-chain = { workspace = true }
+ckb-shared = { workspace = true }
+ckb-test-chain-utils = { workspace = true }
+ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
+rand = { workspace = true }

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-bitflags = { workspace = true }
-ckb-error = { workspace = true }
+bitflags.workspace = true
+ckb-error.workspace = true

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
 
 [dependencies]
-bitflags = "1.0"
-ckb-error = { path = "../../error", version = "= 0.201.0-pre" }
+bitflags = { workspace = true }
+ckb-error = { workspace = true }

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-traits"
-version = "0.201.0-pre"
+version.workspace = true
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"


### PR DESCRIPTION
### What is changed and how it works?

This PR want:
1. manage ckb workspace members' package version in project root: `[workspace.package]`
2. manage ckb workspace members' all dependencies in project root's `[workspace.dependencies]`

This can:
- Simplifies our maintenance
- Ensures version consistency across all workspace members
- Reduces duplication in Cargo.toml files


### Related changes

- Execute cargo autoinherit: <https://github.com/mainmatter/cargo-autoinherit>
- manage ckb workspace members' package version in worksapce root
- Refactor `./devtools/ci/check-cargotoml.sh` 's `check_version` CI action.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```
