### PR TITLE
Fix windows options unused mut warning

### DIFF
--- a/util/onion/src/onion_service.rs
+++ b/util/onion/src/onion_service.rs
@@ -161,8 +161,8 @@ fn create_tor_secret_key(onion_private_key_path: String) -> Result<TorSecretKeyV
         key.public().get_onion_address()
     );
 
-    #[cfg_attr(not(unix), allow(unused_mut))]
     let mut file_options = OpenOptions::new();
+    #[allow(unused_mut)]
     let mut options = file_options.create(true).truncate(true).write(true);
 
     #[cfg(unix)]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR want to fix:
```bash
   Compiling ckb-onion v1.0.0 (C:\Users\Administrator\actions-runner\windows-runner-1\_work\ckb\ckb\util\onion)
error: variable does not need to be mutable
   --> util\onion\src\onion_service.rs:166:9
    |
166 |     let mut options = file_options.create(true).truncate(true).write(true);
    |         ----^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `-D unused-mut` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_mut)]`

error: could not compile `ckb-onion` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: command `'\\?\C:\Users\Administrator\.rustup\toolchains\1.85.0-x86_64-pc-windows-msvc\bin\cargo.exe' test --no-run --message-format json-render-diagnostics --workspace --features deadlock_detection,with_sentry` exited with code 101
make: *** [Makefile:33: test] Error 101

```

https://github.com/nervosnetwork/ckb/actions/runs/19529450466/job/55908806667

### Related changes

- Add `allow(unused_mut)` to fix windows platform clippy happy

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

