### PR TITLE
Update cargo deny workflow to conditionally run security audit

### DIFF
--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -44,7 +44,11 @@ jobs:
       - name: Run cargo deny checks
         run: |
           cargo deny --version || cargo +stable install cargo-deny --locked
-          make security-audit
+          if [[ "${{ github.event_name }}" == "push" && ( "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" || "${{ github.ref }}" == refs/heads/rc/* ) ]]; then
+            make security-audit
+          else
+            echo "Skipping security audit for ${{ github.event_name }} on ${{ github.ref }}"
+          fi
           make check-crates
           make check-licenses
       - name: Disk usage summary

--- a/deny.toml
+++ b/deny.toml
@@ -63,6 +63,10 @@ feature-depth = 1
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
+# Unmaintained advisories are tracked as dependency maintenance and do not fail
+# the security audit.
+unmaintained = "none"
+
 # The path where the advisory databases are cloned/fetched into
 #db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use


### PR DESCRIPTION

What's Changed:

- Let's don't block every pending PR because of `cargo deny`, but only check it on develop branch and rc* branches, or check it when we updated cargo related.
- Unmaintained advisories are tracked as dependency maintenance and do not fail the security audit, fix https://github.com/nervosnetwork/ckb/actions/runs/27117230272/job/80026504349?pr=5228

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
