### PR TITLE
ci: limit scheduled audit app token permissions

### DIFF
--- a/.github/workflows/scheduled_audit.yaml
+++ b/.github/workflows/scheduled_audit.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   audit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/scheduled_audit.yaml
+++ b/.github/workflows/scheduled_audit.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-checks: write
       - uses: yangby-cryptape/cargo-audit-check-action@customized-for-ckb
         with:
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION

### What problem does this PR solve?
Limit the GitHub App token generated by the scheduled security audit workflow to the permissions actually needed by the audit action.

The audit action only needs to:
- create/search issues for scheduled runs
- publish check results for manual runs

So this PR explicitly requests:

- `permission-issues: write`
- `permission-checks: write`

This avoids inheriting the broader permissions granted to the release bot app, such as contents, pull requests, and actions write access.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
