### PR TITLE
Update thin-vec into patched version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6775,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
```console
thin-vec v0.2.14
└── rhai v1.23.4
    └── ckb-indexer-sync
        ├── ckb-indexer
        ├── ckb-rich-indexer
        └── ckb-rpc -> ckb-launcher -> ckb-bin -> ckb
```

we don't have code affected after analysis, but it's better to update thin-vec to a patched version.

Fixes #5178 
