### PR TITLE
windows: Hint windows user to install latest vc-redist if host vc-redist is lower than 14.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "ckb-test",
  "console-subscriber",
  "tikv-jemallocator",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3780,7 +3781,7 @@ dependencies = [
  "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -7858,6 +7859,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ ckb-bin.workspace = true
 ckb-test.workspace = true
 console-subscriber = { workspace = true, optional = true }
 
+[target.'cfg(target_env = "msvc")'.dependencies]
+winreg = "0.55"
+
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 tikv-jemallocator = { version = "0.5.0", features = [
     "unprefixed_malloc_on_supported_platforms",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,75 @@ fn main() {
     #[cfg(feature = "tokio-trace")]
     console_subscriber::init();
 
+    #[cfg(target_os = "windows")]
+    check_msvc_version();
+
     let version = get_version();
     if let Some(exit_code) = run_app(version).err() {
         ::std::process::exit(exit_code.into());
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn check_msvc_version() {
+    use winreg::RegKey;
+    use winreg::enums::*;
+    // if users msvc version less than 14.44, print a warning
+
+    fn get_vc_redist_version(arch: &str) -> io::Result<Option<String>> {
+        // arch: "x64" or "x86"
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let key_path = format!(
+            r"SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\{}",
+            arch
+        );
+        match hklm.open_subkey(&key_path) {
+            Ok(key) => {
+                let version: String = key.get_value("Version")?;
+                Ok(Some(version))
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn version_string_to_tuple(ver: &str) -> Option<(u32, u32, u32, u32)> {
+        let parts: Vec<&str> = ver.split('.').collect();
+        if parts.len() >= 4 {
+            let major = parts[0].parse().ok()?;
+            let minor = parts[1].parse().ok()?;
+            let bld = parts[2].parse().ok()?;
+            let rbld = parts[3].parse().ok()?;
+            Some((major, minor, bld, rbld))
+        } else {
+            None
+        }
+    }
+    fn is_version_at_least(current: &str, threshold: &str) -> bool {
+        if let (Some(cur), Some(thr)) = (
+            version_string_to_tuple(current),
+            version_string_to_tuple(threshold),
+        ) {
+            cur >= thr
+        } else {
+            false
+        }
+    }
+
+    if let Some(version) = get_vc_redist_version("x64")? {
+        eprintln!("Detected VC++ Redistributable version (x64): {}", version);
+        let threshold = "14.44.0.0";
+        if !is_version_at_least(&version, threshold) {
+            eprintln!(
+                "Version is below {}. Please download/upgrade the Visual C++ Redistributable. Help: https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version ",
+                threshold
+            );
+        } else {
+            eprintln!("MSVC Version: {} meets the requirement.", version);
+        }
+    } else {
+        eprintln!(
+            "Visual C++ Redistributable version not found. Please install it. Help: https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version"
+        );
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to fix #4995

- Hint windows user to install/upgrade latest Visual C++ Redistribution if user's host miss it or version is lower than 14.44.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

