### PR TITLE
feat: Syscall generator shall be customizable

### DIFF
--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod scheduler;
 mod syscalls;
 mod type_id;
-mod types;
+pub mod types;
 mod verify;
 mod verify_env;
 

--- a/script/src/scheduler.rs
+++ b/script/src/scheduler.rs
@@ -5,9 +5,9 @@ use crate::syscalls::{
 };
 
 use crate::types::{
-    CoreMachineType, DataLocation, DataPieceId, DebugContext, FIRST_FD_SLOT, FIRST_VM_ID, Fd,
-    FdArgs, FullSuspendedState, Machine, Message, ReadState, RunMode, SgData, SyscallGenerator,
-    VmArgs, VmContext, VmId, VmState, WriteState,
+    CoreMachineType, DataLocation, DataPieceId, FIRST_FD_SLOT, FIRST_VM_ID, Fd, FdArgs,
+    FullSuspendedState, Machine, Message, ReadState, RunMode, SgData, SyscallGenerator, VmArgs,
+    VmContext, VmId, VmState, WriteState,
 };
 use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
 use ckb_types::core::Cycle;
@@ -43,18 +43,17 @@ pub const MAX_FDS: u64 = 64;
 /// A scheduler holds & manipulates a core, the scheduler also holds
 /// all CKB-VM machines, each CKB-VM machine also gets a mutable reference
 /// of the core for IO operations.
-pub struct Scheduler<DL>
+pub struct Scheduler<DL, V>
 where
     DL: CellDataProvider,
 {
     /// Immutable context data for current running transaction & script.
     pub sg_data: SgData<DL>,
 
-    /// Mutable context data used by current scheduler
-    pub debug_context: DebugContext,
-
     /// Syscall generator
-    pub syscall_generator: SyscallGenerator<DL>,
+    pub syscall_generator: SyscallGenerator<DL, V>,
+    /// Syscall generator context
+    pub syscall_context: V,
 
     /// Total cycles. When a scheduler executes, there are 3 variables
     /// that might all contain charged cycles: +total_cycles+,
@@ -109,20 +108,21 @@ where
     pub message_box: Arc<Mutex<Vec<Message>>>,
 }
 
-impl<DL> Scheduler<DL>
+impl<DL, V> Scheduler<DL, V>
 where
     DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + Clone + 'static,
+    V: Send + Clone,
 {
     /// Create a new scheduler from empty state
     pub fn new(
         sg_data: SgData<DL>,
-        debug_context: DebugContext,
-        syscall_generator: SyscallGenerator<DL>,
+        syscall_generator: SyscallGenerator<DL, V>,
+        syscall_context: V,
     ) -> Self {
         Self {
             sg_data,
-            debug_context,
             syscall_generator,
+            syscall_context,
             total_cycles: Arc::new(AtomicU64::new(0)),
             iteration_cycles: 0,
             next_vm_id: FIRST_VM_ID,
@@ -157,14 +157,14 @@ where
     /// Resume a previously suspended scheduler state
     pub fn resume(
         sg_data: SgData<DL>,
-        debug_context: DebugContext,
-        syscall_generator: SyscallGenerator<DL>,
+        syscall_generator: SyscallGenerator<DL, V>,
+        syscall_context: V,
         full: FullSuspendedState,
     ) -> Self {
         let mut scheduler = Self {
             sg_data,
-            debug_context,
             syscall_generator,
+            syscall_context,
             total_cycles: Arc::new(AtomicU64::new(full.total_cycles)),
             iteration_cycles: 0,
             next_vm_id: full.next_vm_id,
@@ -908,7 +908,7 @@ where
         let machine_builder = DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(estimate_cycles));
         let machine_builder =
-            (self.syscall_generator)(id, &self.sg_data, &vm_context, &self.debug_context)
+            (self.syscall_generator)(id, &self.sg_data, &vm_context, &self.syscall_context)
                 .into_iter()
                 .fold(machine_builder, |builder, syscall| builder.syscall(syscall));
         let default_machine = machine_builder.build();

--- a/script/src/syscalls/debugger.rs
+++ b/script/src/syscalls/debugger.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    DebugContext, DebugPrinter, {SgData, SgInfo},
+    DebugPrinter, {SgData, SgInfo},
 };
 use crate::{cost_model::transferred_byte_cycles, syscalls::DEBUG_PRINT_SYSCALL_NUMBER};
 use ckb_vm::{
@@ -14,10 +14,10 @@ pub struct Debugger {
 }
 
 impl Debugger {
-    pub fn new<DL>(sg_data: &SgData<DL>, debug_context: &DebugContext) -> Debugger {
+    pub fn new<DL>(sg_data: &SgData<DL>, debug_printer: &DebugPrinter) -> Debugger {
         Debugger {
             sg_info: Arc::clone(&sg_data.sg_info),
-            printer: Arc::clone(&debug_context.debug_printer),
+            printer: Arc::clone(debug_printer),
         }
     }
 }

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -9,7 +9,7 @@ use ckb_types::{
     prelude::*,
 };
 use ckb_vm::{
-    ISA_B, ISA_IMC, ISA_MOP,
+    ISA_B, ISA_IMC, ISA_MOP, Syscalls,
     machine::{VERSION0, VERSION1, VERSION2},
 };
 use serde::{Deserialize, Serialize};
@@ -64,6 +64,16 @@ pub(crate) type Machine = AsmMachine;
 pub(crate) type Machine = TraceMachine<CoreMachine>;
 
 pub(crate) type DebugPrinter = Arc<dyn Fn(&Byte32, &str) + Send + Sync>;
+pub(crate) type SyscallGenerator<DL> = Arc<
+    dyn Fn(
+            &VmId,
+            &SgData<DL>,
+            &VmContext<DL>,
+            &DebugContext,
+        ) -> Vec<Box<(dyn Syscalls<CoreMachine>)>>
+        + Send
+        + Sync,
+>;
 
 pub struct DebugContext {
     pub debug_printer: DebugPrinter,

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -43,11 +43,11 @@ pub type VmIsa = u8;
 pub type VmVersion = u32;
 
 #[cfg(has_asm)]
-pub(crate) type CoreMachineType = AsmCoreMachine;
+pub type CoreMachineType = AsmCoreMachine;
 #[cfg(all(not(has_asm), not(feature = "flatmemory")))]
-pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::SparseMemory<u64>>>;
+pub type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::SparseMemory<u64>>>;
 #[cfg(all(not(has_asm), feature = "flatmemory"))]
-pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::FlatMemory<u64>>>;
+pub type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::FlatMemory<u64>>>;
 
 /// The type of core VM machine when uses ASM.
 #[cfg(has_asm)]
@@ -59,12 +59,12 @@ pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::SparseMemory<
 pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<ckb_vm::FlatMemory<u64>>>;
 
 #[cfg(has_asm)]
-pub(crate) type Machine = AsmMachine;
+pub type Machine = AsmMachine;
 #[cfg(not(has_asm))]
-pub(crate) type Machine = TraceMachine<CoreMachine>;
+pub type Machine = TraceMachine<CoreMachine>;
 
-pub(crate) type DebugPrinter = Arc<dyn Fn(&Byte32, &str) + Send + Sync>;
-pub(crate) type SyscallGenerator<DL> = Arc<
+pub type DebugPrinter = Arc<dyn Fn(&Byte32, &str) + Send + Sync>;
+pub type SyscallGenerator<DL> = Arc<
     dyn Fn(
             &VmId,
             &SgData<DL>,
@@ -295,7 +295,7 @@ pub type VmId = u64;
 pub const FIRST_VM_ID: VmId = 0;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Fd(pub(crate) u64);
+pub struct Fd(pub u64);
 
 pub const FIRST_FD_SLOT: u64 = 2;
 
@@ -1044,10 +1044,10 @@ pub struct VmContext<DL>
 where
     DL: CellDataProvider,
 {
-    pub(crate) base_cycles: Arc<AtomicU64>,
+    pub base_cycles: Arc<AtomicU64>,
     /// A mutable reference to scheduler's message box
-    pub(crate) message_box: Arc<Mutex<Vec<Message>>>,
-    pub(crate) snapshot2_context: Arc<Mutex<Snapshot2Context<DataPieceId, SgData<DL>>>>,
+    pub message_box: Arc<Mutex<Vec<Message>>>,
+    pub snapshot2_context: Arc<Mutex<Snapshot2Context<DataPieceId, SgData<DL>>>>,
 }
 
 impl<DL> VmContext<DL>

--- a/script/src/types.rs
+++ b/script/src/types.rs
@@ -72,25 +72,8 @@ pub type Machine = TraceMachine<CoreMachine>;
 /// Debug printer function type
 pub type DebugPrinter = Arc<dyn Fn(&Byte32, &str) + Send + Sync>;
 /// Syscall generator function type
-pub type SyscallGenerator<DL> = Arc<
-    dyn Fn(
-            &VmId,
-            &SgData<DL>,
-            &VmContext<DL>,
-            &DebugContext,
-        ) -> Vec<Box<(dyn Syscalls<CoreMachine>)>>
-        + Send
-        + Sync,
->;
-
-/// VM context used for debugging purposes
-pub struct DebugContext {
-    /// Debug printer in use.
-    pub debug_printer: DebugPrinter,
-    /// A flag to control pausing, only used in tests.
-    #[cfg(test)]
-    pub skip_pause: Arc<std::sync::atomic::AtomicBool>,
-}
+pub type SyscallGenerator<DL, V> =
+    fn(&VmId, &SgData<DL>, &VmContext<DL>, &V) -> Vec<Box<(dyn Syscalls<CoreMachine>)>>;
 
 /// The version of CKB Script Verifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/script/src/verify/tests/ckb_latest/features_since_v2021.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2021.rs
@@ -1157,8 +1157,8 @@ fn load_code_with_snapshot() {
 
     let mut cycles = 0;
     let max_cycles = Cycle::MAX;
-    let verifier = TransactionScriptsVerifierWithEnv::new();
-    let result = verifier.verify_map(script_version, &rtx, |verifier| {
+    let verifier_env = TransactionScriptsVerifierWithEnv::new();
+    let result = verifier_env.verify_map(script_version, &rtx, |verifier| {
         let mut init_snap: Option<TransactionState> = None;
 
         if let VerifyResult::Suspended(state) = verifier.resumable_verify(max_cycles).unwrap() {
@@ -1177,7 +1177,7 @@ fn load_code_with_snapshot() {
             }
         }
 
-        verifier.set_skip_pause(true);
+        verifier_env.set_skip_pause(true);
         verifier.verify(max_cycles)
     });
 

--- a/verification/src/transaction_verifier.rs
+++ b/verification/src/transaction_verifier.rs
@@ -7,6 +7,7 @@ use ckb_dao_utils::DaoError;
 use ckb_error::Error;
 #[cfg(not(target_family = "wasm"))]
 use ckb_script::ChunkCommand;
+use ckb_script::types::DebugPrinter;
 use ckb_script::{TransactionScriptsVerifier, TransactionState};
 use ckb_traits::{
     CellDataProvider, EpochProvider, ExtensionProvider, HeaderFieldsProvider, HeaderProvider,
@@ -336,7 +337,7 @@ impl<'a> SizeVerifier<'a> {
 /// See:
 /// - [ckb-vm](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0003-ckb-vm/0003-ckb-vm.md)
 /// - [vm-cycle-limits](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0014-vm-cycle-limits/0014-vm-cycle-limits.md)
-pub type ScriptVerifier<DL> = TransactionScriptsVerifier<DL>;
+pub type ScriptVerifier<DL> = TransactionScriptsVerifier<DL, DebugPrinter>;
 
 pub struct EmptyVerifier<'a> {
     transaction: &'a TransactionView,


### PR DESCRIPTION
This enables ckb-script to be used in more environments. I do remember that there is discussion about moving ckb-script out of CKB for more usages. However, I implemented this change due to 2 factors:

* The change is not so big
* We had similar APIs for debug printer as well

In a later time, we can re-evaluate the necessity to move ckb-script out of CKB completely.

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

