### PR TITLE
clippy: enable needless_lifetimes and extra_unused_lifetimes lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MOLC    := moleculec
 MOLC_VERSION := 0.9.2
 VERBOSE := $(if ${CI},--verbose,)
 CLIPPY_OPTS := -D warnings -D clippy::clone_on_ref_ptr -D clippy::redundant_clone -D clippy::enum_glob_use -D clippy::fallible_impl_from \
-	-A clippy::mutable_key_type -A clippy::upper_case_acronyms -A clippy::needless_return -A clippy::needless_lifetimes -A clippy::extra_unused_lifetimes
+	-A clippy::mutable_key_type -A clippy::upper_case_acronyms -A clippy::needless_return
 CKB_TEST_ARGS := -c 4 ${CKB_TEST_ARGS}
 CKB_FEATURES ?= deadlock_detection,with_sentry
 ALL_FEATURES := deadlock_detection,with_sentry,with_dns_seeding,profiling,march-native

--- a/tx-pool/src/process.rs
+++ b/tx-pool/src/process.rs
@@ -867,7 +867,7 @@ impl TxPoolService {
         queue.add_tx(tx, is_proposal_tx, remote)
     }
 
-    async fn remove_orphan_txs_by_attach<'a>(&self, txs: &LinkedHashSet<TransactionView>) {
+    async fn remove_orphan_txs_by_attach(&self, txs: &LinkedHashSet<TransactionView>) {
         for tx in txs.iter() {
             self.process_orphan_tx(tx).await;
         }

--- a/util/rational/src/tests.rs
+++ b/util/rational/src/tests.rs
@@ -135,7 +135,7 @@ impl Arbitrary for U256LeBytes {
     }
 }
 
-impl<'a> ::std::convert::From<&'a U256LeBytes> for U256 {
+impl ::std::convert::From<&U256LeBytes> for U256 {
     fn from(bytes: &U256LeBytes) -> Self {
         U256::from_little_endian(&bytes.inner).expect("U256LeBytes convert")
     }


### PR DESCRIPTION
### What problem does this PR solve?

Enable the `clippy::needless_lifetimes` and `clippy::extra_unused_lifetimes` lints by removing their `-A` (allow) flags from the Makefile, and fix the resulting clippy warnings.

### What is changed and how it works?

- **Makefile**: Remove `-A clippy::needless_lifetimes` and `-A clippy::extra_unused_lifetimes` from `CLIPPY_OPTS`, enabling these two lints.
- **tx-pool/src/process.rs**: Remove the unnecessary `'a` lifetime parameter from `remove_orphan_txs_by_attach`.
- **util/rational/src/tests.rs**: Remove the unnecessary `'a` lifetime parameter from `impl<'a> From<&'a U256LeBytes> for U256`.

### Check List

- No behavioral changes — only unused lifetime annotations are removed.