### PR TITLE
Fix benchmark chain service teardown

### DIFF
--- a/benches/benches/benchmarks/always_success.rs
+++ b/benches/benches/benchmarks/always_success.rs
@@ -22,8 +22,8 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_always_success_chain(*i, 2);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
+                        let (_, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -34,6 +34,7 @@ fn bench(c: &mut Criterion) {
                         (0..20).for_each(|_| {
                             let block = gen_always_success_block(&mut blocks, &parent, shared2);
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -41,9 +42,10 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             parent = block;
                         });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(1).for_each(|block| {
                             chain
                                 .blocking_process_block_with_switch(
@@ -71,9 +73,9 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_always_success_chain(*i, 3);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
-                        let (ref chain3, ref shared3) = chains.0[2];
+                        let (chain1, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
+                        let (chain3, shared3) = &chains.0[2];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -84,6 +86,7 @@ fn bench(c: &mut Criterion) {
                         (0..5).for_each(|i| {
                             let block = gen_always_success_block(&mut blocks, &parent, shared2);
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -91,6 +94,7 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             if i < 2 {
                                 chain3
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block.clone()),
                                         Switch::DISABLE_ALL,
@@ -103,6 +107,7 @@ fn bench(c: &mut Criterion) {
                         (0..2).for_each(|_| {
                             let block = gen_always_success_block(&mut blocks, &parent, shared3);
                             chain3
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -117,15 +122,17 @@ fn bench(c: &mut Criterion) {
                             .take(5)
                             .for_each(|block| {
                                 chain1
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block),
                                         Switch::DISABLE_ALL,
                                     )
                                     .expect("process block OK");
                             });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(6).for_each(|block| {
                             chain
                                 .blocking_process_block(Arc::new(block))
@@ -150,9 +157,9 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_always_success_chain(*i, 3);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
-                        let (ref chain3, ref shared3) = chains.0[2];
+                        let (chain1, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
+                        let (chain3, shared3) = &chains.0[2];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -164,6 +171,7 @@ fn bench(c: &mut Criterion) {
                             let block = gen_always_success_block(&mut blocks, &parent, shared2);
                             let arc_block = Arc::new(block.clone());
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::clone(&arc_block),
                                     Switch::DISABLE_ALL,
@@ -171,6 +179,7 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             if i < 2 {
                                 chain3
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         arc_block,
                                         Switch::DISABLE_ALL,
@@ -183,6 +192,7 @@ fn bench(c: &mut Criterion) {
                         (0..4).for_each(|_| {
                             let block = gen_always_success_block(&mut blocks, &parent, shared3);
                             chain3
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -197,15 +207,17 @@ fn bench(c: &mut Criterion) {
                             .take(7)
                             .for_each(|block| {
                                 chain1
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block),
                                         Switch::DISABLE_ALL,
                                     )
                                     .expect("process block OK");
                             });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(8).for_each(|block| {
                             chain
                                 .blocking_process_block_with_switch(

--- a/benches/benches/benchmarks/overall.rs
+++ b/benches/benches/benchmarks/overall.rs
@@ -1,7 +1,7 @@
 use crate::benchmarks::util::{create_2out_transaction, create_secp_tx, secp_cell};
 use ckb_app_config::NetworkConfig;
 use ckb_app_config::{BlockAssemblerConfig, TxPoolConfig};
-use ckb_chain::{ChainController, start_chain_services};
+use ckb_chain::ChainServiceScope;
 use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_dao_utils::genesis_dao_data;
 use ckb_jsonrpc_types::JsonBytes;
@@ -31,6 +31,11 @@ const SIZES: &[usize] = &[500];
 
 #[cfg(feature = "ci")]
 const SIZES: &[usize] = &[2usize];
+
+struct ChainSetup {
+    chain_scope: ChainServiceScope,
+    shared: Shared,
+}
 
 fn block_assembler_config() -> BlockAssemblerConfig {
     let (_, _, secp_script) = secp_cell();
@@ -83,7 +88,7 @@ fn dummy_network(shared: &Shared) -> NetworkController {
     .expect("Start network service failed")
 }
 
-pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
+fn setup_chain(txs_size: usize) -> ChainSetup {
     let (_, _, secp_script) = secp_cell();
     let tx = create_secp_tx();
     let dao = genesis_dao_data(vec![&tx]).unwrap();
@@ -134,9 +139,12 @@ pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
     let network = dummy_network(&shared);
     pack.take_tx_pool_builder().start(network);
 
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
 
-    (shared, chain_controller)
+    ChainSetup {
+        chain_scope,
+        shared,
+    }
 }
 
 pub fn gen_txs_from_block(block: &BlockView) -> Vec<TransactionView> {
@@ -179,9 +187,10 @@ fn bench(c: &mut Criterion) {
             |b, txs_size| {
                 b.iter_batched(
                     || setup_chain(*txs_size),
-                    |(shared, chain)| {
+                    |setup| {
                         let mut i = 10;
                         while i > 0 {
+                            let shared = &setup.shared;
                             let snapshot = Arc::clone(&shared.snapshot());
                             let tip_hash = snapshot.tip_hash();
                             let block = snapshot.get_block(&tip_hash).expect("tip exist");
@@ -218,7 +227,9 @@ fn bench(c: &mut Criterion) {
                                 .verify(&block.header())
                                 .expect("header verified");
 
-                            chain
+                            setup
+                                .chain_scope
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block),
                                     Switch::DISABLE_EXTENSION,

--- a/benches/benches/benchmarks/resolve.rs
+++ b/benches/benches/benchmarks/resolve.rs
@@ -1,6 +1,6 @@
 use crate::benchmarks::util::create_2out_transaction;
 use ckb_app_config::{BlockAssemblerConfig, TxPoolConfig};
-use ckb_chain::{ChainController, start_chain_services};
+use ckb_chain::ChainServiceScope;
 use ckb_chain_spec::{ChainSpec, IssuedCell};
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_resource::Resource;
@@ -25,6 +25,11 @@ const SIZE: usize = 500;
 
 #[cfg(feature = "ci")]
 const SIZE: usize = 10;
+
+struct ChainSetup {
+    _chain_scope: ChainServiceScope,
+    shared: Shared,
+}
 
 const PUBKEY_HASH: H160 = h160!("0x779e5930892a0a9bf2fedfe048f685466c7d0396");
 const DEFAULT_CODE_HASH: H256 =
@@ -67,7 +72,7 @@ fn block_assembler_config() -> BlockAssemblerConfig {
     }
 }
 
-pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
+fn setup_chain(txs_size: usize) -> ChainSetup {
     let secp_script = script();
 
     let mut spec =
@@ -94,7 +99,7 @@ pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
         .tx_pool_config(tx_pool_config)
         .build()
         .unwrap();
-    let chain_controller = start_chain_services(pack.take_chain_services_builder());
+    let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
 
     // FIXME: global cache !!!
     let _ret = setup_system_cell_cache(
@@ -102,7 +107,10 @@ pub fn setup_chain(txs_size: usize) -> (Shared, ChainController) {
         shared.snapshot().as_ref(),
     );
 
-    (shared, chain_controller)
+    ChainSetup {
+        _chain_scope: chain_scope,
+        shared,
+    }
 }
 
 pub fn gen_txs_from_genesis(block: &BlockView) -> Vec<TransactionView> {
@@ -129,8 +137,9 @@ fn bench(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("resolve", SIZE), &SIZE, |b, txs_size| {
         b.iter_batched(
             || setup_chain(*txs_size),
-            |(shared, _)| {
+            |setup| {
                 let mut i = 100;
+                let shared = &setup.shared;
                 let snapshot: &Snapshot = &shared.snapshot();
                 let txs = gen_txs_from_genesis(shared.consensus().genesis_block());
 
@@ -154,8 +163,9 @@ fn bench(c: &mut Criterion) {
         |b, txs_size| {
             b.iter_batched(
                 || setup_chain(*txs_size),
-                |(shared, _)| {
+                |setup| {
                     let mut i = 1;
+                    let shared = &setup.shared;
                     let snapshot: &Snapshot = &shared.snapshot();
                     let txs = gen_txs_from_genesis(shared.consensus().genesis_block());
 

--- a/benches/benches/benchmarks/secp_2in2out.rs
+++ b/benches/benches/benchmarks/secp_2in2out.rs
@@ -22,8 +22,8 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_secp_chain(*txs_size, 2);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
+                        let (_, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -34,6 +34,7 @@ fn bench(c: &mut Criterion) {
                         (0..20).for_each(|_| {
                             let block = gen_secp_block(&mut blocks, &parent, shared2);
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -41,9 +42,10 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             parent = block;
                         });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(1).for_each(|block| {
                             chain
                                 .blocking_process_block_with_switch(
@@ -71,9 +73,9 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_secp_chain(*txs_size, 3);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
-                        let (ref chain3, ref shared3) = chains.0[2];
+                        let (chain1, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
+                        let (chain3, shared3) = &chains.0[2];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -84,6 +86,7 @@ fn bench(c: &mut Criterion) {
                         (0..5).for_each(|i| {
                             let block = gen_secp_block(&mut blocks, &parent, shared2);
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -91,6 +94,7 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             if i < 2 {
                                 chain3
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block.clone()),
                                         Switch::DISABLE_ALL,
@@ -103,6 +107,7 @@ fn bench(c: &mut Criterion) {
                         (0..2).for_each(|_| {
                             let block = gen_secp_block(&mut blocks, &parent, shared3);
                             chain3
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -117,15 +122,17 @@ fn bench(c: &mut Criterion) {
                             .take(5)
                             .for_each(|block| {
                                 chain1
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block),
                                         Switch::DISABLE_ALL,
                                     )
                                     .expect("process block OK");
                             });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(6).for_each(|block| {
                             chain
                                 .blocking_process_block(Arc::new(block))
@@ -150,9 +157,9 @@ fn bench(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let chains = new_secp_chain(*txs_size, 3);
-                        let (ref chain1, ref shared1) = chains.0[0];
-                        let (ref chain2, ref shared2) = chains.0[1];
-                        let (ref chain3, ref shared3) = chains.0[2];
+                        let (chain1, shared1) = &chains.0[0];
+                        let (chain2, shared2) = &chains.0[1];
+                        let (chain3, shared3) = &chains.0[2];
                         let mut blocks = vec![
                             shared1
                                 .snapshot()
@@ -164,6 +171,7 @@ fn bench(c: &mut Criterion) {
                             let block = gen_secp_block(&mut blocks, &parent, shared2);
                             let arc_block = Arc::new(block.clone());
                             chain2
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::clone(&arc_block),
                                     Switch::DISABLE_ALL,
@@ -171,6 +179,7 @@ fn bench(c: &mut Criterion) {
                                 .expect("process block OK");
                             if i < 2 {
                                 chain3
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         arc_block,
                                         Switch::DISABLE_ALL,
@@ -183,6 +192,7 @@ fn bench(c: &mut Criterion) {
                         (0..4).for_each(|_| {
                             let block = gen_secp_block(&mut blocks, &parent, shared3);
                             chain3
+                                .chain_controller()
                                 .blocking_process_block_with_switch(
                                     Arc::new(block.clone()),
                                     Switch::DISABLE_ALL,
@@ -197,15 +207,17 @@ fn bench(c: &mut Criterion) {
                             .take(7)
                             .for_each(|block| {
                                 chain1
+                                    .chain_controller()
                                     .blocking_process_block_with_switch(
                                         Arc::new(block),
                                         Switch::DISABLE_ALL,
                                     )
                                     .expect("process block OK");
                             });
-                        (chain1.clone(), blocks)
+                        (chains, blocks)
                     },
-                    |(chain, blocks)| {
+                    |(chains, blocks)| {
+                        let chain = chains.0[0].0.chain_controller();
                         blocks.into_iter().skip(8).for_each(|block| {
                             chain
                                 .blocking_process_block_with_switch(

--- a/benches/benches/benchmarks/util.rs
+++ b/benches/benches/benchmarks/util.rs
@@ -1,4 +1,4 @@
-use ckb_chain::{ChainController, start_chain_services};
+use ckb_chain::ChainServiceScope;
 use ckb_chain_spec::consensus::{ConsensusBuilder, ProposalWindow};
 use ckb_crypto::secp::Privkey;
 use ckb_dao::DaoCalculator;
@@ -26,10 +26,10 @@ use rand::random;
 use std::collections::HashSet;
 
 #[derive(Default)]
-pub struct Chains(pub Vec<(ChainController, Shared)>);
+pub struct Chains(pub Vec<(ChainServiceScope, Shared)>);
 
 impl Chains {
-    pub fn push(&mut self, chain: (ChainController, Shared)) {
+    pub fn push(&mut self, chain: (ChainServiceScope, Shared)) {
         self.0.push(chain);
     }
 }
@@ -76,9 +76,9 @@ pub fn new_always_success_chain(txs_size: usize, chains_num: usize) -> Chains {
             .consensus(consensus.clone())
             .build()
             .unwrap();
-        let chain_controller = start_chain_services(pack.take_chain_services_builder());
+        let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
 
-        chains.push((chain_controller, shared));
+        chains.push((chain_scope, shared));
     }
 
     chains
@@ -293,9 +293,9 @@ pub fn new_secp_chain(txs_size: usize, chains_num: usize) -> Chains {
             .consensus(consensus.clone())
             .build()
             .unwrap();
-        let chain_controller = start_chain_services(pack.take_chain_services_builder());
+        let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
 
-        chains.push((chain_controller, shared));
+        chains.push((chain_scope, shared));
     }
 
     chains


### PR DESCRIPTION
## Summary
- Use `ChainServiceScope` in benchmark setup instead of `start_chain_services`.
- Keep scoped chain services alive for each Criterion batch and stop/join them before `Shared` and temp DB teardown.
- Adjust the process-block benchmarks to access controllers through the scoped service handle.

## Root cause
The failing Windows benchmark job completes every benchmark case successfully, then the benchmark process exits with `0xc0000005` / `STATUS_ACCESS_VIOLATION`. These benchmark helpers created many short-lived chain services with `start_chain_services`, which registers the service with the process stop handler and does not give the benchmark batch a join handle. That can leave chain service threads alive while per-batch `Shared` and temp DB resources are dropped during Criterion teardown. Recent `develop` benchmark runs showed the same all-success-then-access-violation pattern, so this is independent from PR #5212.

## Validation
- `cargo fmt --check`
- `cargo check -p ckb-benches --benches --features ci`
- `make bench-test`
- `git diff --check`