### PR TITLE
fix: Charge pipe I/O cycles before scheduler-side copies

### DIFF
--- a/script/src/scheduler.rs
+++ b/script/src/scheduler.rs
@@ -420,12 +420,6 @@ where
         limit_cycles: Cycle,
     ) -> Result<(VmId, Cycle), Error> {
         let iterate_return = self.iterate_inner(pause.clone(), limit_cycles);
-        self.consume_cycles(self.iteration_cycles)?;
-        let remaining_cycles = limit_cycles
-            .checked_sub(self.iteration_cycles)
-            .ok_or(Error::CyclesExceeded)?;
-        // Clear iteration cycles intentionally after each run
-        self.iteration_cycles = 0;
         // Process all pending VM reads & writes. Notice ideally, this invocation
         // should be put at the end of `iterate_inner` function. However, 2 things
         // prevent this:
@@ -450,7 +444,13 @@ where
         // after the whole scheduler terminates, and not called at the very beginning
         // when no VM is executing. But since no VMs will be in IO states at this 2 timeslot,
         // we should be fine here.
-        self.process_io()?;
+        self.process_io(limit_cycles)?;
+        self.consume_cycles(self.iteration_cycles)?;
+        let remaining_cycles = limit_cycles
+            .checked_sub(self.iteration_cycles)
+            .ok_or(Error::CyclesExceeded)?;
+        // Clear iteration cycles intentionally after each run
+        self.iteration_cycles = 0;
         let id = iterate_return?;
         Ok((id, remaining_cycles))
     }
@@ -726,7 +726,23 @@ where
         Ok(())
     }
 
-    fn process_io(&mut self) -> Result<(), Error> {
+    fn add_iteration_cycles(
+        &mut self,
+        cycles: Cycle,
+        current_limit_cycles: Cycle,
+    ) -> Result<(), Error> {
+        let iteration_cycles = self
+            .iteration_cycles
+            .checked_add(cycles)
+            .ok_or(Error::CyclesExceeded)?;
+        if iteration_cycles > current_limit_cycles {
+            return Err(Error::CyclesExceeded);
+        }
+        self.iteration_cycles = iteration_cycles;
+        Ok(())
+    }
+
+    fn process_io(&mut self, current_limit_cycles: Cycle) -> Result<(), Error> {
         let mut reads: HashMap<Fd, (VmId, ReadState)> = HashMap::default();
         let mut closed_fds: Vec<VmId> = Vec::new();
 
@@ -804,15 +820,17 @@ where
                 let fillable = read_length;
                 let consumable = write_length - consumed;
                 let copiable = std::cmp::min(fillable, consumable);
+                let transfer_cycles = transferred_byte_cycles(copiable);
+                let io_cycles = transfer_cycles
+                    .checked_add(transfer_cycles)
+                    .ok_or(Error::CyclesExceeded)?;
+                self.add_iteration_cycles(io_cycles, current_limit_cycles)?;
 
                 // Actual data copying
                 let (_, write_machine) = self
                     .instantiated
                     .get_mut(&write_vm_id)
                     .ok_or_else(|| Error::Unexpected("Unable to find VM Id".to_string()))?;
-                write_machine
-                    .inner_mut()
-                    .add_cycles_no_checking(transferred_byte_cycles(copiable))?;
                 let data = write_machine.inner_mut().memory_mut().load_bytes(
                     write_buffer_addr
                         .checked_add(consumed)
@@ -823,9 +841,6 @@ where
                     .instantiated
                     .get_mut(&read_vm_id)
                     .ok_or_else(|| Error::Unexpected("Unable to find VM Id".to_string()))?;
-                read_machine
-                    .inner_mut()
-                    .add_cycles_no_checking(transferred_byte_cycles(copiable))?;
                 read_machine
                     .inner_mut()
                     .memory_mut()

--- a/script/src/verify/tests/ckb_latest/features_since_v2023.rs
+++ b/script/src/verify/tests/ckb_latest/features_since_v2023.rs
@@ -1578,5 +1578,5 @@ fn spawn_create_17_spawn() {
         .verify_without_limit(script_version, &rtx)
         .expect("verify");
 
-    assert_eq!(cycles, 36445673);
+    assert_eq!(cycles, 36445782);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Pipe read/write transferred-byte cycles were added to the participating VM-local cycle counters during `process_io()`. If a writer stayed blocked in `WaitForWrite` and the root VM terminated before that writer became runnable again, those pending VM-local cycles could be discarded when non-root VMs were purged.

The host-side pipe copy also happened before the scheduler consumed and enforced the transfer cycles for the current iteration, so large pipe transfers could perform memory-copy work before the remaining cycle budget reflected that cost.


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Charge pipe transfer cycles directly to the scheduler iteration counter in `process_io()` before performing the memory copy. `process_io()` now receives the current remaining cycle limit and returns `CyclesExceeded` if the transfer would exceed that budget.

The scheduler then consumes the updated `iteration_cycles` in the same `iterate_outer()` iteration, so pipe I/O cycles cannot be lost when a blocked VM is later purged. The existing exact-cycle spawn test was updated for the corrected accounting timing.
### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
