### PR TITLE
fix release scripts

### DIFF
--- a/devtools/release/bump.sh
+++ b/devtools/release/bump.sh
@@ -12,7 +12,7 @@ main() {
   local v="$1"
   find . -name 'Cargo.toml' -print0 | xargs -0 sed -i.bak \
     -e 's/^version = .*/version = "'"$v"'"/' \
-    -e 's/\({.*path = ".*",.* version = "= \)[^"]*/\1'"$v"'/'
+    -e 's/\({.*path = ".*",.* version = "= \?\)[^"]*/\1'"$v"'/'
   find . -name 'Cargo.toml.bak' -exec rm -f {} \;
   sed -i.bak 's/badge\/version-.*-orange/badge\/version-'"$(echo "$v" | sed s/-/--/g)"'-orange/' README.md
   rm -f README.md.bak

--- a/devtools/release/release-pkg.sh
+++ b/devtools/release/release-pkg.sh
@@ -3,7 +3,7 @@
 on_push_pkg() {
   BRANCH=$(git symbolic-ref --quiet HEAD)
   BRANCH="${BRANCH#refs/heads/}"
-  VERSION="v$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)"
+  VERSION="v$(sed -n '/^version = "\(.*\)"/{s//\1/p;q}' Cargo.toml)"
   echo "$BRANCH -> upstream/$BRANCH"
   echo "$BRANCH -> upstream/pkg/$VERSION"
 
@@ -11,12 +11,12 @@ on_push_pkg() {
 }
 
 on_tag() {
-  VERSION="v$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)"
+  VERSION="v$(sed -n '/^version = "\(.*\)"/{s//\1/p;q}' Cargo.toml)"
   git tag -s -m "$VERSION" "$VERSION"
 }
 
 on_push_tag() {
-  VERSION="v$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)"
+  VERSION="v$(sed -n '/^version = "\(.*\)"/{s//\1/p;q}' Cargo.toml)"
   git push upstream "$VERSION"
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: #4818 breaks some release scripts

### What is changed and how it works?

What's Changed:

-   fix `bump.sh`
-   fix `release-pkg.sh`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

-   No code ci-runs-only: [ quick_checks,linters ]

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
