### PR TITLE
chore: when the user configuration is wrong, exit and output log

### DIFF
--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -121,14 +121,7 @@ fn net_service_start(
         discovery_local_address: true,
         bootnode_mode: true,
         reuse_port_on_linux: true,
-        public_addresses: vec![
-            format!(
-                "/ip4/225.0.0.1/tcp/42/p2p/{}",
-                crate::PeerId::random().to_base58()
-            )
-            .parse()
-            .unwrap(),
-        ],
+        public_addresses: vec!["/ip4/225.0.0.1/tcp/42".parse().unwrap()],
         ..Default::default()
     };
 


### PR DESCRIPTION
### What problem does this PR solve?

when the user configuration is wrong, exit and output log(The wasm side code is not modified, because wasm currently has no listen, and this field configuration is meaningless)

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

