### PR TITLE
fix: Notify relayer when remote tx enqueue fails on full verify queue

### DIFF
--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -3,7 +3,7 @@ use crate::component::orphan::OrphanPool;
 use crate::component::tests::util::build_tx;
 use crate::component::verify_queue::{Entry, VerifyQueue};
 use crate::pool::TxPool;
-use crate::service::TxPoolService;
+use crate::service::{TxPoolService, TxVerificationResult};
 use ckb_app_config::{NetworkConfig, TxPoolConfig};
 use ckb_async_runtime::new_background_runtime;
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
@@ -315,26 +315,33 @@ fn network(consensus: &Consensus) -> ckb_network::NetworkController {
 }
 
 fn service() -> TxPoolService {
+    service_with_relay_receiver().0
+}
+
+fn service_with_relay_receiver() -> (TxPoolService, ckb_channel::Receiver<TxVerificationResult>) {
     let consensus = Arc::new(ConsensusBuilder::default().build());
     let snapshot = snapshot(Arc::clone(&consensus));
     let config = tx_pool_config();
-    let (tx_relay_sender, _) = ckb_channel::bounded(16);
+    let (tx_relay_sender, tx_relay_receiver) = ckb_channel::bounded(16);
     let (block_assembler_sender, _) = mpsc::channel(1);
 
-    TxPoolService {
-        tx_pool: Arc::new(RwLock::new(TxPool::new(config.clone(), snapshot))),
-        orphan: Arc::new(RwLock::new(OrphanPool::new())),
-        consensus: Arc::clone(&consensus),
-        tx_pool_config: Arc::new(config.clone()),
-        block_assembler: None,
-        txs_verify_cache: Arc::new(RwLock::new(init_cache())),
-        callbacks: Arc::new(Callbacks::new()),
-        network: network(&consensus),
-        tx_relay_sender,
-        verify_queue: Arc::new(RwLock::new(VerifyQueue::new(config.max_tx_verify_cycles))),
-        block_assembler_sender,
-        fee_estimator: FeeEstimator::new_dummy(),
-    }
+    (
+        TxPoolService {
+            tx_pool: Arc::new(RwLock::new(TxPool::new(config.clone(), snapshot))),
+            orphan: Arc::new(RwLock::new(OrphanPool::new())),
+            consensus: Arc::clone(&consensus),
+            tx_pool_config: Arc::new(config.clone()),
+            block_assembler: None,
+            txs_verify_cache: Arc::new(RwLock::new(init_cache())),
+            callbacks: Arc::new(Callbacks::new()),
+            network: network(&consensus),
+            tx_relay_sender,
+            verify_queue: Arc::new(RwLock::new(VerifyQueue::new(config.max_tx_verify_cycles))),
+            block_assembler_sender,
+            fee_estimator: FeeEstimator::new_dummy(),
+        },
+        tx_relay_receiver,
+    )
 }
 
 #[tokio::test]
@@ -364,4 +371,32 @@ async fn process_orphan_tx_keeps_high_cycle_orphan_when_verify_queue_is_full() {
 
     assert!(service.orphan.read().await.contains_key(&orphan_id));
     assert!(!service.verify_queue.read().await.contains_key(&orphan_id));
+}
+
+#[tokio::test]
+async fn submit_remote_tx_notifies_relayer_when_verify_queue_is_full() {
+    let (service, tx_relay_receiver) = service_with_relay_receiver();
+    let tx = build_tx(vec![(&H256([1; 32]).into(), 0)], 1);
+    let tx_hash = tx.hash();
+
+    service
+        .verify_queue
+        .write()
+        .await
+        .set_total_tx_size_for_test(256_000_000 - 1);
+
+    let ret = service
+        .submit_remote_tx(tx, MAX_TX_VERIFY_CYCLES, 1.into())
+        .await;
+
+    assert!(matches!(ret, Err(crate::error::Reject::Full(_))));
+    match tx_relay_receiver
+        .try_recv()
+        .expect("expected reject notification")
+    {
+        TxVerificationResult::Reject { tx_hash: rejected } => {
+            assert_eq!(rejected, tx_hash);
+        }
+        _ => panic!("expected reject notification"),
+    }
 }

--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -400,3 +400,29 @@ async fn submit_remote_tx_notifies_relayer_when_verify_queue_is_full() {
         _ => panic!("expected reject notification"),
     }
 }
+
+#[tokio::test]
+async fn notify_tx_notifies_relayer_when_verify_queue_is_full() {
+    let (service, tx_relay_receiver) = service_with_relay_receiver();
+    let tx = build_tx(vec![(&H256([1; 32]).into(), 0)], 1);
+    let tx_hash = tx.hash();
+
+    service
+        .verify_queue
+        .write()
+        .await
+        .set_total_tx_size_for_test(256_000_000 - 1);
+
+    let ret = service.notify_tx(tx).await;
+
+    assert!(matches!(ret, Err(crate::error::Reject::Full(_))));
+    match tx_relay_receiver
+        .try_recv()
+        .expect("expected reject notification")
+    {
+        TxVerificationResult::Reject { tx_hash: rejected } => {
+            assert_eq!(rejected, tx_hash);
+        }
+        _ => panic!("expected reject notification"),
+    }
+}

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -352,22 +352,35 @@ impl TxPoolService {
         self.enqueue_verify_queue(tx, is_proposal_tx, remote).await
     }
 
-    pub(crate) async fn submit_remote_tx(
+    async fn resumeble_process_tx_and_notify_full_reject(
         &self,
         tx: TransactionView,
-        declared_cycles: Cycle,
-        peer: PeerIndex,
+        is_proposal_tx: bool,
+        remote: Option<(Cycle, PeerIndex)>,
     ) -> Result<bool, Reject> {
         let tx_hash = tx.hash();
-        let ret = self
-            .resumeble_process_tx(tx, false, Some((declared_cycles, peer)))
-            .await;
+        let ret = self.resumeble_process_tx(tx, is_proposal_tx, remote).await;
 
         if matches!(ret, Err(Reject::Full(_))) {
             self.send_result_to_relayer(TxVerificationResult::Reject { tx_hash });
         }
 
         ret
+    }
+
+    pub(crate) async fn submit_remote_tx(
+        &self,
+        tx: TransactionView,
+        declared_cycles: Cycle,
+        peer: PeerIndex,
+    ) -> Result<bool, Reject> {
+        self.resumeble_process_tx_and_notify_full_reject(tx, false, Some((declared_cycles, peer)))
+            .await
+    }
+
+    pub(crate) async fn notify_tx(&self, tx: TransactionView) -> Result<bool, Reject> {
+        self.resumeble_process_tx_and_notify_full_reject(tx, true, None)
+            .await
     }
 
     pub(crate) async fn test_accept_tx(&self, tx: TransactionView) -> Result<Completed, Reject> {

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -352,6 +352,24 @@ impl TxPoolService {
         self.enqueue_verify_queue(tx, is_proposal_tx, remote).await
     }
 
+    pub(crate) async fn submit_remote_tx(
+        &self,
+        tx: TransactionView,
+        declared_cycles: Cycle,
+        peer: PeerIndex,
+    ) -> Result<bool, Reject> {
+        let tx_hash = tx.hash();
+        let ret = self
+            .resumeble_process_tx(tx, false, Some((declared_cycles, peer)))
+            .await;
+
+        if matches!(ret, Err(Reject::Full(_))) {
+            self.send_result_to_relayer(TxVerificationResult::Reject { tx_hash });
+        }
+
+        ret
+    }
+
     pub(crate) async fn test_accept_tx(&self, tx: TransactionView) -> Result<Completed, Reject> {
         // non contextual verify first
         self.non_contextual_verify(&tx, None).await?;

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -845,9 +845,7 @@ async fn process(mut service: TxPoolService, message: Message) {
             responder,
             arguments: (tx, declared_cycles, peer),
         }) => {
-            let _result = service
-                .resumeble_process_tx(tx, false, Some((declared_cycles, peer)))
-                .await;
+            let _result = service.submit_remote_tx(tx, declared_cycles, peer).await;
             if let Err(e) = responder.send(()) {
                 error!("Responder sending submit_tx result failed {:?}", e);
             };

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -852,7 +852,7 @@ async fn process(mut service: TxPoolService, message: Message) {
         }
         Message::NotifyTxs(Notify { arguments: txs }) => {
             for tx in txs {
-                let _ret = service.resumeble_process_tx(tx, true, None).await;
+                let _ret = service.notify_tx(tx).await;
             }
         }
         Message::FreshProposalsFilter(AsyncRequest {


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Transactions delivered through the block proposal notification path are marked as known by the relayer before they are submitted to the tx-pool via `NotifyTxs`. `NotifyTxs` enqueues these transactions into the verify queue, but previously ignored each enqueue result. When the verify queue was full, the transaction was dropped with `Reject::Full` and never reached verification or the mempool, while its hash remained in the relayer known filter. This could temporarily suppress later re-fetching or acceptance of the same transaction until the known filter expired or evicted the entry.

### What is changed and how it works?

Share the full-queue handling used by remote transaction submission with the notify transaction path. A new helper wraps `resumeble_process_tx` and emits `TxVerificationResult::Reject` when enqueueing fails with `Reject::Full`. Both `submit_remote_tx` and `notify_tx` use this helper, so the relayer removes the affected hash from the known filter and can request or accept the transaction again later.


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
