### PR TITLE
fix: enforce transaction and address isolation for block-relay-only peers

### DIFF
--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -686,7 +686,7 @@ mod tests {
     #[test]
     fn block_only_identify_does_not_store_addresses() {
         use super::{Callback, Flags, IdentifyCallback};
-        use crate::{NetworkState, PeerId, RawSessionType};
+        use crate::{NetworkState, PeerId, RawSessionType, network};
         use std::sync::Arc;
 
         let dir = tempfile::tempdir().unwrap();
@@ -700,7 +700,7 @@ mod tests {
             .unwrap(),
         );
         let mut callback = IdentifyCallback::new(
-            state.clone(),
+            Arc::<network::NetworkState>::clone(&state),
             "test".into(),
             "test".into(),
             Flags::COMPATIBILITY,

--- a/network/src/protocols/identify/mod.rs
+++ b/network/src/protocols/identify/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ckb_logger::{debug, error, trace, warn};
 use ckb_systemtime::{Duration, Instant};
 use p2p::{
-    SessionId, async_trait,
+    ProtocolId, SessionId, async_trait,
     bytes::Bytes,
     context::{ProtocolContext, ProtocolContextMutRef, SessionContext},
     multiaddr::{Multiaddr, Protocol},
@@ -28,6 +28,25 @@ const CHECK_TIMEOUT_TOKEN: u64 = 100;
 const CHECK_TIMEOUT_INTERVAL: u64 = 1;
 const DEFAULT_TIMEOUT: u64 = 8;
 const MAX_ADDRS: usize = 10;
+
+/// Protocols opened towards a block-relay-only session.
+///
+/// Such a connection exists purely to propagate blocks, so the protocols that only
+/// exist to serve the remote peer (address discovery, light client, block filter, ...)
+/// are left closed.
+///
+/// This is defense in depth, not a security boundary: tentacle lets the remote open
+/// any registered protocol on its own, so the actual enforcement has to live in the
+/// protocol handlers themselves.
+fn block_relay_only_protocols() -> [ProtocolId; 5] {
+    [
+        SupportProtocols::Ping.protocol_id(),
+        SupportProtocols::Identify.protocol_id(),
+        SupportProtocols::DisconnectMessage.protocol_id(),
+        SupportProtocols::Sync.protocol_id(),
+        SupportProtocols::RelayV3.protocol_id(),
+    ]
+}
 
 pub(super) fn is_remote_listen_addr_allowed(addr: &Multiaddr, global_ip_only: bool) -> bool {
     if let Some(socket_addr) = multiaddr_to_socketaddr(addr) {
@@ -357,6 +376,38 @@ impl IdentifyCallback {
             .take(MAX_RETURN_LISTEN_ADDRS)
             .collect::<Vec<_>>()
     }
+
+    fn store_remote_listen_addrs(&self, session_id: SessionId, addrs: Vec<Multiaddr>) {
+        // Identify stays open on block-relay-only sessions so the handshake can still
+        // happen, but the addresses such a peer advertises must not reach the peer
+        // store: accepting them would hand an anchor influence over our address
+        // selection, which is precisely the address relay these connections avoid.
+        let flags = self.network_state.with_peer_registry_mut(|reg| {
+            if reg.is_anchor(session_id) {
+                return None;
+            }
+            Some(match reg.get_peer_mut(session_id) {
+                Some(peer) => {
+                    peer.listened_addrs = addrs.clone();
+                    peer.identify_info
+                        .as_ref()
+                        .map(|a| a.flags)
+                        .unwrap_or(Flags::COMPATIBILITY)
+                }
+                None => Flags::COMPATIBILITY,
+            })
+        });
+        let Some(flags) = flags else {
+            return;
+        };
+        self.network_state.with_peer_store_mut(|peer_store| {
+            for addr in addrs {
+                if let Err(err) = peer_store.add_addr(addr.clone(), flags) {
+                    error!("IdentifyProtocol failed to add address to peer store, address: {}, error: {:?}", addr, err);
+                }
+            }
+        })
+    }
 }
 
 #[async_trait]
@@ -418,12 +469,24 @@ impl Callback for IdentifyCallback {
 
                 let required_flags = self.network_state.required_flags;
 
+                // NOTE: `session.ty` is tentacle's transport-level direction. A CKB
+                // block-relay-only session is dialed by us, so it is transport-outbound
+                // and lands here as well.
                 if context.session.ty.is_outbound() {
+                    let is_anchor = self
+                        .network_state
+                        .with_peer_registry(|reg| reg.is_anchor(context.session.id));
+
                     // why don't set inbound here?
                     // because inbound address can't feeler during staying connected
                     // and if set it to peer store, it will be broadcast to the entire network,
                     // but this is an unverified address
-
+                    //
+                    // This stays enabled for block-relay-only sessions on purpose: the
+                    // address is one we dialed ourselves out of the peer store, so it is
+                    // not something the remote peer gets to choose. Filtering what the
+                    // peer *claims* is handled in `store_remote_listen_addrs` and
+                    // `add_observed_addr`.
                     self.network_state.with_peer_store_mut(|peer_store| {
                         peer_store.add_outbound_addr(context.session.address.clone(), flags);
                     });
@@ -443,7 +506,11 @@ impl Callback for IdentifyCallback {
                             .open_protocols(
                                 context.session.id,
                                 TargetProtocol::Filter(Box::new(move |id| {
-                                    id != &SupportProtocols::Feeler.protocol_id()
+                                    if is_anchor {
+                                        block_relay_only_protocols().contains(id)
+                                    } else {
+                                        id != &SupportProtocols::Feeler.protocol_id()
+                                    }
                                 })),
                             )
                             .await;
@@ -477,30 +544,21 @@ impl Callback for IdentifyCallback {
 
     fn add_remote_listen_addrs(&mut self, session: &SessionContext, addrs: Vec<Multiaddr>) {
         trace!(
-            "IdentifyProtocol add remote listening addresses, session: {:?}, addresses : {:?}",
+            "IdentifyProtocol received remote listening addresses, session: {:?}, addresses : {:?}",
             session, addrs,
         );
-        let flags = self.network_state.with_peer_registry_mut(|reg| {
-            if let Some(peer) = reg.get_peer_mut(session.id) {
-                peer.listened_addrs = addrs.clone();
-                peer.identify_info
-                    .as_ref()
-                    .map(|a| a.flags)
-                    .unwrap_or(Flags::COMPATIBILITY)
-            } else {
-                Flags::COMPATIBILITY
-            }
-        });
-        self.network_state.with_peer_store_mut(|peer_store| {
-            for addr in addrs {
-                if let Err(err) = peer_store.add_addr(addr.clone(), flags) {
-                    error!("IdentifyProtocol failed to add address to peer store, address: {}, error: {:?}", addr, err);
-                }
-            }
-        })
+        self.store_remote_listen_addrs(session.id, addrs);
     }
 
     fn add_observed_addr(&mut self, mut addr: Multiaddr, session_id: SessionId) -> MisbehaveResult {
+        // Same reasoning as `store_remote_listen_addrs`: an anchor must not get to
+        // influence which address we believe is ours.
+        if self
+            .network_state
+            .with_peer_registry(|reg| reg.is_anchor(session_id))
+        {
+            return MisbehaveResult::Continue;
+        }
         if extract_peer_id(&addr).is_none() {
             addr.push(Protocol::P2P(Cow::Borrowed(
                 self.network_state.local_peer_id().as_bytes(),
@@ -590,6 +648,114 @@ bitflags::bitflags! {
 mod tests {
     use super::is_remote_listen_addr_allowed;
     use p2p::multiaddr::Multiaddr;
+
+    #[test]
+    fn block_relay_only_protocols_cover_block_propagation_only() {
+        use super::block_relay_only_protocols;
+        use crate::SupportProtocols;
+
+        let opened = block_relay_only_protocols();
+        for proto in [
+            SupportProtocols::Ping,
+            SupportProtocols::Identify,
+            SupportProtocols::DisconnectMessage,
+            SupportProtocols::Sync,
+            SupportProtocols::RelayV3,
+        ] {
+            assert!(
+                opened.contains(&proto.protocol_id()),
+                "{proto:?} is required to propagate blocks"
+            );
+        }
+        // Address relay and the light-client / block-filter server protocols exist only
+        // to serve the remote peer, they have no place on a block-relay-only session.
+        for proto in [
+            SupportProtocols::Discovery,
+            SupportProtocols::Feeler,
+            SupportProtocols::LightClient,
+            SupportProtocols::Filter,
+        ] {
+            assert!(
+                !opened.contains(&proto.protocol_id()),
+                "{proto:?} must not be opened towards an anchor"
+            );
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn block_only_identify_does_not_store_addresses() {
+        use super::{Callback, Flags, IdentifyCallback};
+        use crate::{NetworkState, PeerId, RawSessionType};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(
+            NetworkState::from_config(ckb_app_config::NetworkConfig {
+                path: dir.path().to_owned(),
+                max_peers: 10,
+                max_outbound_peers: 0,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        let mut callback = IdentifyCallback::new(
+            state.clone(),
+            "test".into(),
+            "test".into(),
+            Flags::COMPATIBILITY,
+        );
+        for (id, ty) in [(1, RawSessionType::Outbound), (2, RawSessionType::Inbound)] {
+            let addr: Multiaddr = format!("/ip4/192.0.2.1/tcp/8115/p2p/{}", PeerId::random())
+                .parse()
+                .unwrap();
+            let mut store = state.peer_store.lock();
+            state
+                .peer_registry
+                .write()
+                .accept_peer(addr, id.into(), ty, &mut store)
+                .unwrap();
+        }
+        assert!(state.with_peer_registry(|reg| reg.is_anchor(1.into())));
+        let advertised: Multiaddr = format!("/ip4/192.0.2.2/tcp/8115/p2p/{}", PeerId::random())
+            .parse()
+            .unwrap();
+        let observed: Multiaddr = "/ip4/192.0.2.3/tcp/8115".parse().unwrap();
+        callback.store_remote_listen_addrs(1.into(), vec![advertised.clone()]);
+        callback.add_observed_addr(observed.clone(), 1.into());
+        assert!(
+            state
+                .peer_store
+                .lock()
+                .addr_manager()
+                .get(&advertised)
+                .is_none()
+        );
+        assert!(
+            state.with_peer_registry(|reg| reg
+                .get_peer(1.into())
+                .unwrap()
+                .listened_addrs
+                .is_empty())
+        );
+        assert!(state.observed_addrs(10).is_empty());
+
+        callback.store_remote_listen_addrs(2.into(), vec![advertised.clone()]);
+        callback.add_observed_addr(observed, 2.into());
+        assert!(
+            state
+                .peer_store
+                .lock()
+                .addr_manager()
+                .get(&advertised)
+                .is_some()
+        );
+        assert_eq!(
+            state.with_peer_registry(|reg| reg.get_peer(2.into()).unwrap().listened_addrs.clone()),
+            vec![advertised]
+        );
+        assert_eq!(state.observed_addrs(10).len(), 1);
+    }
 
     #[test]
     fn test_identify_rejects_dns_loopback_listen_addr() {

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -136,6 +136,18 @@ pub trait CKBProtocolContext: Send {
     // Interact with NetworkState
     /// Get peer info
     fn get_peer(&self, peer_index: PeerIndex) -> Option<Peer>;
+    /// Whether the session is a block-relay-only (anchor) connection.
+    ///
+    /// Such connections must not carry transaction or address relay traffic, so that
+    /// they stay hard to detect and keep obfuscating the network topology.
+    ///
+    /// The default implementation goes through [`Self::get_peer`], which clones the
+    /// whole [`Peer`]. Implementations sitting on a hot message path should override
+    /// it with a cheaper lookup.
+    fn is_block_relay_only(&self, peer_index: PeerIndex) -> bool {
+        self.get_peer(peer_index)
+            .is_some_and(|peer| peer.is_block_relay_only())
+    }
     /// Modify peer info
     fn with_peer_mut(&self, peer_index: PeerIndex, f: Box<dyn FnOnce(&mut Peer)>);
     /// Get all session id
@@ -638,6 +650,11 @@ impl CKBProtocolContext for DefaultCKBProtocolContext {
     fn get_peer(&self, peer_index: PeerIndex) -> Option<Peer> {
         self.network_state
             .with_peer_registry(|reg| reg.get_peer(peer_index).cloned())
+    }
+    fn is_block_relay_only(&self, peer_index: PeerIndex) -> bool {
+        // Avoid the `Peer` clone `get_peer` would do, this runs per relay message.
+        self.network_state
+            .with_peer_registry(|reg| reg.is_anchor(peer_index))
     }
     fn with_peer_mut(&self, peer_index: PeerIndex, f: Box<dyn FnOnce(&mut Peer)>) {
         self.network_state.with_peer_registry_mut(|reg| {

--- a/sync/src/relayer/get_block_proposal_process.rs
+++ b/sync/src/relayer/get_block_proposal_process.rs
@@ -64,17 +64,26 @@ impl<'a> GetBlockProposalProcess<'a> {
             }
             fetch_txs.unwrap()
         };
-        // Transactions that do not exist on this node
-        let not_exist_proposals: Vec<packed::ProposalShortId> = proposals
-            .into_iter()
-            .filter(|short_id| !fetched_transactions.contains_key(short_id))
-            .collect();
+        // Cache the misses and try to serve them again on a timer.
+        //
+        // Block-relay-only peers are deliberately excluded: caching their misses would
+        // turn a single GetBlockProposal into a standing subscription that pushes every
+        // matching transaction to them as soon as it enters the pool, which is exactly
+        // the transaction relay traffic such connections must not carry. They still get
+        // whatever is already in the pool, which is what compact block reconstruction
+        // needs.
+        if !self.nc.is_block_relay_only(self.peer) {
+            // Transactions that do not exist on this node
+            let not_exist_proposals: Vec<packed::ProposalShortId> = proposals
+                .into_iter()
+                .filter(|short_id| !fetched_transactions.contains_key(short_id))
+                .collect();
 
-        // Cache request, try process on timer
-        self.relayer
-            .shared()
-            .state()
-            .insert_get_block_proposals(self.peer, not_exist_proposals);
+            self.relayer
+                .shared()
+                .state()
+                .insert_get_block_proposals(self.peer, not_exist_proposals);
+        }
 
         let mut relay_bytes = 0;
         let mut relay_proposals = Vec::new();

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -123,6 +123,20 @@ impl Relayer {
             return StatusCode::TooManyRequests.with_context(message.item_name());
         }
 
+        // RelayV3 also carries compact-block reconstruction messages, so keep the
+        // protocol open on block-relay-only connections and drop only the standalone
+        // transaction relay messages. Ignored instead of banned, an outdated peer may
+        // simply not know about this connection type yet.
+        if matches!(
+            message,
+            packed::RelayMessageUnionReader::RelayTransactions(_)
+                | packed::RelayMessageUnionReader::RelayTransactionHashes(_)
+                | packed::RelayMessageUnionReader::GetRelayTransactions(_)
+        ) && nc.is_block_relay_only(peer)
+        {
+            return Status::ignored();
+        }
+
         match message {
             packed::RelayMessageUnionReader::CompactBlock(reader) => {
                 if reader.check_data() {
@@ -605,6 +619,12 @@ impl Relayer {
     /// Ask for relay transaction by hash from all peers
     pub async fn ask_for_txs(&self, nc: &Arc<dyn CKBProtocolContext + Sync>) {
         for (peer, mut tx_hashes) in self.shared().state().pop_ask_for_txs() {
+            // Defensive: `try_process` already rejects tx announcements from these
+            // peers, so they should never end up queued here. `pop_ask_for_txs` keeps
+            // the hash queued for the next peer in line, nothing is dropped.
+            if nc.is_block_relay_only(peer) {
+                continue;
+            }
             if !tx_hashes.is_empty() {
                 debug_target!(
                     crate::LOG_TARGET_RELAY,

--- a/sync/src/relayer/tests/block_relay_only.rs
+++ b/sync/src/relayer/tests/block_relay_only.rs
@@ -1,0 +1,204 @@
+use super::helper::{MockProtocolContext, build_chain, new_transaction};
+use crate::Status;
+use ckb_network::{CKBProtocolContext, Peer, SessionType, SupportProtocols};
+use ckb_store::ChainStore;
+use ckb_types::{packed, prelude::*};
+use std::sync::Arc;
+
+fn context(session_type: SessionType) -> Arc<MockProtocolContext> {
+    Arc::new(
+        MockProtocolContext::new(SupportProtocols::RelayV3).with_peer(Peer::new(
+            1.into(),
+            session_type,
+            "/ip4/127.0.0.1/tcp/8115".parse().unwrap(),
+            false,
+        )),
+    )
+}
+
+#[test]
+fn block_only_ignores_transaction_messages_but_serves_block_transactions() {
+    let (_chain, mut relayer, out_point) = build_chain(5);
+    let tx = new_transaction(&relayer, 1, &out_point);
+    relayer
+        .shared
+        .shared()
+        .tx_pool_controller()
+        .submit_local_tx(tx.clone())
+        .unwrap()
+        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let nc = context(SessionType::BlockRelayOnly);
+    let messages = [
+        packed::RelayMessage::new_builder()
+            .set(
+                packed::RelayTransactionHashes::new_builder()
+                    .tx_hashes(vec![tx.hash()])
+                    .build(),
+            )
+            .build(),
+        packed::RelayMessage::new_builder()
+            .set(
+                packed::RelayTransactions::new_builder()
+                    .transactions(vec![
+                        packed::RelayTransaction::new_builder()
+                            .transaction(tx.data())
+                            .cycles(0u64)
+                            .build(),
+                    ])
+                    .build(),
+            )
+            .build(),
+        packed::RelayMessage::new_builder()
+            .set(
+                packed::GetRelayTransactions::new_builder()
+                    .tx_hashes(vec![tx.hash()])
+                    .build(),
+            )
+            .build(),
+    ];
+    for message in &messages {
+        assert_eq!(
+            rt.block_on(relayer.try_process(nc.clone(), 1.into(), message.as_reader().to_enum())),
+            Status::ignored()
+        );
+    }
+    assert!(relayer.shared.state().unknown_tx_hashes().is_empty());
+    assert!(!relayer.shared.state().tx_filter().contains(&tx.hash()));
+    assert_eq!(nc.sent_messages_len(), 0);
+
+    // The same transaction query remains available on a full-relay connection.
+    let full = context(SessionType::Outbound);
+    assert_eq!(
+        rt.block_on(relayer.try_process(full.clone(), 1.into(), messages[2].as_reader().to_enum())),
+        Status::ok()
+    );
+    assert_eq!(full.sent_messages_len(), 1);
+
+    let tip_hash = relayer.shared.active_chain().tip_hash();
+    let block = relayer.shared.store().get_block(&tip_hash).unwrap();
+    let request = packed::RelayMessage::new_builder()
+        .set(
+            packed::GetBlockTransactions::new_builder()
+                .block_hash(tip_hash.clone())
+                .indexes(vec![0u32])
+                .build(),
+        )
+        .build();
+    assert_eq!(
+        rt.block_on(relayer.try_process(nc.clone(), 1.into(), request.as_reader().to_enum())),
+        Status::ok()
+    );
+    let response = packed::RelayMessage::new_builder()
+        .set(
+            packed::BlockTransactions::new_builder()
+                .block_hash(tip_hash)
+                .transactions(vec![block.transactions()[0].data()])
+                .build(),
+        )
+        .build();
+    assert!(nc.has_sent(
+        SupportProtocols::RelayV3.protocol_id(),
+        1.into(),
+        response.as_bytes()
+    ));
+}
+
+/// A block-relay-only peer may still ask for proposals, it needs them to reconstruct
+/// the compact blocks we send it. What it must not get is the pending-request cache:
+/// that would turn one GetBlockProposal into a standing subscription pushing every
+/// matching transaction to it as soon as it lands in the pool.
+#[test]
+fn block_only_get_block_proposal_serves_pool_but_leaves_no_subscription() {
+    let (_chain, mut relayer, out_point) = build_chain(5);
+    let in_pool = new_transaction(&relayer, 1, &out_point);
+    relayer
+        .shared
+        .shared()
+        .tx_pool_controller()
+        .submit_local_tx(in_pool.clone())
+        .unwrap()
+        .unwrap();
+    let not_in_pool = new_transaction(&relayer, 2, &out_point);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let tip_hash = relayer.shared.active_chain().tip_hash();
+    let request = |ids: Vec<packed::ProposalShortId>| {
+        packed::RelayMessage::new_builder()
+            .set(
+                packed::GetBlockProposal::new_builder()
+                    .block_hash(tip_hash.clone())
+                    .proposals(ids)
+                    .build(),
+            )
+            .build()
+    };
+    let ids = vec![in_pool.proposal_short_id(), not_in_pool.proposal_short_id()];
+
+    let nc = context(SessionType::BlockRelayOnly);
+    assert_eq!(
+        rt.block_on(relayer.try_process(
+            nc.clone(),
+            1.into(),
+            request(ids.clone()).as_reader().to_enum()
+        )),
+        Status::ok()
+    );
+    // Served from the pool, but nothing cached for later push.
+    assert_eq!(nc.sent_messages_len(), 1);
+    assert!(
+        relayer
+            .shared
+            .state()
+            .drain_get_block_proposals()
+            .is_empty()
+    );
+
+    let full = context(SessionType::Outbound);
+    assert_eq!(
+        rt.block_on(relayer.try_process(
+            full.clone(),
+            1.into(),
+            request(ids).as_reader().to_enum()
+        )),
+        Status::ok()
+    );
+    assert_eq!(full.sent_messages_len(), 1);
+    let pending = relayer.shared.state().drain_get_block_proposals();
+    assert_eq!(pending.len(), 1);
+    assert!(pending.contains_key(&not_in_pool.proposal_short_id()));
+}
+
+#[test]
+fn transaction_requests_skip_block_only_peers() {
+    let (_chain, relayer, out_point) = build_chain(5);
+    relayer.shared.state().peers().relay_connected(1.into());
+    let tx = new_transaction(&relayer, 1, &out_point);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for session_type in [SessionType::BlockRelayOnly, SessionType::Outbound] {
+        relayer.shared.state().unknown_tx_hashes().clear();
+        assert_eq!(
+            relayer
+                .shared
+                .state()
+                .add_ask_for_txs(1.into(), vec![tx.hash()]),
+            Status::ok()
+        );
+        let nc = context(session_type);
+        let protocol: Arc<dyn CKBProtocolContext + Sync> = nc.clone();
+        rt.block_on(relayer.ask_for_txs(&protocol));
+        assert_eq!(
+            nc.sent_messages_len(),
+            usize::from(session_type == SessionType::Outbound)
+        );
+    }
+}

--- a/sync/src/relayer/tests/block_relay_only.rs
+++ b/sync/src/relayer/tests/block_relay_only.rs
@@ -62,7 +62,11 @@ fn block_only_ignores_transaction_messages_but_serves_block_transactions() {
     ];
     for message in &messages {
         assert_eq!(
-            rt.block_on(relayer.try_process(nc.clone(), 1.into(), message.as_reader().to_enum())),
+            rt.block_on(relayer.try_process(
+                Arc::<MockProtocolContext>::clone(&nc),
+                1.into(),
+                message.as_reader().to_enum()
+            )),
             Status::ignored()
         );
     }
@@ -73,7 +77,11 @@ fn block_only_ignores_transaction_messages_but_serves_block_transactions() {
     // The same transaction query remains available on a full-relay connection.
     let full = context(SessionType::Outbound);
     assert_eq!(
-        rt.block_on(relayer.try_process(full.clone(), 1.into(), messages[2].as_reader().to_enum())),
+        rt.block_on(relayer.try_process(
+            Arc::<MockProtocolContext>::clone(&full),
+            1.into(),
+            messages[2].as_reader().to_enum()
+        )),
         Status::ok()
     );
     assert_eq!(full.sent_messages_len(), 1);
@@ -89,7 +97,11 @@ fn block_only_ignores_transaction_messages_but_serves_block_transactions() {
         )
         .build();
     assert_eq!(
-        rt.block_on(relayer.try_process(nc.clone(), 1.into(), request.as_reader().to_enum())),
+        rt.block_on(relayer.try_process(
+            Arc::<MockProtocolContext>::clone(&nc),
+            1.into(),
+            request.as_reader().to_enum()
+        )),
         Status::ok()
     );
     let response = packed::RelayMessage::new_builder()
@@ -144,7 +156,7 @@ fn block_only_get_block_proposal_serves_pool_but_leaves_no_subscription() {
     let nc = context(SessionType::BlockRelayOnly);
     assert_eq!(
         rt.block_on(relayer.try_process(
-            nc.clone(),
+            Arc::<MockProtocolContext>::clone(&nc),
             1.into(),
             request(ids.clone()).as_reader().to_enum()
         )),
@@ -163,7 +175,7 @@ fn block_only_get_block_proposal_serves_pool_but_leaves_no_subscription() {
     let full = context(SessionType::Outbound);
     assert_eq!(
         rt.block_on(relayer.try_process(
-            full.clone(),
+            Arc::<MockProtocolContext>::clone(&full),
             1.into(),
             request(ids).as_reader().to_enum()
         )),
@@ -194,7 +206,7 @@ fn transaction_requests_skip_block_only_peers() {
             Status::ok()
         );
         let nc = context(session_type);
-        let protocol: Arc<dyn CKBProtocolContext + Sync> = nc.clone();
+        let protocol: Arc<dyn CKBProtocolContext + Sync> = Arc::<MockProtocolContext>::clone(&nc);
         rt.block_on(relayer.ask_for_txs(&protocol));
         assert_eq!(
             nc.sent_messages_len(),

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -31,7 +31,7 @@ use ckb_types::{
     utilities::difficulty_to_compact,
 };
 use ckb_verification_traits::Switch;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::{cell::RefCell, future::Future, pin::Pin, sync::Arc, time::Duration};
 
 pub(crate) fn new_index_transaction(index: usize) -> IndexTransaction {
@@ -300,6 +300,7 @@ pub(crate) fn gen_block(
 pub(crate) struct MockProtocolContext {
     protocol: SupportProtocols,
     sent_messages: RefCell<Vec<(ProtocolId, PeerIndex, P2pBytes)>>,
+    peers: HashMap<PeerIndex, Peer>,
 }
 
 // test mock context with single thread
@@ -312,7 +313,13 @@ impl MockProtocolContext {
         Self {
             protocol,
             sent_messages: Default::default(),
+            peers: Default::default(),
         }
+    }
+
+    pub(crate) fn with_peer(mut self, peer: Peer) -> Self {
+        self.peers.insert(peer.session_id, peer);
+        self
     }
 
     pub(crate) fn has_sent(
@@ -480,8 +487,8 @@ impl CKBProtocolContext for MockProtocolContext {
     fn disconnect(&self, _peer_index: PeerIndex, _message: &str) -> Result<(), Error> {
         unimplemented!();
     }
-    fn get_peer(&self, _peer_index: PeerIndex) -> Option<Peer> {
-        unimplemented!();
+    fn get_peer(&self, peer_index: PeerIndex) -> Option<Peer> {
+        self.peers.get(&peer_index).cloned()
     }
     fn with_peer_mut(&self, _peer_index: PeerIndex, _f: Box<dyn FnOnce(&mut Peer)>) {
         unimplemented!();

--- a/sync/src/relayer/tests/mod.rs
+++ b/sync/src/relayer/tests/mod.rs
@@ -1,4 +1,5 @@
 mod block_proposal_process;
+mod block_relay_only;
 mod block_transactions_process;
 mod block_transactions_verifier;
 mod block_uncles_verifier;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Block-relay-only connections are intended to avoid transaction and address relay, making network topology harder to observe. However, these sessions could still process standalone transaction messages, contribute addresses through Identify, and receive deferred transaction responses to GetBlockProposal requests.

### What is changed and how it works?

What's Changed:

- Ignore RelayTransactions, RelayTransactionHashes, and GetRelayTransactions from block-relay-only peers after applying the existing rate limits.
- Skip these peers when scheduling standalone transaction requests.
- Serve currently available GetBlockProposal transactions without caching missing proposals for later delivery.
- Ignore listen addresses and observed addresses supplied by block-relay-only peers.
- Restrict protocols opened locally after Identify to Ping, Identify, DisconnectMessage, Sync, and RelayV3. Message handlers enforce transaction isolation independently of this protocol selection.
- Add a lightweight connection-type lookup that avoids cloning Peer on the message-processing path.

Identify handshakes and block-related RelayV3 messages remain available, including compact-block reconstruction requests.

### Related changes

None.

### Check List

Tests:

- Unit tests cover transaction-message filtering and request scheduling.
- Regression tests verify that full-relay transaction queries and block-transaction responses remain available.
- Tests cover immediate GetBlockProposal responses without deferred subscriptions.
- Identify tests cover protocol selection and address isolation.

Validation commands:

- `cargo nextest run -p ckb-sync --lib --test-threads=2`
- `cargo test -p ckb-network --lib -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`

Side effects:

- Standalone transaction messages on block-relay-only connections are ignored without introducing a new ban condition.
- No wire-format changes.