### PR TITLE
log: reword ConsumeUnverifiedBlocks::verify log on ckb received exit signal

### DIFF
--- a/chain/src/verify.rs
+++ b/chain/src/verify.rs
@@ -87,7 +87,7 @@ impl ConsumeUnverifiedBlocks {
                         let _ = self.tx_pool_controller.continue_chunk_process();
                     },
                     Err(err) => {
-                        error!("unverified_block_rx err: {}", err);
+                        info!("unverified_block_rx closed: {}", err);
                         return;
                     },
                 },


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix: <https://github.com/nervosnetwork/ckb/actions/runs/13813887363/job/38641942486>

### Related changes

- when unverified_block_rx channel closed, use info level log instead of error level

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
