### PR TITLE
cargo: support cargo-binstall: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/nervosnetwork/ckb"
 rust-version = "1.92.0"
 default-run = "ckb"
 
+[package.metadata.binstall]
+bin-dir = "{ name }_v{ version }_{ target }/{ bin }{ binary-ext }"
+
 [[bin]]
 name = "ckb"
 path = "src/main.rs"


### PR DESCRIPTION
### What problem does this PR solve?
This PR want to support install ckb by cargo binstall: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md

In develop branch, we didn't specify `cargo binstall`'s metadata, so if we `cargo binstall ckb`, it can't find the binary from github release, it prompt us to compile from source:
```bash
❯ cargo binstall ckb
 INFO resolve: Resolving package: 'ckb'
ERROR resolve: When resolving ckb bin ckb is not found. This binary is not optional so it must be included in the archive, please contact with upstream to fix this issue.
 WARN resolve: Error while downloading and extracting from fetcher github.com: failed to find or install binaries: bin file /home/exec/.cargo/cargo-binstallk14tjj/bin-ckb-x86_64-unknown-linux-gnu-GhCrateMeta/ckb not found
 WARN The package ckb v0.204.0 will be installed from source (with cargo)
Do you wish to continue? [yes]/no

```

We must specify `--bin-dir` for cargo-binstall:
```bash
❯ cargo binstall ckb --bin-dir "{ name }_v{ version }_{ target }/{ bin }{ binary-ext }"
 INFO resolve: Resolving package: 'ckb'
 WARN The package ckb v0.204.0 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - ckb => /home/exec/.cargo/bin/ckb
Do you wish to continue? [yes]/no yes
 INFO Installing binaries...
 INFO Done in 69.534364684s
❯ which ckb
/home/exec/.cargo/bin/ckb

```


### Related changes

- Add `cargo binstall` metadata for ckb binary's Cargo.toml metadata

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- None
