### PR TITLE
Use nervos-bot for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,24 +24,19 @@ jobs:
       - &install-rust
         name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Free disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          # Remove unnecessary packages and files
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "Disk space after cleanup:"
-          df -h
+      - &generate-token
+        name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   release-plz-pr:
     name: Release-plz PR
@@ -56,9 +51,10 @@ jobs:
     steps:
       - *checkout
       - *install-rust
+      - *generate-token
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: release-plz uses my personal access token to create PRs and tags.

### What is changed and how it works?

What's Changed: Switch to GitHub App token

https://release-plz.dev/docs/github/token#use-a-github-app

### Related Changes

- [x] Add permissions to nervos-bot App
- [x] Accept new permissions request from nervos-bot in org nervosnetwork
- [x] Generate a new private key SHA256:0V/NKhjb8H/U/Vx+qPgY1yFIojOmNFy2RqE+qmRFWsM=
- [x] Set secrets `RELEASE_PLZ_APP_PRIVATE_KEY` and `RELEASE_PLZ_APP_ID`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Wait for pushes to develop, check the release-plz workflow results.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

