### PR TITLE
fix: Ensure integration test required checks fail on chunk failures

### DIFF
--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -179,8 +179,13 @@ jobs:
   ci_integration_tests_macos:
     name: ci_integration_tests_macos
     needs: test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - name: All tests passed
-        run: echo "All test chunks completed successfully"
+      - name: Check test chunks result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Integration test chunks did not complete successfully: ${{ needs.test.result }}"
+            exit 1
+          fi
+          echo "All test chunks completed successfully"

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -185,11 +185,16 @@ jobs:
   ci_integration_tests_ubuntu:
     name: ci_integration_tests_ubuntu
     needs: test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - name: All tests passed
-        run: echo "All test chunks completed successfully"
+      - name: Check test chunks result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Integration test chunks did not complete successfully: ${{ needs.test.result }}"
+            exit 1
+          fi
+          echo "All test chunks completed successfully"
 
   ci_cli_bats_test:
     name: ci_cli_bats_test

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -181,8 +181,13 @@ jobs:
   ci_integration_tests_windows:
     name: ci_integration_tests_windows
     needs: test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - name: All tests passed
-        run: echo "All test chunks completed successfully"
+      - name: Check test chunks result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Integration test chunks did not complete successfully: ${{ needs.test.result }}"
+            exit 1
+          fi
+          echo "All test chunks completed successfully"


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The integration-test workflows run the real tests in matrix jobs named `Run tests (chunk N)`, then keep the historical required-check names as final aggregate jobs:

- `ci_integration_tests_ubuntu`
- `ci_integration_tests_macos`
- `ci_integration_tests_windows`

Those aggregate jobs depended on the matrix `test` job but used the default success condition. If any matrix chunk failed, the aggregate job was skipped. GitHub Actions reports skipped jobs as successful, even for required checks, so branch protection relying on the historical check names could allow a PR to merge despite failed integration-test chunks.


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Run the aggregate required-check jobs with `always()` and explicitly inspect `needs.test.result`.

If the matrix test job result is not `success`, the aggregate job now exits with failure. This preserves the old required-check names while ensuring they accurately reflect the real integration-test result.
### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
