### PR TITLE
fix: Respect tx-pool suspend commands before popping verify tasks

### DIFF
--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -108,11 +108,11 @@ impl Worker {
 
     async fn process_inner(&mut self) {
         loop {
-            self.refresh_status();
             if self.exit_signal.is_cancelled() {
                 info!("Verify worker::process_inner exit_signal is cancelled");
                 return;
             }
+            self.refresh_status();
             if self.status != ChunkCommand::Resume {
                 return;
             }

--- a/tx-pool/src/verify_mgr.rs
+++ b/tx-pool/src/verify_mgr.rs
@@ -85,14 +85,14 @@ impl Worker {
 
     async fn run(mut self) {
         let queue_ready = self.tasks.read().await.subscribe();
-        self.status = self.command_rx.borrow().to_owned();
+        self.refresh_status();
         loop {
             tokio::select! {
                 _ = self.exit_signal.cancelled() => {
                     break;
                 }
                 _ = self.command_rx.changed() => {
-                    self.status = self.command_rx.borrow().to_owned();
+                    self.status = self.command_rx.borrow_and_update().to_owned();
                     self.process_inner().await;
                 }
                 _ = queue_ready.notified() => {
@@ -102,8 +102,13 @@ impl Worker {
         }
     }
 
+    fn refresh_status(&mut self) {
+        self.status = self.command_rx.borrow().to_owned();
+    }
+
     async fn process_inner(&mut self) {
         loop {
+            self.refresh_status();
             if self.exit_signal.is_cancelled() {
                 info!("Verify worker::process_inner exit_signal is cancelled");
                 return;
@@ -113,6 +118,11 @@ impl Worker {
             }
             // cheap query to check queue is not empty
             if self.tasks.read().await.is_empty() {
+                return;
+            }
+
+            self.refresh_status();
+            if self.status != ChunkCommand::Resume {
                 return;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Tx-pool verify workers cache the current chunk command in `self.status`, but that cached status was only updated when the outer `tokio::select!` received a command notification. If a queue notification triggered processing first, or if a suspend command arrived while the worker was already inside `process_inner()`, the worker could keep looping with a stale `Resume` status and continue popping queued transactions. This weakened the suspend mechanism used during block processing and could let remote transaction traffic keep verification workers consuming CPU.
### What is changed and how it works?



Refresh the worker command status from the watch receiver before each `process_inner()` iteration and again before popping a transaction from the verify queue. The command notification branch now uses `borrow_and_update()` to keep the receiver state consistent. With this change, a worker observes the latest Suspend command before taking more queued verification work.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
