### PR TITLE
build: sort WalkDir entries in resource bundling

### DIFF
--- a/resource/build.rs
+++ b/resource/build.rs
@@ -21,7 +21,11 @@ fn main() {
             .expect("add files to resource bundle");
     }
 
-    for entry in WalkDir::new("specs").follow_links(true).into_iter() {
+    for entry in WalkDir::new("specs")
+        .follow_links(true)
+        .sort_by_file_name()
+        .into_iter()
+    {
         match entry {
             Ok(ref e)
                 if !e.file_name().to_string_lossy().starts_with('.')


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`resource/build.rs` relied on unsorted `WalkDir` traversal for bundled spec files, which can make generated resource ordering depend on filesystem enumeration order and weaken bit-for-bit reproducibility.

### What is changed and how it works?

What's Changed:
- call `sort_by_file_name()` on the `WalkDir` used for `specs/*.toml` to make resource bundling order deterministic
- refs: https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html , https://docs.rs/walkdir/latest/walkdir/struct.WalkDir.html

### Check List

Tests

- Manual test: `cargo check -p ckb-resource`