### PR TITLE
Config `Dependabot` group multiple PRs into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
     timezone: Asia/Shanghai
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
-  ignore:
-  - dependency-name: ctrlc
-    versions:
-    - 3.1.9
-  - dependency-name: futures
-    versions:
-    - 0.3.12
-  - dependency-name: hyper
-    versions:
-    - 0.13.10
-  rebase-strategy: disabled
+  groups:
+    all-dependencies:
+      patterns: ["*"]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to config dependabot group multiple PR into one PR. 

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

### What is changed and how it works?

### Related changes

- Config dependabot.yml group multiple PRs into one PR

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

