### PR TITLE
feat: disable compress on filter

### DIFF
--- a/util/launcher/src/lib.rs
+++ b/util/launcher/src/lib.rs
@@ -314,11 +314,14 @@ impl Launcher {
         if support_protocols.contains(&SupportProtocol::Filter) {
             let filter = BlockFilter::new(Arc::clone(&sync_shared));
 
-            protocols.push(CKBProtocol::new_with_support_protocol(
-                SupportProtocols::Filter,
-                Box::new(filter),
-                Arc::clone(&network_state),
-            ));
+            protocols.push(
+                CKBProtocol::new_with_support_protocol(
+                    SupportProtocols::Filter,
+                    Box::new(filter),
+                    Arc::clone(&network_state),
+                )
+                .compress(false),
+            );
         } else {
             flags.remove(Flags::BLOCK_FILTER);
         }


### PR DESCRIPTION
### What problem does this PR solve?

After about a week of metrics collection, the following data can be seen:

| Protocol Number | Number of Uncompressed Messages / Number of Compressed Messages | Percentage of Compressed Messages | Average Compression Ratio | Compare values ​​from a specific time segment (1.1:1.0:0.9:0.8:0.7:0.6:0.5:0.4) |
| ---- | ---- | ---- | ---- | ---- |
| Filter (121) | 0.614 | 62% | 0.990 | 40: 1: 3: 0: 0: 0: 0 |
| Sync (100) | 0.226 | 82% | 0.685 | 0: 1825: 5: 5787: 3186: 2646: 992:23 |
| Relay (101) | 0.312 | 76% | 0.801 | 26411: 140: 1: 16: 355: 3603: 12906 |
| LightClient (120) | 11.8 | 7.8% | 0.685 | 0: 0: 0: 6: 30: 0: 0 |

The messages in the filter protocol are actually uncompressible, so we disable it.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None: Exclude this PR from the release note.
```

