### PR TITLE
feat: support cross-compiling to aarch64-linux-android

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+# Linker is also set via env (CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER) inside
+# the nix devShell defined by flake.nix, but this stanza documents the target.
+[target.aarch64-linux-android]

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ cobertura.xml
 *.profraw
 lcov-unit-test.info
 lcov-integration-test.info
+.android-libgcc-stub/

--- a/ckb-bin/Cargo.toml
+++ b/ckb-bin/Cargo.toml
@@ -51,7 +51,7 @@ ckb-stop-handler.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 time = { workspace = true }
 
-[target.'cfg(not(target_os="windows"))'.dependencies]
+[target.'cfg(all(not(target_os="windows"), not(target_os="android")))'.dependencies]
 daemonize-me = { version = "2" }
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
 colored = "2.0"

--- a/ckb-bin/src/cli.rs
+++ b/ckb-bin/src/cli.rs
@@ -157,7 +157,7 @@ pub fn basic_app() -> Command {
         .subcommand(peer_id())
         .subcommand(migrate());
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     let command = command.subcommand(daemon());
 
     command
@@ -229,7 +229,7 @@ to disable the default behavior and execute full verification for all blocks, \
             .help("Start the built-in rich-indexer service"),
         );
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     let command = command.arg(
         Arg::new(ARG_DAEMON)
             .long(ARG_DAEMON)
@@ -475,7 +475,7 @@ fn migrate() -> Command {
         )
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 fn daemon() -> Command {
     Command::new(CMD_DAEMON)
         .about("Runs ckb daemon command")

--- a/ckb-bin/src/lib.rs
+++ b/ckb-bin/src/lib.rs
@@ -20,11 +20,11 @@ use setup::Setup;
 use setup_guard::SetupGuard;
 use time::OffsetDateTime;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 use colored::Colorize;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 use daemonize_me::Daemon;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 use subcommand::check_process;
 #[cfg(feature = "with_sentry")]
 pub(crate) const LOG_TARGET_SENTRY: &str = "sentry";
@@ -92,7 +92,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
         .subcommand()
         .expect("SubcommandRequiredElseHelp");
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     if run_daemon(cmd, matches) {
         return run_app_in_daemon(version, bin_name, cmd, matches);
     }
@@ -101,7 +101,7 @@ pub fn run_app(version: Version) -> Result<(), ExitCode> {
     run_app_inner(version, bin_name, cmd, matches)
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 fn run_app_in_daemon(
     version: Version,
     bin_name: String,
@@ -171,7 +171,7 @@ fn run_app_inner(
         cli::CMD_STATS => subcommand::stats(setup.stats(matches)?, handle.clone()),
         cli::CMD_RESET_DATA => subcommand::reset_data(setup.reset_data(matches)?),
         cli::CMD_MIGRATE => subcommand::migrate(setup.migrate(matches)?),
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
         cli::CMD_DAEMON => subcommand::daemon(setup.daemon(matches)?),
         _ => unreachable!(),
     };
@@ -198,7 +198,7 @@ fn run_app_inner(
     ret
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 fn run_daemon(cmd: &str, matches: &ArgMatches) -> bool {
     match cmd {
         cli::CMD_RUN => matches.get_flag(cli::ARG_DAEMON),

--- a/ckb-bin/src/setup.rs
+++ b/ckb-bin/src/setup.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 use ckb_app_config::DaemonArgs;
 use ckb_app_config::{
     AppConfig, CustomizeSpec, ExitCode, ExportArgs, ExportTarget, ImportArgs, ImportSource,
@@ -123,7 +123,7 @@ H256::from_str(&target[2..]).expect("default assume_valid_target for testnet mus
             chain_spec_hash,
             indexer: matches.get_flag(cli::ARG_INDEXER),
             rich_indexer: matches.get_flag(cli::ARG_RICH_INDEXER),
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
             daemon: matches.get_flag(cli::ARG_DAEMON),
         })
     }
@@ -311,7 +311,7 @@ H256::from_str(&target[2..]).expect("default assume_valid_target for testnet mus
     }
 
     /// Executes `ckb daemon`.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     pub fn daemon(self, matches: &ArgMatches) -> Result<DaemonArgs, ExitCode> {
         let check = matches.get_flag(cli::ARG_DAEMON_CHECK);
         let stop = matches.get_flag(cli::ARG_DAEMON_STOP);
@@ -470,7 +470,7 @@ H256::from_str(&target[2..]).expect("default assume_valid_target for testnet mus
     }
 
     /// Resolves the pid file path for ckb from the command line arguments.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     pub fn daemon_pid_file_path(matches: &ArgMatches) -> Result<PathBuf, ExitCode> {
         let root_dir = Self::root_dir_from_matches(matches)?;
         Ok(root_dir.join("data/daemon/ckb-run.pid"))

--- a/ckb-bin/src/subcommand/mod.rs
+++ b/ckb-bin/src/subcommand/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 mod daemon;
 mod export;
 mod import;
@@ -12,7 +12,7 @@ mod reset_data;
 mod run;
 mod stats;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 pub use self::daemon::{check_process, daemon};
 pub use self::export::export;
 pub use self::import::import;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,127 @@
+{
+  description = "CKB cross-compilation environment for aarch64-linux-android";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true;
+          config.android_sdk.accept_license = true;
+        };
+
+        rustToolchain = pkgs.rust-bin.stable."1.92.0".default.override {
+          extensions = [ "rust-src" ];
+          targets = [ "aarch64-linux-android" ];
+        };
+
+        # NDK cross toolchain (clang) for aarch64 Android.
+        androidPkgs = pkgs.pkgsCross.aarch64-android-prebuilt;
+        ndkCC = androidPkgs.stdenv.cc;
+        ndkBintools = androidPkgs.stdenv.cc.bintools.bintools;
+        ndkPrefix = ndkCC.targetPrefix; # e.g. "aarch64-unknown-linux-android-"
+        sysroot = "${ndkCC}/sysroot";
+
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            rustToolchain
+            ndkCC
+            pkgs.pkg-config
+            pkgs.cmake
+            pkgs.perl
+            pkgs.python3
+            pkgs.llvmPackages.libclang
+            pkgs.git
+          ];
+
+          shellHook = ''
+            # The pkgsCross devShell pollutes CC/CXX/LD/AR/RANLIB with the NDK
+            # cross tools.  Force them back to host tools for HOST_* (used by
+            # cc-rs for build-script compilation) and use the NDK tools for
+            # CC/CXX so that rocksdb's `build_detect_platform` shell script
+            # probes the *target* compiler when checking for SSE / etc.
+            export HOST_CC=gcc
+            export HOST_CXX=g++
+            export HOST_AR=ar
+            export HOST_LD=ld
+            export HOST_RANLIB=ranlib
+            export CC=${ndkCC}/bin/${ndkPrefix}cc
+            export CXX=${ndkCC}/bin/${ndkPrefix}c++
+            export LD=${ndkCC}/bin/${ndkPrefix}cc
+            export AR=${ndkBintools}/bin/${ndkPrefix}ar
+            export RANLIB=${ndkBintools}/bin/${ndkPrefix}ranlib
+            export STRIP=${ndkBintools}/bin/${ndkPrefix}strip
+
+            export NDK_PREFIX=${ndkPrefix}
+            export NDK_BIN=${ndkCC}/bin
+            export NDK_SYSROOT=${sysroot}
+
+            export CC_aarch64_linux_android=${ndkCC}/bin/${ndkPrefix}cc
+            export CXX_aarch64_linux_android=${ndkCC}/bin/${ndkPrefix}c++
+            export AR_aarch64_linux_android=${ndkBintools}/bin/${ndkPrefix}ar
+            export RANLIB_aarch64_linux_android=${ndkBintools}/bin/${ndkPrefix}ranlib
+            export STRIP_aarch64_linux_android=${ndkBintools}/bin/${ndkPrefix}strip
+
+            export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${ndkCC}/bin/${ndkPrefix}cc
+            export CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${ndkBintools}/bin/${ndkPrefix}ar
+
+            # Force the host (build-scripts) target to use the system gcc as
+            # linker; otherwise rust-overlay's rustc picks up `clang` from PATH
+            # which is the NDK clang and lacks Linux glibc CRT files.
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
+
+            # bindgen needs to find Android headers; libclang must be findable.
+            # Use NDK's bundled libclang (clang 18) to match the NDK clang
+            # binary; nixpkgs' default libclang is a different major version
+            # which can cause header lookups to fail.
+            export LIBCLANG_PATH=${ndkBintools}/toolchain/musl/lib
+            BINDGEN_FLAGS="--sysroot=${ndkBintools}/sysroot --target=aarch64-linux-android -D__ANDROID_API__=35 -I${ndkBintools}/sysroot/usr/include -I${ndkBintools}/sysroot/usr/include/aarch64-linux-android"
+            export BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="$BINDGEN_FLAGS"
+            # Older bindgen versions don't honour the per-target form.
+            export BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_FLAGS"
+
+            # Some build scripts (jemalloc, secp256k1) inspect generic CC/AR.
+            export TARGET_CC=${ndkCC}/bin/${ndkPrefix}cc
+            export TARGET_CXX=${ndkCC}/bin/${ndkPrefix}c++
+            export TARGET_AR=${ndkBintools}/bin/${ndkPrefix}ar
+            export TARGET_RANLIB=${ndkBintools}/bin/${ndkPrefix}ranlib
+
+            # Hints for rocksdb's `build_detect_platform` shell script so it
+            # uses the cross arch/OS branch and skips x86 SSE flags.
+            export TARGET_OS=OS_ANDROID_CROSSCOMPILE
+            export TARGET_ARCHITECTURE=aarch64
+
+            # OpenSSL vendored requires perl already provided.
+            unset OPENSSL_DIR OPENSSL_LIB_DIR OPENSSL_INCLUDE_DIR
+
+            # NDK 23+ removed libgcc. Rustc still passes `-lgcc` when targeting
+            # *-linux-android, so create a stub libgcc.a that redirects to
+            # libunwind.  Place it on a per-shell directory and add it to the
+            # Android linker search path.
+            export NDK_GCC_STUB="$PWD/.android-libgcc-stub"
+            mkdir -p "$NDK_GCC_STUB"
+            if [ ! -f "$NDK_GCC_STUB/libgcc.a" ]; then
+              echo 'INPUT(-lunwind)' > "$NDK_GCC_STUB/libgcc.a"
+            fi
+            export CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS="-L $NDK_GCC_STUB"
+
+            echo "CKB Android cross-compile shell ready."
+            echo "  NDK prefix : $NDK_PREFIX"
+            echo "  sysroot    : $NDK_SYSROOT"
+            echo "Run: cargo build --release --target aarch64-linux-android"
+          '';
+        };
+      });
+}

--- a/util/app-config/src/args.rs
+++ b/util/app-config/src/args.rs
@@ -84,7 +84,7 @@ pub struct RunArgs {
     /// Whether start rich-indexer, default false
     pub rich_indexer: bool,
     /// Whether start in daemon mode
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     pub daemon: bool,
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

CKB has not been buildable for `aarch64-linux-android`. Cross-compiling out of the box fails on:

- `daemonize-me` (referenced by `ckb-bin`) does not support `target_os = "android"` — its `FFIPasswd` struct is gated to linux/macos/freebsd/openbsd/netbsd only.
- `ckb-librocksdb-sys`'s `build_detect_platform` script unconditionally adds x86 SSE/AVX/BMI/PCLMUL flags when the probing compiler accepts them, which breaks the NDK aarch64 clang during the C++ build.
- bindgen for rocksdb cannot find Android system headers without explicit sysroot/clang configuration.
- NDK 23+ no longer ships `libgcc`, but `rustc` still passes `-lgcc` to the linker when targeting `*-linux-android`.

Problem Summary: provide a reproducible cross-compilation environment (Nix flake, NixOS-friendly) and the small source patches needed to actually build `ckb` for `aarch64-linux-android`.

### What is changed and how it works?

What's Changed:

- **`flake.nix`** (new): devShell wiring rust-overlay (rustc 1.92.0 + `aarch64-linux-android` target) and `pkgsCross.aarch64-android-prebuilt` (Android NDK 27).
  - `HOST_CC/CXX/AR/LD/RANLIB` point at host gcc/g++/ar/ld/ranlib so cargo build scripts that compile and link on the host work correctly.
  - `CC/CXX/AR/RANLIB/STRIP` and `CARGO_TARGET_AARCH64_LINUX_ANDROID_*` point at the NDK toolchain so the *target* compiler is used for cross-compilation (and so `build_detect_platform`'s SSE probes correctly fail on aarch64, skipping the x86 flags).
  - `LIBCLANG_PATH` and `BINDGEN_EXTRA_CLANG_ARGS` use the NDK's bundled clang-18 with the *unwrapped* sysroot so bindgen finds Android headers (`uint32_t`, etc.).
  - `TARGET_OS=OS_ANDROID_CROSSCOMPILE` and `TARGET_ARCHITECTURE=aarch64` hint rocksdb's detect script.
  - A stub `libgcc.a` containing `INPUT(-lunwind)` is generated and added to the Android linker search path via `CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS` to satisfy rustc's hardcoded `-lgcc`.
- **`.cargo/config.toml`**: add empty `[target.aarch64-linux-android]` stanza; linker comes from the env vars set by the devShell.
- **`.gitignore`**: ignore `.android-libgcc-stub/`.
- **Source `cfg` changes**: extend `cfg(not(target_os = "windows"))` to also exclude `target_os = "android"` for daemonization-related code, in:
  - `ckb-bin/Cargo.toml`, `ckb-bin/src/{lib.rs,setup.rs,cli.rs,subcommand/mod.rs}`
  - `util/app-config/src/args.rs` (the `daemon` field of `RunArgs`)

Build command:

```bash
nix develop --command cargo build --release --target aarch64-linux-android --bin ckb
```

Produces `target/aarch64-linux-android/release/ckb`:

```
ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV),
dynamically linked, interpreter /system/bin/linker64
```

### Related changes

- No companion PRs.
- No cherry-pick to release branches needed.

### Check List

Tests

- Manual test: built `--release --bin ckb` for `aarch64-linux-android` from a NixOS x86_64 host using `nix develop`; verified the resulting ELF is `ARM aarch64` and dynamically linked against Android's `/system/bin/linker64`.

Side effects

- No behavior change for existing supported targets: changes are limited to additional `cfg` exclusions for `target_os = "android"` (which was previously unbuildable) and a new `flake.nix`/`.cargo/config.toml` stanza that only affects the new target.
