### PR TITLE
fix: rate-limit SendHeaders processing by header count

### DIFF
--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -300,6 +300,7 @@ pub(crate) fn gen_block(
 pub(crate) struct MockProtocolContext {
     protocol: SupportProtocols,
     sent_messages: RefCell<Vec<(ProtocolId, PeerIndex, P2pBytes)>>,
+    disconnected_peers: RefCell<Vec<PeerIndex>>,
 }
 
 // test mock context with single thread
@@ -312,6 +313,7 @@ impl MockProtocolContext {
         Self {
             protocol,
             sent_messages: Default::default(),
+            disconnected_peers: Default::default(),
         }
     }
 
@@ -328,6 +330,10 @@ impl MockProtocolContext {
 
     pub(crate) fn sent_messages_len(&self) -> usize {
         self.sent_messages.borrow().len()
+    }
+
+    pub(crate) fn disconnected_peers(&self) -> Vec<PeerIndex> {
+        self.disconnected_peers.borrow().clone()
     }
 }
 
@@ -477,8 +483,9 @@ impl CKBProtocolContext for MockProtocolContext {
     fn filter_broadcast(&self, target: TargetSession, data: P2pBytes) -> Result<(), Error> {
         self.quick_filter_broadcast(target, data)
     }
-    fn disconnect(&self, _peer_index: PeerIndex, _message: &str) -> Result<(), Error> {
-        unimplemented!();
+    fn disconnect(&self, peer_index: PeerIndex, _message: &str) -> Result<(), Error> {
+        self.disconnected_peers.borrow_mut().push(peer_index);
+        Ok(())
     }
     fn get_peer(&self, _peer_index: PeerIndex) -> Option<Peer> {
         unimplemented!();

--- a/sync/src/synchronizer/headers_process.rs
+++ b/sync/src/synchronizer/headers_process.rs
@@ -95,6 +95,25 @@ impl<'a> HeadersProcess<'a> {
         debug!("HeadersProcess begins");
         let shared: &SyncShared = self.synchronizer.shared();
         let consensus = shared.consensus();
+        let headers_len = self.message.headers().len();
+        // Reject oversized batches before allocating or hashing HeaderViews. Keep
+        // the existing invalid-message status even when the peer is rate limited.
+        if headers_len > MAX_HEADERS_LEN {
+            warn!("HeadersProcess is oversized");
+            return StatusCode::HeadersIsInvalid.with_context("oversize");
+        }
+        if !self
+            .synchronizer
+            .headers_rate_limiter
+            .check(self.peer, headers_len)
+        {
+            // A dropped response would otherwise leave header sync waiting for a
+            // timeout. Disconnect without an IP ban so sync can select another peer.
+            let _ = self
+                .nc
+                .disconnect(self.peer, "SendHeaders work budget exceeded");
+            return StatusCode::TooManyRequests.with_context("SendHeaders work budget exceeded");
+        }
         let headers = self
             .message
             .headers()
@@ -102,11 +121,6 @@ impl<'a> HeadersProcess<'a> {
             .into_iter()
             .map(packed::Header::into_view)
             .collect::<Vec<_>>();
-
-        if headers.len() > MAX_HEADERS_LEN {
-            warn!("HeadersProcess is oversized");
-            return StatusCode::HeadersIsInvalid.with_context("oversize");
-        }
 
         if headers.is_empty() {
             // Empty means that the other peer's tip may be consistent with our own best known,

--- a/sync/src/synchronizer/headers_rate_limiter.rs
+++ b/sync/src/synchronizer/headers_rate_limiter.rs
@@ -1,0 +1,160 @@
+use ckb_network::PeerIndex;
+use governor::{
+    Quota, RateLimiter,
+    clock::{Clock, DefaultClock},
+    middleware::NoOpMiddleware,
+    state::keyed::HashMapStateStore,
+};
+use std::num::NonZeroU32;
+
+// Allow ten maximum-size batches per second, with twenty batches of burst
+// capacity to accommodate header-sync pipelining and network jitter.
+const HEADERS_PER_SECOND: u32 = 20_000;
+const HEADERS_BURST: u32 = 40_000;
+
+pub(super) struct HeadersRateLimiter<C: Clock = DefaultClock> {
+    limiter: RateLimiter<PeerIndex, HashMapStateStore<PeerIndex>, C, NoOpMiddleware<C::Instant>>,
+}
+
+impl Default for HeadersRateLimiter {
+    fn default() -> Self {
+        Self::new(DefaultClock::default())
+    }
+}
+
+impl<C: Clock> HeadersRateLimiter<C> {
+    fn new(clock: C) -> Self {
+        let quota = Quota::per_second(NonZeroU32::new(HEADERS_PER_SECOND).unwrap())
+            .allow_burst(NonZeroU32::new(HEADERS_BURST).unwrap());
+        Self {
+            limiter: RateLimiter::new(quota, HashMapStateStore::default(), clock),
+        }
+    }
+
+    pub(super) fn check(&self, peer: PeerIndex, headers: usize) -> bool {
+        // Empty responses still consume parsing and sync-state work. Do not let
+        // integer conversion truncate the cost if a caller omits the batch cap.
+        let Ok(cost) = u32::try_from(headers.max(1)) else {
+            return false;
+        };
+        matches!(
+            self.limiter
+                .check_key_n(&peer, NonZeroU32::new(cost).unwrap()),
+            Ok(Ok(()))
+        )
+    }
+
+    pub(super) fn retain_recent(&self) {
+        self.limiter.retain_recent();
+        self.limiter.shrink_to_fit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ckb_constant::sync::MAX_HEADERS_LEN;
+    use governor::clock::FakeRelativeClock;
+    use std::time::Duration;
+
+    #[test]
+    fn budget_is_weighted_atomic_and_independent_per_peer() {
+        let limiter = HeadersRateLimiter::new(FakeRelativeClock::default());
+        assert!(limiter.check(1.into(), HEADERS_BURST as usize - MAX_HEADERS_LEN));
+        assert!(limiter.check(1.into(), MAX_HEADERS_LEN - 1));
+        assert!(!limiter.check(1.into(), MAX_HEADERS_LEN));
+        // Rejection must not consume the remaining single-header allowance.
+        assert!(limiter.check(1.into(), 1));
+        assert!(!limiter.check(1.into(), 1));
+        assert!(limiter.check(2.into(), MAX_HEADERS_LEN));
+    }
+
+    #[test]
+    fn empty_responses_cost_one_and_budget_refills() {
+        let clock = FakeRelativeClock::default();
+        let limiter = HeadersRateLimiter::new(clock.clone());
+        assert!(limiter.check(1.into(), HEADERS_BURST as usize - 1));
+        assert!(limiter.check(1.into(), 0));
+        assert!(!limiter.check(1.into(), 0));
+        clock.advance(Duration::from_secs(1));
+        assert!(limiter.check(1.into(), HEADERS_PER_SECOND as usize));
+        assert!(!limiter.check(1.into(), 1));
+        // Cleanup expires records strictly after their refill deadline.
+        clock.advance(Duration::from_secs(3));
+        limiter.retain_recent();
+        assert!(limiter.limiter.is_empty());
+        assert!(limiter.check(1.into(), HEADERS_BURST as usize));
+    }
+
+    #[test]
+    fn maximum_batches_fit_but_oversized_costs_do_not_wrap() {
+        let limiter = HeadersRateLimiter::new(FakeRelativeClock::default());
+        assert!(!limiter.check(1.into(), usize::MAX));
+        for _ in 0..HEADERS_BURST as usize / MAX_HEADERS_LEN {
+            assert!(limiter.check(1.into(), MAX_HEADERS_LEN));
+        }
+        assert!(!limiter.check(1.into(), MAX_HEADERS_LEN));
+    }
+
+    #[test]
+    fn exhausted_budget_rejects_before_header_processing_and_preserves_batch_cap() {
+        use crate::relayer::tests::helper::{MockProtocolContext, build_chain};
+        use crate::synchronizer::HeadersProcess;
+        use crate::{Status, StatusCode, Synchronizer};
+        use ckb_network::{CKBProtocolContext, SupportProtocols};
+        use ckb_types::{packed, prelude::*};
+        use std::sync::Arc;
+
+        let (chain, relayer, _) = build_chain(2);
+        let shared = Arc::clone(relayer.shared());
+        let mut sync = Synchronizer::new(chain.chain_controller().clone(), Arc::clone(&shared));
+        // Give this test a slow refill instead of relying on wall-clock sleeps.
+        sync.headers_rate_limiter = HeadersRateLimiter {
+            limiter: RateLimiter::hashmap(
+                Quota::per_hour(NonZeroU32::new(1).unwrap())
+                    .allow_burst(NonZeroU32::new(2).unwrap()),
+            ),
+        };
+        assert!(sync.headers_rate_limiter.check(1.into(), 2));
+        let mock = Arc::new(MockProtocolContext::new(SupportProtocols::Sync));
+        let nc: Arc<dyn CKBProtocolContext + Sync> = Arc::<MockProtocolContext>::clone(&mock);
+        let unverified = packed::Header::default();
+        let hash = unverified.calc_header_hash();
+        let message = packed::SendHeaders::new_builder()
+            .headers(vec![unverified.clone(), unverified.clone()])
+            .build();
+        let status = HeadersProcess::new(message.as_reader(), &sync, 1.into(), &nc).execute();
+        assert_eq!(status.code(), StatusCode::TooManyRequests);
+        assert!(status.should_ban().is_none());
+        assert_eq!(mock.disconnected_peers(), vec![1.into()]);
+        assert!(shared.shared().header_map().get(&hash).is_none());
+        assert!(shared.shared().get_block_status(&hash).is_empty());
+        assert_eq!(mock.sent_messages_len(), 0);
+
+        let oversized = packed::SendHeaders::new_builder()
+            .headers(vec![unverified; MAX_HEADERS_LEN + 1])
+            .build();
+        let status = HeadersProcess::new(oversized.as_reader(), &sync, 1.into(), &nc).execute();
+        assert_eq!(status.code(), StatusCode::HeadersIsInvalid);
+        assert_eq!(
+            status.should_ban(),
+            Some(ckb_constant::sync::BAD_MESSAGE_BAN_TIME)
+        );
+
+        // Another peer can still finish a normal header exchange, including an
+        // empty response and a replay of a known valid header.
+        let empty = packed::SendHeaders::default();
+        assert_eq!(
+            HeadersProcess::new(empty.as_reader(), &sync, 2.into(), &nc).execute(),
+            Status::ok()
+        );
+        let known = packed::SendHeaders::new_builder()
+            .headers(vec![shared.active_chain().tip_header().data()])
+            .build();
+        assert_eq!(
+            HeadersProcess::new(known.as_reader(), &sync, 2.into(), &nc).execute(),
+            Status::ok()
+        );
+        assert_eq!(mock.disconnected_peers(), vec![1.into()]);
+    }
+}

--- a/sync/src/synchronizer/mod.rs
+++ b/sync/src/synchronizer/mod.rs
@@ -11,6 +11,7 @@ mod block_process;
 mod get_blocks_process;
 mod get_headers_process;
 mod headers_process;
+mod headers_rate_limiter;
 mod in_ibd_process;
 
 pub(crate) use self::block_fetcher::BlockFetcher;
@@ -41,6 +42,7 @@ use ckb_network::{
 use ckb_shared::types::HeaderIndexView;
 use ckb_stop_handler::{new_crossbeam_exit_rx, register_thread};
 use ckb_systemtime::unix_time_as_millis;
+use headers_rate_limiter::HeadersRateLimiter;
 
 #[cfg(test)]
 use ckb_types::core;
@@ -354,6 +356,7 @@ pub struct Synchronizer {
     /// Sync shared state
     pub shared: Arc<SyncShared>,
     fetch_channel: Option<channel::Sender<FetchCMD>>,
+    headers_rate_limiter: HeadersRateLimiter,
 }
 
 impl Synchronizer {
@@ -365,6 +368,7 @@ impl Synchronizer {
             chain,
             shared,
             fetch_channel: None,
+            headers_rate_limiter: HeadersRateLimiter::default(),
         }
     }
 
@@ -985,6 +989,9 @@ impl CKBProtocolHandler for Synchronizer {
     }
 
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {
+        if token == SEND_GET_HEADERS_TOKEN {
+            self.headers_rate_limiter.retain_recent();
+        }
         if !self.peers().state.is_empty() {
             let start_time = Instant::now();
             trace!("Start notify token={}", token);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

SendHeaders limits each message to 2,000 headers but has no per-peer work budget across messages. Repeated batches can therefore trigger sustained header processing without a limit proportional to their size.

### What is changed and how it works?

What's Changed:

- Add a per-peer budget of 20,000 headers per second with a burst capacity of 40,000.
- Charge each batch by its header count, with a minimum cost of one for empty responses.
- Check the budget before constructing HeaderViews, checking continuity, or verifying headers.
- Disconnect peers that exceed the budget and return TooManyRequests without an IP ban, allowing synchronization to select another peer.
- Preserve the existing oversized-batch rejection and move it before HeaderView allocation.
- Periodically remove expired limiter entries and reclaim unused capacity.

### Related changes

Expected epoch difficulty validation is a separate issue and is not addressed by this PR.

### Check List

Tests:

- Unit tests cover weighted charging, atomic batch rejection, per-peer isolation, empty responses, budget refill, and limiter cleanup.
- Handler regression tests verify early rejection, disconnect behavior, oversized-batch handling, and normal responses from another peer.
- `cargo nextest run -p ckb-sync --lib --test-threads=2`: 87 passed.
- `make clippy`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.

Side effects:

- Peers exceeding the configured-in-code budget are disconnected, including legitimate peers sending sustained high-volume header responses.
- No wire-format changes.