### PR TITLE
ci(cargo-deny): install latest version [no-changelog]

### DIFF
--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -42,7 +42,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Run cargo deny checks
         run: |
-          cargo deny --version || cargo +stable install cargo-deny --locked --version 0.17.0
+          cargo deny --version || cargo +stable install cargo-deny --locked
           make security-audit
           make check-crates
           make check-licenses


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The CI cargo-deny workflow is currently installing a pinned version (0.17.0) of cargo-deny, which may be outdated and missing important security updates and features. For example, now it fails because it does not recoganize the new CVSS version.

https://github.com/nervosnetwork/ckb/actions/runs/20387098573/job/58589985924

### What is changed and how it works?

What's Changed:

- Updated .github/workflows/ci_cargo_deny_ubuntu.yaml to install the latest version of cargo-deny instead of the pinned version 0.17.0

This ensures the CI always uses the most up-to-date version of cargo-deny with the latest security checks and features.

### Check List

Tests

- No code

Side effects

- None

### Release note

```release-note
None: Exclude this PR from the release note.
```