### PR TITLE
ci: restrict ci triggers to pushing branches

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 env:

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -5,7 +5,8 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push: {}
+  push:
+    branches: ['**']
   merge_group: {}
   workflow_dispatch: {}
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: CI workflows are also triggered on pushing any tags. Release-plz will create a lot of tags when release crates, leading to a huge pending queue.

### What is changed and how it works?

What's Changed: CI workflows should only be triggered on pushing branches.

### Related changes

Manually cancel the triggered runs:

```
gh api "repos/:owner/:repo/actions/runs?event=push&per_page=100" --paginate --jq '.workflow_runs[] | select((.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending" or .status == "action_required") and (.head_branch | startswith("ckb-"))) | .id' | tee /tmp/pending_run_ids.txt
cat /tmp/pending_run_ids.txt | while read run_id; do gh run cancel $run_id 2>&1
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    Check that new tags will not trigger CI workflows

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
