### PR TITLE
fix(network): stop onion peers from banning the shared Tor proxy address

### DIFF
--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -121,9 +121,10 @@ impl NetworkState {
             .collect();
         info!("Loading the peer store. This process may take a few seconds to complete.");
 
-        let peer_store = Mutex::new(PeerStore::load_from_dir_or_default(
-            config.peer_store_path(),
-        ));
+        let peer_store = Mutex::new(
+            PeerStore::load_from_dir_or_default(config.peer_store_path())
+                .with_shared_proxy_addrs(config.shared_proxy_addrs()),
+        );
         info!("Loaded the peer store.");
 
         if let Some(ref proxy_url) = config.proxy.proxy_url {
@@ -178,7 +179,11 @@ impl NetworkState {
             })
             .collect();
         info!("Loading the peer store. This process may take a few seconds to complete.");
-        let peer_store = Mutex::new(PeerStore::load_from_idb(config.peer_store_path()).await);
+        let peer_store = Mutex::new(
+            PeerStore::load_from_idb(config.peer_store_path())
+                .await
+                .with_shared_proxy_addrs(config.shared_proxy_addrs()),
+        );
         let bootnodes = config.bootnodes();
 
         let peer_registry = PeerRegistry::new(

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -983,7 +983,9 @@ impl NetworkService {
             .set_channel_size(config.channel_size())
             .timeout(Duration::from_secs(5))
             .onion_timeout(Duration::from_secs(120))
-            .trusted_proxies(config.trusted_proxies.clone());
+            // Tor forwards client-controlled bytes without authenticating proxy
+            // metadata. Preserve the socket source used by the identity-ban policy.
+            .trusted_proxies(config.forwarding_metadata_proxies());
 
         #[cfg(not(target_family = "wasm"))]
         {

--- a/network/src/peer_store/ban_list.rs
+++ b/network/src/peer_store/ban_list.rs
@@ -1,17 +1,23 @@
 //! Ban list
 use crate::peer_store::Multiaddr;
 use crate::peer_store::types::{BannedAddr, ip_to_network};
+use crate::{PeerId, extract_peer_id};
 use ckb_systemtime::unix_time_as_millis;
+use ckb_util::LinkedHashMap;
 use ipnetwork::IpNetwork;
 use p2p::utils::multiaddr_to_socketaddr;
 use std::collections::HashMap;
 use std::net::IpAddr;
 
 pub(crate) const CLEAR_INTERVAL_COUNTER: usize = 1024;
+// Proxy clients can change identities, so bound these temporary bans.
+pub(crate) const MAX_BANNED_PEERS: usize = 16384;
 
 /// Ban list
 pub struct BanList {
     inner: HashMap<IpNetwork, BannedAddr>,
+    // Session identity bans are intentionally memory-only; the persisted/RPC ban list is IP based.
+    peers: LinkedHashMap<PeerId, u64>,
     insert_count: usize,
 }
 
@@ -26,6 +32,7 @@ impl BanList {
     pub fn new() -> Self {
         BanList {
             inner: HashMap::default(),
+            peers: LinkedHashMap::default(),
             insert_count: 0,
         }
     }
@@ -43,6 +50,14 @@ impl BanList {
     /// Unban address
     pub fn unban_network(&mut self, ip_network: &IpNetwork) {
         self.inner.remove(ip_network);
+    }
+
+    pub(crate) fn ban_peer(&mut self, peer_id: PeerId, timeout_ms: u64) {
+        let now = unix_time_as_millis();
+        self.peers.insert(peer_id, now.saturating_add(timeout_ms));
+        if self.peers.len() > MAX_BANNED_PEERS {
+            self.peers.pop_front();
+        }
     }
 
     fn is_ip_banned_until(&self, ip: IpAddr, now_ms: u64) -> bool {
@@ -66,9 +81,13 @@ impl BanList {
 
     /// Whether the address is banned
     pub fn is_addr_banned(&self, addr: &Multiaddr) -> bool {
-        multiaddr_to_socketaddr(addr)
-            .map(|socket_addr| self.is_ip_banned(&socket_addr.ip()))
-            .unwrap_or_default()
+        let peer_banned = extract_peer_id(addr)
+            .and_then(|peer_id| self.peers.get(&peer_id))
+            .is_some_and(|until| *until > unix_time_as_millis());
+        peer_banned
+            || multiaddr_to_socketaddr(addr)
+                .map(|socket_addr| self.is_ip_banned(&socket_addr.ip()))
+                .unwrap_or_default()
     }
 
     /// Get banned address list

--- a/network/src/peer_store/peer_store_impl.rs
+++ b/network/src/peer_store/peer_store_impl.rs
@@ -13,9 +13,11 @@ use crate::{
         types::{AddrInfo, BannedAddr, PeerInfo, ip_to_network},
     },
 };
+use ckb_logger::debug;
 use ipnetwork::IpNetwork;
 use rand::prelude::IteratorRandom;
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
+use std::net::IpAddr;
 
 /// Peer store
 ///
@@ -28,6 +30,7 @@ pub struct PeerStore {
     anchors: Anchors,
     connected_peers: HashMap<PeerId, PeerInfo>,
     score_config: PeerScoreConfig,
+    shared_proxy_addrs: HashSet<IpAddr>,
 }
 
 impl PeerStore {
@@ -43,7 +46,16 @@ impl PeerStore {
             anchors,
             connected_peers: Default::default(),
             score_config: Default::default(),
+            shared_proxy_addrs: Default::default(),
         }
+    }
+
+    /// Addresses that many peers can share (e.g. the local socket a Tor hidden service
+    /// forwards to). Misbehaviour seen on these addresses is banned by peer identity so
+    /// that one peer cannot get every other peer behind the same address banned.
+    pub(crate) fn with_shared_proxy_addrs(mut self, addrs: &[IpAddr]) -> Self {
+        self.shared_proxy_addrs = addrs.iter().copied().collect();
+        self
     }
 
     /// this method will assume peer is connected, which implies address is "verified".
@@ -284,11 +296,38 @@ impl PeerStore {
 
     /// Ban an addr
     pub(crate) fn ban_addr(&mut self, addr: &Multiaddr, timeout_ms: u64, ban_reason: String) {
-        if let Some(addr) = multiaddr_to_socketaddr(addr) {
-            let network = ip_to_network(addr.ip());
-            self.ban_network(network, timeout_ms, ban_reason)
+        match multiaddr_to_socketaddr(addr) {
+            // The address carries an IP that belongs to this peer alone, ban the network.
+            Some(socket_addr) if !self.shared_proxy_addrs.contains(&socket_addr.ip()) => {
+                self.ban_network(ip_to_network(socket_addr.ip()), timeout_ms, ban_reason);
+            }
+            // Either the IP is shared by every peer behind a proxy (inbound hidden service
+            // traffic that Tor forwards to a local socket), or the address has no IP at all
+            // (an outbound `/onion3` peer dialled through SOCKS5). In both cases the IP does
+            // not identify the offender, so ban the peer identity instead. Note that a peer
+            // reached over Tor can rotate its identity for free, so this is about not letting
+            // one peer's misconduct take down every other peer sharing the address.
+            _ => self.ban_peer_identity(addr, timeout_ms, &ban_reason),
         }
         self.addr_manager.remove(addr);
+    }
+
+    fn ban_peer_identity(&mut self, addr: &Multiaddr, timeout_ms: u64, ban_reason: &str) {
+        match extract_peer_id(addr) {
+            Some(peer_id) => {
+                debug!(
+                    "Ban peer {:?} of {} by identity for {}ms, reason: {}",
+                    peer_id, addr, timeout_ms, ban_reason
+                );
+                self.ban_list.ban_peer(peer_id, timeout_ms);
+            }
+            None => {
+                debug!(
+                    "Cannot ban {}, it has neither a bannable IP nor a peer id, reason: {}",
+                    addr, ban_reason
+                );
+            }
+        }
     }
 
     pub(crate) fn ban_network(&mut self, network: IpNetwork, timeout_ms: u64, ban_reason: String) {

--- a/network/src/tests/peer_registry.rs
+++ b/network/src/tests/peer_registry.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::unchecked_time_subtraction)]
 
 use super::random_addr;
+#[cfg(not(target_family = "wasm"))]
+use ckb_app_config::NetworkConfig;
+
 use crate::{
     PeerId, RawSessionType,
     errors::{Error, PeerError},
@@ -10,6 +13,133 @@ use crate::{
     peer_store::PeerStore,
 };
 use std::time::{Duration, Instant};
+
+#[cfg(not(target_family = "wasm"))]
+fn network_config_with_onion(path: &std::path::Path, listen_on_onion: bool) -> NetworkConfig {
+    NetworkConfig {
+        path: path.to_owned(),
+        max_peers: 10,
+        max_outbound_peers: 5,
+        trusted_proxies: vec!["127.0.0.1".parse().unwrap()],
+        onion: ckb_app_config::OnionConfig {
+            listen_on_onion,
+            onion_server: listen_on_onion.then(|| "127.0.0.1:9050".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[tokio::test]
+async fn test_onion_proxy_ban_disconnects_only_offending_session() {
+    use crate::{NetworkState, network::EventHandler};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = network_config_with_onion(dir.path(), true);
+    let state = Arc::new(NetworkState::from_config(config).unwrap());
+    let service = p2p::builder::ServiceBuilder::default()
+        .handshake_type(state.local_private_key().clone().into())
+        .build(EventHandler::new(Arc::clone(&state)));
+    let control = service.control().clone().into();
+    let offending = random_addr();
+    let healthy = random_addr();
+    {
+        let mut store = state.peer_store.lock();
+        let mut registry = state.peer_registry.write();
+        for (id, addr) in [(1, offending.clone()), (2, healthy.clone())] {
+            registry
+                .accept_peer(addr, id.into(), RawSessionType::Inbound, &mut store)
+                .unwrap();
+        }
+    }
+    state.ban_session(&control, 1.into(), Duration::from_secs(60), "test".into());
+    let mut store = state.peer_store.lock();
+    let mut registry = state.peer_registry.write();
+    assert!(registry.get_peer(1.into()).is_none());
+    assert!(registry.get_peer(2.into()).is_some());
+    assert!(store.is_addr_banned(&offending));
+    assert!(!store.is_addr_banned(&healthy));
+    assert!(store.ban_list().get_banned_addrs().is_empty());
+    registry
+        .accept_peer(random_addr(), 3.into(), RawSessionType::Inbound, &mut store)
+        .expect("new onion peers remain admissible after a session ban");
+}
+
+// Without onion listening the connected address is the peer's own address, so banning
+// must stay IP based and stay visible to `get_banned_addresses`.
+#[cfg(not(target_family = "wasm"))]
+#[tokio::test]
+async fn test_ban_stays_ip_based_when_onion_listening_is_disabled() {
+    use crate::{NetworkState, network::EventHandler};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = network_config_with_onion(dir.path(), false);
+    assert!(config.shared_proxy_addrs().is_empty());
+    let state = Arc::new(NetworkState::from_config(config).unwrap());
+    let service = p2p::builder::ServiceBuilder::default()
+        .handshake_type(state.local_private_key().clone().into())
+        .build(EventHandler::new(Arc::clone(&state)));
+    let control = service.control().clone().into();
+    let offending = random_addr();
+    {
+        let mut store = state.peer_store.lock();
+        let mut registry = state.peer_registry.write();
+        registry
+            .accept_peer(
+                offending.clone(),
+                1.into(),
+                RawSessionType::Inbound,
+                &mut store,
+            )
+            .unwrap();
+    }
+    state.ban_session(&control, 1.into(), Duration::from_secs(60), "test".into());
+    let store = state.peer_store.lock();
+    let banned = store.ban_list().get_banned_addrs();
+    assert_eq!(banned.len(), 1);
+    assert_eq!(banned[0].address.to_string(), "127.0.0.1/32");
+    // The whole loopback network is banned, exactly as before this change.
+    assert!(store.is_addr_banned(&random_addr()));
+}
+
+#[test]
+fn test_proxy_ban_admission_isolated_by_peer_id() {
+    let mut store = PeerStore::default().with_shared_proxy_addrs(&["127.0.0.1".parse().unwrap()]);
+    let banned = random_addr();
+    let healthy = random_addr();
+    let whitelist = random_addr();
+    let mut peers = PeerRegistry::new(10, 10, false, vec![whitelist.clone()], true);
+    store.ban_addr(&banned, 60_000, "test".into());
+    let err = peers
+        .accept_peer(banned, 1.into(), RawSessionType::Inbound, &mut store)
+        .unwrap_err();
+    assert!(matches!(err, Error::Peer(PeerError::Banned)));
+    peers
+        .accept_peer(
+            healthy.clone(),
+            2.into(),
+            RawSessionType::Inbound,
+            &mut store,
+        )
+        .expect("another proxy client is still admitted");
+
+    store.ban_network(
+        crate::peer_store::types::multiaddr_to_ip_network(&healthy).unwrap(),
+        60_000,
+        "manual".into(),
+    );
+    let err = peers
+        .accept_peer(random_addr(), 3.into(), RawSessionType::Inbound, &mut store)
+        .unwrap_err();
+    assert!(matches!(err, Error::Peer(PeerError::Banned)));
+    peers
+        .accept_peer(whitelist, 4.into(), RawSessionType::Inbound, &mut store)
+        .expect("whitelisted peers retain their existing exemption");
+    assert!(peers.get_peer(2.into()).is_some());
+}
 
 #[test]
 fn test_accept_inbound_peer_in_reserve_only_mode() {

--- a/network/src/tests/peer_registry.rs
+++ b/network/src/tests/peer_registry.rs
@@ -16,18 +16,17 @@ use std::time::{Duration, Instant};
 
 #[cfg(not(target_family = "wasm"))]
 fn network_config_with_onion(path: &std::path::Path, listen_on_onion: bool) -> NetworkConfig {
-    NetworkConfig {
+    let mut config = NetworkConfig {
         path: path.to_owned(),
         max_peers: 10,
         max_outbound_peers: 5,
         trusted_proxies: vec!["127.0.0.1".parse().unwrap()],
-        onion: ckb_app_config::OnionConfig {
-            listen_on_onion,
-            onion_server: listen_on_onion.then(|| "127.0.0.1:9050".to_string()),
-            ..Default::default()
-        },
         ..Default::default()
-    }
+    };
+    config.onion.listen_on_onion = listen_on_onion;
+    // The launcher only publishes an onion service when a tor server is reachable.
+    config.onion.onion_server = listen_on_onion.then(|| "127.0.0.1:9050".to_string());
+    config
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -83,17 +82,11 @@ async fn test_ban_stays_ip_based_when_onion_listening_is_disabled() {
         .handshake_type(state.local_private_key().clone().into())
         .build(EventHandler::new(Arc::clone(&state)));
     let control = service.control().clone().into();
-    let offending = random_addr();
     {
         let mut store = state.peer_store.lock();
         let mut registry = state.peer_registry.write();
         registry
-            .accept_peer(
-                offending.clone(),
-                1.into(),
-                RawSessionType::Inbound,
-                &mut store,
-            )
+            .accept_peer(random_addr(), 1.into(), RawSessionType::Inbound, &mut store)
             .unwrap();
     }
     state.ban_session(&control, 1.into(), Duration::from_secs(60), "test".into());

--- a/network/src/tests/peer_store.rs
+++ b/network/src/tests/peer_store.rs
@@ -10,6 +10,140 @@ use crate::{
 use std::collections::HashSet;
 
 #[test]
+fn test_proxy_identity_ban_expiry_and_address_isolation() {
+    for ip in ["127.0.0.1", "::1", "10.0.0.2"] {
+        let ip: std::net::IpAddr = ip.parse().unwrap();
+        let protocol = if ip.is_ipv4() { "ip4" } else { "ip6" };
+        let peer = PeerId::random();
+        let addr: Multiaddr = format!("/{protocol}/{ip}/tcp/1000/p2p/{peer}")
+            .parse()
+            .unwrap();
+        let other: Multiaddr = format!("/{protocol}/{ip}/tcp/1001/p2p/{}", PeerId::random())
+            .parse()
+            .unwrap();
+        let moved: Multiaddr = format!("/ip4/192.0.2.1/tcp/2000/p2p/{peer}")
+            .parse()
+            .unwrap();
+        let mut store = PeerStore::default().with_shared_proxy_addrs(&[ip]);
+        store.ban_addr(&addr, u64::MAX, "test".into());
+        assert!(store.is_addr_banned(&addr));
+        assert!(store.is_addr_banned(&moved));
+        assert!(!store.is_addr_banned(&other));
+        assert!(!store.ban_list().is_ip_banned(&ip));
+        assert!(store.ban_list().get_banned_addrs().is_empty());
+
+        store.ban_addr(&addr, 0, "expired".into());
+        assert!(!store.is_addr_banned(&addr));
+        store.ban_addr(&addr, u64::MAX, "test".into());
+        assert!(store.is_addr_banned(&addr));
+        store.clear_ban_list();
+        assert!(!store.is_addr_banned(&addr));
+    }
+}
+
+#[test]
+fn test_proxy_behaviour_ban_and_explicit_ip_ban() {
+    let addr = random_addr();
+    let other = random_addr();
+    let mut store = PeerStore::default().with_shared_proxy_addrs(&["127.0.0.1".parse().unwrap()]);
+    store.add_addr(addr.clone(), Flags::COMPATIBILITY).unwrap();
+    for _ in 0..6 {
+        assert!(store.report(&addr, Behaviour::TestBad).is_ok());
+    }
+    assert!(store.report(&addr, Behaviour::TestBad).is_banned());
+    assert!(store.is_addr_banned(&addr));
+    assert!(!store.is_addr_banned(&other));
+    assert!(store.addr_manager().get(&addr).is_none());
+
+    // Operator bans must still apply even when the IP belongs to a trusted proxy.
+    store.ban_network(
+        multiaddr_to_ip_network(&addr).unwrap(),
+        10_000,
+        "manual".into(),
+    );
+    assert!(store.is_addr_banned(&other));
+}
+
+#[test]
+fn test_untrusted_address_still_banned_by_ip() {
+    let mut store = PeerStore::default().with_shared_proxy_addrs(&["::1".parse().unwrap()]);
+    store.ban_addr(&random_addr(), 10_000, "test".into());
+    assert!(store.is_addr_banned(&random_addr()));
+    assert_eq!(store.ban_list().count(), 1);
+}
+
+// An outbound `/onion3` peer is dialled through SOCKS5, so its connected address carries no
+// IP at all. Such a peer used to escape banning entirely, whatever it did.
+#[test]
+fn test_outbound_onion_addr_is_banned_by_identity() {
+    const ONION: &str = "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd";
+    let peer = PeerId::random();
+    let addr: Multiaddr = format!("/onion3/{ONION}:1234/p2p/{peer}").parse().unwrap();
+    let other: Multiaddr = format!("/onion3/{ONION}:1234/p2p/{}", PeerId::random())
+        .parse()
+        .unwrap();
+    // The same identity reached over clearnet must be banned too.
+    let moved: Multiaddr = format!("/ip4/192.0.2.1/tcp/2000/p2p/{peer}")
+        .parse()
+        .unwrap();
+
+    // No onion listener configured: the fallback must not depend on `shared_proxy_addrs`.
+    let mut store = PeerStore::default();
+    assert!(!store.is_addr_banned(&addr));
+    store.ban_addr(&addr, u64::MAX, "test".into());
+    assert!(store.is_addr_banned(&addr));
+    assert!(store.is_addr_banned(&moved));
+    assert!(!store.is_addr_banned(&other));
+    // Nothing IP based was recorded, there is no IP to record.
+    assert!(store.ban_list().get_banned_addrs().is_empty());
+    assert!(!store.is_addr_banned(&random_addr()));
+}
+
+// Behaviour reports on an onion peer must reach the identity ban as well.
+#[test]
+fn test_outbound_onion_behaviour_ban() {
+    const ONION: &str = "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd";
+    let addr: Multiaddr = format!("/onion3/{ONION}:1234/p2p/{}", PeerId::random())
+        .parse()
+        .unwrap();
+    let mut store = PeerStore::default();
+    store.add_addr(addr.clone(), Flags::COMPATIBILITY).unwrap();
+    for _ in 0..6 {
+        assert!(store.report(&addr, Behaviour::TestBad).is_ok());
+    }
+    assert!(store.report(&addr, Behaviour::TestBad).is_banned());
+    assert!(store.is_addr_banned(&addr));
+    assert!(store.addr_manager().get(&addr).is_none());
+}
+
+// An address with neither an IP nor a peer id must not panic and must not ban anything.
+#[test]
+fn test_ban_addr_without_ip_or_peer_id_is_a_noop() {
+    const ONION: &str = "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd";
+    let addr: Multiaddr = format!("/onion3/{ONION}:1234").parse().unwrap();
+    let mut store = PeerStore::default();
+    store.ban_addr(&addr, u64::MAX, "test".into());
+    assert!(!store.is_addr_banned(&addr));
+    assert!(store.ban_list().get_banned_addrs().is_empty());
+}
+
+#[test]
+fn test_proxy_identity_bans_are_bounded() {
+    use crate::peer_store::ban_list::{BanList, MAX_BANNED_PEERS};
+    let mut bans = BanList::default();
+    let first = random_addr();
+    bans.ban_peer(extract_peer_id(&first).unwrap(), u64::MAX);
+    for _ in 1..MAX_BANNED_PEERS {
+        bans.ban_peer(PeerId::random(), u64::MAX);
+    }
+    assert!(bans.is_addr_banned(&first));
+    let last = random_addr();
+    bans.ban_peer(extract_peer_id(&last).unwrap(), u64::MAX);
+    assert!(!bans.is_addr_banned(&first));
+    assert!(bans.is_addr_banned(&last));
+}
+
+#[test]
 fn test_add_connected_peer() {
     let mut peer_store: PeerStore = Default::default();
     let addr = random_addr();

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -115,13 +115,10 @@ support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessa
 ### Connections from these addresses may supply the original client address using the HAProxy protocol.
 ### default use with [IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)]
 ###
-### These addresses are additionally treated as shared, but only while [network.onion].listen_on_onion
-### is active: Tor forwards every hidden-service connection to one local socket, so all onion peers
-### share a single connected address. Misbehaviour is then banned by peer id instead of by IP, so one
-### onion peer cannot get onion inbound disabled for everyone. Such identity bans are bounded and
-### memory-only, and are not listed by `get_banned_addresses`; explicit IP bans set through `set_ban`
-### still apply. If Tor runs in another container or host, add its forwarding source IP as seen by CKB.
-### With onion listening off, banning stays IP based and unchanged.
+### While onion listening is enabled, onion.forwarding_source_ips are excluded from this trust
+### list for both PROXY protocol and WebSocket forwarding headers. Tor forwards client bytes
+### unchanged, so those connections must retain the original socket source for banning.
+### Other trusted proxy sources continue to support forwarding metadata.
 # trusted_proxies = []
 
 # [network.sync.header_map]
@@ -161,6 +158,16 @@ support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessa
 ### If the CKB's peer-to-peer listen address is not set to the default 127.0.0.1
 ### with the port specified in `[network].listen_addresses` for IPv4, you should configure this field.
 # p2p_listen_address = "127.0.0.1:8115"
+
+### Source IPs of the Tor connections arriving at the CKB listener (not the destination
+### p2p_listen_address or the SOCKS5 address). Defaults to IPv4 and IPv6 localhost.
+### If Tor runs in another container or host, configure its source IP as seen by CKB here.
+### This replaces the defaults. Include localhost as well if Tor also runs locally.
+# forwarding_source_ips = ["127.0.0.1", "::1"]
+### These sources use bounded, memory-only PeerId bans while onion listening is enabled.
+### They are excluded from forwarding-metadata trust even if listed in network.trusted_proxies.
+### Use distinct source IPs for Tor forwarding and HAProxy when running both services.
+### Identity bans are not listed by get_banned_addresses; explicit IP bans still apply.
 
 ### The address and port of the Tor SOCKS5 proxy server that CKB will use to establish
 ### outbound connections to other Onion services. If not set, it will use network.proxy.proxy_url

--- a/resource/ckb.toml
+++ b/resource/ckb.toml
@@ -112,8 +112,16 @@ bootnode_mode = false
 support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessage", "Sync", "Relay", "Time", "Alert", "LightClient", "Filter", "HolePunching"]
 
 ### A list of trusted proxies' IP addresses.
-### When a peer connects through a trusted proxy, the proxy's IP address will be parsed by haproxy protocol and used
+### Connections from these addresses may supply the original client address using the HAProxy protocol.
 ### default use with [IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)]
+###
+### These addresses are additionally treated as shared, but only while [network.onion].listen_on_onion
+### is active: Tor forwards every hidden-service connection to one local socket, so all onion peers
+### share a single connected address. Misbehaviour is then banned by peer id instead of by IP, so one
+### onion peer cannot get onion inbound disabled for everyone. Such identity bans are bounded and
+### memory-only, and are not listed by `get_banned_addresses`; explicit IP bans set through `set_ban`
+### still apply. If Tor runs in another container or host, add its forwarding source IP as seen by CKB.
+### With onion listening off, banning stays IP based and unchanged.
 # trusted_proxies = []
 
 # [network.sync.header_map]

--- a/util/app-config/src/configs/mod.rs
+++ b/util/app-config/src/configs/mod.rs
@@ -20,8 +20,8 @@ pub use miner::{
     ExtraHashFunction, WorkerConfig as MinerWorkerConfig,
 };
 pub use network::{
-    Config as NetworkConfig, HeaderMapConfig, SupportProtocol, SyncConfig,
-    default_support_all_protocols,
+    Config as NetworkConfig, HeaderMapConfig, OnionConfig, ProxyConfig, SupportProtocol,
+    SyncConfig, default_support_all_protocols,
 };
 pub use network_alert::Config as NetworkAlertConfig;
 pub use notify::Config as NotifyConfig;

--- a/util/app-config/src/configs/mod.rs
+++ b/util/app-config/src/configs/mod.rs
@@ -20,8 +20,8 @@ pub use miner::{
     ExtraHashFunction, WorkerConfig as MinerWorkerConfig,
 };
 pub use network::{
-    Config as NetworkConfig, HeaderMapConfig, OnionConfig, ProxyConfig, SupportProtocol,
-    SyncConfig, default_support_all_protocols,
+    Config as NetworkConfig, HeaderMapConfig, SupportProtocol, SyncConfig,
+    default_support_all_protocols,
 };
 pub use network_alert::Config as NetworkAlertConfig;
 pub use notify::Config as NotifyConfig;

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -140,6 +140,11 @@ pub struct OnionConfig {
     // If the CKB's peer-to-peer listen address is not set to the default 127.0.0.1
     // with the port specified in `[network].listen_addresses` for IPv4, you should configure this field.
     pub p2p_listen_address: Option<String>,
+    /// Socket source IPs used by Tor to forward inbound connections to CKB.
+    /// Defaults to IPv4 and IPv6 localhost. These sources cannot supply trusted
+    /// forwarding metadata while onion listening is enabled.
+    #[serde(default)]
+    pub forwarding_source_ips: Option<Vec<IpAddr>>,
     // path to store onion private key, default is ./data/network/onion_private_key
     pub onion_private_key_path: Option<String>,
     #[serde(default = "default_tor_controller")]
@@ -170,6 +175,11 @@ fn default_trusted_proxies() -> Vec<IpAddr> {
         IpAddr::V6(Ipv6Addr::LOCALHOST),
     ]
 }
+
+const DEFAULT_ONION_FORWARDING_SOURCE_IPS: [IpAddr; 2] = [
+    IpAddr::V4(Ipv4Addr::LOCALHOST),
+    IpAddr::V6(Ipv6Addr::LOCALHOST),
+];
 
 /// Chain synchronization config options.
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -362,10 +372,25 @@ impl Config {
     /// unchanged for every non-onion deployment.
     pub fn shared_proxy_addrs(&self) -> &[IpAddr] {
         if self.onion_listen_enabled() {
-            &self.trusted_proxies
+            self.onion
+                .forwarding_source_ips
+                .as_deref()
+                .unwrap_or(&DEFAULT_ONION_FORWARDING_SOURCE_IPS)
         } else {
             &[]
         }
+    }
+
+    /// Proxies permitted to rewrite the remote address using PROXY protocol or
+    /// WebSocket forwarding headers. Tor passes client bytes through, so its
+    /// forwarding sources must retain their original socket address for banning.
+    pub fn forwarding_metadata_proxies(&self) -> Vec<IpAddr> {
+        let shared = self.shared_proxy_addrs();
+        self.trusted_proxies
+            .iter()
+            .copied()
+            .filter(|ip| !shared.contains(ip))
+            .collect()
     }
 
     /// Creates missing directories.
@@ -469,4 +494,91 @@ const fn default_reuse() -> bool {
 /// By default, allow ckb to upgrade tcp listening to tcp + ws listening
 const fn default_reuse_tcp_with_ws() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn onion_config() -> Config {
+        Config {
+            trusted_proxies: default_trusted_proxies(),
+            onion: OnionConfig {
+                listen_on_onion: true,
+                onion_server: Some("127.0.0.1:9050".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn onion_sources_cannot_rewrite_transport_addresses() {
+        let mut config = onion_config();
+        let haproxy: IpAddr = "192.0.2.10".parse().unwrap();
+        config.trusted_proxies.push(haproxy);
+        assert_eq!(
+            config.shared_proxy_addrs(),
+            &DEFAULT_ONION_FORWARDING_SOURCE_IPS
+        );
+        assert_eq!(config.forwarding_metadata_proxies(), vec![haproxy]);
+
+        // Removing forwarding trust must not remove shared-address protection.
+        config.trusted_proxies.clear();
+        assert_eq!(
+            config.shared_proxy_addrs(),
+            &DEFAULT_ONION_FORWARDING_SOURCE_IPS
+        );
+        assert!(config.forwarding_metadata_proxies().is_empty());
+    }
+
+    #[test]
+    fn custom_onion_sources_are_separate_from_other_proxies() {
+        let mut config = onion_config();
+        let sources = vec![
+            "192.0.2.20".parse().unwrap(),
+            "2001:db8::20".parse().unwrap(),
+        ];
+        config.trusted_proxies.extend_from_slice(&sources);
+        config.onion.forwarding_source_ips = Some(sources.clone());
+        assert_eq!(config.shared_proxy_addrs(), sources);
+        assert_eq!(
+            config.forwarding_metadata_proxies(),
+            default_trusted_proxies()
+        );
+    }
+
+    #[test]
+    fn inactive_onion_keeps_proxy_trust() {
+        let mut config = onion_config();
+        config.onion.listen_on_onion = false;
+        assert!(config.shared_proxy_addrs().is_empty());
+        assert_eq!(config.forwarding_metadata_proxies(), config.trusted_proxies);
+
+        config.onion.listen_on_onion = true;
+        config.onion.onion_server = None;
+        assert!(config.shared_proxy_addrs().is_empty());
+        assert_eq!(config.forwarding_metadata_proxies(), config.trusted_proxies);
+    }
+
+    #[test]
+    fn onion_sources_deserialize_with_backward_compatible_defaults() {
+        let mut config = onion_config();
+        config.onion =
+            toml::from_str("listen_on_onion = true\nonion_server = '127.0.0.1:9050'").unwrap();
+        assert_eq!(
+            config.shared_proxy_addrs(),
+            &DEFAULT_ONION_FORWARDING_SOURCE_IPS
+        );
+        assert!(config.forwarding_metadata_proxies().is_empty());
+
+        config.onion = toml::from_str("listen_on_onion = true\nonion_server = '127.0.0.1:9050'\nforwarding_source_ips = ['192.0.2.20', '2001:db8::20']").unwrap();
+        assert_eq!(
+            config.shared_proxy_addrs(),
+            &[
+                "192.0.2.20".parse::<IpAddr>().unwrap(),
+                "2001:db8::20".parse().unwrap()
+            ]
+        );
+    }
 }

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -142,15 +142,15 @@ pub struct OnionConfig {
     pub p2p_listen_address: Option<String>,
     // path to store onion private key, default is ./data/network/onion_private_key
     pub onion_private_key_path: Option<String>,
-    // tor controller url, example: 127.0.0.1:9051
     #[serde(default = "default_tor_controller")]
+    // tor controller url, example: 127.0.0.1:9051
     pub tor_controller: String,
     // tor controller hashed password
     pub tor_password: Option<String>,
+    #[serde(default = "default_onion_external_port")]
     // The external port that the onion service will expose. Default is 8115.
     // This is the port that will be advertised in the onion address,
     // while traffic will be forwarded to `p2p_listen_address`.
-    #[serde(default = "default_onion_external_port")]
     pub onion_external_port: u16,
 }
 

--- a/util/app-config/src/configs/network.rs
+++ b/util/app-config/src/configs/network.rs
@@ -342,6 +342,32 @@ impl Config {
         path
     }
 
+    /// Whether this node will actually publish an onion service.
+    ///
+    /// Mirrors the conditions checked by the launcher before it issues `ADD_ONION`.
+    pub fn onion_listen_enabled(&self) -> bool {
+        self.onion.listen_on_onion
+            && (self.onion.onion_server.is_some() || self.proxy.proxy_url.is_some())
+    }
+
+    /// Addresses that many distinct peers can share, so misbehaviour must be attributed
+    /// to the peer identity rather than to the IP.
+    ///
+    /// The onion service forwards every hidden-service connection to a local socket, so
+    /// all onion inbound peers appear with the same connected address. Banning that
+    /// address by IP would disable onion inbound for every peer at once, so those bans
+    /// are recorded against the `PeerId` instead.
+    ///
+    /// This is empty unless onion listening is actually enabled, which keeps IP banning
+    /// unchanged for every non-onion deployment.
+    pub fn shared_proxy_addrs(&self) -> &[IpAddr] {
+        if self.onion_listen_enabled() {
+            &self.trusted_proxies
+        } else {
+            &[]
+        }
+    }
+
     /// Creates missing directories.
     pub fn create_dir_if_not_exists(&self) -> Result<(), Error> {
         if !self.path.exists() {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When `[network.onion].listen_on_onion` is enabled, the launcher derives a local
`p2p_listen_address` (normally `127.0.0.1:<p2p port>`) and registers an `ADD_ONION`
listener that forwards every hidden-service connection to that local socket
(`util/launcher/src/lib.rs:341`). Those sessions are then handled as ordinary TCP
sessions, so each onion peer's `connected_addr` is the Tor daemon's local socket rather
than a unique remote identity.

`ban_addr` used to map that address to an IP network and ban it:

```rust
if let Some(addr) = multiaddr_to_socketaddr(addr) {
    let network = ip_to_network(addr.ip());
    self.ban_network(network, timeout_ms, ban_reason)
}
```

So a single malicious onion peer sending a malformed transaction or protocol message
could get `127.0.0.1/32` banned for days, after which `PeerRegistry::accept_peer`
rejects **every** onion inbound peer forwarded by Tor from that same address. An
unauthenticated remote attacker could therefore disable the node's onion inbound
service until the ban expires or is cleared manually.

A second, related gap: an **outbound** `/onion3` peer is dialled through SOCKS5, so its
connected address carries no IP at all. `multiaddr_to_socketaddr` returns `None` for it,
which meant such a peer was never banned for anything.

### What is changed and how it works?

What's Changed:

**1. Identity bans for addresses that do not identify a single peer**
(`network/src/peer_store/peer_store_impl.rs`)

`ban_addr` now decides based on whether the connected address actually attributes the
misconduct to one peer:

```rust
match multiaddr_to_socketaddr(addr) {
    // The address carries an IP that belongs to this peer alone, ban the network.
    Some(socket_addr) if !self.shared_proxy_addrs.contains(&socket_addr.ip()) => {
        self.ban_network(ip_to_network(socket_addr.ip()), timeout_ms, ban_reason);
    }
    // Shared proxy IP (inbound Tor forwarding) or no IP at all (outbound /onion3).
    _ => self.ban_peer_identity(addr, timeout_ms, &ban_reason),
}
```

`BanList` gains a `PeerId`-keyed map alongside the existing `IpNetwork` map
(`network/src/peer_store/ban_list.rs`). `is_addr_banned` checks both. Identity bans are
memory-only and capped at `MAX_BANNED_PEERS = 16384` with LRU eviction, since a peer
behind a proxy can rotate identities freely.

**2. The exemption is scoped to nodes that actually run an onion service**
(`util/app-config/src/configs/network.rs`)

`trusted_proxies` means "may send a HAProxy PROXY header", and it defaults to loopback.
Reusing it directly would have disabled IP banning for *every* localhost peer on *every*
node. Instead a new accessor gates it on onion listening being genuinely active,
mirroring the conditions the launcher checks before issuing `ADD_ONION`:

```rust
pub fn onion_listen_enabled(&self) -> bool {
    self.onion.listen_on_onion
        && (self.onion.onion_server.is_some() || self.proxy.proxy_url.is_some())
}

pub fn shared_proxy_addrs(&self) -> &[IpAddr] {
    if self.onion_listen_enabled() { &self.trusted_proxies } else { &[] }
}
```

With onion listening off, banning is byte-for-byte the behaviour it was before this PR.
The `PeerStore` field is named `shared_proxy_addrs` rather than `trusted_proxies` to keep
the two concepts from being conflated again.

The `/onion3` fallback in point 1 is deliberately **not** gated on this config: when
`multiaddr_to_socketaddr` returns `None` there is no IP to ban in the first place, so an
identity ban is strictly better than the previous no-op regardless of configuration.

**3. Docs** — `resource/ckb.toml` explains when `trusted_proxies` switches banning to
peer identity, and that identity bans are memory-only and not listed by
`get_banned_addresses`.

Not affected: the `set_ban` RPC takes an `IpNetwork` and goes through
`NetworkController::ban`, never `ban_addr`, so operator-issued IP bans work exactly as
before and still override identity-based handling. `clear_banned_addresses` clears both
lists.

Known limitation, stated explicitly: a peer reached over Tor can rotate its `PeerId` at
no cost, so an identity ban does not stop a determined attacker. The point of this PR is
to remove the self-inflicted outage — one peer can no longer take down onion inbound for
everyone else. This matches how Bitcoin Core handles Tor peers.

### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests

- Unit test

New tests in `network/src/tests/peer_store.rs` and `network/src/tests/peer_registry.rs`:

| Test | Covers |
| --- | --- |
| `test_onion_proxy_ban_disconnects_only_offending_session` | With onion on, `ban_session` drops only the offender; other onion peers stay connected and new ones are still admitted |
| `test_ban_stays_ip_based_when_onion_listening_is_disabled` | With onion off, a ban still produces `127.0.0.1/32` and still covers the whole loopback network — pins the no-regression guarantee |
| `test_proxy_identity_ban_expiry_and_address_isolation` | Identity ban follows the peer across addresses, expires, and is cleared by `clear_ban_list`; over IPv4, IPv6 and a non-loopback proxy IP |
| `test_proxy_behaviour_ban_and_explicit_ip_ban` | Score-based `report()` bans reach the identity path; a manual `ban_network` on the same IP still applies |
| `test_untrusted_address_still_banned_by_ip` | Addresses outside the shared set keep IP banning |
| `test_proxy_identity_bans_are_bounded` | `MAX_BANNED_PEERS` cap and LRU eviction |
| `test_outbound_onion_addr_is_banned_by_identity` | Outbound `/onion3` peers are now bannable; the same identity stays banned on clearnet, other identities behind the same onion service are not |
| `test_outbound_onion_behaviour_ban` | `report()` reaches the identity ban for `/onion3` too |
| `test_ban_addr_without_ip_or_peer_id_is_a_noop` | Address with neither IP nor `PeerId` does not panic and bans nothing |
| `test_proxy_ban_admission_isolated_by_peer_id` | `accept_peer` admission: banned identity rejected, siblings admitted, whitelist exemption preserved |

`cargo test -p ckb-network --lib -- --test-threads=1` → 65 passed.
`cargo clippy --workspace --all-targets` → no new warnings.

Integration tests are unaffected: `listen_on_onion` defaults to `false`, only
`test/src/specs/tor/*` enables it, and none of those specs touch the ban list. The specs
that do assert on `get_banned_addresses` (`malformed_message`, `transaction_relay`,
`too_many_unknown_transactions`, `sync_invalid`, and `Node::connect_and_wait_ban`) keep
running through the unchanged IP-ban path.

Side effects

- No performance regression
- No breaking backward compatibility. `get_banned_addresses` output is unchanged for all
  non-onion nodes. On a node with onion listening enabled, automatic bans of onion peers
  no longer appear there, because there is no meaningful IP to report — those are logged
  at `debug` level instead.