### PR TITLE
fix: avoid replay profile zero-duration panic

### DIFF
--- a/ckb-bin/src/subcommand/replay.rs
+++ b/ckb-bin/src/subcommand/replay.rs
@@ -87,11 +87,14 @@ fn profile(shared: Shared, chain_controller: ChainController, from: Option<u64>,
             duration, MIN_PROFILING_TIME
         );
     }
+    let tps = if duration.as_secs() == 0 {
+        0
+    } else {
+        tx_count as u64 / duration.as_secs()
+    };
     println!(
         "\n----------------------------\nEnd profiling, duration:{:?}, txs:{}, tps:{}\n----------------------------",
-        duration,
-        tx_count,
-        tx_count as u64 / duration.as_secs()
+        duration, tx_count, tps
     );
 }
 


### PR DESCRIPTION
### What changed

- Avoid the `duration.as_secs() == 0` path before formatting replay profile TPS.
- Keep the existing TPS calculation for non-zero-second profiling durations.

### Why

Fixes #5216. Very short `ckb replay --profile` runs can measure `duration.as_secs() == 0`, causing a local CLI panic while formatting the final TPS output.

### Validation

- `cargo fmt --all --check`
- `cargo test -p ckb-bin`
- `git diff --check`