### PR TITLE
ci: fix develop CI fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/ckb-bin/src/subcommand/import.rs
+++ b/ckb-bin/src/subcommand/import.rs
@@ -1,5 +1,6 @@
 use ckb_app_config::{ExitCode, ImportArgs};
 use ckb_async_runtime::Handle;
+use ckb_chain::ChainServiceScope;
 use ckb_instrument::Import;
 use ckb_shared::SharedBuilder;
 
@@ -14,7 +15,8 @@ pub fn import(args: ImportArgs, async_handle: Handle) -> Result<(), ExitCode> {
     )?;
     let (shared, mut pack) = builder.build()?;
 
-    let chain_controller = ckb_chain::start_chain_services(pack.take_chain_services_builder());
+    let chain_scope = ChainServiceScope::new(pack.take_chain_services_builder());
+    let chain_controller = chain_scope.chain_controller().clone();
 
     // manual drop tx_pool_builder and relay_tx_receiver
     pack.take_tx_pool_builder();

--- a/ckb-bin/src/tests/bats_tests/export_import.bats
+++ b/ckb-bin/src/tests/bats_tests/export_import.bats
@@ -60,9 +60,20 @@ function export_to_pipe() { #@test
 
 setup_file() {
   rm -f ${TMP_DIR}/ckb*.jsonl
+  rm -rvf ${TMP_DIR}/import
+  rm -rvf ${TMP_DIR}/import_range
+  rm -rvf ${TMP_DIR}/export_to_stdout
+  rm -rvf ${TMP_DIR}/import_from_stdin
+  rm -rvf ${TMP_DIR}/export_to_pipe
+  rm -rvf ${TMP_DIR}/import_from_pipe
 }
 
 teardown_file() {
   rm -f ${TMP_DIR}/ckb*.jsonl
   rm -rvf ${TMP_DIR}/import
+  rm -rvf ${TMP_DIR}/import_range
+  rm -rvf ${TMP_DIR}/export_to_stdout
+  rm -rvf ${TMP_DIR}/import_from_stdin
+  rm -rvf ${TMP_DIR}/export_to_pipe
+  rm -rvf ${TMP_DIR}/import_from_pipe
 }


### PR DESCRIPTION
## Summary

Fix develop CI failures by:
- Updating `anyhow` to `1.0.103` for `RUSTSEC-2026-0190`.
- Making `ckb import` own its chain service lifecycle via `ChainServiceScope`.
- Cleaning all `export_import.bats` temp dirs so retries are not polluted by prior failed runs.