### PR TITLE
ci: skip CI workflows for pull requests from the same repository

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_aarch64_build_ubuntu:
     name: ci_aarch64_build_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_benchmarks_macos:
     name: ci_benchmarks_macos
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-15
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -16,6 +16,7 @@ env:
 jobs:
   ci_benchmarks_ubuntu:
     name: ci_benchmarks_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_benchmarks_windows:
     name: ci_benchmarks_windows
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-2022
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_cargo_deny_ubuntu:
     name: ci_cargo_deny_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   ci_integration_tests_macos:
     name: ci_integration_tests_macos
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     timeout-minutes: 140
     runs-on: macos-15
     steps:

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   ci_integration_tests_ubuntu:
     name: ci_integration_tests_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     timeout-minutes: 140
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
@@ -72,6 +73,7 @@ jobs:
           du -sh target/*/ 2>/dev/null || echo "No subdirectories in target/"
   ci_cli_bats_test:
     name: ci_cli_bats_test
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   ci_integration_tests_windows:
     name: ci_integration_tests_windows
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-2022
     timeout-minutes: 140
     steps:

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_linters_macos:
     name: ci_linters_macos
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-15
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_linters_ubuntu:
     name: ci_linters_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-15
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_quick_checks_ubuntu:
     name: ci_quick_checks_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_unit_tests_macos:
     name: ci_unit_tests_macos
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-15
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_unit_tests_ubuntu:
     name: ci_unit_tests_ubuntu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'self-hosted-ci-ubuntu-20.04' || 'ubuntu-22.04' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   ci_unit_tests_windows:
     name: ci_unit_tests_windows
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-2022
     steps:
       - name: Free up disk space


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Redundant CI runs by skipping workflows on pull requests that originate from branches within the same repository (nervosnetwork/ckb). These are already covered by push events.

Related: #4567

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Add jobs condition to prevent redundant CI runs.

CI workflows will run only for:
- Pushes to branches in nervosnetwork/ckb
- Pull requests from forks

This avoids duplication, as PRs from the main repo trigger both a push and a pull_request event.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
None: Exclude this PR from the release note.
```
