### PR TITLE
clippy: use is_multiple_of to replace % operator

### DIFF
--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1130,7 +1130,7 @@ impl SyncShared {
         self.state
             .peers()
             .may_set_best_known_header(peer, header_view.as_header_index());
-        if header_view.number() % 10000 == 0 {
+        if header_view.number().is_multiple_of(10000) {
             info!(
                 "inserted valid header: header {}-{}",
                 header_view.number(),


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

```bash
make clippy
...
    Checking ckb-test v1.0.0 (/home/exec/Projects/github.com/nervosnetwork/ckb.develop/test)
    Checking ckb-sync v1.3.0 (/home/exec/Projects/github.com/nervosnetwork/ckb.develop/sync)
    Checking ckb-instrument v1.1.0 (/home/exec/Projects/github.com/nervosnetwork/ckb.develop/util/instrument)
    Checking tikv-jemalloc-ctl v0.5.4
    Checking tikv-jemallocator v0.5.4
    Checking ckb-memory-tracker v1.1.0 (/home/exec/Projects/github.com/nervosnetwork/ckb.develop/util/memory-tracker)
error: manual implementation of `.is_multiple_of()`
    --> sync/src/types/mod.rs:1133:12
     |
1133 |         if header_view.number() % 10000 == 0 {
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `header_view.number().is_multiple_of(10000)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#manual_is_multiple_of
     = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`

error: could not compile `ckb-sync` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `ckb-sync` (lib test) due to 1 previous error
make: *** [Makefile:190: clippy] Error 101

```
### Related changes

- fix clippy, use is_multiple_of to replace %

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- None
