### PR TITLE
ci: harden Rust supply-chain checks

### DIFF
--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -6,7 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - master
+      - develop
+      - rc/**
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -6,7 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - master
+      - develop
+      - rc/**
   merge_group: {}
   workflow_dispatch: {}
 

--- a/deny.toml
+++ b/deny.toml
@@ -173,7 +173,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "allow"
+wildcards = "deny"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted
@@ -245,10 +245,10 @@ skip-tree = [
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered
-unknown-registry = "warn"
+unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "warn"
+unknown-git = "deny"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION

- Restrict the Ubuntu integration and aarch64 workflows so push-triggered runs only happen on `master`, `develop`, and `rc/**`.
- Restore `cargo-deny` guardrails for wildcard dependencies and unknown registry/git sources.


### Related changes

The affected Ubuntu workflows currently run on every branch push in `nervosnetwork/ckb` and select self-hosted runners for the upstream repository. Since those jobs check out the pushed branch and execute repository code, any account or token with upstream branch push permission can run modified workflow/build/test scripts on self-hosted CI.
What's Changed:


- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
