### PR TITLE
[Benchmark] mimalloc vs jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "ckb-bin",
  "ckb-build-info",
  "console-subscriber",
+ "mimalloc",
  "tikv-jemallocator",
  "version-compare",
  "winreg 0.55.0",
@@ -790,8 +791,10 @@ dependencies = [
  "ckb-verification",
  "ckb-verification-traits",
  "criterion",
+ "mimalloc",
  "rand 0.8.6",
  "tempfile",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -2755,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3585,7 +3588,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3910,7 +3913,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4079,6 +4082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4248,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5652,7 +5673,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6653,7 +6674,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7678,7 +7699,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,7 +331,7 @@ lto = true
 codegen-units = 1
 
 [features]
-default = ["mimalloc"]
+default = []
 deadlock_detection = ["ckb-bin/deadlock_detection"]
 with_sentry = ["ckb-bin/with_sentry"]
 with_dns_seeding = ["ckb-bin/with_dns_seeding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,14 @@ ckb-build-info.workspace = true
 ckb-build-info.workspace = true
 ckb-bin.workspace = true
 console-subscriber = { workspace = true, optional = true }
+mimalloc = { version = "0.1", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 winreg = "0.55"
 version-compare = "0.2"
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
-tikv-jemallocator = { version = "0.5.0", features = [
+tikv-jemallocator = { version = "0.5.0", optional = true, features = [
   "unprefixed_malloc_on_supported_platforms",
 ] }
 
@@ -330,11 +331,13 @@ lto = true
 codegen-units = 1
 
 [features]
-default = []
+default = ["mimalloc"]
 deadlock_detection = ["ckb-bin/deadlock_detection"]
 with_sentry = ["ckb-bin/with_sentry"]
 with_dns_seeding = ["ckb-bin/with_dns_seeding"]
-profiling = ["tikv-jemallocator/profiling", "ckb-bin/profiling"]
+mimalloc = ["dep:mimalloc"]
+jemalloc = ["dep:tikv-jemallocator", "ckb-bin/jemalloc"]
+profiling = ["jemalloc", "tikv-jemallocator/profiling", "ckb-bin/profiling"]
 portable = ["ckb-bin/portable"]
 march-native = ["ckb-bin/march-native"]
 tokio-trace = ["console-subscriber"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,10 @@ repository = "https://github.com/nervosnetwork/ckb"
 rust-version = "1.92.0"
 
 [dependencies]
-
+mimalloc = { version = "0.1", optional = true }
+tikv-jemallocator = { version = "0.5.0", optional = true, features = [
+  "unprefixed_malloc_on_supported_platforms",
+] }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -39,8 +42,14 @@ tempfile.workspace = true
 name = "bench_main"
 harness = false
 
+[[bench]]
+name = "allocator_memory"
+harness = false
+
 [features]
-default = []
+default = ["mimalloc"]
 ci = []
+mimalloc = ["dep:mimalloc"]
+jemalloc = ["dep:tikv-jemallocator"]
 portable = ["ckb-store/portable", "ckb-chain/portable"]
 march-native = ["ckb-store/march-native", "ckb-chain/march-native"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -47,7 +47,7 @@ name = "allocator_memory"
 harness = false
 
 [features]
-default = ["mimalloc"]
+default = []
 ci = []
 mimalloc = ["dep:mimalloc"]
 jemalloc = ["dep:tikv-jemallocator"]

--- a/benches/benches/allocator_memory.rs
+++ b/benches/benches/allocator_memory.rs
@@ -3,7 +3,10 @@
 mod benchmarks;
 
 use benchmarks::overall::{run_overall_rounds, setup_chain};
-use std::{fs, thread, time::Duration};
+use std::{
+    fs, thread,
+    time::{Duration, Instant},
+};
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
@@ -96,6 +99,7 @@ fn main() {
     println!("txs_size={txs_size}");
     println!("rounds={rounds}");
 
+    let started_at = Instant::now();
     let before = read_memory_snapshot();
     let after_setup;
     let after_workload;
@@ -109,9 +113,26 @@ fn main() {
 
     thread::sleep(Duration::from_millis(250));
     let after_drop = read_memory_snapshot();
+    let elapsed_ms = started_at.elapsed().as_millis();
 
     print_snapshot("before", before);
     print_snapshot("after_setup", after_setup);
     print_snapshot("after_workload", after_workload);
     print_snapshot("after_drop", after_drop);
+    println!(
+        "result_csv,allocator,txs_size,rounds,elapsed_ms,before_rss_bytes,after_setup_rss_bytes,after_workload_rss_bytes,after_drop_rss_bytes,peak_rss_bytes,virtual_memory_bytes"
+    );
+    println!(
+        "result_csv,{},{},{},{},{},{},{},{},{},{}",
+        allocator_name(),
+        txs_size,
+        rounds,
+        elapsed_ms,
+        before.rss_bytes,
+        after_setup.rss_bytes,
+        after_workload.rss_bytes,
+        after_drop.rss_bytes,
+        after_drop.peak_rss_bytes,
+        after_drop.virtual_memory_bytes
+    );
 }

--- a/benches/benches/allocator_memory.rs
+++ b/benches/benches/allocator_memory.rs
@@ -1,0 +1,117 @@
+#![allow(dead_code)]
+
+mod benchmarks;
+
+use benchmarks::overall::{run_overall_rounds, setup_chain};
+use std::{fs, thread, time::Duration};
+
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(all(not(feature = "jemalloc"), feature = "mimalloc"))]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(not(feature = "ci"))]
+const DEFAULT_TXS_SIZE: usize = 500;
+#[cfg(feature = "ci")]
+const DEFAULT_TXS_SIZE: usize = 16;
+
+#[cfg(not(feature = "ci"))]
+const DEFAULT_ROUNDS: usize = 10;
+#[cfg(feature = "ci")]
+const DEFAULT_ROUNDS: usize = 3;
+
+#[derive(Clone, Copy)]
+struct MemorySnapshot {
+    rss_bytes: u64,
+    peak_rss_bytes: u64,
+    virtual_memory_bytes: u64,
+}
+
+fn parse_status_value(line: &str) -> Option<u64> {
+    line.split_ascii_whitespace()
+        .nth(1)
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|value| value * 1024)
+}
+
+fn read_memory_snapshot() -> MemorySnapshot {
+    let status = fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
+    let mut rss_bytes = None;
+    let mut peak_rss_bytes = None;
+    let mut virtual_memory_bytes = None;
+
+    for line in status.lines() {
+        if line.starts_with("VmRSS:") {
+            rss_bytes = parse_status_value(line);
+        } else if line.starts_with("VmHWM:") {
+            peak_rss_bytes = parse_status_value(line);
+        } else if line.starts_with("VmSize:") {
+            virtual_memory_bytes = parse_status_value(line);
+        }
+    }
+
+    MemorySnapshot {
+        rss_bytes: rss_bytes.expect("VmRSS exists"),
+        peak_rss_bytes: peak_rss_bytes.expect("VmHWM exists"),
+        virtual_memory_bytes: virtual_memory_bytes.expect("VmSize exists"),
+    }
+}
+
+fn parse_arg(index: usize, default: usize) -> usize {
+    std::env::args()
+        .nth(index)
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("invalid numeric argument: {value}"))
+        })
+        .unwrap_or(default)
+}
+
+fn allocator_name() -> &'static str {
+    if cfg!(feature = "jemalloc") {
+        "jemalloc"
+    } else if cfg!(feature = "mimalloc") {
+        "mimalloc"
+    } else {
+        "system"
+    }
+}
+
+fn print_snapshot(label: &str, snapshot: MemorySnapshot) {
+    println!(
+        "{label}: rss_bytes={} peak_rss_bytes={} virtual_memory_bytes={}",
+        snapshot.rss_bytes, snapshot.peak_rss_bytes, snapshot.virtual_memory_bytes
+    );
+}
+
+fn main() {
+    let txs_size = parse_arg(1, DEFAULT_TXS_SIZE);
+    let rounds = parse_arg(2, DEFAULT_ROUNDS);
+
+    println!("allocator={}", allocator_name());
+    println!("txs_size={txs_size}");
+    println!("rounds={rounds}");
+
+    let before = read_memory_snapshot();
+    let after_setup;
+    let after_workload;
+
+    {
+        let (shared, chain) = setup_chain(txs_size);
+        after_setup = read_memory_snapshot();
+        run_overall_rounds(&shared, &chain, rounds);
+        after_workload = read_memory_snapshot();
+    }
+
+    thread::sleep(Duration::from_millis(250));
+    let after_drop = read_memory_snapshot();
+
+    print_snapshot("before", before);
+    print_snapshot("after_setup", after_setup);
+    print_snapshot("after_workload", after_workload);
+    print_snapshot("after_drop", after_drop);
+}

--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -169,6 +169,51 @@ pub fn gen_txs_from_block(block: &BlockView) -> Vec<TransactionView> {
     }
 }
 
+pub fn run_overall_rounds(shared: &Shared, chain: &ChainController, rounds: usize) {
+    let mut remaining = rounds;
+    while remaining > 0 {
+        let snapshot = Arc::clone(&shared.snapshot());
+        let tip_hash = snapshot.tip_hash();
+        let block = snapshot.get_block(&tip_hash).expect("tip exist");
+        let txs = gen_txs_from_block(&block);
+        let tx_pool = shared.tx_pool_controller();
+        if !txs.is_empty() {
+            for tx in txs {
+                tx_pool.submit_local_tx(tx).unwrap().expect("submit_tx");
+            }
+        }
+
+        let mut block_template = tx_pool
+            .get_block_template(None, None, None)
+            .unwrap()
+            .expect("get_block_template");
+
+        while block_template.number != (snapshot.tip_number() + 1).into() {
+            block_template = tx_pool
+                .get_block_template(None, None, None)
+                .unwrap()
+                .expect("get_block_template");
+        }
+        let raw_block: Block = block_template.into();
+        let raw_header = raw_block.header().raw();
+        let header = Header::new_builder()
+            .raw(raw_header)
+            .nonce(random::<u128>())
+            .build();
+        let block = raw_block.as_builder().header(header).build().into_view();
+
+        let header_verifier = HeaderVerifier::new(snapshot.as_ref(), shared.consensus());
+        header_verifier
+            .verify(&block.header())
+            .expect("header verified");
+
+        chain
+            .blocking_process_block_with_switch(Arc::new(block), Switch::DISABLE_EXTENSION)
+            .expect("process_block");
+        remaining -= 1;
+    }
+}
+
 fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("overall");
 
@@ -180,52 +225,7 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || setup_chain(*txs_size),
                     |(shared, chain)| {
-                        let mut i = 10;
-                        while i > 0 {
-                            let snapshot = Arc::clone(&shared.snapshot());
-                            let tip_hash = snapshot.tip_hash();
-                            let block = snapshot.get_block(&tip_hash).expect("tip exist");
-                            let txs = gen_txs_from_block(&block);
-                            let tx_pool = shared.tx_pool_controller();
-                            if !txs.is_empty() {
-                                for tx in txs {
-                                    tx_pool.submit_local_tx(tx).unwrap().expect("submit_tx");
-                                }
-                            }
-
-                            let mut block_template = tx_pool
-                                .get_block_template(None, None, None)
-                                .unwrap()
-                                .expect("get_block_template");
-
-                            while block_template.number != (snapshot.tip_number() + 1).into() {
-                                block_template = tx_pool
-                                    .get_block_template(None, None, None)
-                                    .unwrap()
-                                    .expect("get_block_template");
-                            }
-                            let raw_block: Block = block_template.into();
-                            let raw_header = raw_block.header().raw();
-                            let header = Header::new_builder()
-                                .raw(raw_header)
-                                .nonce(random::<u128>())
-                                .build();
-                            let block = raw_block.as_builder().header(header).build().into_view();
-
-                            let header_verifier =
-                                HeaderVerifier::new(snapshot.as_ref(), shared.consensus());
-                            header_verifier
-                                .verify(&block.header())
-                                .expect("header verified");
-
-                            chain
-                                .blocking_process_block_with_switch(
-                                    Arc::new(block),
-                                    Switch::DISABLE_EXTENSION,
-                                )
-                                .expect("process_block");
-                            i -= 1;
-                        }
+                        run_overall_rounds(&shared, &chain, 10);
                     },
                     BatchSize::PerIteration,
                 )

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -7,6 +7,6 @@
 //! Compare allocator memory behavior with:
 //!
 //! ```console
-//! cargo bench --bench allocator_memory --features ci
+//! cargo bench --bench allocator_memory --no-default-features --features "ci mimalloc"
 //! cargo bench --bench allocator_memory --no-default-features --features "ci jemalloc"
 //! ```

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -3,3 +3,10 @@
 //! ```console
 //! cd benches && cargo bench --features ci -- --test
 //! ```
+//!
+//! Compare allocator memory behavior with:
+//!
+//! ```console
+//! cargo bench --bench allocator_memory --features ci
+//! cargo bench --bench allocator_memory --no-default-features --features "ci jemalloc"
+//! ```

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -58,6 +58,7 @@ colored = "2.0"
 
 [features]
 deadlock_detection = ["ckb-util/deadlock_detection"]
+jemalloc = ["ckb-memory-tracker/jemalloc"]
 profiling = ["ckb-memory-tracker/profiling", "ckb-shared/stats"]
 with_sentry = [
     "sentry",

--- a/devtools/bench-allocator/README.md
+++ b/devtools/bench-allocator/README.md
@@ -21,6 +21,7 @@ The script writes raw logs, a CSV file, and a Markdown summary under
 When GNU `time` is available as `/usr/bin/time` or `gtime`, the CSV also
 includes CPU time, max RSS, and page fault counters from the process wrapper.
 Without GNU `time`, the benchmark still runs and those fields are left empty.
+Allocator order alternates by run to reduce fixed-order bias.
 
 For a production decision, also collect node-level profiles for both allocator
 builds:

--- a/devtools/bench-allocator/README.md
+++ b/devtools/bench-allocator/README.md
@@ -17,6 +17,8 @@ REPEAT=5 TXS_SIZE=500 ROUNDS=10 devtools/bench-allocator/run-allocator-memory.sh
 
 The script writes raw logs, a CSV file, and a Markdown summary under
 `target/allocator-bench/<timestamp>/`.
+The Markdown report uses seconds and MiB for readability and includes mean,
+median, standard deviation, min/max, and mimalloc-vs-jemalloc deltas.
 
 When GNU `time` is available as `/usr/bin/time` or `gtime`, the CSV also
 includes CPU time, max RSS, and page fault counters from the process wrapper.

--- a/devtools/bench-allocator/README.md
+++ b/devtools/bench-allocator/README.md
@@ -1,0 +1,35 @@
+# Allocator Benchmark
+
+This directory contains a repeatable harness for comparing CKB allocator builds.
+It is intended to collect evidence before changing the production default
+allocator.
+
+The minimum comparison is:
+
+- `jemalloc`: current Linux production allocator baseline.
+- `mimalloc`: candidate allocator.
+
+Run the in-process block/tx-pool workload repeatedly:
+
+```sh
+REPEAT=5 TXS_SIZE=500 ROUNDS=10 devtools/bench-allocator/run-allocator-memory.sh
+```
+
+The script writes raw logs, a CSV file, and a Markdown summary under
+`target/allocator-bench/<timestamp>/`.
+
+When GNU `time` is available as `/usr/bin/time` or `gtime`, the CSV also
+includes CPU time, max RSS, and page fault counters from the process wrapper.
+Without GNU `time`, the benchmark still runs and those fields are left empty.
+
+For a production decision, also collect node-level profiles for both allocator
+builds:
+
+- Block import or sync from the same data set.
+- Tx-pool churn with repeated submit, eviction, and block template generation.
+- Long-running node steady state, including RSS after idle periods.
+- RPC/indexer/rich-indexer scenarios if those services are part of the target
+  deployment.
+
+Record at least wall time, CPU time, peak RSS, steady RSS, page faults,
+throughput, and p95/p99 latency where the workload has request latency.

--- a/devtools/bench-allocator/report.py
+++ b/devtools/bench-allocator/report.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import statistics
+from pathlib import Path
+
+
+FIELDS = [
+    "allocator",
+    "run",
+    "txs_size",
+    "rounds",
+    "elapsed_ms",
+    "before_rss_bytes",
+    "after_setup_rss_bytes",
+    "after_workload_rss_bytes",
+    "after_drop_rss_bytes",
+    "peak_rss_bytes",
+    "virtual_memory_bytes",
+    "time_elapsed_seconds",
+    "time_user_seconds",
+    "time_system_seconds",
+    "time_max_rss_kb",
+    "time_minor_faults",
+    "time_major_faults",
+]
+
+
+def parse_elapsed(value):
+    parts = value.strip().split(":")
+    if len(parts) == 2:
+        minutes, seconds = parts
+        return int(minutes) * 60 + float(seconds)
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    return float(value)
+
+
+def read_time_log(path):
+    data = {}
+    for line in Path(path).read_text().splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if key == "Elapsed (wall clock) time (h:mm:ss or m:ss)":
+            data["time_elapsed_seconds"] = parse_elapsed(value)
+        elif key == "User time (seconds)":
+            data["time_user_seconds"] = float(value)
+        elif key == "System time (seconds)":
+            data["time_system_seconds"] = float(value)
+        elif key == "Maximum resident set size (kbytes)":
+            data["time_max_rss_kb"] = int(value)
+        elif key == "Minor (reclaiming a frame) page faults":
+            data["time_minor_faults"] = int(value)
+        elif key == "Major (requiring I/O) page faults":
+            data["time_major_faults"] = int(value)
+    return data
+
+
+def read_result_csv_line(path):
+    rows = [
+        line.strip().split(",")
+        for line in Path(path).read_text().splitlines()
+        if line.startswith("result_csv,") and not line.startswith("result_csv,allocator,")
+    ]
+    if not rows:
+        raise SystemExit(f"missing result_csv line in {path}")
+    row = rows[-1]
+    keys = [
+        "marker",
+        "allocator",
+        "txs_size",
+        "rounds",
+        "elapsed_ms",
+        "before_rss_bytes",
+        "after_setup_rss_bytes",
+        "after_workload_rss_bytes",
+        "after_drop_rss_bytes",
+        "peak_rss_bytes",
+        "virtual_memory_bytes",
+    ]
+    return dict(zip(keys, row))
+
+
+def append(args):
+    row = read_result_csv_line(args.log)
+    row.update(read_time_log(args.time_log))
+    row["allocator"] = args.allocator
+    row["run"] = args.run
+
+    csv_path = Path(args.csv)
+    exists = csv_path.exists()
+    with csv_path.open("a", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=FIELDS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow({field: row.get(field, "") for field in FIELDS})
+
+
+def as_number(value):
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def summarize(args):
+    rows = list(csv.DictReader(Path(args.csv).open()))
+    metrics = [
+        "elapsed_ms",
+        "after_workload_rss_bytes",
+        "after_drop_rss_bytes",
+        "peak_rss_bytes",
+        "time_elapsed_seconds",
+        "time_user_seconds",
+        "time_system_seconds",
+        "time_max_rss_kb",
+        "time_minor_faults",
+        "time_major_faults",
+    ]
+    allocators = sorted({row["allocator"] for row in rows})
+    lines = ["# Allocator Benchmark Summary", ""]
+    lines.append(f"runs={len(rows)}")
+    lines.append("")
+    lines.append("| allocator | metric | mean | stdev | min | max |")
+    lines.append("| --- | --- | ---: | ---: | ---: | ---: |")
+    for allocator in allocators:
+        allocator_rows = [row for row in rows if row["allocator"] == allocator]
+        for metric in metrics:
+            values = [as_number(row[metric]) for row in allocator_rows if row.get(metric)]
+            values = [value for value in values if value is not None]
+            if not values:
+                continue
+            stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+            lines.append(
+                f"| {allocator} | {metric} | {statistics.mean(values):.2f} | "
+                f"{stdev:.2f} | {min(values):.2f} | {max(values):.2f} |"
+            )
+    Path(args.output).write_text("\n".join(lines) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+
+    append_parser = subparsers.add_parser("append")
+    append_parser.add_argument("--allocator", required=True)
+    append_parser.add_argument("--run", required=True)
+    append_parser.add_argument("--log", required=True)
+    append_parser.add_argument("--time-log", required=True)
+    append_parser.add_argument("--csv", required=True)
+    append_parser.set_defaults(func=append)
+
+    summarize_parser = subparsers.add_parser("summarize")
+    summarize_parser.add_argument("--csv", required=True)
+    summarize_parser.add_argument("--output", required=True)
+    summarize_parser.set_defaults(func=summarize)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/devtools/bench-allocator/report.py
+++ b/devtools/bench-allocator/report.py
@@ -103,8 +103,31 @@ def append(args):
 def as_number(value):
     try:
         return float(value)
-    except ValueError:
+    except (TypeError, ValueError):
         return None
+
+
+def metric_values(rows, allocator, metric):
+    values = [
+        as_number(row.get(metric))
+        for row in rows
+        if row.get("allocator") == allocator and row.get(metric)
+    ]
+    return [value for value in values if value is not None]
+
+
+def metric_stats(rows, allocator, metric):
+    values = metric_values(rows, allocator, metric)
+    if not values:
+        return None
+    stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+    return {
+        "count": len(values),
+        "mean": statistics.mean(values),
+        "stdev": stdev,
+        "min": min(values),
+        "max": max(values),
+    }
 
 
 def summarize(args):
@@ -128,16 +151,30 @@ def summarize(args):
     lines.append("| allocator | metric | mean | stdev | min | max |")
     lines.append("| --- | --- | ---: | ---: | ---: | ---: |")
     for allocator in allocators:
-        allocator_rows = [row for row in rows if row["allocator"] == allocator]
         for metric in metrics:
-            values = [as_number(row[metric]) for row in allocator_rows if row.get(metric)]
-            values = [value for value in values if value is not None]
-            if not values:
+            stats = metric_stats(rows, allocator, metric)
+            if stats is None:
                 continue
-            stdev = statistics.stdev(values) if len(values) > 1 else 0.0
             lines.append(
-                f"| {allocator} | {metric} | {statistics.mean(values):.2f} | "
-                f"{stdev:.2f} | {min(values):.2f} | {max(values):.2f} |"
+                f"| {allocator} | {metric} | {stats['mean']:.2f} | "
+                f"{stats['stdev']:.2f} | {stats['min']:.2f} | {stats['max']:.2f} |"
+            )
+    if {"jemalloc", "mimalloc"}.issubset(set(allocators)):
+        lines.append("")
+        lines.append("## Mimalloc Delta")
+        lines.append("")
+        lines.append("| metric | jemalloc mean | mimalloc mean | delta | delta % |")
+        lines.append("| --- | ---: | ---: | ---: | ---: |")
+        for metric in metrics:
+            jemalloc = metric_stats(rows, "jemalloc", metric)
+            mimalloc = metric_stats(rows, "mimalloc", metric)
+            if jemalloc is None or mimalloc is None or jemalloc["mean"] == 0:
+                continue
+            delta = mimalloc["mean"] - jemalloc["mean"]
+            delta_percent = delta / jemalloc["mean"] * 100
+            lines.append(
+                f"| {metric} | {jemalloc['mean']:.2f} | {mimalloc['mean']:.2f} | "
+                f"{delta:.2f} | {delta_percent:.2f}% |"
             )
     Path(args.output).write_text("\n".join(lines) + "\n")
 

--- a/devtools/bench-allocator/report.py
+++ b/devtools/bench-allocator/report.py
@@ -26,6 +26,21 @@ FIELDS = [
 ]
 
 
+SUMMARY_METRICS = [
+    ("elapsed_ms", "elapsed_s", 1000.0),
+    ("after_workload_rss_bytes", "workload_rss_mib", 1024.0 * 1024.0),
+    ("after_drop_rss_bytes", "drop_rss_mib", 1024.0 * 1024.0),
+    ("peak_rss_bytes", "peak_rss_mib", 1024.0 * 1024.0),
+    ("virtual_memory_bytes", "vms_mib", 1024.0 * 1024.0),
+    ("time_elapsed_seconds", "time_elapsed_s", 1.0),
+    ("time_user_seconds", "time_user_s", 1.0),
+    ("time_system_seconds", "time_system_s", 1.0),
+    ("time_max_rss_kb", "time_max_rss_mib", 1024.0),
+    ("time_minor_faults", "minor_faults", 1.0),
+    ("time_major_faults", "major_faults", 1.0),
+]
+
+
 def parse_elapsed(value):
     parts = value.strip().split(":")
     if len(parts) == 2:
@@ -116,65 +131,93 @@ def metric_values(rows, allocator, metric):
     return [value for value in values if value is not None]
 
 
-def metric_stats(rows, allocator, metric):
-    values = metric_values(rows, allocator, metric)
+def scaled_metric_values(rows, allocator, metric, scale):
+    return [value / scale for value in metric_values(rows, allocator, metric)]
+
+
+def metric_stats(rows, allocator, metric, scale=1.0):
+    values = scaled_metric_values(rows, allocator, metric, scale)
     if not values:
         return None
     stdev = statistics.stdev(values) if len(values) > 1 else 0.0
     return {
         "count": len(values),
         "mean": statistics.mean(values),
+        "median": statistics.median(values),
         "stdev": stdev,
         "min": min(values),
         "max": max(values),
     }
 
 
+def paired_deltas(rows, metric, scale):
+    by_run = {}
+    for row in rows:
+        allocator = row.get("allocator")
+        run = row.get("run")
+        value = as_number(row.get(metric))
+        if allocator not in {"jemalloc", "mimalloc"} or run is None or value is None:
+            continue
+        by_run.setdefault(run, {})[allocator] = value / scale
+
+    deltas = []
+    for run, values in by_run.items():
+        if "jemalloc" in values and "mimalloc" in values:
+            deltas.append(values["mimalloc"] - values["jemalloc"])
+    return deltas
+
+
+def fmt(value):
+    if abs(value) >= 1000:
+        return f"{value:,.1f}"
+    return f"{value:.2f}"
+
+
 def summarize(args):
     rows = list(csv.DictReader(Path(args.csv).open()))
-    metrics = [
-        "elapsed_ms",
-        "after_workload_rss_bytes",
-        "after_drop_rss_bytes",
-        "peak_rss_bytes",
-        "time_elapsed_seconds",
-        "time_user_seconds",
-        "time_system_seconds",
-        "time_max_rss_kb",
-        "time_minor_faults",
-        "time_major_faults",
-    ]
     allocators = sorted({row["allocator"] for row in rows})
     lines = ["# Allocator Benchmark Summary", ""]
-    lines.append(f"runs={len(rows)}")
+    lines.append(f"Rows: {len(rows)}")
+    for key in ("txs_size", "rounds"):
+        values = sorted({row.get(key, "") for row in rows if row.get(key)})
+        if len(values) == 1:
+            lines.append(f"{key}: {values[0]}")
     lines.append("")
-    lines.append("| allocator | metric | mean | stdev | min | max |")
-    lines.append("| --- | --- | ---: | ---: | ---: | ---: |")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Allocator | Metric | Mean | Median | Stddev | Min | Max |")
+    lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
     for allocator in allocators:
-        for metric in metrics:
-            stats = metric_stats(rows, allocator, metric)
+        for metric, label, scale in SUMMARY_METRICS:
+            stats = metric_stats(rows, allocator, metric, scale)
             if stats is None:
                 continue
             lines.append(
-                f"| {allocator} | {metric} | {stats['mean']:.2f} | "
-                f"{stats['stdev']:.2f} | {stats['min']:.2f} | {stats['max']:.2f} |"
+                f"| {allocator} | {label} | {fmt(stats['mean'])} | "
+                f"{fmt(stats['median'])} | {fmt(stats['stdev'])} | "
+                f"{fmt(stats['min'])} | {fmt(stats['max'])} |"
             )
     if {"jemalloc", "mimalloc"}.issubset(set(allocators)):
         lines.append("")
         lines.append("## Mimalloc Delta")
         lines.append("")
-        lines.append("| metric | jemalloc mean | mimalloc mean | delta | delta % |")
-        lines.append("| --- | ---: | ---: | ---: | ---: |")
-        for metric in metrics:
-            jemalloc = metric_stats(rows, "jemalloc", metric)
-            mimalloc = metric_stats(rows, "mimalloc", metric)
+        lines.append(
+            "| Metric | Jemalloc Mean | Mimalloc Mean | Delta | Delta % | Paired Median Delta |"
+        )
+        lines.append("| --- | ---: | ---: | ---: | ---: | ---: |")
+        for metric, label, scale in SUMMARY_METRICS:
+            jemalloc = metric_stats(rows, "jemalloc", metric, scale)
+            mimalloc = metric_stats(rows, "mimalloc", metric, scale)
             if jemalloc is None or mimalloc is None or jemalloc["mean"] == 0:
                 continue
             delta = mimalloc["mean"] - jemalloc["mean"]
             delta_percent = delta / jemalloc["mean"] * 100
+            pair_values = paired_deltas(rows, metric, scale)
+            pair_median = statistics.median(pair_values) if pair_values else None
             lines.append(
-                f"| {metric} | {jemalloc['mean']:.2f} | {mimalloc['mean']:.2f} | "
-                f"{delta:.2f} | {delta_percent:.2f}% |"
+                f"| {label} | {fmt(jemalloc['mean'])} | {fmt(mimalloc['mean'])} | "
+                f"{fmt(delta)} | {delta_percent:.2f}% | "
+                f"{fmt(pair_median) if pair_median is not None else ''} |"
             )
     Path(args.output).write_text("\n".join(lines) + "\n")
 

--- a/devtools/bench-allocator/run-allocator-memory.sh
+++ b/devtools/bench-allocator/run-allocator-memory.sh
@@ -68,8 +68,13 @@ run_one() {
 }
 
 for run in $(seq 1 "$REPEAT"); do
-  run_one jemalloc "$run"
-  run_one mimalloc "$run"
+  if (( run % 2 == 1 )); then
+    run_one jemalloc "$run"
+    run_one mimalloc "$run"
+  else
+    run_one mimalloc "$run"
+    run_one jemalloc "$run"
+  fi
 done
 
 "$ROOT/devtools/bench-allocator/report.py" summarize --csv "$CSV" --output "$OUT_DIR/summary.md"

--- a/devtools/bench-allocator/run-allocator-memory.sh
+++ b/devtools/bench-allocator/run-allocator-memory.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+REPEAT="${REPEAT:-5}"
+TXS_SIZE="${TXS_SIZE:-500}"
+ROUNDS="${ROUNDS:-10}"
+OUT_DIR="${OUT_DIR:-"$ROOT/target/allocator-bench/$(date -u +%Y%m%dT%H%M%SZ)"}"
+CSV="$OUT_DIR/allocator-memory.csv"
+TIME_BIN=""
+
+if [[ -x /usr/bin/time ]]; then
+  TIME_BIN="/usr/bin/time"
+elif command -v gtime >/dev/null 2>&1; then
+  TIME_BIN="$(command -v gtime)"
+fi
+
+mkdir -p "$OUT_DIR"
+
+cat >"$OUT_DIR/metadata.txt" <<EOF
+commit=$(git -C "$ROOT" rev-parse HEAD)
+date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+repeat=$REPEAT
+txs_size=$TXS_SIZE
+rounds=$ROUNDS
+rustc=$(rustc --version)
+cargo=$(cargo --version)
+uname=$(uname -a)
+time_bin=${TIME_BIN:-unavailable}
+EOF
+
+printf 'allocator,run,txs_size,rounds,elapsed_ms,before_rss_bytes,after_setup_rss_bytes,after_workload_rss_bytes,after_drop_rss_bytes,peak_rss_bytes,virtual_memory_bytes,time_elapsed_seconds,time_user_seconds,time_system_seconds,time_max_rss_kb,time_minor_faults,time_major_faults\n' >"$CSV"
+
+for allocator in jemalloc mimalloc; do
+  (
+    cd "$ROOT/benches"
+    cargo bench --bench allocator_memory --no-default-features --features "$allocator" --no-run
+  )
+done
+
+run_one() {
+  local allocator="$1"
+  local run="$2"
+  local log="$OUT_DIR/${allocator}-${run}.log"
+  local time_log="$OUT_DIR/${allocator}-${run}.time"
+
+  echo "allocator=$allocator run=$run"
+  if [[ -n "$TIME_BIN" ]]; then
+    (
+      cd "$ROOT/benches"
+      "$TIME_BIN" -v -o "$time_log" \
+        cargo bench --bench allocator_memory --no-default-features --features "$allocator" -- "$TXS_SIZE" "$ROUNDS"
+    ) >"$log" 2>&1
+  else
+    : >"$time_log"
+    (
+      cd "$ROOT/benches"
+      cargo bench --bench allocator_memory --no-default-features --features "$allocator" -- "$TXS_SIZE" "$ROUNDS"
+    ) >"$log" 2>&1
+  fi
+
+  "$ROOT/devtools/bench-allocator/report.py" append \
+    --allocator "$allocator" \
+    --run "$run" \
+    --log "$log" \
+    --time-log "$time_log" \
+    --csv "$CSV"
+}
+
+for run in $(seq 1 "$REPEAT"); do
+  run_one jemalloc "$run"
+  run_one mimalloc "$run"
+done
+
+"$ROOT/devtools/bench-allocator/report.py" summarize --csv "$CSV" --output "$OUT_DIR/summary.md"
+
+echo "wrote $CSV"
+echo "wrote $OUT_DIR/summary.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,13 @@
 use ckb_bin::run_app;
 use ckb_build_info::Version;
 
-#[cfg(all(not(target_env = "msvc"), not(target_os = "macos")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(all(not(feature = "jemalloc"), feature = "mimalloc"))]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
     #[cfg(feature = "tokio-trace")]

--- a/util/memory-tracker/Cargo.toml
+++ b/util/memory-tracker/Cargo.toml
@@ -15,10 +15,11 @@ ckb-metrics.workspace = true
 ckb-db.workspace = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os="macos")))'.dependencies]
-jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.5.0" }
-jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.5.0" }
+jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.5.0", optional = true }
+jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.5.0", optional = true }
 libc = "0.2"
 
 [features]
 default = []
-profiling = []
+jemalloc = ["dep:jemalloc-ctl", "dep:jemalloc-sys"]
+profiling = ["jemalloc"]

--- a/util/memory-tracker/src/lib.rs
+++ b/util/memory-tracker/src/lib.rs
@@ -14,7 +14,8 @@ mod jemalloc;
 mod jemalloc {
     /// A dummy function which is used when the Jemalloc profiling isn't supported.
     ///
-    /// Jemalloc profiling is disabled in default, the feature `profiling` is used to enable it.
+    /// Jemalloc profiling is supported only when CKB is built with the `jemalloc` and
+    /// `profiling` features.
     pub fn jemalloc_profiling_dump(_: &str) -> Result<(), String> {
         Err("jemalloc profiling dump: unsupported".to_string())
     }
@@ -43,7 +44,7 @@ pub use jemalloc::jemalloc_profiling_dump;
 pub use process::track_current_process;
 pub use rocksdb::TrackRocksDBMemory;
 
-/// Track the memory usage of the CKB process and Jemalloc.
+/// Track the memory usage of the CKB process and allocator-specific stats when available.
 pub fn track_current_process_simple(interval: u64) {
     track_current_process::<rocksdb::DummyRocksDB>(interval, None);
 }

--- a/util/memory-tracker/src/process.rs
+++ b/util/memory-tracker/src/process.rs
@@ -1,10 +1,12 @@
 use std::{fs, io, str::FromStr, sync, thread, time};
 
 use ckb_logger::{error, info};
+#[cfg(feature = "jemalloc")]
 use jemalloc_ctl::{epoch, stats};
 
 use crate::rocksdb::TrackRocksDBMemory;
 
+#[cfg(feature = "jemalloc")]
 macro_rules! je_mib {
     ($key:ty) => {
         if let Ok(value) = <$key>::mib() {
@@ -16,6 +18,7 @@ macro_rules! je_mib {
     };
 }
 
+#[cfg(feature = "jemalloc")]
 macro_rules! mib_read {
     ($mib:ident) => {
         if let Ok(value) = $mib.read() {
@@ -27,7 +30,8 @@ macro_rules! mib_read {
     };
 }
 
-/// Track the memory usage of the CKB process, Jemalloc and RocksDB through [ckb-metrics](../../ckb_metrics/index.html).
+/// Track the memory usage of the CKB process, allocator-specific stats and RocksDB through
+/// [ckb-metrics](../../ckb_metrics/index.html).
 pub fn track_current_process<Tracker: 'static + TrackRocksDBMemory + Sync + Send>(
     interval: u64,
     tracker_opt: Option<sync::Arc<Tracker>>,
@@ -38,18 +42,25 @@ pub fn track_current_process<Tracker: 'static + TrackRocksDBMemory + Sync + Send
         info!("track current process: enable");
         let wait_secs = time::Duration::from_secs(interval);
 
+        #[cfg(feature = "jemalloc")]
         let je_epoch = je_mib!(epoch);
+        #[cfg(feature = "jemalloc")]
         // Bytes allocated by the application.
         let allocated = je_mib!(stats::allocated);
+        #[cfg(feature = "jemalloc")]
         // Bytes in physically resident data pages mapped by the allocator.
         let resident = je_mib!(stats::resident);
+        #[cfg(feature = "jemalloc")]
         // Bytes in active pages allocated by the application.
         let active = je_mib!(stats::active);
+        #[cfg(feature = "jemalloc")]
         // Bytes in active extents mapped by the allocator.
         let mapped = je_mib!(stats::mapped);
+        #[cfg(feature = "jemalloc")]
         // Bytes in virtual memory mappings that were retained
         // rather than being returned to the operating system
         let retained = je_mib!(stats::retained);
+        #[cfg(feature = "jemalloc")]
         // Bytes dedicated to jemalloc metadata.
         let metadata = je_mib!(stats::metadata);
 
@@ -57,6 +68,7 @@ pub fn track_current_process<Tracker: 'static + TrackRocksDBMemory + Sync + Send
             .name("MemoryTracker".to_string())
             .spawn(move || {
                 loop {
+                    #[cfg(feature = "jemalloc")]
                     if je_epoch.advance().is_err() {
                         error!("Failed to refresh the jemalloc stats");
                         return;
@@ -72,20 +84,25 @@ pub fn track_current_process<Tracker: 'static + TrackRocksDBMemory + Sync + Send
                             metrics.ckb_sys_mem_process.vms.set(vms);
                         }
 
-                        let allocated = mib_read!(allocated);
-                        let resident = mib_read!(resident);
-                        let active = mib_read!(active);
-                        let mapped = mib_read!(mapped);
-                        let retained = mib_read!(retained);
-                        let metadata = mib_read!(metadata);
-                        if let Some(metrics) = ckb_metrics::handle() {
-                            metrics.ckb_sys_mem_jemalloc.allocated.set(allocated);
-                            metrics.ckb_sys_mem_jemalloc.resident.set(resident);
-                            metrics.ckb_sys_mem_jemalloc.active.set(active);
-                            metrics.ckb_sys_mem_jemalloc.mapped.set(mapped);
-                            metrics.ckb_sys_mem_jemalloc.retained.set(retained);
-                            metrics.ckb_sys_mem_jemalloc.metadata.set(metadata);
+                        #[cfg(feature = "jemalloc")]
+                        {
+                            let allocated = mib_read!(allocated);
+                            let resident = mib_read!(resident);
+                            let active = mib_read!(active);
+                            let mapped = mib_read!(mapped);
+                            let retained = mib_read!(retained);
+                            let metadata = mib_read!(metadata);
+                            if let Some(metrics) = ckb_metrics::handle() {
+                                metrics.ckb_sys_mem_jemalloc.allocated.set(allocated);
+                                metrics.ckb_sys_mem_jemalloc.resident.set(resident);
+                                metrics.ckb_sys_mem_jemalloc.active.set(active);
+                                metrics.ckb_sys_mem_jemalloc.mapped.set(mapped);
+                                metrics.ckb_sys_mem_jemalloc.retained.set(retained);
+                                metrics.ckb_sys_mem_jemalloc.metadata.set(metadata);
+                            }
+                        }
 
+                        if ckb_metrics::handle().is_some() {
                             if let Some(tracker) = tracker_opt.clone() {
                                 tracker.gather_memory_stats();
                             }


### PR DESCRIPTION
### What problem does this PR solve?
https://github.com/microsoft/mimalloc
Problem Summary:

- CKB hard-codes jemalloc in the main binary today, which makes allocator experiments invasive.
- The existing benchmark suite measures throughput, but it does not provide a simple side-by-side allocator memory check.
- A quick allocator-memory run in this environment did **not** show a memory win for mimalloc yet, so the comparison needs to be explicit and easy to repeat.

### What is changed and how it works?

What's Changed:

- makes `mimalloc` the default allocator for `ckb`
- keeps `jemalloc` available behind `--features jemalloc`
- makes `profiling` imply `jemalloc`, so jemalloc-only profiling still builds correctly
- gates jemalloc-specific memory tracker hooks behind a dedicated `jemalloc` feature
- adds `cargo bench -p ckb-benches --bench allocator_memory` to compare allocator RSS / peak RSS on the existing overall block-processing workload
- documents the allocator benchmark commands in the benches crate docs

### Related changes

- None.

### Check List

Tests

- Manual test (add detailed scripts or steps below)

```console
cargo test -p ckb --no-run
cargo test -p ckb --no-run --no-default-features --features jemalloc
cargo test -p ckb --no-run --features profiling
cargo bench -p ckb-benches --bench allocator_memory --no-run --features ci
cargo bench -p ckb-benches --bench allocator_memory --no-run --no-default-features --features "ci jemalloc"
LD_LIBRARY_PATH=/nix/store/xp989kyfg52803fmkzbz5py35jphcpgd-gcc-14.3.0-lib/lib cargo bench -p ckb-benches --bench allocator_memory --features ci -- 16 1
LD_LIBRARY_PATH=/nix/store/xp989kyfg52803fmkzbz5py35jphcpgd-gcc-14.3.0-lib/lib cargo bench -p ckb-benches --bench allocator_memory --no-default-features --features "ci jemalloc" -- 16 1
```

Observed allocator bench output from the last two commands:

- mimalloc: `after_workload rss_bytes=173170688`, `after_drop rss_bytes=174518272`
- jemalloc: `after_workload rss_bytes=125931520`, `after_drop rss_bytes=115007488`

Side effects

- Performance regression: possible. In the small manual memory run above, jemalloc used less RSS than mimalloc, so this PR is best treated as allocator-comparison plumbing plus a default swap that still needs broader benchmarking on realistic workloads.
