### PR TITLE
Upgrade tentacle dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6876,9 +6876,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f236fb0e0985299c3667a1f1d3daefa159d09ffbb01fcb8a7fda4bd3a74f8a7c"
+checksum = "8ab80c50726dc639daf326406efc983c578e65d06efa84f6d11385abc6dc27be"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6910,9 +6910,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-multiaddr"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d2d1d3511bbe6d6a662ee13616a31268d0558c73d25dfe6b5a5dcb376719c7"
+checksum = "b7b06b419ae75898680ae449d5db5bf9dfedb531c49cdb6f24d42054508a2df3"
 dependencies = [
  "arrayref",
  "bs58",
@@ -6926,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0bfdc28264bd49c81ea0d027a9fa3f39b50960cd2b9c7e1748cfdb72d2265e"
+checksum = "410f26213e6f4bf189f661db9c92241f77b84f6eabebe4bf35283d841cbb67ae"
 dependencies = [
  "bs58",
  "bytes",
@@ -7252,15 +7252,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489207fc5dedea9723f5dc1c3ab96103c001449fa6056ca6cdba74ffbd84512"
+checksum = "52ec7b39569c9fc5dada5c87ca70e364bae3ca191b6f72a444842b114a656bd5"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "log",
- "nohash-hasher",
  "tokio",
  "tokio-util",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,10 +263,10 @@ merkle-cbt = "0.3"
 minstant = "0.1.4"
 molecule = { version = "0.9.0", default-features = false }
 multi_index_map = "0.15.0"
-multiaddr = { version = "0.3.6", package = "tentacle-multiaddr" }
+multiaddr = { version = "0.3.7", package = "tentacle-multiaddr" }
 num_cpus = "1.16.0"
 numext-fixed-uint = "0.1"
-p2p = { version = "0.7.1", package = "tentacle", default-features = false }
+p2p = { version = "0.7.6", package = "tentacle", default-features = false }
 parking_lot = "0.12"
 paste = "1.0"
 path-clean = "0.1.0"
@@ -284,7 +284,7 @@ reqwest = { version = "0.12", features = ["blocking", "json"] }
 rhai = "1.16.0"
 rocksdb = { version = "=0.21.1", package = "ckb-rocksdb", default-features = false }
 rustc-hash = "1.1"
-secio = { version = "0.6.6", package = "tentacle-secio" }
+secio = { version = "0.6.8", package = "tentacle-secio" }
 secp256k1 = "0.30"
 semver = "1.0"
 sentry = "0.34.0"

--- a/network/src/protocols/hole_punching/component/connection_request.rs
+++ b/network/src/protocols/hole_punching/component/connection_request.rs
@@ -210,7 +210,8 @@ impl<'a> ConnectionRequestProcess<'a> {
                 | TransportType::Onion
                 | TransportType::Ws
                 | TransportType::Wss
-                | TransportType::Tls => None,
+                | TransportType::Tls
+                | TransportType::QuicV1 => None,
                 TransportType::Tcp => {
                     if addr
                         .iter()

--- a/network/src/protocols/hole_punching/component/connection_request_delivered.rs
+++ b/network/src/protocols/hole_punching/component/connection_request_delivered.rs
@@ -250,7 +250,8 @@ impl<'a> ConnectionRequestDeliveredProcess<'a> {
                 | TransportType::Onion
                 | TransportType::Ws
                 | TransportType::Wss
-                | TransportType::Tls => None,
+                | TransportType::Tls
+                | TransportType::QuicV1 => None,
             })
             .collect::<Vec<_>>();
 

--- a/rpc/src/tests/examples.rs
+++ b/rpc/src/tests/examples.rs
@@ -287,6 +287,7 @@ impl RpcTestSuite {
         };
 
         let started = Instant::now();
+        let timeout = Duration::from_secs(60);
         loop {
             let response = self.rpc(&RpcTestRequest {
                 id: 42,
@@ -304,8 +305,9 @@ impl RpcTestSuite {
             }
 
             assert!(
-                started.elapsed() < Duration::from_secs(10),
-                "sync_state unverified tip did not reach tip: {}",
+                started.elapsed() < timeout,
+                "sync_state unverified tip did not reach tip within {:?}: {}",
+                timeout,
                 response.json(),
             );
             sleep(Duration::from_millis(100));


### PR DESCRIPTION
## Summary

- upgrade `tentacle` to `0.7.6`
- upgrade `tentacle-multiaddr` to `0.3.7`
- upgrade `tentacle-secio` to `0.6.8`
- refresh `Cargo.lock`, including transitive `tokio-yamux` `0.3.19`
- handle the new `TransportType::QuicV1` variant in TCP-only hole-punching filters

This follows nervosnetwork/tentacle#466.

## Validation

- `cargo update -p tentacle --precise 0.7.6`
- `cargo check -p ckb-network -p ckb-app-config --all-targets`
- `cargo fmt --all -- --check`