### PR TITLE
network: initial integration for quic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +263,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -611,7 +673,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -621,7 +694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2092,6 +2165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +2186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2239,6 +2321,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2410,7 +2501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -2527,6 +2618,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2735,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2933,6 +3044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,10 +3222,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3575,7 +3695,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4157,6 +4277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,6 +4529,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4692,6 +4828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,6 +5024,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -5170,7 +5325,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5362,6 +5517,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5393,7 +5605,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -5415,6 +5627,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5475,6 +5698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5500,6 +5729,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5538,6 +5776,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5777,6 +6028,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,6 +6068,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5822,6 +6083,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5831,6 +6093,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6213,7 +6476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6224,7 +6487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6235,7 +6498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6792,7 +7055,11 @@ dependencies = [
  "molecule",
  "nohash-hasher",
  "parking_lot 0.12.5",
+ "quinn",
  "rand 0.8.6",
+ "rcgen",
+ "ring",
+ "rustls",
  "socket2 0.6.3",
  "tentacle-multiaddr",
  "tentacle-secio",
@@ -6805,6 +7072,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "winapi",
+ "x509-parser",
 ]
 
 [[package]]
@@ -7793,7 +8061,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8286,6 +8554,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8317,6 +8602,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7039,8 +7039,6 @@ dependencies = [
 [[package]]
 name = "tentacle"
 version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab80c50726dc639daf326406efc983c578e65d06efa84f6d11385abc6dc27be"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7078,8 +7076,6 @@ dependencies = [
 [[package]]
 name = "tentacle-multiaddr"
 version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b06b419ae75898680ae449d5db5bf9dfedb531c49cdb6f24d42054508a2df3"
 dependencies = [
  "arrayref",
  "bs58",
@@ -7094,8 +7090,6 @@ dependencies = [
 [[package]]
 name = "tentacle-secio"
 version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410f26213e6f4bf189f661db9c92241f77b84f6eabebe4bf35283d841cbb67ae"
 dependencies = [
  "bs58",
  "bytes",
@@ -7420,8 +7414,6 @@ dependencies = [
 [[package]]
 name = "tokio-yamux"
 version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ec7b39569c9fc5dada5c87ca70e364bae3ca191b6f72a444842b114a656bd5"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3695,7 +3695,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5529,7 +5529,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5568,7 +5568,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7038,8 +7038,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.7.6"
-source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece1f30bebb1d7e7dcb2c32591aa677b4ca72c66c6b73be721886b041f22e470"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7076,8 +7077,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-multiaddr"
-version = "0.3.7"
-source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b93edd813d6f875e03013f2cf5bb2b4318b9e440d69a98ce8536bb302699e"
 dependencies = [
  "arrayref",
  "bs58",
@@ -7091,8 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.6.8"
-source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d608a76b7e4947413e54475a077d47f7cec41b58f0ad12d9a27293032b680839"
 dependencies = [
  "bs58",
  "bytes",
@@ -7416,8 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.3.19"
-source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1203db1ac9762aaf041ba62d4fade5959b89af1abd057c5e9bc54ae3e7f00c4b"
 dependencies = [
  "bytes",
  "futures",
@@ -8057,7 +8061,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7039,6 +7039,7 @@ dependencies = [
 [[package]]
 name = "tentacle"
 version = "0.7.6"
+source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7076,6 +7077,7 @@ dependencies = [
 [[package]]
 name = "tentacle-multiaddr"
 version = "0.3.7"
+source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
 dependencies = [
  "arrayref",
  "bs58",
@@ -7090,6 +7092,7 @@ dependencies = [
 [[package]]
 name = "tentacle-secio"
 version = "0.6.8"
+source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
 dependencies = [
  "bs58",
  "bytes",
@@ -7414,6 +7417,7 @@ dependencies = [
 [[package]]
 name = "tokio-yamux"
 version = "0.3.19"
+source = "git+https://github.com/nervosnetwork/tentacle?rev=2541c7a#2541c7a3ae877187b9f7e08d73d38e451bc5e5f7"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,10 +320,10 @@ phf = { version = "0.12", features = ["macros"] }
 sysinfo = "0.37"
 
 [patch.crates-io]
-tentacle = { path = "/root/tentacle/tentacle" }
-tentacle-multiaddr = { path = "/root/tentacle/multiaddr" }
-tentacle-secio = { path = "/root/tentacle/secio" }
-tokio-yamux = { path = "/root/tentacle/yamux" }
+tentacle = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
+tentacle-multiaddr = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
+tentacle-secio = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
+tokio-yamux = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
 
 [profile.release]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,10 +266,10 @@ merkle-cbt = "0.3"
 minstant = "0.1.4"
 molecule = { version = "0.9.0", default-features = false }
 multi_index_map = "0.15.0"
-multiaddr = { version = "0.3.7", package = "tentacle-multiaddr" }
+multiaddr = { version = "0.3.8", package = "tentacle-multiaddr" }
 num_cpus = "1.16.0"
 numext-fixed-uint = "0.1"
-p2p = { version = "0.7.6", package = "tentacle", default-features = false }
+p2p = { version = "0.7.7", package = "tentacle", default-features = false }
 parking_lot = "0.12"
 paste = "1.0"
 path-clean = "0.1.0"
@@ -287,7 +287,7 @@ reqwest = { version = "0.12", features = ["blocking", "json"] }
 rhai = "1.16.0"
 rocksdb = { version = "=0.21.1", package = "ckb-rocksdb", default-features = false }
 rustc-hash = "1.1"
-secio = { version = "0.6.8", package = "tentacle-secio" }
+secio = { version = "0.6.9", package = "tentacle-secio" }
 secp256k1 = "0.30"
 semver = "1.0"
 sentry = "0.34.0"
@@ -319,11 +319,6 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 phf = { version = "0.12", features = ["macros"] }
 sysinfo = "0.37"
 
-[patch.crates-io]
-tentacle = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
-tentacle-multiaddr = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
-tentacle-secio = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
-tokio-yamux = { git = "https://github.com/nervosnetwork/tentacle", rev = "2541c7a" }
 
 [profile.release]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,12 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 phf = { version = "0.12", features = ["macros"] }
 sysinfo = "0.37"
 
+[patch.crates-io]
+tentacle = { path = "/root/tentacle/tentacle" }
+tentacle-multiaddr = { path = "/root/tentacle/multiaddr" }
+tentacle-secio = { path = "/root/tentacle/secio" }
+tokio-yamux = { path = "/root/tentacle/yamux" }
+
 [profile.release]
 overflow-checks = true
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -46,6 +46,7 @@ p2p = { workspace = true, default-features = false, features = [
     "tokio-runtime",
     "tokio-timer",
     "ws",
+    "quic",
 ] }
 socket2 = "0.6"
 governor.workspace = true

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -56,6 +56,18 @@ pub use tokio;
 /// Protocol version used by network protocol open
 pub type ProtocolVersion = String;
 
+/// Extract the IP socket address from a multiaddr, supporting both TCP-based
+/// transports (TCP/WS/WSS) and UDP-based transports (QUIC).
+///
+/// All IP-based logic (ban list, network group eviction, unique-IP dedup,
+/// reachability filtering, ...) must use this helper instead of
+/// `multiaddr_to_socketaddr` alone, otherwise QUIC addresses (which use
+/// `/udp/<port>/quic-v1`) would silently bypass those checks.
+pub fn multiaddr_to_ip_socketaddr(addr: &multiaddr::Multiaddr) -> Option<std::net::SocketAddr> {
+    p2p::utils::multiaddr_to_socketaddr(addr)
+        .or_else(|| p2p::utils::multiaddr_to_udp_socketaddr(addr))
+}
+
 /// Observe listen port occupancy
 pub async fn observe_listen_port_occupancy(
     _addrs: &[multiaddr::Multiaddr],

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -982,7 +982,9 @@ impl NetworkService {
 
         #[cfg(not(target_family = "wasm"))]
         {
-            service_builder = service_builder.upnp(config.upnp);
+            service_builder = service_builder
+                .upnp(config.upnp)
+                .quic_config(p2p::quic::config::QuicConfig::default());
 
             // set proxy and onion config
 
@@ -1077,6 +1079,11 @@ impl NetworkService {
                     }
 
                     match find_type(multi_addr) {
+                        // This loop only installs TCP socket transformers. QUIC
+                        // owns its UDP endpoint and is configured through
+                        // `quic_config`, so QUIC listen addresses are skipped
+                        // here.
+                        TransportType::QuicV1 => continue,
                         TransportType::Tcp => {
                             // only bind once
                             if matches!(init, BindType::Tcp) {
@@ -1133,13 +1140,30 @@ impl NetworkService {
             Box::pin(protocol_type_checker_service) as Pin<Box<_>>,
         ];
         if config.outbound_peer_service_enabled() {
-            let outbound_peer_service = OutboundPeerService::new(
-                Arc::clone(&network_state),
-                p2p_service.control().to_owned().into(),
-                Duration::from_secs(config.connect_outbound_interval_secs),
-                transport_type,
-            );
-            bg_services.push(Box::pin(outbound_peer_service) as Pin<Box<_>>);
+            // Spawn one outbound peer service per distinct transport type we are
+            // able to dial. The `transport_type` argument is always included (it
+            // is the caller's "primary" transport, defaulting to TCP), and any
+            // additional transports configured through `listen_addresses` (e.g.
+            // QUIC) are added so that outbound dialing is not limited to a single
+            // transport.
+            let mut transport_types: Vec<TransportType> = vec![transport_type];
+            #[cfg(not(target_family = "wasm"))]
+            for addr in &config.listen_addresses {
+                let ty = find_type(addr);
+                if !transport_types.contains(&ty) {
+                    transport_types.push(ty);
+                }
+            }
+
+            for ty in transport_types {
+                let outbound_peer_service = OutboundPeerService::new(
+                    Arc::clone(&network_state),
+                    p2p_service.control().to_owned().into(),
+                    Duration::from_secs(config.connect_outbound_interval_secs),
+                    ty,
+                );
+                bg_services.push(Box::pin(outbound_peer_service) as Pin<Box<_>>);
+            }
         };
 
         #[cfg(feature = "with_dns_seeding")]
@@ -1649,6 +1673,8 @@ pub enum TransportType {
     Ws,
     /// Wss only on wasm
     Wss,
+    /// QUIC V1
+    QuicV1,
 }
 
 #[allow(dead_code)]
@@ -1658,7 +1684,29 @@ pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
     iter.find_map(|proto| match proto {
         Protocol::Ws => Some(TransportType::Ws),
         Protocol::Wss => Some(TransportType::Wss),
+        Protocol::QuicV1 => Some(TransportType::QuicV1),
         _ => None,
     })
     .unwrap_or(TransportType::Tcp)
+}
+
+#[cfg(test)]
+mod transport_type_tests {
+    use super::{TransportType, find_type};
+    use p2p::multiaddr::Multiaddr;
+
+    #[test]
+    fn find_transport_type() {
+        let cases = [
+            ("/ip4/127.0.0.1/tcp/8115", TransportType::Tcp),
+            ("/ip4/127.0.0.1/tcp/8115/ws", TransportType::Ws),
+            ("/ip4/127.0.0.1/tcp/8115/wss", TransportType::Wss),
+            ("/ip4/127.0.0.1/udp/8116/quic-v1", TransportType::QuicV1),
+        ];
+
+        for (raw_addr, expected) in cases {
+            let addr: Multiaddr = raw_addr.parse().expect("valid multiaddr");
+            assert_eq!(find_type(&addr), expected);
+        }
+    }
 }

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -46,7 +46,7 @@ use p2p::{
         TargetSession,
     },
     traits::ServiceHandle,
-    utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr},
+    utils::{extract_peer_id, is_reachable},
     yamux::config::Config as YamuxConfig,
 };
 use rand::prelude::IteratorRandom;
@@ -107,7 +107,7 @@ impl NetworkState {
             .chain(config.public_addresses.iter())
             .cloned()
             .filter_map(|mut addr| match multiaddr_to_ip_socketaddr(&addr) {
-                Some(socket_addr) if !is_reachable(socket_addr.ip()) => None,
+                Some(socket_addr) if !config.discovery_local_address && !is_reachable(socket_addr.ip()) => None,
                 _ => {
                     match extract_peer_id(&addr) {
                         Some(peer_id) if peer_id != local_peer_id => {
@@ -170,7 +170,11 @@ impl NetworkState {
             .chain(config.public_addresses.iter())
             .cloned()
             .filter_map(|mut addr| match multiaddr_to_ip_socketaddr(&addr) {
-                Some(socket_addr) if !is_reachable(socket_addr.ip()) => None,
+                Some(socket_addr)
+                    if !config.discovery_local_address && !is_reachable(socket_addr.ip()) =>
+                {
+                    None
+                }
                 _ => {
                     if extract_peer_id(&addr).is_none() {
                         addr.push(Protocol::P2P(Cow::Borrowed(local_peer_id.as_bytes())));
@@ -873,8 +877,11 @@ impl NetworkService {
             identify_announce.1.clone(),
             identify_announce.2,
         );
+        let identify_global_ip_only = !config.discovery_local_address;
         let identify_meta = SupportProtocols::Identify.build_meta_with_service_handle(move || {
-            ProtocolHandle::Callback(Box::new(IdentifyProtocol::new(identify_callback)))
+            ProtocolHandle::Callback(Box::new(
+                IdentifyProtocol::new(identify_callback).global_ip_only(identify_global_ip_only),
+            ))
         });
         protocol_metas.push(identify_meta);
 
@@ -1091,7 +1098,7 @@ impl NetworkService {
                             if matches!(init, BindType::Tcp) {
                                 continue;
                             }
-                            if let Some(addr) = multiaddr_to_socketaddr(multi_addr) {
+                            if let Some(addr) = p2p::utils::multiaddr_to_socketaddr(multi_addr) {
                                 let bind_fn = move |socket: p2p::service::TcpSocket,
                                                     ctxt: p2p::service::TransformerContext| {
                                     bind_fn_with_addr(socket, ctxt, addr)
@@ -1105,7 +1112,7 @@ impl NetworkService {
                             if matches!(init, BindType::Ws) {
                                 continue;
                             }
-                            if let Some(addr) = multiaddr_to_socketaddr(multi_addr) {
+                            if let Some(addr) = p2p::utils::multiaddr_to_socketaddr(multi_addr) {
                                 let bind_fn = move |socket: p2p::service::TcpSocket,
                                                     ctxt: p2p::service::TransformerContext| {
                                     bind_fn_with_addr(socket, ctxt, addr)

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -21,7 +21,9 @@ use crate::services::{
     dump_peer_store::DumpPeerStoreService, outbound_peer::OutboundPeerService,
     protocol_type_checker::ProtocolTypeCheckerService,
 };
-use crate::{Behaviour, CKBProtocol, Peer, PeerIndex, ProtocolId, ServiceControl};
+use crate::{
+    Behaviour, CKBProtocol, Peer, PeerIndex, ProtocolId, ServiceControl, multiaddr_to_ip_socketaddr,
+};
 use ckb_app_config::{NetworkConfig, SupportProtocol, default_support_all_protocols};
 use ckb_logger::{debug, error, info, trace, warn};
 use ckb_spawn::Spawn;
@@ -104,7 +106,7 @@ impl NetworkState {
             .iter()
             .chain(config.public_addresses.iter())
             .cloned()
-            .filter_map(|mut addr| match multiaddr_to_socketaddr(&addr) {
+            .filter_map(|mut addr| match multiaddr_to_ip_socketaddr(&addr) {
                 Some(socket_addr) if !is_reachable(socket_addr.ip()) => None,
                 _ => {
                     match extract_peer_id(&addr) {
@@ -167,7 +169,7 @@ impl NetworkState {
             .iter()
             .chain(config.public_addresses.iter())
             .cloned()
-            .filter_map(|mut addr| match multiaddr_to_socketaddr(&addr) {
+            .filter_map(|mut addr| match multiaddr_to_ip_socketaddr(&addr) {
                 Some(socket_addr) if !is_reachable(socket_addr.ip()) => None,
                 _ => {
                     if extract_peer_id(&addr).is_none() {
@@ -1140,30 +1142,35 @@ impl NetworkService {
             Box::pin(protocol_type_checker_service) as Pin<Box<_>>,
         ];
         if config.outbound_peer_service_enabled() {
-            // Spawn one outbound peer service per distinct transport type we are
-            // able to dial. The `transport_type` argument is always included (it
-            // is the caller's "primary" transport, defaulting to TCP), and any
-            // additional transports configured through `listen_addresses` (e.g.
-            // QUIC) are added so that outbound dialing is not limited to a single
-            // transport.
+            // Transports this node is able to dial, primary transport first.
+            // The `transport_type` argument is the caller's "primary" transport
+            // (defaulting to TCP). Any additional transports configured through
+            // `listen_addresses` (e.g. WS) are appended, and QUIC is always
+            // dialable: `quic_config` is set unconditionally and tentacle
+            // creates a one-shot client endpoint per dial, so no QUIC listen
+            // address is required for outbound QUIC connections.
             let mut transport_types: Vec<TransportType> = vec![transport_type];
             #[cfg(not(target_family = "wasm"))]
-            for addr in &config.listen_addresses {
-                let ty = find_type(addr);
-                if !transport_types.contains(&ty) {
-                    transport_types.push(ty);
+            {
+                for addr in &config.listen_addresses {
+                    let ty = find_type(addr);
+                    if !transport_types.contains(&ty) {
+                        transport_types.push(ty);
+                    }
+                }
+                if !transport_types.contains(&TransportType::QuicV1) {
+                    transport_types.push(TransportType::QuicV1);
                 }
             }
 
-            for ty in transport_types {
-                let outbound_peer_service = OutboundPeerService::new(
-                    Arc::clone(&network_state),
-                    p2p_service.control().to_owned().into(),
-                    Duration::from_secs(config.connect_outbound_interval_secs),
-                    ty,
-                );
-                bg_services.push(Box::pin(outbound_peer_service) as Pin<Box<_>>);
-            }
+            // A single service shares the dial budget across all transports.
+            let outbound_peer_service = OutboundPeerService::new(
+                Arc::clone(&network_state),
+                p2p_service.control().to_owned().into(),
+                Duration::from_secs(config.connect_outbound_interval_secs),
+                transport_types,
+            );
+            bg_services.push(Box::pin(outbound_peer_service) as Pin<Box<_>>);
         };
 
         #[cfg(feature = "with_dns_seeding")]
@@ -1480,7 +1487,7 @@ impl NetworkController {
     fn disconnect_peers_in_ip_range(&self, address: IpNetwork, reason: &str) {
         self.network_state.with_peer_registry(|reg| {
             reg.peers().iter().for_each(|(peer_index, peer)| {
-                if let Some(addr) = multiaddr_to_socketaddr(&peer.connected_addr)
+                if let Some(addr) = multiaddr_to_ip_socketaddr(&peer.connected_addr)
                     && address.contains(addr.ip())
                 {
                     let _ = disconnect_with_message(

--- a/network/src/network_group.rs
+++ b/network/src/network_group.rs
@@ -1,4 +1,4 @@
-use crate::{multiaddr::Multiaddr, multiaddr_to_socketaddr};
+use crate::{multiaddr::Multiaddr, multiaddr_to_ip_socketaddr};
 use std::net::IpAddr;
 
 #[derive(Hash, Eq, PartialEq, Debug)]
@@ -11,7 +11,7 @@ pub enum Group {
 
 impl From<&Multiaddr> for Group {
     fn from(multiaddr: &Multiaddr) -> Group {
-        if let Some(socket_addr) = multiaddr_to_socketaddr(multiaddr) {
+        if let Some(socket_addr) = multiaddr_to_ip_socketaddr(multiaddr) {
             let ip_addr = socket_addr.ip();
             if ip_addr.is_loopback() {
                 return Group::LocalNetwork;
@@ -39,5 +39,24 @@ impl From<&Multiaddr> for Group {
         }
         // Can't group addr
         Group::None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Group, Multiaddr};
+
+    #[test]
+    fn quic_addr_groups_by_ip_like_tcp() {
+        let tcp: Multiaddr = "/ip4/192.168.0.1/tcp/42".parse().unwrap();
+        let quic: Multiaddr = "/ip4/192.168.0.1/udp/42/quic-v1".parse().unwrap();
+
+        // QUIC peers must participate in IP-based eviction grouping instead of
+        // all falling into `Group::None`.
+        assert!(!matches!(Group::from(&quic), Group::None));
+        assert_eq!(Group::from(&tcp), Group::from(&quic));
+
+        let quic_loopback: Multiaddr = "/ip4/127.0.0.1/udp/42/quic-v1".parse().unwrap();
+        assert_eq!(Group::from(&quic_loopback), Group::LocalNetwork);
     }
 }

--- a/network/src/peer_store/addr_manager.rs
+++ b/network/src/peer_store/addr_manager.rs
@@ -1,10 +1,8 @@
 //! Address manager
+use crate::multiaddr_to_ip_socketaddr;
 use crate::peer_store::{base_addr, types::AddrInfo};
 use ckb_logger::debug;
-use p2p::{
-    multiaddr::{Multiaddr, Protocol},
-    utils::multiaddr_to_socketaddr,
-};
+use p2p::multiaddr::{Multiaddr, Protocol};
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
 
@@ -56,7 +54,7 @@ impl AddrManager {
             let j = rng.gen_range(i..self.random_ids.len());
             self.swap_random_id(j, i);
             let addr_info: AddrInfo = self.id_to_info[&self.random_ids[i]].to_owned();
-            match multiaddr_to_socketaddr(&addr_info.addr) {
+            match multiaddr_to_ip_socketaddr(&addr_info.addr) {
                 Some(socket_addr) => {
                     let ip = socket_addr.ip();
                     let is_unique_ip = !duplicate_ips.contains(&ip);

--- a/network/src/peer_store/ban_list.rs
+++ b/network/src/peer_store/ban_list.rs
@@ -1,9 +1,9 @@
 //! Ban list
+use crate::multiaddr_to_ip_socketaddr;
 use crate::peer_store::Multiaddr;
 use crate::peer_store::types::{BannedAddr, ip_to_network};
 use ckb_systemtime::unix_time_as_millis;
 use ipnetwork::IpNetwork;
-use p2p::utils::multiaddr_to_socketaddr;
 use std::collections::HashMap;
 use std::net::IpAddr;
 
@@ -66,7 +66,7 @@ impl BanList {
 
     /// Whether the address is banned
     pub fn is_addr_banned(&self, addr: &Multiaddr) -> bool {
-        multiaddr_to_socketaddr(addr)
+        multiaddr_to_ip_socketaddr(addr)
             .map(|socket_addr| self.is_ip_banned(&socket_addr.ip()))
             .unwrap_or_default()
     }

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -1,7 +1,7 @@
 use crate::{
     Flags, PeerId, SessionType,
     errors::{PeerStoreError, Result},
-    extract_peer_id, multiaddr_to_socketaddr,
+    extract_peer_id, multiaddr_to_ip_socketaddr,
     network_group::Group,
     peer_store::{
         ADDR_COUNT_LIMIT, ADDR_TIMEOUT_MS, ADDR_TRY_TIMEOUT_MS, Behaviour, DIAL_INTERVAL,
@@ -284,7 +284,7 @@ impl PeerStore {
 
     /// Ban an addr
     pub(crate) fn ban_addr(&mut self, addr: &Multiaddr, timeout_ms: u64, ban_reason: String) {
-        if let Some(addr) = multiaddr_to_socketaddr(addr) {
+        if let Some(addr) = multiaddr_to_ip_socketaddr(addr) {
             let network = ip_to_network(addr.ip());
             self.ban_network(network, timeout_ms, ban_reason)
         }

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -7,7 +7,7 @@ use p2p::{
     context::{ProtocolContext, ProtocolContextMutRef, SessionContext},
     multiaddr::Multiaddr,
     traits::ServiceProtocol,
-    utils::{is_reachable, multiaddr_to_socketaddr},
+    utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_socketaddr},
 };
 use rand::seq::SliceRandom;
 
@@ -347,7 +347,7 @@ impl AddressManager for DiscoveryAddressManager {
 
     fn is_valid_addr(&self, addr: &Multiaddr) -> bool {
         if !self.discovery_local_address {
-            match multiaddr_to_socketaddr(addr) {
+            match multiaddr_to_socketaddr(addr).or_else(|| multiaddr_to_udp_socketaddr(addr)) {
                 Some(socket_addr) => is_reachable(socket_addr.ip()),
                 None => true,
             }

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -7,7 +7,7 @@ use p2p::{
     context::{ProtocolContext, ProtocolContextMutRef, SessionContext},
     multiaddr::Multiaddr,
     traits::ServiceProtocol,
-    utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_socketaddr},
+    utils::is_reachable,
 };
 use rand::seq::SliceRandom;
 
@@ -347,7 +347,7 @@ impl AddressManager for DiscoveryAddressManager {
 
     fn is_valid_addr(&self, addr: &Multiaddr) -> bool {
         if !self.discovery_local_address {
-            match multiaddr_to_socketaddr(addr).or_else(|| multiaddr_to_udp_socketaddr(addr)) {
+            match crate::multiaddr_to_ip_socketaddr(addr) {
                 Some(socket_addr) => is_reachable(socket_addr.ip()),
                 None => true,
             }

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -11,7 +11,7 @@ use p2p::{
     multiaddr::{Multiaddr, Protocol},
     service::TargetProtocol,
     traits::ServiceProtocol,
-    utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr},
+    utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_socketaddr},
 };
 
 mod protocol;
@@ -30,7 +30,9 @@ const DEFAULT_TIMEOUT: u64 = 8;
 const MAX_ADDRS: usize = 10;
 
 pub(super) fn is_remote_listen_addr_allowed(addr: &Multiaddr, global_ip_only: bool) -> bool {
-    if let Some(socket_addr) = multiaddr_to_socketaddr(addr) {
+    if let Some(socket_addr) =
+        multiaddr_to_socketaddr(addr).or_else(|| multiaddr_to_udp_socketaddr(addr))
+    {
         !global_ip_only || is_reachable(socket_addr.ip())
     } else {
         addr.iter()

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -108,7 +108,6 @@ impl<T: Callback> IdentifyProtocol<T> {
         }
     }
 
-    #[cfg(test)]
     pub fn global_ip_only(mut self, only: bool) -> Self {
         self.global_ip_only = only;
         self
@@ -494,9 +493,41 @@ impl Callback for IdentifyCallback {
                 Flags::COMPATIBILITY
             }
         });
+        let inbound_quic_ip = session
+            .ty
+            .is_inbound()
+            .then(|| multiaddr_to_ip_socketaddr(&session.address))
+            .flatten()
+            .filter(|_| {
+                session
+                    .address
+                    .iter()
+                    .any(|protocol| matches!(protocol, Protocol::QuicV1))
+            })
+            .map(|socket_addr| socket_addr.ip());
+
         self.network_state.with_peer_store_mut(|peer_store| {
             for addr in addrs {
-                if let Err(err) = peer_store.add_addr(addr.clone(), flags) {
+                // A QUIC dial uses an ephemeral UDP source port, so the address
+                // of an inbound session is not dialable. Once Identify proves
+                // the remote peer's identity, prefer its advertised QUIC
+                // listener when it is on the same IP as the established
+                // session. Restricting this promotion to the connected IP
+                // prevents a peer from making us advertise arbitrary hosts.
+                let is_same_host_quic_listener = inbound_quic_ip.is_some_and(|session_ip| {
+                    addr.iter()
+                        .any(|protocol| matches!(protocol, Protocol::QuicV1))
+                        && multiaddr_to_ip_socketaddr(&addr)
+                            .is_some_and(|listen_addr| listen_addr.ip() == session_ip)
+                });
+
+                let result = if is_same_host_quic_listener {
+                    peer_store.add_outbound_addr(addr.clone(), flags);
+                    Ok(())
+                } else {
+                    peer_store.add_addr(addr.clone(), flags)
+                };
+                if let Err(err) = result {
                     error!("IdentifyProtocol failed to add address to peer store, address: {}, error: {:?}", addr, err);
                 }
             }

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::multiaddr_to_ip_socketaddr;
 use ckb_logger::{debug, error, trace, warn};
 use ckb_systemtime::{Duration, Instant};
 use p2p::{
@@ -11,7 +12,7 @@ use p2p::{
     multiaddr::{Multiaddr, Protocol},
     service::TargetProtocol,
     traits::ServiceProtocol,
-    utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_socketaddr},
+    utils::{extract_peer_id, is_reachable},
 };
 
 mod protocol;
@@ -30,9 +31,7 @@ const DEFAULT_TIMEOUT: u64 = 8;
 const MAX_ADDRS: usize = 10;
 
 pub(super) fn is_remote_listen_addr_allowed(addr: &Multiaddr, global_ip_only: bool) -> bool {
-    if let Some(socket_addr) =
-        multiaddr_to_socketaddr(addr).or_else(|| multiaddr_to_udp_socketaddr(addr))
-    {
+    if let Some(socket_addr) = multiaddr_to_ip_socketaddr(addr) {
         !global_ip_only || is_reachable(socket_addr.ip())
     } else {
         addr.iter()
@@ -223,7 +222,9 @@ impl<T: Callback> ServiceProtocol for IdentifyProtocol<T> {
                 .local_listen_addrs()
                 .iter()
                 .filter(|addr| {
-                    if let Some(socket_addr) = multiaddr_to_socketaddr(addr) {
+                    // Covers both TCP-based and UDP-based (QUIC) transports, so
+                    // that QUIC listen addresses are announced to peers too.
+                    if let Some(socket_addr) = multiaddr_to_ip_socketaddr(addr) {
                         !self.global_ip_only || is_reachable(socket_addr.ip())
                     } else {
                         // allow /onion3 address

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -112,6 +112,40 @@ fn net_service_start(
     required_flags: Flags,
     self_flags: Flags,
 ) -> Node {
+    net_service_start_with_listen(
+        name,
+        enable_discovery_push,
+        required_flags,
+        self_flags,
+        "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+        false,
+    )
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn net_service_start_quic(
+    name: String,
+    required_flags: Flags,
+    self_flags: Flags,
+) -> Node {
+    net_service_start_with_listen(
+        name,
+        true,
+        required_flags,
+        self_flags,
+        "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap(),
+        true,
+    )
+}
+
+fn net_service_start_with_listen(
+    name: String,
+    enable_discovery_push: bool,
+    required_flags: Flags,
+    self_flags: Flags,
+    listen: Multiaddr,
+    enable_quic: bool,
+) -> Node {
     let tmp_dir = tempdir().expect("create tempdir failed");
     let config = NetworkConfig {
         max_peers: 19,
@@ -214,13 +248,23 @@ fn net_service_start(
         .insert_protocol(disconnect_message_meta)
         .insert_protocol(feeler_meta);
 
-    let mut p2p_service = service_builder
+    let service_builder = service_builder
         .handshake_type(network_state.local_private_key().clone().into())
         .upnp(config.upnp)
-        .forever(true)
-        .build(EventHandler {
-            network_state: Arc::clone(&network_state),
-        });
+        .forever(true);
+
+    #[cfg(not(target_family = "wasm"))]
+    let service_builder = if enable_quic {
+        service_builder.quic_config(p2p::quic::config::QuicConfig::default())
+    } else {
+        service_builder
+    };
+    #[cfg(target_family = "wasm")]
+    let _ = enable_quic;
+
+    let mut p2p_service = service_builder.build(EventHandler {
+        network_state: Arc::clone(&network_state),
+    });
 
     let peer_id = network_state.local_peer_id().clone();
 
@@ -238,10 +282,7 @@ fn net_service_start(
             .unwrap()
     });
     rt.spawn(async move {
-        let mut listen_addr = p2p_service
-            .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
-            .await
-            .unwrap();
+        let mut listen_addr = p2p_service.listen(listen).await.unwrap();
         listen_addr.push(Protocol::P2P(Cow::Owned(peer_id.into_bytes())));
         addr_sender.send(listen_addr).unwrap();
         p2p_service.run().await
@@ -308,6 +349,66 @@ fn test_identify_rejects_dns_loopback_listen_addr() {
 
     assert!(!is_remote_listen_addr_allowed(&addr, true));
     assert!(!is_remote_listen_addr_allowed(&addr, false));
+}
+
+#[test]
+fn test_identify_accepts_quic_listen_addr() {
+    let public_addr: Multiaddr = "/ip4/8.8.8.8/udp/8116/quic-v1".parse().unwrap();
+    assert!(is_remote_listen_addr_allowed(&public_addr, true));
+
+    let loopback_addr: Multiaddr = "/ip4/127.0.0.1/udp/8116/quic-v1".parse().unwrap();
+    assert!(!is_remote_listen_addr_allowed(&loopback_addr, true));
+    assert!(is_remote_listen_addr_allowed(&loopback_addr, false));
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn test_quic_connect_behavior() {
+    let node1 = net_service_start_quic(
+        "/test/1".to_string(),
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let node2 = net_service_start_quic(
+        "/test/1".to_string(),
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+
+    // sanity check: both nodes are actually listening on a QUIC address
+    assert!(
+        matches!(
+            crate::network::find_type(&node2.listen_addr),
+            crate::network::TransportType::QuicV1
+        ),
+        "node2 should listen on a QUIC address, got {}",
+        node2.listen_addr
+    );
+
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+
+    wait_connect_state(&node1, 1);
+    wait_connect_state(&node2, 1);
+
+    // the established session should be over QUIC on both ends
+    let session_addr = node1
+        .network_state
+        .peer_registry
+        .read()
+        .peers()
+        .get(&node1.connected_sessions()[0])
+        .map(|peer| peer.connected_addr.clone())
+        .unwrap();
+    assert!(
+        matches!(
+            crate::network::find_type(&session_addr),
+            crate::network::TransportType::QuicV1
+        ),
+        "session should be established over QUIC, got {session_addr}"
+    );
 }
 
 #[test]

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -123,11 +123,7 @@ fn net_service_start(
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn net_service_start_quic(
-    name: String,
-    required_flags: Flags,
-    self_flags: Flags,
-) -> Node {
+fn net_service_start_quic(name: String, required_flags: Flags, self_flags: Flags) -> Node {
     net_service_start_with_listen(
         name,
         true,

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -407,6 +407,36 @@ fn test_quic_connect_behavior() {
     );
 }
 
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn test_quic_outbound_without_quic_listen() {
+    // A node that only listens on TCP must still be able to dial QUIC peers:
+    // tentacle creates a one-shot QUIC client endpoint per dial, so only
+    // `quic_config` (which production `NetworkService::start` always sets) is
+    // required, not a QUIC listen address.
+    let node1 = net_service_start_with_listen(
+        "/test/1".to_string(),
+        true,
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+        "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+        true,
+    );
+    let node2 = net_service_start_quic(
+        "/test/1".to_string(),
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+
+    node1.dial(
+        &node2,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+
+    wait_connect_state(&node1, 1);
+    wait_connect_state(&node2, 1);
+}
+
 #[test]
 fn test_identify_behavior() {
     let node1 = net_service_start(

--- a/network/src/protocols/tests/mod.rs
+++ b/network/src/protocols/tests/mod.rs
@@ -409,6 +409,47 @@ fn test_quic_connect_behavior() {
 
 #[cfg(not(target_family = "wasm"))]
 #[test]
+fn test_quic_inbound_advertises_dialable_listen_addr() {
+    let outbound = net_service_start_quic(
+        "/test/1".to_string(),
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let inbound = net_service_start_quic(
+        "/test/1".to_string(),
+        Flags::COMPATIBILITY,
+        Flags::COMPATIBILITY,
+    );
+    let mut advertised = outbound.listen_addr.clone();
+    advertised.push(Protocol::P2P(Cow::Owned(
+        outbound.network_state.local_peer_id().as_bytes().to_vec(),
+    )));
+    outbound.network_state.add_public_addr(advertised);
+
+    outbound.dial(
+        &inbound,
+        TargetProtocol::Single(SupportProtocols::Identify.protocol_id()),
+    );
+    wait_connect_state(&outbound, 1);
+    wait_connect_state(&inbound, 1);
+
+    let mut expected = outbound.listen_addr.clone();
+    expected.push(Protocol::P2P(Cow::Owned(
+        outbound.network_state.local_peer_id().as_bytes().to_vec(),
+    )));
+    assert!(wait_until(10, || {
+        inbound
+            .network_state
+            .peer_store
+            .lock()
+            .fetch_random_addrs(16, Flags::COMPATIBILITY)
+            .into_iter()
+            .any(|info| info.addr == expected)
+    }));
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
 fn test_quic_outbound_without_quic_listen() {
     // A node that only listens on TCP must still be able to dial QUIC peers:
     // tentacle creates a one-shot QUIC client endpoint per dial, so only

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -90,8 +90,7 @@ impl OutboundPeerService {
     fn dial_feeler(&mut self) {
         let now_ms = unix_time_as_millis();
         let transport_type = self.transport_type;
-        let filter =
-            |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
+        let filter = |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
         let attempt_peers = self.network_state.with_peer_store_mut(|peer_store| {
             let paddrs = peer_store.fetch_addrs_to_feeler(FEELER_CONNECTION_COUNT, filter);
             for paddr in paddrs.iter() {
@@ -131,8 +130,7 @@ impl OutboundPeerService {
         let target = &self.network_state.required_flags;
 
         let transport_type = self.transport_type;
-        let filter =
-            |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
+        let filter = |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
 
         let f = |peer_store: &mut PeerStore, number: usize, now_ms: u64| -> Vec<AddrInfo> {
             let paddrs = peer_store.fetch_addrs_to_attempt(number, *target, filter);

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -53,10 +53,16 @@ impl OutboundPeerService {
         }
     }
 
-    fn dial_feeler(&mut self) {
-        let now_ms = unix_time_as_millis();
-        let filter = |peer_addr: &AddrInfo| match self.transport_type {
-            TransportType::Tcp => true,
+    /// Whether the given peer address is dialable by this service's transport.
+    ///
+    /// A QUIC address always carries an explicit `quic-v1` protocol component,
+    /// so it is only matched by the QUIC service. TCP therefore explicitly
+    /// excludes QUIC addresses to avoid multiple outbound services fighting over
+    /// the same peer when both TCP and QUIC services are running.
+    fn addr_matches_transport(transport_type: TransportType, peer_addr: &AddrInfo) -> bool {
+        let is_quic = peer_addr.addr.iter().any(|p| matches!(p, Protocol::QuicV1));
+        match transport_type {
+            TransportType::Tcp => !is_quic,
             TransportType::Ws => peer_addr
                 .addr
                 .iter()
@@ -65,7 +71,27 @@ impl OutboundPeerService {
                 .addr
                 .iter()
                 .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_))),
-        };
+            TransportType::QuicV1 => is_quic,
+        }
+    }
+
+    /// Complete a bare peer address with the transport-specific protocol
+    /// component so that p2p dials it over the intended transport. QUIC and TCP
+    /// addresses already carry their transport information, so nothing is added.
+    fn complete_dial_addr(transport_type: TransportType, mut addr: Multiaddr) -> Multiaddr {
+        match transport_type {
+            TransportType::Tcp | TransportType::QuicV1 => (),
+            TransportType::Ws => addr.push(Protocol::Ws),
+            TransportType::Wss => addr.push(Protocol::Wss),
+        }
+        addr
+    }
+
+    fn dial_feeler(&mut self) {
+        let now_ms = unix_time_as_millis();
+        let transport_type = self.transport_type;
+        let filter =
+            |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
         let attempt_peers = self.network_state.with_peer_store_mut(|peer_store| {
             let paddrs = peer_store.fetch_addrs_to_feeler(FEELER_CONNECTION_COUNT, filter);
             for paddr in paddrs.iter() {
@@ -83,15 +109,11 @@ impl OutboundPeerService {
             attempt_peers,
         );
 
-        for mut addr in attempt_peers.into_iter().map(|info| info.addr) {
-            self.network_state.dial_feeler(&self.p2p_control, {
-                match &self.transport_type {
-                    TransportType::Tcp => (),
-                    TransportType::Ws => addr.push(Protocol::Ws),
-                    TransportType::Wss => addr.push(Protocol::Wss),
-                }
-                addr
-            });
+        for addr in attempt_peers.into_iter().map(|info| info.addr) {
+            self.network_state.dial_feeler(
+                &self.p2p_control,
+                Self::complete_dial_addr(self.transport_type, addr),
+            );
         }
     }
 
@@ -108,17 +130,9 @@ impl OutboundPeerService {
 
         let target = &self.network_state.required_flags;
 
-        let filter = |peer_addr: &AddrInfo| match self.transport_type {
-            TransportType::Tcp => true,
-            TransportType::Ws => peer_addr
-                .addr
-                .iter()
-                .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Tcp(_))),
-            TransportType::Wss => peer_addr
-                .addr
-                .iter()
-                .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_))),
-        };
+        let transport_type = self.transport_type;
+        let filter =
+            |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
 
         let f = |peer_store: &mut PeerStore, number: usize, now_ms: u64| -> Vec<AddrInfo> {
             let paddrs = peer_store.fetch_addrs_to_attempt(number, *target, filter);
@@ -171,28 +185,20 @@ impl OutboundPeerService {
             Box::new(attempt_peers.into_iter().map(|info| info.addr))
         };
 
-        for mut addr in peers {
-            self.network_state.dial_identify(&self.p2p_control, {
-                match &self.transport_type {
-                    TransportType::Tcp => (),
-                    TransportType::Ws => addr.push(Protocol::Ws),
-                    TransportType::Wss => addr.push(Protocol::Wss),
-                }
-                addr
-            });
+        for addr in peers {
+            self.network_state.dial_identify(
+                &self.p2p_control,
+                Self::complete_dial_addr(self.transport_type, addr),
+            );
         }
     }
 
     fn try_dial_whitelist(&self) {
-        for mut addr in self.network_state.config.whitelist_peers() {
-            self.network_state.dial_identify(&self.p2p_control, {
-                match &self.transport_type {
-                    TransportType::Tcp => (),
-                    TransportType::Ws => addr.push(Protocol::Ws),
-                    TransportType::Wss => addr.push(Protocol::Wss),
-                }
-                addr
-            });
+        for addr in self.network_state.config.whitelist_peers() {
+            self.network_state.dial_identify(
+                &self.p2p_control,
+                Self::complete_dial_addr(self.transport_type, addr),
+            );
         }
     }
 

--- a/network/src/services/outbound_peer.rs
+++ b/network/src/services/outbound_peer.rs
@@ -25,13 +25,19 @@ const FEELER_CONNECTION_COUNT: usize = 10;
 /// Periodically detect and verify data in the peer store
 /// Keep the whitelist nodes connected as much as possible
 /// Periodically detection finds that the observed addresses are all valid
+///
+/// A single service instance handles all dialable transports. The dial budget
+/// of each tick (outbound slots, feeler count) is shared across transports so
+/// that enabling additional transports (e.g. QUIC) does not multiply the
+/// number of dial attempts.
 pub struct OutboundPeerService {
     network_state: Arc<NetworkState>,
     p2p_control: ServiceControl,
     interval: Option<Interval>,
     try_connect_interval: Duration,
     try_identify_count: u8,
-    transport_type: TransportType,
+    /// Transports this node can dial, primary transport first.
+    transport_types: Vec<TransportType>,
     update_outbound_connected_count: u8,
 }
 
@@ -40,8 +46,9 @@ impl OutboundPeerService {
         network_state: Arc<NetworkState>,
         p2p_control: ServiceControl,
         try_connect_interval: Duration,
-        transport_type: TransportType,
+        transport_types: Vec<TransportType>,
     ) -> Self {
+        debug_assert!(!transport_types.is_empty());
         OutboundPeerService {
             network_state,
             p2p_control,
@@ -49,28 +56,40 @@ impl OutboundPeerService {
             try_connect_interval,
             try_identify_count: 0,
             update_outbound_connected_count: 0,
-            transport_type,
+            transport_types,
         }
     }
 
-    /// Whether the given peer address is dialable by this service's transport.
+    fn primary_transport_type(&self) -> TransportType {
+        self.transport_types
+            .first()
+            .copied()
+            .unwrap_or(TransportType::Tcp)
+    }
+
+    /// Whether the given peer address is dialable by the given transport.
     ///
     /// A QUIC address always carries an explicit `quic-v1` protocol component,
-    /// so it is only matched by the QUIC service. TCP therefore explicitly
-    /// excludes QUIC addresses to avoid multiple outbound services fighting over
-    /// the same peer when both TCP and QUIC services are running.
+    /// so it is only matched by the QUIC transport. All TCP-based transports
+    /// (TCP/WS/WSS) explicitly exclude QUIC addresses to avoid dialing a UDP
+    /// address over a TCP-based transport.
     fn addr_matches_transport(transport_type: TransportType, peer_addr: &AddrInfo) -> bool {
         let is_quic = peer_addr.addr.iter().any(|p| matches!(p, Protocol::QuicV1));
         match transport_type {
             TransportType::Tcp => !is_quic,
-            TransportType::Ws => peer_addr
-                .addr
-                .iter()
-                .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Tcp(_))),
-            TransportType::Wss => peer_addr
-                .addr
-                .iter()
-                .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_))),
+            TransportType::Ws => {
+                !is_quic
+                    && peer_addr.addr.iter().any(|p| {
+                        matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Tcp(_))
+                    })
+            }
+            TransportType::Wss => {
+                !is_quic
+                    && peer_addr
+                        .addr
+                        .iter()
+                        .any(|p| matches!(p, Protocol::Dns4(_) | Protocol::Dns6(_)))
+            }
             TransportType::QuicV1 => is_quic,
         }
     }
@@ -87,32 +106,59 @@ impl OutboundPeerService {
         addr
     }
 
-    fn dial_feeler(&mut self) {
+    /// Fetch up to `count` addresses from the peer store, sharing the budget
+    /// across all dialable transports (primary transport first). The returned
+    /// addresses are already completed for their matching transport, and are
+    /// marked as tried in the peer store.
+    fn fetch_dial_addrs<F>(&self, count: usize, mut fetch: F) -> Vec<Multiaddr>
+    where
+        F: FnMut(&mut PeerStore, usize, TransportType) -> Vec<AddrInfo>,
+    {
         let now_ms = unix_time_as_millis();
-        let transport_type = self.transport_type;
-        let filter = |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
-        let attempt_peers = self.network_state.with_peer_store_mut(|peer_store| {
-            let paddrs = peer_store.fetch_addrs_to_feeler(FEELER_CONNECTION_COUNT, filter);
-            for paddr in paddrs.iter() {
-                // mark addr as tried
-                if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&paddr.addr) {
-                    paddr.mark_tried(now_ms);
-                }
+        let mut remain = count;
+        let mut addrs = Vec::with_capacity(count);
+        for &transport_type in &self.transport_types {
+            if remain == 0 {
+                break;
             }
-            paddrs
-        });
+            let paddrs = self.network_state.with_peer_store_mut(|peer_store| {
+                let paddrs = fetch(peer_store, remain, transport_type);
+                for paddr in paddrs.iter() {
+                    // mark addr as tried
+                    if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&paddr.addr) {
+                        paddr.mark_tried(now_ms);
+                    }
+                }
+                paddrs
+            });
+            remain = remain.saturating_sub(paddrs.len());
+            addrs.extend(
+                paddrs
+                    .into_iter()
+                    .map(|info| Self::complete_dial_addr(transport_type, info.addr)),
+            );
+        }
+        addrs
+    }
 
-        trace!(
-            "feeler dial count={}, attempt_peers: {:?}",
-            attempt_peers.len(),
-            attempt_peers,
+    fn dial_feeler(&mut self) {
+        let attempt_addrs = self.fetch_dial_addrs(
+            FEELER_CONNECTION_COUNT,
+            |peer_store, count, transport_type| {
+                peer_store.fetch_addrs_to_feeler(count, |peer_addr: &AddrInfo| {
+                    Self::addr_matches_transport(transport_type, peer_addr)
+                })
+            },
         );
 
-        for addr in attempt_peers.into_iter().map(|info| info.addr) {
-            self.network_state.dial_feeler(
-                &self.p2p_control,
-                Self::complete_dial_addr(self.transport_type, addr),
-            );
+        trace!(
+            "feeler dial count={}, attempt_addrs: {:?}",
+            attempt_addrs.len(),
+            attempt_addrs,
+        );
+
+        for addr in attempt_addrs {
+            self.network_state.dial_feeler(&self.p2p_control, addr);
         }
     }
 
@@ -127,76 +173,63 @@ impl OutboundPeerService {
         }
         self.try_identify_count += 1;
 
-        let target = &self.network_state.required_flags;
-
-        let transport_type = self.transport_type;
-        let filter = |peer_addr: &AddrInfo| Self::addr_matches_transport(transport_type, peer_addr);
-
-        let f = |peer_store: &mut PeerStore, number: usize, now_ms: u64| -> Vec<AddrInfo> {
-            let paddrs = peer_store.fetch_addrs_to_attempt(number, *target, filter);
-            for paddr in paddrs.iter() {
-                // mark addr as tried
-                if let Some(paddr) = peer_store.mut_addr_manager().get_mut(&paddr.addr) {
-                    paddr.mark_tried(now_ms);
-                }
-            }
-            paddrs
+        let required_flags = self.network_state.required_flags;
+        let fetch = |peer_store: &mut PeerStore, number: usize, transport_type: TransportType| {
+            peer_store.fetch_addrs_to_attempt(number, required_flags, |peer_addr: &AddrInfo| {
+                Self::addr_matches_transport(transport_type, peer_addr)
+            })
         };
 
-        let peers: Box<dyn Iterator<Item = Multiaddr>> = if self.try_identify_count > 3 {
+        let peers: Vec<Multiaddr> = if self.try_identify_count > 3 {
             self.try_identify_count = 0;
             let len = self.network_state.bootnodes.len();
             if len < count {
-                let now_ms = unix_time_as_millis();
-                let attempt_peers = self
-                    .network_state
-                    .with_peer_store_mut(|peer_store| f(peer_store, count - len, now_ms));
-
-                Box::new(
-                    attempt_peers
-                        .into_iter()
-                        .map(|info| info.addr)
-                        .chain(self.network_state.bootnodes.iter().cloned()),
-                )
+                let mut peers = self.fetch_dial_addrs(count - len, fetch);
+                // Bootnode addresses already carry their transport information.
+                peers.extend(self.network_state.bootnodes.iter().cloned());
+                peers
             } else {
-                Box::new(
-                    self.network_state
-                        .bootnodes
-                        .iter()
-                        .choose_multiple(&mut rand::thread_rng(), count)
-                        .into_iter()
-                        .cloned(),
-                )
+                self.network_state
+                    .bootnodes
+                    .iter()
+                    .choose_multiple(&mut rand::thread_rng(), count)
+                    .into_iter()
+                    .cloned()
+                    .collect()
             }
         } else {
-            let now_ms = unix_time_as_millis();
-            let attempt_peers = self
-                .network_state
-                .with_peer_store_mut(|peer_store| f(peer_store, count, now_ms));
-
-            trace!(
-                "identify dial count={}, attempt_peers: {:?}",
-                attempt_peers.len(),
-                attempt_peers,
-            );
-
-            Box::new(attempt_peers.into_iter().map(|info| info.addr))
+            self.fetch_dial_addrs(count, fetch)
         };
 
+        trace!(
+            "identify dial count={}, attempt_peers: {:?}",
+            peers.len(),
+            peers
+        );
+
         for addr in peers {
-            self.network_state.dial_identify(
-                &self.p2p_control,
-                Self::complete_dial_addr(self.transport_type, addr),
-            );
+            self.network_state.dial_identify(&self.p2p_control, addr);
         }
     }
 
     fn try_dial_whitelist(&self) {
+        // Whitelist addresses already determine their own transport (a QUIC
+        // whitelist address carries `/quic-v1`, a WSS one carries `/wss`, ...);
+        // only bare TCP addresses need completion for WS/WSS-primary nodes.
+        // Dial each address exactly once to avoid duplicate dial attempts.
+        let primary = self.primary_transport_type();
         for addr in self.network_state.config.whitelist_peers() {
-            self.network_state.dial_identify(
-                &self.p2p_control,
-                Self::complete_dial_addr(self.transport_type, addr),
-            );
+            let addr = if addr.iter().any(|p| {
+                matches!(
+                    p,
+                    Protocol::QuicV1 | Protocol::Ws | Protocol::Wss | Protocol::Onion3(_)
+                )
+            }) {
+                addr
+            } else {
+                Self::complete_dial_addr(primary, addr)
+            };
+            self.network_state.dial_identify(&self.p2p_control, addr);
         }
     }
 
@@ -259,5 +292,60 @@ impl Future for OutboundPeerService {
             self.update_outbound_connected_ms();
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AddrInfo, OutboundPeerService, TransportType};
+    use p2p::multiaddr::Multiaddr;
+
+    fn addr_info(addr: &str) -> AddrInfo {
+        AddrInfo::new(addr.parse().unwrap(), 0, 0, 0)
+    }
+
+    #[test]
+    fn transport_matching() {
+        let tcp = addr_info("/ip4/127.0.0.1/tcp/8115");
+        let dns_tcp = addr_info("/dns4/example.com/tcp/8115");
+        let quic = addr_info("/ip4/127.0.0.1/udp/8115/quic-v1");
+        let dns_quic = addr_info("/dns4/example.com/udp/8115/quic-v1");
+
+        let matches = OutboundPeerService::addr_matches_transport;
+
+        assert!(matches(TransportType::Tcp, &tcp));
+        assert!(matches(TransportType::Ws, &tcp));
+        assert!(!matches(TransportType::QuicV1, &tcp));
+
+        assert!(matches(TransportType::QuicV1, &quic));
+        assert!(!matches(TransportType::Tcp, &quic));
+        assert!(!matches(TransportType::Ws, &quic));
+        assert!(!matches(TransportType::Wss, &quic));
+
+        // A DNS-based QUIC address contains a Dns4 component; it must still
+        // only be matched by the QUIC transport, never by WS/WSS (which would
+        // append `/ws` to it and produce an undialable address).
+        assert!(matches(TransportType::QuicV1, &dns_quic));
+        assert!(!matches(TransportType::Ws, &dns_quic));
+        assert!(!matches(TransportType::Wss, &dns_quic));
+
+        assert!(matches(TransportType::Ws, &dns_tcp));
+        assert!(matches(TransportType::Wss, &dns_tcp));
+    }
+
+    #[test]
+    fn complete_dial_addr_keeps_quic_untouched() {
+        let quic: Multiaddr = "/ip4/127.0.0.1/udp/8115/quic-v1".parse().unwrap();
+        assert_eq!(
+            OutboundPeerService::complete_dial_addr(TransportType::QuicV1, quic.clone()),
+            quic
+        );
+
+        let tcp: Multiaddr = "/ip4/127.0.0.1/tcp/8115".parse().unwrap();
+        let ws: Multiaddr = "/ip4/127.0.0.1/tcp/8115/ws".parse().unwrap();
+        assert_eq!(
+            OutboundPeerService::complete_dial_addr(TransportType::Ws, tcp),
+            ws
+        );
     }
 }

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -123,6 +123,44 @@ fn test_ban_peer() {
 }
 
 #[test]
+fn test_ban_quic_addr() {
+    // Banning must work for QUIC (UDP-based) addresses too: the ban must be
+    // recorded as an IP ban and apply to both QUIC and TCP addresses of the
+    // same IP, otherwise a banned peer could evade the ban by reconnecting
+    // over another transport.
+    let _faketime_guard = ckb_systemtime::faketime();
+    _faketime_guard.set_faketime(0);
+
+    let mut peer_store: PeerStore = Default::default();
+    let quic_addr: Multiaddr = format!(
+        "/ip4/127.0.0.1/udp/8115/quic-v1/p2p/{}",
+        PeerId::random().to_base58()
+    )
+    .parse()
+    .unwrap();
+    peer_store.add_connected_peer(quic_addr.clone(), SessionType::Inbound);
+    peer_store.ban_addr(&quic_addr, 10_000, "no reason".into());
+
+    assert_eq!(peer_store.ban_list().count(), 1);
+    assert!(peer_store.is_addr_banned(&quic_addr));
+
+    // Same IP over TCP is banned as well, and vice versa.
+    let tcp_addr: Multiaddr = format!(
+        "/ip4/127.0.0.1/tcp/8115/p2p/{}",
+        PeerId::random().to_base58()
+    )
+    .parse()
+    .unwrap();
+    assert!(peer_store.is_addr_banned(&tcp_addr));
+
+    peer_store
+        .mut_ban_list()
+        .unban_network(&multiaddr_to_ip_network(&quic_addr).unwrap());
+    assert!(!peer_store.is_addr_banned(&quic_addr));
+    assert!(!peer_store.is_addr_banned(&tcp_addr));
+}
+
+#[test]
 fn test_ban_addr_timeout_saturates_instead_of_overflowing() {
     let _faketime_guard = ckb_systemtime::faketime();
     _faketime_guard.set_faketime(1_000);

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -70,6 +70,10 @@ options_file = "default.db-options"
 listen_addresses = ["/ip4/0.0.0.0/tcp/8115"] # {{
 # _ => listen_addresses = ["/ip4/0.0.0.0/tcp/{p2p_port}"]
 # }}
+# To also accept QUIC connections, add a UDP multiaddr ending in `/quic-v1`.
+# QUIC runs over UDP, so it can share the same port number as TCP (they are
+# distinct sockets); a different port also works. For example:
+# listen_addresses = ["/ip4/0.0.0.0/tcp/8115", "/ip4/0.0.0.0/udp/8115/quic-v1"]
 ### Specify the public and routable network addresses
 # public_addresses = []
 

--- a/util/rich-indexer/Cargo.toml
+++ b/util/rich-indexer/Cargo.toml
@@ -23,7 +23,7 @@ ckb-metrics.workspace = true
 futures.workspace = true
 log.workspace = true
 sql-builder.workspace = true
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "any", "sqlite", "postgres"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "tls-rustls-aws-lc-rs"] }
 include_dir.workspace = true
 tempfile.workspace = true
 


### PR DESCRIPTION

<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Problem Summary:

Integrate tentacle QUIC support for CKB

### What is changed and how it works?

What's Changed:

- Enable Tentacle QUIC support for non-WASM CKB builds.
- Configure QUIC with the default QuicConfig.
- Support /udp/.../quic-v1 address classification, discovery, Identify validation, and outbound peer selection.
- Keep QUIC UDP endpoints separate from TCP/WS socket configuration.
- Add QUIC address tests and a dual TCP/QUIC configuration example.

### Related changes

- PR to update `owner/repo`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
- Breaking backward compatibility

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787809409&installation_model_id=10242&pr_number=5295&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5295&signature=3b09b6ea0cc45d105477972972949c82069decacf30e381fdd56a0bf0505192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->