### PR TITLE
feat: bump crates MSRV to 1.92.0

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 description = "CKB Benches"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 

--- a/block-filter/Cargo.toml
+++ b/block-filter/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Create block filter data for client-side filtering"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB chain service"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB executable"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 clap = { workspace = true, features = ["string", "wrap_help"] }

--- a/db-migration/Cargo.toml
+++ b/db-migration/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Database migration framework"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/db-schema/Cargo.toml
+++ b/db-schema/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The schema include constants define the low level database column families"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The ckb data persistent implementation"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-app-config.workspace = true

--- a/devtools/doc/rpc-gen/Cargo.toml
+++ b/devtools/doc/rpc-gen/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 description = "CKB RPC documentation generator"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-rpc ={ workspace = true }

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Underlying error types used over ckb crates"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 thiserror.workspace = true

--- a/freezer/Cargo.toml
+++ b/freezer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Freezer is an memory mapped append-only database to store immutable chain data into flat files"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Miner implementation for CKB block mining"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "ckb network module"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 exclude = ["fuzz"]
 
 [dependencies]

--- a/network/fuzz/Cargo.toml
+++ b/network/fuzz/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "ckb network fuzz testing"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Notification service for blockchain events"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Proof of Work (PoW) engine implementations"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 byteorder.workspace = true

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 description = "Bundles resources in the ckb binary"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 phf = "= 0.8.0" # ckb-resource's build script need this, and cargo shear think ckb don't need this

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB RPC server"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-chain-spec.workspace = true

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 description = "CKB component to run the type/lock scripts"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [features]
 default = ["logging", "detect-asm"]

--- a/script/fuzz/Cargo.toml
+++ b/script/fuzz/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "ckb-script crate fuzz test"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 publish = false
 
 [package.metadata]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Shared blockchain data and services"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The Chain Specification"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "ckb chain related persistent implementation"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The ckb sync/relayer protocols implementation"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-chain.workspace = true

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 description = "CKB integration tests"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [[bin]]
 name = "ckb-test"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Common traits for accessing blockchain data"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/tx-pool/Cargo.toml
+++ b/tx-pool/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB Tx-pool stores transactions, which is designed for CKB Two Step Transaction Confirmation mechanism"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB utilities"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 parking_lot.workspace = true

--- a/util/app-config/Cargo.toml
+++ b/util/app-config/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "CKB command line arguments and config options"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/util/build-info/Cargo.toml
+++ b/util/build-info/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2024"
 description = "The crate `ckb-build-info` generates CKB version from the build environment"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]

--- a/util/chain-iter/Cargo.toml
+++ b/util/chain-iter/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Chain iterator utilities"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/channel/Cargo.toml
+++ b/util/channel/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Reexports `crossbeam_channel` to uniform the dependency version"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/constant/Cargo.toml
+++ b/util/constant/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Collect constants used across ckb components"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/crypto/Cargo.toml
+++ b/util/crypto/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB crypto util library"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-fixed-hash.workspace = true

--- a/util/dao/Cargo.toml
+++ b/util/dao/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "This crate provides implementation to calculate dao field"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 byteorder.workspace = true

--- a/util/dao/utils/Cargo.toml
+++ b/util/dao/utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "This crate provides several util functions to operate the dao field and NervosDAO related errors"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 byteorder.workspace = true

--- a/util/fee-estimator/Cargo.toml
+++ b/util/fee-estimator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB's built-in fee estimator, which shares data with the ckb node through the tx-pool service"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Provide several simple fixed-sized hash data type and their static constructors"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-fixed-hash-core.workspace = true

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Provide several fixed-length binary data, aka fixed-sized hashes"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 thiserror.workspace = true

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Provide several proc-macros to construct const fixed-sized hashes"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [lib]
 proc-macro = true

--- a/util/gen-types/Cargo.toml
+++ b/util/gen-types/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Provides the generated types for CKB"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dev-dependencies]
 ckb-hash.workspace = true

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB default hash function"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [features]
 default = ["blake2b-ref", "blake2b-rs"]

--- a/util/indexer-sync/Cargo.toml
+++ b/util/indexer-sync/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The built-in synchronization service in CKB can provide block synchronization services for indexers"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/indexer/Cargo.toml
+++ b/util/indexer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB's built-in indexer, which shares data with the ckb node by creating secondary db instances"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Instruments for ckb for working with `Export`, `Import`"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Wrappers for JSON serialization"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/util/launcher/Cargo.toml
+++ b/util/launcher/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB launcher"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/light-client-protocol-server/Cargo.toml
+++ b/util/light-client-protocol-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Server-side implementation for CKB light client protocol"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-network.workspace = true

--- a/util/logger-config/Cargo.toml
+++ b/util/logger-config/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB logger configurations"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/util/logger-service/Cargo.toml
+++ b/util/logger-service/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB logger and logging service"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-util.workspace = true

--- a/util/logger/Cargo.toml
+++ b/util/logger/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB logging facade"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 log.workspace = true

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Track the memory usage of CKB"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/util/metrics-config/Cargo.toml
+++ b/util/metrics-config/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB metrics configurations"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/util/metrics-service/Cargo.toml
+++ b/util/metrics-service/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The service which handles the metrics data in CKB"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-metrics-config.workspace = true

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "A lightweight metrics facade used in CKB"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 prometheus.workspace = true

--- a/util/migrate/Cargo.toml
+++ b/util/migrate/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB migrate"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/migrate/migration-template/Cargo.toml
+++ b/util/migrate/migration-template/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Provide proc-macros to setup migration"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [lib]
 proc-macro = true

--- a/util/multisig/Cargo.toml
+++ b/util/multisig/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Multi-signatures"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-error.workspace = true

--- a/util/network-alert/Cargo.toml
+++ b/util/network-alert/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Network Alert"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-multisig.workspace = true

--- a/util/occupied-capacity/Cargo.toml
+++ b/util/occupied-capacity/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Data wrapper for capacity"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-occupied-capacity-macros.workspace = true

--- a/util/occupied-capacity/core/Cargo.toml
+++ b/util/occupied-capacity/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Data wrapper for capacity"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/util/occupied-capacity/macros/Cargo.toml
+++ b/util/occupied-capacity/macros/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Procedural macros for occupied capacity calculation"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [lib]
 proc-macro = true

--- a/util/onion/Cargo.toml
+++ b/util/onion/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Onion service module"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 base64.workspace = true

--- a/util/proposal-table/Cargo.toml
+++ b/util/proposal-table/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 description = "The ckb proposal-table design for two-step-transaction-confirmation"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/util/rational/Cargo.toml
+++ b/util/rational/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Rational numbers"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/reward-calculator/Cargo.toml
+++ b/util/reward-calculator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "This mod implemented a ckb block reward calculator"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB's built-in rich-indexer, based on relational database."
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/runtime/Cargo.toml
+++ b/util/runtime/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Utilities for tokio runtime"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/util/snapshot/Cargo.toml
+++ b/util/snapshot/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "Rocksdb snapshot wrapper"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/util/spawn/Cargo.toml
+++ b/util/spawn/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "`Spawn` abstract async runtime, spawns a future onto the runtime"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/util/stop-handler/Cargo.toml
+++ b/util/stop-handler/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Stop handler utilities for graceful shutdown"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-logger.workspace = true

--- a/util/systemtime/Cargo.toml
+++ b/util/systemtime/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "ckb_systemtime provide real system timestamp, and faketime when `enable_faketime` feature is enabled"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 

--- a/util/test-chain-utils/Cargo.toml
+++ b/util/test-chain-utils/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "Provide several functions used for testing"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/util/types/Cargo.toml
+++ b/util/types/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "The Core Types Library"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 molecule.workspace = true

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB verification"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "CKB verification contextual"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 ckb-types.workspace = true

--- a/verification/traits/Cargo.toml
+++ b/verification/traits/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 description = "The trait abstract for particular verification"
 homepage = "https://github.com/nervosnetwork/ckb"
 repository = "https://github.com/nervosnetwork/ckb"
+rust-version = "1.92.0"
 
 [dependencies]
 bitflags.workspace = true


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: MSRV is missing in crates Cargo.toml. It may break user projects because some crates start use syntax only available in 1.92.0.

### What is changed and how it works?

What's Changed:

- Add MSRV into Cargo.toml for all crates
- Mark the PR with `feat:` so release-plz will bump the minor version for all crates. This should be done in #4993 but have not. If you bump MSRV in a patch release (e.g., 1.1.1 → 1.1.2), users automatically get the broken build when they run cargo update, with no easy way to opt out.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- Choose from None, Title Only and Note. Bugfixes or new features need a release note. -->

```release-note
Title Only: Include only the PR title in the release note.
```

