### PR TITLE
fix(tx-pool): bound verify queue transaction count

### DIFF
--- a/tx-pool/src/component/tests/chunk.rs
+++ b/tx-pool/src/component/tests/chunk.rs
@@ -91,6 +91,22 @@ async fn verify_queue_basic() {
     assert!(!queue.contains_key(&id));
 }
 
+#[test]
+fn verify_queue_rejects_when_transaction_count_limit_is_reached() {
+    let mut queue = VerifyQueue::new(MAX_TX_VERIFY_CYCLES);
+    queue.set_max_transactions_for_test(1);
+
+    let tx0 = TransactionBuilder::default().build();
+    let tx1 = TransactionBuilder::default().version(1u32).build();
+
+    assert!(queue.add_tx(tx0, false, None).unwrap());
+    assert!(matches!(
+        queue.add_tx(tx1, false, None),
+        Err(crate::error::Reject::Full(_))
+    ));
+    assert_eq!(queue.len(), 1);
+}
+
 #[tokio::test]
 async fn test_verify_different_cycles() {
     let (exit_tx, mut exit_rx) = watch::channel(());

--- a/tx-pool/src/component/verify_queue.rs
+++ b/tx-pool/src/component/verify_queue.rs
@@ -16,6 +16,10 @@ use tokio::sync::Notify;
 
 // 256mb for total_tx_size limit, default max_tx_pool_size is 180mb
 const DEFAULT_MAX_VERIFY_QUEUE_TX_SIZE: usize = 256_000_000;
+// Serialized size does not account for the fixed overhead of TransactionView and
+// the indexes maintained for every VerifyEntry. Keep a count limit as a second
+// line of defense against queues containing a large number of small transactions.
+const DEFAULT_MAX_VERIFY_TRANSACTIONS: usize = 100_000;
 const SHRINK_THRESHOLD: usize = 100;
 
 /// The verify queue Entry to verify.
@@ -62,6 +66,8 @@ pub(crate) struct VerifyQueue {
     ready_rx: Arc<Notify>,
     /// total tx size in the queue, will reject new transaction if exceed the limit
     total_tx_size: usize,
+    /// transaction count limit, independent of the serialized-size limit
+    max_transactions: usize,
     /// large cycle threshold, from `pool_config.max_tx_verify_cycles`
     large_cycle_threshold: u64,
 }
@@ -73,6 +79,7 @@ impl VerifyQueue {
             inner: MultiIndexVerifyEntryMap::default(),
             ready_rx: Arc::new(Notify::new()),
             total_tx_size: 0,
+            max_transactions: DEFAULT_MAX_VERIFY_TRANSACTIONS,
             large_cycle_threshold,
         }
     }
@@ -102,9 +109,15 @@ impl VerifyQueue {
         self.total_tx_size = total_tx_size;
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_max_transactions_for_test(&mut self, max_transactions: usize) {
+        self.max_transactions = max_transactions;
+    }
+
     /// Returns true if the queue is full.
     pub fn is_full(&self, add_tx_size: usize) -> bool {
-        add_tx_size >= DEFAULT_MAX_VERIFY_QUEUE_TX_SIZE - self.total_tx_size
+        self.len() >= self.max_transactions
+            || add_tx_size >= DEFAULT_MAX_VERIFY_QUEUE_TX_SIZE - self.total_tx_size
     }
 
     /// Returns true if the queue contains a tx with the specified id.
@@ -238,7 +251,7 @@ impl VerifyQueue {
         };
         if self.is_full(tx_size) {
             return Err(Reject::Full(format!(
-                "verify_queue total_tx_size exceeded, failed to add tx: {:#x}",
+                "verify_queue count or total_tx_size exceeded, failed to add tx: {:#x}",
                 tx.hash()
             )));
         }


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read [CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the [Conventional Commit Messages](https://www.conventionalcommits.org/) format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->
### What problem does this PR solve?

Problem Summary:

The verify queue currently limits admission using only the sum of each
transaction's serialized block size, with a 256 MB limit.

Serialized size does not include the fixed per-entry memory overhead from
`TransactionView`, `VerifyEntry`, and the indexes maintained by
`MultiIndexMap`. A remote peer can therefore relay a large number of small
transactions and cause actual memory consumption to substantially exceed the
configured byte limit.

In testing, 120,000 small transactions accounted for approximately 29 MB of
serialized data but increased the node RSS by approximately 124 MB.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- Retain the existing 256 MB serialized-size limit.
- Add an independent verify queue limit of 100,000 transactions.
- Reject new transactions with `Reject::Full` when either limit is reached.
- Add a regression test covering the transaction-count boundary.

The two limits protect against different cases:

- The byte limit bounds queues containing large transactions.
- The count limit bounds fixed per-entry overhead from large numbers of small
  transactions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- `cargo fmt --check`
- `cargo test -p ckb-tx-pool component::tests::chunk --lib`
- `cargo test -p ckb-tx-pool --lib`
- `git diff --check`

Side effects

- Performance regression
- Breaking backward compatibility
