### PR TITLE
chore: avoid stored renotify permits in verify queue

### DIFF
--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -181,6 +181,30 @@ async fn test_verify_different_cycles() {
 }
 
 #[tokio::test]
+async fn verify_queue_renotify_does_not_store_permit() {
+    let queue = VerifyQueue::new(MAX_TX_VERIFY_CYCLES);
+    let queue_rx = queue.subscribe();
+
+    queue.re_notify();
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(10), queue_rx.notified())
+            .await
+            .is_err()
+    );
+
+    let queue_rx = queue.subscribe();
+    let waiter = tokio::spawn(async move {
+        tokio::time::timeout(std::time::Duration::from_millis(500), queue_rx.notified())
+            .await
+            .is_ok()
+    });
+    sleep(std::time::Duration::from_millis(10)).await;
+
+    queue.re_notify();
+    assert!(waiter.await.unwrap());
+}
+
+#[tokio::test]
 async fn verify_queue_remove() {
     let entry1 = Entry {
         tx: TransactionBuilder::default()

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -238,7 +238,7 @@ impl VerifyQueue {
 
     /// When OnlySmallCycleTx Worker is wakeup, but found the tx is large cycle tx, notify other workers.
     pub fn re_notify(&self) {
-        self.ready_rx.notify_one();
+        self.ready_rx.notify_waiters();
     }
 
     /// Clears the map, removing all elements.


### PR DESCRIPTION

## Problem Summary:
Fix `VerifyQueue::re_notify()` to wake only currently waiting workers without storing a notification permit.

Previously, `re_notify()` used `notify_one()`. When the `OnlySmallCycleTx` worker found that the queue still contained only large-cycle transactions, `notify_one()` could store a permit if no other worker was waiting. The same worker could then consume that permit and repeatedly wake itself.

This PR switches `re_notify()` to `notify_waiters()`, which preserves the intended handoff behavior while avoiding stored self-wakeup permits.


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
