### PR TITLE
CI: fix ci_aarch64_build_ubuntu not check ckb git repo

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -42,6 +42,7 @@ jobs:
     needs: prologue
     runs-on: ${{ needs.prologue.outputs.linux_runner_label }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0


### PR DESCRIPTION
### What problem does this PR solve?

This PR want to fix: https://github.com/nervosnetwork/ckb/actions/runs/15949795066/job/44988260041


What's Changed:

### Related changes

- checkout ckb's git repo before running ci

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

