### PR TITLE
Fix/unbounded memory growth

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -59,6 +59,7 @@ pub const TX_HASHES_TOKEN: u64 = 2;
 pub const MAX_RELAY_PEERS: usize = 128;
 pub const MAX_RELAY_TXS_NUM_PER_BATCH: usize = 32767;
 pub const MAX_RELAY_TXS_BYTES_PER_BATCH: usize = 1024 * 1024;
+const MAX_PENDING_RELAY_TX_VERIFY_RESULTS: usize = MAX_RELAY_TXS_NUM_PER_BATCH * 2;
 
 type RateLimiter<T> = governor::RateLimiter<
     T,
@@ -631,6 +632,7 @@ impl Relayer {
     pub async fn send_bulk_of_tx_hashes(&self, nc: &Arc<dyn CKBProtocolContext + Sync>) {
         const BUFFER_SIZE: usize = 42;
 
+        self.trim_relay_tx_verify_results();
         let connected_peers = nc.full_relay_connected_peers();
         if connected_peers.is_empty() {
             return;
@@ -703,6 +705,20 @@ impl Relayer {
                     err,
                 );
             }
+        }
+    }
+
+    fn trim_relay_tx_verify_results(&self) {
+        let dropped = self
+            .shared
+            .state()
+            .trim_relay_tx_verify_results(MAX_PENDING_RELAY_TX_VERIFY_RESULTS);
+        if dropped > 0 {
+            warn_target!(
+                crate::LOG_TARGET_RELAY,
+                "Dropped {} oldest transaction verification results from the relay queue",
+                dropped
+            );
         }
     }
 }
@@ -937,6 +953,9 @@ impl CKBProtocolHandler for Relayer {
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {
         // If self is in the IBD state, don't trigger any relayer notify.
         if self.shared.active_chain().is_initial_block_download() {
+            if token == TX_HASHES_TOKEN {
+                self.trim_relay_tx_verify_results();
+            }
             return;
         }
 

--- a/sync/src/tests/sync_shared.rs
+++ b/sync/src/tests/sync_shared.rs
@@ -7,11 +7,13 @@ use crate::synchronizer::HeadersProcess;
 use crate::tests::util::{build_chain, inherit_block};
 use crate::{Relayer, Status, SyncShared, Synchronizer};
 use ckb_chain::{ChainServiceScope, RemoteBlock, VerifyResult};
+use ckb_channel::unbounded;
 use ckb_logger::info;
 use ckb_shared::block_status::BlockStatus;
 use ckb_shared::{Shared, SharedBuilder};
 use ckb_store::{self, ChainStore};
 use ckb_test_chain_utils::always_success_cellbase;
+use ckb_tx_pool::service::TxVerificationResult;
 use ckb_types::core::{BlockBuilder, BlockView, Capacity};
 use ckb_types::packed::Byte32;
 use ckb_types::prelude::*;
@@ -33,6 +35,40 @@ fn wait_for_expected_block_status(
         std::thread::sleep(std::time::Duration::from_micros(100));
     }
     false
+}
+
+#[test]
+fn trim_relay_tx_verify_results_drops_oldest() {
+    let (shared, _pack) = SharedBuilder::with_temp_db().build().unwrap();
+    let (sender, receiver) = unbounded();
+    let sync_shared = SyncShared::new(shared, Default::default(), receiver);
+
+    for value in 0..5 {
+        sender
+            .send(TxVerificationResult::Ok {
+                original_peer: None,
+                tx_hash: Byte32::from_slice(&[value; 32]).unwrap(),
+            })
+            .unwrap();
+    }
+
+    assert_eq!(sync_shared.state().trim_relay_tx_verify_results(2), 3);
+
+    let remaining = sync_shared.state().take_relay_tx_verify_results(10);
+    let remaining_hashes = remaining
+        .into_iter()
+        .map(|result| match result {
+            TxVerificationResult::Ok { tx_hash, .. } => tx_hash,
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        remaining_hashes,
+        vec![
+            Byte32::from_slice(&[3; 32]).unwrap(),
+            Byte32::from_slice(&[4; 32]).unwrap(),
+        ]
+    );
 }
 
 #[test]

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1384,7 +1384,25 @@ impl SyncState {
     }
 
     pub fn take_relay_tx_verify_results(&self, limit: usize) -> Vec<TxVerificationResult> {
-        self.tx_relay_receiver.try_iter().take(limit).collect()
+        let results = self.tx_relay_receiver.try_iter().take(limit).collect();
+        self.update_relay_tx_verify_result_queue_size();
+        results
+    }
+
+    pub fn trim_relay_tx_verify_results(&self, limit: usize) -> usize {
+        let excess = self.tx_relay_receiver.len().saturating_sub(limit);
+        let dropped = self.tx_relay_receiver.try_iter().take(excess).count();
+        self.update_relay_tx_verify_result_queue_size();
+        dropped
+    }
+
+    fn update_relay_tx_verify_result_queue_size(&self) {
+        if let Some(metrics) = ckb_metrics::handle() {
+            let queue_size = i64::try_from(self.tx_relay_receiver.len()).unwrap_or(i64::MAX);
+            metrics
+                .ckb_relay_tx_verify_result_queue_size
+                .set(queue_size);
+        }
     }
 
     pub fn shared_best_header(&self) -> HeaderIndexView {

--- a/sync/src/types/mod.rs
+++ b/sync/src/types/mod.rs
@@ -1389,7 +1389,10 @@ impl SyncState {
         results
     }
 
-    pub fn trim_relay_tx_verify_results(&self, limit: usize) -> usize {
+    pub(crate) fn trim_relay_tx_verify_results(&self, limit: usize) -> usize {
+        if self.tx_relay_receiver.len() <= limit {
+            return 0;
+        }
         let excess = self.tx_relay_receiver.len().saturating_sub(limit);
         let dropped = self.tx_relay_receiver.try_iter().take(excess).count();
         self.update_relay_tx_verify_result_queue_size();

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -1,7 +1,7 @@
 //! CKB logger and logging service.
 
 use backtrace::Backtrace;
-use ckb_channel::{self, unbounded};
+use ckb_channel::{self, bounded};
 use ckb_notify::{LogEntry, NotifyController};
 use env_logger::filter::{Builder, Filter};
 use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
@@ -26,6 +26,8 @@ mod tests;
 static CONTROL_HANDLE: OnceLock<ckb_channel::Sender<Message>> = OnceLock::new();
 static FORMAT: OnceLock<Vec<FormatItem<'static>>> = OnceLock::new();
 static RE: OnceLock<regex::Regex> = OnceLock::new();
+
+const LOG_CHANNEL_SIZE: usize = 8192;
 
 enum Message {
     Record {
@@ -114,7 +116,7 @@ impl Logger {
             }
         }
 
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(LOG_CHANNEL_SIZE);
         CONTROL_HANDLE
             .set(sender.clone())
             .expect("CONTROL_HANDLE init once");
@@ -450,7 +452,7 @@ impl Log for Logger {
                         record.args()
                     )
                 };
-                let _ = self.sender.send(Message::Record {
+                let message = Message::Record {
                     is_match,
                     extras,
                     data: with_color,
@@ -458,7 +460,8 @@ impl Log for Logger {
                     target: record.target().to_string(),
                     date: dt,
                     original_message: format!("{}", record.args()),
-                });
+                };
+                try_send_record(&self.sender, message);
             }
         }
     }
@@ -468,6 +471,10 @@ impl Log for Logger {
         let _ = self.sender.send(Message::Terminate);
         let _ = handle.join();
     }
+}
+
+fn try_send_record(sender: &ckb_channel::Sender<Message>, message: Message) -> bool {
+    sender.try_send(message).is_ok()
 }
 
 fn sanitize_color(s: &str) -> String {

--- a/util/logger-service/src/lib.rs
+++ b/util/logger-service/src/lib.rs
@@ -352,12 +352,7 @@ impl Logger {
         CONTROL_HANDLE
             .get()
             .ok_or_else(|| "no sender for logger service".to_owned())
-            .and_then(|sender| {
-                sender
-                    .send(message)
-                    .map_err(|err| format!("failed to send message to logger service: {err}"))
-                    .map(|_| ())
-            })
+            .and_then(|sender| try_send_message(sender, message))
     }
 
     /// Updates the main logger.
@@ -475,6 +470,12 @@ impl Log for Logger {
 
 fn try_send_record(sender: &ckb_channel::Sender<Message>, message: Message) -> bool {
     sender.try_send(message).is_ok()
+}
+
+fn try_send_message(sender: &ckb_channel::Sender<Message>, message: Message) -> Result<(), String> {
+    sender
+        .try_send(message)
+        .map_err(|err| format!("failed to send message to logger service: {err}"))
 }
 
 fn sanitize_color(s: &str) -> String {

--- a/util/logger-service/src/tests.rs
+++ b/util/logger-service/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Message, convert_compatible_crate_name, try_send_record};
+use crate::{Message, convert_compatible_crate_name, try_send_message, try_send_record};
 use ckb_channel::bounded;
 use log::Level;
 
@@ -28,6 +28,23 @@ fn full_log_channel_drops_newest_record() {
     let (sender, receiver) = bounded(1);
     assert!(try_send_record(&sender, record_message("oldest")));
     assert!(!try_send_record(&sender, record_message("newest")));
+
+    match receiver.try_recv().unwrap() {
+        Message::Record {
+            original_message, ..
+        } => assert_eq!(original_message, "oldest"),
+        _ => unreachable!(),
+    }
+    assert!(receiver.try_recv().is_err());
+}
+
+#[test]
+fn full_log_channel_rejects_control_message_without_blocking() {
+    let (sender, receiver) = bounded(1);
+    assert!(try_send_record(&sender, record_message("oldest")));
+
+    let result = try_send_message(&sender, Message::RemoveExtraLogger("test".to_owned()));
+    assert!(result.is_err());
 
     match receiver.try_recv().unwrap() {
         Message::Record {

--- a/util/logger-service/src/tests.rs
+++ b/util/logger-service/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::convert_compatible_crate_name;
+use crate::{Message, convert_compatible_crate_name, try_send_record};
+use ckb_channel::bounded;
+use log::Level;
 
 #[test]
 fn test_convert_compatible_crate_name() {
@@ -19,4 +21,31 @@ fn test_convert_compatible_crate_name() {
     let expected = "info";
     let result = convert_compatible_crate_name(spec);
     assert_eq!(&result, &expected);
+}
+
+#[test]
+fn full_log_channel_drops_newest_record() {
+    let (sender, receiver) = bounded(1);
+    assert!(try_send_record(&sender, record_message("oldest")));
+    assert!(!try_send_record(&sender, record_message("newest")));
+
+    match receiver.try_recv().unwrap() {
+        Message::Record {
+            original_message, ..
+        } => assert_eq!(original_message, "oldest"),
+        _ => unreachable!(),
+    }
+    assert!(receiver.try_recv().is_err());
+}
+
+fn record_message(original_message: &str) -> Message {
+    Message::Record {
+        is_match: true,
+        extras: Vec::new(),
+        data: original_message.to_owned(),
+        level: Level::Info,
+        target: "test".to_owned(),
+        date: String::new(),
+        original_message: original_message.to_owned(),
+    }
 }

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -94,6 +94,8 @@ pub struct Metrics {
     pub ckb_freezer_number: IntGauge,
     /// Counter for relay transaction short id collide
     pub ckb_relay_transaction_short_id_collide: IntCounter,
+    /// Gauge for pending transaction verification results waiting for relay
+    pub ckb_relay_tx_verify_result_queue_size: IntGauge,
     /// Histogram for relay compact block verify duration
     pub ckb_relay_cb_verify_duration: Histogram,
     /// Histogram for block process duration
@@ -223,6 +225,11 @@ static METRICS: std::sync::LazyLock<Metrics> = std::sync::LazyLock::new(|| {
     ckb_relay_transaction_short_id_collide: register_int_counter!(
         "ckb_relay_transaction_short_id_collide",
         "The CKB relay transaction short id collide"
+    )
+            .unwrap(),
+    ckb_relay_tx_verify_result_queue_size: register_int_gauge!(
+        "ckb_relay_tx_verify_result_queue_size",
+        "Pending transaction verification results waiting for relay"
     )
             .unwrap(),
     ckb_relay_cb_verify_duration: register_histogram!(


### PR DESCRIPTION
Fix memory growth because of unbounded channel.

What's Changed:

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787456364&installation_model_id=10242&pr_number=5292&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5292&signature=42e47a933d5a9809b36e8e990f484a1e22ef7890c9afbc73f9943e3c7e61a6ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->