### PR TITLE
ci: improve robustness of bats test case load_notify_config

### DIFF
--- a/ckb-bin/src/tests/bats_tests/load_notify_config.bats
+++ b/ckb-bin/src/tests/bats_tests/load_notify_config.bats
@@ -2,7 +2,6 @@
 bats_load_library 'bats-assert'
 bats_load_library 'bats-support'
 
-
 _init() {
   bash -c "ckb init -C ${CKB_DIRNAME} -f "
 }
@@ -11,25 +10,42 @@ _uncomment_notify_config() {
   sed -i 's/# \[notify\]/\[notify\]/g' ${CKB_DIRNAME}/ckb.toml
 }
 
-
 _run() {
-  ckb run -C ${CKB_DIRNAME} &> ${TMP_DIR}/ckb_notify.log &
+  ckb run -C ${CKB_DIRNAME} &>${TMP_DIR}/ckb_notify.log &
   PID=$!
   sleep 3
-  kill ${PID}
+  kill ${PID} 2>/dev/null || true
 
-  while kill -0 ${PID}; do
-      sleep 1
+  # Wait for process to terminate, with timeout and error suppression
+  # The process may already be dead, so we ignore "No such process" errors
+  local timeout=10
+  local count=0
+  while kill -0 ${PID} 2>/dev/null && [ $count -lt $timeout ]; do
+    sleep 1
+    count=$((count + 1))
   done
+
+  # Ensure process is really dead
+  kill -0 ${PID} 2>/dev/null && kill -9 ${PID} 2>/dev/null || true
 
   grep -q "CKB shutdown" ${TMP_DIR}/ckb_notify.log
 }
 
 _log_no_error() {
-  if grep -q -i error ${TMP_DIR}/ckb_notify.log; then
-    echo "error found in log: " $(grep -i error ${TMP_DIR}/ckb_notify.log)
+  # Filter out expected shutdown errors that occur during graceful termination
+  # These are normal when channels/connections are closed during shutdown
+  # Use grep with inverted patterns to exclude expected errors
+  local unexpected_errors=$(grep -i error ${TMP_DIR}/ckb_notify.log |
+    grep -v "unverified_block_rx err: receiving on an empty and disconnected channel" |
+    grep -v "nc.send_message GetHeaders, error: P2P(Send(BrokenPipe))" || true)
+
+  # If there are unexpected errors after filtering, report them
+  if [ -n "$unexpected_errors" ]; then
+    echo "error found in log: " "$unexpected_errors"
     return 1
   fi
+
+  return 0
 }
 
 function run_with_uncomment_notify_config { #@test


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
The `load_notify_config` bats test case was experiencing flaky failures due to:
1. Race conditions when terminating the ckb process - the test would fail if the process terminated before `kill` was called
2. False positives from expected errors that occur during graceful shutdown (channel disconnections, broken pipes)

### What is changed and how it works?

What's Changed:
- Added timeout mechanism (10 seconds) for process termination with proper error handling
- Suppress expected "No such process" errors when checking if process is still running
- Force kill with SIGKILL if process doesn't terminate within timeout
- Filter out known benign errors from log checks:
  - `unverified_block_rx err: receiving on an empty and disconnected channel`
  - `nc.send_message GetHeaders, error: P2P(Send(BrokenPipe))`

These errors are expected during graceful shutdown when channels and connections are closed.

### Related changes

- No related changes

### Check List

Tests
- Integration test (bats test case)

Side effects
- None

### Release note

```release-note
None: Exclude this PR from the release note.
```
