### PR TITLE
CI: fix load_notify failed on CI

### DIFF
--- a/chain/src/preload_unverified_blocks_channel.rs
+++ b/chain/src/preload_unverified_blocks_channel.rs
@@ -1,6 +1,6 @@
 use crate::{LonelyBlockHash, UnverifiedBlock};
 use ckb_channel::{Receiver, Sender};
-use ckb_logger::{debug, error, info};
+use ckb_logger::{debug, info};
 use ckb_shared::Shared;
 use ckb_store::ChainStore;
 use crossbeam::select;
@@ -37,8 +37,8 @@ impl PreloadUnverifiedBlocksChannel {
                     Ok(preload_unverified_block_task) =>{
                         self.preload_unverified_channel(preload_unverified_block_task);
                     },
-                    Err(err) =>{
-                        error!("recv preload_task_rx failed, err: {:?}", err);
+                    Err(_err) =>{
+                        info!("recv preload_task_rx failed");
                         break;
                     }
                 },

--- a/ckb-bin/src/tests/bats_tests/load_notify_config.bats
+++ b/ckb-bin/src/tests/bats_tests/load_notify_config.bats
@@ -27,7 +27,7 @@ _run() {
 
 _log_no_error() {
   if grep -q -i error ${TMP_DIR}/ckb_notify.log; then
-    echo "error found in log"
+    echo "error found in log: " $(grep -i error ${TMP_DIR}/ckb_notify.log)
     return 1
   fi
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix: <https://github.com/nervosnetwork/ckb/actions/runs/13806791367/job/38619170328?pr=4848>

### Related changes

- change `recv preload_task_rx failed` log level to `info!`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
