### PR TITLE
fix(rich-indexer): skip empty spent-cell resets

### DIFF
--- a/util/rich-indexer/src/indexer/remove.rs
+++ b/util/rich-indexer/src/indexer/remove.rs
@@ -84,6 +84,10 @@ async fn remove_batch_by_blobs(
 }
 
 async fn reset_spent_cells(tx_id_list: &[i64], tx: &mut Transaction<'_, Any>) -> Result<(), Error> {
+    if tx_id_list.is_empty() {
+        return Ok(());
+    }
+
     let query = SqlBuilder::update_table("output")
         .set("is_spent", 0)
         .and_where_in_query(
@@ -288,6 +292,21 @@ mod tests {
         };
         pool.connect(&config).await.unwrap();
         pool
+    }
+
+    #[tokio::test]
+    async fn empty_transaction_list_skips_spent_cell_reset() {
+        let storage = connect_sqlite_memory().await;
+        let mut tx = storage.transaction().await.unwrap();
+
+        SQLXPool::new_query("DROP TABLE input")
+            .execute(tx.as_mut())
+            .await
+            .unwrap();
+
+        reset_spent_cells(&[], &mut tx).await.unwrap();
+
+        tx.rollback().await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- skip the spent-cell reset when a rolled-back block has no indexed transactions
- add a regression test proving the empty-list path does not access the database

## Context

Block filters can persist a tip block without any corresponding transaction rows. Rolling back that block produces an empty transaction ID list, and the generated subquery contains `consumed_tx_id IN ()`, which PostgreSQL rejects. Returning early keeps the rich-indexer rollback operational for filtered blocks.

## Tests

- `cargo test -p ckb-rich-indexer empty_transaction_list_skips_spent_cell_reset -- --nocapture`
- `cargo test -p ckb-rich-indexer test_block_filter_and_rollback_block -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787905993&installation_model_id=10242&pr_number=5300&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5300&signature=339a082d74c16df6dfcbc5b6d844979772a3f3dbd045533d107695aed3be25a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->