### PR TITLE
ci: try blacksmith desktop runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
       GITHUB_REPO: ${{ github.repository }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: nervosnetwork/ckb-integration-test
       - name: Get branch name when event is pr review comments

--- a/.github/workflows/build_ckb_image.yml
+++ b/.github/workflows/build_ckb_image.yml
@@ -16,7 +16,7 @@ jobs:
       version: ${{ steps.validate.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Checkout specific tag
@@ -74,7 +74,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Checkout specific tag
@@ -105,7 +105,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Validate version (for output)

--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -31,10 +31,10 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-aarch64-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_aarch64_build_ubuntu.yaml
+++ b/.github/workflows/ci_aarch64_build_ubuntu.yaml
@@ -33,7 +33,7 @@ jobs:
           sudo docker image prune --all --force
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -64,7 +64,7 @@ jobs:
           export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
           cargo build --locked --target=aarch64-unknown-linux-gnu --features portable
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -27,10 +27,10 @@ jobs:
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android
           brew cleanup
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_benchmarks_macos-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -17,7 +18,6 @@ env:
 jobs:
   ci_benchmarks_macos:
     name: ci_benchmarks_macos
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_benchmarks_macos:
     name: ci_benchmarks_macos
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -29,7 +29,7 @@ jobs:
           brew cleanup
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -42,7 +42,7 @@ jobs:
         env:
           CKB_BENCH_FEATURES: ci,portable
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_benchmarks_macos.yaml
+++ b/.github/workflows/ci_benchmarks_macos.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -34,7 +34,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -45,7 +45,7 @@ jobs:
         run: make bench-test
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_benchmarks_ubuntu.yaml
+++ b/.github/workflows/ci_benchmarks_ubuntu.yaml
@@ -32,10 +32,10 @@ jobs:
           toolchain: 1.95.0
           components: rustfmt, clippy
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -29,7 +29,7 @@ jobs:
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -50,7 +50,7 @@ jobs:
         run: make bench-test
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           Get-PSDrive -PSProvider FileSystem | Format-Table

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_benchmarks_windows:
     name: ci_benchmarks_windows
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2022
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_benchmarks_windows.yaml
+++ b/.github/workflows/ci_benchmarks_windows.yaml
@@ -27,10 +27,10 @@ jobs:
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_cancel_desktop_on_ubuntu_failure.yaml
+++ b/.github/workflows/ci_cancel_desktop_on_ubuntu_failure.yaml
@@ -36,7 +36,7 @@ jobs:
       }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cancel running macOS/Windows CI for the same commit
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci_cancel_desktop_on_ubuntu_failure.yaml
+++ b/.github/workflows/ci_cancel_desktop_on_ubuntu_failure.yaml
@@ -1,0 +1,47 @@
+name: ci_cancel_desktop_on_ubuntu_failure
+
+on:
+  workflow_run:
+    workflows:
+      - ci_aarch64_build_ubuntu
+      - ci_benchmarks_ubuntu
+      - ci_cargo_deny_ubuntu
+      - ci_integration_tests_ubuntu
+      - ci_linters_ubuntu
+      - ci_quick_checks_ubuntu
+      - ci_unit_tests_ubuntu
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: Head SHA whose desktop CI runs should be cancelled
+        required: true
+      event_name:
+        description: Optional event name filter, for example pull_request or push
+        required: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel_desktop_ci:
+    name: Cancel desktop CI
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'failure' ||
+        github.event.workflow_run.conclusion == 'cancelled' ||
+        github.event.workflow_run.conclusion == 'timed_out'
+      }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cancel running macOS/Windows CI for the same commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          FAILED_WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+          FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
+          FAILED_EVENT_NAME: ${{ github.event.workflow_run.event || github.event.inputs.event_name }}
+        run: node devtools/ci/cancel-desktop-workflows.js

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -43,7 +43,10 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Run cargo deny checks
         run: |
-          cargo deny --version || cargo +stable install cargo-deny --locked
+          if ! command -v cargo-deny >/dev/null 2>&1; then
+            cargo +stable install cargo-deny --locked
+          fi
+          cargo deny --version
           if [[ "${{ github.event_name }}" == "push" && ( "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" || "${{ github.ref }}" == refs/heads/rc/* ) ]]; then
             make security-audit
           else

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -30,7 +30,7 @@ jobs:
           sudo docker image prune --all --force
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -52,7 +52,7 @@ jobs:
           make check-crates
           make check-licenses
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_cargo_deny_ubuntu.yaml
+++ b/.github/workflows/ci_cargo_deny_ubuntu.yaml
@@ -28,10 +28,10 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -166,7 +166,7 @@ jobs:
           RUST_BACKTRACE=1 RUST_LOG=info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug \
             ${{ github.workspace }}/target/release/ckb-test --bin ${{ github.workspace }}/target/release/ckb \
             --obfs4proxy-bin ${{ github.workspace }}/test/obfs4/obfs4proxy/obfs4proxy \
-            -c 1 --no-report --max-time 7200 $CHUNK_SPECS
+            --no-report --max-time 7200 $CHUNK_SPECS
         shell: bash
         env:
           CKB_FEATURES: deadlock_detection,with_sentry,portable

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_integration_tests_macos-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -19,7 +20,6 @@ env:
 jobs:
   build:
     name: Build and prepare test chunks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     outputs:
       test_chunks: ${{ steps.chunk_tests.outputs.test_chunks }}
@@ -121,7 +121,6 @@ jobs:
   test:
     name: Run tests (chunk ${{ matrix.chunk_index }})
     needs: build
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     strategy:
       fail-fast: false
@@ -179,7 +178,7 @@ jobs:
   ci_integration_tests_macos:
     name: ci_integration_tests_macos
     needs: test
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check test chunks result

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -179,7 +179,7 @@ jobs:
   ci_integration_tests_macos:
     name: ci_integration_tests_macos
     needs: test
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check test chunks result

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -27,6 +27,7 @@ jobs:
       chunk_indices: ${{ steps.chunk_tests.outputs.chunk_indices }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build and prepare test chunks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     outputs:
       test_chunks: ${{ steps.chunk_tests.outputs.test_chunks }}
       chunk_indices: ${{ steps.chunk_tests.outputs.chunk_indices }}
@@ -122,7 +122,7 @@ jobs:
     name: Run tests (chunk ${{ matrix.chunk_index }})
     needs: build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -34,7 +34,7 @@ jobs:
           brew cleanup
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -125,7 +125,7 @@ jobs:
     needs: build
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:

--- a/.github/workflows/ci_integration_tests_macos.yaml
+++ b/.github/workflows/ci_integration_tests_macos.yaml
@@ -32,10 +32,10 @@ jobs:
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android
           brew cleanup
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-it-${{ hashFiles('**/Cargo.lock') }}
@@ -102,19 +102,19 @@ jobs:
           echo "$test_chunks" | jq .
         shell: bash
       - name: Upload ckb binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/ckb
           retention-days: 1
       - name: Upload ckb-test binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/ckb-test
           retention-days: 1
       - name: Upload obfs4proxy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/obfs4proxy
@@ -129,21 +129,21 @@ jobs:
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Download ckb binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/
       - name: Download ckb-test binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/
       - name: Download obfs4proxy
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/
@@ -172,7 +172,7 @@ jobs:
           CKB_FEATURES: deadlock_detection,with_sentry,portable
       - name: upload log files
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ runner.os }}_integration_logs_chunk_${{ matrix.chunk_index }}
           path: ${{ runner.temp }}/ckb-integration-test

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.20"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-it-${{ hashFiles('**/Cargo.lock') }}
@@ -108,19 +108,19 @@ jobs:
           echo "$test_chunks" | jq .
         shell: bash
       - name: Upload ckb binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/ckb
           retention-days: 1
       - name: Upload ckb-test binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/ckb-test
           retention-days: 1
       - name: Upload obfs4proxy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/obfs4proxy
@@ -136,21 +136,21 @@ jobs:
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Download ckb binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/
       - name: Download ckb-test binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/
       - name: Download obfs4proxy
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/
@@ -177,7 +177,7 @@ jobs:
         shell: bash
       - name: upload log files
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ runner.os }}_integration_logs_chunk_${{ matrix.chunk_index }}
           path: ${{ runner.temp }}/ckb-integration-test
@@ -214,10 +214,10 @@ jobs:
           toolchain: 1.95.0
           components: rustfmt, clippy
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential procps wget
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -43,7 +43,7 @@ jobs:
           go-version: "1.20"
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -130,9 +130,9 @@ jobs:
     name: Run tests (chunk ${{ matrix.chunk_index }})
     needs: build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-16vcpu-ubuntu-2204' || 'ubuntu-22.04' }}
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-ubuntu-2204' || 'ubuntu-22.04' }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:
@@ -216,7 +216,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential procps wget
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target

--- a/.github/workflows/ci_integration_tests_ubuntu.yaml
+++ b/.github/workflows/ci_integration_tests_ubuntu.yaml
@@ -173,7 +173,7 @@ jobs:
           RUST_BACKTRACE=1 RUST_LOG=info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug \
             ${{ github.workspace }}/target/release/ckb-test --bin ${{ github.workspace }}/target/release/ckb \
             --obfs4proxy-bin ${{ github.workspace }}/test/obfs4/obfs4proxy/obfs4proxy \
-            -c 1 --no-report --max-time 7200 $CHUNK_SPECS
+            --no-report --max-time 7200 $CHUNK_SPECS
         shell: bash
       - name: upload log files
         if: failure()

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build and prepare test chunks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2022
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-16vcpu-windows-2025' || 'windows-2022' }}
     outputs:
       test_chunks: ${{ steps.chunk_tests.outputs.test_chunks }}
       chunk_indices: ${{ steps.chunk_tests.outputs.chunk_indices }}
@@ -132,7 +132,7 @@ jobs:
     name: Run tests (chunk ${{ matrix.chunk_index }})
     needs: build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2022
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_integration_tests_windows-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ["**"]
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -19,7 +20,6 @@ env:
 jobs:
   build:
     name: Build and prepare test chunks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-16vcpu-windows-2025' || 'windows-2022' }}
     outputs:
       test_chunks: ${{ steps.chunk_tests.outputs.test_chunks }}
@@ -131,7 +131,6 @@ jobs:
   test:
     name: Run tests (chunk ${{ matrix.chunk_index }})
     needs: build
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     strategy:
       fail-fast: false
@@ -181,7 +180,7 @@ jobs:
   ci_integration_tests_windows:
     name: ci_integration_tests_windows
     needs: test
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check test chunks result

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -32,10 +32,10 @@ jobs:
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-it-${{ hashFiles('**/Cargo.lock') }}
@@ -112,19 +112,19 @@ jobs:
           echo "$test_chunks" | jq .
         shell: bash
       - name: Upload ckb binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/ckb.exe
           retention-days: 1
       - name: Upload ckb-test binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/ckb-test.exe
           retention-days: 1
       - name: Upload obfs4proxy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/obfs4proxy
@@ -139,21 +139,21 @@ jobs:
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Download ckb binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-binary-${{ runner.os }}
           path: target/release/
       - name: Download ckb-test binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb-test-binary-${{ runner.os }}
           path: target/release/
       - name: Download obfs4proxy
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: obfs4proxy-${{ runner.os }}
           path: test/obfs4/obfs4proxy/
@@ -174,7 +174,7 @@ jobs:
         shell: bash
       - name: upload log files
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ runner.os }}_integration_logs_chunk_${{ matrix.chunk_index }}
           path: ${{ runner.temp }}/ckb-integration-test

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -170,7 +170,7 @@ jobs:
           RUST_BACKTRACE=1 RUST_LOG=info,ckb_test=debug,ckb_sync=debug,ckb_relay=debug,ckb_network=debug \
             ./target/release/ckb-test.exe --bin "$(pwd)/target/release/ckb.exe" \
             --obfs4proxy-bin "$(pwd)/test/obfs4/obfs4proxy/obfs4proxy" \
-            -c 1 --no-report --max-time 900 $CHUNK_SPECS
+            --no-report --max-time 900 $CHUNK_SPECS
         shell: bash
       - name: upload log files
         if: failure()

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -181,7 +181,7 @@ jobs:
   ci_integration_tests_windows:
     name: ci_integration_tests_windows
     needs: test
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check test chunks result

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -34,7 +34,7 @@ jobs:
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -135,7 +135,7 @@ jobs:
     needs: build
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         chunk_index: ${{ fromJson(needs.build.outputs.chunk_indices) }}
     steps:

--- a/.github/workflows/ci_integration_tests_windows.yaml
+++ b/.github/workflows/ci_integration_tests_windows.yaml
@@ -27,6 +27,7 @@ jobs:
       chunk_indices: ${{ steps.chunk_tests.outputs.chunk_indices }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -29,7 +29,7 @@ jobs:
           brew cleanup
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -46,7 +46,7 @@ jobs:
           git diff --exit-code Cargo.lock
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_linters_macos-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -17,7 +18,6 @@ env:
 jobs:
   ci_linters_macos:
     name: ci_linters_macos
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -27,10 +27,10 @@ jobs:
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android
           brew cleanup
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_linters_macos:
     name: ci_linters_macos
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_linters_macos.yaml
+++ b/.github/workflows/ci_linters_macos.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0
@@ -38,7 +38,7 @@ jobs:
           go-version: 1.20
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_linters_ubuntu.yaml
+++ b/.github/workflows/ci_linters_ubuntu.yaml
@@ -36,27 +36,23 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: 1.20
-      - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ci-${{ runner.os }}-cargo-
-      - run: cargo fmt --all -- --check
       - run: sudo apt-get update && sudo apt-get install libssl-dev pkg-config libclang-dev build-essential -y
       - name: Run linters
         run: |
-          cargo fmt --version || rustup component add rustfmt
-          cargo clippy --version || rustup component add clippy
           make fmt
           make clippy
           git diff --exit-code Cargo.lock
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -21,10 +21,10 @@ env:
 jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
-        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -34,7 +34,7 @@ jobs:
           toolchain: 1.95.0
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -58,7 +58,7 @@ jobs:
           devtools/ci/check-relaxed.sh
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -21,10 +21,10 @@ env:
 jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
-        if: github.repository_owner != 'nervosnetwork'
+        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -6,7 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -17,7 +20,6 @@ env:
 jobs:
   ci_quick_checks_macos:
     name: ci_quick_checks_macos
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -28,6 +28,9 @@ jobs:
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android
           brew cleanup
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.95.0
       - uses: actions/checkout@v4
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
@@ -37,6 +40,9 @@ jobs:
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ci-${{ runner.os }}-cargo-
+      - name: Run cargo check
+        run: cargo check --locked --workspace --all-targets --features deadlock_detection,with_sentry,portable
+        shell: bash
       - name: Run quick checks
         run: |
           brew unlink yq

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -10,6 +10,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_quick_checks_macos.yaml
+++ b/.github/workflows/ci_quick_checks_macos.yaml
@@ -32,10 +32,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.20'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_quick_checks_ubuntu.yaml
+++ b/.github/workflows/ci_quick_checks_ubuntu.yaml
@@ -37,7 +37,7 @@ jobs:
           go-version: '1.20'
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -61,7 +61,7 @@ jobs:
           devtools/ci/check-relaxed.sh
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-quick-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -1,8 +1,10 @@
-name: ci_benchmarks_windows
+name: ci_quick_checks_windows
 concurrency:
-  group: ci_benchmarks_windows-${{ github.event_name }}-${{ github.ref }}
+  group: ci_quick_checks_windows-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - develop
@@ -16,39 +18,55 @@ env:
   RUST_BACKTRACE: full
   RUSTFLAGS: -D warnings
 jobs:
-  ci_benchmarks_windows:
-    name: ci_benchmarks_windows
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
+  ci_quick_checks_windows:
+    name: ci_quick_checks_windows
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.95.0
+          components: rustfmt
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request'
         uses: actions/cache@v4
         with:
           path: target
-          key: ci-${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          key: ci-${{ runner.os }}-cargo-quick-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ci-${{ runner.os }}-cargo-bench-
-      - name: install required tools
+            ci-${{ runner.os }}-cargo-quick-
+      - name: Install required tools
         run: |
           iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
           .\install-scoop.ps1 -RunAsAdmin
           echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           scoop install git
-          scoop bucket add extras
-          scoop install llvm
-      - name: Run benchmark tests
-        run: make bench-test
+          scoop install jq
+          python -m pip install yq
+      - name: Run quick checks
+        run: |
+          echo tomlq path: $(which tomlq)
+          echo jq path: $(which jq)
+          tomlq --version
+          jq --version
+          cargo fmt --all -- --check
+          make check-cargo-metadata
+          make check-cargotoml
+          make check-whitespaces
+          devtools/ci/check-cyclic-dependencies.py
+          devtools/ci/check-relaxed.sh
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && github.event_name == 'pull_request'
         run: |
           echo "=== Disk Space Summary ==="
           Get-PSDrive -PSProvider FileSystem | Format-Table

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -21,10 +21,10 @@ env:
 jobs:
   ci_quick_checks_windows:
     name: ci_quick_checks_windows
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
-        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -21,10 +21,10 @@ env:
 jobs:
   ci_quick_checks_windows:
     name: ci_quick_checks_windows
-    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'blacksmith-4vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
-        if: github.repository_owner != 'nervosnetwork'
+        if: ${{ github.repository_owner != 'nervosnetwork' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue
@@ -51,6 +51,7 @@ jobs:
           .\install-scoop.ps1 -RunAsAdmin
           echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ github.workspace }}\devtools\windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           scoop install git
           scoop bucket add extras
           scoop install llvm

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -10,6 +10,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_quick_checks_windows.yaml
+++ b/.github/workflows/ci_quick_checks_windows.yaml
@@ -51,8 +51,13 @@ jobs:
           echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           scoop install git
+          scoop bucket add extras
+          scoop install llvm
           scoop install jq
           python -m pip install yq
+      - name: Run cargo check
+        run: cargo check --locked --workspace --all-targets --features deadlock_detection,with_sentry,portable
+        shell: bash
       - name: Run quick checks
         run: |
           echo tomlq path: $(which tomlq)

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_unit_tests_macos:
     name: ci_unit_tests_macos
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-15
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_unit_tests_macos-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -17,7 +18,6 @@ env:
 jobs:
   ci_unit_tests_macos:
     name: ci_unit_tests_macos
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -29,10 +29,10 @@ jobs:
           brew cleanup
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: taiki-e/install-action@nextest
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -44,7 +44,7 @@ jobs:
         env:
           CKB_FEATURES: deadlock_detection,with_sentry,portable
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_unit_tests_macos.yaml
+++ b/.github/workflows/ci_unit_tests_macos.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-6vcpu-macos-15' || 'macos-15' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           sudo rm -rf /Applications/Xcode_*.app
           sudo rm -rf /usr/local/lib/android

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -34,10 +34,10 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libclang-dev build-essential
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_unit_tests_ubuntu.yaml
+++ b/.github/workflows/ci_unit_tests_ubuntu.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: taiki-e/install-action@nextest
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -47,7 +47,7 @@ jobs:
         run: make test
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           df -h

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -18,7 +18,7 @@ jobs:
   ci_unit_tests_windows:
     name: ci_unit_tests_windows
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2022
+    runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space
+        if: github.repository_owner != 'nervosnetwork'
         run: |
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -27,10 +27,10 @@ jobs:
           Remove-Item -Path "C:\Program Files\dotnet" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "C:\Program Files (x86)\Android" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cargo target
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ci-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -29,7 +29,7 @@ jobs:
           Remove-Item -Path "$env:PROGRAMDATA\chocolatey" -Recurse -Force -ErrorAction SilentlyContinue
       - uses: actions/checkout@v4
       - name: Cache cargo target
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/'))
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/'))
         uses: actions/cache@v4
         with:
           path: target
@@ -52,7 +52,7 @@ jobs:
         run: make test
         shell: bash
       - name: Disk usage summary
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/')))
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/rc/') && !startsWith(github.ref, 'refs/heads/pkg/')))
         run: |
           echo "=== Disk Space Summary ==="
           Get-PSDrive -PSProvider FileSystem | Format-Table

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -8,6 +8,7 @@ on:
       - develop
       - master
       - "rc/**"
+      - "pkg/*"
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/ci_unit_tests_windows.yaml
+++ b/.github/workflows/ci_unit_tests_windows.yaml
@@ -3,10 +3,11 @@ concurrency:
   group: ci_unit_tests_windows-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - develop
+      - master
+      - "rc/**"
   merge_group: {}
   workflow_dispatch: {}
 
@@ -17,7 +18,6 @@ env:
 jobs:
   ci_unit_tests_windows:
     name: ci_unit_tests_windows
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ github.repository_owner == 'nervosnetwork' && 'blacksmith-8vcpu-windows-2025' || 'windows-2022' }}
     steps:
       - name: Free up disk space

--- a/.github/workflows/ckb-integration-test.yml
+++ b/.github/workflows/ckb-integration-test.yml
@@ -18,7 +18,7 @@ jobs:
     # * Target workflow file must locate at `.github/workflows`, so putting a
     # reusable workflow in `.github/actions/` is invalid.
     #
-    # * `actions/checkout@v3` inside reusable workflow check-out the current
+    # * `actions/checkout` inside reusable workflow check-out the current
     # repository but not the reusable workflow belong in.
     if: ${{ github.repository_owner == 'nervosnetwork' }}
     uses: nervosnetwork/ckb-integration-test/.github/workflows/ckb-integration-test.yml@main

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -13,7 +13,7 @@ jobs:
     if: |
         github.repository_owner == 'nervosnetwork'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0
@@ -35,7 +35,7 @@ jobs:
           files: ${{github.workspace}}/lcov-integration-test.info
           flags: integration
           override_commit: ${{github.sha}}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage_report
           path: ${{github.workspace}}/*.info

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,7 +1,7 @@
 name: Package
 
 permissions:
-  # for actions/create-release, actions/upload-release-asset
+  # for gh release create/upload
   contents: write
 
 concurrency:
@@ -33,24 +33,16 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-22.04
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set tag
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
           echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
       - name: Create release
-        id: create-release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.GIT_TAG_NAME}}
-          release_name: ${{ env.GIT_TAG_NAME}}
-          draft: true
-          prerelease: true
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GIT_TAG_NAME}" --title "${GIT_TAG_NAME}" --draft --prerelease
 
   package-for-linux:
     name: package-for-linux
@@ -65,7 +57,7 @@ jobs:
           - rel_pkg: "x86_64-unknown-linux-gnu-portable.tar.gz"
             build_target: "prod_portable"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Env
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
@@ -83,12 +75,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
       - name: upload-zip-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-asc-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -103,7 +95,7 @@ jobs:
     needs:
       - get-ckb-cli-version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Env
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
@@ -127,12 +119,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
       - name: upload-zip-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-asc-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -153,7 +145,7 @@ jobs:
           - rel_pkg: "x86_64-unknown-centos-gnu-portable.tar.gz"
             build_target: "prod_portable"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Env
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
@@ -171,12 +163,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
       - name: upload-zip-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-asc-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -198,7 +190,7 @@ jobs:
           - rel_pkg: "x86_64-apple-darwin-portable.zip"
             build_target: "prod_portable"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Env
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
@@ -218,12 +210,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
       - name: upload-zip-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-asc-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -249,7 +241,7 @@ jobs:
           echo /opt/homebrew/bin >> $GITHUB_PATH
           echo /opt/homebrew/sbin >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Env
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
@@ -277,12 +269,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }} ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc ${{ github.workspace }}
       - name: upload-zip-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-asc-file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -306,7 +298,7 @@ jobs:
           echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "LIBCLANG_PATH=$env:USERPROFILE\scoop\apps\llvm\current\bin" >> $env:GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           devtools/windows/make prod
@@ -340,12 +332,12 @@ jobs:
           mv ${{ github.workspace }}/releases/ckb_$($env:GIT_TAG_NAME)_$($env:REL_PKG) ${{ github.workspace }}
           mv ${{ github.workspace }}/releases/ckb_$($env:GIT_TAG_NAME)_$($env:REL_PKG).asc ${{ github.workspace }}
       - name: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}
       - name: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
           path: ckb_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
@@ -378,34 +370,24 @@ jobs:
       - package-for-windows
       - package-for-centos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set tag
         run: |
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
           echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
       - name: Prepare - Download tar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}
       - name: Prepare - Download asc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}.asc
       - name: Upload tar assets
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}
-          asset_path: ${{ github.workspace }}/ckb_${{env.GIT_TAG_NAME }}_${{ matrix.REL_PKG }}
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GIT_TAG_NAME}" "${{ github.workspace }}/ckb_${GIT_TAG_NAME}_${{ matrix.REL_PKG }}"
       - name: Upload asc assets
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}.asc
-          asset_path: ${{ github.workspace }}/ckb_${{env.GIT_TAG_NAME }}_${{ matrix.REL_PKG }}.asc
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GIT_TAG_NAME}" "${{ github.workspace }}/ckb_${GIT_TAG_NAME}_${{ matrix.REL_PKG }}.asc"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,7 +1,7 @@
 name: Package
 
 permissions:
-  # for gh release create/upload
+  # for actions/create-release, actions/upload-release-asset
   contents: write
 
 concurrency:
@@ -33,6 +33,8 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-22.04
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v6
       - name: Set tag
@@ -40,9 +42,15 @@ jobs:
           export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
           echo "GIT_TAG_NAME=$GIT_TAG_NAME" >> $GITHUB_ENV
       - name: Create release
+        id: create-release
+        uses: actions/create-release@v1
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GIT_TAG_NAME}" --title "${GIT_TAG_NAME}" --draft --prerelease
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.GIT_TAG_NAME}}
+          release_name: ${{ env.GIT_TAG_NAME}}
+          draft: true
+          prerelease: true
 
   package-for-linux:
     name: package-for-linux
@@ -384,10 +392,20 @@ jobs:
         with:
           name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}.asc
       - name: Upload tar assets
+        uses: actions/upload-release-asset@v1
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GIT_TAG_NAME}" "${{ github.workspace }}/ckb_${GIT_TAG_NAME}_${{ matrix.REL_PKG }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}
+          asset_path: ${{ github.workspace }}/ckb_${{env.GIT_TAG_NAME }}_${{ matrix.REL_PKG }}
+          asset_content_type: application/octet-stream
       - name: Upload asc assets
+        uses: actions/upload-release-asset@v1
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GIT_TAG_NAME}" "${{ github.workspace }}/ckb_${GIT_TAG_NAME}_${{ matrix.REL_PKG }}.asc"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_name: ckb_${{env.GIT_TAG_NAME}}_${{ matrix.REL_PKG }}.asc
+          asset_path: ${{ github.workspace }}/ckb_${{env.GIT_TAG_NAME }}_${{ matrix.REL_PKG }}.asc
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,7 +37,7 @@ jobs:
           components: rustfmt
       - &generate-token
         name: Generate GitHub token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}

--- a/.github/workflows/scheduled_audit.yaml
+++ b/.github/workflows/scheduled_audit.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}

--- a/devtools/ci/cancel-desktop-workflows.js
+++ b/devtools/ci/cancel-desktop-workflows.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const DESKTOP_WORKFLOWS = new Set([
+  'ci_benchmarks_macos',
+  'ci_benchmarks_windows',
+  'ci_integration_tests_macos',
+  'ci_integration_tests_windows',
+  'ci_linters_macos',
+  'ci_quick_checks_macos',
+  'ci_quick_checks_windows',
+  'ci_unit_tests_macos',
+  'ci_unit_tests_windows',
+]);
+
+const RUN_STATUSES = ['queued', 'in_progress', 'waiting', 'requested', 'pending'];
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function githubRequest(url, options = {}) {
+  const token = requiredEnv('GITHUB_TOKEN');
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'x-github-api-version': '2022-11-28',
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    const error = new Error(`${options.method || 'GET'} ${url} failed: ${response.status} ${body}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  const body = await response.text();
+  if (!body) {
+    return null;
+  }
+  return JSON.parse(body);
+}
+
+async function listWorkflowRuns({ apiBase, owner, repo, headSha, eventName, status }) {
+  const runs = [];
+  for (let page = 1; ; page += 1) {
+    const params = new URLSearchParams({
+      head_sha: headSha,
+      status,
+      per_page: '100',
+      page: String(page),
+    });
+    if (eventName) {
+      params.set('event', eventName);
+    }
+
+    const data = await githubRequest(`${apiBase}/repos/${owner}/${repo}/actions/runs?${params}`);
+    runs.push(...data.workflow_runs);
+    if (data.workflow_runs.length < 100) {
+      return runs;
+    }
+  }
+}
+
+async function main() {
+  const repository = requiredEnv('GITHUB_REPOSITORY');
+  const [owner, repo] = repository.split('/');
+  const headSha = requiredEnv('FAILED_HEAD_SHA');
+  const eventName = process.env.FAILED_EVENT_NAME || '';
+  const failedWorkflowName = process.env.FAILED_WORKFLOW_NAME || 'manual dispatch';
+  const failedRunId = process.env.FAILED_RUN_ID || '';
+  const currentRunId = process.env.GITHUB_RUN_ID || '';
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+  const runsById = new Map();
+  for (const status of RUN_STATUSES) {
+    const runs = await listWorkflowRuns({ apiBase, owner, repo, headSha, eventName, status });
+    for (const run of runs) {
+      if (String(run.id) === failedRunId || String(run.id) === currentRunId) {
+        continue;
+      }
+      if (!DESKTOP_WORKFLOWS.has(run.name)) {
+        continue;
+      }
+      runsById.set(run.id, run);
+    }
+  }
+
+  if (runsById.size === 0) {
+    console.log(`No running desktop CI workflows found for ${headSha}.`);
+    return;
+  }
+
+  console.log(`Cancelling desktop CI after ${failedWorkflowName} failed for ${headSha}.`);
+  for (const run of runsById.values()) {
+    try {
+      console.log(`Cancelling ${run.name} #${run.run_number}: ${run.html_url}`);
+      await githubRequest(`${apiBase}/repos/${owner}/${repo}/actions/runs/${run.id}/cancel`, {
+        method: 'POST',
+      });
+    } catch (error) {
+      if (error.status === 404 || error.status === 409) {
+        console.warn(`Could not cancel ${run.name} #${run.run_number}: ${error.message}`);
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/devtools/ci/cancel-desktop-workflows.js
+++ b/devtools/ci/cancel-desktop-workflows.js
@@ -12,7 +12,7 @@ const DESKTOP_WORKFLOWS = new Set([
   'ci_unit_tests_windows',
 ]);
 
-const RUN_STATUSES = ['queued', 'in_progress', 'waiting', 'requested', 'pending'];
+const RUN_STATUSES = ['queued', 'in_progress', 'waiting'];
 
 function requiredEnv(name) {
   const value = process.env[name];

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -43,7 +43,7 @@ Ubuntu jobs are configured as **required status checks** in the repository setti
 macOS and Windows jobs are split into quick PR checks and full protected-branch checks:
 
 - ✅ PRs run quick macOS/Windows checks, including `cargo check`, for early cross-platform signal
-- ✅ Fork PR quick macOS/Windows checks use GitHub-hosted fallback runners instead of Blacksmith runners
+- ✅ Trusted fork PR quick macOS/Windows checks use Blacksmith runners; external fork PRs use GitHub-hosted fallback runners
 - ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, `pkg/*`, and manual dispatch
 - ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
 - ✅ If a Ubuntu CI workflow fails, is cancelled, or times out, `ci_cancel_desktop_on_ubuntu_failure` cancels queued or running macOS/Windows CI for the same commit

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -42,7 +42,7 @@ Ubuntu jobs are configured as **required status checks** in the repository setti
 
 macOS and Windows jobs are split into quick PR checks and full protected-branch checks:
 
-- ✅ PRs run quick macOS/Windows checks for early cross-platform signal
+- ✅ PRs run quick macOS/Windows checks, including `cargo check`, for early cross-platform signal
 - ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, `pkg/*`, and manual dispatch
 - ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
 - ✅ If a Ubuntu CI workflow fails, is cancelled, or times out, `ci_cancel_desktop_on_ubuntu_failure` cancels queued or running macOS/Windows CI for the same commit

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -6,7 +6,9 @@ This document explains how the CKB CI (Continuous Integration) workflow operates
 
 The CI workflow runs tests and checks across multiple operating systems (Ubuntu, macOS, Windows) for various job types (quick checks, unit tests, integration tests, benchmarks, linters, etc.). The workflow is designed to:
 
-- Run all tests automatically on PRs and protected branches
+- Run all Ubuntu jobs automatically on PRs and protected branches
+- Run only quick macOS/Windows checks on PRs
+- Run full macOS/Windows jobs on merge queue, protected branches, and manual dispatch
 - Make Ubuntu jobs required for PR merges while other OS jobs are optional (but still block if they fail)
 - Prevent duplicate workflow runs on both PR events and push events
 - Support manual workflow triggering for testing purposes
@@ -18,7 +20,7 @@ All CI workflows support manual triggering via `workflow_dispatch` and can run o
 1. Go to the Actions tab in GitHub
 2. Select the workflow you want to run
 3. Click "Run workflow"
-4. Choose any branch to run on (not limited to master, develop, or rc/*)
+4. Choose any branch to run on (not limited to master, develop, or rc/**)
 
 This is useful for testing workflow changes on dedicated branches without creating a PR. To test changes:
 
@@ -36,21 +38,20 @@ Ubuntu jobs are configured as **required status checks** in the repository setti
 - ✅ Ubuntu jobs block PR merges immediately if they fail
 - ✅ These are the "essential path" - the minimum validation required
 
-### Other OS Jobs: Optional but Blocking
+### macOS/Windows Jobs: Layered Desktop Path
 
-macOS and Windows jobs are **not** configured as required status checks, which means:
+macOS and Windows jobs are split into quick PR checks and full protected-branch checks:
 
-- ✅ PRs **can be merged** even if macOS/Windows jobs are still running
-- ⚠️ However, if macOS/Windows jobs **finish and fail**, the PR **cannot be merged**
-- ✅ This allows faster iteration - you don't have to wait for slower macOS/Windows runners
-- ⚠️ But ensures cross-platform compatibility - failures still block merges
+- ✅ PRs run quick macOS/Windows checks for early cross-platform signal
+- ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, and manual dispatch
+- ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
 
 ### Why This Design?
 
-1. **Speed**: Ubuntu runners are typically faster and more available, allowing quicker feedback
-2. **Flexibility**: Developers can merge PRs without waiting for all OS tests if Ubuntu passes
-3. **Safety**: Cross-platform failures still prevent merges, ensuring compatibility
-4. **Resource Efficiency**: macOS and Windows runners may be slower or have limited capacity
+1. **Speed**: Ubuntu runners provide full PR feedback quickly
+2. **Cost control**: PRs avoid running the most expensive full macOS/Windows jobs by default
+3. **Safety**: merge queue and protected branches still run full desktop validation
+4. **Flexibility**: maintainers can manually dispatch full desktop workflows when needed
 
 ## Avoiding Duplicate Runs
 
@@ -75,39 +76,39 @@ concurrency:
 Workflows trigger on:
 
 - `pull_request`: `opened`, `synchronize`, `reopened`
-- `push`: On all branches (master, develop, rc/*, and any other branch)
+- `push`: Ubuntu workflows run on all branches; desktop workflows run on `develop`, `master`, and `rc/**`
 - `merge_group`: For merge queue
 - `workflow_dispatch`: For manual triggering
 
 This means:
 
 - PR events always run
-- Push events run on any branch
+- Ubuntu push events run on any branch
+- Desktop push events run only on protected branches
 - Manual dispatch always runs
 
 ### 3. Workflow Execution Flow
 
 When a PR is opened/updated:
 
-1. Workflow runs triggered by `pull_request` event
-2. Concurrency group ensures only one run per workflow
+1. Ubuntu workflows run the full CI set
+2. macOS and Windows quick-check workflows run
+3. Full macOS/Windows workflows wait for `merge_group`, protected-branch pushes, or manual dispatch
 
 When a PR is merged (push to `develop`):
 
 1. The merge commit triggers `push` event
-2. Concurrency group matches the PR's reference, canceling any remaining PR runs
-3. New push-based run executes
-
-This prevents the same commit from running tests twice - once as a PR and once as a push.
+2. Ubuntu workflows run again on the protected branch
+3. Full macOS/Windows workflows run on the protected branch
 
 ## Workflow Files
 
 CI workflows are organized by job type and OS:
 
-- `ci_quick_checks_ubuntu.yaml` / `ci_quick_checks_macos.yaml`
-- `ci_unit_tests_ubuntu.yaml` / `ci_unit_tests_macos.yaml`
+- `ci_quick_checks_ubuntu.yaml` / `ci_quick_checks_macos.yaml` / `ci_quick_checks_windows.yaml`
+- `ci_unit_tests_ubuntu.yaml` / `ci_unit_tests_macos.yaml` / `ci_unit_tests_windows.yaml`
 - `ci_integration_tests_ubuntu.yaml` / `ci_integration_tests_macos.yaml` / `ci_integration_tests_windows.yaml`
-- `ci_benchmarks_ubuntu.yaml` / `ci_benchmarks_macos.yaml`
+- `ci_benchmarks_ubuntu.yaml` / `ci_benchmarks_macos.yaml` / `ci_benchmarks_windows.yaml`
 - `ci_linters_ubuntu.yaml` / `ci_linters_macos.yaml`
 - `ci_cargo_deny_ubuntu.yaml`
 - `ci_aarch64_build_ubuntu.yaml`

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -43,7 +43,7 @@ Ubuntu jobs are configured as **required status checks** in the repository setti
 macOS and Windows jobs are split into quick PR checks and full protected-branch checks:
 
 - ✅ PRs run quick macOS/Windows checks for early cross-platform signal
-- ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, and manual dispatch
+- ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, `pkg/*`, and manual dispatch
 - ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
 
 ### Why This Design?
@@ -76,7 +76,7 @@ concurrency:
 Workflows trigger on:
 
 - `pull_request`: `opened`, `synchronize`, `reopened`
-- `push`: Ubuntu workflows run on all branches; desktop workflows run on `develop`, `master`, and `rc/**`
+- `push`: Ubuntu workflows run on all branches; desktop workflows run on `develop`, `master`, `rc/**`, and `pkg/*`
 - `merge_group`: For merge queue
 - `workflow_dispatch`: For manual triggering
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -43,6 +43,7 @@ Ubuntu jobs are configured as **required status checks** in the repository setti
 macOS and Windows jobs are split into quick PR checks and full protected-branch checks:
 
 - ✅ PRs run quick macOS/Windows checks, including `cargo check`, for early cross-platform signal
+- ✅ Fork PR quick macOS/Windows checks use GitHub-hosted fallback runners instead of Blacksmith runners
 - ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, `pkg/*`, and manual dispatch
 - ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
 - ✅ If a Ubuntu CI workflow fails, is cancelled, or times out, `ci_cancel_desktop_on_ubuntu_failure` cancels queued or running macOS/Windows CI for the same commit

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -45,6 +45,7 @@ macOS and Windows jobs are split into quick PR checks and full protected-branch 
 - ✅ PRs run quick macOS/Windows checks for early cross-platform signal
 - ✅ Full macOS/Windows jobs run in `merge_group`, `develop`, `master`, `rc/**`, `pkg/*`, and manual dispatch
 - ✅ This keeps regular PR feedback cheaper while preserving full desktop validation before or after protected-branch changes
+- ✅ If a Ubuntu CI workflow fails, is cancelled, or times out, `ci_cancel_desktop_on_ubuntu_failure` cancels queued or running macOS/Windows CI for the same commit
 
 ### Why This Design?
 

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -279,6 +279,39 @@ impl RpcTestSuite {
         self.wait_block_template_array_ge("proposals", 1)
     }
 
+    fn wait_sync_state_unverified_tip(&self) {
+        use ckb_jsonrpc_types::Uint64;
+        use std::{
+            thread::sleep,
+            time::{Duration, Instant},
+        };
+
+        let started = Instant::now();
+        loop {
+            let response = self.rpc(&RpcTestRequest {
+                id: 42,
+                jsonrpc: "2.0".to_string(),
+                method: "sync_state".to_string(),
+                params: vec![],
+            });
+            let tip_number: Uint64 =
+                serde_json::from_value(response.result["tip_number"].clone()).unwrap();
+            let unverified_tip_number: Uint64 =
+                serde_json::from_value(response.result["unverified_tip_number"].clone()).unwrap();
+
+            if unverified_tip_number.value() >= tip_number.value() {
+                break;
+            }
+
+            assert!(
+                started.elapsed() < Duration::from_secs(10),
+                "sync_state unverified tip did not reach tip: {}",
+                response.json(),
+            );
+            sleep(Duration::from_millis(100));
+        }
+    }
+
     fn run_example(&self, example: &RpcTestExample) {
         let mut actual = self.rpc(&example.request);
         mock_rpc_response(example, &mut actual);
@@ -401,6 +434,7 @@ fn before_rpc_example(suite: &RpcTestSuite, example: &mut RpcTestExample) -> boo
         ("notify_transaction", 42) => return false,
         ("truncate", 42) => return false,
         ("get_block_template", 42) => suite.wait_block_template_update(),
+        ("sync_state", 42) => suite.wait_sync_state_unverified_tip(),
         _ => return true,
     }
 

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -22,21 +22,31 @@ impl Spec for TransactionRelayBasic {
     fn run(&self, nodes: &mut Vec<Node>) {
         out_ibd_mode(nodes);
         connect_all(nodes);
+        waiting_for_sync(nodes);
 
         let node1 = &nodes[1];
         let cells = gen_spendable(node1, 1);
         let transaction = always_success_transaction(node1, &cells[0]);
         let hash = node1.submit_transaction(&transaction);
 
-        let relayed = wait_until(10, || {
+        let relayed = wait_until(60, || {
             nodes.iter().all(|node| {
                 node.rpc_client().get_transaction(hash.clone()).cycles == Some(537.into())
             })
         });
-        assert!(
-            relayed,
-            "Transaction should be relayed from node0 to others"
-        );
+        if !relayed {
+            let tx_states = nodes
+                .iter()
+                .enumerate()
+                .map(|(index, node)| {
+                    let response = node.rpc_client().get_transaction(hash.clone());
+                    (index, response.tx_status.status, response.cycles)
+                })
+                .collect::<Vec<_>>();
+            panic!(
+                "Transaction should be relayed from node1 to all nodes, tx: {hash:?}, node states: {tx_states:?}"
+            );
+        }
     }
 }
 

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -25,6 +25,9 @@ impl Spec for TransactionRelayBasic {
         waiting_for_sync(nodes);
 
         let node1 = &nodes[1];
+        wait_relay_protocol_connected(node1, &nodes[0]);
+        wait_relay_protocol_connected(node1, &nodes[2]);
+
         let cells = gen_spendable(node1, 1);
         let transaction = always_success_transaction(node1, &cells[0]);
         let hash = node1.submit_transaction(&transaction);
@@ -48,6 +51,41 @@ impl Spec for TransactionRelayBasic {
             );
         }
     }
+}
+
+fn wait_relay_protocol_connected(node: &Node, peer: &Node) {
+    let connected = wait_until(10, || relay_protocol_connected(node, peer));
+    if !connected {
+        let peers = node
+            .rpc_client()
+            .get_peers()
+            .into_iter()
+            .map(|remote_node| {
+                let protocol_ids = remote_node
+                    .protocols
+                    .into_iter()
+                    .map(|protocol| protocol.id.value())
+                    .collect::<Vec<_>>();
+                (remote_node.node_id, protocol_ids)
+            })
+            .collect::<Vec<_>>();
+        panic!(
+            "RelayV3 protocol should be active from node {} to peer {}, peers: {peers:?}",
+            node.node_id(),
+            peer.node_id(),
+        );
+    }
+}
+
+fn relay_protocol_connected(node: &Node, peer: &Node) -> bool {
+    let relay_protocol_id = SupportProtocols::RelayV3.protocol_id().value() as u64;
+    node.rpc_client().get_peers().iter().any(|remote_node| {
+        remote_node.node_id == peer.node_id()
+            && remote_node
+                .protocols
+                .iter()
+                .any(|protocol| protocol.id.value() == relay_protocol_id)
+    })
 }
 
 pub struct TransactionRelayMultiple;

--- a/test/src/specs/relay/transaction_relay.rs
+++ b/test/src/specs/relay/transaction_relay.rs
@@ -25,10 +25,10 @@ impl Spec for TransactionRelayBasic {
         waiting_for_sync(nodes);
 
         let node1 = &nodes[1];
-        wait_relay_protocol_connected(node1, &nodes[0]);
-        wait_relay_protocol_connected(node1, &nodes[2]);
-
         let cells = gen_spendable(node1, 1);
+        waiting_for_sync(nodes);
+        wait_relay_protocols_connected(nodes);
+
         let transaction = always_success_transaction(node1, &cells[0]);
         let hash = node1.submit_transaction(&transaction);
 
@@ -49,6 +49,16 @@ impl Spec for TransactionRelayBasic {
             panic!(
                 "Transaction should be relayed from node1 to all nodes, tx: {hash:?}, node states: {tx_states:?}"
             );
+        }
+    }
+}
+
+fn wait_relay_protocols_connected(nodes: &[Node]) {
+    for (node_index, node) in nodes.iter().enumerate() {
+        for (peer_index, peer) in nodes.iter().enumerate() {
+            if node_index != peer_index {
+                wait_relay_protocol_connected(node, peer);
+            }
         }
     }
 }
@@ -98,6 +108,9 @@ impl Spec for TransactionRelayMultiple {
 
         let node0 = &nodes[0];
         let cells = gen_spendable(node0, 10);
+        waiting_for_sync(nodes);
+        wait_relay_protocols_connected(nodes);
+
         let transactions = always_success_transactions(node0, &cells);
         transactions.iter().for_each(|tx| {
             node0.submit_transaction(tx);


### PR DESCRIPTION
Experiment with Blacksmith runners for desktop CI.

This PR moves macOS and Windows CI jobs to Blacksmith runners for the main repository, while keeping GitHub-hosted runner fallbacks for forks.

To control cost, PRs only run quick macOS/Windows checks. Full macOS/Windows unit, integration, benchmark, and linter jobs are limited to `develop`, `master`, `rc/**`, `merge_group`, and manual dispatch. Ubuntu CI remains the full PR validation path.

Changes:
- use Blacksmith runners for macOS and Windows CI jobs
- add `ci_quick_checks_windows`
- keep full desktop CI off regular PR runs
- update CI workflow documentation

This keeps package/release workflows unchanged and preserves GitHub-hosted fallbacks for forks.
