### PR TITLE
Fix stale parent handling during tx-pool ancestor eviction

### DIFF
--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -600,31 +600,37 @@ impl PoolMap {
             return Ok(evicted);
         }
 
-        if ancestors_count.saturating_sub(cell_ref_parents.len()) <= self.max_ancestors_count {
-            // if ancestors count exceed limitation,
-            // try to evict some conflicted transactions due to ref cells
-
-            // sort them to find out the transactions with lowest fees
-            let evict_candidates: Vec<ProposalShortId> = self
-                .entries
-                .iter_by_evict_key()
-                .filter(move |entry| cell_ref_parents.contains(&entry.id))
-                .map(|x| x.id.clone())
-                .collect();
-
-            let mut iter = evict_candidates.iter();
-            while ancestors_count > self.max_ancestors_count {
-                if let Some(next_id) = iter.next() {
-                    let removed = self.remove_entry_and_descendants(next_id);
-                    ancestors_count = ancestors_count.saturating_sub(1);
-                    parents.remove(next_id);
-                    evicted.extend(removed);
-                } else {
-                    break;
-                }
-            }
-        } else {
+        if ancestors_count.saturating_sub(cell_ref_parents.len()) > self.max_ancestors_count {
             return Err(Reject::ExceededMaximumAncestorsCount);
+        }
+
+        // if ancestors count exceed limitation,
+        // try to evict some conflicted transactions due to ref cells
+
+        // sort them to find out the transactions with lowest fees
+        let evict_candidates: Vec<ProposalShortId> = self
+            .entries
+            .iter_by_evict_key()
+            .filter(move |entry| cell_ref_parents.contains(&entry.id))
+            .map(|x| x.id.clone())
+            .collect();
+
+        let mut iter = evict_candidates.iter();
+        while ancestors_count > self.max_ancestors_count {
+            if let Some(next_id) = iter.next() {
+                let removed = self.remove_entry_and_descendants(next_id);
+                for removed_id in removed.iter().map(|entry| entry.proposal_short_id()) {
+                    parents.remove(&removed_id);
+                }
+                ancestors_count = self
+                    .links
+                    .calc_relation_ids(parents.clone(), Relation::Parents)
+                    .len()
+                    + 1;
+                evicted.extend(removed);
+            } else {
+                break;
+            }
         }
 
         // some txs in `parents` are removed, now `ancestors` need to re-caculate,

--- a/tx-pool/src/component/tests/proposed.rs
+++ b/tx-pool/src/component/tests/proposed.rs
@@ -696,6 +696,58 @@ fn test_max_ancestors_with_dep() {
 }
 
 #[test]
+fn test_max_ancestors_evicts_stale_parent_descendant() {
+    let mut pool = PoolMap::new(2);
+    let dep_hash: Byte32 = h256!("0x1").into();
+
+    let tx1 = build_tx_with_dep(vec![(&Byte32::zero(), 0)], vec![(&dep_hash, 0)], 1);
+    let tx1_id = tx1.proposal_short_id();
+    let tx1_hash = tx1.hash();
+
+    let tx2 = build_tx(vec![(&tx1_hash, 0)], 1);
+    let tx2_id = tx2.proposal_short_id();
+    let tx2_hash = tx2.hash();
+
+    let tx3 = build_tx(vec![(&dep_hash, 0), (&tx2_hash, 0)], 1);
+    let tx3_id = tx3.proposal_short_id();
+
+    pool.add_proposed(TxEntry::new(
+        dummy_resolve(tx1, |_| None),
+        MOCK_CYCLES,
+        MOCK_FEE,
+        MOCK_SIZE,
+    ))
+    .unwrap();
+    pool.add_proposed(TxEntry::dummy_resolve(
+        tx2,
+        MOCK_CYCLES,
+        MOCK_FEE,
+        MOCK_SIZE,
+    ))
+    .unwrap();
+
+    let (inserted, evicted) = pool
+        .add_entry(
+            TxEntry::dummy_resolve(tx3, MOCK_CYCLES, MOCK_FEE, MOCK_SIZE),
+            Status::Proposed,
+        )
+        .unwrap();
+    assert!(inserted);
+
+    let evicted_ids: HashSet<_> = evicted
+        .iter()
+        .map(|entry| entry.proposal_short_id())
+        .collect();
+    assert_eq!(evicted_ids.len(), 2);
+    assert!(evicted_ids.contains(&tx1_id));
+    assert!(evicted_ids.contains(&tx2_id));
+    assert!(pool.get(&tx1_id).is_none());
+    assert!(pool.get(&tx2_id).is_none());
+    assert!(pool.get(&tx3_id).is_some());
+    assert!(pool.calc_ancestors(&tx3_id).is_empty());
+}
+
+#[test]
 fn test_container_bench_add_limits() {
     use rand::Rng;
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
## Summary

- Remove all actually evicted entries from the local parent snapshot during ancestor-limit conflict eviction.
- Recompute ancestor count from the cleaned snapshot before continuing eviction.
- Add a regression test covering cascading removal of a stale parent descendant.

## Root Cause

When ancestor-limit insertion evicted a cell-dep conflict with descendants, `remove_entry_and_descendants` could delete both the selected seed and its descendants. The local `parents` snapshot only removed the selected seed, leaving a stale descendant id that later reached a checked pool lookup and panicked with `inconsistent pool`.

## Validation

- `cargo fmt --all`
- `cargo test -p ckb-tx-pool test_max_ancestors -- --nocapture`
- `cargo test -p ckb-tx-pool`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475275&installation_model_id=10242&pr_number=5293&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5293&signature=b1e612a722205fac10eaddd398f22bcbab5c5e9765b40be4c8c8e63875495500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->