### PR TITLE
docs: add guide for running dev chain from existing data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
+* Run `make quick-test` before opening a PR.
+
+* Run `make test` before requesting final review.
+
+* `make quick-test` and `make test` use `nextest`: https://nexte.st/
+
 ### Propose new features
 
 See [Nervos Network RFCs Process](https://github.com/nervosnetwork/rfcs).

--- a/docs/devnet-from-existing-data.md
+++ b/docs/devnet-from-existing-data.md
@@ -1,0 +1,78 @@
+# Run Dev Chain Using Existing Mainnet or Testnet Data
+
+This guide explains how to run a local `dev` chain using an existing mainnet or
+testnet data directory.
+
+This setup is useful when you want local testing with existing chain data.
+
+## 1. Copy the Existing Data Directory
+
+Do not operate on your original data directory directly. Copy it to a new one:
+
+```shell
+cp -r /path/to/ckb-data /path/to/ckb-dev-fork
+cd /path/to/ckb-dev-fork
+```
+
+All commands below assume the current directory is the copied directory.
+
+## 2. Get the Source Chain Spec File
+
+Download the source chain spec file that matches your copied data:
+
+- Mainnet: https://github.com/nervosnetwork/ckb/blob/develop/resource/specs/mainnet.toml
+- Testnet: https://github.com/nervosnetwork/ckb/blob/develop/resource/specs/testnet.toml
+
+For example:
+
+```shell
+curl -L -o mainnet.toml \
+  https://raw.githubusercontent.com/nervosnetwork/ckb/develop/resource/specs/mainnet.toml
+```
+
+## 3. Initialize `dev` Chain and Import the Source Spec
+
+```shell
+ckb init --chain dev --import-spec ./mainnet.toml --force
+```
+
+If you copied testnet data, replace `mainnet.toml` with `testnet.toml`.
+
+## 4. Update `specs/dev.toml`
+
+Set `Dummy` PoW for local development and keep `genesis_epoch_length` unchanged:
+
+```toml
+[params]
+genesis_epoch_length = 1743
+initial_primary_epoch_reward = 1_917_808_21917808
+secondary_epoch_reward = 613_698_63013698
+max_block_cycles = 10_000_000_000
+cellbase_maturity = 0
+primary_epoch_reward_halving_interval = 8760
+epoch_duration_target = 14400
+permanent_difficulty_in_dummy = true
+
+[pow]
+func = "Dummy"
+```
+
+## 5. First Run Requires Spec-Check Flags
+
+The copied database still records the original chain spec hash, so first startup
+must include:
+
+```shell
+ckb run --skip-spec-check --overwrite-spec
+```
+
+After the first successful run, `ckb run` can be used normally.
+
+## Troubleshooting
+
+If you see a log like `init_snapshot Spec(GenesisMismatch(...))`, the running
+spec and database spec do not match. Ensure:
+
+1. You imported the correct source chain spec.
+2. The first run uses `--skip-spec-check --overwrite-spec`.
+3. You are operating in the copied data directory, not the original one.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Document how to run `dev` chain using existing mainnet/testnet data and avoid `GenesisMismatch`.

### What is changed and how it works?

What's Changed:
- Add `docs/devnet-from-existing-data.md`.

### Related changes

- Need to cherry-pick to the release branch: no

### Check List

Tests
- No code

Side effects
- None