### PR TITLE
build: bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,9 +5679,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`make security-audit` fails because `Cargo.lock` pins `rustls-webpki` `0.103.10`, which is flagged by `cargo-deny` for `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099`.

### What is changed and how it works?

What's Changed:

- update the `Cargo.lock` entry for `rustls-webpki` from `0.103.10` to `0.103.12`
- pull in the patched release that fixes the reported name-constraint vulnerabilities
- keep the fix limited to the lockfile without changing any manifest requirements

### Related changes

None.

### Check List

Tests

- Manual test (steps below)

Manual test steps:

1. `make security-audit`
2. `cargo check --workspace --locked`
