### PR TITLE
Update `DaoCalculator` so it can be used in light client

### DIFF
--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -25,6 +25,129 @@ pub struct DaoCalculator<'a, DL> {
     data_loader: &'a DL,
 }
 
+impl<'a, DL: CellDataProvider + HeaderProvider> DaoCalculator<'a, DL> {
+    /// Returns the total transactions fee of `rtx`.
+    pub fn transaction_fee(&self, rtx: &ResolvedTransaction) -> Result<Capacity, DaoError> {
+        let maximum_withdraw = self.transaction_maximum_withdraw(rtx)?;
+        rtx.transaction
+            .outputs_capacity()
+            .and_then(|y| maximum_withdraw.safe_sub(y))
+            .map_err(Into::into)
+    }
+    fn transaction_maximum_withdraw(
+        &self,
+        rtx: &ResolvedTransaction,
+    ) -> Result<Capacity, DaoError> {
+        let header_deps: HashSet<Byte32> = rtx.transaction.header_deps_iter().collect();
+        rtx.resolved_inputs.iter().enumerate().try_fold(
+            Capacity::zero(),
+            |capacities, (i, cell_meta)| {
+                let capacity: Result<Capacity, DaoError> = {
+                    let output = &cell_meta.cell_output;
+                    let is_dao_type_script = |type_script: Script| {
+                        Into::<u8>::into(type_script.hash_type())
+                            == Into::<u8>::into(ScriptHashType::Type)
+                            && type_script.code_hash() == self.consensus.dao_type_hash()
+                    };
+                    let is_withdrawing_input =
+                        |cell_meta: &CellMeta| match self.data_loader.load_cell_data(cell_meta) {
+                            Some(data) => data.len() == 8 && LittleEndian::read_u64(&data) > 0,
+                            None => false,
+                        };
+                    if output
+                        .type_()
+                        .to_opt()
+                        .map(is_dao_type_script)
+                        .unwrap_or(false)
+                        && is_withdrawing_input(cell_meta)
+                    {
+                        let withdrawing_header_hash = cell_meta
+                            .transaction_info
+                            .as_ref()
+                            .map(|info| &info.block_hash)
+                            .filter(|hash| header_deps.contains(hash))
+                            .ok_or(DaoError::InvalidOutPoint)?;
+                        let deposit_header_hash = rtx
+                            .transaction
+                            .witnesses()
+                            .get(i)
+                            .ok_or(DaoError::InvalidOutPoint)
+                            .and_then(|witness_data| {
+                                // dao contract stores header deps index as u64 in the input_type field of WitnessArgs
+                                let witness = WitnessArgs::from_slice(&Unpack::<Bytes>::unpack(
+                                    &witness_data,
+                                ))
+                                .map_err(|_| DaoError::InvalidDaoFormat)?;
+                                let header_deps_index_data: Option<Bytes> = witness
+                                    .input_type()
+                                    .to_opt()
+                                    .map(|witness| witness.unpack());
+                                if header_deps_index_data.is_none()
+                                    || header_deps_index_data.clone().map(|data| data.len())
+                                        != Some(8)
+                                {
+                                    return Err(DaoError::InvalidDaoFormat);
+                                }
+                                Ok(LittleEndian::read_u64(&header_deps_index_data.unwrap()))
+                            })
+                            .and_then(|header_dep_index| {
+                                rtx.transaction
+                                    .header_deps()
+                                    .get(header_dep_index as usize)
+                                    .and_then(|hash| header_deps.get(&hash))
+                                    .ok_or(DaoError::InvalidOutPoint)
+                            })?;
+                        self.calculate_maximum_withdraw(
+                            output,
+                            Capacity::bytes(cell_meta.data_bytes as usize)?,
+                            deposit_header_hash,
+                            withdrawing_header_hash,
+                        )
+                    } else {
+                        Ok(output.capacity().unpack())
+                    }
+                };
+                capacity.and_then(|c| c.safe_add(capacities).map_err(Into::into))
+            },
+        )
+    }
+
+    /// Calculate maximum withdraw capacity of a deposited dao output
+    pub fn calculate_maximum_withdraw(
+        &self,
+        output: &CellOutput,
+        output_data_capacity: Capacity,
+        deposit_header_hash: &Byte32,
+        withdrawing_header_hash: &Byte32,
+    ) -> Result<Capacity, DaoError> {
+        let deposit_header = self
+            .data_loader
+            .get_header(deposit_header_hash)
+            .ok_or(DaoError::InvalidHeader)?;
+        let withdrawing_header = self
+            .data_loader
+            .get_header(withdrawing_header_hash)
+            .ok_or(DaoError::InvalidHeader)?;
+        if deposit_header.number() >= withdrawing_header.number() {
+            return Err(DaoError::InvalidOutPoint);
+        }
+
+        let (deposit_ar, _, _, _) = extract_dao_data(deposit_header.dao());
+        let (withdrawing_ar, _, _, _) = extract_dao_data(withdrawing_header.dao());
+
+        let occupied_capacity = output.occupied_capacity(output_data_capacity)?;
+        let output_capacity: Capacity = output.capacity().unpack();
+        let counted_capacity = output_capacity.safe_sub(occupied_capacity)?;
+        let withdraw_counted_capacity = u128::from(counted_capacity.as_u64())
+            * u128::from(withdrawing_ar)
+            / u128::from(deposit_ar);
+        let withdraw_capacity =
+            Capacity::shannons(withdraw_counted_capacity as u64).safe_add(occupied_capacity)?;
+
+        Ok(withdraw_capacity)
+    }
+}
+
 impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a, DL> {
     /// Creates a new `DaoCalculator`.
     pub fn new(consensus: &'a Consensus, data_loader: &'a DL) -> Self {
@@ -146,15 +269,6 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
         self.dao_field_with_current_epoch(rtxs, parent, &current_block_epoch)
     }
 
-    /// Returns the total transactions fee of `rtx`.
-    pub fn transaction_fee(&self, rtx: &ResolvedTransaction) -> Result<Capacity, DaoError> {
-        let maximum_withdraw = self.transaction_maximum_withdraw(rtx)?;
-        rtx.transaction
-            .outputs_capacity()
-            .and_then(|y| maximum_withdraw.safe_sub(y))
-            .map_err(Into::into)
-    }
-
     fn added_occupied_capacities(
         &self,
         mut rtxs: impl Iterator<Item = &'a ResolvedTransaction>,
@@ -205,119 +319,6 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
         maximum_withdraws
             .safe_sub(input_capacities)
             .map_err(Into::into)
-    }
-
-    fn transaction_maximum_withdraw(
-        &self,
-        rtx: &ResolvedTransaction,
-    ) -> Result<Capacity, DaoError> {
-        let header_deps: HashSet<Byte32> = rtx.transaction.header_deps_iter().collect();
-        rtx.resolved_inputs.iter().enumerate().try_fold(
-            Capacity::zero(),
-            |capacities, (i, cell_meta)| {
-                let capacity: Result<Capacity, DaoError> = {
-                    let output = &cell_meta.cell_output;
-                    let is_dao_type_script = |type_script: Script| {
-                        Into::<u8>::into(type_script.hash_type())
-                            == Into::<u8>::into(ScriptHashType::Type)
-                            && type_script.code_hash() == self.consensus.dao_type_hash()
-                    };
-                    let is_withdrawing_input =
-                        |cell_meta: &CellMeta| match self.data_loader.load_cell_data(cell_meta) {
-                            Some(data) => data.len() == 8 && LittleEndian::read_u64(&data) > 0,
-                            None => false,
-                        };
-                    if output
-                        .type_()
-                        .to_opt()
-                        .map(is_dao_type_script)
-                        .unwrap_or(false)
-                        && is_withdrawing_input(cell_meta)
-                    {
-                        let withdrawing_header_hash = cell_meta
-                            .transaction_info
-                            .as_ref()
-                            .map(|info| &info.block_hash)
-                            .filter(|hash| header_deps.contains(hash))
-                            .ok_or(DaoError::InvalidOutPoint)?;
-                        let deposit_header_hash = rtx
-                            .transaction
-                            .witnesses()
-                            .get(i)
-                            .ok_or(DaoError::InvalidOutPoint)
-                            .and_then(|witness_data| {
-                                // dao contract stores header deps index as u64 in the input_type field of WitnessArgs
-                                let witness = WitnessArgs::from_slice(&Unpack::<Bytes>::unpack(
-                                    &witness_data,
-                                ))
-                                .map_err(|_| DaoError::InvalidDaoFormat)?;
-                                let header_deps_index_data: Option<Bytes> = witness
-                                    .input_type()
-                                    .to_opt()
-                                    .map(|witness| witness.unpack());
-                                if header_deps_index_data.is_none()
-                                    || header_deps_index_data.clone().map(|data| data.len())
-                                        != Some(8)
-                                {
-                                    return Err(DaoError::InvalidDaoFormat);
-                                }
-                                Ok(LittleEndian::read_u64(&header_deps_index_data.unwrap()))
-                            })
-                            .and_then(|header_dep_index| {
-                                rtx.transaction
-                                    .header_deps()
-                                    .get(header_dep_index as usize)
-                                    .and_then(|hash| header_deps.get(&hash))
-                                    .ok_or(DaoError::InvalidOutPoint)
-                            })?;
-                        self.calculate_maximum_withdraw(
-                            output,
-                            Capacity::bytes(cell_meta.data_bytes as usize)?,
-                            deposit_header_hash,
-                            withdrawing_header_hash,
-                        )
-                    } else {
-                        Ok(output.capacity().unpack())
-                    }
-                };
-                capacity.and_then(|c| c.safe_add(capacities).map_err(Into::into))
-            },
-        )
-    }
-
-    /// Calculate maximum withdraw capacity of a deposited dao output
-    pub fn calculate_maximum_withdraw(
-        &self,
-        output: &CellOutput,
-        output_data_capacity: Capacity,
-        deposit_header_hash: &Byte32,
-        withdrawing_header_hash: &Byte32,
-    ) -> Result<Capacity, DaoError> {
-        let deposit_header = self
-            .data_loader
-            .get_header(deposit_header_hash)
-            .ok_or(DaoError::InvalidHeader)?;
-        let withdrawing_header = self
-            .data_loader
-            .get_header(withdrawing_header_hash)
-            .ok_or(DaoError::InvalidHeader)?;
-        if deposit_header.number() >= withdrawing_header.number() {
-            return Err(DaoError::InvalidOutPoint);
-        }
-
-        let (deposit_ar, _, _, _) = extract_dao_data(deposit_header.dao());
-        let (withdrawing_ar, _, _, _) = extract_dao_data(withdrawing_header.dao());
-
-        let occupied_capacity = output.occupied_capacity(output_data_capacity)?;
-        let output_capacity: Capacity = output.capacity().unpack();
-        let counted_capacity = output_capacity.safe_sub(occupied_capacity)?;
-        let withdraw_counted_capacity = u128::from(counted_capacity.as_u64())
-            * u128::from(withdrawing_ar)
-            / u128::from(deposit_ar);
-        let withdraw_capacity =
-            Capacity::shannons(withdraw_counted_capacity as u64).safe_add(occupied_capacity)?;
-
-        Ok(withdraw_capacity)
     }
 }
 

--- a/util/dao/src/lib.rs
+++ b/util/dao/src/lib.rs
@@ -146,9 +146,6 @@ impl<'a, DL: CellDataProvider + HeaderProvider> DaoCalculator<'a, DL> {
 
         Ok(withdraw_capacity)
     }
-}
-
-impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a, DL> {
     /// Creates a new `DaoCalculator`.
     pub fn new(consensus: &'a Consensus, data_loader: &'a DL) -> Self {
         DaoCalculator {
@@ -156,7 +153,9 @@ impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a
             data_loader,
         }
     }
+}
 
+impl<'a, DL: CellDataProvider + EpochProvider + HeaderProvider> DaoCalculator<'a, DL> {
     /// Returns the primary block reward for `target` block.
     pub fn primary_block_reward(&self, target: &HeaderView) -> Result<Capacity, DaoError> {
         let target_epoch = self


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Problem Summary: `DaoCalculator` requires a generic argument `DL` to implement `EpochProvider`, but some functions (such as `transaction_fee`) are not using `EpochProvider`. This makes it impossible to use DaoCalculator in light client, since there is no `EpochProvider` in light client

### What is changed and how it works?

What's Changed:

This PR splits functions in `DaoCalculator` that doesn't use `EpochProvider` into an individual `impl` block which doesn't require `DL` to implement `EpochProvider`

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

N/A

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

Title Only

