### PR TITLE
Change foreground color of datetime to darkslategray for better readability

### DIFF
--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -423,9 +423,10 @@ impl Log for Logger {
             if let Ok(dt) = utc.format(&fmt) {
                 let with_color = {
                     let thread_name = format!("{}", Paint::blue(thread_name).bold());
+                    let date = format!("{}", Paint::rgb(47, 79, 79, dt).bold()); // darkslategrey
                     format!(
                         "{} {} {} {}  {}",
-                        Paint::black(dt).bold(),
+                        date,
                         thread_name,
                         record.level(),
                         record.target(),


### PR DESCRIPTION
### What problem does this PR solve?

In log, the default foreground color of datetime is black, if my background color of terminal is also black, the datetime is invisible.


What's Changed:

### Related changes

- Change foreground color of datetime to darkslategray for better readability

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- NOne

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

