### PR TITLE
docs: split mainnet/testnet params in devnet-from-existing-data

### DIFF
--- a/docs/devnet-from-existing-data.md
+++ b/docs/devnet-from-existing-data.md
@@ -40,22 +40,54 @@ If you copied testnet data, replace `mainnet.toml` with `testnet.toml`.
 
 ## 4. Update `specs/dev.toml`
 
-Set `Dummy` PoW for local development and keep `genesis_epoch_length` unchanged:
+Set `Dummy` PoW for local development. The `[params]` section differs between
+mainnet and testnet — pick the matching block below.
+
+> Why this matters: `genesis_epoch_length` (together with the epoch reward
+> fields) participates in the genesis cellbase reward calculation, which
+> determines the genesis block hash. If the value here does not match the
+> value the source chain was launched with, the node will refuse to start with
+> `chainspec error: ChainSpec: genesis hash mismatch`.
+
+### Mainnet
+
+Mainnet was launched with `genesis_epoch_length = 1743`, so this value must be
+preserved:
 
 ```toml
 [params]
 genesis_epoch_length = 1743
-initial_primary_epoch_reward = 1_917_808_21917808
-secondary_epoch_reward = 613_698_63013698
-max_block_cycles = 10_000_000_000
 cellbase_maturity = 0
-primary_epoch_reward_halving_interval = 8760
-epoch_duration_target = 14400
 permanent_difficulty_in_dummy = true
 
 [pow]
 func = "Dummy"
 ```
+
+### Testnet
+
+The bundled testnet spec has no `[params]` section and was launched with the
+default `genesis_epoch_length = 1000`. Do **not** add `genesis_epoch_length`
+here — leaving it unset lets it fall back to the default and keeps the genesis
+hash consistent:
+
+```toml
+[params]
+cellbase_maturity = 0
+permanent_difficulty_in_dummy = true
+
+[pow]
+func = "Dummy"
+```
+
+`cellbase_maturity = 0` makes locally mined cellbase outputs immediately
+spendable, which is convenient for development.
+
+`permanent_difficulty_in_dummy = true` keeps the difficulty constant when
+running with `Dummy` PoW. Its default is `false`, which would let difficulty be
+recalculated from the dummy block timestamps and swing wildly once you start
+mining locally; the bundled `resource/specs/dev.toml` therefore enables it by
+default and the same is recommended here.
 
 ## 5. First Run Requires Spec-Check Flags
 


### PR DESCRIPTION
## What

Address [this Copilot review comment on #5125](https://github.com/nervosnetwork/ckb/pull/5125#discussion_r2887785427) about the testnet path of `docs/devnet-from-existing-data.md`.

## Why

Following the original step 4 verbatim against a testnet datadir fails at startup with:

```
chainspec error: ChainSpec: genesis hash mismatch, expected: 0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606 actual: 0xeaf926b9...
```

Root cause: the original guide hard-codes `genesis_epoch_length = 1743`, which is mainnet's launch value. The bundled `resource/specs/testnet.toml` has no `[params]` section, so testnet was launched with the default `genesis_epoch_length = 1000`. `genesis_epoch_length` participates in the genesis cellbase reward calculation and therefore changes the genesis block hash; setting it to `1743` for testnet produces a different genesis hash and the node refuses to start.

## What changed

`docs/devnet-from-existing-data.md`:

- Split step 4 into separate **Mainnet** and **Testnet** variants of the `[params]` block.
- Mainnet variant keeps `genesis_epoch_length = 1743`.
- Testnet variant omits `genesis_epoch_length` so it falls back to the consensus default `1000`.
- Add a callout explaining why this field matters (genesis hash).
- Drop the unrelated reward / cycle / epoch fields that were already equal to the consensus defaults in [`spec/src/consensus.rs`](../blob/develop/spec/src/consensus.rs).
- Keep `cellbase_maturity = 0` and `permanent_difficulty_in_dummy = true` and add brief explanations for both (they are intentional non-default overrides for local Dummy-PoW development).

## How verified

Locally with `ckb v0.206.0 (2c91814 2026-05-06)` on macOS (aarch64), against a freshly synced datadir for each chain (using `cp -R` per step 1):

| | mainnet | testnet |
|---|---|---|
| `ckb init --chain dev --import-spec` | Genesis Hash `0x92b197aa…450d0e5` ✅ | Genesis Hash `0x10639e08…0aae3f9606` ✅ |
| `ckb run --skip-spec-check --overwrite-spec` | recognized tip 5504, no `GenesisMismatch`, syncing ✅ | recognized tip 31647, no `GenesisMismatch`, syncing ✅ |

Also confirmed that the original (pre-PR) doc reproduces the testnet failure.
