### PR TITLE
CI: let dependabot PR add fetch metadata

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -1,0 +1,16 @@
+name: Dependabot Pull Request
+on: pull_request
+jobs:
+  dependabot:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'nervosnetwork/ckb'
+    steps:
+    - name: Fetch Dependabot metadata
+      id: dependabot-metadata
+      uses: dependabot/fetch-metadata@v2
+      with:
+        alert-lookup: true
+        compat-lookup: true
+        github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### What problem does this PR solve?

This PR want dependabot generated PR add crates update info

https://github.com/dependabot/fetch-metadata

### What is changed and how it works?



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

