### PR TITLE
Fix CI runner(Ubuntu 22.04) missing `make` command

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           toolchain: 1.85.0
           components: rustfmt
-      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib build-essential
       - name: ci_aarch64_build_ubuntu
         run: |
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           toolchain: 1.85.0
           components: rustfmt, clippy
-      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - uses: actions/checkout@v4
       - run: |
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           toolchain: 1.85.0
           components: rustfmt, clippy
-      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - uses: actions/checkout@v4
       - run: |
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
@@ -85,7 +85,7 @@ jobs:
         with:
           toolchain: 1.85.0
           components: rustfmt, clippy
-      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential procps wget
       - uses: actions/checkout@v4
       - name: build ckb and run bats cli test
         run: |

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -56,7 +56,7 @@ jobs:
           toolchain: 1.85.0
           components: rustfmt, clippy
       - run: cargo fmt --all -- --check
-      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y
+      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev build-essential -y
       - run: |
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
               devtools/ci/ci_main.sh

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -56,8 +56,8 @@ jobs:
           components: rustfmt, clippy
       - uses: actions/checkout@v4
       - run: cargo fmt --all -- --check
-      - run: pip install yq
-      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev jq -y
+      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev jq build-essential python3-pip -y
+      - run: pip3 install yq
       - run: |
           if [[ ${{ needs.prologue.outputs.os_skip }} == run ]] && [[ ${{ needs.prologue.outputs.job_skip }} == run ]];then
               echo tomlq path: $(which tomlq)

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0
-      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           toolchain: 1.85.0
           components: rustfmt,llvm-tools-preview
-      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib build-essential
       - name: unit coverage
         run: make cov
       - name: integration cov

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Add rust target
         run: rustup target add aarch64-unknown-linux-gnu
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: sudo apt-get update && sudo apt-get install -y gcc-multilib && sudo apt-get install -y build-essential clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu build-essential
       - name: Build CKB and Package CKB
         env:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}

--- a/.github/workflows/smoking_test.yaml
+++ b/.github/workflows/smoking_test.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo systemctl daemon-reload
           sudo systemctl reset-failed
           rm ${{ github.workspace }}/ckb
-      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib build-essential
       - run: sudo apt-get install -y wget ca-certificates && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - && sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list' && sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
       - name: Download target ckb release pkg and copy binary to github workspace
         if: |


### PR DESCRIPTION
### What problem does this PR solve?

CKB's CI has upgraded to ubuntu 22.04, this PR want to fix the CI runner's missing `make` command issue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None


### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

