### PR TITLE
ci(integration): trace RpcTruncate failure [no-changelog]

### DIFF
--- a/test/src/rpc.rs
+++ b/test/src/rpc.rs
@@ -225,9 +225,13 @@ impl RpcClient {
     }
 
     pub fn send_transaction(&self, tx: Transaction) -> Byte32 {
-        self.send_transaction_result(tx)
-            .expect("rpc call send_transaction")
-            .into()
+        match self.send_transaction_result(tx.clone()) {
+            Ok(hash) => hash.into(),
+            Err(err) => {
+                ckb_logger::debug!("failed to send transaction {:?}", tx);
+                panic!("rpc call send_transaction: {}", err);
+            }
+        }
     }
 
     pub fn send_transaction_result(&self, tx: Transaction) -> Result<H256, AnyError> {

--- a/test/src/specs/rpc/truncate.rs
+++ b/test/src/specs/rpc/truncate.rs
@@ -56,12 +56,8 @@ impl Spec for RpcTruncate {
             "old_tip_block should be truncated",
         );
 
-        let cell1 = node
-            .rpc_client()
-            .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
-        assert_eq!(cell1.status, "live", "cell1 is alive after roll-backing");
-
         node.wait_for_tx_pool();
+
         let tx_pool_info = node.get_tip_tx_pool_info();
         assert_eq!(tx_pool_info.orphan.value(), 0, "tx-pool was cleared");
         assert_eq!(tx_pool_info.pending.value(), 0, "tx-pool was cleared");
@@ -75,6 +71,12 @@ impl Spec for RpcTruncate {
 
         // The chain can generate new blocks
         node.mine(3);
+
+        let cell1 = node
+            .rpc_client()
+            .get_live_cell(tx1.inputs().get(0).unwrap().previous_output().into(), false);
+        assert_eq!(cell1.status, "live", "cell1 is alive after roll-backing");
+
         info!("submit tx1 again");
         node.submit_transaction(tx1);
         node.mine_until_transaction_confirm(&tx1.hash());


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: https://github.com/nervosnetwork/ckb/actions/runs/20362512946/attempts/2?pr=5058

### What is changed and how it works?

What's Changed:

- The `send_transaction` method now logs the transaction before panicking on RPC failure, aiding debugging.
- Adjust test assertion timing in `RpcTruncate`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
