### PR TITLE
Fix relay tx request matching in tests

### DIFF
--- a/test/src/util/transaction.rs
+++ b/test/src/util/transaction.rs
@@ -68,21 +68,27 @@ pub fn send_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
 }
 
 pub fn relay_tx(net: &Net, node: &Node, tx: TransactionView, cycles: u64) {
+    let tx_hash = tx.hash();
     let tx_hashes_msg = packed::RelayMessage::new_builder()
         .set(
             packed::RelayTransactionHashes::new_builder()
-                .tx_hashes(vec![tx.hash()])
+                .tx_hashes(vec![tx_hash.clone()])
                 .build(),
         )
         .build();
     net.send(node, SupportProtocols::RelayV3, tx_hashes_msg.as_bytes());
 
-    let ret = net.should_receive(node, |data: &Bytes| {
-        packed::RelayMessage::from_slice(data)
-            .map(|message| message.to_enum().item_name() == packed::GetRelayTransactions::NAME)
-            .unwrap_or(false)
-    });
-    assert!(ret, "node should ask for tx");
+    let ret = net.should_receive(
+        node,
+        |data: &Bytes| match packed::RelayMessage::from_slice(data).map(|message| message.to_enum())
+        {
+            Ok(packed::RelayMessageUnion::GetRelayTransactions(get_txs)) => {
+                get_txs.tx_hashes().into_iter().any(|hash| hash == tx_hash)
+            }
+            _ => false,
+        },
+    );
+    assert!(ret, "node should ask for tx {tx_hash}");
 
     let relay_tx = packed::RelayTransaction::new_builder()
         .cycles(cycles)


### PR DESCRIPTION
## Summary

Fixes https://github.com/nervosnetwork/ckb/actions/runs/26389285156/job/77682085873

- Make the integration-test `relay_tx` helper wait for a `GetRelayTransactions` message that contains the transaction hash it just announced.
- Include the expected transaction hash in the assertion message when the node does not request it.

## Root cause

`relay_tx` previously accepted any `GetRelayTransactions` message before sending the transaction body. In `TxPoolOrphanDoubleSpend`, the first orphan transaction can also make the node ask for its missing parent. The helper could consume that stale parent request while relaying the second transaction, send the second transaction body before the node actually requested it, and leave the tx-pool with only one orphan. This matches the Windows CI failure: `expected orphan=2, pending=0 within 30s, got orphan=1, pending=0`.