### PR TITLE
ci: stop using dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -35,10 +35,10 @@ jobs:
           key: ci-aarch64-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ci-aarch64-cargo-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Build for aarch64
         run: |

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -25,12 +25,12 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt, clippy
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -35,9 +35,8 @@ jobs:
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ci-${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
+      - name: Install Rust toolchain
+        run: rustup toolchain install
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Run cargo deny checks
         run: |

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -28,15 +28,15 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt, clippy
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential tor
       - uses: actions/setup-go@v6
         with:
           go-version: "1.20"
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4
@@ -81,12 +81,12 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt, clippy
-      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential procps wget
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
+      - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential procps wget
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -26,15 +26,14 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt, clippy
       - uses: actions/setup-go@v6
         with:
           go-version: 1.20
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -26,14 +26,14 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt, clippy
       - uses: actions/setup-go@v6
         with:
           go-version: '1.20'
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt clippy
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -26,13 +26,12 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - uses: actions/checkout@v4
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
         uses: actions/cache@v4

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -14,10 +14,10 @@ jobs:
         github.repository_owner == 'nervosnetwork'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.85.0
-          components: rustfmt,llvm-tools-preview
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt llvm-tools-preview
       - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev -y && sudo apt-get install -y gcc-multilib build-essential
       - name: unit coverage
         run: make cov

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,9 @@ jobs:
           persist-credentials: true
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt
       - &generate-token
         name: Generate GitHub token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: There's little benefit to use the action. Call `rustup` directly.

### What is changed and how it works?

What's Changed: Avoid the dependency by calling `rustup` directly. This also avoid
specifying the toolchain version because it has already been specified
in `rust-toolchain.toml`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    Watch workflow running status

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

