### PR TITLE
docs: update docs to enforce conventional commits in pr titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,17 @@ If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetw
 
 If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
 
-PR Title Format:
-1. module [, module2, module3]: what's changed
-2. *: what's changed
--->
+**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
+Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.
 
+The most important prefixes you should use:
+
+- `fix:`: represents bug fixes, and results in a SemVer patch bump.
+- `feat:`: represents a new feature, and results in a SemVer minor bump.
+- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.
+
+Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
+-->
 ### What problem does this PR solve?
 
 Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->
@@ -40,12 +46,3 @@ Side effects
 
 - Performance regression
 - Breaking backward compatibility
-
-### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->
-
-```release-note
-None: Exclude this PR from the release note.
-Title Only: Include only the PR title in the release note.
-Note: Add a note under the PR title in the release note.
-```
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 # Contributing
 
-
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the community before making a change. The developer Discord channel
 ([English] | [Chinese]) should be used to discuss complicated or controversial changes before working on a patch.
@@ -26,6 +25,12 @@ Please note we have a code of conduct, please follow it in all your interactions
 ### Send PR
 
 * See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+* **PR Title Format**: Since we use **Squash Merge** to merge PRs, the PR title will become the commit message. Please ensure your PR title follows the Conventional Commit Messages format:
+  - `fix:`: for bug fixes
+  - `feat:`: for new features
+  - `<prefix>!:` (e.g. `feat!:`): for breaking changes
+  - Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, etc.)
 
 * Open a new GitHub pull request with the patch.
 

--- a/devtools/release/release-cheatsheet.md
+++ b/devtools/release/release-cheatsheet.md
@@ -35,6 +35,8 @@ The most important prefixes you should have in mind are:
 
 Commits that don't follow the Conventional Commit format result in a SemVer patch bump.
 
+**Note**: Since we use Squash Merge to merge PRs, the PR title will become the commit message. Therefore, the Conventional Commit Messages rule applies to PR titles as well. Please ensure your PR titles follow the Conventional Commit format.
+
 ### Important Notes
 
 ⚠️ **Breaking Changes**: Release-plz may not catch all breaking changes automatically. Manual version bumping is appreciated when you know a change is breaking.


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: CHANGELOG tools extract history from commit messages. In PR workflow, we'd prefer a CHANGELOG from merged PRs.

### What is changed and how it works?

What's Changed:

- Updated pull request template to emphasize Conventional Commits for PR titles
- Added PR title format guidance to CONTRIBUTING.md
- Clarified in release cheatsheet that PR titles must follow Conventional Commit format due to squash merging

### Related changes

- Update develop auto merge strategy to Squash Merge.
- Only enable Squash Merge PR

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
