### PR TITLE
ci: remove pkg/* branch push trigger from benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,9 +4,6 @@ on:
   # Submit your review with a comment body containing "#benchmark"
   pull_request_review:
     types: [submitted]
-  push:
-    branches:
-      - "pkg/*"
   schedule:
     - cron: "0 0 * * *"
   # Manurally trigger


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: The trigger is useless because the job condition is never true on
pushing events.

### What is changed and how it works?

What's Changed: Remove the trigger

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```

