### PR TITLE
build: make vendored OpenSSL opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,6 +333,7 @@ codegen-units = 1
 [features]
 default = []
 deadlock_detection = ["ckb-bin/deadlock_detection"]
+openssl-vendored = ["ckb-bin/openssl-vendored"]
 with_sentry = ["ckb-bin/with_sentry"]
 with_dns_seeding = ["ckb-bin/with_dns_seeding"]
 profiling = ["tikv-jemallocator/profiling", "ckb-bin/profiling"]

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ trace-tokio: ## Build binary for production release and with tokio trace feature
 
 .PHONY: prod_portable
 prod_portable: ## Build binary for portable production release.
-	cargo build --locked --bin ckb ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding,portable"
+	cargo build --locked --bin ckb ${VERBOSE} ${CKB_BUILD_TARGET} --profile prod --features "with_sentry,with_dns_seeding,portable,openssl-vendored"
 
 .PHONY: prod-docker
 prod-docker:

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -59,6 +59,7 @@ colored = "2.0"
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]
 profiling = ["ckb-memory-tracker/profiling", "ckb-shared/stats"]
+openssl-vendored = ["ckb-network/openssl-vendored"]
 with_sentry = [
     "sentry",
     "ckb-launcher/with_sentry",

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -3,7 +3,7 @@ FROM nervos/ckb-docker-builder:focal-rust-1.92.0 as ckb-docker-builder
 WORKDIR /ckb
 COPY ./ .
 
-RUN make OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/local/lib64 OPENSSL_INCLUDE_DIR=/usr/local/include prod-docker
+RUN make prod-docker
 
 FROM ubuntu:focal
 LABEL description="Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network."
@@ -15,12 +15,17 @@ RUN groupadd -g 1000 ckb \
 
 WORKDIR /var/lib/ckb
 
+COPY --from=ckb-docker-builder \
+     /usr/local/lib64/libssl.so.* \
+     /usr/local/lib64/libcrypto.so.* \
+     /usr/local/lib64/
 COPY --from=ckb-docker-builder /ckb/target/prod/ckb /ckb/docker/docker-entrypoint.sh /bin/
 RUN chown -R ckb:ckb /var/lib/ckb \
  && chmod 755 /var/lib/ckb
 
 USER ckb
 ENV CKB_CHAIN=mainnet
+ENV LD_LIBRARY_PATH=/usr/local/lib64
 
 EXPOSE 8114 8115
 VOLUME ["/var/lib/ckb"]

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,11 +1,29 @@
-FROM nervos/ckb-docker-builder:focal-rust-1.92.0 as ckb-docker-builder
+FROM ubuntu:22.04 AS ckb-docker-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    libclang-dev \
+    libssl-dev \
+    pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
 
 WORKDIR /ckb
 COPY ./ .
 
 RUN make prod-docker
 
-FROM ubuntu:focal
+FROM ubuntu:22.04
 LABEL description="Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network."
 LABEL maintainer="Nervos Core Dev <dev@nervos.org>"
 
@@ -15,17 +33,12 @@ RUN groupadd -g 1000 ckb \
 
 WORKDIR /var/lib/ckb
 
-COPY --from=ckb-docker-builder \
-     /usr/local/lib64/libssl.so.* \
-     /usr/local/lib64/libcrypto.so.* \
-     /usr/local/lib64/
 COPY --from=ckb-docker-builder /ckb/target/prod/ckb /ckb/docker/docker-entrypoint.sh /bin/
 RUN chown -R ckb:ckb /var/lib/ckb \
  && chmod 755 /var/lib/ckb
 
 USER ckb
 ENV CKB_CHAIN=mainnet
-ENV LD_LIBRARY_PATH=/usr/local/lib64
 
 EXPOSE 8114 8115
 VOLUME ["/var/lib/ckb"]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -42,7 +42,6 @@ url.workspace = true
 p2p = { workspace = true, default-features = false, features = [
     "upnp",
     "parking_lot",
-    "openssl-vendored",
     "tokio-runtime",
     "tokio-timer",
     "ws",
@@ -57,6 +56,7 @@ serde-wasm-bindgen = "0.6.5"
 
 
 [features]
+openssl-vendored = ["p2p/openssl-vendored"]
 with_sentry = ["sentry"]
 with_dns_seeding = ["bs58", "faster-hex", "hickory-resolver", "secp256k1"]
 fuzz = []


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Default non-WASM CKB builds always enable vendored OpenSSL, and the x86_64 Docker image relied on a focal/static OpenSSL path that is not ideal for reproducibility.

### What is changed and how it works?

What's Changed:
- gate `openssl-vendored` behind an explicit feature
- keep `prod_portable` on the vendored path
- move the x86_64 Docker build/runtime to Ubuntu 22.04 and remove the `LD_LIBRARY_PATH` workaround

### Related changes

- None

### Check List

Tests

- Manual test
  - `cargo tree -p ckb-network -i openssl-src`
  - `cargo tree --features openssl-vendored -p ckb-network -i openssl-src`
  - `cargo check --locked -p ckb-network --features openssl-vendored`
  - `docker build -f docker/hub/Dockerfile -t ckb:x64-jammy-test .`
  - `docker run --rm --entrypoint bash ckb:x64-jammy-test -lc 'ldd /bin/ckb | grep -E "libssl|libcrypto"; /bin/ckb --version'`
