### PR TITLE
fix: correct jemalloc profiling dump FFI

### DIFF
--- a/util/memory-tracker/src/jemalloc.rs
+++ b/util/memory-tracker/src/jemalloc.rs
@@ -1,5 +1,5 @@
 use ckb_logger::info;
-use std::{ffi, mem, ptr};
+use std::{ffi, io, mem, ptr};
 
 /// Dumps the heap through Jemalloc's API.
 ///
@@ -9,19 +9,28 @@ use std::{ffi, mem, ptr};
 ///
 /// [Jemallocator]: https://docs.rs/jemallocator/*/jemallocator/index.html
 pub fn jemalloc_profiling_dump(filename: &str) -> Result<(), String> {
-    let mut filename0 = format!("{filename}\0");
+    let filename_c = ffi::CString::new(filename)
+        .map_err(|err| format!("invalid jemalloc profiling dump filename: {err}"))?;
+    let mut filename_ptr = filename_c.as_ptr();
     let opt_name = "prof.dump";
     let opt_c_name = ffi::CString::new(opt_name).unwrap();
     info!("jemalloc profiling dump: {filename}");
-    unsafe {
+    let result = unsafe {
         jemalloc_sys::mallctl(
             opt_c_name.as_ptr(),
             ptr::null_mut(),
             ptr::null_mut(),
-            &mut filename0 as *mut _ as *mut _,
-            mem::size_of::<*mut ffi::c_void>(),
-        );
-    }
+            ptr::from_mut(&mut filename_ptr).cast(),
+            mem::size_of_val(&filename_ptr),
+        )
+    };
 
-    Ok(())
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "jemalloc profiling dump failed: {}",
+            io::Error::from_raw_os_error(result)
+        ))
+    }
 }


### PR DESCRIPTION
## What changed

- Build the profiling dump filename as a `CString`.
- Pass `mallctl("prof.dump")` a pointer to the C string pointer.
- Return an error when `mallctl` returns a nonzero status.

## Why

The previous FFI call passed the address of a Rust `String` as though it were a
`const char **`. Rust does not guarantee `String`'s internal field layout, and
with Rust 1.95 jemalloc received the string capacity (`0x34`) as the pathname
pointer. The resulting `creat(0x34, ...)` failed with `EFAULT`, while the ignored
`mallctl` return code caused the RPC to report false success.

## Impact

`jemalloc_profiling_dump` now writes to the requested path and reports dump
failures to the RPC caller.

## Validation

- `cargo fmt --package ckb-memory-tracker`
- `git diff --check`
- Generated and symbolized `ckb-jeprof.1784823804.heap` from the rebuilt CKB
  binary, confirming the dump succeeds.
- Tests were not run.
