### PR TITLE
fix: bound pending sync response tasks and memory

### DIFF
--- a/sync/src/synchronizer/get_blocks_process.rs
+++ b/sync/src/synchronizer/get_blocks_process.rs
@@ -1,5 +1,4 @@
 use crate::synchronizer::Synchronizer;
-use crate::utils::async_send_message_to;
 use crate::{Status, StatusCode};
 use ckb_constant::sync::{INIT_BLOCKS_IN_TRANSIT_PER_PEER, MAX_HEADERS_LEN};
 use ckb_logger::debug;
@@ -75,12 +74,12 @@ impl<'a> GetBlocksProcess<'a> {
                 let content = packed::SendBlock::new_builder().block(block.data()).build();
                 let message = packed::SyncMessage::new_builder().set(content).build();
 
-                let nc = Arc::clone(self.nc);
-                self.synchronizer
-                    .shared()
-                    .shared()
-                    .async_handle()
-                    .spawn(async move { async_send_message_to(&nc, self.peer, &message).await });
+                let status =
+                    self.synchronizer
+                        .send_sync_response(Arc::clone(self.nc), self.peer, message);
+                if !status.is_ok() {
+                    return status;
+                }
             } else {
                 // TODO response not found
                 // TODO add timeout check in synchronizer

--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -1,9 +1,8 @@
 use crate::synchronizer::Synchronizer;
-use crate::utils::{async_send_message, async_send_message_to};
 use crate::{Status, StatusCode};
 use ckb_constant::sync::MAX_LOCATOR_SIZE;
 use ckb_logger::{debug, info};
-use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
+use ckb_network::{CKBProtocolContext, PeerIndex};
 use ckb_types::{
     core,
     packed::{self, Byte32},
@@ -85,32 +84,19 @@ impl<'a> GetHeadersProcess<'a> {
                 .headers(headers.into_iter().map(|x| x.data()).collect::<Vec<_>>())
                 .build();
             let message = packed::SyncMessage::new_builder().set(content).build();
-            let nc = Arc::clone(self.nc);
             self.synchronizer
-                .shared()
-                .shared()
-                .async_handle()
-                .spawn(async move { async_send_message_to(&nc, self.peer, &message).await });
+                .send_sync_response(Arc::clone(self.nc), self.peer, message)
         } else {
-            return StatusCode::GetHeadersMissCommonAncestors
-                .with_context(format!("{block_locator_hashes:#x?}"));
+            StatusCode::GetHeadersMissCommonAncestors
+                .with_context(format!("{block_locator_hashes:#x?}"))
         }
-        Status::ok()
     }
 
     fn send_in_ibd(&self) {
         let content = packed::InIBD::new_builder().build();
         let message = packed::SyncMessage::new_builder().set(content).build();
-        let nc = Arc::clone(self.nc);
-        let peer = self.peer;
-        self.synchronizer
-            .shared()
-            .shared()
-            .async_handle()
-            .spawn(async move {
-                let _ignore =
-                    async_send_message(SupportProtocols::Sync.protocol_id(), &nc, peer, &message)
-                        .await;
-            });
+        let _ignore = self
+            .synchronizer
+            .send_sync_response(Arc::clone(self.nc), self.peer, message);
     }
 }

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -354,7 +354,17 @@ pub struct Synchronizer {
     /// Sync shared state
     pub shared: Arc<SyncShared>,
     fetch_channel: Option<channel::Sender<FetchCMD>>,
+    pending_response_bytes: Arc<tokio::sync::Semaphore>,
+    pending_response_tasks: Arc<tokio::sync::Semaphore>,
+    max_pending_response_bytes: usize,
+    max_pending_response_tasks: usize,
 }
+
+// This is large enough for a full 32-block GetBlocks response at the default
+// consensus block-size limit, while bounding detached responses independently
+// of the network's message-count based channels.
+const MAX_PENDING_RESPONSE_BYTES: usize = 24 * 1024 * 1024;
+const MAX_PENDING_RESPONSE_TASKS: usize = 1_024;
 
 impl Synchronizer {
     /// Init sync protocol handle
@@ -365,7 +375,75 @@ impl Synchronizer {
             chain,
             shared,
             fetch_channel: None,
+            pending_response_bytes: Arc::new(tokio::sync::Semaphore::new(
+                MAX_PENDING_RESPONSE_BYTES,
+            )),
+            pending_response_tasks: Arc::new(tokio::sync::Semaphore::new(
+                MAX_PENDING_RESPONSE_TASKS,
+            )),
+            max_pending_response_bytes: MAX_PENDING_RESPONSE_BYTES,
+            max_pending_response_tasks: MAX_PENDING_RESPONSE_TASKS,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_pending_response_limits(
+        chain: ChainController,
+        shared: Arc<SyncShared>,
+        max_pending_response_bytes: usize,
+        max_pending_response_tasks: usize,
+    ) -> Self {
+        Self {
+            chain,
+            shared,
+            fetch_channel: None,
+            pending_response_bytes: Arc::new(tokio::sync::Semaphore::new(
+                max_pending_response_bytes,
+            )),
+            pending_response_tasks: Arc::new(tokio::sync::Semaphore::new(
+                max_pending_response_tasks,
+            )),
+            max_pending_response_bytes,
+            max_pending_response_tasks,
+        }
+    }
+
+    pub(crate) fn send_sync_response(
+        &self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer: PeerIndex,
+        message: packed::SyncMessage,
+    ) -> Status {
+        let response_bytes = message.as_bytes().len();
+        let Ok(response_bytes) = u32::try_from(response_bytes) else {
+            return StatusCode::TooManyRequests.with_context("sync response is too large");
+        };
+        let task_permit = match Arc::clone(&self.pending_response_tasks).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return StatusCode::TooManyRequests.with_context(format!(
+                    "pending sync responses exceed {} tasks",
+                    self.max_pending_response_tasks
+                ));
+            }
+        };
+        let permit =
+            match Arc::clone(&self.pending_response_bytes).try_acquire_many_owned(response_bytes) {
+                Ok(permit) => permit,
+                Err(_) => {
+                    return StatusCode::TooManyRequests.with_context(format!(
+                        "pending sync responses exceed {} bytes",
+                        self.max_pending_response_bytes
+                    ));
+                }
+            };
+
+        self.shared.shared().async_handle().spawn(async move {
+            let _task_permit = task_permit;
+            let _permit = permit;
+            async_send_message_to(&nc, peer, &message).await
+        });
+        Status::ok()
     }
 
     /// Get shared state

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -31,9 +31,13 @@ use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
     pin::Pin,
-    sync::{Arc, atomic::Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
+use tokio::sync::Semaphore;
 
 use crate::{
     Status, StatusCode, SyncShared,
@@ -417,6 +421,23 @@ fn test_get_locator_response() {
 struct DummyNetworkContext {
     pub peers: HashMap<PeerIndex, Peer>,
     pub disconnected: Arc<Mutex<HashSet<PeerIndex>>>,
+    pending_sends: Option<Arc<PendingSends>>,
+}
+
+struct PendingSends {
+    active: AtomicUsize,
+    retained_bytes: AtomicUsize,
+    release: Semaphore,
+}
+
+impl Default for PendingSends {
+    fn default() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            retained_bytes: AtomicUsize::new(0),
+            release: Semaphore::new(0),
+        }
+    }
 }
 
 fn mock_peer_info() -> Peer {
@@ -478,8 +499,19 @@ impl CKBProtocolContext for DummyNetworkContext {
         &self,
         _proto_id: ProtocolId,
         _peer_index: PeerIndex,
-        _data: Bytes,
+        data: Bytes,
     ) -> Result<(), ckb_network::Error> {
+        if let Some(pending) = &self.pending_sends {
+            pending.active.fetch_add(1, Ordering::SeqCst);
+            pending
+                .retained_bytes
+                .fetch_add(data.len(), Ordering::SeqCst);
+            let _permit = pending.release.acquire().await.unwrap();
+            pending.active.fetch_sub(1, Ordering::SeqCst);
+            pending
+                .retained_bytes
+                .fetch_sub(data.len(), Ordering::SeqCst);
+        }
         Ok(())
     }
     async fn async_send_message_to(
@@ -613,7 +645,15 @@ fn mock_network_context(peer_num: usize) -> DummyNetworkContext {
     DummyNetworkContext {
         peers,
         disconnected: Arc::new(Mutex::new(HashSet::default())),
+        pending_sends: None,
     }
+}
+
+fn backpressured_network_context(peer_num: usize) -> (DummyNetworkContext, Arc<PendingSends>) {
+    let mut context = mock_network_context(peer_num);
+    let pending = Arc::new(PendingSends::default());
+    context.pending_sends = Some(Arc::clone(&pending));
+    (context, pending)
 }
 
 #[test]
@@ -1268,6 +1308,109 @@ fn get_blocks_process() {
         process.execute(),
         StatusCode::RequestDuplicate.with_context("Request duplicate block")
     );
+}
+
+#[test]
+fn get_blocks_backpressure_respects_pending_response_budget() {
+    const REQUESTS: usize = 2_048;
+    const RESPONSE_BUDGET: usize = 4 * 1024;
+    const TASK_BUDGET: usize = 16;
+
+    let consensus = Consensus::default();
+    let (chain, shared, original_synchronizer) = start_chain(Some(consensus));
+    insert_block(chain.chain_controller(), &shared, 1, 1);
+    let synchronizer = Synchronizer::new_with_pending_response_limits(
+        chain.chain_controller().clone(),
+        Arc::clone(&original_synchronizer.shared),
+        RESPONSE_BUDGET,
+        TASK_BUDGET,
+    );
+
+    let hash = shared.snapshot().get_block_hash(1).unwrap();
+    let message = packed::GetBlocks::new_builder()
+        .block_hashes(vec![hash])
+        .build();
+    let (context, pending) = backpressured_network_context(1);
+    let nc = Arc::new(context) as Arc<dyn CKBProtocolContext + Sync + 'static>;
+    let peer: PeerIndex = 0.into();
+
+    let mut accepted = 0;
+    let mut rejected = 0;
+    for _ in 0..REQUESTS {
+        let status = GetBlocksProcess::new(message.as_reader(), &synchronizer, peer, &nc).execute();
+        if status.is_ok() {
+            accepted += 1;
+        } else {
+            assert_eq!(status.code(), StatusCode::TooManyRequests);
+            rejected += 1;
+        }
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while pending.active.load(Ordering::SeqCst) != accepted && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert_eq!(pending.active.load(Ordering::SeqCst), accepted);
+    assert!(accepted > 0);
+    assert!(accepted <= TASK_BUDGET);
+    assert!(rejected > 0);
+    let retained_bytes = pending.retained_bytes.load(Ordering::SeqCst);
+    assert!(retained_bytes <= RESPONSE_BUDGET);
+    eprintln!(
+        "requests: {REQUESTS}, accepted: {accepted}, rejected: {rejected}, retained response bytes: {retained_bytes}"
+    );
+
+    pending.release.add_permits(accepted);
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while pending.active.load(Ordering::SeqCst) != 0 && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(pending.active.load(Ordering::SeqCst), 0);
+
+    assert_eq!(
+        GetBlocksProcess::new(message.as_reader(), &synchronizer, peer, &nc).execute(),
+        Status::ok(),
+        "completed sends must return their byte budget"
+    );
+    pending.release.add_permits(1);
+}
+
+#[test]
+fn get_blocks_backpressure_respects_pending_task_budget() {
+    const REQUESTS: usize = 32;
+    const TASK_BUDGET: usize = 4;
+
+    let (chain, shared, original_synchronizer) = start_chain(Some(Consensus::default()));
+    insert_block(chain.chain_controller(), &shared, 1, 1);
+    let synchronizer = Synchronizer::new_with_pending_response_limits(
+        chain.chain_controller().clone(),
+        Arc::clone(&original_synchronizer.shared),
+        1024 * 1024,
+        TASK_BUDGET,
+    );
+    let message = packed::GetBlocks::new_builder()
+        .block_hashes(vec![shared.snapshot().get_block_hash(1).unwrap()])
+        .build();
+    let (context, pending) = backpressured_network_context(1);
+    let nc = Arc::new(context) as Arc<dyn CKBProtocolContext + Sync + 'static>;
+    let peer: PeerIndex = 0.into();
+
+    let statuses: Vec<_> = (0..REQUESTS)
+        .map(|_| GetBlocksProcess::new(message.as_reader(), &synchronizer, peer, &nc).execute())
+        .collect();
+    assert_eq!(
+        statuses.iter().filter(|status| status.is_ok()).count(),
+        TASK_BUDGET
+    );
+    assert!(
+        statuses[TASK_BUDGET..]
+            .iter()
+            .all(|status| status.code() == StatusCode::TooManyRequests)
+    );
+
+    pending.release.add_permits(TASK_BUDGET);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read the
[CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md)
document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the
[Conventional Commit Messages](https://www.conventionalcommits.org/)
format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change and results in a
  SemVer major bump.

Other conventional prefixes are also acceptable (e.g. `docs:`, `refactor:`,
`test:`, `chore:`, etc.).
-->

### What problem does this PR solve?

Problem Summary:

`GetBlocks` and `GetHeaders` responses were sent using detached asynchronous
tasks. When the P2P send path was backpressured, these tasks could remain
pending while retaining complete serialized block or header responses.

The request handlers returned immediately and did not enforce limits on either
the number of pending response tasks or the total response bytes retained by
them. A peer could therefore repeatedly submit valid sync requests and cause
pending tasks and their retained memory to accumulate.

A single `GetBlocks` request can create up to 32 detached block-response tasks.
Because repeated requests were not subject to a pending-response budget, this
provided substantial request-to-memory amplification.

### What is changed and how it works?

What's Changed:

- Add a shared pending sync-response budget to `Synchronizer`.
- Limit pending serialized response data to 24 MiB.
- Limit the number of pending response tasks to 1,024.
- Route `GetBlocks`, `GetHeaders`, and `InIBD` responses through the bounded
  response-sending path.
- Reserve both task and byte permits before spawning an asynchronous send.
- Return `TooManyRequests` without creating a task when either budget is
  exhausted.
- Automatically return permits when a send completes or its task is cancelled.
- Add regression tests covering both retained-response bytes and task-count
  limits.

The byte limit prevents large block or header responses from exhausting memory,
while the independent task limit prevents large numbers of small responses from
accumulating runtime task overhead.

The 24 MiB byte budget is large enough for a normal 32-block `GetBlocks`
response at the default consensus block-size limit.

### Related changes

None.

### Check List

Tests:

- Unit test
  - `cargo test -p ckb-sync get_blocks_backpressure_respects -- --test-threads=1`
  - Byte-budget test:
    - 2,048 requests
    - 8 accepted
    - 2,040 rejected
    - 3,880 retained bytes with a 4,096-byte test budget
  - Task-budget test:
    - 32 requests
    - 4 accepted
    - 28 rejected with a four-task test budget
- `cargo test -p ckb-sync tests::synchronizer::functions -- --test-threads=1`
  - 15 passed, 0 failed
- `cargo check -p ckb-sync`
- `git diff --check`

Side effects:

- Under sustained P2P send backpressure, excess sync responses are rejected with
  `TooManyRequests` instead of being queued indefinitely.
- No breaking backward compatibility.
- No expected performance regression under normal network conditions.