### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-app-config"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ckb-build-info",
  "ckb-chain-spec",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-async-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-logger",
  "ckb-spawn",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-bin"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.21.7",
  "ckb-app-config",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-block-filter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-async-runtime",
  "ckb-logger",
@@ -850,11 +850,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-build-info"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "ckb-chain"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-iter"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-store",
  "ckb-types",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-spec"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "cacache",
  "ckb-constant",
@@ -923,21 +923,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "ckb-constant"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "phf 0.12.1",
 ]
 
 [[package]]
 name = "ckb-crypto"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-db"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-db-schema",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-db-migration"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-channel",
@@ -1001,11 +1001,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-db-schema"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "ckb-error"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fee-estimator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-chain-spec",
  "ckb-logger",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb_schemars",
  "faster-hex",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-gen-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "cfg-if",
  "ckb-error",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-indexer"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-indexer-sync"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-instrument"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-chain",
  "ckb-chain-iter",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-types",
  "ckb_schemars",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-launcher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-light-client-protocol-server"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ckb-app-config",
  "ckb-chain",
@@ -1222,14 +1222,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ckb-logger-config"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "serde",
  "toml",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger-service"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "backtrace",
  "ckb-channel",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-memory-tracker"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-db",
  "ckb-logger",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prometheus",
  "prometheus-static-metric",
@@ -1284,14 +1284,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-metrics-config"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-metrics-service"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-async-runtime",
  "ckb-logger",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-migrate"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-migration-template"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-miner"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.21.7",
  "ckb-app-config",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-multisig"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-crypto",
  "ckb-error",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-network"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitflags 2.10.0",
  "bloom-filters",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-network-alert"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-notify"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -1458,14 +1458,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-onion"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64 0.21.7",
  "ckb-async-runtime",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-pow"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-proposal-table"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-chain-spec",
  "ckb-logger",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "numext-fixed-uint",
  "proptest",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-resource"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-reward-calculator"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rich-indexer"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "ckb-app-config",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-script"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-shared"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arc-swap",
  "bitflags 2.10.0",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-snapshot"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arc-swap",
  "ckb-chain-spec",
@@ -1730,11 +1730,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-spawn"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "ckb-stop-handler"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-async-runtime",
  "ckb-channel",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-store"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-sync"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ckb-app-config",
  "ckb-chain",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-systemtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "web-time",
 ]
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-test-chain-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -1886,14 +1886,14 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-tx-pool"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bit-vec 0.6.3",
  "bytes",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-util"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ckb-fixed-hash",
  "linked-hash-map",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-chain-spec",
  "ckb-constant",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification-contextual"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ckb-async-runtime",
  "ckb-chain",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification-traits"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 2.10.0",
  "ckb-error",

--- a/block-filter/CHANGELOG.md
+++ b/block-filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-block-filter"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/ckb-bin/CHANGELOG.md
+++ b/ckb-bin/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/nervosnetwork/ckb/compare/ckb-bin-v1.0.1...ckb-bin-v1.0.2) - 2025-12-12
+
+### <!-- 9 -->⚙️ Miscellaneous
+
+- improve robustness of bats test case load_notify_config (by @doitian) - #5033
+
+### Contributors
+
+* @doitian
+
 ## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-bin-v1.0.0...ckb-bin-v1.0.1) - 2025-12-10
 
 ### Other

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-bin"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-migration"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db-schema/CHANGELOG.md
+++ b/db-schema/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/db-schema/Cargo.toml
+++ b/db-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db-schema"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-db"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-error"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-miner"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-notify"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-pow"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/resource/CHANGELOG.md
+++ b/resource/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/nervosnetwork/ckb/compare/ckb-resource-v1.0.1...ckb-resource-v1.0.2) - 2025-12-12
+
+### <!-- 9 -->⚙️ Miscellaneous
+
+- Add default promethues server config (by @eval-exec) - #5035
+
+### Contributors
+
+* @doitian
+* @eval-exec
+
 ## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-resource-v1.0.0...ckb-resource-v1.0.1) - 2025-12-10
 
 ### Other

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-resource"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rpc"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-script"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-shared"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-spec"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-store"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/sync/CHANGELOG.md
+++ b/sync/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-sync-v1.1.0...ckb-sync-v1.2.0) - 2025-12-12
+
+### <!-- 1 -->⛰️ Features
+
+- add default time cost limit on indexer rpc (by @driftluo) - #5012
+
+### Contributors
+
+* @driftluo
+* @doitian
+
 ## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-sync-v1.0.0...ckb-sync-v1.1.0) - 2025-12-10
 
 ### Added

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sync"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-traits"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-tx-pool"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-util-v1.1.0...ckb-util-v1.2.0) - 2025-12-12
+
+### <!-- 1 -->⛰️ Features
+
+- add default time cost limit on indexer rpc (by @driftluo) - #5012
+
+### Contributors
+
+* @driftluo
+* @doitian
+
 ## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-util-v1.0.0...ckb-util-v1.1.0) - 2025-12-10
 
 ### Added

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-util"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/app-config/CHANGELOG.md
+++ b/util/app-config/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-app-config-v1.0.1...ckb-app-config-v1.1.0) - 2025-12-12
+
+### <!-- 1 -->⛰️ Features
+
+- add default time cost limit on indexer rpc (by @driftluo) - #5012
+
+### Contributors
+
+* @driftluo
+* @doitian
+
 ## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-app-config-v1.0.0...ckb-app-config-v1.0.1) - 2025-12-10
 
 ### Other

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-app-config"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/build-info/CHANGELOG.md
+++ b/util/build-info/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/build-info/Cargo.toml
+++ b/util/build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-build-info"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-chain-iter"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-channel"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/constant/CHANGELOG.md
+++ b/util/constant/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/constant/Cargo.toml
+++ b/util/constant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-constant"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/crypto/CHANGELOG.md
+++ b/util/crypto/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-crypto"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-dao-utils"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/fee-estimator/CHANGELOG.md
+++ b/util/fee-estimator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fee-estimator"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-core"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/macros/CHANGELOG.md
+++ b/util/fixed-hash/macros/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-macros"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-gen-types"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/util/hash/CHANGELOG.md
+++ b/util/hash/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-hash"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/indexer-sync/CHANGELOG.md
+++ b/util/indexer-sync/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-indexer-sync"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/indexer/CHANGELOG.md
+++ b/util/indexer/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-indexer-v1.0.1...ckb-indexer-v1.1.0) - 2025-12-12
+
+### <!-- 1 -->⛰️ Features
+
+- add default time cost limit on indexer rpc (by @driftluo) - #5012
+
+### Contributors
+
+* @driftluo
+* @doitian
+
 ## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-indexer-v1.0.0...ckb-indexer-v1.0.1) - 2025-12-10
 
 ### Other

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-indexer"
-version = "1.0.1"
+version = "1.1.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-instrument"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-jsonrpc-types"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-launcher"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client-protocol-server"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-config"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger-service"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/logger/CHANGELOG.md
+++ b/util/logger/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-logger"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/memory-tracker/CHANGELOG.md
+++ b/util/memory-tracker/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-memory-tracker"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/metrics-config/CHANGELOG.md
+++ b/util/metrics-config/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/metrics-config/Cargo.toml
+++ b/util/metrics-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-config"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics-service"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-metrics"
-version = "1.1.0"
+version = "1.1.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/migrate/Cargo.toml
+++ b/util/migrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-migrate"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/migrate/migration-template/Cargo.toml
+++ b/util/migrate/migration-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-migration-template"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-multisig"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-network-alert"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/core/CHANGELOG.md
+++ b/util/occupied-capacity/core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-core"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-occupied-capacity-macros"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/onion/Cargo.toml
+++ b/util/onion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-onion"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/util/proposal-table/CHANGELOG.md
+++ b/util/proposal-table/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-proposal-table"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rational"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-reward-calculator"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rich-indexer"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/runtime/CHANGELOG.md
+++ b/util/runtime/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-async-runtime"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/snapshot/CHANGELOG.md
+++ b/util/snapshot/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-snapshot"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/spawn/CHANGELOG.md
+++ b/util/spawn/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/spawn/Cargo.toml
+++ b/util/spawn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-spawn"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-stop-handler"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/systemtime/CHANGELOG.md
+++ b/util/systemtime/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/systemtime/Cargo.toml
+++ b/util/systemtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-systemtime"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/test-chain-utils/CHANGELOG.md
+++ b/util/test-chain-utils/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-test-chain-utils"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-types"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"
 license = "MIT"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-contextual"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/verification/traits/CHANGELOG.md
+++ b/verification/traits/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-traits"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `ckb-util`: 1.1.0 -> 1.2.0 (✓ API compatible changes)
* `ckb-fixed-hash-core`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-fixed-hash-macros`: 1.0.0 -> 1.0.1
* `ckb-fixed-hash`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-occupied-capacity-core`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-channel`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-systemtime`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-build-info`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-logger`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-logger-config`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-metrics-config`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-hash`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-rational`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-constant`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-crypto`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-occupied-capacity-macros`: 1.0.1 -> 1.0.2
* `ckb-occupied-capacity`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-error`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-gen-types`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-types`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-dao-utils`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-jsonrpc-types`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-pow`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-resource`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-traits`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-chain-spec`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-app-config`: 1.0.1 -> 1.1.0 (✓ API compatible changes)
* `ckb-db-schema`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-db`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-metrics`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-spawn`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-async-runtime`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-stop-handler`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-network`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-proposal-table`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-fee-estimator`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-db-migration`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-migration-template`: 1.0.1 -> 1.0.2
* `ckb-store`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-migrate`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-notify`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-snapshot`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-dao`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-reward-calculator`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-script`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-verification-traits`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-verification`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-tx-pool`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-shared`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-verification-contextual`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-chain`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-test-chain-utils`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-logger-service`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-onion`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-metrics-service`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-multisig`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-miner`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-memory-tracker`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-network-alert`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-indexer-sync`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-indexer`: 1.0.1 -> 1.1.0 (✓ API compatible changes)
* `ckb-rich-indexer`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-chain-iter`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-block-filter`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `ckb-sync`: 1.1.0 -> 1.2.0 (✓ API compatible changes)
* `ckb-instrument`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `ckb-rpc`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-light-client-protocol-server`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-launcher`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `ckb-bin`: 1.0.1 -> 1.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ckb-util`

<blockquote>

## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-util-v1.1.0...ckb-util-v1.2.0) - 2025-12-12

### <!-- 1 -->⛰️ Features

- add default time cost limit on indexer rpc (by @driftluo) - #5012

### Contributors

* @driftluo
* @doitian
</blockquote>

## `ckb-fixed-hash-core`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-core-v1.0.0...ckb-fixed-hash-core-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>


## `ckb-fixed-hash`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-v1.0.0...ckb-fixed-hash-v1.0.1) - 2025-12-10

### Other

- release-plz update
</blockquote>


## `ckb-channel`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-channel-v1.0.0...ckb-channel-v1.1.0) - 2025-12-10

### Added

- sync use async send
- relay use async send msg
</blockquote>




## `ckb-logger-config`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-logger-config-v1.0.0...ckb-logger-config-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>



## `ckb-rational`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-rational-v1.0.0...ckb-rational-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>



## `ckb-occupied-capacity-macros`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-occupied-capacity-macros-v1.0.0...ckb-occupied-capacity-macros-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-occupied-capacity`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-occupied-capacity-v1.0.0...ckb-occupied-capacity-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-error`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-error-v1.0.0...ckb-error-v1.0.1) - 2025-12-10

### Other

- Address review feedback on documentation
- Add documentation for remaining TODO(doc) markers in smaller modules
</blockquote>

## `ckb-gen-types`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-gen-types-v1.0.0...ckb-gen-types-v1.0.1) - 2025-12-10

### Other

- upgrade molecule
</blockquote>

## `ckb-types`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-types-v1.0.0...ckb-types-v1.0.1) - 2025-12-10

### Other

- Address review feedback on documentation
- Add documentation for util/types/src/core/extras.rs TODO(doc) markers
- Add documentation for util/types/src/core/cell.rs TODO(doc) markers
- Add documentation for remaining TODO(doc) markers in smaller modules
- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-dao-utils`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-dao-utils-v1.0.0...ckb-dao-utils-v1.0.1) - 2025-12-10

### Other

- remove unpack use on other crate
</blockquote>

## `ckb-jsonrpc-types`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-jsonrpc-types-v1.0.0...ckb-jsonrpc-types-v1.0.1) - 2025-12-10

### Other

- Merge pull request #5007 from driftluo/remove-unpack-on-other-crate
- remove unpack use on other crate
</blockquote>

## `ckb-pow`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-pow-v1.0.0...ckb-pow-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-resource`

<blockquote>

## [1.0.2](https://github.com/nervosnetwork/ckb/compare/ckb-resource-v1.0.1...ckb-resource-v1.0.2) - 2025-12-12

### <!-- 9 -->⚙️ Miscellaneous

- Add default promethues server config (by @eval-exec) - #5035

### Contributors

* @doitian
* @eval-exec
</blockquote>

## `ckb-traits`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-traits-v1.0.0...ckb-traits-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-chain-spec`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-chain-spec-v1.0.0...ckb-chain-spec-v1.0.1) - 2025-12-10

### Other

- remove unpack use on other crate
</blockquote>

## `ckb-app-config`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-app-config-v1.0.1...ckb-app-config-v1.1.0) - 2025-12-12

### <!-- 1 -->⛰️ Features

- add default time cost limit on indexer rpc (by @driftluo) - #5012

### Contributors

* @driftluo
* @doitian
</blockquote>


## `ckb-db`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-db-v1.0.0...ckb-db-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `ckb-metrics`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-metrics-v1.0.0...ckb-metrics-v1.1.0) - 2025-12-10

### Added

- add metrics
</blockquote>



## `ckb-stop-handler`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-stop-handler-v1.0.0...ckb-stop-handler-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-network`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-network-v1.0.0...ckb-network-v1.1.0) - 2025-12-10

### Added

- sync use async send
- relay use async send msg
- add metrics

### Fixed

- add invalid data test

### Other

- impl review advice
- Remove `struct NetworkAddresses`
- Change MultiAddr to Multiaddr
- Apply code readbility suggestion
- update network state for public address management
- update identify protocol for onion address sharing
- update peer store to handle onion addresses
- update service builder for proxy support
- add proxy URL validation and configuration
- add NetworkAddresses struct for onion addresses
- improve compress impl
</blockquote>



## `ckb-db-migration`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-db-migration-v1.0.0...ckb-db-migration-v1.0.1) - 2025-12-10

### Other

- Add documentation for remaining TODO(doc) markers in smaller modules
- fix indicatif api changes
</blockquote>

## `ckb-migration-template`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-migration-template-v1.0.0...ckb-migration-template-v1.0.1) - 2025-12-10

### Other

- fix indicatif api changes
</blockquote>

## `ckb-store`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-store-v1.0.0...ckb-store-v1.0.1) - 2025-12-10

### Other

- Add documentation for shared and store module TODO(doc) markers
- Add documentation for module-level TODO(doc) markers
- remove unpack use on other crate
</blockquote>

## `ckb-migrate`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-migrate-v1.0.0...ckb-migrate-v1.0.1) - 2025-12-10

### Other

- fix indicatif api changes
</blockquote>

## `ckb-notify`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-notify-v1.0.0...ckb-notify-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>


## `ckb-dao`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-dao-v1.0.0...ckb-dao-v1.0.1) - 2025-12-10

### Other

- remove unpack use on other crate
</blockquote>

## `ckb-reward-calculator`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-reward-calculator-v1.0.0...ckb-reward-calculator-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `ckb-script`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-script-v1.0.0...ckb-script-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>


## `ckb-verification`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-verification-v1.0.0...ckb-verification-v1.0.1) - 2025-12-10

### Other

- remove unpack use on other crate
</blockquote>

## `ckb-tx-pool`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-tx-pool-v1.0.0...ckb-tx-pool-v1.1.0) - 2025-12-10

### Added

- compact block async
- sync use async send
- relay use async send msg

### Other

- Add documentation for remaining TODO(doc) markers in smaller modules
- tweak tx verify workers
</blockquote>

## `ckb-shared`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-shared-v1.0.0...ckb-shared-v1.0.1) - 2025-12-10

### Other

- Add documentation for shared and store module TODO(doc) markers
- Add documentation for module-level TODO(doc) markers
</blockquote>

## `ckb-verification-contextual`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-verification-contextual-v1.0.0...ckb-verification-contextual-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `ckb-chain`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-chain-v1.0.0...ckb-chain-v1.1.0) - 2025-12-10

### Added

- relay use async send msg
</blockquote>


## `ckb-logger-service`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-logger-service-v1.0.0...ckb-logger-service-v1.0.1) - 2025-12-10

### Other

- Change MultiAddr to Multiaddr
- Apply code readbility suggestion
- extract modify_logger_filter to mute fast-socks5 log
- add onion service configuration options
</blockquote>

## `ckb-onion`

<blockquote>

## [1.0.0](https://github.com/nervosnetwork/ckb/releases/tag/ckb-onion-v1.0.0) - 2025-12-10

### Added

- add onion crate for Tor integration

### Other

- impl review advice
- fix indicatif api changes
- Fix ubuntu integration missing go env, fix clippy warning on windows
- support config onion service port by `onion_external_port`
- Change MultiAddr to Multiaddr
- Apply code readbility suggestion
</blockquote>

## `ckb-metrics-service`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-metrics-service-v1.0.0...ckb-metrics-service-v1.0.1) - 2025-12-10

### Other

- add missing features in metrics-service
</blockquote>

## `ckb-multisig`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-multisig-v1.0.0...ckb-multisig-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `ckb-miner`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-miner-v1.0.0...ckb-miner-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
- fix indicatif api changes
</blockquote>


## `ckb-network-alert`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-network-alert-v1.0.0...ckb-network-alert-v1.0.1) - 2025-12-10

### Other

- update Cargo.toml dependencies
</blockquote>


## `ckb-indexer`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-indexer-v1.0.1...ckb-indexer-v1.1.0) - 2025-12-12

### <!-- 1 -->⛰️ Features

- add default time cost limit on indexer rpc (by @driftluo) - #5012

### Contributors

* @driftluo
* @doitian
</blockquote>

## `ckb-rich-indexer`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-rich-indexer-v1.0.0...ckb-rich-indexer-v1.0.1) - 2025-12-10

### Other

- remove unpack use on other crate
</blockquote>

## `ckb-chain-iter`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-chain-iter-v1.0.0...ckb-chain-iter-v1.0.1) - 2025-12-10

### Other

- Add documentation for module-level TODO(doc) markers
</blockquote>


## `ckb-sync`

<blockquote>

## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-sync-v1.1.0...ckb-sync-v1.2.0) - 2025-12-12

### <!-- 1 -->⛰️ Features

- add default time cost limit on indexer rpc (by @driftluo) - #5012

### Contributors

* @driftluo
* @doitian
</blockquote>

## `ckb-instrument`

<blockquote>

## [1.0.1](https://github.com/nervosnetwork/ckb/compare/ckb-instrument-v1.0.0...ckb-instrument-v1.0.1) - 2025-12-10

### Other

- fix indicatif api changes
</blockquote>

## `ckb-rpc`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-rpc-v1.0.0...ckb-rpc-v1.1.0) - 2025-12-10

### Added

- relay use async send msg

### Other

- minor improvement for docs
</blockquote>

## `ckb-light-client-protocol-server`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-light-client-protocol-server-v1.0.0...ckb-light-client-protocol-server-v1.1.0) - 2025-12-10

### Added

- sync use async send
- relay use async send msg

### Other

- remove unpack use on other crate
- impl review advice
</blockquote>

## `ckb-launcher`

<blockquote>

## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-launcher-v1.0.0...ckb-launcher-v1.1.0) - 2025-12-10

### Added

- relay use async send msg
- disabale compress on filter

### Other

- support config onion service port by `onion_external_port`
- Change MultiAddr to Multiaddr
- Apply code readbility suggestion
- add onion service configuration options
- add onion/tor dependencies
</blockquote>

## `ckb-bin`

<blockquote>

## [1.0.2](https://github.com/nervosnetwork/ckb/compare/ckb-bin-v1.0.1...ckb-bin-v1.0.2) - 2025-12-12

### <!-- 9 -->⚙️ Miscellaneous

- improve robustness of bats test case load_notify_config (by @doitian) - #5033

### Contributors

* @doitian
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).