### PR TITLE
Fix RPC test chain service teardown on Windows

### DIFF
--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use ckb_chain::ChainController;
+use ckb_chain::{ChainController, ChainServiceScope};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_dao::DaoCalculator;
 use ckb_reward_calculator::RewardCalculator;
@@ -77,6 +77,7 @@ pub(crate) struct RpcTestSuite {
     tcp_uri: Option<String>,
     shared: Shared,
     chain_controller: ChainController,
+    _chain_scope: ChainServiceScope,
     _tmp_dir: tempfile::TempDir,
 }
 

--- a/rpc/src/tests/setup.rs
+++ b/rpc/src/tests/setup.rs
@@ -5,7 +5,7 @@ use crate::{
 use ckb_app_config::{
     BlockAssemblerConfig, NetworkAlertConfig, NetworkConfig, RpcConfig, RpcModule,
 };
-use ckb_chain::start_chain_services;
+use ckb_chain::ChainServiceScope;
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
 use ckb_chain_spec::versionbits::{ActiveMode, Deployment, DeploymentPos};
 use ckb_dao_utils::genesis_dao_data;
@@ -88,10 +88,10 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
         }))
         .build()
         .unwrap();
-    // Most of CKB will be started as part of RpcTestSuite, using ChainServiceScope
-    // to simplify chain termination actually brings more issues. We will keep this line
-    // as it is till we run into pthread issues in RPC tests for real.
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    // Keep the chain service scoped to the RPC test process so Windows does not
+    // abort while tearing down still-running background threads after a test exits.
+    let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain_scope.chain_controller().clone();
 
     // Start network services
     let temp_dir = tempfile::tempdir().expect("create tmp_dir failed");
@@ -252,6 +252,7 @@ pub(crate) fn setup_rpc_test_suite(height: u64, consensus: Option<Consensus>) ->
     let suite = RpcTestSuite {
         shared,
         chain_controller: chain_controller.clone(),
+        _chain_scope: chain_scope,
         rpc_uri,
         tcp_uri,
         rpc_client,


### PR DESCRIPTION
## Background

The `ci_unit_tests_windows` job failed on `develop` in:

https://github.com/nervosnetwork/ckb/actions/runs/26389285158/job/77674861273

The failing entry was `ckb-rpc tests::module::miner::test_get_block_template_cache`, but the test body itself had already reported `ok`. The process aborted afterwards with Windows error `0xc0000409`, which points at teardown/background-service lifetime rather than the block template assertion logic.

## Changes

`setup_rpc_test_suite` now starts the chain service with `ChainServiceScope` and stores that scope in `RpcTestSuite`.

This keeps the chain service owned by the RPC test suite and lets teardown join the service instead of only broadcasting the exit signal while leaving the background service lifetime detached from the test process.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --workspace -p ckb-rpc tests::module::miner::test_get_block_template_cache --features deadlock_detection,with_sentry -- --exact --ignored --nocapture`
- `cargo nextest run --workspace -p ckb-rpc tests::module::miner::test_get_block_template_cache --features deadlock_detection,with_sentry --no-fail-fast --hide-progress-bar --success-output immediate-final --failure-output immediate-final --run-ignored all`
- broader local nextest slice: `986 passed`
