### PR TITLE
windows: fix version may start with v char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "ckb-test",
  "console-subscriber",
  "tikv-jemallocator",
+ "version-compare",
  "winreg 0.55.0",
 ]
 
@@ -7431,6 +7432,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ console-subscriber = { workspace = true, optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 winreg = "0.55"
+version-compare = "0.2"
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
 tikv-jemallocator = { version = "0.5.0", features = [


### PR DESCRIPTION
### What problem does this PR solve?

Close https://github.com/nervosnetwork/ckb/pull/4997#discussion_r2538140409

### What is changed and how it works?

On windows platform, the version may start with `v` or `V` char. this PR want to trim `v` or `V` first, then compare with version by https://gitlab.com/timvisee/version-compare

### Related changes

- trim `v` or `V` char on windows platform for version compare.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code ci-runs-only: [ quick_checks,linters ]

Side effects

- None

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

