### PR TITLE
spec: support data field in IssuedCell

### DIFF
--- a/benches/benches/benchmarks/resolve.rs
+++ b/benches/benches/benchmarks/resolve.rs
@@ -76,7 +76,7 @@ pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
         .map(|_| IssuedCell {
             capacity: capacity_bytes!(100_000),
             lock: secp_script.clone().into(),
-            data: JsonBytes::default(),
+            data: None,
             type_: None,
         })
         .collect();

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -401,8 +401,7 @@ pub struct IssuedCell {
     /// The cell capacity
     pub capacity: Capacity,
     /// The cell data, can be ignored in spec
-    #[serde(default)]
-    pub data: JsonBytes,
+    pub data: Option<JsonBytes>,
     /// The cell type script
     #[serde(rename = "type")]
     pub type_: Option<Script>,
@@ -836,7 +835,7 @@ impl ChainSpec {
             self.genesis
                 .issued_cells
                 .iter()
-                .map(|x| x.data.clone().into_bytes()),
+                .map(|x| x.data.clone().unwrap_or_default().into_bytes()),
         );
 
         let script: packed::Script = self.genesis.bootstrap_lock.clone().into();

--- a/test/src/specs/dao/satoshi_dao_occupied.rs
+++ b/test/src/specs/dao/satoshi_dao_occupied.rs
@@ -7,7 +7,6 @@ use crate::{Node, Spec};
 use ckb_chain_spec::IssuedCell;
 use ckb_crypto::secp::{Generator, Privkey, Pubkey};
 use ckb_dao_utils::extract_dao_data;
-use ckb_jsonrpc_types::JsonBytes;
 use ckb_test_chain_utils::always_success_cell;
 use ckb_types::core::{EpochNumberWithFraction, TransactionBuilder};
 use ckb_types::packed::{CellInput, CellOutput, OutPoint};
@@ -155,7 +154,7 @@ fn issue_satoshi_cell() -> IssuedCell {
     IssuedCell {
         capacity: SATOSHI_CELL_CAPACITY,
         lock: lock.into(),
-        data: JsonBytes::default(),
+        data: None,
         type_: None,
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?
Table `IssuedCell` in spec cannot specify output data of a cell

### What is changed and how it works?

This PR adds a field named `data` and can be ignored (to keep compatibility with previous spec), used to specify data of cells

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
