### PR TITLE
ci: only cancel in-progress pr checks

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_aarch64_build_ubuntu
 concurrency:
   group: ci_aarch64_build_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -1,7 +1,7 @@
 name: ci_benchmarks_macos
 concurrency:
   group: ci_benchmarks_macos-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_benchmarks_ubuntu
 concurrency:
   group: ci_benchmarks_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -1,7 +1,7 @@
 name: ci_benchmarks_windows
 concurrency:
   group: ci_benchmarks_windows-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_cargo_deny_ubuntu
 concurrency:
   group: ci_cargo_deny_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -1,7 +1,7 @@
 name: ci_integration_tests_macos
 concurrency:
   group: ci_integration_tests_macos-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_integration_tests_ubuntu
 concurrency:
   group: ci_integration_tests_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -1,7 +1,7 @@
 name: ci_integration_tests_windows
 concurrency:
   group: ci_integration_tests_windows-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -1,7 +1,7 @@
 name: ci_linters_macos
 concurrency:
   group: ci_linters_macos-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_linters_ubuntu
 concurrency:
   group: ci_linters_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -1,7 +1,7 @@
 name: ci_quick_checks_macos
 concurrency:
   group: ci_quick_checks_macos-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_quick_checks_ubuntu
 concurrency:
   group: ci_quick_checks_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -1,7 +1,7 @@
 name: ci_unit_tests_macos
 concurrency:
   group: ci_unit_tests_macos-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -1,7 +1,7 @@
 name: ci_unit_tests_ubuntu
 concurrency:
   group: ci_unit_tests_ubuntu-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -1,7 +1,7 @@
 name: ci_unit_tests_windows
 concurrency:
   group: ci_unit_tests_windows-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -19,21 +19,6 @@ Each CI workflow follows a consistent pattern:
 2. **Runner Selection**: Linux workflows use self-hosted runners for nervosnetwork, GitHub-hosted runners for forks. Windows and macOS workflows use GitHub-hosted runners.
 3. **Test/Check Jobs**: Execute the actual tests or checks
 
-### Concurrency Control
-
-Each workflow uses GitHub Actions concurrency groups to prevent duplicate runs:
-
-```yaml
-concurrency:
-  group: <workflow_name>-${{ github.ref }}
-  cancel-in-progress: true
-```
-
-This ensures that:
-- Only one workflow run per branch/PR is active at a time
-- New pushes/PR updates cancel in-progress runs
-- The same workflow won't run simultaneously on both PR and push events for the same commit
-
 ## Runner Selection
 
 Runner selection varies by platform:


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Cancel a push may leave develop branch in a failure status.

### What is changed and how it works?

What's Changed: Only enable `cancel-in-progress` for pull request events.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
