### PR TITLE
rich-indexer: Do not insert uncle block into database

### DIFF
--- a/util/rich-indexer/resources/create_postgres_index.sql
+++ b/util/rich-indexer/resources/create_postgres_index.sql
@@ -1,7 +1,6 @@
 CREATE INDEX IF NOT EXISTS "index_block_table_block_hash" ON "block" ("block_hash");
 
 CREATE INDEX IF NOT EXISTS "index_block_association_proposal_table_block_id" ON "block_association_proposal" ("block_id");
-CREATE INDEX IF NOT EXISTS "index_block_association_uncle_table_block_id" ON "block_association_uncle" ("block_id");
 
 CREATE INDEX IF NOT EXISTS "index_tx_table_tx_hash" ON "ckb_transaction" ("tx_hash");
 CREATE INDEX IF NOT EXISTS "index_tx_table_block_id" ON "ckb_transaction" ("block_id");

--- a/util/rich-indexer/resources/create_postgres_table.sql
+++ b/util/rich-indexer/resources/create_postgres_table.sql
@@ -21,12 +21,6 @@ CREATE TABLE IF NOT EXISTS block_association_proposal(
     proposal BYTEA NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS block_association_uncle(
-    id BIGSERIAL,
-    block_id BIGINT NOT NULL,
-    uncle_id BIGINT NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS ckb_transaction(
     id BIGSERIAL PRIMARY KEY,
     tx_hash BYTEA NOT NULL,

--- a/util/rich-indexer/resources/create_sqlite_index.sql
+++ b/util/rich-indexer/resources/create_sqlite_index.sql
@@ -1,7 +1,6 @@
 CREATE INDEX IF NOT EXISTS "index_block_table_block_hash" ON "block" ("block_hash");
 
 CREATE INDEX IF NOT EXISTS "index_block_association_proposal_table_block_id" ON "block_association_proposal" ("block_id");
-CREATE INDEX IF NOT EXISTS "index_block_association_uncle_table_block_id" ON "block_association_uncle" ("block_id");
 
 CREATE INDEX IF NOT EXISTS "index_tx_table_tx_hash" ON "ckb_transaction" ("tx_hash");
 CREATE INDEX IF NOT EXISTS "index_tx_table_block_id" ON "ckb_transaction" ("block_id");

--- a/util/rich-indexer/resources/create_sqlite_table.sql
+++ b/util/rich-indexer/resources/create_sqlite_table.sql
@@ -21,12 +21,6 @@ CREATE TABLE IF NOT EXISTS block_association_proposal(
     proposal BLOB NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS block_association_uncle(
-    id INTEGER PRIMARY KEY,
-    block_id INTEGER NOT NULL,
-    uncle_id INTEGER NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS ckb_transaction(
     id INTEGER PRIMARY KEY,
     tx_hash BLOB NOT NULL,

--- a/util/rich-indexer/src/indexer/mod.rs
+++ b/util/rich-indexer/src/indexer/mod.rs
@@ -26,7 +26,6 @@ use std::sync::{Arc, RwLock};
 /// - output
 /// - script
 /// - block_association_proposal
-/// - block_association_uncle
 /// - tx_association_header_dep
 /// - tx_association_cell_dep
 ///   The detailed table design can be found in the SQL files in the resources folder of this crate

--- a/util/rich-indexer/src/indexer/remove.rs
+++ b/util/rich-indexer/src/indexer/remove.rs
@@ -39,14 +39,8 @@ pub(crate) async fn rollback_block(tx: &mut Transaction<'_, Any>) -> Result<(), 
     remove_batch_by_blobs("script", "id", &script_id_list_to_remove, tx).await?;
 
     // remove block and block associations
-    let uncle_id_list = query_uncle_id_list_by_block_id(block_id, tx).await?;
     remove_batch_by_blobs("block", "id", &[block_id], tx).await?;
     remove_batch_by_blobs("block_association_proposal", "block_id", &[block_id], tx).await?;
-    remove_batch_by_blobs("block_association_uncle", "block_id", &[block_id], tx).await?;
-
-    // remove uncles
-    remove_batch_by_blobs("block", "id", &uncle_id_list, tx).await?;
-    remove_batch_by_blobs("block_association_proposal", "block_id", &uncle_id_list, tx).await?;
 
     Ok(())
 }
@@ -103,24 +97,6 @@ async fn reset_spent_cells(tx_id_list: &[i64], tx: &mut Transaction<'_, Any>) ->
         .map_err(|err| Error::DB(err.to_string()))?;
 
     Ok(())
-}
-
-async fn query_uncle_id_list_by_block_id(
-    block_id: i64,
-    tx: &mut Transaction<'_, Any>,
-) -> Result<Vec<i64>, Error> {
-    SQLXPool::new_query(
-        r#"
-            SELECT DISTINCT uncle_id
-            FROM block_association_uncle
-            WHERE block_id = $1
-            "#,
-    )
-    .bind(block_id)
-    .fetch_all(tx.as_mut())
-    .await
-    .map(|rows| rows.into_iter().map(|row| row.get("uncle_id")).collect())
-    .map_err(|err| Error::DB(err.to_string()))
 }
 
 async fn query_tip_id(tx: &mut Transaction<'_, Any>) -> Result<Option<i64>, Error> {

--- a/util/rich-indexer/src/tests/insert.rs
+++ b/util/rich-indexer/src/tests/insert.rs
@@ -45,13 +45,6 @@ async fn test_append_block_0() {
     assert_eq!(
         0,
         storage
-            .fetch_count("block_association_uncle")
-            .await
-            .unwrap()
-    );
-    assert_eq!(
-        0,
-        storage
             .fetch_count("tx_association_header_dep")
             .await
             .unwrap()

--- a/util/rich-indexer/src/tests/rollback.rs
+++ b/util/rich-indexer/src/tests/rollback.rs
@@ -38,13 +38,6 @@ async fn test_rollback_block_0() {
     assert_eq!(
         0,
         storage
-            .fetch_count("block_association_uncle")
-            .await
-            .unwrap()
-    );
-    assert_eq!(
-        0,
-        storage
             .fetch_count("tx_association_header_dep")
             .await
             .unwrap()
@@ -71,7 +64,7 @@ async fn test_rollback_block_9() {
     );
     insert_blocks(storage.clone()).await;
 
-    assert_eq!(15, storage.fetch_count("block").await.unwrap()); // 10 blocks, 5 uncles
+    assert_eq!(10, storage.fetch_count("block").await.unwrap()); // 10 blocks
     assert_eq!(11, storage.fetch_count("ckb_transaction").await.unwrap());
     assert_eq!(12, storage.fetch_count("output").await.unwrap());
     assert_eq!(1, storage.fetch_count("input").await.unwrap());
@@ -80,13 +73,6 @@ async fn test_rollback_block_9() {
         0,
         storage
             .fetch_count("block_association_proposal")
-            .await
-            .unwrap()
-    );
-    assert_eq!(
-        5,
-        storage
-            .fetch_count("block_association_uncle")
             .await
             .unwrap()
     );
@@ -107,7 +93,7 @@ async fn test_rollback_block_9() {
 
     indexer.rollback().await.unwrap();
 
-    assert_eq!(12, storage.fetch_count("block").await.unwrap()); // 9 blocks, 3 uncles
+    assert_eq!(9, storage.fetch_count("block").await.unwrap()); // 9 blocks
     assert_eq!(10, storage.fetch_count("ckb_transaction").await.unwrap());
     assert_eq!(12, storage.fetch_count("output").await.unwrap());
     assert_eq!(1, storage.fetch_count("input").await.unwrap());
@@ -116,13 +102,6 @@ async fn test_rollback_block_9() {
         0,
         storage
             .fetch_count("block_association_proposal")
-            .await
-            .unwrap()
-    );
-    assert_eq!(
-        3,
-        storage
-            .fetch_count("block_association_uncle")
             .await
             .unwrap()
     );


### PR DESCRIPTION
### What problem does this PR solve?

For rich-indexer, we don't really need to insert uncle block related info into database. This PR remove the related logic.
### Related changes

- Remove the uncle block logic for rich-indexer

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Note: Rich Indexer: Uncle Block Tracking Removed

The rich-indexer no longer tracks uncle blocks. The `block_association_uncle` table has been removed from the schema.

**Action Required:** If you have an existing rich-indexer database, manually drop the unused table: DROP TABLE block_association_uncle;
```

