### PR TITLE
fix(test): stabilize RPC test teardown

### DIFF
--- a/rpc/src/tests/mod.rs
+++ b/rpc/src/tests/mod.rs
@@ -75,9 +75,11 @@ pub(crate) struct RpcTestSuite {
     rpc_client: Client,
     rpc_uri: String,
     tcp_uri: Option<String>,
-    shared: Shared,
+    // Drop the extra controller before joining the chain service, then keep
+    // Shared/runtime alive until the service has stopped.
     chain_controller: ChainController,
     _chain_scope: ChainServiceScope,
+    shared: Shared,
     _tmp_dir: tempfile::TempDir,
 }
 


### PR DESCRIPTION
### Summary
- keep `Shared` after `ChainServiceScope` in `RpcTestSuite` so the shared runtime stays alive until the chain service has been joined
- keep the existing stop signal path unchanged; this is only a test-fixture teardown ordering fix

### Root cause
The failed macOS CI job aborted after `ckb-rpc tests::module::test::test_generate_epochs` had already passed:
https://github.com/nervosnetwork/ckb/actions/runs/28146907652/job/83355925139

The failure ended with `pthread lock: Invalid argument` / SIGABRT during teardown, which points at background-thread/runtime lifetime rather than RPC logic. `RpcTestSuite` declared `shared` before `_chain_scope`, so after the custom Drop broadcast, field teardown could release the shared runtime handle before the chain service scope got joined. Reordering the fields makes the extra controller drop first, then joins the chain service, and only then releases `Shared`.

### Validation
- `cargo fmt --all -- --check`
- `cargo nextest run --workspace -p ckb-rpc --features deadlock_detection,with_sentry,portable test_generate_epochs --success-output immediate-final --failure-output immediate-final --run-ignored all`
- 30x focused `test_generate_epochs` loop with `deadlock_detection,with_sentry,portable`
- `make test`
- `CKB_FEATURES=deadlock_detection,with_sentry,portable make test`