### PR TITLE
Fix(network): bound hole punching forward limiter keys

### DIFF
--- a/network/src/protocols/hole_punching/component/connection_request.rs
+++ b/network/src/protocols/hole_punching/component/connection_request.rs
@@ -124,16 +124,14 @@ impl<'a> ConnectionRequestProcess<'a> {
             return StatusCode::InvalidRoute.with_context("the route length is too long");
         }
 
-        let self_peer_id = self.protocol.network_state.local_peer_id();
-        if content.route.contains(self_peer_id) {
+        let self_peer_id = self.protocol.network_state.local_peer_id().clone();
+        if content.route.contains(&self_peer_id) {
             return StatusCode::Ignore.with_context("the message is passed, ignore it");
         }
 
-        if self
+        if !self
             .protocol
-            .forward_rate_limiter
-            .check_key(&(content.from.clone(), content.to.clone(), self.msg_item_id))
-            .is_err()
+            .check_forward_rate_limit(&content.from, &content.to, self.msg_item_id)
         {
             debug!(
                 "from: {}, to {}, item_name: {}, rate limit is reached",
@@ -142,13 +140,13 @@ impl<'a> ConnectionRequestProcess<'a> {
             return StatusCode::TooManyRequests.with_context("ConnectionRequest");
         }
 
-        if self_peer_id == &content.to {
+        if self_peer_id == content.to {
             self.respond_delivered(content.from, &content.to, content.listen_addrs)
                 .await
         } else if content.max_hops == 0u8 {
             StatusCode::ReachedMaxHops.into()
         } else {
-            self.forward_message(self_peer_id, &content.to).await
+            self.forward_message(&self_peer_id, &content.to).await
         }
     }
 

--- a/network/src/protocols/hole_punching/component/connection_request_delivered.rs
+++ b/network/src/protocols/hole_punching/component/connection_request_delivered.rs
@@ -131,11 +131,9 @@ impl<'a> ConnectionRequestDeliveredProcess<'a> {
             return StatusCode::InvalidRoute.with_context("the route length is too long");
         }
 
-        if self
+        if !self
             .protocol
-            .forward_rate_limiter
-            .check_key(&(content.from.clone(), content.to.clone(), self.msg_item_id))
-            .is_err()
+            .check_forward_rate_limit(&content.from, &content.to, self.msg_item_id)
         {
             debug!(
                 "from: {}, to {}, item_name: {}, rate limit is reached",

--- a/network/src/protocols/hole_punching/component/connection_sync.rs
+++ b/network/src/protocols/hole_punching/component/connection_sync.rs
@@ -50,7 +50,7 @@ impl TryFrom<&packed::ConnectionSyncReader<'_>> for SyncContent {
 
 pub(crate) struct ConnectionSyncProcess<'a> {
     message: packed::ConnectionSyncReader<'a>,
-    protocol: &'a HolePunching,
+    protocol: &'a mut HolePunching,
     p2p_control: &'a ServiceAsyncControl,
     bind_addr: Option<SocketAddr>,
     msg_item_id: u32,
@@ -59,7 +59,7 @@ pub(crate) struct ConnectionSyncProcess<'a> {
 impl<'a> ConnectionSyncProcess<'a> {
     pub(crate) fn new(
         message: packed::ConnectionSyncReader<'a>,
-        protocol: &'a HolePunching,
+        protocol: &'a mut HolePunching,
         p2p_control: &'a ServiceAsyncControl,
         bind_addr: Option<SocketAddr>,
         msg_item_id: u32,
@@ -82,11 +82,9 @@ impl<'a> ConnectionSyncProcess<'a> {
         if content.route.len() > MAX_HOPS as usize {
             return StatusCode::InvalidRoute.with_context("the route length is too long");
         }
-        if self
+        if !self
             .protocol
-            .forward_rate_limiter
-            .check_key(&(content.from.clone(), content.to.clone(), self.msg_item_id))
-            .is_err()
+            .check_forward_rate_limit(&content.from, &content.to, self.msg_item_id)
         {
             debug!(
                 "from: {}, to {}, item_name: {}, rate limit is reached",

--- a/network/src/protocols/hole_punching/mod.rs
+++ b/network/src/protocols/hole_punching/mod.rs
@@ -26,6 +26,8 @@ const CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const CHECK_TOKEN: u64 = 0;
 const ADDRS_COUNT_LIMIT: usize = 24;
 const TIMEOUT: u64 = 5 * 60 * 1000; // 5 minutes
+const FORWARD_RATE_LIMIT_INTERVAL: u64 = 1000;
+pub(super) const MAX_FORWARD_RATE_LIMITER_KEYS: usize = 4096;
 
 type PendingDeliveredInfo = (Vec<Multiaddr>, u64);
 type RateLimiter<T> = governor::RateLimiter<
@@ -33,6 +35,51 @@ type RateLimiter<T> = governor::RateLimiter<
     governor::state::keyed::HashMapStateStore<T>,
     governor::clock::DefaultClock,
 >;
+type ForwardRateLimiterKey = (PeerId, PeerId, u32);
+
+struct ForwardRateLimiter {
+    keys: HashMap<ForwardRateLimiterKey, u64>,
+    max_keys: usize,
+}
+
+impl ForwardRateLimiter {
+    fn new(max_keys: usize) -> Self {
+        Self {
+            keys: HashMap::new(),
+            max_keys,
+        }
+    }
+
+    fn check_key(&mut self, key: ForwardRateLimiterKey, now: u64) -> bool {
+        self.retain_recent(now);
+        if let Some(last_seen) = self.keys.get_mut(&key) {
+            if now.saturating_sub(*last_seen) < FORWARD_RATE_LIMIT_INTERVAL {
+                return false;
+            }
+            *last_seen = now;
+            true
+        } else if self.keys.len() >= self.max_keys {
+            false
+        } else {
+            self.keys.insert(key, now);
+            true
+        }
+    }
+
+    fn retain_recent(&mut self, now: u64) {
+        self.keys
+            .retain(|_, last_seen| now.saturating_sub(*last_seen) < FORWARD_RATE_LIMIT_INTERVAL);
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.keys.shrink_to_fit();
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+}
 
 /// Hole Punching Protocol
 pub(crate) struct HolePunching {
@@ -43,7 +90,7 @@ pub(crate) struct HolePunching {
     // Delivered timestamp recorded
     pending_delivered: HashMap<PeerId, PendingDeliveredInfo>,
     rate_limiter: RateLimiter<(PeerIndex, u32)>,
-    forward_rate_limiter: RateLimiter<(PeerId, PeerId, u32)>,
+    forward_rate_limiter: ForwardRateLimiter,
 }
 
 #[async_trait]
@@ -64,8 +111,7 @@ impl ServiceProtocol for HolePunching {
     }
 
     async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-        self.rate_limiter.retain_recent();
-        self.forward_rate_limiter.retain_recent();
+        self.cleanup_rate_limiters();
         debug!("HolePunching.disconnected session={}", context.session.id);
     }
 
@@ -173,6 +219,7 @@ impl ServiceProtocol for HolePunching {
         self.pending_delivered
             .retain(|_, (_, t)| (now - *t) < TIMEOUT);
         self.inflight_requests.retain(|_, t| (now - *t) < TIMEOUT);
+        self.cleanup_rate_limiters();
 
         if status.non_whitelist_outbound < status.max_outbound && status.total > 0 {
             let target = &self.network_state.required_flags;
@@ -251,10 +298,10 @@ impl HolePunching {
         let quota = governor::Quota::per_second(std::num::NonZeroU32::new(30).unwrap());
         let rate_limiter = RateLimiter::hashmap(quota);
 
-        // In the request forwarding process, the same group of from/to should not be received by the same
-        // node more than 1 times within one second.
-        let quota = governor::Quota::per_second(std::num::NonZeroU32::new(1).unwrap());
-        let forward_rate_limiter = RateLimiter::hashmap(quota);
+        // In the request forwarding process, the same group of from/to should not be received by
+        // the same node more than once within one second. Keep the original from/to/message-keyed
+        // semantics, but bound the message-controlled key space.
+        let forward_rate_limiter = ForwardRateLimiter::new(MAX_FORWARD_RATE_LIMITER_KEYS);
 
         Self {
             #[cfg(not(target_os = "linux"))]
@@ -281,5 +328,49 @@ impl HolePunching {
             rate_limiter,
             forward_rate_limiter,
         }
+    }
+
+    pub(super) fn check_forward_rate_limit(
+        &mut self,
+        from: &PeerId,
+        to: &PeerId,
+        msg_item_id: u32,
+    ) -> bool {
+        self.check_forward_rate_limit_at(from, to, msg_item_id, unix_time_as_millis())
+    }
+
+    fn check_forward_rate_limit_at(
+        &mut self,
+        from: &PeerId,
+        to: &PeerId,
+        msg_item_id: u32,
+        now: u64,
+    ) -> bool {
+        self.forward_rate_limiter
+            .check_key((from.clone(), to.clone(), msg_item_id), now)
+    }
+
+    #[cfg(test)]
+    pub(super) fn forward_rate_limiter_len(&self) -> usize {
+        self.forward_rate_limiter.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn check_forward_rate_limit_at_for_test(
+        &mut self,
+        from: &PeerId,
+        to: &PeerId,
+        msg_item_id: u32,
+        now: u64,
+    ) -> bool {
+        self.check_forward_rate_limit_at(from, to, msg_item_id, now)
+    }
+
+    fn cleanup_rate_limiters(&mut self) {
+        self.rate_limiter.retain_recent();
+        self.rate_limiter.shrink_to_fit();
+        self.forward_rate_limiter
+            .retain_recent(unix_time_as_millis());
+        self.forward_rate_limiter.shrink_to_fit();
     }
 }

--- a/network/src/protocols/tests/hole_punching.rs
+++ b/network/src/protocols/tests/hole_punching.rs
@@ -1,0 +1,60 @@
+use crate::{
+    NetworkState, PeerId,
+    protocols::hole_punching::{HolePunching, MAX_FORWARD_RATE_LIMITER_KEYS},
+};
+use ckb_app_config::NetworkConfig;
+use std::sync::Arc;
+
+fn hole_punching() -> HolePunching {
+    let temp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let config = NetworkConfig {
+        path: temp_dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    let network_state = Arc::new(NetworkState::from_config(config).unwrap());
+    HolePunching::new(network_state)
+}
+
+#[test]
+fn forward_rate_limiter_keeps_from_to_message_semantics() {
+    let mut protocol = hole_punching();
+    let from = PeerId::random();
+    let to = PeerId::random();
+    let now = 1_000;
+
+    assert!(protocol.check_forward_rate_limit_at_for_test(&from, &to, 2, now));
+    assert!(!protocol.check_forward_rate_limit_at_for_test(&from, &to, 2, now));
+
+    assert!(protocol.check_forward_rate_limit_at_for_test(&PeerId::random(), &to, 2, now));
+    assert!(protocol.check_forward_rate_limit_at_for_test(&from, &PeerId::random(), 2, now));
+    assert!(protocol.check_forward_rate_limit_at_for_test(&from, &to, 3, now));
+}
+
+#[test]
+fn forward_rate_limiter_bounds_message_controlled_peer_ids() {
+    let mut protocol = hole_punching();
+    let now = 1_000;
+
+    assert_eq!(protocol.forward_rate_limiter_len(), 0);
+
+    let message_controlled_peer_pairs =
+        (0..MAX_FORWARD_RATE_LIMITER_KEYS).map(|_| (PeerId::random(), PeerId::random()));
+    for (_from, _to) in message_controlled_peer_pairs {
+        assert!(protocol.check_forward_rate_limit_at_for_test(&_from, &_to, 2, now));
+    }
+
+    assert_eq!(
+        protocol.forward_rate_limiter_len(),
+        MAX_FORWARD_RATE_LIMITER_KEYS
+    );
+    assert!(!protocol.check_forward_rate_limit_at_for_test(
+        &PeerId::random(),
+        &PeerId::random(),
+        2,
+        now
+    ));
+    assert_eq!(
+        protocol.forward_rate_limiter_len(),
+        MAX_FORWARD_RATE_LIMITER_KEYS
+    );
+}

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -29,6 +29,8 @@ use p2p::{
 use tempfile::tempdir;
 
 mod discovery;
+#[cfg(not(target_family = "wasm"))]
+mod hole_punching;
 
 struct Node {
     listen_addr: Multiaddr,


### PR DESCRIPTION
### Problem Summary:

The previous limiter used `(from, to, message type)` as the key, where `from` and `to` come from forwarded messages. A peer could keep sending messages with fresh peer IDs and grow the keyed rate limiter state indefinitely.

### What is changed and how it works?

Keep the existing per-(from, to, message type) forwarding rate-limit semantics, but replace the unbounded governor keyed store with a bounded TTL-backed limiter. This prevents peers from growing limiter state indefinitely by sending messages with fresh message-controlled peer ids.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
