### PR TITLE
fix macos runners in package workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -187,7 +187,7 @@ jobs:
 
   package-for-mac:
     name: package-for-mac
-    runs-on: macos-15
+    runs-on: macos-15-intel
     needs:
       - get-ckb-cli-version
     strategy:
@@ -233,7 +233,7 @@ jobs:
 
   package-for-mac-aarch64:
     name: package-for-mac-aarch64
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-15
     needs:
       - get-ckb-cli-version
     strategy:


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: The binaries for macOS x86-64 in v0.204.0 are indeed for ARM64.

### What is changed and how it works?

What's Changed: Switch the Intel macOS job to use `macos-15-intel` and the ARM64 job to use
the standard `macos-15` runner.

See https://github.com/actions/runner-images

### Related changes

- Delete macOS x86-64 packages from v0.204.0-rc2
- Replace macOS x86-64 packages in v0.204.0 with correct ones.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    - Push to `pkg/*` branch
    - Wait for the package workflow to finish
    - Download macOS x86-64 binaries, and check the binaries using command `file`.

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

