### PR TITLE
feat: add default time cost limit on indexer rpc

### DIFF
--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -274,12 +274,14 @@ block_uncles_cache_size    = 30
 # cell_filter = "let script = output.type;script!=() && script.code_hash == \"0x00000000000000000000000000000000000000000000000000545950455f4944\""
 # # The initial tip can be set higher than the current indexer tip as the starting height for indexing.
 # init_tip_hash = "0x8fbd0ec887159d2814cee475911600e3589849670f5ee1ed9798b38fdeef4e44"
-# By default, there is no limitation on the size of indexer request
-# However, because serde json serialization consumes too much memory(10x),
-# it may cause the physical machine to become unresponsive.
-# We recommend a consumption limit of 2g, which is 400 as the limit,
-# which is a safer approach
+# # By default, there is no limitation on the size of indexer request
+# # However, because serde json serialization consumes too much memory(10x),
+# # it may cause the physical machine to become unresponsive.
+# # We recommend a consumption limit of 2g, which is 400 as the limit,
+# # which is a safer approach
 # request_limit = 400
+# # By default, there is a timeout limit of 10 seconds for each indexer request
+# timeout_limit = 10
 #
 # # CKB rich-indexer has its unique configuration.
 # [indexer_v2.rich_indexer]

--- a/sync/src/relayer/tests/compact_block_process.rs
+++ b/sync/src/relayer/tests/compact_block_process.rs
@@ -162,6 +162,7 @@ fn test_unknow_parent() {
     let message = packed::SyncMessage::new_builder().set(content).build();
     let data = message.as_bytes();
 
+    std::thread::sleep(std::time::Duration::from_millis(100));
     // send_getheaders_to_peer
     assert!(nc.has_sent(SupportProtocols::Sync.protocol_id(), peer_index, data));
 }

--- a/util/app-config/src/configs/indexer.rs
+++ b/util/app-config/src/configs/indexer.rs
@@ -38,6 +38,9 @@ pub struct IndexerConfig {
     /// limit of indexer request
     #[serde(default)]
     pub request_limit: Option<usize>,
+    /// limit of indexer request timeout
+    #[serde(default)]
+    pub timeout_limit: Option<u64>,
     /// Rich indexer config options
     #[serde(default)]
     pub rich_indexer: RichIndexerConfig,
@@ -60,6 +63,7 @@ impl Default for IndexerConfig {
             db_keep_log_file_num: None,
             init_tip_hash: None,
             request_limit: None,
+            timeout_limit: None,
             rich_indexer: RichIndexerConfig::default(),
         }
     }

--- a/util/indexer/src/service.rs
+++ b/util/indexer/src/service.rs
@@ -16,13 +16,50 @@ use ckb_types::{H256, core, packed, prelude::*};
 use memchr::memmem;
 use rocksdb::{Direction, IteratorMode, prelude::*};
 
-use std::convert::TryInto;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, RwLock};
+use std::{
+    convert::TryInto,
+    num::NonZeroUsize,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 
 pub(crate) const SUBSCRIBER_NAME: &str = "Indexer";
 const DEFAULT_LOG_KEEP_NUM: usize = 1;
 const DEFAULT_MAX_BACKGROUND_JOBS: usize = 6;
+
+struct TimeoutIterator<I> {
+    inner: I,
+    start_time: Instant,
+    timeout: Duration,
+    timed_out: bool,
+}
+
+impl<I> TimeoutIterator<I> {
+    fn new(inner: I, timeout: Duration) -> Self {
+        Self {
+            inner,
+            start_time: Instant::now(),
+            timeout,
+            timed_out: false,
+        }
+    }
+
+    fn is_timed_out(&self) -> bool {
+        self.timed_out
+    }
+}
+
+impl<I: Iterator> Iterator for TimeoutIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start_time.elapsed() > self.timeout {
+            self.timed_out = true;
+            return None;
+        }
+        self.inner.next()
+    }
+}
 
 /// Indexer service
 #[derive(Clone)]
@@ -32,6 +69,7 @@ pub struct IndexerService {
     block_filter: Option<String>,
     cell_filter: Option<String>,
     request_limit: usize,
+    timeout_limit: Duration,
 }
 
 impl IndexerService {
@@ -58,6 +96,7 @@ impl IndexerService {
             block_filter: config.block_filter.clone(),
             cell_filter: config.cell_filter.clone(),
             request_limit: config.request_limit.unwrap_or(usize::MAX),
+            timeout_limit: Duration::from_secs(config.timeout_limit.unwrap_or(10)),
         }
     }
 
@@ -70,6 +109,7 @@ impl IndexerService {
             store: self.store.clone(),
             pool: self.sync.pool(),
             request_limit: self.request_limit,
+            timeout_limit: self.timeout_limit,
         }
     }
 
@@ -128,6 +168,7 @@ pub struct IndexerHandle {
     pub(crate) store: RocksdbStore,
     pub(crate) pool: Option<Arc<RwLock<Pool>>>,
     request_limit: usize,
+    timeout_limit: Duration,
 }
 
 impl IndexerHandle {
@@ -198,7 +239,7 @@ impl IndexerHandle {
         let filter_options: FilterOptions = search_key.try_into()?;
         let mode = IteratorMode::From(from_key.as_ref(), direction);
         let snapshot = self.store.inner().snapshot();
-        let iter = snapshot.iterator(mode).skip(skip);
+        let mut iter = TimeoutIterator::new(snapshot.iterator(mode).skip(skip), self.timeout_limit);
 
         let mut last_key = Vec::new();
         let pool = self
@@ -206,6 +247,7 @@ impl IndexerHandle {
             .as_ref()
             .map(|pool| pool.read().expect("acquire lock"));
         let cells = iter
+            .by_ref()
             .take_while(|(key, _value)| key.starts_with(&prefix))
             .filter_map(|(key, value)| {
                 if script_search_exact {
@@ -328,8 +370,11 @@ impl IndexerHandle {
             })
             .take(limit)
             .collect::<Vec<_>>();
-
-        Ok(IndexerPagination::new(cells, JsonBytes::from_vec(last_key)))
+        if iter.is_timed_out() {
+            Err(Error::invalid_params("Indexer request timeout"))
+        } else {
+            Ok(IndexerPagination::new(cells, JsonBytes::from_vec(last_key)))
+        }
     }
 
     /// Get transaction by specified params
@@ -414,12 +459,15 @@ impl IndexerHandle {
 
         let mode = IteratorMode::From(from_key.as_ref(), direction);
         let snapshot = self.store.inner().snapshot();
-        let iter = snapshot.iterator(mode).skip(skip);
+        let mut iter = TimeoutIterator::new(snapshot.iterator(mode).skip(skip), self.timeout_limit);
 
         if search_key.group_by_transaction.unwrap_or_default() {
             let mut tx_with_cells: Vec<IndexerTxWithCells> = Vec::new();
             let mut last_key = Vec::new();
-            for (key, value) in iter.take_while(|(key, _value)| key.starts_with(&prefix)) {
+            for (key, value) in iter
+                .by_ref()
+                .take_while(|(key, _value)| key.starts_with(&prefix))
+            {
                 if script_search_exact {
                     // Exact match mode, check key length is equal to full script len + BlockNumber (8) + TxIndex (4) + CellIndex (4) + CellType (1)
                     if key.len() != prefix.len() + 17 {
@@ -523,14 +571,18 @@ impl IndexerHandle {
                     });
                 }
             }
-
-            Ok(IndexerPagination::new(
-                tx_with_cells.into_iter().map(IndexerTx::Grouped).collect(),
-                JsonBytes::from_vec(last_key),
-            ))
+            if iter.is_timed_out() {
+                Err(Error::invalid_params("Indexer request timeout"))
+            } else {
+                Ok(IndexerPagination::new(
+                    tx_with_cells.into_iter().map(IndexerTx::Grouped).collect(),
+                    JsonBytes::from_vec(last_key),
+                ))
+            }
         } else {
             let mut last_key = Vec::new();
             let txs = iter
+                .by_ref()
                 .take_while(|(key, _value)| key.starts_with(&prefix))
                 .filter_map(|(key, value)| {
                     if script_search_exact {
@@ -622,7 +674,11 @@ impl IndexerHandle {
                 .take(limit)
                 .collect::<Vec<_>>();
 
-            Ok(IndexerPagination::new(txs, JsonBytes::from_vec(last_key)))
+            if iter.is_timed_out() {
+                Err(Error::invalid_params("Indexer request timeout"))
+            } else {
+                Ok(IndexerPagination::new(txs, JsonBytes::from_vec(last_key)))
+            }
         }
     }
 
@@ -661,13 +717,14 @@ impl IndexerHandle {
         let filter_options: FilterOptions = search_key.try_into()?;
         let mode = IteratorMode::From(from_key.as_ref(), direction);
         let snapshot = self.store.inner().snapshot();
-        let iter = snapshot.iterator(mode).skip(skip);
+        let mut iter = TimeoutIterator::new(snapshot.iterator(mode).skip(skip), self.timeout_limit);
         let pool = self
             .pool
             .as_ref()
             .map(|pool| pool.read().expect("acquire lock"));
 
         let capacity: u64 = iter
+            .by_ref()
             .take_while(|(key, _value)| key.starts_with(&prefix))
             .filter_map(|(key, value)| {
                 if script_search_exact {
@@ -778,18 +835,22 @@ impl IndexerHandle {
             })
             .sum();
 
-        let tip_mode = IteratorMode::From(&[KeyPrefix::Header as u8 + 1], Direction::Reverse);
-        let mut tip_iter = snapshot.iterator(tip_mode);
-        Ok(tip_iter.next().map(|(key, _value)| IndexerCellsCapacity {
-            capacity: capacity.into(),
-            block_hash: packed::Byte32::from_slice(&key[9..41])
-                .expect("stored block key")
+        if iter.is_timed_out() {
+            Err(Error::invalid_params("Indexer request timeout"))
+        } else {
+            let tip_mode = IteratorMode::From(&[KeyPrefix::Header as u8 + 1], Direction::Reverse);
+            let mut tip_iter = snapshot.iterator(tip_mode);
+            Ok(tip_iter.next().map(|(key, _value)| IndexerCellsCapacity {
+                capacity: capacity.into(),
+                block_hash: packed::Byte32::from_slice(&key[9..41])
+                    .expect("stored block key")
+                    .into(),
+                block_number: core::BlockNumber::from_be_bytes(
+                    key[1..9].try_into().expect("stored block key"),
+                )
                 .into(),
-            block_number: core::BlockNumber::from_be_bytes(
-                key[1..9].try_into().expect("stored block key"),
-            )
-            .into(),
-        }))
+            }))
+        }
     }
 }
 
@@ -941,6 +1002,15 @@ mod tests {
     }
 
     #[test]
+    fn timeout_iter() {
+        let vec = vec![1, 2, 3, 4, 5];
+        let mut iter = TimeoutIterator::new(vec.into_iter(), Duration::from_millis(1));
+        std::thread::sleep(Duration::from_millis(2));
+        assert_eq!(iter.next(), None);
+        assert!(iter.is_timed_out());
+    }
+
+    #[test]
     fn rpc() {
         let store: RocksdbStore = new_store("rpc");
         let pool = Arc::new(RwLock::new(Pool::default()));
@@ -949,6 +1019,7 @@ mod tests {
             store,
             pool: Some(Arc::clone(&pool)),
             request_limit: usize::MAX,
+            timeout_limit: Duration::from_secs(u64::MAX),
         };
 
         // setup test data
@@ -1542,6 +1613,7 @@ mod tests {
             store,
             pool: None,
             request_limit: usize::MAX,
+            timeout_limit: Duration::from_secs(u64::MAX),
         };
 
         // setup test data
@@ -1789,6 +1861,7 @@ mod tests {
             store,
             pool: None,
             request_limit: 2,
+            timeout_limit: Duration::from_secs(u64::MAX),
         };
 
         let lock_script1 = ScriptBuilder::default()
@@ -1822,6 +1895,7 @@ mod tests {
             store,
             pool: None,
             request_limit: usize::MAX,
+            timeout_limit: Duration::from_secs(u64::MAX),
         };
 
         // setup test data


### PR DESCRIPTION
### What problem does this PR solve?

Relation Issue Number:  #5011

As data volume increases, the cost of some RPCs increases linearly, while the return value remains relatively unchanged. Imposing hard timeout limits on these RPCs reduces the likelihood of attacks.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Note: Add a note under the PR title in the release note.
Add a new config option `timeout_limit` under `indexer_v2` to timeout indexer RPC in 10 seconds by default.
```

