### PR TITLE
chore(deps): fix` make security-audit`: update keccak to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -74,9 +74,6 @@ ignore = [
   # so we need to wait for sled to update its version，
   # for now, temporarily ignore it first.
   "RUSTSEC-2025-0057",
-  # Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
-  # proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.
-  "RUSTSEC-2024-0370",
   # instant's maintainer no longer maintained, use web-time instead
   "RUSTSEC-2024-0384",
   # paste's maintainer no longer maintained


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`make security-audit` warned about yanked `keccak 0.1.5` and a stale ignored advisory.
```rust
❯ make security-audit
cargo deny check --hide-inclusion-graph --show-stats advisories sources
warning[yanked]: detected yanked crate (try `cargo update -p keccak`)
    ┌─ /home/exec/Projects/github.com/nervosnetwork/ckb.develop/Cargo.lock:304:1
    │
304 │ keccak 0.1.5 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version

warning[advisory-not-detected]: advisory was not encountered
   ┌─ /home/exec/Projects/github.com/nervosnetwork/ckb.develop/deny.toml:79:4
   │
79 │   "RUSTSEC-2024-0370",
   │    ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

 advisories ok: 0 errors, 2 warnings, 12 notes
    sources ok: 0 errors, 0 warnings, 0 notes
```

### What is changed and how it works?

What's Changed:
- update `keccak` to `0.1.6` in `Cargo.lock`
- remove `RUSTSEC-2024-0370` from `deny.toml`

### Related changes

### Check List

Tests
- Manual test: `make security-audit`
- No code
