### PR TITLE
Improve import shutdown handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "ckb-channel",
  "ckb-jsonrpc-types",
  "ckb-shared",
+ "ckb-stop-handler",
  "ckb-store",
  "ckb-types",
  "ckb-verification-traits",

--- a/ckb-bin/src/subcommand/import.rs
+++ b/ckb-bin/src/subcommand/import.rs
@@ -2,8 +2,15 @@ use ckb_app_config::{ExitCode, ImportArgs};
 use ckb_async_runtime::Handle;
 use ckb_instrument::Import;
 use ckb_shared::SharedBuilder;
+use ckb_stop_handler::broadcast_exit_signals;
 
 pub fn import(args: ImportArgs, async_handle: Handle) -> Result<(), ExitCode> {
+    ctrlc::set_handler(|| {
+        eprintln!("Trapped exit signal, exiting...");
+        broadcast_exit_signals();
+    })
+    .expect("Error setting Ctrl-C handler");
+
     let builder = SharedBuilder::new(
         &args.config.bin_name,
         args.config.root_dir.as_path(),

--- a/util/instrument/Cargo.toml
+++ b/util/instrument/Cargo.toml
@@ -22,6 +22,7 @@ indicatif = { workspace = true, optional = true }
 rayon.workspace = true
 itertools.workspace = true
 ckb-app-config.workspace = true
+ckb-stop-handler.workspace = true
 
 
 [features]

--- a/util/instrument/src/import.rs
+++ b/util/instrument/src/import.rs
@@ -2,6 +2,8 @@ use ckb_app_config::ImportSource;
 use ckb_chain::ChainController;
 use ckb_jsonrpc_types::BlockView as JsonBlock;
 use ckb_shared::Shared;
+#[cfg(feature = "progress_bar")]
+use ckb_stop_handler::{has_received_stop_signal, new_crossbeam_exit_rx};
 use ckb_store::ChainStore;
 use ckb_types::core;
 use ckb_verification_traits::Switch;
@@ -76,7 +78,19 @@ impl Import {
         use ckb_chain::VerifyResult;
         use ckb_types::core::BlockView;
 
+        let interrupted_error = || -> Box<dyn Error> {
+            Box::new(io::Error::other("Import interrupted by stop signal"))
+        };
+
+        let stop_rx = new_crossbeam_exit_rx();
+        if has_received_stop_signal() {
+            return Err(interrupted_error());
+        }
+
         while self.chain.is_verifying_unverified_blocks_on_startup() {
+            if has_received_stop_signal() {
+                return Err(interrupted_error());
+            }
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
 
@@ -154,7 +168,7 @@ impl Import {
         const BLOCKS_COUNT_PER_CHUNK: usize = 1024 * 6;
         let (blocks_tx, blocks_rx) =
             ckb_channel::bounded::<(Arc<BlockView>, usize)>(BLOCKS_COUNT_PER_CHUNK);
-        std::thread::spawn({
+        let parse_jh = std::thread::spawn({
             let num_threads = self.num_threads;
             move || {
                 let pool = rayon::ThreadPoolBuilder::new()
@@ -163,6 +177,9 @@ impl Import {
                     .expect("rayon thread pool must build");
                 pool.install(|| {
                     loop {
+                        if has_received_stop_signal() {
+                            break;
+                        }
                         let batch: Vec<String> = lines
                             .by_ref()
                             .take(BLOCKS_COUNT_PER_CHUNK)
@@ -172,12 +189,15 @@ impl Import {
                             break;
                         }
                         batch.par_iter().for_each(|line| {
+                            if has_received_stop_signal() {
+                                return;
+                            }
                             let block: JsonBlock =
                                 serde_json::from_str(line).expect("parse block from json");
                             let block: Arc<core::BlockView> = Arc::new(block.into());
-                            blocks_tx
-                                .send((block, line.len()))
-                                .expect("send block to channel");
+                            if blocks_tx.send((block, line.len())).is_err() {
+                                return;
+                            }
                         });
                     }
                     drop(blocks_tx);
@@ -185,28 +205,53 @@ impl Import {
             }
         });
 
-        for (block, block_size) in blocks_rx {
-            if !block.is_genesis() {
-                use ckb_chain::LonelyBlock;
-
-                largest_block_number = largest_block_number.max(block.number());
-
-                let progress_bar = progress_bar.clone();
-                let callback = Box::new(move |verify_result: VerifyResult| {
-                    if let Err(err) = verify_result {
-                        eprintln!("Error verifying block: {:?}", err);
-                    } else {
-                        progress_bar.inc(block_size as u64);
-                    }
-                });
-
-                let lonely_block = LonelyBlock {
-                    block,
-                    switch: Some(self.switch),
-                    verify_callback: Some(callback),
-                };
-                self.chain.asynchronous_process_lonely_block(lonely_block);
+        let mut interrupted = false;
+        loop {
+            if has_received_stop_signal() {
+                interrupted = true;
+                break;
             }
+            ckb_channel::select! {
+                recv(stop_rx) -> _ => {
+                    interrupted = true;
+                    break;
+                }
+                recv(blocks_rx) -> msg => {
+                    match msg {
+                        Ok((block, block_size)) => {
+                            if !block.is_genesis() {
+                                use ckb_chain::LonelyBlock;
+
+                                largest_block_number = largest_block_number.max(block.number());
+
+                                let progress_bar = progress_bar.clone();
+                                let callback = Box::new(move |verify_result: VerifyResult| {
+                                    if let Err(err) = verify_result {
+                                        eprintln!("Error verifying block: {:?}", err);
+                                    } else {
+                                        progress_bar.inc(block_size as u64);
+                                    }
+                                });
+
+                                let lonely_block = LonelyBlock {
+                                    block,
+                                    switch: Some(self.switch),
+                                    verify_callback: Some(callback),
+                                };
+                                self.chain.asynchronous_process_lonely_block(lonely_block);
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+        drop(blocks_rx);
+        let _ = parse_jh.join();
+
+        if interrupted || has_received_stop_signal() {
+            progress_bar.finish_with_message("interrupted");
+            return Err(interrupted_error());
         }
 
         while self
@@ -215,6 +260,10 @@ impl Import {
             .get_block_hash(largest_block_number)
             .is_none()
         {
+            if has_received_stop_signal() {
+                progress_bar.finish_with_message("interrupted");
+                return Err(interrupted_error());
+            }
             std::thread::sleep(std::time::Duration::from_secs(1));
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`ckb import` does not wire stop signals, so SIGINT/SIGTERM can terminate abruptly or leave the import loop waiting indefinitely.

### What is changed and how it works?

What's Changed:
- Add Ctrl-C handler in `ckb import` to broadcast stop signals.
- Make the import loop check stop signals and exit promptly; avoid panics when shutdown occurs during parsing.
- Mark progress as interrupted and return a clear error when stopped.

### Related changes

- PR to update `owner/repo`: N/A
- Need to cherry-pick to the release branch: N/A

### Check List

Tests

- [x] Unit test (attempted `cargo test -p ckb-instrument --features progress_bar`, timed out after 120s)
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression
- [ ] Breaking backward compatibility
