### PR TITLE
fix!: bump crate versions for breaking ckb_schemars to schemars migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "faster-hex",
  "schemars",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "ckb-types",
  "faster-hex",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-rpc"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ ckb-db-schema = { path = "db-schema", version = "1" }
 ckb-error = { path = "error", version = "1" }
 ckb-fee-estimator = { path = "util/fee-estimator", version = "1" }
 ckb-fixed-hash = { path = "util/fixed-hash", version = "1" }
-ckb-fixed-hash-core = { path = "util/fixed-hash/core", version = "1" }
+ckb-fixed-hash-core = { path = "util/fixed-hash/core", version = "2" }
 ckb-fixed-hash-macros = { path = "util/fixed-hash/macros", version = "1" }
 ckb-freezer = { path = "freezer", version = "1" }
 ckb-gen-types = { path = "util/gen-types", version = "1" }
@@ -165,7 +165,7 @@ ckb-hash = { path = "util/hash", default-features = false, version = "1" }
 ckb-indexer = { path = "util/indexer", version = "1" }
 ckb-indexer-sync = { path = "util/indexer-sync", version = "1" }
 ckb-instrument = { path = "util/instrument", version = "1" }
-ckb-jsonrpc-types = { path = "util/jsonrpc-types", version = "1" }
+ckb-jsonrpc-types = { path = "util/jsonrpc-types", version = "2" }
 ckb-launcher = { path = "util/launcher", version = "1" }
 ckb-light-client-protocol-server = { path = "util/light-client-protocol-server", version = "1" }
 ckb-logger = { path = "util/logger", version = "1" }
@@ -193,7 +193,7 @@ ckb-rational = { path = "util/rational", version = "1" }
 ckb-resource = { path = "resource", version = "1" }
 ckb-reward-calculator = { path = "util/reward-calculator", version = "1" }
 ckb-rich-indexer = { path = "util/rich-indexer", version = "1" }
-ckb-rpc = { path = "rpc", version = "1" }
+ckb-rpc = { path = "rpc", version = "2" }
 ckb-script = { path = "script", version = "1" }
 ckb-shared = { path = "shared", version = "1" }
 ckb-snapshot = { path = "util/snapshot", version = "1" }

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.1](https://github.com/nervosnetwork/ckb/compare/ckb-rpc-v1.2.0...ckb-rpc-v1.2.1) - 2026-03-08
+## [2.0.0](https://github.com/nervosnetwork/ckb/compare/ckb-rpc-v1.2.1...ckb-rpc-v2.0.0)
+
+### Changed
+
+- **BREAKING**: switch from `ckb_schemars` to `schemars` ([#5128](https://github.com/nervosnetwork/ckb/pull/5128))
+
+## [1.2.1](https://github.com/nervosnetwork/ckb/compare/ckb-rpc-v1.2.0...ckb-rpc-v1.2.1) - 2026-03-08 [YANKED]
 
 ### Changed
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-rpc"
-version = "1.2.1"
+version = "2.0.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/CHANGELOG.md
+++ b/util/fixed-hash/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-v1.1.0...ckb-fixed-hash-v1.2.0)
+
+### Changed
+
+- bump `ckb-fixed-hash-core` to 2.0.0 for `ckb_schemars` to `schemars` migration
+
 ## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-v1.0.2...ckb-fixed-hash-v1.1.0) - 2026-03-02
 
 ### Added

--- a/util/fixed-hash/Cargo.toml
+++ b/util/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/core/CHANGELOG.md
+++ b/util/fixed-hash/core/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-core-v1.1.0...ckb-fixed-hash-core-v1.1.1) - 2026-03-08
+## [2.0.0](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-core-v1.1.1...ckb-fixed-hash-core-v2.0.0)
+
+### Changed
+
+- **BREAKING**: switch from `ckb_schemars` to `schemars` ([#5128](https://github.com/nervosnetwork/ckb/pull/5128))
+
+## [1.1.1](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-core-v1.1.0...ckb-fixed-hash-core-v1.1.1) - 2026-03-08 [YANKED]
 
 ### Changed
 

--- a/util/fixed-hash/core/Cargo.toml
+++ b/util/fixed-hash/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-core"
-version = "1.1.1"
+version = "2.0.0"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/fixed-hash/macros/CHANGELOG.md
+++ b/util/fixed-hash/macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-macros-v1.1.0...ckb-fixed-hash-macros-v1.2.0)
+
+### Changed
+
+- bump `ckb-fixed-hash-core` to 2.0.0 for `ckb_schemars` to `schemars` migration
+
 ## [1.1.0](https://github.com/nervosnetwork/ckb/compare/ckb-fixed-hash-macros-v1.0.1...ckb-fixed-hash-macros-v1.1.0) - 2026-03-02
 
 ### Added

--- a/util/fixed-hash/macros/Cargo.toml
+++ b/util/fixed-hash/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-fixed-hash-macros"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = ["Nervos <dev@nervos.org>"]
 edition = "2024"

--- a/util/jsonrpc-types/CHANGELOG.md
+++ b/util/jsonrpc-types/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.1](https://github.com/nervosnetwork/ckb/compare/ckb-jsonrpc-types-v1.1.0...ckb-jsonrpc-types-v1.1.1) - 2026-03-08
+## [2.0.0](https://github.com/nervosnetwork/ckb/compare/ckb-jsonrpc-types-v1.1.1...ckb-jsonrpc-types-v2.0.0)
+
+### Changed
+
+- **BREAKING**: switch from `ckb_schemars` to `schemars` ([#5128](https://github.com/nervosnetwork/ckb/pull/5128))
+
+## [1.1.1](https://github.com/nervosnetwork/ckb/compare/ckb-jsonrpc-types-v1.1.0...ckb-jsonrpc-types-v1.1.1) - 2026-03-08 [YANKED]
 
 ### Changed
 

--- a/util/jsonrpc-types/Cargo.toml
+++ b/util/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-jsonrpc-types"
-version = "1.1.1"
+version = "2.0.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The switch from `ckb_schemars` to `schemars` in #5128 was a breaking change that was incorrectly released as patch/minor bumps by release-plz (#5129). This causes a semver resolution issue:

- `ckb-fixed-hash v1.1.0` on crates.io depends on `ckb-fixed-hash-core = "^1"` (`>=1.0.0, <2.0.0`)
- Cargo resolves this to `ckb-fixed-hash-core v1.1.1`, which depends on `schemars` instead of `ckb_schemars`
- Downstream consumers expecting `ckb_schemars` are silently broken

The same issue applies to `ckb-jsonrpc-types` and `ckb-rpc`.

### What is changed and how it works?

Bump crates with the breaking `schemars` dependency change to major version 2.0.0, so Cargo's semver resolver cannot mix old consumers with new dependencies:

| Crate | Old Version | New Version | Reason |
|---|---|---|---|
| `ckb-fixed-hash-core` | `1.1.1` | `2.0.0` | Breaking: `ckb_schemars` → `schemars` |
| `ckb-jsonrpc-types` | `1.1.1` | `2.0.0` | Breaking: `ckb_schemars` → `schemars` |
| `ckb-rpc` | `1.2.1` | `2.0.0` | Breaking: `ckb_schemars` → `schemars` |
| `ckb-fixed-hash` | `1.1.0` | `1.2.0` | Depends on `ckb-fixed-hash-core` |
| `ckb-fixed-hash-macros` | `1.1.0` | `1.2.0` | Depends on `ckb-fixed-hash-core` |

**After publishing, the following versions should be yanked from crates.io:**

- `ckb-fixed-hash-core v1.1.1`
- `ckb-jsonrpc-types v1.1.1`
- `ckb-rpc v1.2.1`

### Related changes

- Need to yank broken versions from crates.io after this is published

### Check List

Tests

- No code

Side effects

- Breaking backward compatibility

---
*This PR description was generated with the assistance of AI.*
