### PR TITLE
refactor(tx-pool): simplify verify queue priority index

### DIFF
--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -181,6 +181,47 @@ async fn test_verify_different_cycles() {
 }
 
 #[tokio::test]
+async fn verify_queue_pops_proposals_by_arrival_order() {
+    let mut queue = VerifyQueue::new(MAX_TX_VERIFY_CYCLES);
+    let remote = |cycles| Some((cycles, SessionId::default()));
+
+    let tx0 = build_tx(vec![(&H256([0; 32]).into(), 0)], 1);
+    assert!(queue.add_tx(tx0.clone(), false, remote(1001)).unwrap());
+    sleep(std::time::Duration::from_millis(100)).await;
+
+    let tx1_proposal = build_tx(vec![(&H256([1; 32]).into(), 0)], 1);
+    assert!(
+        queue
+            .add_tx(tx1_proposal.clone(), true, remote(1001))
+            .unwrap()
+    );
+    sleep(std::time::Duration::from_millis(100)).await;
+
+    let tx2_proposal = build_tx(vec![(&H256([2; 32]).into(), 0)], 1);
+    assert!(
+        queue
+            .add_tx(tx2_proposal.clone(), true, remote(1001))
+            .unwrap()
+    );
+    sleep(std::time::Duration::from_millis(100)).await;
+
+    let tx3 = build_tx(vec![(&H256([3; 32]).into(), 0)], 1);
+    assert!(queue.add_tx(tx3.clone(), false, remote(1001)).unwrap());
+
+    let cur = queue.pop_front(false);
+    assert_eq!(cur.unwrap().tx, tx1_proposal);
+
+    let cur = queue.pop_front(false);
+    assert_eq!(cur.unwrap().tx, tx2_proposal);
+
+    let cur = queue.pop_front(false);
+    assert_eq!(cur.unwrap().tx, tx0);
+
+    let cur = queue.pop_front(false);
+    assert_eq!(cur.unwrap().tx, tx3);
+}
+
+#[tokio::test]
 async fn verify_queue_remove() {
     let entry1 = Entry {
         tx: TransactionBuilder::default()

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -47,6 +47,9 @@ struct VerifyEntry {
     is_large_cycle: bool,
     /// whether the tx is a proposal tx
     is_proposal_tx: bool,
+    /// Orders proposal txs before non-proposal txs, preserving arrival order within each group.
+    #[multi_index(ordered_non_unique)]
+    proposal_order: (bool, u64),
 
     /// other sort key
     inner: Entry,
@@ -178,9 +181,12 @@ impl VerifyQueue {
 
     /// Returns the first entry in the queue
     pub fn peek(&self, only_small_cycle: bool) -> Option<ProposalShortId> {
-        let mut iter = self.inner.iter_by_added_time();
-
-        if let Some(proposal_entry) = iter.find(|e| e.is_proposal_tx) {
+        if let Some(proposal_entry) = self
+            .inner
+            .iter_by_proposal_order()
+            .next()
+            .filter(|entry| entry.is_proposal_tx)
+        {
             return Some(proposal_entry.inner.tx.proposal_short_id());
         }
 
@@ -212,6 +218,7 @@ impl VerifyQueue {
         let is_large_cycle = remote
             .map(|(cycles, _)| cycles > self.large_cycle_threshold)
             .unwrap_or(false);
+        let added_time = unix_time_as_millis();
         if self.is_full(tx_size) {
             return Err(Reject::Full(format!(
                 "verify_queue total_tx_size exceeded, failed to add tx: {:#x}",
@@ -226,10 +233,11 @@ impl VerifyQueue {
         })?;
         self.inner.insert(VerifyEntry {
             id: tx.proposal_short_id(),
-            added_time: unix_time_as_millis(),
+            added_time,
             inner: Entry { tx, remote },
             is_large_cycle,
             is_proposal_tx,
+            proposal_order: (!is_proposal_tx, added_time),
         });
         self.total_tx_size = total_tx_size;
         self.ready_rx.notify_one();

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -36,23 +36,22 @@ struct VerifyEntry {
     /// The transaction id
     #[multi_index(hashed_unique)]
     id: ProposalShortId,
-    /// The unix timestamp when entering the Txpool, unit: Millisecond
-    /// This field is used to sort the txs in the queue
-    /// We may add more other sort keys in the future
-    #[multi_index(ordered_non_unique)]
-    added_time: u64,
 
     /// whether the tx is a large cycle tx
     #[multi_index(hashed_non_unique)]
     is_large_cycle: bool,
-    /// whether the tx is a proposal tx
-    is_proposal_tx: bool,
     /// Orders proposal txs before non-proposal txs, preserving arrival order within each group.
     #[multi_index(ordered_non_unique)]
-    proposal_order: (bool, u64),
+    priority_order: (VerifyPriority, u64),
 
     /// other sort key
     inner: Entry,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+enum VerifyPriority {
+    Proposal,
+    Normal,
 }
 
 /// The verify queue is a priority queue of transactions to verify.
@@ -181,19 +180,19 @@ impl VerifyQueue {
 
     /// Returns the first entry in the queue
     pub fn peek(&self, only_small_cycle: bool) -> Option<ProposalShortId> {
-        if let Some(proposal_entry) = self
-            .inner
-            .iter_by_proposal_order()
-            .next()
-            .filter(|entry| entry.is_proposal_tx)
+        let first_entry = self.inner.iter_by_priority_order().next();
+        if let Some(entry) = first_entry
+            && matches!(entry.priority_order.0, VerifyPriority::Proposal)
         {
-            return Some(proposal_entry.inner.tx.proposal_short_id());
+            return Some(entry.inner.tx.proposal_short_id());
         }
 
         let entry = if only_small_cycle {
-            self.inner.iter_by_added_time().find(|e| !e.is_large_cycle)
+            self.inner
+                .iter_by_priority_order()
+                .find(|e| !e.is_large_cycle)
         } else {
-            self.inner.iter_by_added_time().next()
+            first_entry
         };
 
         entry.map(|e| e.inner.tx.proposal_short_id())
@@ -219,6 +218,11 @@ impl VerifyQueue {
             .map(|(cycles, _)| cycles > self.large_cycle_threshold)
             .unwrap_or(false);
         let added_time = unix_time_as_millis();
+        let priority = if is_proposal_tx {
+            VerifyPriority::Proposal
+        } else {
+            VerifyPriority::Normal
+        };
         if self.is_full(tx_size) {
             return Err(Reject::Full(format!(
                 "verify_queue total_tx_size exceeded, failed to add tx: {:#x}",
@@ -233,11 +237,9 @@ impl VerifyQueue {
         })?;
         self.inner.insert(VerifyEntry {
             id: tx.proposal_short_id(),
-            added_time,
             inner: Entry { tx, remote },
             is_large_cycle,
-            is_proposal_tx,
-            proposal_order: (!is_proposal_tx, added_time),
+            priority_order: (priority, added_time),
         });
         self.total_tx_size = total_tx_size;
         self.ready_rx.notify_one();


### PR DESCRIPTION

### What problem does this PR solve?

This PR fixes a tx-pool verify queue CPU DoS caused by repeatedly scanning the full queue to find proposal transactions.

Previously, `VerifyQueue::peek()` iterated through transactions ordered by arrival time to find any proposal transaction before falling back to normal FIFO selection. When the queue contained only normal transactions, every `pop_front()` performed a full scan, so draining the queue could degrade to O(N^2).

The fix adds a proposal-priority ordered index and uses it to check proposal transactions directly while preserving FIFO order within proposal and normal transaction groups.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
