### PR TITLE
chore(deps): update crossbeam-epoch for RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- Update `crossbeam-epoch` from `0.9.18` to `0.9.20` in `Cargo.lock`.
- Clear `RUSTSEC-2026-0204`, which currently causes the develop branch security audit to fail when `make security-audit` runs.

## Root Cause

`ci_cargo_deny_ubuntu` runs `make security-audit` on protected branches. The latest RustSec advisory database flags `crossbeam-epoch 0.9.18` as vulnerable and recommends upgrading to `>=0.9.20`.

## Validation

- `git diff --check`
- `make security-audit`
- `make check-crates`
- `make check-licenses`
- `cargo check -p ckb --bin ckb`