### PR TITLE
fix(sync): rate limit transaction fetches by hash count

### DIFF
--- a/sync/src/relayer/get_transactions_process.rs
+++ b/sync/src/relayer/get_transactions_process.rs
@@ -39,6 +39,20 @@ impl<'a> GetTransactionsProcess<'a> {
             }
         }
 
+        // The batch bound above makes this conversion safe. Empty requests still
+        // consume the outer message quota, but do not require any pool lookup.
+        let Some(hash_count) = std::num::NonZeroU32::new(message_len as u32) else {
+            return Status::ok();
+        };
+        if !matches!(
+            self.relayer
+                .tx_fetch_rate_limiter
+                .check_key_n(&self.peer, hash_count),
+            Ok(Ok(_))
+        ) {
+            return StatusCode::TooManyRequests.with_context("GetRelayTransactions hashes");
+        }
+
         let tx_hashes = self.message.tx_hashes();
 
         trace_target!(

--- a/sync/src/relayer/get_transactions_process.rs
+++ b/sync/src/relayer/get_transactions_process.rs
@@ -1,4 +1,7 @@
-use crate::relayer::{MAX_RELAY_TXS_BYTES_PER_BATCH, MAX_RELAY_TXS_NUM_PER_BATCH, Relayer};
+use crate::relayer::{
+    MAX_RELAY_TXS_BYTES_PER_BATCH, MAX_RELAY_TXS_BYTES_PER_REQUEST, MAX_RELAY_TXS_NUM_PER_BATCH,
+    Relayer, tx_fetch_work_units,
+};
 use crate::utils::async_send_message_to;
 use crate::{Status, StatusCode, attempt};
 use ckb_logger::{debug_target, trace_target};
@@ -52,6 +55,14 @@ impl<'a> GetTransactionsProcess<'a> {
         ) {
             return StatusCode::TooManyRequests.with_context("GetRelayTransactions hashes");
         }
+        if !matches!(
+            self.relayer
+                .tx_fetch_work_rate_limiter
+                .check_n(tx_fetch_work_units(hash_count.get())),
+            Ok(Ok(_))
+        ) {
+            return StatusCode::TooManyRequests.with_context("GetRelayTransactions node work");
+        }
 
         let tx_hashes = self.message.tx_hashes();
 
@@ -74,7 +85,9 @@ impl<'a> GetTransactionsProcess<'a> {
                 return StatusCode::RequestDuplicate.with_context("Request duplicate transaction");
             }
 
-            let fetch_txs_with_cycles = tx_pool.fetch_txs_with_cycles(tx_hashes_set).await;
+            let fetch_txs_with_cycles = tx_pool
+                .fetch_txs_with_cycles_limited(tx_hashes_set, MAX_RELAY_TXS_BYTES_PER_REQUEST)
+                .await;
 
             if let Err(e) = fetch_txs_with_cycles {
                 debug_target!(
@@ -97,22 +110,31 @@ impl<'a> GetTransactionsProcess<'a> {
                 .collect()
         };
 
-        if !transactions.is_empty() {
-            let mut relay_bytes = 0;
-            let mut relay_txs = Vec::new();
-            for tx in transactions {
-                if relay_bytes + tx.total_size() > MAX_RELAY_TXS_BYTES_PER_BATCH {
+        self.send_relay_transaction_batches(transactions).await
+    }
+
+    pub(super) async fn send_relay_transaction_batches(
+        &self,
+        transactions: Vec<packed::RelayTransaction>,
+    ) -> Status {
+        let mut relay_bytes = 0;
+        let mut relay_txs = Vec::new();
+        for tx in transactions {
+            if !relay_txs.is_empty()
+                && relay_bytes + tx.total_size() > MAX_RELAY_TXS_BYTES_PER_BATCH
+            {
+                attempt!(
                     self.send_relay_transactions(std::mem::take(&mut relay_txs))
-                        .await;
-                    relay_bytes = tx.total_size();
-                } else {
-                    relay_bytes += tx.total_size();
-                }
-                relay_txs.push(tx);
+                        .await
+                );
+                relay_bytes = tx.total_size();
+            } else {
+                relay_bytes += tx.total_size();
             }
-            if !relay_txs.is_empty() {
-                attempt!(self.send_relay_transactions(relay_txs).await);
-            }
+            relay_txs.push(tx);
+        }
+        if !relay_txs.is_empty() {
+            attempt!(self.send_relay_transactions(relay_txs).await);
         }
         Status::ok()
     }
@@ -125,6 +147,22 @@ impl<'a> GetTransactionsProcess<'a> {
                     .build(),
             )
             .build();
+        let Some(message_bytes) = std::num::NonZeroU32::new(message.as_slice().len() as u32) else {
+            return Status::ok();
+        };
+        if !matches!(
+            self.relayer
+                .tx_fetch_bytes_rate_limiter
+                .check_key_n(&self.peer, message_bytes),
+            Ok(Ok(_))
+        ) || !matches!(
+            self.relayer
+                .tx_fetch_global_bytes_rate_limiter
+                .check_n(message_bytes),
+            Ok(Ok(_))
+        ) {
+            return StatusCode::TooManyRequests.with_context("RelayTransactions response bytes");
+        }
         async_send_message_to(&self.nc, self.peer, &message).await
     }
 }

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -59,13 +59,27 @@ pub const TX_HASHES_TOKEN: u64 = 2;
 pub const MAX_RELAY_PEERS: usize = 128;
 pub const MAX_RELAY_TXS_NUM_PER_BATCH: usize = 32767;
 pub const MAX_RELAY_TXS_BYTES_PER_BATCH: usize = 1024 * 1024;
+// Bound one pool lookup to four network batches so the response can be sent
+// incrementally without retaining matches proportional to the whole pool.
+pub const MAX_RELAY_TXS_BYTES_PER_REQUEST: usize = MAX_RELAY_TXS_BYTES_PER_BATCH * 4;
 const MAX_PENDING_RELAY_TX_VERIFY_RESULTS: usize = MAX_RELAY_TXS_NUM_PER_BATCH * 2;
+// A fixed charge prevents repeated one-hash requests (including requests from
+// reconnected sessions) from bypassing the node-wide hash-work budget.
+const TX_FETCH_BASE_WORK_UNITS: u32 = 4096;
+const TX_FETCH_GLOBAL_WORK_UNITS_PER_SECOND: u32 =
+    (MAX_RELAY_TXS_NUM_PER_BATCH as u32 + TX_FETCH_BASE_WORK_UNITS) * 4;
+// The response budgets include headroom for the envelope around the four MiB
+// of relay-transaction payloads admitted by one pool lookup.
+const TX_FETCH_BYTES_PER_SECOND_PER_PEER: u32 = 8 * MAX_RELAY_TXS_BYTES_PER_BATCH as u32;
+const TX_FETCH_BYTES_PER_SECOND_GLOBAL: u32 = 4 * TX_FETCH_BYTES_PER_SECOND_PER_PEER;
 
-type RateLimiter<T> = governor::RateLimiter<
-    T,
-    governor::state::keyed::HashMapStateStore<T>,
-    governor::clock::DefaultClock,
->;
+type RateLimiter<T> = governor::DefaultKeyedRateLimiter<T>;
+type DirectRateLimiter = governor::DefaultDirectRateLimiter;
+
+fn tx_fetch_work_units(hash_count: u32) -> std::num::NonZeroU32 {
+    std::num::NonZeroU32::new(hash_count.saturating_add(TX_FETCH_BASE_WORK_UNITS))
+        .expect("transaction fetch work cost is non-zero")
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ReconstructionResult {
@@ -81,6 +95,9 @@ pub struct Relayer {
     pub(crate) shared: Arc<SyncShared>,
     rate_limiter: RateLimiter<(PeerIndex, u32)>,
     tx_fetch_rate_limiter: RateLimiter<PeerIndex>,
+    tx_fetch_work_rate_limiter: DirectRateLimiter,
+    tx_fetch_bytes_rate_limiter: RateLimiter<PeerIndex>,
+    tx_fetch_global_bytes_rate_limiter: DirectRateLimiter,
 }
 
 impl Relayer {
@@ -97,12 +114,26 @@ impl Relayer {
         let tx_fetch_quota = governor::Quota::per_second(
             std::num::NonZeroU32::new(MAX_RELAY_TXS_NUM_PER_BATCH as u32).unwrap(),
         );
+        let tx_fetch_work_quota = governor::Quota::per_second(
+            std::num::NonZeroU32::new(TX_FETCH_GLOBAL_WORK_UNITS_PER_SECOND).unwrap(),
+        );
+        let tx_fetch_bytes_quota = governor::Quota::per_second(
+            std::num::NonZeroU32::new(TX_FETCH_BYTES_PER_SECOND_PER_PEER).unwrap(),
+        );
+        let tx_fetch_global_bytes_quota = governor::Quota::per_second(
+            std::num::NonZeroU32::new(TX_FETCH_BYTES_PER_SECOND_GLOBAL).unwrap(),
+        );
 
         Relayer {
             chain,
             shared,
             rate_limiter,
             tx_fetch_rate_limiter: RateLimiter::hashmap(tx_fetch_quota),
+            tx_fetch_work_rate_limiter: DirectRateLimiter::direct(tx_fetch_work_quota),
+            tx_fetch_bytes_rate_limiter: RateLimiter::hashmap(tx_fetch_bytes_quota),
+            tx_fetch_global_bytes_rate_limiter: DirectRateLimiter::direct(
+                tx_fetch_global_bytes_quota,
+            ),
         }
     }
 
@@ -956,6 +987,7 @@ impl CKBProtocolHandler for Relayer {
         // Retains all keys in the rate limiter that were used recently enough.
         self.rate_limiter.retain_recent();
         self.tx_fetch_rate_limiter.retain_recent();
+        self.tx_fetch_bytes_rate_limiter.retain_recent();
     }
 
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {

--- a/sync/src/relayer/mod.rs
+++ b/sync/src/relayer/mod.rs
@@ -80,6 +80,7 @@ pub struct Relayer {
     chain: ChainController,
     pub(crate) shared: Arc<SyncShared>,
     rate_limiter: RateLimiter<(PeerIndex, u32)>,
+    tx_fetch_rate_limiter: RateLimiter<PeerIndex>,
 }
 
 impl Relayer {
@@ -91,11 +92,17 @@ impl Relayer {
         // current max rps is 10 (ASK_FOR_TXS_TOKEN / TX_PROPOSAL_TOKEN), 30 is a flexible hard cap with buffer
         let quota = governor::Quota::per_second(std::num::NonZeroU32::new(30).unwrap());
         let rate_limiter = RateLimiter::hashmap(quota);
+        // Allow one maximum-sized fetch batch as a burst and replenish that many
+        // hashes per second. Small requests share the same per-peer work budget.
+        let tx_fetch_quota = governor::Quota::per_second(
+            std::num::NonZeroU32::new(MAX_RELAY_TXS_NUM_PER_BATCH as u32).unwrap(),
+        );
 
         Relayer {
             chain,
             shared,
             rate_limiter,
+            tx_fetch_rate_limiter: RateLimiter::hashmap(tx_fetch_quota),
         }
     }
 
@@ -948,6 +955,7 @@ impl CKBProtocolHandler for Relayer {
         );
         // Retains all keys in the rate limiter that were used recently enough.
         self.rate_limiter.retain_recent();
+        self.tx_fetch_rate_limiter.retain_recent();
     }
 
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {

--- a/sync/src/relayer/tests/get_transactions_process.rs
+++ b/sync/src/relayer/tests/get_transactions_process.rs
@@ -7,6 +7,65 @@ use ckb_types::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+#[test]
+fn test_fetch_budget_counts_hashes_and_isolates_peers() {
+    let (_chain, mut relayer, _) = build_chain(5);
+    // Use a small, slowly replenished budget to exercise the handler without
+    // timing-dependent sleeps or large requests.
+    relayer.tx_fetch_rate_limiter = governor::RateLimiter::hashmap(governor::Quota::per_hour(
+        std::num::NonZeroU32::new(3).unwrap(),
+    ));
+    let hash = packed::Byte32::default();
+    let pair = packed::GetRelayTransactions::new_builder()
+        .tx_hashes(vec![hash.clone(), alternate_hash(&hash)])
+        .build();
+    let single = packed::GetRelayTransactions::new_builder()
+        .tx_hashes(vec![hash.clone()])
+        .build();
+    let duplicate = packed::GetRelayTransactions::new_builder()
+        .tx_hashes(vec![hash.clone(), hash])
+        .build();
+    let empty = packed::GetRelayTransactions::default();
+    let nc = Arc::new(MockProtocolContext::new(SupportProtocols::RelayV3));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let execute = |content: &packed::GetRelayTransactions, peer: usize| {
+        rt.block_on(
+            GetTransactionsProcess::new(
+                content.as_reader(),
+                &relayer,
+                Arc::<MockProtocolContext>::clone(&nc),
+                peer.into(),
+            )
+            .execute(),
+        )
+    };
+    let limited = StatusCode::TooManyRequests.with_context("GetRelayTransactions hashes");
+    assert_eq!(execute(&pair, 1), crate::Status::ok());
+    assert_eq!(execute(&pair, 1), limited);
+    // A denied batch does not consume the remaining one-hash allowance.
+    assert_eq!(execute(&single, 1), crate::Status::ok());
+    assert_eq!(execute(&single, 1), limited);
+    // Admission precedes even construction/validation of the hash set.
+    assert_eq!(execute(&duplicate, 1), limited);
+    assert_eq!(execute(&empty, 1), crate::Status::ok());
+    assert_eq!(execute(&pair, 2), crate::Status::ok());
+    assert_eq!(nc.sent_messages_len(), 0);
+}
+
+#[test]
+fn test_fetch_budget_allows_maximum_batch() {
+    let (_chain, relayer, _) = build_chain(5);
+    let count =
+        std::num::NonZeroU32::new(crate::relayer::MAX_RELAY_TXS_NUM_PER_BATCH as u32).unwrap();
+    assert!(matches!(
+        relayer.tx_fetch_rate_limiter.check_key_n(&1.into(), count),
+        Ok(Ok(_))
+    ));
+}
+
 fn alternate_hash(tx_hash: &packed::Byte32) -> packed::Byte32 {
     let mut bytes = tx_hash.as_slice().to_vec();
     bytes[31] ^= 1;

--- a/sync/src/relayer/tests/get_transactions_process.rs
+++ b/sync/src/relayer/tests/get_transactions_process.rs
@@ -1,6 +1,7 @@
 use crate::StatusCode;
 use crate::relayer::get_transactions_process::GetTransactionsProcess;
 use crate::relayer::tests::helper::{MockProtocolContext, build_chain, new_transaction};
+use crate::relayer::{MAX_RELAY_TXS_BYTES_PER_BATCH, tx_fetch_work_units};
 use ckb_network::{PeerIndex, SupportProtocols};
 use ckb_types::packed;
 use ckb_types::prelude::*;
@@ -64,6 +65,112 @@ fn test_fetch_budget_allows_maximum_batch() {
         relayer.tx_fetch_rate_limiter.check_key_n(&1.into(), count),
         Ok(Ok(_))
     ));
+}
+
+#[test]
+fn test_fetch_work_budget_is_shared_by_all_peers() {
+    let (_chain, mut relayer, _) = build_chain(5);
+    let work = tx_fetch_work_units(1);
+    relayer.tx_fetch_work_rate_limiter =
+        governor::RateLimiter::direct(governor::Quota::per_hour(work));
+    let content = packed::GetRelayTransactions::new_builder()
+        .tx_hashes(vec![packed::Byte32::default()])
+        .build();
+    let nc = Arc::new(MockProtocolContext::new(SupportProtocols::RelayV3));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let execute = |peer: usize| {
+        rt.block_on(
+            GetTransactionsProcess::new(
+                content.as_reader(),
+                &relayer,
+                Arc::<MockProtocolContext>::clone(&nc),
+                peer.into(),
+            )
+            .execute(),
+        )
+    };
+
+    assert_eq!(execute(1), crate::Status::ok());
+    assert_eq!(
+        execute(2),
+        StatusCode::TooManyRequests.with_context("GetRelayTransactions node work")
+    );
+}
+
+#[test]
+fn test_intermediate_send_failure_stops_later_batches() {
+    let (_chain, relayer, always_success_out_point) = build_chain(5);
+    let tx = new_transaction(&relayer, 1, &always_success_out_point);
+    let relay_tx = packed::RelayTransaction::new_builder()
+        .cycles(0u64)
+        .transaction(tx.data())
+        .build();
+    let repeat_count = MAX_RELAY_TXS_BYTES_PER_BATCH / relay_tx.total_size() * 2 + 1;
+    let transactions = vec![relay_tx; repeat_count];
+    let content = packed::GetRelayTransactions::default();
+    let nc = Arc::new(MockProtocolContext::with_send_failure(
+        SupportProtocols::RelayV3,
+        1,
+    ));
+    let process = GetTransactionsProcess::new(
+        content.as_reader(),
+        &relayer,
+        Arc::<MockProtocolContext>::clone(&nc),
+        1.into(),
+    );
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    assert!(
+        !rt.block_on(process.send_relay_transaction_batches(transactions))
+            .is_ok()
+    );
+    assert_eq!(nc.sent_messages_len(), 1);
+    assert_eq!(nc.send_attempts(), 2);
+}
+
+#[test]
+fn test_response_byte_budget_is_shared_by_all_peers() {
+    let (_chain, mut relayer, always_success_out_point) = build_chain(5);
+    let tx = new_transaction(&relayer, 1, &always_success_out_point);
+    let relay_tx = packed::RelayTransaction::new_builder()
+        .cycles(0u64)
+        .transaction(tx.data())
+        .build();
+    let response_bytes = relay_message(&tx, 0).as_slice().len() as u32;
+    relayer.tx_fetch_global_bytes_rate_limiter = governor::RateLimiter::direct(
+        governor::Quota::per_hour(std::num::NonZeroU32::new(response_bytes).unwrap()),
+    );
+    let content = packed::GetRelayTransactions::default();
+    let nc = Arc::new(MockProtocolContext::new(SupportProtocols::RelayV3));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    for peer in [1usize, 2] {
+        let process = GetTransactionsProcess::new(
+            content.as_reader(),
+            &relayer,
+            Arc::<MockProtocolContext>::clone(&nc),
+            peer.into(),
+        );
+        let status = rt.block_on(process.send_relay_transaction_batches(vec![relay_tx.clone()]));
+        if peer == 1 {
+            assert_eq!(status, crate::Status::ok());
+        } else {
+            assert_eq!(
+                status,
+                StatusCode::TooManyRequests.with_context("RelayTransactions response bytes")
+            );
+        }
+    }
+    assert_eq!(nc.sent_messages_len(), 1);
 }
 
 fn alternate_hash(tx_hash: &packed::Byte32) -> packed::Byte32 {
@@ -172,6 +279,22 @@ fn test_fetch_transactions_by_hash() {
         )
         .expect("fetch response");
     let cycles = fetched.first().expect("resident transaction returned").1;
+    let relay_tx_size = packed::RelayTransaction::new_builder()
+        .cycles(cycles)
+        .transaction(tx.data())
+        .build()
+        .total_size();
+    let capped_fetch = rt
+        .block_on(
+            relayer
+                .shared
+                .shared()
+                .tx_pool_controller()
+                .fetch_txs_with_cycles_limited(HashSet::from([tx_hash.clone()]), relay_tx_size - 1),
+        )
+        .expect("fetch response");
+    assert!(capped_fetch.is_empty());
+
     let expected = relay_message(&tx, cycles).as_bytes();
     let peer_index: PeerIndex = 1.into();
 

--- a/sync/src/relayer/tests/helper.rs
+++ b/sync/src/relayer/tests/helper.rs
@@ -32,7 +32,13 @@ use ckb_types::{
 };
 use ckb_verification_traits::Switch;
 use std::collections::HashSet;
-use std::{cell::RefCell, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    cell::{Cell, RefCell},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
 
 pub(crate) fn new_index_transaction(index: usize) -> IndexTransaction {
     let transaction = TransactionBuilder::default()
@@ -300,6 +306,8 @@ pub(crate) fn gen_block(
 pub(crate) struct MockProtocolContext {
     protocol: SupportProtocols,
     sent_messages: RefCell<Vec<(ProtocolId, PeerIndex, P2pBytes)>>,
+    send_attempts: Cell<usize>,
+    fail_sends_after: Option<usize>,
 }
 
 // test mock context with single thread
@@ -312,7 +320,38 @@ impl MockProtocolContext {
         Self {
             protocol,
             sent_messages: Default::default(),
+            send_attempts: Cell::new(0),
+            fail_sends_after: None,
         }
+    }
+
+    pub(crate) fn with_send_failure(protocol: SupportProtocols, successful_sends: usize) -> Self {
+        Self {
+            protocol,
+            sent_messages: Default::default(),
+            send_attempts: Cell::new(0),
+            fail_sends_after: Some(successful_sends),
+        }
+    }
+
+    fn record_send(
+        &self,
+        protocol_id: ProtocolId,
+        peer_index: PeerIndex,
+        data: P2pBytes,
+    ) -> Result<(), Error> {
+        let send_attempt = self.send_attempts.get();
+        self.send_attempts.set(send_attempt + 1);
+        if self
+            .fail_sends_after
+            .is_some_and(|successful_sends| send_attempt >= successful_sends)
+        {
+            return Err(std::io::Error::other("mock send failure").into());
+        }
+        self.sent_messages
+            .borrow_mut()
+            .push((protocol_id, peer_index, data));
+        Ok(())
     }
 
     pub(crate) fn has_sent(
@@ -328,6 +367,10 @@ impl MockProtocolContext {
 
     pub(crate) fn sent_messages_len(&self) -> usize {
         self.sent_messages.borrow().len()
+    }
+
+    pub(crate) fn send_attempts(&self) -> usize {
+        self.send_attempts.get()
     }
 }
 
@@ -374,10 +417,7 @@ impl CKBProtocolContext for MockProtocolContext {
         peer_index: PeerIndex,
         data: P2pBytes,
     ) -> Result<(), Error> {
-        self.sent_messages
-            .borrow_mut()
-            .push((proto_id, peer_index, data));
-        Ok(())
+        self.record_send(proto_id, peer_index, data)
     }
     async fn async_send_message_to(
         &self,
@@ -464,10 +504,7 @@ impl CKBProtocolContext for MockProtocolContext {
         peer_index: PeerIndex,
         data: P2pBytes,
     ) -> Result<(), Error> {
-        self.sent_messages
-            .borrow_mut()
-            .push((proto_id, peer_index, data));
-        Ok(())
+        self.record_send(proto_id, peer_index, data)
     }
     fn send_message_to(&self, peer_index: PeerIndex, data: P2pBytes) -> Result<(), Error> {
         let protocol_id = self.protocol_id();

--- a/tx-pool/src/pool.rs
+++ b/tx-pool/src/pool.rs
@@ -14,7 +14,8 @@ use ckb_snapshot::Snapshot;
 use ckb_store::ChainStore;
 use ckb_types::core::tx_pool::PoolTxDetailInfo;
 use ckb_types::core::{BlockNumber, CapacityError, FeeRate};
-use ckb_types::packed::OutPoint;
+use ckb_types::packed::{self, OutPoint};
+use ckb_types::prelude::*;
 use ckb_types::{
     core::{
         Capacity, Cycle, TransactionView, UncleBlockView,
@@ -200,11 +201,38 @@ impl TxPool {
             .collect()
     }
 
-    /// Returns a transaction and its cycles by transaction hash.
-    pub(crate) fn get_tx_with_cycles(&self, tx_hash: &Byte32) -> Option<(TransactionView, Cycle)> {
-        self.pool_map
-            .get_by_tx_hash(tx_hash)
-            .map(|entry| (entry.inner.transaction().clone(), entry.inner.cycles))
+    /// Returns matching transactions without cloning more serialized payload
+    /// data than the caller is prepared to process.
+    pub(crate) fn get_txs_with_cycles_limited(
+        &self,
+        tx_hashes: HashSet<Byte32>,
+        max_serialized_bytes: usize,
+    ) -> Vec<(TransactionView, Cycle)> {
+        let mut serialized_bytes = 0usize;
+        let mut transactions = Vec::new();
+        for tx_hash in tx_hashes {
+            let Some(entry) = self.pool_map.get_by_tx_hash(&tx_hash) else {
+                continue;
+            };
+            let transaction = entry.inner.transaction();
+            let relay_transaction = packed::RelayTransaction::new_builder()
+                .cycles(entry.inner.cycles)
+                .transaction(transaction.data())
+                .build();
+            let Some(next_bytes) = serialized_bytes.checked_add(relay_transaction.total_size())
+            else {
+                break;
+            };
+            if next_bytes > max_serialized_bytes {
+                break;
+            }
+            serialized_bytes = next_bytes;
+            transactions.push((transaction.clone(), entry.inner.cycles));
+            if serialized_bytes == max_serialized_bytes {
+                break;
+            }
+        }
+        transactions
     }
 
     pub(crate) fn get_pool_entry(&self, id: &ProposalShortId) -> Option<&PoolEntry> {

--- a/tx-pool/src/service.rs
+++ b/tx-pool/src/service.rs
@@ -104,6 +104,7 @@ pub(crate) type TestAcceptTxResult = Result<EntryCompleted, Reject>;
 type GetTxStatusResult = Result<(TxStatus, Option<Cycle>), AnyError>;
 type GetTransactionWithStatusResult = Result<TransactionWithStatus, AnyError>;
 type FetchTxsWithCyclesResult = Vec<(TransactionView, Cycle)>;
+type FetchTxsWithCyclesArgs = (HashSet<Byte32>, usize);
 
 pub(crate) type ChainReorgArgs = (
     VecDeque<BlockView>,
@@ -123,7 +124,7 @@ pub(crate) enum Message {
     NotifyTxs(Notify<Vec<TransactionView>>),
     FreshProposalsFilter(AsyncRequest<Vec<ProposalShortId>, Vec<ProposalShortId>>),
     FetchTxs(AsyncRequest<HashSet<ProposalShortId>, HashMap<ProposalShortId, TransactionView>>),
-    FetchTxsWithCycles(AsyncRequest<HashSet<Byte32>, FetchTxsWithCyclesResult>),
+    FetchTxsWithCycles(AsyncRequest<FetchTxsWithCyclesArgs, FetchTxsWithCyclesResult>),
     GetTxPoolInfo(Request<(), TxPoolInfo>),
     GetLiveCell(Request<(OutPoint, bool), CellStatus>),
     GetTxStatus(Request<Byte32, GetTxStatusResult>),
@@ -366,8 +367,19 @@ impl TxPoolController {
         &self,
         tx_hashes: HashSet<Byte32>,
     ) -> Result<FetchTxsWithCyclesResult, AnyError> {
+        self.fetch_txs_with_cycles_limited(tx_hashes, usize::MAX)
+            .await
+    }
+
+    /// Return transactions with cycles up to `max_serialized_bytes` worth of
+    /// relay-transaction payloads.
+    pub async fn fetch_txs_with_cycles_limited(
+        &self,
+        tx_hashes: HashSet<Byte32>,
+        max_serialized_bytes: usize,
+    ) -> Result<FetchTxsWithCyclesResult, AnyError> {
         let (responder, response) = tokio::sync::oneshot::channel();
-        let request = AsyncRequest::call(tx_hashes, responder);
+        let request = AsyncRequest::call((tx_hashes, max_serialized_bytes), responder);
         self.sender
             .try_send(Message::FetchTxsWithCycles(request))
             .map_err(|e| {
@@ -962,13 +974,10 @@ async fn process(mut service: TxPoolService, message: Message) {
         }
         Message::FetchTxsWithCycles(AsyncRequest {
             responder,
-            arguments: tx_hashes,
+            arguments: (tx_hashes, max_serialized_bytes),
         }) => {
             let tx_pool = service.tx_pool.read().await;
-            let txs = tx_hashes
-                .into_iter()
-                .filter_map(|tx_hash| tx_pool.get_tx_with_cycles(&tx_hash))
-                .collect();
+            let txs = tx_pool.get_txs_with_cycles_limited(tx_hashes, max_serialized_bytes);
             if let Err(e) = responder.send(txs) {
                 error!("Responder sending fetch_txs_with_cycles failed {:?}", e);
             };


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`GetRelayTransactions` accepts up to 32,767 hashes per request, but the existing limiter charges one unit per message. Large requests therefore consume more allocation and tx-pool lookup work without consuming additional rate-limit quota.

### What is changed and how it works?

What's Changed:

- Add a per-peer hash-count limiter with a refill rate of 32,767 hashes per second and the same burst capacity, allowing one maximum-sized request.
- Check the budget before constructing the hash set or submitting a tx-pool query. Reject requests exceeding the budget with `TooManyRequests`.
- Preserve the existing per-peer, per-message-type limiter.
- Return early for empty requests and clean up expired limiter entries on disconnect.

### Check List

Tests:

- Add unit tests covering weighted accounting, peer isolation, remaining budget after rejection, empty requests, and maximum-batch admission.
- `cargo nextest run -p ckb-sync --lib`: 85 tests passed.
- `make clippy`: passed.
- `cargo fmt --all -- --check`: passed.

Side effects:

- Sustained large fetch requests may now be throttled even when they satisfy the message-count limit.
- The initial hash budget has not been calibrated through performance benchmarks.