### PR TITLE
test: Attempted fixes on unstable tests

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -30,7 +30,7 @@ use ckb_logger::{error, info};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_types::prelude::{Pack, Unpack};
 use ckb_types::{BlockNumberAndHash, H256};
-pub use init::{build_chain_services, start_chain_services};
+pub use init::{ChainServiceScope, build_chain_services, start_chain_services};
 
 type ProcessBlockRequest = Request<LonelyBlock, ()>;
 type TruncateRequest = Request<Byte32, Result<(), Error>>;

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -30,7 +30,7 @@ use ckb_logger::{error, info};
 use ckb_store::{ChainDB, ChainStore};
 use ckb_types::prelude::{Pack, Unpack};
 use ckb_types::{BlockNumberAndHash, H256};
-pub use init::start_chain_services;
+pub use init::{build_chain_services, start_chain_services};
 
 type ProcessBlockRequest = Request<LonelyBlock, ()>;
 type TruncateRequest = Request<Byte32, Result<(), Error>>;

--- a/chain/src/tests/basic.rs
+++ b/chain/src/tests/basic.rs
@@ -1,4 +1,4 @@
-use crate::ChainController;
+use crate::ChainServiceScope;
 use crate::tests::util::start_chain;
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_dao_utils::genesis_dao_data;
@@ -28,7 +28,8 @@ use std::sync::Arc;
 
 #[test]
 fn repeat_process_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block_with_nonce(100u128, &mock_store);
@@ -90,7 +91,8 @@ fn process_genesis_block() {
     let consensus = ConsensusBuilder::default()
         .genesis_block(genesis_block)
         .build();
-    let (chain_controller, shared, _parent) = start_chain(Some(consensus));
+    let (chain, shared, _parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let block = Arc::new(shared.consensus().genesis_block().clone());
 
@@ -148,7 +150,8 @@ fn test_genesis_transaction_spend() {
     let consensus = ConsensusBuilder::default()
         .genesis_block(genesis_block)
         .build();
-    let (chain_controller, shared, parent) = start_chain(Some(consensus));
+    let (chain, shared, parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let end = 21;
 
@@ -183,7 +186,8 @@ fn test_genesis_transaction_spend() {
 
 #[test]
 fn test_transaction_spend_in_same_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block(&mock_store);
@@ -278,7 +282,8 @@ fn test_transaction_spend_in_same_block() {
 
 #[test]
 fn test_transaction_conflict_in_same_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block(&mock_store);
@@ -315,7 +320,8 @@ fn test_transaction_conflict_in_same_block() {
 
 #[test]
 fn test_transaction_conflict_in_different_blocks() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block(&mock_store);
@@ -355,7 +361,8 @@ fn test_transaction_conflict_in_different_blocks() {
 
 #[test]
 fn test_invalid_out_point_index_in_same_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block(&mock_store);
@@ -392,7 +399,8 @@ fn test_invalid_out_point_index_in_same_block() {
 
 #[test]
 fn test_invalid_out_point_index_in_different_blocks() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain_scope, shared, parent) = start_chain(None);
+    let chain_controller = chain_scope.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
     let mut chain = MockChain::new(parent, shared.consensus());
     chain.gen_empty_block_with_nonce(100u128, &mock_store);
@@ -464,7 +472,8 @@ fn test_genesis_transaction_fetch() {
 
 #[test]
 fn test_chain_fork_by_total_difficulty() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
 
     let mock_store = MockStore::new(&parent, shared.store());
@@ -503,7 +512,8 @@ fn test_chain_fork_by_total_difficulty() {
 
 #[test]
 fn test_chain_fork_by_first_received() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
 
     let mock_store = MockStore::new(&parent, shared.store());
@@ -553,8 +563,9 @@ fn prepare_context_chain(
     consensus: Consensus,
     orphan_count: u64,
     timestep: u64,
-) -> (ChainController, Shared, HeaderView) {
-    let (chain_controller, shared, genesis) = start_chain(Some(consensus));
+) -> (ChainServiceScope, Shared, HeaderView) {
+    let (chain, shared, genesis) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
     let final_number = shared.consensus().genesis_epoch_ext().length();
 
     let mut chain1: Vec<BlockView> = Vec::new();
@@ -636,7 +647,7 @@ fn prepare_context_chain(
         mock_store.insert_block(&new_block, &epoch);
         parent = new_block.header().clone();
     }
-    (chain_controller, shared, genesis)
+    (chain, shared, genesis)
 }
 
 #[test]

--- a/chain/src/tests/delay_verify.rs
+++ b/chain/src/tests/delay_verify.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 #[test]
 fn test_dead_cell_in_same_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
     let switch_fork_number = 10;
 
@@ -75,7 +76,8 @@ fn test_dead_cell_in_same_block() {
 
 #[test]
 fn test_dead_cell_in_different_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
     let switch_fork_number = 10;
 
@@ -136,7 +138,8 @@ fn test_dead_cell_in_different_block() {
 
 #[test]
 fn test_invalid_out_point_index_in_same_block() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
     let switch_fork_number = 10;
 
@@ -198,7 +201,8 @@ fn test_invalid_out_point_index_in_same_block() {
 
 #[test]
 fn test_invalid_out_point_index_in_different_blocks() {
-    let (chain_controller, shared, parent) = start_chain(None);
+    let (chain, shared, parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
     let switch_fork_number = 10;
 
@@ -261,7 +265,8 @@ fn test_invalid_out_point_index_in_different_blocks() {
 
 #[test]
 fn test_full_dead_transaction() {
-    let (chain_controller, shared, mut parent) = start_chain(None);
+    let (chain, shared, mut parent) = start_chain(None);
+    let chain_controller = chain.chain_controller();
     let final_number = 20;
     let switch_fork_number = 10;
     let proposal_number = 3;

--- a/chain/src/tests/dep_cell.rs
+++ b/chain/src/tests/dep_cell.rs
@@ -107,7 +107,8 @@ fn test_package_txs_with_deps() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, _parent) = start_chain(Some(consensus));
+    let (chain, shared, _parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let tx_pool = shared.tx_pool_controller();
 
@@ -246,7 +247,8 @@ fn test_package_txs_with_deps_unstable_sort() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, _parent) = start_chain(Some(consensus));
+    let (chain, shared, _parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let tx_pool = shared.tx_pool_controller();
 
@@ -390,7 +392,8 @@ fn test_package_txs_with_deps2() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, _parent) = start_chain(Some(consensus));
+    let (chain, shared, _parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let tx_pool = shared.tx_pool_controller();
 
@@ -520,7 +523,8 @@ fn test_package_txs_with_deps_priority() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, _parent) = start_chain(Some(consensus));
+    let (chain, shared, _parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let tx_pool = shared.tx_pool_controller();
 

--- a/chain/src/tests/find_fork.rs
+++ b/chain/src/tests/find_fork.rs
@@ -1,6 +1,6 @@
 use crate::utils::forkchanges::ForkChanges;
 use crate::verify::ConsumeUnverifiedBlockProcessor;
-use crate::{UnverifiedBlock, start_chain_services};
+use crate::{ChainServiceScope, UnverifiedBlock};
 use ckb_chain_spec::consensus::{Consensus, ProposalWindow};
 use ckb_proposal_table::ProposalTable;
 use ckb_shared::SharedBuilder;
@@ -389,7 +389,8 @@ fn repeatedly_switch_fork() {
     let mut fork1 = MockChain::new(genesis.clone(), shared.consensus());
     let mut fork2 = MockChain::new(genesis, shared.consensus());
 
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain.chain_controller();
 
     for _ in 0..2 {
         fork1.gen_empty_block_with_nonce(1u128, &mock_store);
@@ -525,7 +526,8 @@ fn test_fork_proposal_table() {
     };
 
     let (shared, mut pack) = builder.consensus(consensus).build().unwrap();
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain.chain_controller();
 
     let genesis = shared
         .store()

--- a/chain/src/tests/non_contextual_block_txs_verify.rs
+++ b/chain/src/tests/non_contextual_block_txs_verify.rs
@@ -148,7 +148,8 @@ fn non_contextual_block_txs_verify() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, parent) = start_chain(Some(consensus));
+    let (chain, shared, parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
     let mock_store = MockStore::new(&parent, shared.store());
 
     let tx0 = create_transaction(&issue_tx, 0, true);

--- a/chain/src/tests/reward.rs
+++ b/chain/src/tests/reward.rs
@@ -163,7 +163,8 @@ fn finalize_reward() {
         .genesis_block(genesis_block)
         .build();
 
-    let (chain_controller, shared, mut parent) = start_chain(Some(consensus));
+    let (chain, shared, mut parent) = start_chain(Some(consensus));
+    let chain_controller = chain.chain_controller();
 
     let mock_store = MockStore::new(&parent, shared.store());
 

--- a/chain/src/tests/truncate.rs
+++ b/chain/src/tests/truncate.rs
@@ -1,4 +1,4 @@
-use crate::start_chain_services;
+use crate::ChainServiceScope;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_shared::SharedBuilder;
 use ckb_store::ChainStore;
@@ -11,7 +11,8 @@ fn test_truncate() {
     let builder = SharedBuilder::with_temp_db();
 
     let (shared, mut pack) = builder.consensus(Consensus::default()).build().unwrap();
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain.chain_controller();
 
     let genesis = shared
         .store()

--- a/chain/src/tests/uncle.rs
+++ b/chain/src/tests/uncle.rs
@@ -1,4 +1,4 @@
-use crate::start_chain_services;
+use crate::ChainServiceScope;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_shared::SharedBuilder;
 use ckb_store::ChainStore;
@@ -10,7 +10,8 @@ use std::sync::Arc;
 fn test_get_block_body_after_inserting() {
     let builder = SharedBuilder::with_temp_db();
     let (shared, mut pack) = builder.consensus(Consensus::default()).build().unwrap();
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain.chain_controller();
 
     let genesis = shared
         .store()

--- a/rpc/src/tests/setup.rs
+++ b/rpc/src/tests/setup.rs
@@ -88,6 +88,9 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
         }))
         .build()
         .unwrap();
+    // Most of CKB will be started as part of RpcTestSuite, using ChainServiceScope
+    // to simplify chain termination actually brings more issues. We will keep this line
+    // as it is till we run into pthread issues in RPC tests for real.
     let chain_controller = start_chain_services(pack.take_chain_services_builder());
 
     // Start network services

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -49,6 +49,7 @@ faux.workspace = true
 ckb-systemtime = { workspace = true, features = ["enable_faketime"] }
 ckb-proposal-table.workspace = true
 ckb-logger-service.workspace = true
+ckb-tx-pool = { workspace = true, features = ["internal"] }
 
 [features]
 default = []

--- a/sync/src/relayer/tests/block_proposal_process.rs
+++ b/sync/src/relayer/tests/block_proposal_process.rs
@@ -6,7 +6,7 @@ use ckb_types::prelude::*;
 
 #[test]
 fn test_no_unknown() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
     let transaction = new_transaction(&relayer, 1, &always_success_out_point);
 
     let transactions = vec![transaction.clone()];
@@ -25,7 +25,7 @@ fn test_no_unknown() {
 
 #[test]
 fn test_no_asked() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
     let transaction = new_transaction(&relayer, 1, &always_success_out_point);
 
     let transactions = vec![transaction.clone()];
@@ -43,7 +43,7 @@ fn test_no_asked() {
 
 #[test]
 fn test_ok() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
     let transaction = new_transaction(&relayer, 1, &always_success_out_point);
     let transactions = vec![transaction.clone()];
     let proposals: Vec<ProposalShortId> = transactions
@@ -73,7 +73,7 @@ fn test_ok() {
 #[test]
 fn test_clear_expired_inflight_proposals() {
     // mark the inflight proposals as block number 2, the default farthest proposal window is 10, it will be expired and ignored
-    let (relayer, always_success_out_point) = build_chain(13);
+    let (_chain, relayer, always_success_out_point) = build_chain(13);
     let transaction = new_transaction(&relayer, 1, &always_success_out_point);
     let transactions = vec![transaction];
     let proposals: Vec<ProposalShortId> = transactions

--- a/sync/src/relayer/tests/block_transactions_process.rs
+++ b/sync/src/relayer/tests/block_transactions_process.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 #[test]
 fn test_accept_block() {
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
     let peer_index: PeerIndex = 100.into();
     let other_peer_index: PeerIndex = 101.into();
 
@@ -99,7 +99,7 @@ fn test_accept_block() {
 
 #[test]
 fn test_unknown_request() {
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
     let peer_index: PeerIndex = 100.into();
 
     let tx1 = TransactionBuilder::default().build();
@@ -152,7 +152,7 @@ fn test_unknown_request() {
 
 #[test]
 fn test_invalid_transaction_root() {
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
     let peer_index: PeerIndex = 100.into();
 
     let tx1 = TransactionBuilder::default().build();
@@ -220,7 +220,7 @@ fn test_invalid_transaction_root() {
 
 #[test]
 fn test_collision_and_send_missing_indexes() {
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
 
     let active_chain = relayer.shared.active_chain();
     let last_block = relayer
@@ -365,7 +365,7 @@ fn test_missing() {
     //  3. When the relayer receives the return from tx2, tx3 is not in the transaction pool
     //  4. Relayer must make another request for tx2 and tx3
 
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
     let peer_index: PeerIndex = 100.into();
 
     let tx1 = TransactionBuilder::default().build();

--- a/sync/src/relayer/tests/get_block_proposal_process.rs
+++ b/sync/src/relayer/tests/get_block_proposal_process.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 #[test]
 fn test_duplicate() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
 
     let tx = new_transaction(&relayer, 1, &always_success_out_point);
     let id = tx.proposal_short_id();

--- a/sync/src/relayer/tests/get_transactions_process.rs
+++ b/sync/src/relayer/tests/get_transactions_process.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 #[test]
 fn test_duplicate() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
 
     let tx = new_transaction(&relayer, 1, &always_success_out_point);
     let tx_hash = tx.hash();

--- a/sync/src/relayer/tests/reconstruct_block.rs
+++ b/sync/src/relayer/tests/reconstruct_block.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 // There are more test cases in block_transactions_process and compact_block_process.rs
 #[test]
 fn test_missing_txs() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
     let prepare: Vec<TransactionView> = (0..20)
         .map(|i| new_transaction(&relayer, i, &always_success_out_point))
         .collect();
@@ -63,7 +63,7 @@ fn test_missing_txs() {
 
 #[test]
 fn test_reconstruct_transactions_and_uncles() {
-    let (relayer, always_success_out_point) = build_chain(5);
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
     let parent = new_transaction(&relayer, 0, &always_success_out_point);
 
     // create a chain of transactions as prepare
@@ -144,7 +144,7 @@ fn test_reconstruct_transactions_and_uncles() {
 
 #[test]
 fn test_reconstruct_invalid_uncles() {
-    let (relayer, _) = build_chain(5);
+    let (_chain, relayer, _) = build_chain(5);
 
     let uncle = BlockBuilder::default().build();
     // BLOCK_VALID

--- a/sync/src/tests/mod.rs
+++ b/sync/src/tests/mod.rs
@@ -195,6 +195,9 @@ impl TestNode {
         if let Some(th) = self.th.take() {
             th.join().expect("th join");
         }
+        // Dropping self is required since this structure might
+        // contain a copy of ChainController in one protocol.
+        drop(self);
     }
 }
 

--- a/sync/src/tests/sync_shared.rs
+++ b/sync/src/tests/sync_shared.rs
@@ -4,9 +4,9 @@
 use crate::relayer::CompactBlockProcess;
 use crate::relayer::tests::helper::MockProtocolContext;
 use crate::synchronizer::HeadersProcess;
-use crate::tests::util::{ChainServiceScope, build_chain, inherit_block};
+use crate::tests::util::{build_chain, inherit_block};
 use crate::{Relayer, Status, SyncShared, Synchronizer};
-use ckb_chain::{RemoteBlock, VerifyResult};
+use ckb_chain::{ChainServiceScope, RemoteBlock, VerifyResult};
 use ckb_logger::info;
 use ckb_shared::block_status::BlockStatus;
 use ckb_shared::{Shared, SharedBuilder};

--- a/sync/src/tests/synchronizer/basic_sync.rs
+++ b/sync/src/tests/synchronizer/basic_sync.rs
@@ -3,8 +3,8 @@ use crate::synchronizer::{
     TIMEOUT_EVICTION_TOKEN,
 };
 use crate::tests::TestNode;
+use crate::tests::util::ChainServiceScope;
 use crate::{SyncShared, Synchronizer};
-use ckb_chain::start_chain_services;
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_channel::bounded;
 use ckb_dao::DaoCalculator;
@@ -38,9 +38,9 @@ fn basic_sync() {
     _faketime_guard.set_faketime(0);
     let thread_name = "fake_time=0".to_string();
 
-    let (mut node1, shared1) = setup_node(1);
+    let (mut node1, shared1, _chain1) = setup_node(1);
     info!("finished setup node1");
-    let (mut node2, shared2) = setup_node(3);
+    let (mut node2, shared2, _chain2) = setup_node(3);
     info!("finished setup node2");
 
     info!("connnectiong node1 and node2");
@@ -91,7 +91,7 @@ fn basic_sync() {
     panic!("node1 and node2 should sync in 3 seconds");
 }
 
-fn setup_node(height: u64) -> (TestNode, Shared) {
+fn setup_node(height: u64) -> (TestNode, Shared, ChainServiceScope) {
     let (always_success_cell, always_success_cell_data, always_success_script) =
         always_success_cell();
     let always_success_tx = TransactionBuilder::default()
@@ -119,9 +119,12 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
         .build()
         .unwrap();
 
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain = ChainServiceScope::new(pack.take_chain_services_builder());
 
-    while chain_controller.is_verifying_unverified_blocks_on_startup() {
+    while chain
+        .chain_controller()
+        .is_verifying_unverified_blocks_on_startup()
+    {
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 
@@ -189,7 +192,8 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
             .extension(Some(bytes))
             .build();
 
-        chain_controller
+        chain
+            .chain_controller()
             .blocking_process_block_with_switch(Arc::new(block.clone()), Switch::DISABLE_ALL)
             .expect("process block should be OK");
     }
@@ -199,7 +203,7 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
         Default::default(),
         pack.take_relay_tx_receiver(),
     ));
-    let synchronizer = Synchronizer::new(chain_controller, sync_shared);
+    let synchronizer = Synchronizer::new(chain.chain_controller().clone(), sync_shared);
     let mut node = TestNode::new();
     let protocol = Arc::new(RwLock::new(synchronizer)) as Arc<_>;
     node.add_protocol(
@@ -212,5 +216,5 @@ fn setup_node(height: u64) -> (TestNode, Shared) {
             TIMEOUT_EVICTION_TOKEN,
         ],
     );
-    (node, shared)
+    (node, shared, chain)
 }

--- a/sync/src/tests/synchronizer/basic_sync.rs
+++ b/sync/src/tests/synchronizer/basic_sync.rs
@@ -3,8 +3,8 @@ use crate::synchronizer::{
     TIMEOUT_EVICTION_TOKEN,
 };
 use crate::tests::TestNode;
-use crate::tests::util::ChainServiceScope;
 use crate::{SyncShared, Synchronizer};
+use ckb_chain::ChainServiceScope;
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_channel::bounded;
 use ckb_dao::DaoCalculator;

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -1,4 +1,4 @@
-use ckb_chain::ChainController;
+use ckb_chain::{ChainController, ChainServiceScope};
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_constant::sync::{CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME, MAX_TIP_AGE};
 use ckb_dao::DaoCalculator;
@@ -38,7 +38,6 @@ use std::{
 use crate::{
     Status, StatusCode, SyncShared,
     synchronizer::{BlockFetcher, BlockProcess, GetBlocksProcess, HeadersProcess, Synchronizer},
-    tests::util::ChainServiceScope,
     types::{HeadersSyncController, IBDState, PeerState},
 };
 

--- a/sync/src/tests/util.rs
+++ b/sync/src/tests/util.rs
@@ -1,8 +1,8 @@
 use crate::SyncShared;
-use ckb_chain::{ChainController, build_chain_services};
+use ckb_chain::{ChainController, ChainServiceScope};
 use ckb_dao::DaoCalculator;
 use ckb_reward_calculator::RewardCalculator;
-use ckb_shared::{ChainServicesBuilder, Shared, SharedBuilder, Snapshot};
+use ckb_shared::{Shared, SharedBuilder, Snapshot};
 use ckb_store::ChainStore;
 use ckb_test_chain_utils::{always_success_cellbase, always_success_consensus};
 use ckb_types::prelude::*;
@@ -13,7 +13,6 @@ use ckb_types::{
 use ckb_verification_traits::Switch;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::thread::JoinHandle;
 
 pub fn build_chain(tip: BlockNumber) -> (SyncShared, ChainServiceScope) {
     let (shared, mut pack) = SharedBuilder::with_temp_db()
@@ -24,32 +23,6 @@ pub fn build_chain(tip: BlockNumber) -> (SyncShared, ChainServiceScope) {
     generate_blocks(&shared, chain_scope.chain_controller(), tip);
     let sync_shared = SyncShared::new(shared, Default::default(), pack.take_relay_tx_receiver());
     (sync_shared, chain_scope)
-}
-
-// This structure restricts the scope of chain service, and forces chain
-// service threads to terminate before dropping the structure.
-// The content of this struct will always be present, the reason we
-// wrap them in an option, is that we will need to consume them in
-// Drop trait impl of this struct.
-pub struct ChainServiceScope(Option<(ChainController, JoinHandle<()>)>);
-
-impl ChainServiceScope {
-    pub fn new(builder: ChainServicesBuilder) -> Self {
-        let (controller, join_handle) = build_chain_services(builder);
-        Self(Some((controller, join_handle)))
-    }
-
-    pub fn chain_controller(&self) -> &ChainController {
-        &self.0.as_ref().unwrap().0
-    }
-}
-
-impl Drop for ChainServiceScope {
-    fn drop(&mut self) {
-        let (controller, join_handle) = self.0.take().unwrap();
-        drop(controller);
-        let _ = join_handle.join();
-    }
 }
 
 pub fn generate_blocks(

--- a/util/light-client-protocol-server/src/tests/utils/chain.rs
+++ b/util/light-client-protocol-server/src/tests/utils/chain.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use ckb_app_config::{BlockAssemblerConfig, NetworkConfig};
-use ckb_chain::{ChainController, start_chain_services};
+use ckb_chain::{ChainController, ChainServiceScope};
 use ckb_chain_spec::consensus::{ConsensusBuilder, build_genesis_epoch_ext};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::ScriptHashType;
@@ -23,7 +23,7 @@ use ckb_types::{
 use crate::{LightClientProtocol, tests::prelude::*};
 
 pub(crate) struct MockChain {
-    chain_controller: ChainController,
+    chain: ChainServiceScope,
     shared: Shared,
     always_success_cell_dep: packed::CellDep,
 }
@@ -87,17 +87,17 @@ impl MockChain {
         let network = dummy_network(&shared);
         pack.take_tx_pool_builder().start(network);
 
-        let chain_controller = start_chain_services(pack.take_chain_services_builder());
+        let chain = ChainServiceScope::new(pack.take_chain_services_builder());
 
         Self {
-            chain_controller,
+            chain,
             shared,
             always_success_cell_dep,
         }
     }
 
     pub(crate) fn controller(&self) -> &ChainController {
-        &self.chain_controller
+        self.chain.chain_controller()
     }
 
     pub(crate) fn shared(&self) -> &Shared {


### PR DESCRIPTION
Some of our sync tests have been slightly unstable: they pass in 95%+ of the time, however from time to time, they would break, if we try to rerun them in CI, in most cases those tests would then pass.

I managed to dig into those tests with a little help from rr, it seems that 2 timings would affect those unstable tests:

1. When a test finishes, C++'s destructors decide to destruct rocksdb's global Timer structure.
2. When all the threads spawned by ChainService terminates, Rust decides to drop ChainService. However, a RocksDB instance is buried deep in ChainService. When the RocksDB instance is destructed, C++ code would eventually run Timer::Cancel on the global Timer structure.

If timing 2 happens before timing 1, everything is fine, the test will pass. However from time to time, timing 1 might happen before timing 2, in this case unit tests would fail, and we see errors relating to pthread.

This change is an attempt to fix this issue.

Please do note that it attempts to fix those unstable tests we know of in ckb-sync package, however there might or might not be other unstable tests in other CKB packages. Later changes can be used to fix more unstable tests, following the change made in this commit.

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
Title Only: Include only the PR title in the release note.
Note: Add a note under the PR title in the release note.
```

