### PR TITLE
remove release-plz token from workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - &install-rust
         name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Release-plz workflow failed https://github.com/nervosnetwork/ckb/actions/runs/20227556648/job/58062643793

### What is changed and how it works?

What's Changed:

The RELEASE_PLZ_TOKEN secret is no longer required because release-plz can
now authenticate using the default GitHub token.

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)
    - Check result of the Release-plz

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

