### PR TITLE
chore: change secondary db options

### DIFF
--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -113,9 +113,6 @@ pub struct IndexerSyncConfig {
     pub poll_interval: u64,
     /// Whether to index the pending txs in the ckb tx-pool
     pub index_tx_pool: bool,
-    /// Maximal db info log files to be kept.
-    #[serde(default)]
-    pub db_keep_log_file_num: Option<NonZeroUsize>,
 }
 
 impl From<&IndexerConfig> for IndexerSyncConfig {
@@ -124,7 +121,6 @@ impl From<&IndexerConfig> for IndexerSyncConfig {
             secondary_path: config.secondary_path.clone(),
             poll_interval: config.poll_interval,
             index_tx_pool: config.index_tx_pool,
-            db_keep_log_file_num: config.db_keep_log_file_num,
         }
     }
 }

--- a/util/indexer-sync/src/lib.rs
+++ b/util/indexer-sync/src/lib.rs
@@ -28,15 +28,13 @@ use ckb_types::{
     core::{self, BlockNumber, BlockView},
     packed::Byte32,
 };
-use rocksdb::prelude::*;
+use rocksdb::{LogLevel, prelude::*};
 
 use std::marker::Send;
-use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 use std::thread::sleep;
 use std::time::Duration;
 
-const DEFAULT_LOG_KEEP_NUM: usize = 1;
 const INDEXER_NODE_TIP_GAP: u64 = 10;
 
 /// Trait for an indexer's synchronization interface
@@ -64,7 +62,7 @@ pub fn new_secondary_db(ckb_db_config: &DBConfig, config: &IndexerSyncConfig) ->
         COLUMN_BLOCK_PROPOSAL_IDS,
         COLUMN_BLOCK_EXTENSION,
     ];
-    let secondary_opts = indexer_secondary_options(config);
+    let secondary_opts = indexer_secondary_options();
     SecondaryDB::open_cf(
         &secondary_opts,
         &ckb_db_config.path,
@@ -301,15 +299,10 @@ impl IndexerSyncService {
     }
 }
 
-fn indexer_secondary_options(config: &IndexerSyncConfig) -> Options {
+fn indexer_secondary_options() -> Options {
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
-    opts.set_keep_log_file_num(
-        config
-            .db_keep_log_file_num
-            .map(NonZeroUsize::get)
-            .unwrap_or(DEFAULT_LOG_KEEP_NUM),
-    );
+    opts.set_log_level(LogLevel::Warn);
     opts
 }


### PR DESCRIPTION
### What problem does this PR solve?

The `keep_log_file_num` setting for the secondary DB is invalid, which will cause it to generate a large number of synchronized logs.  Now adjust the log level to Warn to reduce unnecessary log output.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

