### PR TITLE
fix: simplify removal of terminated VMs by using remove instead of retain

### DIFF
--- a/script/src/scheduler.rs
+++ b/script/src/scheduler.rs
@@ -572,7 +572,7 @@ where
                             .inner_mut()
                             .set_register(A0, Self::u8_to_reg(SUCCESS));
                         self.states.insert(vm_id, VmState::Runnable);
-                        self.terminated_vms.retain(|id, _| id != &args.target_id);
+                        self.terminated_vms.remove(&args.target_id);
                         continue;
                     }
                     if !self.states.contains_key(&args.target_id) {


### PR DESCRIPTION
### What problem does this PR solve?

The time complexity of this operation is O(n²).

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility
