### PR TITLE
chore: ignore fxhash unmaintained advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,10 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+  # The fxhash crate is no longer maintained, but fxhash was introduced by sled,
+  # so we need to wait for sled to update its version，
+  # for now, temporarily ignore it first.
+  "RUSTSEC-2025-0057",
   # Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
   # proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.
   "RUSTSEC-2024-0370",


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
The fxhash crate is no longer maintained, but fxhash was introduced by sled, so we need to wait for sled to update its version，for now, temporarily ignore it first.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
- Breaking backward compatibility

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

