### PR TITLE
network: redact proxy credentials in startup logs

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -992,7 +992,7 @@ impl NetworkService {
                     .tcp_proxy_random_auth(config.proxy.proxy_random_auth);
                 info!(
                     "set tcp_proxy_config: {:?}, proxy_random_auth: {}",
-                    config.proxy.proxy_url.clone(),
+                    proxy::redact_proxy_url(proxy_url),
                     config.proxy.proxy_random_auth
                 );
             };
@@ -1007,7 +1007,10 @@ impl NetworkService {
                 })
             };
             if let Some(onion_proxy_url) = onion_proxy_url {
-                info!("set tcp_onion_config: {:?}", onion_proxy_url);
+                info!(
+                    "set tcp_onion_config: {:?}",
+                    proxy::redact_proxy_url(&onion_proxy_url)
+                );
                 service_builder = service_builder.tcp_onion_config(&onion_proxy_url);
             }
         }

--- a/network/src/proxy.rs
+++ b/network/src/proxy.rs
@@ -15,6 +15,19 @@ pub(crate) fn check_proxy_url(proxy_url: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub(crate) fn redact_proxy_url(proxy_url: &str) -> String {
+    let Ok(mut parsed_url) = Url::parse(proxy_url) else {
+        return "<invalid proxy url>".to_owned();
+    };
+    if !parsed_url.username().is_empty() {
+        let _ = parsed_url.set_username("redacted");
+    }
+    if parsed_url.password().is_some() {
+        let _ = parsed_url.set_password(Some("redacted"));
+    }
+    parsed_url.to_string()
+}
+
 #[test]
 fn parse_socks5_url() {
     let result = Url::parse("socks5://username:password@localhost:1080");
@@ -29,4 +42,20 @@ fn parse_socks5_url() {
     assert_eq!(parsed_url.host_str(), Some("localhost"));
     // port
     assert_eq!(parsed_url.port(), Some(1080));
+}
+
+#[test]
+fn redact_socks5_url_credentials() {
+    assert_eq!(
+        redact_proxy_url("socks5://username:password@localhost:1080"),
+        "socks5://redacted:redacted@localhost:1080"
+    );
+    assert_eq!(
+        redact_proxy_url("socks5://username@localhost:1080"),
+        "socks5://redacted@localhost:1080"
+    );
+    assert_eq!(
+        redact_proxy_url("socks5://localhost:1080"),
+        "socks5://localhost:1080"
+    );
 }


### PR DESCRIPTION
## Summary

- redact usernames and passwords from proxy URLs before writing startup logs
- apply the same redaction to the onion proxy configuration
- cover authenticated, username-only, and unauthenticated SOCKS5 URLs

## Context

CKB proxy URLs support credentials in the `username:password@host` form. Network startup currently logs the configured proxy and onion proxy URLs verbatim at info level, which can expose those credentials to local or centralized logs. This change preserves the non-sensitive connection details while replacing credentials with `redacted`.

The outbound double-bind behavior originally grouped into the same report is already fixed on `develop`; this PR addresses the remaining credential-disclosure path.

## Tests

- `cargo test -p ckb-network proxy -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check upstream/develop...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787906790&installation_model_id=10242&pr_number=5301&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5301&signature=fc1eb587e0efd606c5ed9339456f56d2d0d932c4f4434923020f51345f664de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->