### PR TITLE
fix: validate GetHeaders locator length before allocation

### DIFF
--- a/sync/src/synchronizer/get_headers_process.rs
+++ b/sync/src/synchronizer/get_headers_process.rs
@@ -36,19 +36,19 @@ impl<'a> GetHeadersProcess<'a> {
     pub fn execute(self) -> Status {
         let active_chain = self.synchronizer.shared.active_chain();
 
-        let block_locator_hashes = self
-            .message
-            .block_locator_hashes()
-            .iter()
-            .map(|x| x.to_entity())
-            .collect::<Vec<Byte32>>();
-        let hash_stop = self.message.hash_stop().to_entity();
+        let block_locator_hashes = self.message.block_locator_hashes();
         let locator_size = block_locator_hashes.len();
         if locator_size > MAX_LOCATOR_SIZE {
             return StatusCode::ProtocolMessageIsMalformed.with_context(format!(
                 "Locator count({locator_size}) > MAX_LOCATOR_SIZE({MAX_LOCATOR_SIZE})"
             ));
         }
+
+        let block_locator_hashes = block_locator_hashes
+            .iter()
+            .map(|x| x.to_entity())
+            .collect::<Vec<Byte32>>();
+        let hash_stop = self.message.hash_stop().to_entity();
 
         if active_chain.is_initial_block_download() {
             info!(

--- a/sync/src/tests/synchronizer/functions.rs
+++ b/sync/src/tests/synchronizer/functions.rs
@@ -1,6 +1,8 @@
 use ckb_chain::{ChainController, ChainServiceScope};
 use ckb_chain_spec::consensus::{Consensus, ConsensusBuilder};
-use ckb_constant::sync::{CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME, MAX_TIP_AGE};
+use ckb_constant::sync::{
+    CHAIN_SYNC_TIMEOUT, EVICTION_HEADERS_RESPONSE_TIME, MAX_LOCATOR_SIZE, MAX_TIP_AGE,
+};
 use ckb_dao::DaoCalculator;
 use ckb_error::InternalErrorKind;
 use ckb_network::{
@@ -37,7 +39,10 @@ use std::{
 
 use crate::{
     Status, StatusCode, SyncShared,
-    synchronizer::{BlockFetcher, BlockProcess, GetBlocksProcess, HeadersProcess, Synchronizer},
+    synchronizer::{
+        BlockFetcher, BlockProcess, GetBlocksProcess, GetHeadersProcess, HeadersProcess,
+        Synchronizer,
+    },
     types::{HeadersSyncController, IBDState, PeerState},
 };
 
@@ -1267,6 +1272,28 @@ fn get_blocks_process() {
     assert_eq!(
         process.execute(),
         StatusCode::RequestDuplicate.with_context("Request duplicate block")
+    );
+}
+
+#[test]
+fn get_headers_rejects_oversized_locator_before_processing() {
+    let (_chain, _shared, synchronizer) = start_chain(Some(Consensus::default()));
+    let message = packed::GetHeaders::new_builder()
+        .block_locator_hashes(vec![Byte32::zero(); MAX_LOCATOR_SIZE + 1])
+        .hash_stop(Byte32::zero())
+        .build();
+    let nc = Arc::new(mock_network_context(1)) as Arc<dyn CKBProtocolContext + Sync + 'static>;
+
+    let status =
+        GetHeadersProcess::new(message.as_reader(), &synchronizer, 0.into(), &nc).execute();
+
+    assert_eq!(status.code(), StatusCode::ProtocolMessageIsMalformed);
+    assert_eq!(
+        status.to_string(),
+        format!(
+            "ProtocolMessageIsMalformed(400): Locator count({}) > MAX_LOCATOR_SIZE({MAX_LOCATOR_SIZE})",
+            MAX_LOCATOR_SIZE + 1
+        )
     );
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to nervosnetwork/ckb!

If you haven't already, please read the
[CONTRIBUTING](https://github.com/nervosnetwork/ckb/blob/develop/CONTRIBUTING.md)
document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

**Important**: We use Squash Merge to merge PRs, so the PR title will become the commit message.
Please ensure your PR title follows the
[Conventional Commit Messages](https://www.conventionalcommits.org/)
format.

The most important prefixes you should use:

- `fix:`: represents bug fixes, and results in a SemVer patch bump.
- `feat:`: represents a new feature, and results in a SemVer minor bump.
- `<prefix>!:` (e.g. `feat!:`): represents a breaking change and results in a
  SemVer major bump.

Other conventional prefixes are also acceptable (e.g. `docs:`, `refactor:`,
`test:`, `chore:`, etc.).
-->

### What problem does this PR solve?

Problem Summary:

The `GetHeaders` handler collected every remotely supplied
`block_locator_hashes` entry into a `Vec<Byte32>` before checking whether the
number of entries exceeded `MAX_LOCATOR_SIZE`.

Converting each locator with `to_entity()` allocates owned storage. An oversized
request could therefore cause unnecessary allocation and processing before
being rejected.

The network frame and decompression limits bound the maximum impact, but the
handler should enforce its stricter protocol-level limit before materializing
peer-controlled data.

### What is changed and how it works?

What's Changed:

- Read the Molecule `block_locator_hashes` vector length before iterating over
  its entries.
- Return `ProtocolMessageIsMalformed` immediately when the locator count exceeds
  `MAX_LOCATOR_SIZE`.
- Only convert locator readers into owned `Byte32` entities after the length has
  been validated.
- Add a regression test using `MAX_LOCATOR_SIZE + 1` entries and verify that the
  request is rejected with the expected status and context.

This avoids unnecessary per-entry allocation for malformed `GetHeaders`
requests while preserving existing behavior for valid requests.

### Related changes

None.

### Check List

Tests:

- Unit test
  - `cargo test -p ckb-sync get_headers_rejects_oversized_locator_before_processing -- --nocapture --test-threads=1`
- `cargo test -p ckb-sync tests::synchronizer::functions -- --test-threads=1`
  - 14 passed, 0 failed
- `cargo check -p ckb-sync`
- `git diff --check`

Side effects:

- Oversized `GetHeaders` locator lists are rejected before allocation.
- No breaking backward compatibility.
- No expected performance regression.