### PR TITLE
fix ci integration tests on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,13 +83,13 @@ integration: integration-release
 .PHONY: integration-release
 integration-release: submodule-init
 	cargo build --locked --bin ckb ${VERBOSE} --release --features "deadlock_detection"
-	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -p ckb-test --features "deadlock_detection" --release -- --bin ${CARGO_TARGET_DIR}/release/${BINARY_NAME} ${CKB_TEST_ARGS}
+	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -p ckb-test --features "deadlock_detection" --release -- --bin '${CARGO_TARGET_DIR}/release/${BINARY_NAME}' ${CKB_TEST_ARGS}
 
 .PHONY: integration-cov
 integration-cov: cov-install-tools submodule-init ## Run integration tests and generate coverage report.
 	mkdir -p "${COV_PROFRAW_DIR}"; rm -f "${COV_PROFRAW_DIR}/*.profraw"
 	RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="${COV_PROFRAW_DIR}/ckb-cov-%p-%m.profraw" cargo +nightly-2022-03-22 build --bin ckb --features deadlock_detection
-	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -p ckb-test --features "deadlock_detection" -- --bin ${CARGO_TARGET_DIR}/debug/${BINARY_NAME} ${CKB_TEST_ARGS}
+	RUST_BACKTRACE=1 RUST_LOG=${INTEGRATION_RUST_LOG} cargo run -p ckb-test --features "deadlock_detection" -- --bin '${CARGO_TARGET_DIR}/debug/${BINARY_NAME}' ${CKB_TEST_ARGS}
 	GRCOV_OUTPUT=lcov-integration-test.info make cov-collect-data
 
 ##@ Document


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Workflow `ci_integration_tests_windows` fails on develop because the path to the ckb executable is not properly quoted.

### What is changed and how it works?

What's Changed: Quote the CKB executable path in Makefile

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
    - Run `make integration` in Windows using make from mingw

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

