### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-metrics-service"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-async-runtime",
  "ckb-logger",

--- a/util/fixed-hash/CHANGELOG.md
+++ b/util/fixed-hash/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-v1.0.0...ckb-fixed-hash-v1.0.1) - 2025-12-10
+
+### Other
+
+- release-plz update

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics-service/CHANGELOG.md
+++ b/util/metrics-service/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-metrics-service-v1.0.0...ckb-metrics-service-v1.0.1) - 2025-12-10
+
+### Other
+
+- add missing features in metrics-service

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-service"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `ckb-fixed-hash`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-onion`: 1.0.0
* `ckb-metrics-service`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ckb-fixed-hash`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-v1.0.0...ckb-fixed-hash-v1.0.1) - 2025-12-10

### Other

- release-plz update
</blockquote>

## `ckb-onion`

<blockquote>

## [1.0.0](https://github.com/nervosnetwork/ckb/releases/tag/ckb-onion-v1.0.0) - 2025-12-10

### Added

- add onion crate for Tor integration

### Other

- impl review advice
- fix indicatif api changes
- Fix ubuntu integration missing go env, fix clippy warning on windows
- support config onion service port by `onion_external_port`
- Change MultiAddr to Multiaddr
- Apply code readbility suggestion
</blockquote>

## `ckb-metrics-service`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-metrics-service-v1.0.0...ckb-metrics-service-v1.0.1) - 2025-12-10

### Other

- add missing features in metrics-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).