### PR TITLE
fix: Consider headers of molecule objects when limiting size of BlockFilters message

### DIFF
--- a/sync/src/filter/get_block_filters_process.rs
+++ b/sync/src/filter/get_block_filters_process.rs
@@ -49,9 +49,9 @@ impl<'a> GetBlockFiltersProcess<'a> {
                             + 4
                             + block_filter.as_slice().len()
                             + 4
-                            >= (2.0 * 1024.0 * 1024.0) as usize
+                            >= (1.8 * 1024.0 * 1024.0) as usize
                         {
-                            // Break if the encoded size of `block_hash` + `block_filter` + `start_number` + molecule header increase reaches 2.0MB, to avoid frame size too large
+                            // Break if the encoded size of `block_hash` + `block_filter` + `start_number` + molecule header increase reaches 1.8MB, to avoid frame size too large
                             break;
                         }
                         current_content_size +=


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

The previous PR limits the size of content of BlockFilter to 2M, but it doesn't consider size overhead introduces by molecule

### What is changed and how it works?

What's Changed:

This PR adds headers of molecule into size calculation, and limits the size to 1.8MB
