### PR TITLE
fix(sync): prevent relay backpressure from blocking block verification

### DIFF
--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -305,7 +305,12 @@ impl Relayer {
                         return;
                     }
 
-                    build_and_broadcast_compact_block(nc.as_ref(), shared.shared(), peer_id, block);
+                    schedule_build_and_broadcast_compact_block(
+                        nc,
+                        shared.shared().clone(),
+                        peer_id,
+                        block,
+                    );
                 }
                 Err(err) => {
                     error!(
@@ -723,8 +728,23 @@ impl Relayer {
     }
 }
 
-fn build_and_broadcast_compact_block(
-    nc: &dyn CKBProtocolContext,
+fn schedule_build_and_broadcast_compact_block(
+    nc: Arc<dyn CKBProtocolContext + Sync>,
+    shared: Shared,
+    peer: PeerIndex,
+    block: Arc<BlockView>,
+) {
+    // Verification callbacks run synchronously on the chain service. Keep P2P
+    // backpressure from stalling that service by doing all relay I/O in an
+    // independent runtime task.
+    let handle = shared.async_handle().clone();
+    handle.spawn(async move {
+        build_and_broadcast_compact_block(nc.as_ref(), &shared, peer, block).await;
+    });
+}
+
+async fn build_and_broadcast_compact_block(
+    nc: &(dyn CKBProtocolContext + Sync),
     shared: &Shared,
     peer: PeerIndex,
     block: Arc<BlockView>,
@@ -746,11 +766,13 @@ fn build_and_broadcast_compact_block(
         .filter(|target_peer| peer != *target_peer)
         .take(MAX_RELAY_PEERS)
         .collect();
-    let handle = shared.async_handle();
-    if let Err(err) = handle.block_on(nc.async_quick_filter_broadcast(
-        TargetSession::Multi(Box::new(selected_peers.into_iter())),
-        message.as_bytes(),
-    )) {
+    if let Err(err) = nc
+        .async_quick_filter_broadcast(
+            TargetSession::Multi(Box::new(selected_peers.into_iter())),
+            message.as_bytes(),
+        )
+        .await
+    {
         debug_target!(
             crate::LOG_TARGET_RELAY,
             "relayer send block when accept block error: {:?}",
@@ -795,11 +817,14 @@ fn build_and_broadcast_compact_block(
         .filter(|(_id, peer)| peer.if_lightclient_subscribed)
         .map(|(id, _)| id)
         .collect();
-    if let Err(err) = handle.block_on(nc.async_filter_broadcast_with_proto(
-        SupportProtocols::LightClient.protocol_id(),
-        TargetSession::Filter(Box::new(move |id| light_client_peers.contains(id))),
-        light_client_message.as_bytes(),
-    )) {
+    if let Err(err) = nc
+        .async_filter_broadcast_with_proto(
+            SupportProtocols::LightClient.protocol_id(),
+            TargetSession::Filter(Box::new(move |id| light_client_peers.contains(id))),
+            light_client_message.as_bytes(),
+        )
+        .await
+    {
         debug_target!(
             crate::LOG_TARGET_RELAY,
             "relayer send last state to light client when accept block, error: {:?}",

--- a/sync/src/relayer/tests/broadcast_backpressure.rs
+++ b/sync/src/relayer/tests/broadcast_backpressure.rs
@@ -1,0 +1,40 @@
+use super::helper::{MockProtocolContext, build_chain, gen_block};
+use crate::relayer::schedule_build_and_broadcast_compact_block;
+use ckb_network::{CKBProtocolContext, SupportProtocols};
+use std::{
+    sync::{Arc, mpsc},
+    time::Duration,
+};
+
+#[test]
+fn compact_block_broadcast_backpressure_does_not_block_caller() {
+    let (_chain, relayer, _) = build_chain(1);
+    let parent = relayer.shared.active_chain().tip_header();
+    let block = Arc::new(gen_block(&parent, relayer.shared().shared(), 0, 0, None));
+
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::channel();
+    let context: Arc<dyn CKBProtocolContext + Sync> =
+        Arc::new(MockProtocolContext::with_blocked_broadcast(
+            SupportProtocols::RelayV3,
+            entered_tx,
+            release_rx,
+        ));
+    let shared = relayer.shared().shared().clone();
+    let (done_tx, done_rx) = mpsc::channel();
+
+    let worker = std::thread::spawn(move || {
+        schedule_build_and_broadcast_compact_block(context, shared, 1.into(), block);
+        done_tx.send(()).unwrap();
+    });
+
+    done_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("verification callback remained blocked by P2P backpressure");
+    entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("broadcast future was not polled");
+
+    release_tx.send(()).unwrap();
+    worker.join().unwrap();
+}

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -32,7 +32,17 @@ use ckb_types::{
 };
 use ckb_verification_traits::Switch;
 use std::collections::HashSet;
-use std::{cell::RefCell, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, SyncSender},
+    },
+    time::Duration,
+};
 
 pub(crate) fn new_index_transaction(index: usize) -> IndexTransaction {
     let transaction = TransactionBuilder::default()
@@ -300,6 +310,13 @@ pub(crate) fn gen_block(
 pub(crate) struct MockProtocolContext {
     protocol: SupportProtocols,
     sent_messages: RefCell<Vec<(ProtocolId, PeerIndex, P2pBytes)>>,
+    broadcast_gate: Option<BroadcastGate>,
+}
+
+struct BroadcastGate {
+    entered: SyncSender<()>,
+    release: Mutex<Receiver<()>>,
+    blocked: AtomicBool,
 }
 
 // test mock context with single thread
@@ -312,6 +329,33 @@ impl MockProtocolContext {
         Self {
             protocol,
             sent_messages: Default::default(),
+            broadcast_gate: None,
+        }
+    }
+
+    pub(crate) fn with_blocked_broadcast(
+        protocol: SupportProtocols,
+        entered: SyncSender<()>,
+        release: Receiver<()>,
+    ) -> Self {
+        Self {
+            protocol,
+            sent_messages: Default::default(),
+            broadcast_gate: Some(BroadcastGate {
+                entered,
+                release: Mutex::new(release),
+                blocked: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    fn block_first_broadcast(&self) {
+        let Some(gate) = &self.broadcast_gate else {
+            return;
+        };
+        if !gate.blocked.swap(true, Ordering::SeqCst) {
+            gate.entered.send(()).unwrap();
+            gate.release.lock().unwrap().recv().unwrap();
         }
     }
 
@@ -359,6 +403,7 @@ impl CKBProtocolContext for MockProtocolContext {
         target: TargetSession,
         data: P2pBytes,
     ) -> Result<(), Error> {
+        self.block_first_broadcast();
         self.quick_filter_broadcast(target, data)
     }
     async fn async_future_task(

--- a/sync/src/relayer/tests/mod.rs
+++ b/sync/src/relayer/tests/mod.rs
@@ -2,6 +2,7 @@ mod block_proposal_process;
 mod block_transactions_process;
 mod block_transactions_verifier;
 mod block_uncles_verifier;
+mod broadcast_backpressure;
 mod compact_block;
 mod compact_block_process;
 mod compact_block_verifier;


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read the
[CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md)
document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the
[Conventional Commit Messages](https://www.conventionalcommits.org/)
format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change (indicated by the !) and results in a SemVer major bump.

Other conventional prefixes are also acceptable (e.g., `docs:`, `refactor:`, `test:`, `chore:`, etc.).
-->

### What problem does this PR solve?

Problem Summary:

After a remote block is successfully verified, the relayer broadcasts a compact
block and a light-client last-state update from the synchronous chain
verification callback.

These broadcasts used `Handle::block_on` to execute asynchronous P2P operations.
When the P2P control queue was backpressured, the verification callback could
remain blocked while waiting for queue capacity. This allowed network
backpressure to propagate into the chain verification path and delay subsequent
block processing.

### What is changed and how it works?

What's Changed:

- Schedule post-verification relay broadcasts in an independent async runtime
  task.
- Replace `Handle::block_on` with direct `.await` calls inside the spawned task.
- Keep compact-block and light-client broadcast backpressure isolated from the
  synchronous chain verification callback.
- Add a regression test that deliberately blocks the P2P broadcast future and
  verifies that the scheduling caller returns without waiting for the
  backpressure to clear.

A congested P2P queue may still delay block propagation, but it no longer blocks
the chain verification callback.

### Related changes

None.

### Check List

Tests:

- Unit test
  - `cargo test -p ckb-sync compact_block_broadcast_backpressure_does_not_block_caller`
  - `cargo test -p ckb-sync relayer::tests -- --test-threads=1`
    - 46 passed, 0 failed
- `cargo check -p ckb-sync`
- `git diff --check`

Side effects:

- No breaking backward compatibility.
- No expected performance regression.