### PR TITLE
perf(script): reuse loaded cell data in syscall

### DIFF
--- a/script/src/syscalls/load_cell_data.rs
+++ b/script/src/syscalls/load_cell_data.rs
@@ -58,7 +58,7 @@ where
             .map_err(|e| VMError::Unexpected(e.to_string()))?;
 
         match sc.load_data(&data_piece_id, offset, u64::MAX) {
-            Ok((cell, _)) => {
+            Ok((mut cell, _)) => {
                 let size = machine.memory_mut().load64(&size_addr)?.to_u64();
                 if size == 0 {
                     machine
@@ -67,23 +67,16 @@ where
                     machine.set_register(A0, Mac::REG::from_u8(SUCCESS));
                     return Ok(());
                 }
-                let (wrote_size, _) = match sc.store_bytes(
-                    machine,
-                    addr,
-                    &data_piece_id,
-                    offset,
-                    size,
-                    size_addr.to_u64(),
-                ) {
-                    Ok(val) => val,
-                    Err(VMError::SnapshotDataLoadError) => {
-                        // This comes from TxData results in an out of bound error, to
-                        // mimic current behavior, we would return INDEX_OUT_OF_BOUND error.
-                        machine.set_register(A0, Mac::REG::from_u8(INDEX_OUT_OF_BOUND));
-                        return Ok(());
-                    }
-                    Err(e) => return Err(e),
-                };
+                // Keep Snapshot2Context::store_bytes ordering while reusing the
+                // cell already loaded above, including its remaining length.
+                let wrote_size = cell.len().min(size as usize) as u64;
+                machine
+                    .memory_mut()
+                    .store64(&size_addr, &Mac::REG::from_u64(cell.len() as u64))?;
+                cell.truncate(wrote_size as usize);
+                sc.untrack_pages(machine, addr, wrote_size)?;
+                machine.memory_mut().store_bytes(addr, &cell)?;
+                sc.track_pages(machine, addr, wrote_size, &data_piece_id, offset)?;
                 machine.add_cycles_no_checking(transferred_byte_cycles(wrote_size))?;
                 machine.set_register(A0, Mac::REG::from_u8(SUCCESS));
                 return Ok(());

--- a/script/src/syscalls/tests/vm_latest/syscalls_1.rs
+++ b/script/src/syscalls/tests/vm_latest/syscalls_1.rs
@@ -2187,3 +2187,158 @@ fn test_load_cell_data_size_zero_index_out_of_bound() {
     load_code.ecall(&mut machine).unwrap();
     assert_eq!(machine.registers()[A0], u64::from(INDEX_OUT_OF_BOUND));
 }
+
+// The reference delegates writing/tracking to Snapshot2Context, independently
+// checking the syscall's use of data loaded before the size-pointer check.
+#[test]
+fn test_load_cell_data_reads_once_and_preserves_snapshot_store_semantics() {
+    use crate::types::{DataPieceId, ScriptVersion, SgData, TxData};
+    use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
+    use ckb_vm::SupportMachine;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone)]
+    struct CountingLoader {
+        data: Bytes,
+        reads: Arc<AtomicUsize>,
+    }
+    impl CellDataProvider for CountingLoader {
+        fn get_cell_data(&self, _: &OutPoint) -> Option<Bytes> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Some(self.data.clone())
+        }
+        fn get_cell_data_hash(&self, _: &OutPoint) -> Option<packed::Byte32> {
+            Some(CellOutput::calc_data_hash(&self.data))
+        }
+    }
+    impl HeaderProvider for CountingLoader {
+        fn get_header(&self, _: &packed::Byte32) -> Option<ckb_types::core::HeaderView> {
+            None
+        }
+    }
+    impl ExtensionProvider for CountingLoader {
+        fn get_block_extension(&self, _: &packed::Byte32) -> Option<packed::Bytes> {
+            None
+        }
+    }
+
+    let data = Bytes::from((0..12288).map(|i| (i % 251) as u8).collect::<Vec<_>>());
+    let mut dep = build_cell_meta(20000, data.clone());
+    dep.mem_cell_data = None;
+    let rtx = Arc::new(ResolvedTransaction {
+        transaction: TransactionBuilder::default().build(),
+        resolved_cell_deps: vec![dep],
+        resolved_inputs: vec![],
+        resolved_dep_groups: vec![],
+    });
+    let base = build_sg_data(Arc::clone(&rtx), vec![], vec![]);
+    for version in [ScriptVersion::V0, ScriptVersion::V1, ScriptVersion::V2] {
+        // offset, requested length, dep index, destination, invalid size pointer, frozen
+        for (offset, size, index, addr, bad_size_pointer, frozen) in [
+            (0, 0, 0, 8192, false, false),
+            (17, 7, 0, 8192, false, false),
+            (17, 8192, 0, 8192, false, false),
+            (0, 7, 0, 100, false, false),
+            (17, 8192, 0, 96, false, false),
+            (12288, 7, 0, 8192, false, false),
+            (u64::MAX, 7, 0, 8192, false, false),
+            (0, u64::MAX, 0, 8192, false, false),
+            (0, 7, 1, 8192, true, false),
+            (0, 7, 0, 8192, true, false),
+            (0, 7, 0, u64::MAX, false, false),
+            (0, 8192, 0, 8192, false, true),
+        ] {
+            let reads = Arc::new(AtomicUsize::new(0));
+            let tx_data = TxData::new(
+                Arc::clone(&rtx),
+                CountingLoader {
+                    data: data.clone(),
+                    reads: Arc::clone(&reads),
+                },
+                Arc::clone(&base.tx_info.consensus),
+                Arc::clone(&base.tx_info.tx_env),
+            );
+            let sg_data = SgData {
+                rtx: Arc::clone(&rtx),
+                tx_info: tx_data.info,
+                sg_info: Arc::clone(&base.sg_info),
+            };
+            let context = VmContext::new(&sg_data, &Arc::new(Mutex::new(Vec::new())));
+            let reference_context = VmContext::new(&sg_data, &Arc::new(Mutex::new(Vec::new())));
+            let mut machine = version.init_core_machine_without_limit();
+            let mut reference = version.init_core_machine_without_limit();
+            let size_addr = if bad_size_pointer { u64::MAX } else { 100 };
+            for current in [&mut machine, &mut reference] {
+                if !bad_size_pointer {
+                    current.memory_mut().store64(&size_addr, &size).unwrap();
+                }
+                if frozen {
+                    current
+                        .memory_mut()
+                        .init_pages(addr, 8192, FLAG_EXECUTABLE | FLAG_FREEZED, None, 0)
+                        .unwrap();
+                }
+                current.set_register(A0, addr);
+                current.set_register(A1, size_addr);
+                current.set_register(A2, offset);
+                current.set_register(A3, index);
+                current.set_register(A4, u64::from(Source::Transaction(SourceEntry::CellDep)));
+                current.set_register(A7, LOAD_CELL_DATA_SYSCALL_NUMBER);
+            }
+            let actual = LoadCellData::new(&context).ecall(&mut machine);
+            assert_eq!(reads.load(Ordering::SeqCst), usize::from(index == 0));
+            let expected = (|| -> Result<bool, VMError> {
+                let id = DataPieceId::CellDep(index as u32);
+                let mut sc = reference_context.snapshot2_context.lock().unwrap();
+                let cell = match sc.load_data(&id, offset, u64::MAX) {
+                    Ok((cell, _)) => cell,
+                    Err(VMError::SnapshotDataLoadError) => {
+                        reference.set_register(A0, u64::from(INDEX_OUT_OF_BOUND));
+                        return Ok(true);
+                    }
+                    Err(error) => return Err(error),
+                };
+                let size = reference.memory_mut().load64(&size_addr)?;
+                if size == 0 {
+                    reference
+                        .memory_mut()
+                        .store64(&size_addr, &(cell.len() as u64))?;
+                } else {
+                    let (written, _) =
+                        sc.store_bytes(&mut reference, addr, &id, offset, size, size_addr)?;
+                    reference.add_cycles_no_checking(
+                        crate::cost_model::transferred_byte_cycles(written),
+                    )?;
+                }
+                reference.set_register(A0, u64::from(SUCCESS));
+                Ok(true)
+            })();
+            assert_eq!(actual, expected);
+            assert_eq!(machine.registers(), reference.registers());
+            assert_eq!(machine.cycles(), reference.cycles());
+            let mut actual_snapshot = context
+                .snapshot2_context
+                .lock()
+                .unwrap()
+                .make_snapshot(&mut machine)
+                .unwrap();
+            let mut expected_snapshot = reference_context
+                .snapshot2_context
+                .lock()
+                .unwrap()
+                .make_snapshot(&mut reference)
+                .unwrap();
+            actual_snapshot.pages_from_source.sort_by_key(|page| page.0);
+            expected_snapshot
+                .pages_from_source
+                .sort_by_key(|page| page.0);
+            actual_snapshot.dirty_pages.sort_by_key(|page| page.0);
+            expected_snapshot.dirty_pages.sort_by_key(|page| page.0);
+            assert_eq!(
+                actual_snapshot.pages_from_source,
+                expected_snapshot.pages_from_source
+            );
+            assert_eq!(actual_snapshot.dirty_pages, expected_snapshot.dirty_pages);
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

`load_cell_data` loads the cell data to check the source and get the remaining length. For a nonzero-size request, it then calls `Snapshot2Context::store_bytes`, which loads the same data again. We already have the bytes, so this second lookup is unnecessary.

I'm splitting this optimization out of #5316 so it can be reviewed and merged independently of the tx-pool refactor.

### What is changed and how it works?

Reuse the loaded bytes when writing VM memory, preserving the existing length write-back, truncation, page tracking order, return code, and cycle accounting.

Add a regression test for VM V0, V1, and V2 that counts provider reads and compares the result against `Snapshot2Context::store_bytes`. It covers empty and partial reads, page boundaries, overlapping buffers, invalid indices and pointers, oversized offsets and lengths, and frozen pages. Errors, registers, cycles, and snapshot pages must match.

The old implementation fails the read-count assertion with two reads instead of one.

### Check List

- [x] Counting and differential regression tests.
- [x] Strict workspace Clippy with all targets and the Makefile feature/lint flags.
- [x] Formatting and `git diff --check`.



