### PR TITLE
store: validate freezer hash lookups

### DIFF
--- a/store/src/store.rs
+++ b/store/src/store.rs
@@ -46,10 +46,11 @@ pub trait ChainStore: Send + Sync + Sized {
             && header.number() < freezer.number()
         {
             let raw_block = freezer.retrieve(header.number()).expect("block frozen")?;
-            let raw_block = packed::BlockReader::from_compatible_slice(&raw_block)
-                .expect("checked data")
-                .to_entity();
-            return Some(raw_block.into_view());
+            let raw_block_reader =
+                packed::BlockReader::from_compatible_slice(&raw_block).expect("checked data");
+            if raw_block_reader.calc_header_hash().as_slice() == h.as_slice() {
+                return Some(raw_block_reader.to_entity().into_view());
+            }
         }
         let body = self.get_block_body(h);
         let uncles = self
@@ -326,8 +327,12 @@ pub trait ChainStore: Send + Sync + Sized {
                 .expect("block frozen")?;
             let raw_block_reader =
                 packed::BlockReader::from_compatible_slice(&raw_block).expect("checked data");
-            let tx_reader = raw_block_reader.transactions().get(tx_info.index)?;
-            return Some((tx_reader.to_entity().into_view(), tx_info));
+            if raw_block_reader.calc_header_hash().as_slice() == tx_info.block_hash.as_slice()
+                && let Some(tx_reader) = raw_block_reader.transactions().get(tx_info.index)
+                && tx_reader.calc_tx_hash().as_slice() == hash.as_slice()
+            {
+                return Some((tx_reader.to_entity().into_view(), tx_info));
+            }
         }
         self.get(COLUMN_BLOCK_BODY, tx_info.key().as_slice())
             .map(|slice| {

--- a/store/src/tests/db.rs
+++ b/store/src/tests/db.rs
@@ -158,3 +158,103 @@ fn freeze_blockv1_with_extension() {
     let block = store.get_block(&block_hash).expect("get_block");
     assert_eq!(store.get_block(&block_hash), Some(block));
 }
+
+#[test]
+fn freezer_get_block_keeps_hash_lookup_contract_for_same_height_side_block() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let tmp_dir2 = TempDir::new().unwrap();
+    let freezer = Freezer::open_in(&tmp_dir2).expect("tmp freezer");
+    let store = ChainDB::new_with_freezer(db, freezer.clone(), Default::default());
+
+    let frozen_block = packed::Block::new_builder()
+        .header(
+            packed::Header::new_builder()
+                .raw(packed::RawHeader::new_builder().number(1u64).build())
+                .nonce(1u128)
+                .build(),
+        )
+        .build()
+        .into_view();
+    let side_block = packed::Block::new_builder()
+        .header(
+            packed::Header::new_builder()
+                .raw(packed::RawHeader::new_builder().number(1u64).build())
+                .nonce(2u128)
+                .build(),
+        )
+        .build()
+        .into_view();
+    let side_hash = side_block.hash();
+    assert_ne!(frozen_block.hash(), side_hash);
+
+    let txn = store.begin_transaction();
+    txn.insert_block(&frozen_block).unwrap();
+    txn.insert_block(&side_block).unwrap();
+    txn.commit().unwrap();
+
+    freezer
+        .freeze(2, |_number| Some(frozen_block.clone()))
+        .expect("freeze");
+
+    assert_eq!(store.get_block(&side_hash), Some(side_block));
+}
+
+#[test]
+fn freezer_get_transaction_keeps_hash_lookup_contract_for_same_height_side_tx() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db = RocksDB::open_in(&tmp_dir, COLUMNS);
+    let tmp_dir2 = TempDir::new().unwrap();
+    let freezer = Freezer::open_in(&tmp_dir2).expect("tmp freezer");
+    let store = ChainDB::new_with_freezer(db, freezer.clone(), Default::default());
+
+    let frozen_tx = packed::Transaction::new_builder()
+        .raw(packed::RawTransaction::new_builder().version(1u32).build())
+        .build()
+        .into_view();
+    let side_tx = packed::Transaction::new_builder()
+        .raw(packed::RawTransaction::new_builder().version(2u32).build())
+        .build()
+        .into_view();
+    let side_tx_hash = side_tx.hash();
+    assert_ne!(frozen_tx.hash(), side_tx_hash);
+
+    let frozen_block = packed::Block::new_builder()
+        .header(
+            packed::Header::new_builder()
+                .raw(packed::RawHeader::new_builder().number(1u64).build())
+                .nonce(1u128)
+                .build(),
+        )
+        .transactions(vec![frozen_tx.data()])
+        .build();
+    let frozen_block = frozen_block.into_view();
+    let side_block = packed::Block::new_builder()
+        .header(
+            packed::Header::new_builder()
+                .raw(packed::RawHeader::new_builder().number(1u64).build())
+                .nonce(2u128)
+                .build(),
+        )
+        .transactions(vec![side_tx.data()])
+        .build();
+    let side_block = side_block.into_view();
+    let side_block_hash = side_block.hash();
+    assert_ne!(frozen_block.hash(), side_block_hash);
+
+    let txn = store.begin_transaction();
+    txn.insert_block(&frozen_block).unwrap();
+    txn.insert_block(&side_block).unwrap();
+    txn.attach_block(&side_block).unwrap();
+    txn.commit().unwrap();
+
+    freezer
+        .freeze(2, |_number| Some(frozen_block.clone()))
+        .expect("freeze");
+
+    let (tx, tx_info) = store
+        .get_transaction_with_info(&side_tx_hash)
+        .expect("get side transaction");
+    assert_eq!(tx, side_tx);
+    assert_eq!(tx_info.block_hash, side_block_hash);
+}


### PR DESCRIPTION
### What problem does this PR solve?

When freezer storage is enabled, ChainStore may use the requested hash only to find a header/transaction index, then fetch the frozen canonical block by height without checking the hash. If same-height side-chain data remains in RocksDB, a lookup by side-chain block or transaction hash can incorrectly return data from the canonical frozen block at that height. This violates the hash-addressed lookup contract and may make RPC or internal chain logic operate on the wrong block/transaction.


### What is changed and how it works?

Freezer stores canonical blocks by height, but ChainStore lookup APIs are hash-addressed. When a requested hash points at a frozen height, verify the frozen block or transaction still matches the requested hash before returning it. If the freezer data does not match, fall back to the RocksDB keyed path instead of aliasing a side-chain hash to canonical frozen data.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
