### PR TITLE
fix: bump ckb-verification-contextual to 1.2.0 (unblock cargo package/publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-verification-contextual"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "ckb-async-runtime",
  "ckb-chain",

--- a/verification/contextual/CHANGELOG.md
+++ b/verification/contextual/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/nervosnetwork/ckb/compare/ckb-verification-contextual-v1.1.1...ckb-verification-contextual-v1.2.0) - 2026-08-05
+
+### Changed
+
+- Adapt to the `ckb-verification` cache API change that removed the `EntryCache`
+  suspend status; import the new `VerifyCacheKey` / `CachedScriptCycles` /
+  `FetchedTxVerificationCache` / `TxVerificationCacheLookup` types from
+  `ckb_verification::cache` ([#5262](https://github.com/nervosnetwork/ckb/pull/5262)).
+
 ## [1.1.1](https://github.com/nervosnetwork/ckb/compare/ckb-verification-contextual-v1.1.0...ckb-verification-contextual-v1.1.1) - 2026-06-08
 
 ### Changed

--- a/verification/contextual/Cargo.toml
+++ b/verification/contextual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-verification-contextual"
-version = "1.1.1"
+version = "1.2.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2024"


### PR DESCRIPTION
## Problem

`cargo package` / `cargo publish --dry-run` of the top-level `ckb` crate fails during tarball verification:

```
   Verifying ckb v0.209.0
   Compiling ckb-verification-contextual v1.1.1
error[E0432]: unresolved import `ckb_verification::cache::CacheEntry`
  --> ~/.cargo/registry/src/.../ckb-verification-contextual-1.1.1/src/contextual_block_verifier.rs:26:27
   |
26 |     TxVerificationCache, {CacheEntry, Completed},
   |                           ^^^^^^^^^^ no `CacheEntry` in `cache`

error: could not compile `ckb-verification-contextual` (lib) due to 1 previous error
error: failed to verify package tarball
```

## Root cause

In #5262 the `ckb-verification` cache API dropped the `EntryCache`/`CacheEntry` suspend status. `ckb-verification` was correctly bumped `1.1.x → 1.2.0` and **published** to crates.io (registry now serves `ckb-verification 1.2.0` without `CacheEntry`).

`ckb-verification-contextual` had its source adapted to the new API in the same change, but **its version was never bumped** — it stayed at `1.1.1`, colliding with the *already-published* `1.1.1` whose source still imports the removed `CacheEntry`. The corrected source was never republished.

During `cargo package`/`publish` verification the path dependency is stripped and `ckb-verification-contextual = "1"` is resolved **from the registry** → the stale `1.1.1` → compile error against `ckb-verification 1.2.0`. The published `ckb-verification-contextual 1.1.1` is effectively broken on crates.io against `ckb-verification 1.2.0`.

| crate | registry | local source |
|---|---|---|
| `ckb-verification` | `1.2.0` (no `CacheEntry`) | `1.2.0` ✅ |
| `ckb-verification-contextual` | `1.1.1` (imports `CacheEntry`) | `1.1.1` but source is the new API ❌ |

## Fix

Bump `ckb-verification-contextual` `1.1.1 → 1.2.0` to match the `ckb-verification` family, update `Cargo.lock`, and add a `CHANGELOG.md` entry. This supersedes the broken published `1.1.1` with a `1.2.0` whose source matches `ckb-verification 1.2.0`.

## Verification

- ✅ `cargo package -p ckb-verification-contextual` now packages and builds cleanly against the published `ckb-verification 1.2.0`.
- ✅ Full workspace `cargo check` passes with the bumped version.
- ✅ Confirmed `ckb-verification-contextual` was the only stale crate — the other consumer of the new cache API (`ckb-tx-pool`) was already bumped to `1.3.0`.

> **Note on the root `cargo package` error:** package verification resolves dependencies from the registry, so the top-level `ckb` `cargo package`/`cargo publish` will continue to surface this error **until `ckb-verification-contextual 1.2.0` is published** to crates.io (standard release ordering). This PR is the prerequisite — once `1.2.0` ships, the root verification resolves the fixed version and passes.

## Checklist

- [x] Version bumped in `verification/contextual/Cargo.toml`
- [x] `Cargo.lock` updated
- [x] `CHANGELOG.md` entry added

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nervosnetwork/codesmith/ckb/pr/5303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788501085&installation_model_id=10242&pr_number=5303&repository=nervosnetwork%2Fckb&return_to=https%3A%2F%2Fgithub.com%2Fnervosnetwork%2Fckb%2Fpull%2F5303&signature=02f20da816128c5d4795b3ab8c3f464c6c68a35e9274b5ff5202480481c04d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->