### PR TITLE
refactor: simplify ancestor eviction loop

### DIFF
--- a/tx-pool/src/component/pool_map.rs
+++ b/tx-pool/src/component/pool_map.rs
@@ -617,20 +617,20 @@ impl PoolMap {
 
         let mut iter = evict_candidates.iter();
         while ancestors_count > self.max_ancestors_count {
-            if let Some(next_id) = iter.next() {
-                let removed = self.remove_entry_and_descendants(next_id);
-                for removed_id in removed.iter().map(|entry| entry.proposal_short_id()) {
-                    parents.remove(&removed_id);
-                }
-                ancestors_count = self
-                    .links
-                    .calc_relation_ids(parents.clone(), Relation::Parents)
-                    .len()
-                    + 1;
-                evicted.extend(removed);
-            } else {
+            let Some(next_id) = iter.next() else {
                 break;
+            };
+
+            let removed = self.remove_entry_and_descendants(next_id);
+            for removed_id in removed.iter().map(|entry| entry.proposal_short_id()) {
+                parents.remove(&removed_id);
             }
+            ancestors_count = self
+                .links
+                .calc_relation_ids(parents.clone(), Relation::Parents)
+                .len()
+                + 1;
+            evicted.extend(removed);
         }
 
         // some txs in `parents` are removed, now `ancestors` need to re-caculate,


### PR DESCRIPTION
## What changed

- Replace the `if let`/`else` branch in the ancestor-eviction loop with a `let ... else` guard.
- Keep the eviction, parent cleanup, and ancestor-count recomputation in the main loop body.

## Why

The iterator-exhaustion case is an early exit. Expressing it as a guard reduces nesting and keeps the successful eviction path linear.

## Impact

This is a behavior-preserving refactor. The stale-parent cleanup and ancestor-count recomputation introduced in #5293 remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p ckb-tx-pool test_max_ancestors_evicts_stale_parent_descendant`
