### PR TITLE
refactor(sync): simplify header sync ETA log

### DIFF
--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -154,7 +154,7 @@ impl BlockFetchCMD {
                     info!(
                         "best known header {}-{}, \
                                  CKB is syncing to latest Header to find the assume valid target: {}. \
-                                 Please wait. {}",
+                                 {}",
                         number,
                         best_known.hash(),
                         assume_valid_target,
@@ -170,18 +170,13 @@ impl BlockFetchCMD {
             Some(remaining) => {
                 let secs = remaining.as_secs();
                 match secs {
-                    0 => "Almost synced.".to_string(),
-                    1..=59 => format!("Need {} seconds to sync to the latest Header.", secs),
-                    60..=3599 => {
-                        format!("Need {} minutes to sync to the latest Header.", secs / 60)
-                    }
+                    0 => "ETA: almost synced.".to_string(),
+                    1..=59 => format!("ETA: {} seconds.", secs),
+                    60..=3599 => format!("ETA: {} minutes.", secs / 60),
                     _ => {
                         let hours = secs / 3600;
                         let minutes = (secs % 3600) / 60;
-                        format!(
-                            "Need {} hours {} minutes to sync to the latest Header.",
-                            hours, minutes
-                        )
+                        format!("ETA: {} hours {} minutes.", hours, minutes)
                     }
                 }
             }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The assume-valid header sync progress log repeats a verbose wait message on every update.

### What is changed and how it works?

Whats Changed:

- Remove `Please wait.` from the progress log.
- Replace the verbose remaining-time sentence with concise `ETA` output for seconds, minutes, and hours.

Example:

- Before: `Please wait. Need 114 minutes to sync to the latest Header.`
- After: `ETA: 114 minutes.`

### Check List

Tests

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Manually reviewed the generated ETA strings for all duration branches

`cargo check -p ckb-sync` was attempted but is currently blocked by an unrelated `ckb-librocksdb-sys` C++ compilation error in the local environment.