### PR TITLE
chore: use trusted publishing for root crate (no-changelog)

### DIFF
--- a/.github/workflows/publish-root-ckb-crate.yaml
+++ b/.github/workflows/publish-root-ckb-crate.yaml
@@ -30,7 +30,10 @@ jobs:
           fi
           echo "Version check passed: $CARGO_VERSION"
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish to crates.io
         run: cargo publish -p ckb
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: The workflow that publishes the root crate has failed.

### What is changed and how it works?

What's Changed: Use trusted publishing to obtain the token
