### PR TITLE
ci: install rustfmt for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,10 @@ jobs:
           persist-credentials: true
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85.0
+          components: rustfmt
       - &generate-token
         name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: release-plz release job fails because rustfmt is missing when publishing ckb-store.

https://github.com/nervosnetwork/ckb/actions/runs/20329255628/job/58400652745

### What is changed and how it works?

What's Changed: Install rustfmt component

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    Check workflow result when merged into develop

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

