### PR TITLE
CI: upgrade macos-13 to macos-15, https://github.com/actions/runner-images/issues/13046

### DIFF
--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -48,7 +48,7 @@ jobs:
   ci_benchmarks_macos:
     name: ci_benchmarks_macos
     needs: prologue
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -51,7 +51,7 @@ jobs:
     name: ci_integration_tests_macos
     needs: prologue
     timeout-minutes: 140
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: brew install tor go

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -48,7 +48,7 @@ jobs:
   ci_linters_macos:
     name: ci_linters_macos
     needs: prologue
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -48,7 +48,7 @@ jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
     needs: prologue
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -48,7 +48,7 @@ jobs:
   ci_unit_tests_macos:
     name: ci_unit_tests_macos
     needs: prologue
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -171,7 +171,7 @@ jobs:
 
   package-for-mac:
     name: package-for-mac
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         include:


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?



The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.
### Related changes

- Upgrade CI macos-13 to macos-15

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

