### PR TITLE
chore: skip fee statistics blocks without tx sizes

### DIFF
--- a/rpc/src/tests/fee_rate.rs
+++ b/rpc/src/tests/fee_rate.rs
@@ -141,3 +141,40 @@ fn test_fee_rate_statics_handles_large_values() {
         })
     );
 }
+
+#[test]
+fn test_fee_rate_statics_skips_missing_txs_sizes() {
+    let mut provider = DummyFeeRateProvider::new(3);
+    provider.append(
+        1,
+        BlockExt {
+            received_at: 0,
+            total_difficulty: 0u64.into(),
+            total_uncles_count: 0,
+            verified: None,
+            txs_fees: vec![Capacity::shannons(10_000)],
+            cycles: Some(vec![0]),
+            txs_sizes: None,
+        },
+    );
+    provider.append(
+        2,
+        BlockExt {
+            received_at: 0,
+            total_difficulty: 0u64.into(),
+            total_uncles_count: 0,
+            verified: None,
+            txs_fees: vec![Capacity::shannons(400)],
+            cycles: Some(vec![0]),
+            txs_sizes: Some(vec![0, 200]),
+        },
+    );
+
+    assert_eq!(
+        FeeRateCollector::new(&provider).statistics(Some(3)),
+        Some(FeeRateStatistics {
+            mean: 2_000.into(),
+            median: 2_000.into(),
+        })
+    );
+}

--- a/rpc/src/util/fee_rate.rs
+++ b/rpc/src/util/fee_rate.rs
@@ -90,7 +90,10 @@ where
                 txs_fees,
                 ..
             } = block_ext;
-            let txs_sizes = txs_sizes.expect("expect txs_size's length >= 1");
+            // Older BlockExt records may not contain transaction size data.
+            let Some(txs_sizes) = txs_sizes else {
+                return fee_rates;
+            };
             if txs_sizes.len() > 1 && !txs_fees.is_empty() {
                 // block_ext.txs_fees's length == block_ext.cycles's length
                 // block_ext.txs_fees's length + 1 == txs_sizes's length


### PR DESCRIPTION

### What problem does this PR solve?

Fix `get_fee_rate_statistics` so it does not panic when recent block extensions are missing transaction size data.


### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
