### PR TITLE
tx_pool: RPC `get_live_cell` should return `CellStatus::Dead` if possible

### DIFF
--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -1110,7 +1110,8 @@ impl TxPoolService {
                 }
                 CellStatus::live_cell(cell_meta)
             }
-            _ => CellStatus::Unknown,
+            CellStatus::Dead => CellStatus::Dead,
+            CellStatus::Unknown => CellStatus::Unknown,
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

When review RPC get_live_cell, I think `fn get_live_cell` should return `CellStatus::Dead` if possible.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- in `fn get_live_cell`, return `CellStatus::Dead` if possible

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

