### PR TITLE
fix: avoid panic on malformed versionbits cache entry

### DIFF
--- a/spec/src/versionbits/mod.rs
+++ b/spec/src/versionbits/mod.rs
@@ -48,14 +48,14 @@ pub enum ThresholdState {
 }
 
 impl ThresholdState {
-    fn from_u8(value: u8) -> ThresholdState {
+    fn from_u8(value: u8) -> Option<ThresholdState> {
         match value {
-            0 => ThresholdState::Defined,
-            1 => ThresholdState::Started,
-            2 => ThresholdState::LockedIn,
-            3 => ThresholdState::Active,
-            4 => ThresholdState::Failed,
-            _ => panic!("Unknown value: {}", value),
+            0 => Some(ThresholdState::Defined),
+            1 => Some(ThresholdState::Started),
+            2 => Some(ThresholdState::LockedIn),
+            3 => Some(ThresholdState::Active),
+            4 => Some(ThresholdState::Failed),
+            _ => None,
         }
     }
 }
@@ -154,7 +154,13 @@ impl Cache {
     #[cfg(not(target_family = "wasm"))]
     pub fn get(&self, key: &Byte32) -> Option<ThresholdState> {
         match cacache::read_sync(&self.path, Self::encode_key(key)) {
-            Ok(bytes) => Some(Self::decode_value(bytes)),
+            Ok(bytes) => {
+                let state = Self::decode_value(bytes);
+                if state.is_none() {
+                    error!("cacache entry for key {} is malformed", Self::encode_key(key));
+                }
+                state
+            }
             Err(cacache::Error::EntryNotFound(_path, _key)) => None,
             Err(err) => {
                 error!("cacache read_sync failed {:?}", err);
@@ -187,8 +193,8 @@ impl Cache {
         unimplemented!()
     }
 
-    fn decode_value(value: Vec<u8>) -> ThresholdState {
-        ThresholdState::from_u8(value[0])
+    fn decode_value(value: Vec<u8>) -> Option<ThresholdState> {
+        value.first().copied().and_then(ThresholdState::from_u8)
     }
 
     fn encode_key(key: &Byte32) -> String {


### PR DESCRIPTION
### What problem does this PR solve?

`Cache::get` in `spec/src/versionbits/mod.rs` panics when a persisted cache entry decodes to an invalid `ThresholdState`:

- `decode_value` indexes `value[0]`, which panics on an empty value;
- `ThresholdState::from_u8` panics on any byte outside `0..=4`.

Such an entry cannot be produced by remote peers: values are only ever written by the node itself as a single byte in `0..=4`, and cacache verifies content integrity on read. However, a corrupted or version-mismatched entry in the local data directory would panic the calling thread (e.g. the RPC `get_deployments_info` handler or the block assembler) instead of falling back to recomputing the state.

### What is changed

- `ThresholdState::from_u8` now returns `Option<ThresholdState>` instead of panicking on unknown values.
- `decode_value` returns `Option<ThresholdState>` and handles empty or unknown values.
- `Cache::get` logs an error and returns `None` for a malformed entry, so the state is recomputed — the same failure behavior already used for unreadable cache entries.

### Check List

- [x] No breaking change (cache read fallback only; no consensus, RPC schema, or storage format change)

Tests:

- `cargo check -p ckb-chain-spec` passes.
- `cargo test -p ckb-chain-spec test_versionbits_active` and `cargo test -p ckb-chain-spec test_versionbits_failed` pass. Running both versionbits filters in a single process hits a pre-existing `DATA_DIR set only once` conflict between the two tests, which also fails on the unmodified base commit and is unrelated to this change.
